### PR TITLE
docs: clarify reactMaxHeadersLength does not fix 431 incoming request errors

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/reactMaxHeadersLength.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/reactMaxHeadersLength.mdx
@@ -14,3 +14,14 @@ module.exports = {
 > **Good to know**: This option is only available in App Router.
 
 Depending on the type of proxy between the browser and the server, the headers can be truncated. For example, if you are using a reverse proxy that doesn't support long headers, you should set a lower value to ensure that the headers are not truncated.
+
+> **Good to know**: `reactMaxHeadersLength` only controls the size of outgoing
+> preload headers emitted by React during static rendering (e.g. `Link:` headers
+> for fonts, stylesheets, and scripts). It does **not** affect Node.js's incoming
+> request header size limit. If you are seeing `431 Request Header Fields Too Large`
+> errors caused by large incoming request headers (e.g. long query strings or cookies),
+> increase Node.js's limit instead:
+>
+> ```bash
+> NODE_OPTIONS='--max-http-header-size=32768' next start
+> ```


### PR DESCRIPTION
Fixes #86208

Users are setting `reactMaxHeadersLength` to fix 431 errors caused by
large incoming request headers, but this option only controls outgoing
React preload headers emitted during static rendering. Added a note
clarifying the distinction and pointing to `--max-http-header-size`
for the actual fix.