### PR TITLE
Move outputHashSalt out of experimental

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -149,6 +149,10 @@ pub struct NextConfig {
     /// [API Reference](https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages)
     server_external_packages: Option<Vec<RcStr>>,
 
+    /// A salt to mix into chunk and asset content hashes. Empty string means
+    /// no salt.
+    output_hash_salt: Option<RcStr>,
+
     #[serde(rename = "_originalRedirects")]
     original_redirects: Option<Vec<Redirect>>,
 
@@ -1293,10 +1297,6 @@ pub struct ExperimentalConfig {
     durable_use_cache_entries: Option<bool>,
     runtime_server_deployment_id: Option<bool>,
     expose_testing_api_in_production_build: Option<bool>,
-
-    /// A salt to mix into chunk and asset content hashes. Empty string means
-    /// no salt.
-    output_hash_salt: Option<RcStr>,
 
     /// CSS chunking strategy. See [`CssChunkingConfig`] for the accepted shapes.
     css_chunking: Option<CssChunkingConfig>,
@@ -2749,12 +2749,7 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn output_hash_salt(&self) -> Vc<RcStr> {
-        Vc::cell(
-            self.experimental
-                .output_hash_salt
-                .clone()
-                .unwrap_or_default(),
-        )
+        Vc::cell(self.output_hash_salt.clone().unwrap_or_default())
     }
 }
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/outputHashSalt.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/outputHashSalt.mdx
@@ -1,19 +1,16 @@
 ---
 title: outputHashSalt
 description: Learn how to incorporate a custom salt string into content-addressed output filenames.
-version: experimental
 ---
 
-`outputHashSalt` is an experimental option that incorporates a configurable salt string into every content-addressed output filename (chunks, assets). Changing this value forces all output hashes to change, which is useful for invalidating cached assets across deployments without modifying source files.
+`outputHashSalt` is an option that incorporates a configurable salt string into every content-addressed output filename (chunks, assets). Changing this value forces all output hashes to change, which is useful for invalidating cached assets across deployments without modifying source files.
 
-To configure the output hash salt, set `experimental.outputHashSalt` in `next.config.js`:
+To configure the output hash salt, set `outputHashSalt` in `next.config.js`:
 
 ```js filename="next.config.js"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    outputHashSalt: 'my-deployment-salt',
-  },
+  outputHashSalt: 'my-deployment-salt',
 }
 
 module.exports = nextConfig
@@ -21,7 +18,7 @@ module.exports = nextConfig
 
 This works with both Webpack and Turbopack bundlers.
 
-The `NEXT_HASH_SALT` environment variable can also be used for the same purpose. When both are set, the values are **concatenated** (`experimental.outputHashSalt + NEXT_HASH_SALT`) to form the effective salt. This lets you combine a per-project salt baked into the config with a per-deployment salt injected at build time via environment variable.
+The `NEXT_HASH_SALT` environment variable can also be used for the same purpose. When both are set, the values are **concatenated** (`outputHashSalt + NEXT_HASH_SALT`) to form the effective salt. This lets you combine a per-project salt baked into the config with a per-deployment salt injected at build time via environment variable.
 
 ```bash filename="Terminal"
 NEXT_HASH_SALT=my-deployment-salt next build
@@ -29,6 +26,6 @@ NEXT_HASH_SALT=my-deployment-salt next build
 
 ## Version History
 
-| Version  | Changes                                  |
-| -------- | ---------------------------------------- |
-| `16.3.0` | `experimental.outputHashSalt` was added. |
+| Version  | Changes                     |
+| -------- | --------------------------- |
+| `16.3.0` | `outputHashSalt` was added. |

--- a/docs/01-app/03-api-reference/07-adapters/12-immutable-static-assets.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/12-immutable-static-assets.mdx
@@ -9,7 +9,7 @@ When `config.supportsImmutableAssets` is enabled, Next.js outputs immutable cont
 
 At runtime, these immutable static assets are requested without the `?dpl` query parameter and thus live in a shared namespace across deployments. You must ensure that these assets are immutable and not changed (even after a new deployment) or deleted (for as long as there are active deployments using them) . Next.js may use a truncated shorter content hash as the filename, so `outputs.staticFiles[].immutableHash` contains the full content hash which can be used to validate that no hash collision occurred.
 
-You can use `config.experimental.outputHashSalt` to set a salt for the content hashes, if you want to rotate the hashes for any reason (e.g. after a detected hash collision).
+You can use `config.outputHashSalt` to set a salt for the content hashes, if you want to rotate the hashes for any reason (e.g. after a detected hash collision).
 
 Note that you need to continue supporting non-immutable static assets (which may change between deployments and continue to be requested with the `?dpl` query parameter), e.g. for the `public` folder or for older Next.js versions.
 
@@ -32,7 +32,7 @@ const adapter = {
         config.supportsImmutableAssets ?? true
 
       // Optionally, pass a salt for the content hashes
-      // config.experimental.outputHashSalt = getSaltForCurrentProject()
+      // config.outputHashSalt = getSaltForCurrentProject()
     }
     return config
   },

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1046,7 +1046,7 @@ export async function handleBuildComplete({
               path.relative(repoRoot, pageFile),
               pageFile,
               bundler,
-              config.experimental.outputHashSalt || ''
+              config.outputHashSalt || ''
             )
             continue
           }
