### PR TITLE
Turbopack HMR: extract deferring build messages and use it in server hmr

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
+++ b/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
@@ -1,5 +1,6 @@
 import type { TurbopackMessage } from '../../../server/dev/hot-reloader-types'
 import type { Update as TurbopackUpdate } from '../../../build/swc/types'
+import { DeferredEmit } from '../../../shared/lib/turbopack/deferred-emit'
 
 declare global {
   interface Window {
@@ -22,53 +23,46 @@ export class TurbopackHmr {
   #updatedModules: Set<string>
   #startMsSinceEpoch: number | undefined
   #lastUpdateMsSinceEpoch: number | undefined
-  #deferredReportHmrStartId: ReturnType<typeof setTimeout> | undefined
-  #reportedHmrStart: boolean
-
-  constructor() {
-    this.#updatedModules = new Set()
-    this.#reportedHmrStart = false
-  }
-
   // HACK: Turbopack tends to generate a lot of irrelevant "BUILDING" actions,
   // as it reports *any* compilation, including fully no-op/cached compilations
   // and those unrelated to HMR. Fixing this would require significant
   // architectural changes.
   //
-  // Work around this by deferring any "rebuilding" message by 100ms. If we get
-  // a BUILT event within that threshold and nothing has changed, just suppress
-  // the message entirely.
-  #runDeferredReportHmrStart() {
-    if (this.#deferredReportHmrStartId != null) {
-      console.log('[Fast Refresh] rebuilding')
-      this.#reportedHmrStart = true
-      this.#cancelDeferredReportHmrStart()
-    }
-  }
+  // Work around this by deferring the `[Fast Refresh] rebuilding` message by
+  // 100ms. If we get a BUILT event within that threshold and nothing has
+  // changed, just suppress the message entirely. (The dev server applies the
+  // same defer to the BUILDING HMR message itself; see `DeferredEmit` usage in
+  // hot-reloader-turbopack.ts.)
+  #deferredReportHmrStart: DeferredEmit
+  #reportedHmrStart: boolean
 
-  #cancelDeferredReportHmrStart() {
-    clearTimeout(this.#deferredReportHmrStartId)
-    this.#deferredReportHmrStartId = undefined
+  constructor() {
+    this.#updatedModules = new Set()
+    this.#deferredReportHmrStart = new DeferredEmit()
+    this.#reportedHmrStart = false
   }
 
   onBuilding() {
     this.#lastUpdateMsSinceEpoch = undefined
-    this.#cancelDeferredReportHmrStart()
+    this.#deferredReportHmrStart.cancel()
     this.#startMsSinceEpoch = Date.now()
 
     // report the HMR start after a short delay
-    this.#deferredReportHmrStartId = setTimeout(
-      () => this.#runDeferredReportHmrStart(),
+    this.#deferredReportHmrStart.schedule(
       // debugging feature: don't defer/suppress noisy no-op HMR update messages
       self.__NEXT_HMR_TURBOPACK_REPORT_NOISY_NOOP_EVENTS
         ? 0
-        : TURBOPACK_HMR_START_DELAY_MS
+        : TURBOPACK_HMR_START_DELAY_MS,
+      () => {
+        console.log('[Fast Refresh] rebuilding')
+        this.#reportedHmrStart = true
+      }
     )
   }
 
   /** Helper for other `onEvent` methods. */
   #onUpdate() {
-    this.#runDeferredReportHmrStart()
+    this.#deferredReportHmrStart.flush()
     this.#lastUpdateMsSinceEpoch = Date.now()
   }
 
@@ -107,10 +101,10 @@ export class TurbopackHmr {
       this.#lastUpdateMsSinceEpoch != null && this.#startMsSinceEpoch != null
     if (!hasUpdates && !this.#reportedHmrStart) {
       // suppress the update entirely
-      this.#cancelDeferredReportHmrStart()
+      this.#deferredReportHmrStart.cancel()
       return null
     }
-    this.#runDeferredReportHmrStart()
+    this.#deferredReportHmrStart.flush()
 
     const result = {
       hasUpdates,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -104,6 +104,7 @@ import { devIndicatorServerState } from './dev-indicator-server-state'
 import { getDisableDevIndicatorMiddleware } from '../../next-devtools/server/dev-indicator-middleware'
 import { getRestartDevServerMiddleware } from '../../next-devtools/server/restart-dev-server-middleware'
 import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
+import { DeferredEmit } from '../../shared/lib/turbopack/deferred-emit'
 import { getSupportedBrowsers } from '../../build/get-supported-browsers'
 import { printBuildErrors } from '../../build/print-build-errors'
 import { receiveBrowserLogsTurbopack } from './browser-logs/receive-logs'
@@ -712,6 +713,12 @@ export async function createHotReloaderTurbopack(
   // advance it at all when no client is connected.
   let hmrHash = 0
 
+  // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every
+  // foreground-job cycle, including empty no-op recompiles scheduled by
+  // request/render activity that changed no files. This allows us to prevent
+  // sending them if we quickly get a `built` message after a `building` message.
+  const pendingBuilding = new DeferredEmit()
+
   const clientsWithoutHtmlRequestId = new Set<ws>()
   const clientsByHtmlRequestId = new Map<string, ws>()
   const cacheStatusesByHtmlRequestId = new Map<string, ServerCacheStatus>()
@@ -792,6 +799,7 @@ export async function createHotReloaderTurbopack(
   const sendEnqueuedMessagesDebounce = debounce(sendEnqueuedMessages, 2)
 
   const sendHmr: SendHmr = (id: string, message: HmrMessageSentToBrowser) => {
+    pendingBuilding.flush()
     for (const client of [
       ...clientsWithoutHtmlRequestId,
       ...clientsByHtmlRequestId.values(),
@@ -809,6 +817,7 @@ export async function createHotReloaderTurbopack(
     //   They are currently not handled on the client at all, so might as well not send them for now.
     payload.diagnostics = []
     payload.issues = []
+    pendingBuilding.flush()
 
     for (const client of [
       ...clientsWithoutHtmlRequestId,
@@ -1903,11 +1912,14 @@ export async function createHotReloaderTurbopack(
   })
 
   async function handleProjectUpdates() {
+    const BUILDING_MESSAGE_DEFER_MS = 100
     for await (const updateMessage of project.updateInfoSubscribe(30)) {
       switch (updateMessage.updateType) {
         case 'start': {
           updateInProgress = true
-          hotReloader.send({ type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING })
+          pendingBuilding.schedule(BUILDING_MESSAGE_DEFER_MS, () => {
+            hotReloader.send({ type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING })
+          })
           // Mark that HMR has started and we need to call the callback after it settles
           // This ensures onBeforeDeferredEntries will be called again during HMR
           if (hasDeferredEntriesConfig) {
@@ -1919,6 +1931,7 @@ export async function createHotReloaderTurbopack(
         }
         case 'end': {
           updateInProgress = false
+          pendingBuilding.cancel()
           if (pendingServerComponentChanges) {
             pendingServerComponentChanges = false
             sendServerComponentChanges()

--- a/packages/next/src/shared/lib/turbopack/deferred-emit.ts
+++ b/packages/next/src/shared/lib/turbopack/deferred-emit.ts
@@ -1,0 +1,56 @@
+/**
+ * Fires a callback after a delay unless it's cancelled or flushed first.
+ *
+ * `schedule()` replaces any still-pending emit.
+ */
+export class DeferredEmit {
+  #timer: ReturnType<typeof setTimeout> | undefined
+  #fn: (() => void) | undefined
+
+  /**
+   * Arm `fn` to run after `delayMs`, replacing any still-pending emit.
+   *
+   * @param delayMs The delay in milliseconds before the callback is fired.
+   * @param fn The callback function to be executed after the delay.
+   */
+  schedule(delayMs: number, scheduledFn: () => void): void {
+    this.cancel()
+    this.#fn = scheduledFn
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined
+      const fn = this.#fn
+      this.#fn = undefined
+      fn?.()
+    }, delayMs)
+  }
+
+  /**
+   * If an emit is pending, run it now instead of waiting for the delay.
+   */
+  flush(): void {
+    if (this.#timer === undefined) {
+      return
+    }
+    clearTimeout(this.#timer)
+    this.#timer = undefined
+    const fn = this.#fn
+    this.#fn = undefined
+    fn?.()
+  }
+
+  /**
+   * Cancel a pending emit without running it.
+   */
+  cancel(): void {
+    if (this.#timer === undefined) {
+      return
+    }
+    clearTimeout(this.#timer)
+    this.#timer = undefined
+    this.#fn = undefined
+  }
+
+  get isPending(): boolean {
+    return this.#timer !== undefined
+  }
+}


### PR DESCRIPTION
Churn in the graph can lead to a `building` message quickly followed by a `built` message. The underlying issue should be addressed, but for now, extract this debounce from the client HMR implementation and use it in server hmr.