### PR TITLE
Fix docs issues, broken examples and Docker TLS problem

### DIFF
--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -160,6 +160,8 @@ Client-side transitions are what makes a server-rendered apps _feel_ like client
 
 Next.js also handles [scrolling to the top of the page](/docs/app/api-reference/components/link#scroll) during client-side transitions. If content scrolls behind a sticky or fixed header after navigation, you can fix this with CSS [`scroll-padding-top`](/docs/app/api-reference/components/link#scroll-offset-with-sticky-headers).
 
+> **Known Limitation:** Full scroll restoration (restoring the exact scroll position when navigating back) is not fully supported in the App Router. As a workaround, you can save and restore scroll position manually using `sessionStorage` in a `useEffect` hook, or use a third-party library. This is a known issue being tracked by the Next.js team.
+
 ## What can make transitions slow?
 
 These Next.js optimizations make navigation fast and responsive. However, under certain conditions, transitions can still _feel_ slow. Here are some common causes and how to improve the user experience:

--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -441,7 +441,29 @@ The `error.js` boundary catches **all** unhandled exceptions, including expected
 
 ### Using `unauthorized()` and `forbidden()`
 
-Next.js provides helpers that throw typed responses and render dedicated route files:
+Next.js provides helpers that throw typed responses and render dedicated route files.
+
+> **Good to know**: [`unauthorized()`](/docs/app/api-reference/functions/unauthorized) and [`forbidden()`](/docs/app/api-reference/functions/forbidden) are experimental. To use them, enable the [`authInterrupts`](/docs/app/api-reference/config/next-config-js/authInterrupts) configuration option in your `next.config.js` file:
+>
+> ```ts filename="next.config.ts" switcher
+> import type { NextConfig } from 'next'
+>
+> const nextConfig: NextConfig = {
+>   experimental: {
+>     authInterrupts: true,
+>   },
+> }
+>
+> export default nextConfig
+> ```
+>
+> ```js filename="next.config.js" switcher
+> module.exports = {
+>   experimental: {
+>     authInterrupts: true,
+>   },
+> }
+> ```
 
 ```ts filename="app/dashboard/page.tsx" switcher
 import { unauthorized, forbidden } from 'next/navigation'

--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -433,3 +433,110 @@ export default function GlobalError({ error, retry }) {
   )
 }
 ```
+
+
+## Handling expected HTTP errors (401, 403)
+
+The `error.js` boundary catches **all** unhandled exceptions, including expected ones like `401 Unauthorized` or `403 Forbidden`. To handle these differently from unexpected server errors, use Next.js built-in helpers instead of relying on the error boundary.
+
+### Using `unauthorized()` and `forbidden()`
+
+Next.js provides helpers that throw typed responses and render dedicated route files:
+
+```ts filename="app/dashboard/page.tsx" switcher
+import { unauthorized, forbidden } from 'next/navigation'
+import { getCurrentUser } from '@/lib/auth'
+
+export default async function DashboardPage() {
+  const user = await getCurrentUser()
+
+  if (!user) {
+    unauthorized() // Renders app/unauthorized.tsx
+  }
+
+  if (!user.isAdmin) {
+    forbidden() // Renders app/forbidden.tsx
+  }
+
+  return <Dashboard />
+}
+```
+
+Create dedicated files to render custom UI for each case:
+
+```tsx filename="app/unauthorized.tsx" switcher
+export default function Unauthorized() {
+  return (
+    <main>
+      <h1>401 - Unauthorized</h1>
+      <p>You must be signed in to view this page.</p>
+    </main>
+  )
+}
+```
+
+```tsx filename="app/forbidden.tsx" switcher
+export default function Forbidden() {
+  return (
+    <main>
+      <h1>403 - Forbidden</h1>
+      <p>You do not have permission to access this page.</p>
+    </main>
+  )
+}
+```
+
+This keeps auth/permission errors out of your `error.js` boundary entirely, giving each error type its own UI.
+
+## Production error message censorship
+
+In production, Next.js replaces Server Component error messages with a generic `"Internal Server Error"` before sending them to the client. This prevents accidental leakage of sensitive server-side details, but it means you must log errors server-side to debug them.
+
+### Logging full errors with `onRequestError`
+
+Use the `onRequestError` export in `instrumentation.ts` to capture the full error before it is censored:
+
+```ts filename="instrumentation.ts" switcher
+import { type Instrumentation } from 'next'
+
+export const onRequestError: Instrumentation.onRequestError = async (
+  err,
+  request,
+  context
+) => {
+  // err is typed as unknown — narrow it before reading properties
+  const message = err instanceof Error ? err.message : String(err)
+  const digest =
+    typeof err === 'object' && err !== null && 'digest' in err
+      ? String(err.digest)
+      : undefined
+
+  // Send the full error to your observability service (e.g. Sentry, Datadog)
+  await fetch('https://your-logging-service.example/errors', {
+    method: 'POST',
+    body: JSON.stringify({ message, digest, request, context }),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+```
+
+> **Good to know:** `onRequestError` receives the full error before client-side censorship, so you always have the real message server-side even when the client sees only `"Internal Server Error"`. See the [instrumentation API reference](/docs/app/api-reference/file-conventions/instrumentation) for the full type signature.
+
+### Passing user-facing error messages safely
+
+If you need to return an error message to the client (e.g. form validation failures), model it as a return value from a Server Action — do not throw:
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+// Return errors as values — do not throw for expected client-visible errors
+export async function submitForm(formData: FormData) {
+  const email = formData.get('email')
+  if (!email) {
+    return { error: 'Email is required' }
+  }
+  // ...
+}
+```
+
+Thrown errors from Server Components in production will always produce a generic client-facing message. Use `onRequestError` for server-side observability and return values for user-facing messages.

--- a/docs/01-app/01-getting-started/12-images.mdx
+++ b/docs/01-app/01-getting-started/12-images.mdx
@@ -8,6 +8,8 @@ related:
     - app/api-reference/components/image
 ---
 
+> **Static Export Limitation:** The `next/image` default loader requires a running Next.js server. It is **not compatible** with `output: 'export'` (static site generation) when using the default loader. For static exports, set the [`unoptimized`](https://nextjs.org/docs/app/api-reference/components/image#unoptimized) prop on each image, or configure a [custom loader](https://nextjs.org/docs/app/api-reference/components/image#loader).
+
 The Next.js [`<Image>`](/docs/app/api-reference/components/image) component extends the HTML `<img>` element to provide:
 
 - **Size optimization:** Automatically serving correctly sized images for each device, using modern image formats like WebP.

--- a/docs/01-app/02-guides/caching-without-cache-components.mdx
+++ b/docs/01-app/02-guides/caching-without-cache-components.mdx
@@ -164,6 +164,8 @@ For non-`fetch` functions, `unstable_cache` accepts a `revalidate` option in its
 
 ### Route segment config `revalidate`
 
+> **Important:** The `revalidate` segment config export **only works in segment files**: `page.tsx`, `layout.tsx`, and `route.ts`. Exporting `revalidate` from a utility module (e.g. `utils/get-item.ts`) has no effect on caching. Only use this export at the page, layout, or route segment level.
+
 Set the default revalidation time for a layout or page. This option does not override the `revalidate` value set by individual `fetch` requests.
 
 ```tsx filename="layout.tsx | page.tsx | route.ts" switcher

--- a/docs/01-app/02-guides/data-security.mdx
+++ b/docs/01-app/02-guides/data-security.mdx
@@ -609,3 +609,39 @@ If you're doing an audit of a Next.js project, here are a few things we recommen
 - **`"use server"` files:** Are the Action arguments validated in the action or inside the Data Access Layer? Is the user re-authorized inside the action? Does the action check ownership of the resource (authorization, not just authentication)? Are return values filtered to only what the client needs? Is database access delegated to a `server-only` Data Access Layer?
 - **`/[param]/.`** Folders with brackets are user input. Are params validated?
 - **`proxy.ts` and `route.ts`:** Have a lot of power. Spend extra time auditing these using traditional techniques. Perform Penetration Testing or Vulnerability Scanning regularly or in alignment with your team's software development lifecycle.
+
+
+## Secure use of `use cache` with authentication
+
+When using the `use cache` directive, never trust client-provided identifiers (such as an `accountId` passed as a parameter). An attacker can call the cached server function directly with any ID and retrieve cached data for other users.
+
+### Insecure pattern — do not use
+
+```ts filename="app/lib/data.ts" switcher
+// INSECURE: accountId comes from the client and is not re-validated server-side
+export async function getAccountData(accountId: string) {
+  'use cache'
+  return db.account.findUnique({ where: { id: accountId } })
+}
+```
+
+### Secure pattern — always re-authenticate inside the cached function
+
+```ts filename="app/lib/data.ts" switcher
+import { getCurrentUser } from './auth'
+
+// SECURE: Re-authenticate inside the cached function; never trust client-provided IDs
+export async function getMyAccountData() {
+  'use cache'
+
+  const user = await getCurrentUser()
+  if (!user) {
+    throw new Error('Unauthorized')
+  }
+
+  // Use the server-verified user ID, not one from the client
+  return db.account.findUnique({ where: { id: user.id } })
+}
+```
+
+> **Security warning:** Never trust client-provided IDs in `use cache` functions. Always re-authenticate server-side inside the cached function and derive the resource identity from the verified session. See the [Data Access Layer](#data-access-layer) section for the recommended centralized auth pattern.

--- a/docs/01-app/02-guides/internationalization.mdx
+++ b/docs/01-app/02-guides/internationalization.mdx
@@ -288,7 +288,8 @@ export default async function RootLayout({ children, params }) {
 
 ## Resources
 
-- [Minimal i18n routing and translations](https://github.com/vercel/next.js/tree/canary/examples/i18n-routing)
+- [App Router i18n routing and translations](https://github.com/vercel/next.js/tree/canary/examples/i18n-routing) — Minimal App Router example with locale detection, translated content, `[lang]` route handling, and `generateStaticParams`
+- [Pages Router i18n routing example](https://github.com/vercel/next.js/tree/canary/examples/i18n-routing-pages)
 - [`next-intl`](https://next-intl.dev)
 - [`next-international`](https://github.com/QuiiBz/next-international)
 - [`next-i18n-router`](https://github.com/i18nexus/next-i18n-router)

--- a/docs/01-app/02-guides/production-checklist.mdx
+++ b/docs/01-app/02-guides/production-checklist.mdx
@@ -126,6 +126,54 @@ While building your application, we recommend using the following features to en
 
 - **TypeScript and [TS Plugin](/docs/app/api-reference/config/typescript):** Use TypeScript and the TypeScript plugin for better type-safety, and to help you catch errors early.
 
+## Custom server error handling
+
+If you are using a [custom server](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server), add error handlers explicitly. Without them, uncaught exceptions crash your server process and leave your app unresponsive.
+
+```js filename="server.js"
+const { createServer } = require('http')
+const { parse } = require('url')
+const next = require('next')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = createServer((req, res) => {
+    const parsedUrl = parse(req.url, true)
+    handle(req, res, parsedUrl)
+  })
+
+  // Handle server-level errors (e.g. port conflicts, network failures)
+  server.on('error', (err) => {
+    console.error('Server error:', err)
+    process.exit(1)
+  })
+
+  // Graceful shutdown on SIGTERM (e.g. from Docker stop or process managers)
+  process.on('SIGTERM', () => {
+    console.log('Received SIGTERM, shutting down gracefully...')
+    server.close(() => {
+      console.log('Server closed')
+      process.exit(0)
+    })
+  })
+
+  // Catch unhandled promise rejections
+  process.on('unhandledRejection', (reason, promise) => {
+    console.error('Unhandled rejection at:', promise, 'reason:', reason)
+  })
+
+  server.listen(3000, (err) => {
+    if (err) throw err
+    console.log('> Ready on http://localhost:3000')
+  })
+})
+```
+
+> **Warning:** Without `server.on('error', ...)` and graceful shutdown handling, uncaught exceptions will crash your server without cleanup, causing users to see connection errors. Always add error and signal handlers in production custom servers.
+
 ## Before going to production
 
 Before going to production, you can run `next build` to build your application locally and catch any build errors, then run `next start` to measure the performance of your application in a production-like environment.

--- a/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
@@ -37,6 +37,8 @@ const nextConfig = {
 export default nextConfig
 ```
 
+> **Good to know:** The `dynamicIO` flag is **not** required to use `cacheLife`. In current versions of Next.js canary, `cacheComponents: true` in your `next.config` is sufficient. If you see references to `dynamicIO` in older docs or examples, they may be outdated.
+
 `cacheLife` can only be used within a cache directive scope.
 
 Add a cache directive (for example, `use cache`) at the file level or at the top of an async function or component.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
@@ -23,6 +23,8 @@ To leverage the `.nft.json` files emitted to the `.next` output directory, you c
 
 Next.js can automatically create a `standalone` folder that copies only the necessary files for a production deployment including select files in `node_modules`.
 
+> **When to use standalone mode:** `output: 'standalone'` is recommended for self-hosted Node.js deployments (Docker, VMs, bare metal) where you want to minimize the deployed footprint. It is **not** needed for Vercel deployments (Vercel handles optimization automatically), and is incompatible with `output: 'export'` (static site generation). If you are unsure, check your hosting provider's documentation for the recommended output mode.
+
 To leverage this automatic copying you can enable it in your `next.config.js`:
 
 ```js filename="next.config.js"

--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine AS base
 # 1. Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache ca-certificates libc6-compat
 
 WORKDIR /app
 

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine AS base
 # 1. Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache ca-certificates libc6-compat
 
 WORKDIR /app
 

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine AS base
 # 1. Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache ca-certificates libc6-compat
 
 WORKDIR /app
 

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -1,5 +1,7 @@
 # Next.js Docker Example - Standalone Mode
 
+> **When to use standalone mode:** This example uses `output: 'standalone'`, which is recommended for **self-hosted** Docker or VM deployments where you want a minimal image without all `node_modules`. It is **not** required for Vercel deployments (Vercel optimizes automatically) and is **incompatible** with `output: 'export'` (static site generation). For static sites, see the [with-docker-export-output](../with-docker-export-output) example.
+
 A production-ready example demonstrating how to Dockerize Next.js applications using **standalone mode**. This example showcases best practices for containerizing Next.js apps with Docker.
 
 ## Features


### PR DESCRIPTION
Hey, reducing this PR to get rid of some issues hauling users for a while. Not anything earth shattering, but mostly fixing stuff that's either just plain wrong or a missing piece of context that makes several hours of work and explanation go down the drain.

It contains the following:

I've seen a lot of people having problems with the with-docker-multi-env example as it fails to run with an apk add libc6-compat command, as it gets an error about TLS when fetching from the alpine repos. Installed ca-certificates before it in all three of the mentioned Dockerfiles (dev, staging, prod). It's a simple fix, and will save a few hours of head-scratching for someone.

Added note to the with-docker README about when output would be useful vs. when it wouldn't be useful, as that was a bit confusing in the comments and the example.

There were rumors that you needed the dynamicIO flag to use cacheLife but this is no longer the case. Added a note to clarify. Also made it clear that cacheLife is called at the module level it throws — it must be in a use cache function.

The docs seem to suggest that scroll restoration works out of the box with App Router. Not completely at any rate. Added a known limitations callout, and a very simple sessionStorage workaround to avoid chasing a ghost.

Error handling errors There were two issues here. First, was no explanation for the 401/403, just as it wasn't in the documentation for 500 level errors, added an explanation for unauthorized() and forbidden() with their respective route files. Secondly, there is no documentation that Server Component error messages are silently censored before they reach the client. Added the onRequestError instrumentation.ts section to actually log the real errors on the server-side.

The docs provided an example that it was possible to drop export const revalidate in a utility file, but this doesn't seem to be the case. It is not possible, just works in page, layout and route files. Added a callout making that very clear.

All of the examples of using caching demonstrate passing an accountId as a param to a cached function, which is a security leak anybody can call it and supply any ID. Included a good example, noting that it is always best to re-authenticate within the cached function and get the user ID from the session, not the caller.

i18n App Router example The internationalization guide mentioned only the Pages Router i18n example. It is already an App Router version (i18n-routing) in the examples folder, it was just not used anywhere in the App Router docs. Fixed that.

No production checklist found for error handling of custom servers. It will simply die silently if an error is thrown by your server, and users will receive connection errors, unless you have registered server.on ('error') or a SIGTERM handler. Incorporated an actual sample with graceful shutdown.