### PR TITLE
Fix Request Insights span collection

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -98,7 +98,7 @@ describe('request insights trace viewer', () => {
     ])
   })
 
-  it('shows high-level spans by default and reveals hidden spans in verbose mode', () => {
+  it('filters collected spans for presentation without changing collection', () => {
     const request = createRequest({
       spans: [
         {
@@ -335,7 +335,7 @@ describe('request insights trace viewer', () => {
           startTime: 100,
           durationMs: 10,
           attributes: {
-            'next.span.category': 'nextjs',
+            'next.span_category': 'nextjs',
             'next.span_type': 'BaseServer.render',
           },
         },
@@ -344,7 +344,7 @@ describe('request insights trace viewer', () => {
           startTime: 110,
           durationMs: 10,
           attributes: {
-            'next.span.category': 'application',
+            'next.span_category': 'application',
             'next.span_type': 'ResolveMetadata.generateMetadata',
           },
         },
@@ -384,7 +384,7 @@ describe('request insights trace viewer', () => {
           startTime: 120,
           durationMs: 30,
           attributes: {
-            'next.span.category': 'application',
+            'next.span_category': 'application',
             'next.span_type': 'AppRender.fetch',
             'next.fetch.idx': 1,
           },
@@ -396,7 +396,7 @@ describe('request insights trace viewer', () => {
           startTime: 155,
           durationMs: 10,
           attributes: {
-            'next.span.category': 'nextjs',
+            'next.span_category': 'nextjs',
             'next.span_type': 'AppRender.fetch',
             'next.fetch.idx': 2,
           },

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -323,7 +323,7 @@ function getFetchIndex(span: RequestInsightSpan): number | undefined {
 }
 
 function getSpanCategory(span: RequestInsightSpan): 'nextjs' | 'application' {
-  const category = span.attributes?.['next.span.category']
+  const category = span.attributes?.['next.span_category']
   if (category === 'nextjs' || category === 'application') {
     return category
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -94,6 +94,7 @@ import {
 import { isRedirectError } from '../../client/components/redirect-error'
 import { getImplicitTags, type ImplicitTags } from '../lib/implicit-tags'
 import { AppRenderSpan, NextNodeServerSpan } from '../lib/trace/constants'
+import { getRequestInsightsIdentity } from '../lib/trace/request-insights-identity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { FlightRenderResult } from './flight-render-result'
 import {
@@ -2672,6 +2673,9 @@ async function renderToHTMLOrFlightImpl(
 
   let requestId: string
   let htmlRequestId: string
+  const requestInsightsIdentity = process.env.__NEXT_REQUEST_INSIGHTS
+    ? getRequestInsightsIdentity()
+    : undefined
 
   const {
     flightRouterState,
@@ -2686,6 +2690,10 @@ async function renderToHTMLOrFlightImpl(
   if (parsedRequestHeaders.requestId) {
     // If the client has provided a request ID (in development mode), we use it.
     requestId = parsedRequestHeaders.requestId
+  } else if (requestInsightsIdentity) {
+    // Request Insights starts recording before the work store exists. Reuse
+    // the identity from that outer request scope so all spans stay together.
+    requestId = requestInsightsIdentity.requestId
   } else {
     // Otherwise we generate a new request ID.
     if (isStaticGeneration) {
@@ -2706,7 +2714,10 @@ async function renderToHTMLOrFlightImpl(
   // send debug information to the associated WebSocket client. Otherwise, this
   // is the request for the HTML document, so we use the request ID also as the
   // HTML request ID.
-  htmlRequestId = parsedRequestHeaders.htmlRequestId || requestId
+  htmlRequestId =
+    parsedRequestHeaders.htmlRequestId ||
+    requestInsightsIdentity?.htmlRequestId ||
+    requestId
   workStore.requestId = requestId
   workStore.htmlRequestId = htmlRequestId
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -998,6 +998,9 @@ export default abstract class Server<
       typeof requestIdHeader === 'string' ? requestIdHeader : nanoid()
     const htmlRequestIdHeader = req.headers[NEXT_HTML_REQUEST_ID_HEADER]
 
+    // The request root and route-matching spans start before App Render creates
+    // its workStore. Carry their identity in this outer scope; App Render copies
+    // it into the workStore so the complete timeline uses one request ID.
     return runWithRequestInsightsIdentity(
       {
         requestId,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -84,6 +84,8 @@ import {
 import { getNextPathnameInfo } from '../shared/lib/router/utils/get-next-pathname-info'
 import {
   RSC_HEADER,
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
   NEXT_RSC_UNION_QUERY,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -92,6 +94,7 @@ import {
   NEXT_INSTANT_TEST_COOKIE,
   NEXT_HMR_REFRESH_HEADER,
 } from '../client/components/app-router-headers'
+import { nanoid } from 'next/dist/compiled/nanoid'
 import type {
   MatchOptions,
   RouteMatcherManager,
@@ -110,6 +113,8 @@ import {
   SpanStatusCode,
 } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
+import { runWithRequestInsightsIdentity } from './lib/trace/request-insights-identity'
+import { isRequestInsightsEnabled } from './lib/trace/span-store'
 import { I18NProvider } from './lib/i18n-provider'
 import { sendResponse } from './send-response'
 import { normalizeNextQueryParam } from './web/utils'
@@ -902,86 +907,108 @@ export default abstract class Server<
     const method = req.method.toUpperCase()
     const tracer = getTracer()
 
-    return tracer.withPropagatedContext(req.headers, () => {
-      // Capture the parent span before creating the handleRequest span.
-      // When deployed with an adapter, the platform's runtime may create its
-      // own OTEL HTTP server span before Next.js runs. We propagate http.route
-      // to this parent span so APM tools (e.g. Datadog) can derive the
-      // resource name correctly.
-      const parentSpan = tracer.getActiveScopeSpan()
+    const handleRequest = () =>
+      tracer.withPropagatedContext(req.headers, () => {
+        // Capture the parent span before creating the handleRequest span.
+        // When deployed with an adapter, the platform's runtime may create its
+        // own OTEL HTTP server span before Next.js runs. We propagate http.route
+        // to this parent span so APM tools (e.g. Datadog) can derive the
+        // resource name correctly.
+        const parentSpan = tracer.getActiveScopeSpan()
 
-      return tracer.trace(
-        BaseServerSpan.handleRequest,
-        {
-          spanName: `${method}`,
-          kind: SpanKind.SERVER,
-          attributes: {
-            'http.method': method,
-            'http.target': req.url,
+        return tracer.trace(
+          BaseServerSpan.handleRequest,
+          {
+            spanName: `${method}`,
+            kind: SpanKind.SERVER,
+            attributes: {
+              'http.method': method,
+              'http.target': req.url,
+            },
           },
-        },
-        async (span) =>
-          this.handleRequestImpl(req, res, parsedUrl).finally(() => {
-            if (!span) return
+          async (span) =>
+            this.handleRequestImpl(req, res, parsedUrl).finally(() => {
+              if (!span) return
 
-            const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
-            span.setAttributes({
-              'http.status_code': res.statusCode,
-              'next.rsc': isRSCRequest,
-            })
-
-            if (res.statusCode && res.statusCode >= 500) {
-              // For 5xx status codes: SHOULD be set to 'Error' span status.
-              // x-ref: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
-              span.setStatus({
-                code: SpanStatusCode.ERROR,
-              })
-              // For span status 'Error', SHOULD set 'error.type' attribute.
-              span.setAttribute('error.type', res.statusCode.toString())
-            }
-
-            const rootSpanAttributes = tracer.getRootSpanAttributes()
-            // We were unable to get attributes, probably OTEL is not enabled
-            if (!rootSpanAttributes) return
-
-            if (
-              rootSpanAttributes.get('next.span_type') !==
-              BaseServerSpan.handleRequest
-            ) {
-              console.warn(
-                `Unexpected root span type '${rootSpanAttributes.get(
-                  'next.span_type'
-                )}'. Please report this Next.js issue https://github.com/vercel/next.js`
-              )
-              return
-            }
-
-            const route = rootSpanAttributes.get('next.route')
-            if (route) {
-              const name = isRSCRequest
-                ? `RSC ${method} ${route}`
-                : `${method} ${route}`
-
+              const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
               span.setAttributes({
-                'next.route': route,
-                'http.route': route,
-                'next.span_name': name,
+                'http.status_code': res.statusCode,
+                'next.rsc': isRSCRequest,
               })
-              span.updateName(name)
 
-              // Propagate http.route to the parent span if one exists and
-              // is different from the handleRequest span. This ensures APM
-              // tools that read attributes from the outermost span (e.g.
-              // a platform-created HTTP span) can derive the resource name.
-              if (parentSpan && parentSpan !== span) {
-                parentSpan.setAttribute('http.route', route)
+              if (res.statusCode && res.statusCode >= 500) {
+                // For 5xx status codes: SHOULD be set to 'Error' span status.
+                // x-ref: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                })
+                // For span status 'Error', SHOULD set 'error.type' attribute.
+                span.setAttribute('error.type', res.statusCode.toString())
               }
-            } else {
-              span.updateName(isRSCRequest ? `RSC ${method}` : `${method}`)
-            }
-          })
-      )
-    })
+
+              const rootSpanAttributes = tracer.getRootSpanAttributes()
+              // We were unable to get attributes, probably OTEL is not enabled
+              if (!rootSpanAttributes) return
+
+              if (
+                rootSpanAttributes.get('next.span_type') !==
+                BaseServerSpan.handleRequest
+              ) {
+                console.warn(
+                  `Unexpected root span type '${rootSpanAttributes.get(
+                    'next.span_type'
+                  )}'. Please report this Next.js issue https://github.com/vercel/next.js`
+                )
+                return
+              }
+
+              const route = rootSpanAttributes.get('next.route')
+              if (route) {
+                const name = isRSCRequest
+                  ? `RSC ${method} ${route}`
+                  : `${method} ${route}`
+
+                span.setAttributes({
+                  'next.route': route,
+                  'http.route': route,
+                  'next.span_name': name,
+                })
+                span.updateName(name)
+
+                // Propagate http.route to the parent span if one exists and
+                // is different from the handleRequest span. This ensures APM
+                // tools that read attributes from the outermost span (e.g.
+                // a platform-created HTTP span) can derive the resource name.
+                if (parentSpan && parentSpan !== span) {
+                  parentSpan.setAttribute('http.route', route)
+                }
+              } else {
+                span.updateName(isRSCRequest ? `RSC ${method}` : `${method}`)
+              }
+            })
+        )
+      })
+
+    if (!isRequestInsightsEnabled()) {
+      return handleRequest()
+    }
+
+    const requestIdHeader = req.headers[NEXT_REQUEST_ID_HEADER]
+    const requestId =
+      typeof requestIdHeader === 'string' ? requestIdHeader : nanoid()
+    const htmlRequestIdHeader = req.headers[NEXT_HTML_REQUEST_ID_HEADER]
+
+    return runWithRequestInsightsIdentity(
+      {
+        requestId,
+        htmlRequestId:
+          typeof htmlRequestIdHeader === 'string'
+            ? htmlRequestIdHeader
+            : requestId,
+        url: req.url,
+      },
+      handleRequest
+    )
   }
 
   private async handleRequestImpl(

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -49,8 +49,6 @@ const INTERNAL_HEADERS = [
   'x-now-route-matches',
   'x-matched-path',
   'x-nextjs-data',
-  'x-nextjs-request-id',
-  'x-nextjs-html-request-id',
   'x-next-resume-state-length',
   'next-resume',
 ]

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -49,6 +49,8 @@ const INTERNAL_HEADERS = [
   'x-now-route-matches',
   'x-matched-path',
   'x-nextjs-data',
+  'x-nextjs-request-id',
+  'x-nextjs-html-request-id',
   'x-next-resume-state-length',
   'next-resume',
 ]

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -6,6 +6,7 @@ import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
 import { createLocalSpan } from './local-span-recorder'
+import { runWithRequestInsightsIdentity } from './request-insights-identity'
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -115,6 +116,47 @@ describe('local recording span', () => {
             },
           }),
         ],
+      }),
+    ])
+  })
+
+  it('uses the request insights identity before the work store exists', () => {
+    runWithRequestInsightsIdentity(
+      {
+        requestId: 'request-1',
+        htmlRequestId: 'html-1',
+        url: '/dashboard?tab=overview',
+      },
+      () => {
+        const span = createLocalSpan({ name: 'test.request-root' })
+        span.end()
+      }
+    )
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'test.request-root',
+        requestId: 'request-1',
+        htmlRequestId: 'html-1',
+        url: '/dashboard?tab=overview',
+      }),
+    ])
+  })
+
+  it('records explicit performance timestamps', () => {
+    const startTime = performance.now() - 10
+    const span = createLocalSpan({
+      name: 'test.local-span.explicit-time',
+      startTime,
+    })
+
+    span.end(startTime + 0.2)
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'test.local-span.explicit-time',
+        startTime: performance.timeOrigin + startTime,
+        durationMs: expect.closeTo(0.2, 3),
       }),
     ])
   })

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -7,6 +7,7 @@ import type { AsyncLocalStorage } from 'async_hooks'
 import { SpanStatusCode } from 'next/dist/compiled/@opentelemetry/api'
 import {
   isLocalSpanRecordingEnabled,
+  isRequestInsightsEnabled,
   recordSpan,
   type SpanStoreAttributes,
   type SpanStoreEvent,
@@ -34,6 +35,7 @@ export function createLocalSpan({
   name,
   attributes,
   links,
+  startTime,
   traceId,
   spanId,
   parentSpanId,
@@ -42,6 +44,7 @@ export function createLocalSpan({
   name: string
   attributes?: LocalSpanAttributes
   links?: SpanOptions['links']
+  startTime?: SpanOptions['startTime']
   traceId?: string
   spanId?: string
   parentSpanId?: string
@@ -51,6 +54,7 @@ export function createLocalSpan({
     name,
     attributes,
     links,
+    startTime,
     delegateSpan,
     traceId: traceId ?? getLocalTraceId(),
     spanId: spanId ?? getLocalSpanId(),
@@ -76,6 +80,7 @@ export type LocalSpanRecorder = {
   getActiveLocalSpan: typeof getActiveLocalSpan
   isLocalRecordingSpan: typeof isLocalRecordingSpan
   isLocalSpanRecordingEnabled: typeof isLocalSpanRecordingEnabled
+  isRequestInsightsEnabled: typeof isRequestInsightsEnabled
   withLocalSpan: typeof withLocalSpan
 }
 
@@ -90,6 +95,7 @@ export function registerLocalSpanRecorder(): void {
     getActiveLocalSpan,
     isLocalRecordingSpan,
     isLocalSpanRecordingEnabled,
+    isRequestInsightsEnabled,
     withLocalSpan,
   }
 }
@@ -122,7 +128,6 @@ class LocalRecordingSpan implements Span {
   private readonly parentSpanId?: string
   private requestIdentity: RequestIdentity
   private readonly startTime: number
-  private readonly startTimeMs: number
   private statusCode: number | undefined
   private statusMessage: string | undefined
   private exception:
@@ -137,6 +142,7 @@ class LocalRecordingSpan implements Span {
     name,
     attributes,
     links,
+    startTime,
     delegateSpan,
     traceId,
     spanId,
@@ -146,6 +152,7 @@ class LocalRecordingSpan implements Span {
     name: string
     attributes?: LocalSpanAttributes
     links?: SpanOptions['links']
+    startTime?: SpanOptions['startTime']
     delegateSpan?: Span
     traceId: string
     spanId: string
@@ -164,8 +171,7 @@ class LocalRecordingSpan implements Span {
     this.links = getSpanStoreLinks(links)
     this.parentSpanId = parentSpanId
     this.requestIdentity = requestIdentity
-    this.startTime = Date.now()
-    this.startTimeMs = getCurrentTimeMs()
+    this.startTime = getTimestamp(startTime)
     this.statusCode = undefined
     this.statusMessage = undefined
     this.exception = undefined
@@ -254,7 +260,7 @@ class LocalRecordingSpan implements Span {
       this.delegateSpan?.end(endTime)
     } finally {
       try {
-        this.record()
+        this.record(endTime)
       } finally {
         this.releaseReferences()
       }
@@ -282,14 +288,14 @@ class LocalRecordingSpan implements Span {
     this.delegateSpan?.recordException(exception, time)
   }
 
-  private record(): void {
+  private record(endTime: Parameters<Span['end']>[0]): void {
     const recordAttributes =
       Object.keys(this.attributes).length > 0 ? this.attributes : undefined
 
     recordSpan({
       name: this.name,
       startTime: this.startTime,
-      durationMs: getCurrentTimeMs() - this.startTimeMs,
+      durationMs: Math.max(0, getTimestamp(endTime) - this.startTime),
       status: this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok',
       traceId: this.spanContextValue.traceId,
       spanId: this.spanContextValue.spanId,
@@ -374,8 +380,31 @@ function cleanSpanStoreAttributes(
   return cleanedAttributes
 }
 
-function getCurrentTimeMs(): number {
-  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+function getTimestamp(time?: SpanOptions['startTime']): number {
+  if (time instanceof Date) {
+    return time.getTime()
+  }
+
+  if (Array.isArray(time)) {
+    return time[0] * 1000 + time[1] / 1_000_000
+  }
+
+  if (typeof time === 'number') {
+    const timeOrigin = getPerformanceTimeOrigin()
+    return timeOrigin !== undefined && time < timeOrigin
+      ? timeOrigin + time
+      : time
+  }
+
+  const timeOrigin = getPerformanceTimeOrigin()
+  return timeOrigin === undefined ? Date.now() : timeOrigin + performance.now()
+}
+
+function getPerformanceTimeOrigin(): number | undefined {
+  return typeof performance !== 'undefined' &&
+    typeof performance.timeOrigin === 'number'
+    ? performance.timeOrigin
+    : undefined
 }
 
 function getStringAttribute(
@@ -452,20 +481,24 @@ function getSpanStoreExceptionAttributes(
 
 function getCurrentRequestIdentity(): RequestIdentity {
   try {
+    const { getRequestInsightsIdentity } =
+      require('./request-insights-identity') as typeof import('./request-insights-identity')
     const { workAsyncStorage } =
       require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
     const { workUnitAsyncStorage } =
       require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
     const workStore = workAsyncStorage.getStore()
     const workUnitStore = workUnitAsyncStorage.getStore()
+    const requestInsightsIdentity = getRequestInsightsIdentity()
     const url =
       workUnitStore && 'url' in workUnitStore ? workUnitStore.url : undefined
 
     return {
-      requestId: workStore?.requestId,
-      htmlRequestId: workStore?.htmlRequestId,
+      requestId: workStore?.requestId ?? requestInsightsIdentity?.requestId,
+      htmlRequestId:
+        workStore?.htmlRequestId ?? requestInsightsIdentity?.htmlRequestId,
       route: workStore?.route,
-      url: url ? `${url.pathname}${url.search}` : undefined,
+      url: url ? `${url.pathname}${url.search}` : requestInsightsIdentity?.url,
     }
   } catch {
     return {}

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -7,6 +7,9 @@ export type RequestInsightsIdentity = {
   url: string | undefined
 }
 
+// This storage covers the part of BaseServer request handling that runs before
+// App Render creates workAsyncStorage. Once available, workStore remains the
+// primary identity source for locally recorded spans.
 const REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY = Symbol.for(
   '@next/request-insights-identity-storage'
 )

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -1,0 +1,34 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+
+export type RequestInsightsIdentity = {
+  requestId: string
+  htmlRequestId: string
+  url: string | undefined
+}
+
+const REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY = Symbol.for(
+  '@next/request-insights-identity-storage'
+)
+
+function getRequestInsightsIdentityStorage(): AsyncLocalStorage<RequestInsightsIdentity> {
+  const globalStore = globalThis as typeof globalThis & {
+    [REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY]?: AsyncLocalStorage<RequestInsightsIdentity>
+  }
+
+  return (globalStore[REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY] ??=
+    createAsyncLocalStorage())
+}
+
+export function runWithRequestInsightsIdentity<T>(
+  identity: RequestInsightsIdentity,
+  fn: () => T
+): T {
+  return getRequestInsightsIdentityStorage().run(identity, fn)
+}
+
+export function getRequestInsightsIdentity():
+  | RequestInsightsIdentity
+  | undefined {
+  return getRequestInsightsIdentityStorage().getStore()
+}

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -42,6 +42,7 @@ describe('request insights', () => {
       htmlRequestId: 'html_1',
       route: '/products/[id]',
       attributes: {
+        'next.span_category': 'nextjs',
         'next.span_type': 'AppRender.getBodyResult',
       },
       events: [
@@ -67,6 +68,7 @@ describe('request insights', () => {
       htmlRequestId: 'html_1',
       route: '/products/[id]',
       attributes: {
+        'next.span_category': 'application',
         'next.span_type': 'AppRender.fetch',
         'http.url': 'https://example.vercel.sh/',
         'http.method': 'GET',
@@ -88,10 +90,16 @@ describe('request insights', () => {
           spans: expect.arrayContaining([
             expect.objectContaining({
               name: 'fetch GET https://example.vercel.sh/',
+              attributes: expect.objectContaining({
+                'next.span_category': 'application',
+              }),
             }),
             expect.objectContaining({
               traceId: 'trace_1',
               spanId: 'span_1',
+              attributes: expect.objectContaining({
+                'next.span_category': 'nextjs',
+              }),
               events: [
                 {
                   name: 'metadata ready',
@@ -144,6 +152,53 @@ describe('request insights', () => {
     )
 
     unsubscribe()
+  })
+
+  it('uses the HTTP request span as the end-to-end request timing', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'render route (app) /dashboard',
+      requestId: 'req_timing',
+      startTime: 100,
+      durationMs: 60,
+    })
+    recordSpan({
+      name: 'GET /dashboard',
+      requestId: 'req_timing',
+      startTime: 100,
+      durationMs: 50,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    recordRequestInsightFetch(
+      { requestId: 'req_timing' },
+      { url: 'https://example.com/late', startTime: 145, durationMs: 20 }
+    )
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        startTime: 100,
+        durationMs: 50,
+      })
+    )
+  })
+
+  it('does not treat aggregate client component loading as a trace span', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'NextNodeServer.clientComponentLoading',
+      requestId: 'req_client_loading',
+      startTime: 100,
+      durationMs: 50,
+      attributes: {
+        'next.span_type': 'NextNodeServer.clientComponentLoading',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([])
   })
 
   it('records request fetch metrics when the OTel fetch span does not complete locally', () => {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -9,6 +9,8 @@ export { isRequestInsightsEnabled } from './span-store'
 
 const MAX_REQUEST_INSIGHTS = 100
 const REQUEST_INSIGHTS_STORE_KEY = Symbol.for('@next/request-insights-store')
+const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
+  'NextNodeServer.clientComponentLoading'
 
 type RequestInsightsListener = (insight: RequestInsight) => void
 type RequestInsightIdentity = {
@@ -32,6 +34,7 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.route',
   'next.rsc',
   'next.segment',
+  'next.span_category',
   'next.span_name',
   'next.span_type',
 ])
@@ -40,6 +43,10 @@ const SENSITIVE_PARAM_NAME_RE =
 
 class InMemoryRequestInsightsStore {
   private readonly requests = new Map<string, RequestInsight>()
+  private readonly requestTimings = new Map<
+    string,
+    { startTime: number; durationMs: number }
+  >()
   private readonly requestOrder: string[] = []
   private readonly listeners = new Set<RequestInsightsListener>()
 
@@ -54,19 +61,15 @@ class InMemoryRequestInsightsStore {
     )
 
     const spanStartTime = span.startTime ?? span.timestamp
-    const spanEndTime = span.durationMs
-      ? spanStartTime + span.durationMs
-      : spanStartTime
-    const requestEndTime = insight.durationMs
-      ? insight.startTime + insight.durationMs
-      : insight.startTime
-
     insight.htmlRequestId = span.htmlRequestId ?? insight.htmlRequestId
     insight.route = insight.route ?? span.route
     insight.url = insight.url ?? sanitizeUrl(span.url)
-    insight.startTime = Math.min(insight.startTime, spanStartTime)
-    insight.durationMs =
-      Math.max(requestEndTime, spanEndTime) - insight.startTime
+    this.updateTiming(
+      insight,
+      spanStartTime,
+      span.durationMs,
+      span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+    )
     insight.status =
       insight.status === 'error' || span.status === 'error'
         ? 'error'
@@ -103,15 +106,7 @@ class InMemoryRequestInsightsStore {
 
     const fetchStartTime = fetch.startTime ?? Date.now()
     const insight = this.getOrCreateRequest(identity, fetchStartTime)
-    const fetchEndTime = fetch.durationMs
-      ? fetchStartTime + fetch.durationMs
-      : fetchStartTime
-    const requestEndTime = insight.durationMs
-      ? insight.startTime + insight.durationMs
-      : insight.startTime
-
-    insight.durationMs =
-      Math.max(requestEndTime, fetchEndTime) - insight.startTime
+    this.updateTiming(insight, fetchStartTime, fetch.durationMs, false)
     this.recordFetchForInsight(insight, sanitizeFetchInsight(fetch))
     this.notify(insight)
   }
@@ -133,7 +128,35 @@ class InMemoryRequestInsightsStore {
 
   clear(): void {
     this.requests.clear()
+    this.requestTimings.clear()
     this.requestOrder.length = 0
+  }
+
+  private updateTiming(
+    insight: RequestInsight,
+    startTime: number,
+    durationMs: number | undefined,
+    isRequestSpan: boolean
+  ): void {
+    if (isRequestSpan && durationMs !== undefined) {
+      const requestTiming = { startTime, durationMs }
+      this.requestTimings.set(insight.requestId, requestTiming)
+      insight.startTime = requestTiming.startTime
+      insight.durationMs = requestTiming.durationMs
+      return
+    }
+
+    const requestTiming = this.requestTimings.get(insight.requestId)
+    if (requestTiming) {
+      insight.startTime = requestTiming.startTime
+      insight.durationMs = requestTiming.durationMs
+      return
+    }
+
+    const endTime = startTime + (durationMs ?? 0)
+    const requestEndTime = insight.startTime + (insight.durationMs ?? 0)
+    insight.startTime = Math.min(insight.startTime, startTime)
+    insight.durationMs = Math.max(requestEndTime, endTime) - insight.startTime
   }
 
   private notify(insight: RequestInsight): void {
@@ -197,12 +220,19 @@ class InMemoryRequestInsightsStore {
       const requestId = this.requestOrder.shift()
       if (requestId) {
         this.requests.delete(requestId)
+        this.requestTimings.delete(requestId)
       }
     }
   }
 }
 
 export function recordRequestInsightSpan(span: SpanStoreRecord): void {
+  if (
+    span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
+  ) {
+    return
+  }
+
   getRequestInsightsStore().recordSpan(span)
 }
 

--- a/packages/next/src/server/lib/trace/span-store.test.ts
+++ b/packages/next/src/server/lib/trace/span-store.test.ts
@@ -96,6 +96,7 @@ describe('span recording', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     setSpanRecorderForTest(recorder)
 
+    expect(isRequestInsightsEnabled()).toBe(false)
     expect(isLocalSpanRecordingEnabled()).toBe(false)
 
     recordSpan({ name: 'test.production', requestId: 'req_2' })

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -74,6 +74,10 @@ export function isLocalSpanRecordingEnabled(): boolean {
 }
 
 export function isRequestInsightsEnabled(): boolean {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return false
+  }
+
   const value = process.env.__NEXT_REQUEST_INSIGHTS
   return isEnabledEnvValue(value)
 }

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -20,12 +20,18 @@ import {
 
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 import { registerLocalSpanRecorder } from './local-span-recorder'
-import { AppRenderSpan, NodeSpan } from './constants'
+import {
+  AppRenderSpan,
+  BaseServerSpan,
+  LoadComponentsSpan,
+  NodeSpan,
+} from './constants'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
+const originalOtelVerbose = process.env.NEXT_OTEL_VERBOSE
 const spanRecords: SpanStoreRecord[] = []
 
 function getSpanRecords(filter: { name?: string } = {}): SpanStoreRecord[] {
@@ -155,6 +161,7 @@ describe('local span recording', () => {
   beforeEach(() => {
     process.env.__NEXT_DEV_SERVER = '1'
     delete process.env.__NEXT_REQUEST_INSIGHTS
+    delete process.env.NEXT_OTEL_VERBOSE
     setSpanRecorderForTest((span) => spanRecords.push(span))
     registerLocalSpanRecorder()
   })
@@ -170,6 +177,11 @@ describe('local span recording', () => {
     } else {
       process.env.__NEXT_DEV_SERVER = originalDevServer
     }
+    if (originalOtelVerbose === undefined) {
+      delete process.env.NEXT_OTEL_VERBOSE
+    } else {
+      process.env.NEXT_OTEL_VERBOSE = originalOtelVerbose
+    }
     trace.disable()
     setSpanRecorderForTest(undefined)
     spanRecords.length = 0
@@ -182,6 +194,90 @@ describe('local span recording', () => {
 
     expect(result).toBe('result')
     expect(getSpanRecords()).toEqual([])
+  })
+
+  it('records non-vanilla trace and wrapped spans for request insights', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    getTracer().trace(BaseServerSpan.render, () => undefined)
+    const wrappedLoadComponents = getTracer().wrap(
+      LoadComponentsSpan.loadComponents,
+      () => undefined
+    )
+    wrappedLoadComponents()
+
+    expect(getSpanRecords()).toEqual([
+      expect.objectContaining({
+        name: BaseServerSpan.render,
+        attributes: expect.objectContaining({
+          'next.span_category': 'nextjs',
+        }),
+      }),
+      expect.objectContaining({
+        name: LoadComponentsSpan.loadComponents,
+        attributes: expect.objectContaining({
+          'next.span_category': 'nextjs',
+        }),
+      }),
+    ])
+  })
+
+  it('only exports non-vanilla spans when verbose tracing is enabled', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const exportedSpans: string[] = []
+    const delegateSpan = trace.wrapSpanContext({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    })
+    trace.setGlobalTracerProvider({
+      getTracer() {
+        return {
+          startSpan(name: string) {
+            exportedSpans.push(name)
+            return delegateSpan
+          },
+          startActiveSpan(...args: unknown[]) {
+            exportedSpans.push(args[0] as string)
+            const callback = args.at(-1) as (
+              span: typeof delegateSpan
+            ) => unknown
+            return callback(delegateSpan)
+          },
+        }
+      },
+    })
+
+    getTracer().trace(BaseServerSpan.render, () => undefined)
+    expect(exportedSpans).toEqual([])
+
+    getTracer().trace(NodeSpan.runHandler, () => undefined)
+    expect(exportedSpans).toEqual([NodeSpan.runHandler])
+
+    process.env.NEXT_OTEL_VERBOSE = '1'
+    getTracer().trace(BaseServerSpan.render, () => undefined)
+    expect(exportedSpans).toEqual([NodeSpan.runHandler, BaseServerSpan.render])
+  })
+
+  it('does not record or export hidden spans', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    let receivedSpan: unknown = 'not-called'
+    const startSpan = jest.fn()
+    const startActiveSpan = jest.fn()
+    trace.setGlobalTracerProvider({
+      getTracer() {
+        return { startSpan, startActiveSpan }
+      },
+    })
+
+    getTracer().trace(BaseServerSpan.render, { hideSpan: true }, (span) => {
+      receivedSpan = span
+    })
+
+    expect(receivedSpan).toBeUndefined()
+    expect(getSpanRecords()).toEqual([])
+    expect(startSpan).not.toHaveBeenCalled()
+    expect(startActiveSpan).not.toHaveBeenCalled()
   })
 
   it('bypasses local span handling outside the dev server', () => {
@@ -221,6 +317,7 @@ describe('local span recording', () => {
         durationMs: expect.any(Number),
         attributes: expect.objectContaining({
           'next.route': '/products/[id]',
+          'next.span_category': 'nextjs',
           'next.span_name': 'test.sync',
           'next.span_type': NodeSpan.runHandler,
         }),
@@ -235,6 +332,7 @@ describe('local span recording', () => {
         kind: SpanKind.CLIENT,
         spanName: 'fetch GET https://example.vercel.sh/',
         attributes: {
+          'next.span_category': 'application',
           'http.url': 'https://example.vercel.sh/',
           'http.method': 'GET',
           'net.peer.name': 'example.vercel.sh',
@@ -253,6 +351,7 @@ describe('local span recording', () => {
         attributes: expect.objectContaining({
           'next.span_name': 'fetch GET https://example.vercel.sh/',
           'next.span_type': AppRenderSpan.fetch,
+          'next.span_category': 'application',
           'http.url': 'https://example.vercel.sh/',
           'http.method': 'GET',
           'net.peer.name': 'example.vercel.sh',
@@ -415,7 +514,10 @@ describe('local span recording', () => {
       expect(getTracer().getActiveScopeSpan()).toBe(parentSpan)
 
       const childSpan = getTracer().startSpan(AppRenderSpan.fetch, {
-        attributes: { 'next.page': 'child' },
+        attributes: {
+          'next.page': 'child',
+          'next.span_category': 'application',
+        },
       })
       childSpanId = childSpan.spanContext().spanId
       childSpan.end()
@@ -434,6 +536,9 @@ describe('local span recording', () => {
       expect.objectContaining({
         name: NodeSpan.runHandler,
         parentSpanId: undefined,
+        attributes: expect.objectContaining({
+          'next.span_category': 'nextjs',
+        }),
       })
     )
     expect(childRecord).toEqual(
@@ -442,6 +547,9 @@ describe('local span recording', () => {
         spanId: childSpanId,
         traceId: parentRecord?.traceId,
         parentSpanId: parentRecord?.spanId,
+        attributes: expect.objectContaining({
+          'next.span_category': 'application',
+        }),
       })
     )
   })

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -366,15 +366,14 @@ class NextTracerImpl implements NextTracer {
 
     const spanName = options.spanName ?? type
 
-    const isVanillaSpan =
+    const shouldDelegateSpan =
       NextVanillaSpanAllowlist.has(type) ||
       process.env.NEXT_OTEL_VERBOSE === '1'
-    const shouldRecordLocalSpan =
-      localSpanRecordingEnabled &&
-      (isVanillaSpan ||
-        (localSpanRecorder?.isRequestInsightsEnabled() ?? false))
+    const shouldTraceSpan =
+      shouldDelegateSpan ||
+      (localSpanRecorder?.isRequestInsightsEnabled() ?? false)
 
-    if ((!isVanillaSpan && !shouldRecordLocalSpan) || options.hideSpan) {
+    if (!shouldTraceSpan || options.hideSpan) {
       return fn()
     }
 
@@ -409,8 +408,8 @@ class NextTracerImpl implements NextTracer {
         spanName,
         options,
         spanContext,
-        tracingEnabled && isVanillaSpan,
-        shouldRecordLocalSpan,
+        tracingEnabled && shouldDelegateSpan,
+        localSpanRecordingEnabled,
         (span: Span) => {
           let startTime: number | undefined
           if (

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -185,6 +185,7 @@ type NextAttributeNames =
   | 'next.page'
   | 'next.rsc'
   | 'next.segment'
+  | 'next.span_category'
   | 'next.span_name'
   | 'next.span_type'
   | 'next.clientComponentLoadCount'
@@ -337,8 +338,9 @@ class NextTracerImpl implements NextTracer {
     const [type, fnOrOptions, fnOrEmpty] = args
     const tracingEnabled =
       Boolean(NEXT_OTEL_PERFORMANCE_PREFIX) || this.isOpenTelemetryEnabled()
+    const localSpanRecorder = getLocalSpanRecorder()
     const localSpanRecordingEnabled =
-      getLocalSpanRecorder()?.isLocalSpanRecordingEnabled() ?? false
+      localSpanRecorder?.isLocalSpanRecordingEnabled() ?? false
 
     if (!tracingEnabled && !localSpanRecordingEnabled) {
       return typeof fnOrOptions === 'function' ? fnOrOptions() : fnOrEmpty()
@@ -364,11 +366,15 @@ class NextTracerImpl implements NextTracer {
 
     const spanName = options.spanName ?? type
 
-    if (
-      (!NextVanillaSpanAllowlist.has(type) &&
-        process.env.NEXT_OTEL_VERBOSE !== '1') ||
-      options.hideSpan
-    ) {
+    const isVanillaSpan =
+      NextVanillaSpanAllowlist.has(type) ||
+      process.env.NEXT_OTEL_VERBOSE === '1'
+    const shouldRecordLocalSpan =
+      localSpanRecordingEnabled &&
+      (isVanillaSpan ||
+        (localSpanRecorder?.isRequestInsightsEnabled() ?? false))
+
+    if ((!isVanillaSpan && !shouldRecordLocalSpan) || options.hideSpan) {
       return fn()
     }
 
@@ -392,6 +398,7 @@ class NextTracerImpl implements NextTracer {
     const spanId = getSpanId()
 
     options.attributes = {
+      'next.span_category': 'nextjs',
       'next.span_name': spanName,
       'next.span_type': type,
       ...options.attributes,
@@ -402,8 +409,8 @@ class NextTracerImpl implements NextTracer {
         spanName,
         options,
         spanContext,
-        tracingEnabled,
-        localSpanRecordingEnabled,
+        tracingEnabled && isVanillaSpan,
+        shouldRecordLocalSpan,
         (span: Span) => {
           let startTime: number | undefined
           if (
@@ -545,6 +552,7 @@ class NextTracerImpl implements NextTracer {
       name,
       attributes: options.attributes,
       links: options.links,
+      startTime: options.startTime,
       delegateSpan,
       traceId: delegateSpanContext?.traceId ?? parentSpanContext?.traceId,
       spanId: delegateSpanContext?.spanId,
@@ -570,7 +578,8 @@ class NextTracerImpl implements NextTracer {
 
     if (
       !NextVanillaSpanAllowlist.has(name) &&
-      process.env.NEXT_OTEL_VERBOSE !== '1'
+      process.env.NEXT_OTEL_VERBOSE !== '1' &&
+      !process.env.__NEXT_DEV_SERVER
     ) {
       return fn
     }
@@ -603,10 +612,20 @@ class NextTracerImpl implements NextTracer {
   public startSpan(type: SpanTypes): Span
   public startSpan(type: SpanTypes, options: TracerSpanOptions): Span
   public startSpan(...args: Array<any>): Span {
-    const [type, options]: [string, TracerSpanOptions | undefined] = args as any
+    const [type, passedOptions]: [string, TracerSpanOptions | undefined] =
+      args as any
+    const options: TracerSpanOptions = passedOptions
+      ? {
+          ...passedOptions,
+          attributes: {
+            'next.span_category': 'nextjs',
+            ...passedOptions.attributes,
+          },
+        }
+      : { attributes: { 'next.span_category': 'nextjs' } }
 
     const parentContext =
-      this.getSpanContext(options?.parentSpan ?? this.getActiveScopeSpan()) ??
+      this.getSpanContext(options.parentSpan ?? this.getActiveScopeSpan()) ??
       context.active()
     const localSpanRecordingEnabled =
       getLocalSpanRecorder()?.isLocalSpanRecordingEnabled() ?? false
@@ -621,7 +640,7 @@ class NextTracerImpl implements NextTracer {
 
     return this.createLocalRecordingSpan(
       type,
-      options ?? {},
+      options,
       parentContext,
       delegateSpan
     )

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createServer } from 'http'
 import type { AddressInfo } from 'net'
+import { retry } from 'next-test-utils'
 
 type RequestInsight = {
   requestId: string
@@ -8,7 +9,9 @@ type RequestInsight = {
   route: string
   startTime: number
   status: 'ok'
-  spans: []
+  spans: Array<{
+    attributes?: Record<string, string | number | boolean>
+  }>
   fetches: Array<{
     durationMs: number
     statusCode: number
@@ -78,6 +81,42 @@ describe('request insights', () => {
     expect(result.cliOutput).toMatch(
       /No request insights captured yet|retained requests \(newest first\)/
     )
+  })
+
+  it('keeps outer server and app render spans on the same request', async () => {
+    await next.render('/')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const pageRequests = snapshot.requests.filter(
+        (request) => request.route === '/'
+      )
+      const requestsWithRelevantSpans = pageRequests.filter((request) =>
+        request.spans.some((span) => {
+          const spanType = span.attributes?.['next.span_type']
+          return (
+            spanType === 'BaseServer.handleRequest' ||
+            spanType === 'AppRender.getBodyResult'
+          )
+        })
+      )
+
+      expect(requestsWithRelevantSpans).toHaveLength(1)
+      expect(
+        requestsWithRelevantSpans[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'BaseServer.handleRequest',
+          'AppRender.getBodyResult',
+        ])
+      )
+    })
   })
 
   it('uses the development endpoint and reports truncated output', async () => {


### PR DESCRIPTION
## Summary

Fix Request Insights collection so the dev server records all non-hidden Next.js spans locally, including non-vanilla trace and wrapped spans, while preserving the existing OpenTelemetry export allowlist unless verbose tracing is enabled.

Keep reporting timelines correct by propagating request identity before work async storage exists, honoring explicit span timestamps, and anchoring request duration to the BaseServer request span. Standardize span categories on `next.span_category`, retain presentation-only UI filtering, and filter internal request identity headers at ingress.

## Verification

- `pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts`

<!-- NEXT_JS_LLM -->