@@ -2170,7 +2170,7 @@ async function getSharedNodeAssets({
   const pagesSharedNodeAssetsHashes: Record<string, string> = {}
   const appPagesSharedNodeAssets: Record<string, string> = {}
   const appPagesSharedNodeAssetsHashes: Record<string, string> = {}
-  const salt = config.experimental.outputHashSalt || ''
+  const salt = config.outputHashSalt || ''
 
   const moduleTypes = ['app-page', 'pages'] as const
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1371,9 +1371,7 @@ export default async function getBaseWebpackConfig(
       hashDigestLength: 16,
       // Webpack requires hashSalt to be a non-empty string; omit it entirely
       // when no salt is configured.
-      ...(config.experimental?.outputHashSalt
-        ? { hashSalt: config.experimental.outputHashSalt }
-        : {}),
+      ...(config.outputHashSalt ? { hashSalt: config.outputHashSalt } : {}),
     },
     performance: false,
     resolve: resolveConfig,
@@ -1821,7 +1819,7 @@ export default async function getBaseWebpackConfig(
                   compilerType,
                   basePath: config.basePath,
                   assetPrefix: config.assetPrefix,
-                  outputHashSalt: config.experimental?.outputHashSalt,
+                  outputHashSalt: config.outputHashSalt,
                 },
               },
             ]

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -595,6 +595,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .optional(),
     deploymentId: z.string().optional(),
     supportsImmutableAssets: z.boolean().optional(),
