### PR TITLE
[15.x][ci] Allow configuring the base URL for preview builds

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -15,6 +15,7 @@ module.exports = function actionInfo() {
     GITHUB_REPOSITORY,
     GITHUB_EVENT_PATH,
     PR_STATS_COMMENT_TOKEN,
+    PREVIEW_BUILDS_BASE_URL,
   } = process.env
 
   delete process.env.GITHUB_TOKEN
@@ -59,6 +60,8 @@ module.exports = function actionInfo() {
     isRelease:
       GITHUB_REPOSITORY === 'vercel/next.js' &&
       (GITHUB_REF || '').includes('canary'),
+    previewBuildsBaseUrl:
+      PREVIEW_BUILDS_BASE_URL || 'https://vercel-packages.vercel.app/next',
   }
 
   if (info.isRelease) {

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -562,7 +562,7 @@ jobs:
       - name: Create tarballs
         # github.event.after is available on push and pull_request#synchronize events.
         # For workflow_dispatch events, github.sha is the head commit.
-        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.after || github.sha }}" "${{ runner.temp }}/preview-tarballs"
+        run: node scripts/create-preview-tarballs.js "${{ github.sha }}" "${{ github.event.after || github.sha }}" "${{ runner.temp }}/preview-tarballs" "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
 
       - name: Upload tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -560,7 +560,8 @@ jobs:
         node scripts/test-new-tests.mjs \
           --flake-detection \
           --mode dev \
-          --group ${{ matrix.group }}
+          --group ${{ matrix.group }} \
+          --preview-builds-base-url "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
       stepName: 'test-new-tests-dev-${{matrix.group}}'
       timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
 
@@ -584,7 +585,8 @@ jobs:
         node scripts/test-new-tests.mjs \
           --flake-detection \
           --mode start \
-          --group ${{ matrix.group }}
+          --group ${{ matrix.group }} \
+          --preview-builds-base-url "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
       stepName: 'test-new-tests-start-${{matrix.group}}'
       timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
     secrets: inherit
@@ -608,7 +610,8 @@ jobs:
         export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }}
         node scripts/test-new-tests.mjs \
           --mode deploy \
-          --group ${{ matrix.group }}
+          --group ${{ matrix.group }} \
+          --preview-builds-base-url "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
       stepName: 'test-new-tests-deploy-${{matrix.group}}'
 
     secrets: inherit

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -105,6 +105,9 @@ env:
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
   NEXT_TEST_PREFER_OFFLINE: 1
   NEXT_CI_RUNNER: ${{ inputs.runs_on_labels }}
