### PR TITLE
[16.2] Reject TypeScript >= 7.0 with an actionable error (mitigation for #95801)

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1141,5 +1141,6 @@
   "1140": "Route %s used \\`import('next/root-params').%s()\\` inside \\`\"use cache\"\\` nested within \\`unstable_cache\\`. Root params are not available in this context.",
   "1141": "Route %s used \\`import('next/root-params').%s()\\` inside \\`unstable_cache\\`. This is not supported. Use \\`\"use cache\"\\` instead.",
   "1142": "Route %s used \\`import('next/root-params').%s()\\` inside \\`generateStaticParams\\`, but the \\`%s\\` parameter was not provided by a parent \\`generateStaticParams\\`. In \\`generateStaticParams\\`, root params are only available for segments nested below the segment that provides them.",
-  "1143": "Response body exceeded maximum size of %s bytes"
+  "1143": "Response body exceeded maximum size of %s bytes",
+  "1144": "TypeScript %s is not supported by this version of Next.js. The TypeScript 7 native compiler does not provide the JavaScript compiler API that Next.js requires. Install TypeScript 6 (e.g. %s) or upgrade to a newer version of Next.js that supports TypeScript 7."
 }

--- a/packages/next/src/lib/has-necessary-dependencies.ts
+++ b/packages/next/src/lib/has-necessary-dependencies.ts
@@ -9,6 +9,8 @@ export interface MissingDependency {
    * If `exportsRestrict` is false, `${file}` MUST also resolve.
    */
   pkg: string
+  /** Package specifier to install when it differs from `pkg` (e.g. to pin a version range). */
+  install?: string
   /**
    * If true, the pkg's package.json needs to be resolvable.
    * If true, will resolve `file` relative to the real path of the package.json.

--- a/packages/next/src/lib/install-dependencies.ts
+++ b/packages/next/src/lib/install-dependencies.ts
@@ -32,7 +32,7 @@ export async function installDependencies(
 
     await install(
       path.resolve(baseDir),
-      deps.map((dep: MissingDependency) => dep.pkg),
+      deps.map((dep: MissingDependency) => dep.install ?? dep.pkg),
       { devDependencies: dev, isOnline, packageManager }
     )
     console.log()

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -22,6 +22,9 @@ import { resolveFrom } from './resolve-from'
 const typescriptPackage: MissingDependency = {
   file: 'typescript/lib/typescript.js',
   pkg: 'typescript',
+  // TypeScript 7 removed the JavaScript compiler API that Next.js requires, so
+  // pin auto-installs to the supported v6 range instead of pulling `latest`.
+  install: 'typescript@^6.0.0',
   exportsRestrict: true,
 }
 
@@ -103,6 +106,32 @@ export async function verifyAndRunTypeScript({
       dir,
       requiredPackages
     )
+
+    // TypeScript 7's native compiler no longer ships the JavaScript compiler API
+    // (`typescript/lib/typescript.js`) that Next.js loads via `require('typescript')`.
+    // Loading it crashes the build worker with a silent SIGSEGV/SIGABRT. When such a
+    // version is already installed it shows up as a "missing" dependency (the API file
+    // isn't there), so check the resolved `package.json` version up front and reject it
+    // before we either auto-install (which would reinstall the unsupported version) or
+    // reach the crashing `require()`.
+    const installedTypescriptPackageJsonPath = deps.resolved.get(
+      join('typescript', 'package.json')
+    )
+    if (installedTypescriptPackageJsonPath) {
+      const installedTypescriptVersion = require(
+        installedTypescriptPackageJsonPath
+      ).version
+      if (
+        installedTypescriptVersion &&
+        semver.gte(installedTypescriptVersion, '7.0.0')
+      ) {
+        throw new CompileError(
+          `TypeScript ${installedTypescriptVersion} is not supported by this version of Next.js. ` +
+            `The TypeScript 7 native compiler does not provide the JavaScript compiler API that Next.js requires. ` +
+            `Install TypeScript 6 (e.g. ${bold('npm install --save-dev typescript@^6')}) or upgrade to a newer version of Next.js that supports TypeScript 7.`
+        )
+      }
+    }
 
     // If @typescript/native-preview is installed and only the typescript package is missing,
     // we can skip auto-installing typescript since the native preview provides TS compilation.

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -107,13 +107,9 @@ export async function verifyAndRunTypeScript({
       requiredPackages
     )
 
-    // TypeScript 7's native compiler no longer ships the JavaScript compiler API
-    // (`typescript/lib/typescript.js`) that Next.js loads via `require('typescript')`.
-    // Loading it crashes the build worker with a silent SIGSEGV/SIGABRT. When such a
-    // version is already installed it shows up as a "missing" dependency (the API file
-    // isn't there), so check the resolved `package.json` version up front and reject it
-    // before we either auto-install (which would reinstall the unsupported version) or
-    // reach the crashing `require()`.
+    // Detect and reject TypeScript >=7. The native compiler no longer ships the JavaScript compiler API
+    // (`typescript/lib/typescript.js`) that Next.js loads.
+    // TODO: directly support the command line api so we are compatible with all TSC versions
     const installedTypescriptPackageJsonPath = deps.resolved.get(
       join('typescript', 'package.json')
     )
@@ -123,7 +119,14 @@ export async function verifyAndRunTypeScript({
       ).version
       if (
         installedTypescriptVersion &&
-        semver.gte(installedTypescriptVersion, '7.0.0')
+        // Use the lowest prerelease sentinel `7.0.0-0` so that TypeScript 7
+        // prereleases (e.g. `7.0.0-beta`, `7.0.0-rc`, or nightly `7.0.0-dev.*`
+        // builds published to the `next` dist-tag) are also rejected. Under
+        // semver precedence a prerelease of `7.0.0` sorts *before* `7.0.0`, so
+        // comparing against `7.0.0` would let those versions slip through.
+        semver.gte(installedTypescriptVersion, '7.0.0-0', {
+          includePrerelease: true,
+        })
       ) {
         throw new CompileError(
           `TypeScript ${installedTypescriptVersion} is not supported by this version of Next.js. ` +


### PR DESCRIPTION
## Summary

A minimal mitigation for #95801, where `next build` / `next dev` crash with a silent `SIGSEGV`/`SIGABRT` on the `16.2.x` line when `typescript@7` is installed. TypeScript 7's native compiler no longer ships the JavaScript compiler API (`typescript/lib/typescript.js`) that Next.js loads via `require('typescript')`, so loading it kills the process with no actionable message.

This is an **alternative to the full backport in #95831**. Rather than backporting the experimental TypeScript CLI backend (and its prerequisites), it makes the unsupported case fail cleanly. The two are mutually exclusive: ship this now for a quick, low-risk fix, or take #95831 for actual TS7 support via `experimental.useTypeScriptCli`.

## What it does

- **TS7 already installed** — because the missing compiler-API file makes an installed TS7 look like a *missing* dependency, the resolved `typescript` `package.json` version is checked up front. If it's `>= 7.0.0`, throw a `CompileError` with guidance to install TypeScript 6 or upgrade Next.js. This runs **before** the auto-install path (so we don't reinstall the unsupported version) and before the crashing `require()`.
- **TypeScript absent entirely** — pin the auto-install to `typescript@^6.0.0` (via a new optional `install` specifier on `MissingDependency`) instead of pulling `latest`, which is TS7.

Applies to both `next dev` and `next build`.

## Fixes

Fixes #95801

## Verification

- `pnpm --filter=next build`
- Reproduced against a `typescript@7.0.2` project (see #95801): `next build` and `CI=1 next build` now exit non-zero with the actionable error and no `SIGSEGV`/`SIGABRT`, and no longer churn through a pointless reinstall of the unsupported version first.
- With `typescript` removed from the project, the auto-install now pulls the v6 range and the build succeeds.
