### PR TITLE
fix: no-html-link-for-pages ESLint rule now respects custom pageExtensions

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -62,6 +62,19 @@ export default defineRule({
           },
         ],
       },
+      {
+        type: 'object',
+        properties: {
+          pageExtensions: {
+            type: 'array',
+            uniqueItems: true,
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
     ],
   },
 
@@ -71,6 +84,15 @@ export default defineRule({
   create(context) {
     const ruleOptions: (string | string[])[] = context.options
     const [customPagesDirectory] = ruleOptions
+    const options = ruleOptions[1] as
+      | { pageExtensions?: string[] }
+      | undefined
+    const pageExtensions = options?.pageExtensions ?? [
+      'tsx',
+      'ts',
+      'jsx',
+      'js',
+    ]
 
     const rootDirs = getRootDirs(context)
 
@@ -107,8 +129,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -25,12 +25,13 @@ function parseUrlForPages(
     withFileTypes: true,
   })
   const extensionRegex = buildExtensionRegex(pageExtensions)
+  const indexFileRegex = new RegExp(`^index\\.(${pageExtensions.join('|')})$`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extensionRegex.test(dirent.name)) {
-      if (/^index/.test(dirent.name)) {
+      if (indexFileRegex.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(extensionRegex, '')}`
+          `${urlprefix}${dirent.name.replace(indexFileRegex, '')}`
         )
       }
       res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -6,27 +6,38 @@ import * as fs from 'fs'
 const fsReadDirSyncCache = {}
 
 /**
+ * Build a regex that matches the given file extensions.
+ * E.g. ['tsx', 'ts', 'jsx', 'js'] -> /\.(tsx|ts|jsx|js)$/
+ */
+function buildExtensionRegex(extensions: string[]): RegExp {
+  return new RegExp(`\\.(${extensions.join('|')})$`)
+}
+
+/**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extensionRegex = buildExtensionRegex(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extensionRegex.test(dirent.name)) {
+      if (/^index/.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(extensionRegex, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions))
       }
     }
   })
@@ -36,24 +47,29 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extensionRegex = buildExtensionRegex(pageExtensions)
+  const pageFileRegex = new RegExp(`^page\\.(${pageExtensions.join('|')})$`)
+  const layoutFileRegex = new RegExp(`^layout\\.(${pageExtensions.join('|')})$`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extensionRegex.test(dirent.name)) {
+      if (pageFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageFileRegex, '')}`)
+      } else if (!layoutFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions))
       }
     }
   })
@@ -136,13 +152,14 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, pageExtensions))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +173,14 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, pageExtensions))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,10 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withCustomExtensionsDir = path.join(
+  __dirname,
+  'with-custom-extensions'
+)
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +30,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withCustomExtensions: new Linter({
+    cwd: withCustomExtensionsDir,
     configType: 'eslintrc',
   }),
 }
@@ -72,12 +80,39 @@ const linterConfigWithNestedContentRootDirDirectory = {
     },
   },
 }
+const linterConfigWithCustomExtensionsAndCustomDir = {
+  ...linterConfig,
+  rules: {
+    'no-html-link-for-pages': [
+      2,
+      path.join(withCustomExtensionsDir, 'app'),
+      {
+        pageExtensions: ['page.tsx', 'page.jsx'],
+      },
+    ],
+  },
+}
 
 for (const linter of Object.values(linters)) {
   linter.defineRules({
     'no-html-link-for-pages': NextESLintRule,
   })
 }
+
+const invalidCodeWithCustomExtensions = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/'>Homepage</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
 
 const validCode = `
 import Link from 'next/link';
@@ -493,6 +528,19 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+
+  it('invalid link element with custom pageExtensions', function () {
+    const [report] = linters.withCustomExtensions.verify(
+      invalidCodeWithCustomExtensions,
+      linterConfigWithCustomExtensionsAndCustomDir,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
 })

--- a/test/unit/eslint-plugin-next/with-custom-extensions/app/page.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-extensions/app/page.page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Page</div>
+}


### PR DESCRIPTION
The `parseUrlForPages` and `parseUrlForAppDir` functions in `url.ts` used hardcoded regex that only matched `.js`, `.jsx`, `.ts`, `.tsx` files. When users configure custom `pageExtensions` (e.g. `['.page.tsx']`) the rule silently skipped all page files.

Changes:
- `url.ts`: accept `pageExtensions` parameter, build regex dynamically
- `no-html-link-for-pages.ts`: accept `pageExtensions` in rule schema, pass it through to URL parsing functions
- Add test fixture and test cases for custom extensions

Fixes #53473