### PR TITLE
Test skip-trailing-slash-redirect deployment

### DIFF
--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -11,6 +11,8 @@ import {
 import { join } from 'path'
 import cheerio from 'cheerio'
 
+console.log('does test-deploy pass?')
+
 describe('skip-trailing-slash-redirect', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),


### PR DESCRIPTION
### Why?

Check whether the skip-trailing-slash-redirect deployment test still fails on the latest canary.

### How?

Replay the existing skip-trailing-slash-redirect deployment diagnostic on the latest canary.