### PR TITLE
Test async modules deployment

### DIFF
--- a/test/e2e/async-modules/index.test.ts
+++ b/test/e2e/async-modules/index.test.ts
@@ -6,6 +6,8 @@ describe('Async modules', () => {
     files: __dirname,
   })
 
+  console.log('noop, see if this passes in CI')
+
   it('ssr async page modules', async () => {
     const $ = await next.render$('/')
     expect($('#app-value').text()).toBe('hello')


### PR DESCRIPTION
### Why?

Check whether the async modules deployment test still fails on the latest canary.

### How?

Replay the existing async modules deployment diagnostic on the latest canary.