### PR TITLE
with-docker: use jemalloc for the production runner

### DIFF
--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -13,7 +13,7 @@ FROM node:${NODE_VERSION} AS dependencies
 WORKDIR /app
 
 # Copy package-related files first to leverage Docker's caching mechanism
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* pnpm-workspace.yaml* .npmrc* ./
 
 # Install project dependencies with frozen lockfile for reproducible builds
 RUN --mount=type=cache,target=/root/.npm \
@@ -80,6 +80,14 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+
+# Sharp recommends jemalloc on glibc-based Linux to reduce memory fragmentation.
+# Remove this setup when using Alpine, which uses musl instead of glibc:
+# https://sharp.pixelplumbing.com/install/#linux-memory-allocator
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libjemalloc2 \
+  && rm -rf /var/lib/apt/lists/*
+ENV LD_PRELOAD=libjemalloc.so.2
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -144,6 +144,9 @@ Learn more about [Next.js standalone output](https://nextjs.org/docs/pages/api-r
 
 **Why Node.js slim image tag?**: The slim variant provides optimal compatibility with npm packages and native dependencies while maintaining a smaller image size (~226MB). Slim uses glibc (standard Linux), ensuring better compatibility than Alpine's musl libc, which can cause issues with some npm packages. This makes it ideal for public examples where reliability and compatibility are priorities.
 
+> [!NOTE]
+> The default glibc allocator can fragment memory in long-running, multi-threaded processes. This Dockerfile installs and preloads [jemalloc](https://github.com/jemalloc/jemalloc), which [Sharp recommends for glibc-based Linux](https://sharp.pixelplumbing.com/install/#linux-memory-allocator). Alpine uses musl and does not need this configuration.
+
 **When to use Alpine?**: Consider using `node:24.11.1-alpine` instead if:
 
 - **Image size is critical**: Alpine images are typically ~100MB smaller than slim variants (~110MB base vs ~226MB)
@@ -151,7 +154,7 @@ Learn more about [Next.js standalone output](https://nextjs.org/docs/pages/api-r
 - **You've tested thoroughly**: You've verified all your dependencies work correctly with musl libc
 - **Security-focused deployments**: Alpine's minimal attack surface can be beneficial for security-sensitive applications
 
-To switch to Alpine, simply change the `NODE_VERSION` ARG in the Dockerfile to `24.11.1-alpine`.
+To switch to Alpine, change the `NODE_VERSION` ARG in the Dockerfile to `24.11.1-alpine`, and remove the `libjemalloc2` installation and the `LD_PRELOAD` environment variable from the runner stage.
 
 > [!IMPORTANT]
 > **Node.js Version Maintenance**: This Dockerfile uses Node.js 24.13.0-slim, which was the latest LTS version at the time of writing. To ensure security and stay up-to-date, regularly check and update the `NODE_VERSION` ARG in the Dockerfile to the latest Node.js LTS version. Check the latest version at [Nodejs official website](https://nodejs.org/) and browse available Node.js images on [Docker Hub](https://hub.docker.com/_/node).

--- a/examples/with-docker/pnpm-workspace.yaml
+++ b/examples/with-docker/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: false


### PR DESCRIPTION
### What?

- In `examples/with-docker`, the Node.js runner stage now installs `libjemalloc2` and sets `LD_PRELOAD=libjemalloc.so.2` for the production process.
- The README now includes a note explaining why jemalloc is used on glibc-based images and documents the changes needed when switching to Alpine.
- The example now includes `pnpm-workspace.yaml` with `allowBuilds.sharp: false`, matching the Sharp build-script setting used by [Create Next App's built-in pnpm templates](https://github.com/vercel/next.js/blob/0156307f550385823df0224e4e6a73b404b3cde2/packages/create-next-app/templates/index.ts#L333-L359).

### Why?

- The Docker example uses a Debian slim image based on glibc.
- [Sharp documents](https://sharp.pixelplumbing.com/install/#linux-memory-allocator) that the default glibc allocator can fragment memory in long-running, multi-threaded workloads and recommends an alternative allocator such as jemalloc.
- Before this change, the Docker example failed to install dependencies with pnpm 11 because it did not specify a build-script policy for Sharp. Create Next App [generates `allowBuilds.sharp: false` for its built-in pnpm templates](https://github.com/vercel/next.js/pull/94544), but the `--example` flow downloads example files directly without running that template-generation logic.

### How?

- `libjemalloc2` is installed only in the final Debian runner stage.
- `LD_PRELOAD=libjemalloc.so.2` uses the library's architecture-independent soname instead of a platform-specific path.
- `pnpm-workspace.yaml` is copied into the dependency stage before `pnpm install` so pnpm applies the Sharp build-script policy.

### Comparison

https://github.com/hynjnk/next-image-allocator-comparison

Container memory usage under a simple image optimization workload:

| Allocator |     Start | After 30 seconds idle |   Increase |
| --------- | --------: | --------------------: | ---------: |
| glibc     | 40.49 MiB |            358.90 MiB | 318.41 MiB |
| jemalloc  | 47.40 MiB |             84.53 MiB |  37.13 MiB |

### Related

- https://github.com/vercel/next.js/issues/20915#issuecomment-797763705
- https://github.com/vercel/next.js/issues/44685#issuecomment-1933035320

