### PR TITLE
Preserve init errors from async route modules

### DIFF
--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -235,6 +235,9 @@ export class AppRouteRouteModule extends RouteModule<
   // Non-null while an async userland module (top-level await) is loading.
   // ensureUserland() awaits this before the first request is handled.
   private _pendingUserland: Promise<void> | null = null
+  // Init error from an async userland module, rethrown by ensureUserland().
+  private _initError: unknown = null
+  private _hasInitError = false
   // Synchronous per-request userland getter for Turbopack dev mode.
   // Called on every request to pick up server HMR updates.
   private readonly _getUserland?: () => AppRouteUserlandModule
@@ -252,7 +255,12 @@ export class AppRouteRouteModule extends RouteModule<
         this._pendingUserland = result.then((mod) => {
           this._userland = mod
           this._pendingUserland = null
-          this._initFromUserland()
+          try {
+            this._initFromUserland()
+          } catch (err) {
+            this._initError = err
+            this._hasInitError = true
+          }
         })
       } else {
         this._userland = result
@@ -274,6 +282,9 @@ export class AppRouteRouteModule extends RouteModule<
     void this.userland
     if (this._pendingUserland) {
       await this._pendingUserland
+    }
+    if (this._hasInitError) {
+      throw this._initError
     }
   }
 
@@ -312,7 +323,12 @@ export class AppRouteRouteModule extends RouteModule<
         this._pendingUserland = result.then((mod) => {
           this._userland = mod
           this._pendingUserland = null
-          this._initFromUserland()
+          try {
+            this._initFromUserland()
+          } catch (err) {
+            this._initError = err
+            this._hasInitError = true
+          }
         })
       } else {
         this._userland = result

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -375,6 +375,7 @@
       "test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts",
       "test/production/app-dir/metadata-streaming-config/metadata-streaming-config.test.ts",
       "test/production/app-dir/next-types-plugin/sync-params-type-check/sync-params-type-check.test.ts",
+      "test/production/app-dir/output-export-async-route-module/**/*",
       "test/production/app-dir/revalidate/revalidate.test.ts",
       "test/production/app-dir/ssg-single-pass/ssg-single-pass.test.ts",
       "test/production/app-dir/subresource-integrity/subresource-integrity.test.ts",

--- a/test/production/app-dir/output-export-async-route-module/fixtures/invalid/app/api/data/route.ts
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/invalid/app/api/data/route.ts
@@ -1,0 +1,6 @@
+// Top-level await makes this an async module.
+await Promise.resolve()
+
+export async function GET() {
+  return Response.json({ ok: true })
+}

--- a/test/production/app-dir/output-export-async-route-module/fixtures/invalid/app/layout.tsx
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/invalid/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/output-export-async-route-module/fixtures/invalid/app/page.tsx
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/invalid/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/output-export-async-route-module/fixtures/invalid/next.config.js
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/invalid/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/output-export-async-route-module/fixtures/valid/app/api/data/route.ts
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/valid/app/api/data/route.ts
@@ -1,0 +1,8 @@
+// Top-level await makes this an async module.
+await Promise.resolve()
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  return Response.json({ ok: true })
+}

--- a/test/production/app-dir/output-export-async-route-module/fixtures/valid/app/layout.tsx
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/valid/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/output-export-async-route-module/fixtures/valid/app/page.tsx
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/valid/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/output-export-async-route-module/fixtures/valid/next.config.js
+++ b/test/production/app-dir/output-export-async-route-module/fixtures/valid/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/output-export-async-route-module/output-export-async-route-module.test.ts
+++ b/test/production/app-dir/output-export-async-route-module/output-export-async-route-module.test.ts
@@ -1,0 +1,35 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('output-export-async-route-module', () => {
+  describe('invalid route', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'fixtures', 'invalid'),
+      skipStart: true,
+    })
+
+    // The route module uses top-level await, so its `output: 'export'`
+    // validation runs after the module settles instead of throwing during
+    // require(). The resulting error must still fail the build.
+    it('fails the build when an async route module is not statically exportable', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(cliOutput).toContain(
+        'not configured on route "/api/data" with "output: export"'
+      )
+      expect(exitCode).toBe(1)
+    })
+  })
+
+  describe('valid route', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'fixtures', 'valid'),
+      skipStart: true,
+    })
+
+    it('exports an async route module that is statically exportable', async () => {
+      const { exitCode } = await next.build()
+      expect(exitCode).toBe(0)
+      expect(await next.readFile('out/api/data')).toBe('{"ok":true}')
+    })
+  })
+})


### PR DESCRIPTION
Extracted from https://github.com/vercel/next.js/pull/95468.

We did not have error handling around async module initialization. As a result, in `output: 'export'` mode, an error during async initialization were reported as unhandled rejections. Now it properly fails the build.