+    outputHashSalt: z.string().optional(),
     devIndicators: z
       .union([
         z.object({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -467,7 +467,7 @@ export function resolveCssChunkingMode(
 
 export interface ExperimentalConfig {
   /**
-   * @deprecated Use the top-level `supportsImmutableAssets` option instead.
+   * @deprecated Use the top-level `outputHashSalt` option instead.
    */
   outputHashSalt?: string
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -467,13 +467,7 @@ export function resolveCssChunkingMode(
 
 export interface ExperimentalConfig {
   /**
-   * A string that is incorporated into content-addressed output filenames
-   * (chunks, assets) for both Webpack and Turbopack. Changing this value
-   * forces all output hashes to change, which is useful for invalidating
-   * cached assets across deployments without modifying source files.
-   *
-   * When `NEXT_HASH_SALT` environment variable is also set, the two values are
-   * concatenated (`outputHashSalt + NEXT_HASH_SALT`) to form the effective salt.
+   * @deprecated Use the top-level `supportsImmutableAssets` option instead.
    */
   outputHashSalt?: string
 
@@ -1971,6 +1965,17 @@ export interface NextConfig {
    * were not detected on a per-page basis.
    */
   outputFileTracingIncludes?: Record<string, string[]>
+
+  /**
+   * A string that is incorporated into content-addressed output filenames
+   * (chunks, assets) for both Webpack and Turbopack. Changing this value
+   * forces all output hashes to change, which is useful for invalidating
+   * cached assets across deployments without modifying source files.
+   *
+   * When `NEXT_HASH_SALT` environment variable is also set, the two values are
+   * concatenated (`outputHashSalt + NEXT_HASH_SALT`) to form the effective salt.
+   */
+  outputHashSalt?: string
 
   watchOptions?: {
     pollIntervalMs?: number

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1150,8 +1150,9 @@ function assignDefaultsAndValidate(
   }
 
   if (process.env.NEXT_HASH_SALT) {
-    result.experimental.outputHashSalt =
-      (result.experimental.outputHashSalt ?? '') + process.env.NEXT_HASH_SALT
+    result.outputHashSalt =
+      (result.outputHashSalt ?? result.experimental.outputHashSalt ?? '') +
+      process.env.NEXT_HASH_SALT
   }
 
   const tracingRoot = result?.outputFileTracingRoot

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1149,10 +1149,6 @@ function assignDefaultsAndValidate(
     result.deploymentId = process.env.NEXT_DEPLOYMENT_ID
   }
 
-  if (result.experimental.outputHashSalt) {
-    result.outputHashSalt =
-      result.outputHashSalt ?? result.experimental.outputHashSalt ?? ''
-  }
   if (process.env.NEXT_HASH_SALT) {
     result.outputHashSalt =
       (result.outputHashSalt ?? '') + (process.env.NEXT_HASH_SALT ?? '')
@@ -1683,6 +1679,14 @@ function finalizeConfig(
     // Particularly output=export should just run through the adapter, with only static assets.
     // TODO remove again once output=export (and output=standalone) are using adapters.
     config.supportsImmutableAssets = false
+  }
+
+  if (
+    config.outputHashSalt !== undefined &&
+    config.experimental.outputHashSalt !== undefined
+  ) {
+    config.outputHashSalt =
+      config.outputHashSalt + config.experimental.outputHashSalt
   }
 
   return config

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1681,12 +1681,9 @@ function finalizeConfig(
     config.supportsImmutableAssets = false
   }
 
-  if (
-    config.outputHashSalt !== undefined &&
-    config.experimental.outputHashSalt !== undefined
-  ) {
+  if (config.experimental.outputHashSalt !== undefined) {
     config.outputHashSalt =
-      config.outputHashSalt + config.experimental.outputHashSalt
+      (config.outputHashSalt ?? '') + config.experimental.outputHashSalt
   }
 
   return config

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1149,10 +1149,13 @@ function assignDefaultsAndValidate(
     result.deploymentId = process.env.NEXT_DEPLOYMENT_ID
   }
 
+  if (result.experimental.outputHashSalt) {
+    result.outputHashSalt =
+      result.outputHashSalt ?? result.experimental.outputHashSalt ?? ''
+  }
   if (process.env.NEXT_HASH_SALT) {
     result.outputHashSalt =
-      (result.outputHashSalt ?? result.experimental.outputHashSalt ?? '') +
-      process.env.NEXT_HASH_SALT
+      (result.outputHashSalt ?? '') + (process.env.NEXT_HASH_SALT ?? '')
   }
 
   const tracingRoot = result?.outputFileTracingRoot

--- a/test/production/app-dir/hash-salt/hash-salt.test.ts
+++ b/test/production/app-dir/hash-salt/hash-salt.test.ts
@@ -83,14 +83,14 @@ describe('outputHashSalt', () => {
   async function buildWithSalts(opts: {
     configSalt?: string
     envSalt?: string
-    experimentalConfigSalt?: string
+    experimentalAdapterSalt?: string
     adapterSalt?: string
   }) {
     const env: Record<string, string> = {}
     if (opts.configSalt) env.OUTPUT_HASH_SALT_CONFIG = opts.configSalt
     if (opts.envSalt) env.NEXT_HASH_SALT = opts.envSalt
-    if (opts.experimentalConfigSalt)
-      env.EXPERIMENTAL_OUTPUT_HASH_SALT_CONFIG = opts.experimentalConfigSalt
+    if (opts.experimentalAdapterSalt)
+      env.EXPERIMENTAL_OUTPUT_HASH_SALT_CONFIG = opts.experimentalAdapterSalt
     if (opts.adapterSalt) env.ADAPTER_HASH_SALT = opts.adapterSalt
     await next.clean()
     await next.build({ env })
@@ -102,7 +102,7 @@ describe('outputHashSalt', () => {
 
   let noSaltChunks: string[]
   let configOnlyChunks: string[]
-  let experimentalConfigOnlyChunks: string[]
+  let experimentalAdapterChunks: string[]
   let envOnlyChunks: string[]
   let adapterEnvOnlyChunks: string[]
   let configAndEnvChunks: string[]
@@ -113,8 +113,8 @@ describe('outputHashSalt', () => {
     async () => {
       noSaltChunks = await buildWithSalts({})
       configOnlyChunks = await buildWithSalts({ configSalt: 'config-salt' })
-      experimentalConfigOnlyChunks = await buildWithSalts({
-        experimentalConfigSalt: 'config-salt',
+      experimentalAdapterChunks = await buildWithSalts({
+        experimentalAdapterSalt: 'experimental-adapter-salt',
       })
       envOnlyChunks = await buildWithSalts({ envSalt: 'env-salt' })
       adapterEnvOnlyChunks = await buildWithSalts({
@@ -140,10 +140,6 @@ describe('outputHashSalt', () => {
     expect(configOnlyChunks).not.toEqual(noSaltChunks)
   })
 
-  it('experimental config salt changes filenames compared to no salt', () => {
-    expect(experimentalConfigOnlyChunks).not.toEqual(noSaltChunks)
-  })
-
   it('config-and-env salt differs', () => {
     expect(configAndEnvChunks).not.toEqual(envOnlyChunks)
     expect(configAndEnvChunks).not.toEqual(configOnlyChunks)
@@ -157,5 +153,9 @@ describe('outputHashSalt', () => {
   it('env-and-adapter-env salt differs', () => {
     expect(envAndAdapterEnvChunks).not.toEqual(envOnlyChunks)
     expect(envAndAdapterEnvChunks).not.toEqual(adapterEnvOnlyChunks)
+  })
+
+  it('adapter experimental config salt changes filenames compared to no salt', () => {
+    expect(experimentalAdapterChunks).not.toEqual(noSaltChunks)
   })
 })

--- a/test/production/app-dir/hash-salt/hash-salt.test.ts
+++ b/test/production/app-dir/hash-salt/hash-salt.test.ts
@@ -72,7 +72,7 @@ describe('NEXT_HASH_SALT', () => {
   })
 })
 
-describe('experimental.outputHashSalt', () => {
+describe('outputHashSalt', () => {
   // Uses the fixture's next.config.js which reads OUTPUT_HASH_SALT_CONFIG from env,
   // allowing multiple builds with different config salts from a single next instance.
   const { next } = nextTestSetup({
@@ -83,11 +83,14 @@ describe('experimental.outputHashSalt', () => {
   async function buildWithSalts(opts: {
     configSalt?: string
     envSalt?: string
+    experimentalConfigSalt?: string
     adapterSalt?: string
   }) {
     const env: Record<string, string> = {}
     if (opts.configSalt) env.OUTPUT_HASH_SALT_CONFIG = opts.configSalt
     if (opts.envSalt) env.NEXT_HASH_SALT = opts.envSalt
+    if (opts.experimentalConfigSalt)
+      env.EXPERIMENTAL_OUTPUT_HASH_SALT_CONFIG = opts.experimentalConfigSalt
     if (opts.adapterSalt) env.ADAPTER_HASH_SALT = opts.adapterSalt
     await next.clean()
     await next.build({ env })
@@ -99,6 +102,7 @@ describe('experimental.outputHashSalt', () => {
 
   let noSaltChunks: string[]
   let configOnlyChunks: string[]
+  let experimentalConfigOnlyChunks: string[]
   let envOnlyChunks: string[]
   let adapterEnvOnlyChunks: string[]
   let configAndEnvChunks: string[]
@@ -109,6 +113,9 @@ describe('experimental.outputHashSalt', () => {
     async () => {
       noSaltChunks = await buildWithSalts({})
       configOnlyChunks = await buildWithSalts({ configSalt: 'config-salt' })
+      experimentalConfigOnlyChunks = await buildWithSalts({
+        experimentalConfigSalt: 'config-salt',
+      })
       envOnlyChunks = await buildWithSalts({ envSalt: 'env-salt' })
       adapterEnvOnlyChunks = await buildWithSalts({
         adapterSalt: 'adapter-salt',
@@ -131,6 +138,10 @@ describe('experimental.outputHashSalt', () => {
 
   it('config salt changes filenames compared to no salt', () => {
     expect(configOnlyChunks).not.toEqual(noSaltChunks)
+  })
+
+  it('experimental config salt changes filenames compared to no salt', () => {
+    expect(experimentalConfigOnlyChunks).not.toEqual(noSaltChunks)
   })
 
   it('config-and-env salt differs', () => {

--- a/test/production/app-dir/hash-salt/my-adapter.mjs
+++ b/test/production/app-dir/hash-salt/my-adapter.mjs
@@ -4,9 +4,8 @@ const myAdapter = {
   name: 'my-custom-adapter',
   modifyConfig: (config) => {
     if (process.env.ADAPTER_HASH_SALT != null) {
-      config.experimental.outputHashSalt =
-        (config.experimental.outputHashSalt ?? '') +
-        process.env.ADAPTER_HASH_SALT
+      config.outputHashSalt =
+        (config.outputHashSalt ?? '') + process.env.ADAPTER_HASH_SALT
     }
     return config
   },

--- a/test/production/app-dir/hash-salt/my-adapter.mjs
+++ b/test/production/app-dir/hash-salt/my-adapter.mjs
@@ -7,6 +7,11 @@ const myAdapter = {
       config.outputHashSalt =
         (config.outputHashSalt ?? '') + process.env.ADAPTER_HASH_SALT
     }
+    if (process.env.EXPERIMENTAL_OUTPUT_HASH_SALT_CONFIG != null) {
+      config.experimental.outputHashSalt =
+        (config.experimental.outputHashSalt ?? '') +
+        process.env.EXPERIMENTAL_OUTPUT_HASH_SALT_CONFIG
+    }
     return config
   },
 }

--- a/test/production/app-dir/hash-salt/next.config.js
+++ b/test/production/app-dir/hash-salt/next.config.js
@@ -1,8 +1,10 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  // Allow tests to inject outputHashSalt via env var without touching source.
+  outputHashSalt: process.env.OUTPUT_HASH_SALT_CONFIG || undefined,
   experimental: {
-    // Allow tests to inject outputHashSalt via env var without touching source.
-    outputHashSalt: process.env.OUTPUT_HASH_SALT_CONFIG || undefined,
+    outputHashSalt:
+      process.env.EXPERIMENTAL_OUTPUT_HASH_SALT_CONFIG || undefined,
   },
   adapterPath: require.resolve('./my-adapter.mjs'),
 }

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -22008,8 +22008,7 @@
       "NEXT_HASH_SALT should produce image files",
       "outputHashSalt combined salt differs from config-only salt",
       "outputHashSalt combined salt differs from env-var-only salt",
-      "outputHashSalt config salt changes filenames compared to no salt",
-      "outputHashSalt experimental config salt changes filenames compared to no salt"
+      "outputHashSalt config salt changes filenames compared to no salt"
     ],
     "failed": [],
     "pending": [],

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -22006,9 +22006,10 @@
       "NEXT_HASH_SALT should produce chunk files",
       "NEXT_HASH_SALT should produce css files",
       "NEXT_HASH_SALT should produce image files",
-      "experimental.outputHashSalt combined salt differs from config-only salt",
-      "experimental.outputHashSalt combined salt differs from env-var-only salt",
-      "experimental.outputHashSalt config salt changes filenames compared to no salt"
+      "outputHashSalt combined salt differs from config-only salt",
+      "outputHashSalt combined salt differs from env-var-only salt",
+      "outputHashSalt config salt changes filenames compared to no salt",
+      "outputHashSalt experimental config salt changes filenames compared to no salt"
     ],
     "failed": [],
     "pending": [],


### PR DESCRIPTION
Keep reading `config.experimental.outputHashSalt` for now to not break existing adapters until they are migrated.