### PR TITLE
Test middleware-general deployment

### DIFF
--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -7,6 +7,8 @@ import { check, fetchViaHTTP, waitFor } from 'next-test-utils'
 
 const urlsError = 'Please use only absolute URLs'
 
+console.log('noop, see if this passes in CI')
+
 describe('Middleware Runtime', () => {
   const isNodeMiddleware = Boolean(process.env.TEST_NODE_MIDDLEWARE)
 


### PR DESCRIPTION
### Why?

Check whether the middleware-general deployment test still fails on the latest canary.

### How?

Replay the existing middleware-general deployment diagnostic on the latest canary.