### PR TITLE
[turbopack] Tell agents not to mention next.config.js options

### DIFF
--- a/turbopack/AGENTS.md
+++ b/turbopack/AGENTS.md
@@ -1,0 +1,5 @@
+# Turbopack Development Guide
+
+Turbopack is a general-purpose bundler that is built and designed for Next.js, but is not necessarily Next.js-specific. Keep Next.js concepts out of it.
+
+- **Do NOT mention Next.js config options** (e.g. anything under `next.config.js`, `experimental.*`, or other `NextConfig` fields) inside `turbopack/` code, comments, or docs. Refer to Turbopack's own options/inputs instead, and let the Next.js (in `packages/next/`) do the translation from Next.js config to Turbopack options. (This only applies to `turbopack/` — the Next.js-specific crates in `crates/` and `packages/next/` may reference Next.js config options.)

--- a/turbopack/CLAUDE.md
+++ b/turbopack/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Common piece of feedback I've gotten on my PRs. Would be nice to have it in the `AGENTS.md` as I often use Claude to one shot the plumbing of a flag.

though - maybe we should have a turbopack-specific AGENTS.md?