### PR TITLE
Fix Dynamic Routes in Symlinks is not working #16660

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -7,6 +7,7 @@ import type { MiddlewareRouteMatch } from '../../../shared/lib/router/utils/midd
 import type { PropagateToWorkersField } from './types'
 import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 
+import { recursiveReadDir } from '../../../lib/recursive-readdir'
 import { createDefineEnv } from '../../../build/swc'
 import { installBindings } from '../../../build/swc/install-bindings'
 import fs from 'fs'
@@ -450,9 +451,21 @@ async function startWatcher(
       staticMetadataFiles.clear()
       devPageFiles.clear()
 
-      const sortedKnownFiles: string[] = [...knownFiles.keys()].sort(
-        sortByPageExts(nextConfig.pageExtensions)
-      )
+      // Watchpack may not report page files that are reachable only through
+      // symlinked directories. Perform a filesystem scan and merge the results
+      // with the watcher entries so all routable pages are considered.
+      const discoveredPageFiles = pagesDir
+        ? await recursiveReadDir(pagesDir, {
+            pathnameFilter: validFileMatcher.isPageFile,
+            relativePathnames: false,
+          })
+        : []
+
+      const discoveredPageFileSet = new Set(discoveredPageFiles)
+
+      const sortedKnownFiles: string[] = [
+        ...new Set([...knownFiles.keys(), ...discoveredPageFiles]),
+      ].sort(sortByPageExts(nextConfig.pageExtensions))
 
       let proxyFilePath: string | undefined
       let middlewareFilePath: string | undefined
@@ -527,7 +540,8 @@ async function startWatcher(
         }
 
         if (
-          meta?.accuracy === undefined ||
+          (meta?.accuracy === undefined &&
+            !discoveredPageFileSet.has(fileName)) ||
           !validFileMatcher.isPageFile(fileName)
         ) {
           continue

--- a/test/e2e/symlink-dynamic-route/pages/nolink/[id].js
+++ b/test/e2e/symlink-dynamic-route/pages/nolink/[id].js
@@ -1,0 +1,11 @@
+export default function Page({ id }) {
+  return <p>Dynamic page works: {id}</p>
+}
+
+export async function getServerSideProps({ params }) {
+  return {
+    props: {
+      id: params.id,
+    },
+  }
+}

--- a/test/e2e/symlink-dynamic-route/pages/nolink/index.js
+++ b/test/e2e/symlink-dynamic-route/pages/nolink/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Index page works</p>
+}

--- a/test/e2e/symlink-dynamic-route/symlink-dynamic-route.test.ts
+++ b/test/e2e/symlink-dynamic-route/symlink-dynamic-route.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import { symlink } from 'fs/promises'
+
+describe('symlink-dynamic-route', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  beforeAll(async () => {
+    await symlink(
+      join(next.testDir, 'pages', 'nolink'),
+      join(next.testDir, 'pages', 'symlinktest')
+    )
+  })
+
+  it('should support dynamic routes through symlinks', async () => {
+    const $ = await next.render$('/symlinktest/123')
+
+    expect($('p').text()).toBe('Dynamic page works: 123')
+  })
+
+  it('should still support dynamic routes without symlinks', async () => {
+    const $ = await next.render$('/nolink/123')
+
+    expect($('p').text()).toBe('Dynamic page works: 123')
+  })
+
+  it('should support index routes through symlinks', async () => {
+    const $ = await next.render$('/symlinktest')
+
+    expect($('p').text()).toBe('Index page works')
+  })
+})


### PR DESCRIPTION
### What?

This PR fixes an issue where dynamic routes located in symlinked directories are not discovered during route generation. Although the page directory is watched by Watchpack, files that are only reachable through a symlink are not always included in `knownFiles`, causing dynamic routes such as `/symlinktest/[id]` to be unavailable.

The fix supplements the watcher's known file list by recursively scanning the `pages` directory for valid page files and merging the discovered files with the Watchpack entries before route generation. This ensures that page files accessible through symlinked directories are included while preserving the existing watcher behavior.

An end-to-end regression test has also been added to verify that:

* Dynamic routes resolve correctly through symlinked directories.
* Dynamic routes continue to work for non-symlinked directories.
* Index routes continue to work through symlinked directories.

### Why?

The current implementation relies solely on Watchpack's `getTimeInfoEntries()` to determine which page files exist. In symlinked directory layouts, Watchpack may not report every routable page, resulting in missing dynamic routes even though the files are present on disk.

By supplementing the watcher state with a filesystem scan, Next.js can correctly discover and register routes that are reachable through symlinked directories without changing the watcher implementation.

### How?

* Use `recursiveReadDir()` to enumerate valid page files within the `pages` directory.
* Merge the discovered page files with the files reported by `Watchpack`.
* Sort the combined set before continuing with route generation.
* Add an e2e regression test covering dynamic and index routes accessed through a symlinked directory.

Fixes #16660