+  # Read token for the auth-protected preview-builds npm mirror, used by deploy
+  # tests to install Next.js artifacts during the remote build.
+  PREVIEW_BUILDS_READ_TOKEN: ${{ secrets.PREVIEW_BUILDS_READ_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -59,3 +59,5 @@ jobs:
 
       - uses: ./.github/actions/next-stats-action
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        env:
+          PREVIEW_BUILDS_BASE_URL: ${{ vars.PREVIEW_BUILDS_BASE_URL }}

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
     with:
-      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" NEXT_TEST_PREVIEW_BUILDS_BASE_URL="${{ vars.PREVIEW_BUILDS_BASE_URL }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-${{ matrix.group }}'

--- a/scripts/create-preview-tarballs.js
+++ b/scripts/create-preview-tarballs.js
@@ -9,7 +9,9 @@ async function main() {
     githubSha,
     githubHeadSha,
     tarballDirectory = path.join(os.tmpdir(), 'vercel-nextjs-preview-tarballs'),
+    baseUrlArg,
   ] = process.argv.slice(2)
+  const baseUrl = baseUrlArg || 'https://vercel-packages.vercel.app/next'
   const repoRoot = path.resolve(__dirname, '..')
 
   await fs.mkdir(tarballDirectory, { recursive: true })
@@ -103,13 +105,13 @@ async function main() {
   for (const packageInfo of packages) {
     packagesByVersion.set(
       packageInfo.name,
-      `https://vercel-packages.vercel.app/next/commits/${githubHeadSha}/${packageInfo.name}`
+      `${baseUrl}/commits/${githubHeadSha}/${packageInfo.name}`
     )
   }
   for (const nextSwcPackageName of nextSwcPackageNames) {
     packagesByVersion.set(
       nextSwcPackageName,
-      `https://vercel-packages.vercel.app/next/commits/${githubHeadSha}/${nextSwcPackageName}`
+      `${baseUrl}/commits/${githubHeadSha}/${nextSwcPackageName}`
     )
   }
 

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -90,13 +90,18 @@ async function main() {
       ? `${previewBuildsBaseUrl}/commits/${commitSha}/next`
       : undefined
 
+  const previewBuildsReadToken = process.env.PREVIEW_BUILDS_READ_TOKEN
+
   if (nextTestVersion) {
     console.log(`Verifying artifacts for commit ${commitSha}`)
     // Attempt to fetch the deploy artifacts for the commit
     // These might take a moment to become available, so we'll retry a few times
+    const fetchHeaders = previewBuildsReadToken
+      ? { Authorization: `Bearer ${previewBuildsReadToken}` }
+      : undefined
     const fetchWithRetry = async (url, retries = 5, timeout = 5000) => {
       for (let i = 0; i < retries; i++) {
-        const res = await fetch(url)
+        const res = await fetch(url, { headers: fetchHeaders })
         if (res.ok) {
           return res
         } else if (i < retries - 1) {
@@ -152,6 +157,7 @@ async function main() {
         env: {
           ...process.env,
           NEXT_TEST_MODE: testMode,
+          NEXT_TEST_PREVIEW_BUILDS_BASE_URL: previewBuildsBaseUrl,
           NEXT_TEST_VERSION: nextTestVersion,
           IS_TURBOPACK_TEST: '1',
           TURBOPACK_BUILD: testMode === 'start' ? '1' : undefined,

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -14,11 +14,14 @@ async function main() {
   let argv = await yargs(process.argv.slice(2))
     .string('mode')
     .string('group')
+    .string('preview-builds-base-url')
     .boolean('flake-detection').argv
 
   let testMode = argv.mode
   const isFlakeDetectionMode = argv['flake-detection']
   const attempts = isFlakeDetectionMode ? 3 : 1
+  const previewBuildsBaseUrl =
+    argv['preview-builds-base-url'] || 'https://vercel-packages.vercel.app/next'
 
   if (testMode && !['dev', 'deploy', 'start'].includes(testMode)) {
     throw new Error(
@@ -79,15 +82,12 @@ async function main() {
   }
 
   const RUN_TESTS_ARGS = ['run-tests.js', '-c', '1', '--retries', '0']
-  const PR_NUMBER = process.env.GH_PR_NUMBER
   // Only override the test version for deploy tests, as they need to run against
   // the artifacts for the pull request. Otherwise, we don't need to specify this property,
   // as tests will run against the local version of Next.js
   const nextTestVersion =
     testMode === 'deploy'
-      ? PR_NUMBER
-        ? `https://vercel-packages.vercel.app/next/prs/${PR_NUMBER}/next`
-        : `https://vercel-packages.vercel.app/next/commits/${commitSha}/next`
+      ? `${previewBuildsBaseUrl}/commits/${commitSha}/next`
       : undefined
 
   if (nextTestVersion) {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -25,6 +25,7 @@ export class NextDeployInstance extends NextInstance {
     super.setup(parentSpan)
     await super.createTestDir({ parentSpan, skipInstall: true })
 
+    await this.writeMirrorNpmrcIfNecessary()
     // ensure Vercel CLI is installed
     try {
       const res = await execa('vercel', ['--version'])
@@ -166,6 +167,30 @@ export class NextDeployInstance extends NextInstance {
     // TODO: Combine with runtime logs (via `vercel logs`)
     // Build logs seem to be piped to stderr, so we'll combine them to make sure we get all the logs.
     this._cliOutput = buildLogs.stdout + buildLogs.stderr
+  }
+
+  // When the preview-builds npm mirror is auth-protected, the deploy build
+  // installs Next.js artifacts from it and needs credentials. We write an
+  // `.npmrc` with a read token (provided as a CI secret) so the remote install
+  // can authenticate. Only written when the token is set, so unprotected and
+  // local deploy runs are unaffected.
+  private async writeMirrorNpmrcIfNecessary(): Promise<void> {
+    const token = process.env.PREVIEW_BUILDS_READ_TOKEN
+    const baseUrlRaw = process.env.NEXT_TEST_PREVIEW_BUILDS_BASE_URL
+
+    if (!token || !baseUrlRaw) {
+      return
+    }
+
+    const baseUrl = new URL(baseUrlRaw)
+    // Derive the npmrc auth key from the mirror base URL: strip the scheme and
+    // ensure a trailing slash so it matches requests to that registry path.
+    const registryKey = `//${baseUrl.host}${baseUrl.pathname.replace(/\/?$/, '/')}`
+
+    await fs.writeFile(
+      path.join(this.testDir, '.npmrc'),
+      `${registryKey}:_authToken=${token}\n`
+    )
   }
 
   public get cliOutput() {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -179,6 +179,9 @@ export class NextDeployInstance extends NextInstance {
     const baseUrlRaw = process.env.NEXT_TEST_PREVIEW_BUILDS_BASE_URL
 
     if (!token || !baseUrlRaw) {
+      require('console').log(
+        `Skipping .npmrc write for preview-builds mirror: missing token or base URL`
+      )
       return
     }
 
@@ -187,6 +190,9 @@ export class NextDeployInstance extends NextInstance {
     // ensure a trailing slash so it matches requests to that registry path.
     const registryKey = `//${baseUrl.host}${baseUrl.pathname.replace(/\/?$/, '/')}`
 
+    require('console').log(
+      `Writing .npmrc for preview-builds mirror: ${registryKey}`
+    )
     await fs.writeFile(
       path.join(this.testDir, '.npmrc'),
       `${registryKey}:_authToken=${token}\n`


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/93464, https://github.com/vercel/next.js/pull/95204, and https://github.com/vercel/next.js/pull/95784/

## Test plan

- [x] [e2e deploy release tests on this branch](https://github.com/vercel/next.js/actions/runs/29442904597) (failures are known)