### PR TITLE
[ci] Avoid apt-get in the next-stats-action Docker image

### DIFF
--- a/.github/actions/next-stats-action/Dockerfile
+++ b/.github/actions/next-stats-action/Dockerfile
@@ -1,11 +1,8 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM ubuntu:24.04 AS base
-
-# use apt-get instead of apt, because apt does not have a stable CLI interface
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends curl ca-certificates git
+# buildpack-deps already includes curl, ca-certificates, and git, so we avoid
+# apt-get entirely (the arm64 apt mirror, ports.ubuntu.com, is unreliable).
+FROM buildpack-deps:noble-scm AS base
 
 RUN curl -sfLS https://install-node.vercel.app/v20.9.0 | bash -s -- -f
 RUN npm i -g corepack@0.34.6

--- a/.github/next-stats-action.Dockerfile
+++ b/.github/next-stats-action.Dockerfile
@@ -1,11 +1,8 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM ubuntu:24.04 AS base
-
-# use apt-get instead of apt, because apt does not have a stable CLI interface
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends curl ca-certificates git
+# buildpack-deps already includes curl, ca-certificates, and git, so we avoid
+# apt-get entirely (the arm64 apt mirror, ports.ubuntu.com, is unreliable).
+FROM buildpack-deps:noble-scm AS base
 
 RUN curl -sfLS https://install-node.vercel.app/v20.9.0 | bash -s -- -f
 RUN npm i -g corepack@0.34.6


### PR DESCRIPTION

The `Stats (webpack)` / `Stats (turbopack)` CI jobs have been intermittently failing on PRs and canary (e.g. [this run](https://github.com/vercel/next.js/actions/runs/29476089144/job/87563318723)). The jobs run on arm64 runners, where the `ubuntu:24.04` base image fetches apt packages from `ports.ubuntu.com`, which is intermittently unreachable. Since `apt-get update` only warns when index fetches fail, the Docker build breaks one layer later at `apt-get install` with "Unable to locate package curl".

This change switches the base image to `buildpack-deps:noble-scm`, which already ships curl, ca-certificates, and git, so the build no longer makes any apt calls at all. The `apt-get upgrade` step is dropped along with it; it was already a silent no-op whenever the mirror was down, and the ephemeral CI container does not rely on it.

Both `.github/next-stats-action.Dockerfile` (the one CI builds via `action.yml`) and the duplicate `.github/actions/next-stats-action/Dockerfile` are updated to stay in sync.
