### PR TITLE
[turbopack] Reduce macOS HMR file watcher latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10193,6 +10193,8 @@ dependencies = [
  "include_dir",
  "indexmap 2.13.0",
  "jsonc-parser",
+ "kqueue-sys",
+ "libc",
  "mime",
  "notify",
  "parking_lot",

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -55,6 +55,10 @@ turbo-tasks-hash = { workspace = true }
 turbo-unix-path = { workspace = true }
 urlencoding = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+kqueue-sys = "1.0.4"
+libc = "0.2.177"
+
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 rand = { workspace = true }
@@ -63,4 +67,3 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }
-

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -10,12 +10,25 @@ use std::{
     },
     time::Duration,
 };
+#[cfg(target_os = "macos")]
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Read, Write},
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::net::UnixStream,
+    },
+    path::Component,
+};
 
 use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
+#[cfg(target_os = "macos")]
+use kqueue_sys::{EventFilter, EventFlag, FilterFlag, kevent, kqueue};
 use notify::{
     Config, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher,
-    event::{MetadataKind, ModifyKind, RenameMode},
+    event::{DataChange, MetadataKind, ModifyKind, RemoveKind, RenameMode},
 };
 use rustc_hash::FxHashSet;
 use tokio::sync::{RwLock, RwLockWriteGuard};
@@ -112,6 +125,8 @@ enum RecursiveState {
     Watching {
         /// Hold onto the watcher: When this is dropped, it will cause the channel to disconnect
         _notify_watcher: NotifyWatcher,
+        #[cfg(target_os = "macos")]
+        fast_file_watcher: Option<FastFileWatcher>,
     },
 }
 
