### PR TITLE
Fix ?dpl=undefined chunk URLs when deployment id is missing at manifest eval time

### DIFF
--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -487,12 +487,17 @@ async fn build_manifest(
                     entry_name = StringifyJs(&normalized_manifest_entry),
                     manifest = &client_reference_manifest_json,
                     suffix = if add_deployment_id_at_runtime {
+                        // Only append the suffix when the deployment id is actually available at
+                        // runtime, otherwise a missing env var would be stringified into every
+                        // chunk URL as `?dpl=undefined`.
                         formatdoc!{
                             r#"
-                            for (const key in globalThis.__RSC_MANIFEST[{entry_name}].clientModules) {{
-                                const val = {{ ...globalThis.__RSC_MANIFEST[{entry_name}].clientModules[key] }}
-                                globalThis.__RSC_MANIFEST[{entry_name}].clientModules[key] = val
-                                val.chunks = val.chunks.map((c) => `${{c}}?dpl=${{process.env.NEXT_DEPLOYMENT_ID}}`)
+                            if (process.env.NEXT_DEPLOYMENT_ID) {{
+                                for (const key in globalThis.__RSC_MANIFEST[{entry_name}].clientModules) {{
+                                    const val = {{ ...globalThis.__RSC_MANIFEST[{entry_name}].clientModules[key] }}
+                                    globalThis.__RSC_MANIFEST[{entry_name}].clientModules[key] = val
+                                    val.chunks = val.chunks.map((c) => `${{c}}?dpl=${{process.env.NEXT_DEPLOYMENT_ID}}`)
+                                }}
                             }}
                             "#,
                             entry_name = StringifyJs(&normalized_manifest_entry),

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -126,6 +126,41 @@ describe.each([
       }
     )
 
+    if (runtimeServerDeploymentId && process.env.IS_TURBOPACK_TEST) {
+      // The client reference manifest defers the deployment id to a runtime
+      // process.env.NEXT_DEPLOYMENT_ID read. If that value is missing when the
+      // manifest is evaluated, it must not be stringified into the chunk URLs
+      // as `?dpl=undefined`.
+      it('should not emit dpl=undefined chunk URLs when the deployment id is missing at manifest eval time', async () => {
+        const vm = require('node:vm')
+        const manifestSource = await next.readFile(
+          '.next/server/app/from-app/page_client-reference-manifest.js'
+        )
+
+        const getChunks = (env: Record<string, string | undefined>) => {
+          const context: any = { process: { env } }
+          vm.runInNewContext(manifestSource, context)
+          const clientModules =
+            context.__RSC_MANIFEST['/from-app/page'].clientModules
+          return Object.values(clientModules).flatMap(
+            (mod: any) => mod.chunks as string[]
+          )
+        }
+
+        const chunksWithoutId = getChunks({})
+        expect(chunksWithoutId).not.toBeEmpty()
+        expect(chunksWithoutId).toSatisfyAll(
+          (chunk: string) => !chunk.includes('dpl=')
+        )
+
+        const chunksWithId = getChunks({ NEXT_DEPLOYMENT_ID: deploymentId })
+        expect(chunksWithId).not.toBeEmpty()
+        expect(chunksWithId).toSatisfyAll((chunk: string) =>
+          chunk.includes(`?dpl=${deploymentId}`)
+        )
+      })
+    }
+
     it.each([{ pathname: '/api/hello' }, { pathname: '/api/hello-app' }])(
       'should have deployment id env available',
       async ({ pathname }) => {


### PR DESCRIPTION
### What?

Fixes dynamically rendered App Router pages emitting `?dpl=undefined` chunk URLs (in both the HTML and the RSC flight payload) when `experimental.runtimeServerDeploymentId` is enabled but `process.env.NEXT_DEPLOYMENT_ID` is not visible at the time the client reference manifest is evaluated.

### Why?

When `runtimeServerDeploymentId` is on (auto-enabled on standard Vercel builds), the Turbopack-generated client reference manifest defers the deployment id to a runtime read and appends it to every chunk URL:

```js
val.chunks = val.chunks.map((c) => `${c}?dpl=${process.env.NEXT_DEPLOYMENT_ID}`)
```

Unlike every other `dpl` producer (`getDeploymentIdQuery`, `getAssetQueryString`, the Turbopack runtime's `globalThis[...] || ''` templates), this interpolation has no guard. If the env var is missing when the manifest is evaluated (`evalManifest` runs it in a `vm` sandbox that only exposes `process.env.NEXT_DEPLOYMENT_ID`), the literal string `undefined` is baked into every chunk URL. The same chunk then gets referenced with two different suffixes in one document, so browsers download every chunk twice, and the `?dpl=undefined` query never changes across deployments, defeating both Skew Protection pinning and cache busting. See #95397 for a deployed reproduction and measurements.

### How?

Wrap the generated suffix code in an `if (process.env.NEXT_DEPLOYMENT_ID)` guard so the query is only appended when the deployment id is actually available, aligning this path with the other asset-suffix code paths. When the id is missing the chunk URLs are left untouched instead of being poisoned.

Added a regression test that evaluates the built manifest the same way `evalManifest` does — once without the env var (chunks must not contain `dpl=`) and once with it (chunks must carry the correct `?dpl=` suffix).

Fixes #95397