@@ -140,6 +155,187 @@ struct NonRecursiveWatchingState {
 enum NotifyWatcher {
     Recommended(RecommendedWatcher),
     Polling(PollWatcher),
+}
+
+#[cfg(target_os = "macos")]
+const FAST_FILE_WATCHER_LIMIT: usize = 2048;
+
+/// A low-latency supplement to FSEvents for files that are likely to be edited directly.
+///
+/// FSEvents remains the authoritative recursive watcher. This sidecar deliberately watches only
+/// individual project files and is bounded so it cannot exhaust file descriptors on dependency
+/// trees. Events from either watcher enter the same invalidation channel.
+#[cfg(target_os = "macos")]
+struct FastFileWatcher {
+    tx: std::sync::mpsc::Sender<PathBuf>,
+    wakeup: UnixStream,
+}
+
+#[cfg(target_os = "macos")]
+impl FastFileWatcher {
+    fn new(event_tx: std::sync::mpsc::Sender<notify::Result<notify::Event>>) -> Option<Self> {
+        let (tx, rx) = channel();
+        let (wakeup, wakeup_rx) = UnixStream::pair().ok()?;
+        wakeup.set_nonblocking(true).ok()?;
+        wakeup_rx.set_nonblocking(true).ok()?;
+        spawn_thread(move || run_fast_file_watcher(rx, event_tx, wakeup_rx));
+        Some(Self { tx, wakeup })
+    }
+
+    fn watch(&self, path: &Path) {
+        if self.tx.send(path.to_owned()).is_ok() {
+            let _ = (&self.wakeup).write(&[0]);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn should_fast_watch(path: &Path, root_path: &Path) -> bool {
+    let Ok(relative_path) = path.strip_prefix(root_path) else {
+        return false;
+    };
+
+    !relative_path.components().any(|component| {
+        matches!(
+            component,
+            Component::Normal(name)
+                if name == "node_modules" || name == ".git" || name == ".next"
+        )
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn run_fast_file_watcher(
+    rx: Receiver<PathBuf>,
+    event_tx: std::sync::mpsc::Sender<notify::Result<notify::Event>>,
+    mut wakeup: UnixStream,
+) {
+    let queue = unsafe { kqueue() };
+    if queue < 0 {
+        return;
+    }
+
+    let wakeup_fd = wakeup.as_raw_fd();
+    let wakeup_change = kevent::new(
+        wakeup_fd as usize,
+        EventFilter::EVFILT_READ,
+        EventFlag::EV_ADD | EventFlag::EV_ENABLE | EventFlag::EV_CLEAR,
+        FilterFlag::empty(),
+    );
+    let wakeup_result = unsafe {
+        kevent(
+            queue,
+            &wakeup_change,
+            1,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null(),
+        )
+    };
+    if wakeup_result != 0 {
+        unsafe {
+            libc::close(queue);
+        }
+        return;
+    }
+
+    let mut files = HashMap::<PathBuf, File>::new();
+    let mut paths_by_fd = HashMap::<RawFd, PathBuf>::new();
+
+    'watching: loop {
+        let mut event = kevent::new(
+            0,
+            EventFilter::EVFILT_VNODE,
+            EventFlag::empty(),
+            FilterFlag::empty(),
+        );
+        let count = unsafe { kevent(queue, std::ptr::null(), 0, &mut event, 1, std::ptr::null()) };
+        if count != 1 {
+            continue;
+        }
+        if event.flags.contains(EventFlag::EV_ERROR) {
+            break;
+        }
+
+        let fd = event.ident as RawFd;
+        if fd == wakeup_fd {
+            let mut buffer = [0; 256];
+            loop {
+                match wakeup.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(_) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(_) => break,
+                }
+            }
+
+            loop {
+                match rx.try_recv() {
+                    Ok(path) => {
+                        if files.contains_key(&path) || files.len() >= FAST_FILE_WATCHER_LIMIT {
+                            continue;
+                        }
+                        let Ok(file) = File::open(&path) else {
+                            continue;
+                        };
+                        let fd = file.as_raw_fd();
+                        let change = kevent::new(
+                            fd as usize,
+                            EventFilter::EVFILT_VNODE,
+                            EventFlag::EV_ADD | EventFlag::EV_ENABLE | EventFlag::EV_CLEAR,
+                            FilterFlag::NOTE_DELETE
+                                | FilterFlag::NOTE_WRITE
+                                | FilterFlag::NOTE_EXTEND
+                                | FilterFlag::NOTE_ATTRIB
+                                | FilterFlag::NOTE_RENAME
+                                | FilterFlag::NOTE_REVOKE,
+                        );
+                        let result = unsafe {
+                            kevent(queue, &change, 1, std::ptr::null_mut(), 0, std::ptr::null())
+                        };
+                        if result == 0 {
+                            paths_by_fd.insert(fd, path.clone());
+                            files.insert(path, file);
+                        }
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => break 'watching,
+                }
+            }
+            continue;
+        }
+
+        let Some(path) = paths_by_fd.get(&fd).cloned() else {
+            continue;
+        };
+        let remove_watch = event.fflags.intersects(
+            FilterFlag::NOTE_DELETE | FilterFlag::NOTE_RENAME | FilterFlag::NOTE_REVOKE,
+        );
+        let kind = if event
+            .fflags
+            .intersects(FilterFlag::NOTE_DELETE | FilterFlag::NOTE_REVOKE)
+        {
+            EventKind::Remove(RemoveKind::Any)
+        } else if event.fflags.contains(FilterFlag::NOTE_RENAME) {
+            EventKind::Modify(ModifyKind::Name(RenameMode::Any))
+        } else if event.fflags.contains(FilterFlag::NOTE_ATTRIB) {
+            EventKind::Modify(ModifyKind::Metadata(MetadataKind::Any))
+        } else {
+            EventKind::Modify(ModifyKind::Data(DataChange::Any))
+        };
+
+        let _ = event_tx.send(Ok(notify::Event::new(kind).add_path(path.clone())));
+
+        if remove_watch {
+            paths_by_fd.remove(&fd);
+            files.remove(&path);
+        }
+    }
+
+    unsafe {
+        libc::close(queue);
+    }
 }
 
 impl NotifyWatcher {
@@ -388,9 +584,9 @@ impl DiskWatcher {
 
         let mut notify_watcher = if let Some(poll_interval) = poll_interval {
             let config = config.with_poll_interval(poll_interval);
-            NotifyWatcher::Polling(PollWatcher::new(tx, config)?)
+            NotifyWatcher::Polling(PollWatcher::new(tx.clone(), config)?)
         } else {
-            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?)
+            NotifyWatcher::Recommended(RecommendedWatcher::new(tx.clone(), config)?)
         };
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the
@@ -400,6 +596,13 @@ impl DiskWatcher {
             StateWriteGuard::Recursive(_) => RecursiveMode::Recursive,
             StateWriteGuard::NonRecursive(_) => RecursiveMode::NonRecursive,
         };
+        #[cfg(target_os = "macos")]
+        let fast_file_watcher =
+            if matches!(&state_guard, StateWriteGuard::Recursive(_)) && poll_interval.is_none() {
+                FastFileWatcher::new(tx)
+            } else {
+                None
+            };
         notify_watcher.watch(root_path, recursive_mode)?;
 
         // We need to invalidate all reads or writes that happened before watching. As a
@@ -449,6 +652,8 @@ impl DiskWatcher {
             StateWriteGuard::Recursive(mut recursive) => {
                 *recursive = RecursiveState::Watching {
                     _notify_watcher: notify_watcher,
+                    #[cfg(target_os = "macos")]
+                    fast_file_watcher,
                 }
             }
             StateWriteGuard::NonRecursive(mut non_recursive) => {
@@ -744,6 +949,17 @@ impl DiskWatcher {
     }
 
     pub async fn ensure_watched_file(&self, path: &Path, root_path: &Path) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        if let State::Recursive(recursive) = &self.state
+            && should_fast_watch(path, root_path)
+            && let RecursiveState::Watching {
+                fast_file_watcher: Some(fast_file_watcher),
+                ..
+            } = &*recursive.read().await
+        {
+            fast_file_watcher.watch(path);
+        }
+
         // Watch the parent directory instead of the specified file, since directories also track
         // their immediate children (even in non-recursive mode), and we need to watch all the
         // parents anyways.
@@ -859,5 +1075,36 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use std::path::Path;
+
+    use super::should_fast_watch;
+
+    #[test]
+    fn fast_file_watcher_is_limited_to_project_files() {
+        let root = Path::new("/project");
+
+        assert!(should_fast_watch(Path::new("/project/app/page.tsx"), root));
+        assert!(should_fast_watch(
+            Path::new("/project/src/node_modules-helper.ts"),
+            root
+        ));
+        assert!(!should_fast_watch(
+            Path::new("/project/node_modules/package/index.js"),
+            root
+        ));
+        assert!(!should_fast_watch(Path::new("/project/.git/index"), root));
+        assert!(!should_fast_watch(
+            Path::new("/project/.next/server/app.js"),
+            root
+        ));
+        assert!(!should_fast_watch(
+            Path::new("/other-project/app/page.tsx"),
+            root
+        ));
     }
 }


### PR DESCRIPTION
# Turbopack macOS HMR latency investigation

> This document is a technical investigation record, not a pull request description. The complete raw experiment notebook, including every AB/BA pair, is available in [`performance-experiments.md`](./performance-experiments.md).

## TL;DR
Approach: On macOS, keep FSEvents as the authoritative recursive watcher and add a bounded kqueue sidecar for up to 2,048 already-read project files, excluding node_modules, .git, and .next. Registration is event-driven through a UnixStream/EVFILT_READ wakeup; vnode events enter the existing notify invalidation channel. FSEvents remains the complete fallback, so correctness and behavior outside the fast path are unchanged.

Why this shape: replacing FSEvents with recursive kqueue improved synthetic HMR but broke the heavy-dependency app. An 8,192-file sidecar preserved the speedup but repeatedly increased startup RSS by 14.6–20.1%. The 2,048-file cap retained the latency benefit without the resource regression.

Results: 5,000-module CSR HMR-to-eval improved by 27.7% and 33.8% in two independent adjacent full Criterion comparisons; both had p < 0.05 and entirely negative 95% relative-change intervals. The five-pair AB/BA screen improved 34.5%. HMR-to-commit improved 28.6% (p < 0.05), and the production small-app aggregate improved 4.1%. In the adjacent heavy-NPM benchmark, the worst latency regression was 4.5%, the worst RSS regression was 3.1%, and HMR improved 23.7–45.2%. The startup Criterion point estimate regressed 21.7%, but was not statistically significant (p = 0.08) and contained one severe high outlier.

Correctness: FSEvents fallback remains active; Criterion and the heavy benchmark confirmed HMR without a full reload. cargo test -p turbo-tasks-fs passed 111/111, the focused Turbopack HMR integration suite passed 5/5, and pnpm build-all passed.


## Outcome

The retained change reduces Criterion's `bench_hmr_to_eval/Turbopack CSR/5000 modules` point estimate by **27.7% to 33.8%** in two independent adjacent full baseline/current comparisons. Both comparisons have `p < 0.05`, and both 95% relative-change intervals are entirely below zero.

The implementation supplements the existing macOS FSEvents watcher with a bounded, event-driven kqueue sidecar for already-read project files. FSEvents remains active and authoritative, so paths outside the sidecar, paths beyond its resource cap, and events the sidecar cannot watch retain the existing behavior.

The final commit is `67b3959a2cf4819b76614b7e23a5e661b912dee1` on `codex/reduce-turbopack-macos-hmr-latency`. The associated empty-description draft is [vercel/next.js#95839](https://github.com/vercel/next.js/pull/95839).

## Goal and constraints

The target was at least a 10% reduction relative to commit `98c9754ad8926932d88a5f037379719323ebad67`, without changing:

- The benchmark workload or generated 5,000-module graph.
- The deterministic module picker or its seed.
- Warmups, browser configuration, or measurement boundaries.
- Compiler profile or feature behavior.
- Default behavior solely for the benchmark.
- Correctness, by skipping work or moving it into an unmeasured phase.

Candidates were screened with at least five alternating AB/BA one-shot pairs using a frozen benchmark driver and frozen baseline CLI. Results between 2% and 5% required a directionally consistent repeat. Candidates that survived screening were checked with full Criterion comparisons and downstream regression/correctness tests.

## Frozen baseline

Both baseline artifacts were built and made read-only before any source change.

| Artifact | Details |
|---|---|
| Baseline commit | `98c9754ad8926932d88a5f037379719323ebad67` |
| Build command | `rustup run nightly-2026-06-24 cargo bench -p turbopack-cli --bench mod --no-run` |
| Compiler | `rustc 1.96.1-nightly (31fca3adb 2026-06-26)`, LLVM 22.1.2, `aarch64-apple-darwin` |
| Profile | Optimized bench/release configuration, thin LTO, one codegen unit |
| Frozen benchmark | SHA-256 `b1f325c95304594c541a9517bdcd809f1298ca661cd4029999ba6b4e2aada88b` |
| Frozen CLI | SHA-256 `2867a5dd860ab13a1d38bd4233fdf595fd60deb4d722d28e6ffc13f2645c4909` |
| Environment | `TURBOPACK_BENCH_COUNTS=5000`, `TURBOPACK_BENCH_PROGRESS=1`, default ten HMR warmups |

An identical-artifact calibration showed substantial one-shot noise, including deltas from -11.19% to +5.92%. This is why one-shot screens were used only for triage and final retention required full Criterion statistics.

## Profile findings

The frozen baseline full Criterion point estimate was 25.100 ms. A tracing run measured 27.580 ms while collecting 1,485 HMR iterations.

Two macOS CPU samples and a 163 MB Turbopack trace identified these hotspot families:

- Turbo Tasks dependency tracking, aggregation locks, and task-cell reads.
- Module graph and browser chunking work.
- Chunk version construction, hashing, and update diffing.
- Update-stream consistency and issue collection.
- WebSocket transport and filesystem-notification arrival.

Important traced totals included:

- Module graph: 7.666 s CPU.
- Browser chunking: 5.439 s CPU.
- `get chunk item info`: 3.851 s CPU.
- Code-generation descendants: 2.389 s CPU.

Several compute-focused experiments looked promising in noisy one-shot screens but disappeared in full comparisons. The remaining end-to-end latency had recurring fast and slow modes, while server-side recomputation often completed below the slow mode. That evidence shifted the investigation toward transport and filesystem notification ingress.

## Experiment summary

The percentage in the “screen” column is the geometric paired delta unless otherwise noted. Negative values are improvements.

| # | Hypothesis or implementation | Hotspot family | Result | Decision |
|---:|---|---|---|---|
| 1 | Directly look up requested items when a chunk has one 5,000-item batch group, avoiding a temporary flattened map. | Chunk batch metadata | First screen +3.20%; repeat -5.81%. | Reverted because the direction did not reproduce. |
| 2 | Reserve the flattened batch-info map once from the known total length. | Chunk batch metadata | Preliminary screening reversed direction and did not produce a retained candidate. | Reverted. |
| 3 | Avoid redundant reverse-dependency insertion when the forward dependency already proves the edge exists. | Turbo Tasks dependency tracking | Screen -13.75%; full change +0.586%, CI crossing zero, `p=0.94`. | Reverted after the full comparison found no change. |
| 4 | Replace hash-backed reverse edges with SmallVec-backed list edges after Experiment 3 guarantees uniqueness. | Turbo Tasks dependency tracking | Screen +8.88% regression. | Reverted with Experiment 3's prerequisite. |
| 5 | Cache construction of content entries for the stable 5,000-module batch. | Content/version construction | Screen -9.94%, dominated by opposing outliers; full +2.670%, `p=0.65`. | Reverted. |
| 6 | Reuse the current version's existing hash map rather than reading all 5,000 hash Vcs again during update diffing. | Version/update diffing | Screen +5.19% regression. | Reverted. |
| 7 | Replace the flat 5,000-item batch-size reduction with stable 64-item partial sums. | Chunking metadata | Screen -5.79%; full +1.736%, `p=0.82`. | Reverted. |
| 8 | Skip the aggregate batch-size calculation that development chunking immediately discards before recomputing real item sizes. | Chunking metadata | Screen -7.19%; full +3.344%, `p=0.60`. | Reverted. |
| 9 | Partition current-version hash collection into stable 64-entry tasks. | Version hashing | First screen -2.47%; required repeat +6.03% regression. | Reverted because the direction did not reproduce. |
| 10 | Retain 64-entry hash partitions in version snapshots and skip unchanged partitions by identity. | Version hashing/update diffing | Screen +6.85% regression. | Rejected; task overhead exceeded avoided scanning. |
| 11 | Reduce retained-version overhead by using 512-entry partitions instead of 64-entry partitions. | Version hashing/update diffing | Screen +2.83% regression. | Reverted with the retained-partition architecture. |
| 12 | Read update content and captured issues concurrently instead of serially. | Update-stream consistency | Screen +340.69% regression. | Reverted; the concurrent strong-consistency traversals contended heavily. |
| 13 | Read the mostly cached 5,000 hashes sequentially to avoid a large ordered future set. | Version hashing/future scheduling | Screen +4.58% regression. | Reverted. |
| 14 | Collect hashes in 16-wide inline concurrent groups, reducing the outer ordered future heap. | Version hashing/future scheduling | Screen -11.14%; full +2.666%, `p=0.68`. | Reverted after the full comparison found no improvement. |
| 15 | Increase inline group width to 29, the maximum that remains on the small-future path. | Version hashing/future scheduling | Screen -5.85%; full -1.122%, CI crossing zero, `p=0.87`. | Reverted. |
| 16 | Enable `TCP_NODELAY` on accepted development-server sockets to remove a possible Nagle/delayed-ACK mode. | HMR WebSocket transport | Screen +1.99% regression. | Reverted; it did not remove the slow mode. |
| 17 | Replace recursive FSEvents with recursive kqueue notifications on macOS. | Filesystem notification ingress | Screen -33.22%; two qualifying full comparisons around -44%. | Rejected because the heavy dependency app repeatedly failed its initial page request with `ERR_EMPTY_RESPONSE`; recursive kqueue did not scale to the dependency tree. |
| 18 | Keep FSEvents authoritative and add a project-file-only kqueue sidecar, excluding dependency/build trees and capping it at 8,192 files. | Filesystem notification ingress | Screen -31.53%; full -42.299% and -44.223%; benchmark guardrails passed. | Refined because registration used a 5 ms polling timeout, causing 200 idle wakeups per second—an unacceptable unmeasured trade. |
| 19 | Replace the 5 ms registration polling loop with an event-driven UnixStream/`EVFILT_READ` wakeup. | Filesystem notification ingress | Screen -30.76%; full -34.973% and -38.453%. | Rejected at the 8,192-file cap because heavy-app startup RSS repeatedly regressed 14.6% to 20.1%. |
| 20 | Keep the event-driven design but reduce the sidecar cap to 2,048 project files. | Filesystem notification ingress | Screen -34.46%; full -27.731% and -33.792%. | Retained after all statistical, resource, and correctness gates passed. |

## Why the final approach works

FSEvents is optimized for scalable recursive observation, but its delivery can add visible latency to a small file edit even when configured with zero nominal latency and `NoDefer`. kqueue can deliver a vnode change immediately, but recursively registering an entire dependency tree is too resource-intensive.

The retained design combines the strengths of both:

1. The existing recursive FSEvents watcher is created and remains active exactly as before.
2. On macOS, when recursive watching is active and polling mode is not requested, a `FastFileWatcher` sidecar is also created.
3. `ensure_watched_file` offers already-read project files to the sidecar.
4. Paths outside the filesystem root, and paths containing `node_modules`, `.git`, or `.next`, are excluded.
5. The sidecar registers at most 2,048 files, bounding descriptors and memory.
6. A UnixStream pair wakes the kqueue thread through `EVFILT_READ` whenever registration work arrives. There is no timer or idle polling loop.
7. Each registered file uses `EVFILT_VNODE` for writes, extension, metadata, delete, rename, and revoke notifications.
8. Sidecar events are converted into the existing `notify::Event` representation and sent through the same invalidation channel as FSEvents.
9. Deleted, renamed, or revoked files are removed from the sidecar maps and their file handles are released.
10. If kqueue creation, registration, file opening, the resource cap, or the path filter prevents sidecar coverage, FSEvents continues to provide complete recursive correctness.

The sidecar therefore removes notification-arrival delay for a bounded set of likely-to-be-edited project files without replacing the scalable watcher or weakening behavior outside the fast path.

## Final source changes

Only three repository files are part of the final commit:

- `Cargo.lock`
  - Records the direct `kqueue-sys` and `libc` dependencies for `turbo-tasks-fs`.
- `turbopack/crates/turbo-tasks-fs/Cargo.toml`
  - Adds `kqueue-sys` and `libc` as macOS-only dependencies.
- `turbopack/crates/turbo-tasks-fs/src/watcher.rs`
  - Implements the bounded event-driven kqueue sidecar.
  - Integrates it only with the macOS recursive watcher path.
  - Adds project-path eligibility coverage.

No benchmark source, test workload, generated graph, module picker, defaults specific to the benchmark, or unrelated Next.js behavior was changed.

## Final HMR-to-eval measurements

### Alternating frozen-baseline/current screen

| Pair/order | Baseline | Current | Paired delta |
|---:|---:|---:|---:|
| 1 / AB | 38.944 ms | 27.926 ms | -28.29% |
| 2 / BA | 39.165 ms | 26.415 ms | -32.56% |
| 3 / AB | 41.449 ms | 25.361 ms | -38.81% |
| 4 / BA | 40.500 ms | 24.802 ms | -38.76% |
| 5 / AB | 37.715 ms | 25.167 ms | -33.27% |

Geometric paired delta: **-34.46%**.

### Independent adjacent full Criterion comparisons

| Comparison | Baseline point estimate | Current point estimate | Relative change | 95% relative-change interval | Significance |
|---:|---:|---:|---:|---:|---:|
| 1 | 26.248 ms | 17.535 ms | **-27.731%** | **[-39.069%, -14.424%]** | `p < 0.05` |
| 2 | 26.670 ms | 16.396 ms | **-33.792%** | **[-43.238%, -22.427%]** | `p < 0.05` |

An attempted second comparison was discarded before producing a baseline measurement because the benchmark browser receiver exited while opening `about:blank`. No partial result was used; the comparison was rerun from a fresh adjacent baseline/current pair.

## Regression guardrails

### Criterion guardrails

| Benchmark | Baseline | Current | Change | Result |
|---|---:|---:|---:|---|
| 5,000-module `bench_startup` | 2.2689 s | 2.7622 s | +21.745%, CI [+4.6696%, +50.205%], `p=0.08` | Not statistically significant under the requested rule; one of ten current measurements was a severe high outlier. |
| 5,000-module `bench_hmr_to_commit` | 27.376 ms | 18.884 ms | **-28.559%**, CI [-37.614%, -19.317%], `p<0.05` | Significant improvement; work was not shifted beyond the commit boundary. |
| Production small-app aggregate | 2447.99 ms | 2347.20 ms | **-4.12%** | Aggregate improvement. |

### Heavy-NPM-dependencies Next.js development benchmark

The exact frozen baseline and candidate native bindings were run adjacently after an older non-adjacent baseline produced a misleading RSS signal. The adjacent control showed that later-mode baseline RSS itself was around 645–651 MB.

| Mode | Startup latency | Page latency | HMR median | Startup RSS | Page RSS |
|---|---:|---:|---:|---:|---:|
| `d` | -13.6% | -1.1% | -45.2% | -0.7% | -2.5% |
| `e` | +2.1% | -6.6% | -23.7% | +0.4% | +2.3% |
| `v` | +3.9% | -5.5% | -41.9% | -1.4% | +3.1% |

Cached startup RSS changed by -1.3%, -1.3%, and +1.5%; cached page latency changed by -7.7%, +4.5%, and +4.5%. Every page status and every measured HMR status was successful. A single older-run startup latency regression above 10% reversed direction in the adjacent repeat and therefore did not reproduce.

## Correctness and verification

- `cargo fmt --all -- --check` passed with the pinned nightly toolchain.
- `cargo test -p turbo-tasks-fs` passed: 111 tests, 0 failures; doc tests passed.
- `pnpm build-all` passed with the pinned nightly toolchain on `PATH`.
- `HEADLESS=true pnpm test-dev-turbo test/development/app-hmr/hmr.test.ts` passed: one suite, five tests.
- The integration suite covered file and folder changes, environment-file changes, Fast Refresh, and an explicit no-full-navigation assertion.
- All measured heavy-app HMR status values were successful.
- Criterion's HMR teardown assertion confirmed that the page retained its HMR marker and did not fully reload.
- `git diff --check` passed before commit.
- The committed change is verified-signed.

## Final finding

The dominant remaining opportunity was not another reduction in module-graph, chunking, or hash computation. Multiple profile-guided compute candidates either regressed, failed to reproduce, or disappeared under full Criterion statistics. The stable improvement came from reducing macOS filesystem-notification arrival latency while retaining FSEvents for scalable and complete recursive coverage.

The final 2,048-file cap is essential. Unbounded recursive kqueue failed the heavy dependency workload, and an 8,192-file sidecar caused repeated RSS regressions. The smaller event-driven sidecar preserves the HMR gain, avoids idle polling, stays under the resource regression thresholds, and keeps correctness fallback behavior unchanged.