### PR TITLE
docs: expand and modernize the Single-Page Applications guide

### DIFF
--- a/docs/01-app/01-getting-started/05-server-and-client-components.mdx
+++ b/docs/01-app/01-getting-started/05-server-and-client-components.mdx
@@ -416,6 +416,8 @@ Your Server Component will now be able to directly render your provider, and all
 
 > **Good to know**: You should render providers as deep as possible in the tree – notice how `ThemeProvider` only wraps `{children}` instead of the entire `<html>` document. This makes it easier for Next.js to optimize the static parts of your Server Components.
 
+To pass server-fetched data through context and read it in Client Components with `use()`, see [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider).
+
 ### Third-party components
 
 When using a third-party component that relies on client-only features, you can wrap it in a Client Component to ensure it works as expected.

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -538,11 +538,9 @@ export default async function Page({ params }) {
 
 > **Good to know:** If one request fails when using `Promise.all`, the entire operation will fail. To handle this, you can use the [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) method instead.
 
-### Sharing data with context and `React.cache`
+### Reusing data with `React.cache`
 
-You can share fetched data across both Server and Client Components by combining [`React.cache`](https://react.dev/reference/react/cache) with context providers.
-
-Create a cached function that fetches data:
+Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:
 
 ```ts filename="app/lib/user.ts" switcher
 import { cache } from 'react'
@@ -562,144 +560,7 @@ export const getUser = cache(async () => {
 })
 ```
 
-Create a context provider that stores the promise:
-
-```tsx filename="app/user-provider.tsx" switcher
-'use client'
-
-import { createContext } from 'react'
-
-type User = {
-  id: string
-  name: string
-}
-
-export const UserContext = createContext<Promise<User> | null>(null)
-
-export default function UserProvider({
-  children,
-  userPromise,
-}: {
-  children: React.ReactNode
-  userPromise: Promise<User>
-}) {
-  return <UserContext value={userPromise}>{children}</UserContext>
-}
-```
-
-```jsx filename="app/user-provider.js" switcher
-'use client'
-
-import { createContext } from 'react'
-
-export const UserContext = createContext(null)
-
-export default function UserProvider({ children, userPromise }) {
-  return <UserContext value={userPromise}>{children}</UserContext>
-}
-```
-
-In a layout, pass the promise to the provider without awaiting:
-
-```tsx filename="app/layout.tsx" switcher
-import UserProvider from './user-provider'
-import { getUser } from './lib/user'
-
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  const userPromise = getUser() // Don't await
-
-  return (
-    <html>
-      <body>
-        <UserProvider userPromise={userPromise}>{children}</UserProvider>
-      </body>
-    </html>
-  )
-}
-```
-
-```jsx filename="app/layout.js" switcher
-import UserProvider from './user-provider'
-import { getUser } from './lib/user'
-
-export default function RootLayout({ children }) {
-  const userPromise = getUser() // Don't await
-
-  return (
-    <html>
-      <body>
-        <UserProvider userPromise={userPromise}>{children}</UserProvider>
-      </body>
-    </html>
-  )
-}
-```
-
-Client Components use [`use()`](https://react.dev/reference/react/use) to resolve the promise from context, wrapped in `<Suspense>` for fallback UI:
-
-```tsx filename="app/ui/profile.tsx" switcher
-'use client'
-
-import { use, useContext } from 'react'
-import { UserContext } from '../user-provider'
-
-export function Profile() {
-  const userPromise = useContext(UserContext)
-  if (!userPromise) {
-    throw new Error('useContext must be used within a UserProvider')
-  }
-  const user = use(userPromise)
-  return <p>Welcome, {user.name}</p>
-}
-```
-
-```jsx filename="app/ui/profile.js" switcher
-'use client'
-
-import { use, useContext } from 'react'
-import { UserContext } from '../user-provider'
-
-export function Profile() {
-  const userPromise = useContext(UserContext)
-  if (!userPromise) {
-    throw new Error('useContext must be used within a UserProvider')
-  }
-  const user = use(userPromise)
-  return <p>Welcome, {user.name}</p>
-}
-```
-
-```tsx filename="app/page.tsx" switcher
-import { Suspense } from 'react'
-import { Profile } from './ui/profile'
-
-export default function Page() {
-  return (
-    <Suspense fallback={<div>Loading profile...</div>}>
-      <Profile />
-    </Suspense>
-  )
-}
-```
-
-```jsx filename="app/page.js" switcher
-import { Suspense } from 'react'
-import { Profile } from './ui/profile'
-
-export default function Page() {
-  return (
-    <Suspense fallback={<div>Loading profile...</div>}>
-      <Profile />
-    </Suspense>
-  )
-}
-```
-
-Server Components can also call `getUser()` directly:
+Server Components can call `getUser()` directly:
 
 ```tsx filename="app/dashboard/page.tsx" switcher
 import { getUser } from '../lib/user'
@@ -720,5 +581,7 @@ export default async function DashboardPage() {
 ```
 
 Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
+
+You can resolve a Promise on the server with `await`, or pass it to a Client Component and resolve it there with [`use()`](https://react.dev/reference/react/use). React covers [when to resolve a Promise in a Server or Client Component](https://react.dev/reference/react/use#resolve-promise-in-server-or-client-component). To share the cached value with Client Components through context, see [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider).
 
 > **Good to know**: `React.cache` is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -2,9 +2,10 @@
 title: Fetching Data
 description: Learn how to fetch data and stream content that depends on data.
 related:
-  title: API Reference
-  description: Learn more about the features mentioned in this page by reading the API Reference.
+  title: Next steps
+  description: Learn more about advanced data-fetching patterns and the features mentioned in this page.
   links:
+    - app/guides/single-page-applications
     - app/guides/data-security
     - app/api-reference/functions/fetch
     - app/api-reference/file-conventions/loading
@@ -313,6 +314,8 @@ export default function Posts({ posts }) {
 
 In the example above, the `<Posts>` component is wrapped in a [`<Suspense>` boundary](https://react.dev/reference/react/Suspense). This means the fallback will be shown while the promise is being resolved. Learn more about [streaming](#streaming).
 
+You can resolve a promise on the server with `await` or in a Client Component with `use()`. React covers [when to resolve a Promise in a Server or Client Component](https://react.dev/reference/react/use#resolve-promise-in-server-or-client-component). To share one promise with many Client Components instead of passing it as a prop, provide it through context. See [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider).
+
 #### Community libraries
 
 You can use a community library like [SWR](https://swr.vercel.app/) or [React Query](https://tanstack.com/query/latest) to fetch data in Client Components. These libraries have their own semantics for caching, streaming, and other features. For example, with SWR:
@@ -581,7 +584,5 @@ export default async function DashboardPage() {
 ```
 
 Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
-
-You can resolve a Promise on the server with `await`, or pass it to a Client Component and resolve it there with [`use()`](https://react.dev/reference/react/use). React covers [when to resolve a Promise in a Server or Client Component](https://react.dev/reference/react/use#resolve-promise-in-server-or-client-component). To share the cached value with Client Components through context, see [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider).
 
 > **Good to know**: `React.cache` is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.

--- a/docs/01-app/01-getting-started/08-caching.mdx
+++ b/docs/01-app/01-getting-started/08-caching.mdx
@@ -523,7 +523,7 @@ function SlugHeading({ slug }: { slug: string }) {
 
 Now `<Sidebar />`, `{children}`, and the Suspense fallback are all part of the static shell. Only `SlugHeading` streams in at request time. You can also pass the entire `params` promise and await it in the child component.
 
-The same principle applies to `cookies()`, `headers()`, `searchParams`, and data fetches. See [Sharing data with context and `React.cache`](/docs/app/getting-started/fetching-data#sharing-data-with-context-and-reactcache) for a related pattern.
+The same principle applies to `cookies()`, `headers()`, `searchParams`, and data fetches. See [Reusing data with `React.cache`](/docs/app/getting-started/fetching-data#reusing-data-with-reactcache) for a related pattern.
 
 ### Instant navigation
 

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1361,7 +1361,7 @@ Session and user data often appear in shell UI (header, nav) that repeats across
 
 If only part of the shell needs session data (for example, a user menu), move the `await` into a nested Server Component and wrap it in `<Suspense>` so the rest of the page streams first. See [Push dynamic access down](/docs/app/guides/streaming#push-dynamic-access-down) for the pattern.
 
-Client Components can't import the DAL. Run `verifySession()`, `getUser()`, or similar in a parent Server Component, then pass data to client children as props or through a [Context Provider](#context-providers). To share data across multiple Server Components without re-fetching, see [Sharing data with context and `React.cache`](/docs/app/getting-started/fetching-data#sharing-data-with-context-and-reactcache).
+Client Components can't import the DAL. Run `verifySession()`, `getUser()`, or similar in a parent Server Component, then pass data to client children as props or through a [Context Provider](#context-providers). To share data across multiple Server Components without re-fetching, see [Reusing data with `React.cache`](/docs/app/getting-started/fetching-data#reusing-data-with-reactcache).
 
 #### Auth checks in page components
 
@@ -1599,6 +1599,8 @@ export default function Profile() {
 ```
 
 If session data is needed in Client Components (e.g. for client-side data fetching), use React’s [`taintUniqueValue`](https://react.dev/reference/react/experimental_taintUniqueValue) API to prevent sensitive session data from being exposed to the client.
+
+For the general pattern of passing server-fetched data through context and reading it with `use()`, see [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider).
 
 </AppOnly>
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -35,7 +35,7 @@ Let's explore common patterns used to build SPAs and how Next.js solves them.
 
 We recommend fetching data in a parent component (or layout), returning the Promise, and then unwrapping the value in a Client Component with React’s [`use` API](https://react.dev/reference/react/use).
 
-Next.js can start data fetching early on the server. In this example, that’s the root layout — the entry point to your application. The server can immediately begin streaming a response to the client.
+Next.js can start data fetching early on the server. In this example, that’s the root layout, the entry point to your application. The server can immediately begin streaming a response to the client.
 
 By “hoisting” your data fetching to the root layout, Next.js starts the specified requests on the server early before any other components in your application. This eliminates client waterfalls and prevents having multiple roundtrips between client and server. It can also significantly improve performance, as your server is closer (and ideally colocated) to where your database is located.
 
@@ -184,6 +184,8 @@ With SWR 2.3.0 (and React 19+), you can gradually adopt server features alongsid
 - **Server-only:** `useSWR(key)` + RSC-provided data
 - **Mixed:** `useSWR(key, fetcher)` + RSC-provided data
 
+> **Good to know:** Reach for SWR when you need its client-side features, such as revalidation on focus or interval, [`mutate`](https://swr.vercel.app/docs/mutation), or request deduplication across components. If a Client Component only needs to read server data once, pass a Promise to it and unwrap it with [`use()`](#using-reacts-use-within-a-context-provider) instead. That avoids adding a data-fetching library for data that never revalidates on the client.
+
 For example, wrap your application with `<SWRConfig>` and a `fallback`:
 
 ```tsx filename="app/layout.tsx" switcher
@@ -273,11 +275,199 @@ Since the initial `fallback` data is automatically handled by Next.js, you can n
 | Deduplicate requests | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | Client-side features | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> |
 
+#### Scoping server data to the components that use it
+
+`<SWRConfig>` can live in any Server Component, not only the root layout. Placing it on the route segment that owns the data keeps the `fallback` close to where it is read, keeps unrelated keys out of a global config, and lets each segment start its own server-side requests:
+
+```tsx filename="app/projects/[id]/page.tsx" switcher
+import { SWRConfig } from 'swr'
+import { getProject } from './data' // some server-side function
+import { ProjectView } from './project-view'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  return (
+    <SWRConfig
+      value={{
+        fallback: {
+          // Start the request on the server without awaiting it.
+          // Only components that read this key will suspend.
+          [`/api/projects/${id}`]: getProject(id),
+        },
+      }}
+    >
+      <ProjectView id={id} />
+    </SWRConfig>
+  )
+}
+```
+
+```jsx filename="app/projects/[id]/page.js" switcher
+import { SWRConfig } from 'swr'
+import { getProject } from './data' // some server-side function
+import { ProjectView } from './project-view'
+
+export default async function Page({ params }) {
+  const { id } = await params
+
+  return (
+    <SWRConfig
+      value={{
+        fallback: {
+          // Start the request on the server without awaiting it.
+          // Only components that read this key will suspend.
+          [`/api/projects/${id}`]: getProject(id),
+        },
+      }}
+    >
+      <ProjectView id={id} />
+    </SWRConfig>
+  )
+}
+```
+
+The Client Component reads the data with `useSWR` using the same key:
+
+```tsx filename="app/projects/[id]/project-view.tsx" switcher
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json())
+
+export function ProjectView({ id }: { id: string }) {
+  // This key must match the `fallback` key exactly. If it does not, the
+  // server data is ignored and SWR fetches again on the client.
+  const { data } = useSWR(`/api/projects/${id}`, fetcher)
+
+  return <h1>{data.name}</h1>
+}
+```
+
+```jsx filename="app/projects/[id]/project-view.js" switcher
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url) => fetch(url).then((res) => res.json())
+
+export function ProjectView({ id }) {
+  // This key must match the `fallback` key exactly. If it does not, the
+  // server data is ignored and SWR fetches again on the client.
+  const { data } = useSWR(`/api/projects/${id}`, fetcher)
+
+  return <h1>{data.name}</h1>
+}
+```
+
+> **Good to know:** The `fallback` key and the `useSWR` key must match exactly, since SWR looks up the seeded value by key. Nothing warns on a mismatch: the seeded value is never read, `data` starts as `undefined`, and SWR fetches again on the client. When a key is built from dynamic values (route params, search params), derive it in one shared place so the server and client cannot drift apart. To reuse the same request when SWR revalidates after hydration rather than starting a new one, see [`preload`](https://swr.vercel.app/docs/prefetching).
+
 ### SPAs with React Query
 
-You can use React Query with Next.js on both the client and server. This enables you to build both strict SPAs, as well as take advantage of server features in Next.js paired with React Query.
+You can use React Query with Next.js on the client and the server, and seed its cache from a Server Component the same way as [SWR](#spas-with-swr): prefetch on the server, hand the cache to the client, and let React Query own revalidation from there.
 
-Learn more in the [React Query documentation](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr).
+A Server Component starts the request with `prefetchQuery` **without awaiting it**, then serializes the cache into the streamed HTML with `<HydrationBoundary>`:
+
+```tsx filename="app/projects/[id]/page.tsx" switcher
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { getQueryClient } from '@/app/get-query-client'
+import { getProject } from './data' // runs on the server and the client
+import { ProjectView } from './project-view'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const queryClient = getQueryClient()
+
+  // Start the request on the server without awaiting it, so rendering is
+  // not blocked. Only components that read this query will suspend.
+  queryClient.prefetchQuery({
+    queryKey: ['project', id],
+    queryFn: () => getProject(id),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProjectView id={id} />
+    </HydrationBoundary>
+  )
+}
+```
+
+```jsx filename="app/projects/[id]/page.js" switcher
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { getQueryClient } from '@/app/get-query-client'
+import { getProject } from './data' // runs on the server and the client
+import { ProjectView } from './project-view'
+
+export default async function Page({ params }) {
+  const { id } = await params
+  const queryClient = getQueryClient()
+
+  // Start the request on the server without awaiting it, so rendering is
+  // not blocked. Only components that read this query will suspend.
+  queryClient.prefetchQuery({
+    queryKey: ['project', id],
+    queryFn: () => getProject(id),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProjectView id={id} />
+    </HydrationBoundary>
+  )
+}
+```
+
+The Client Component reads the data with `useSuspenseQuery` (or `useQuery`) using the same query key:
+
+```tsx filename="app/projects/[id]/project-view.tsx" switcher
+'use client'
+
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { getProject } from './data'
+
+export function ProjectView({ id }: { id: string }) {
+  // This query key must match the server prefetch, or the hydrated cache
+  // is ignored and React Query fetches again on the client.
+  const { data } = useSuspenseQuery({
+    queryKey: ['project', id],
+    queryFn: () => getProject(id),
+  })
+
+  return <h1>{data.name}</h1>
+}
+```
+
+```jsx filename="app/projects/[id]/project-view.js" switcher
+'use client'
+
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { getProject } from './data'
+
+export function ProjectView({ id }) {
+  // This query key must match the server prefetch, or the hydrated cache
+  // is ignored and React Query fetches again on the client.
+  const { data } = useSuspenseQuery({
+    queryKey: ['project', id],
+    queryFn: () => getProject(id),
+  })
+
+  return <h1>{data.name}</h1>
+}
+```
+
+The query key connects the two sides, the same way the matching `fallback` and `useSWR` keys do above.
+
+> **Good to know:** This example assumes the one-time setup React Query requires: a shared `getQueryClient` (a new instance per request on the server, a singleton in the browser), a `<QueryClientProvider>` Client Component wrapping your app, and the client configured to dehydrate pending queries so data can stream. React Query also ships an experimental `@tanstack/react-query-next-experimental` package that streams without an explicit prefetch, at the cost of reintroducing request waterfalls on navigation. Because React Query owns and continues to evolve this integration, follow the [React Query App Router guide](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr) for the full setup and current APIs.
 
 ### Rendering components only in the browser
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -290,7 +290,7 @@ export function Profile() {
 
 The `fallback` data can be prerendered and included in the initial HTML response, then immediately read in the child components using `useSWR`. SWR’s polling, revalidation, and caching still run **client-side only**, so it preserves all the interactivity you rely on for an SPA.
 
-Because Next.js seeds the `fallback` on the server, `useSWR` has data on first render, so there's no need for conditional logic to handle an `undefined` `data`. Note that `isLoading` still flips to `true` while SWR revalidates on the client, even though the seeded `data` is present, so avoid gating the whole render on `isLoading`. To suspend at the closest `<Suspense>` boundary instead, enable SWR's [Suspense mode](https://swr.vercel.app/docs/suspense).
+Because Next.js seeds the `fallback` on the server, `useSWR` has data on first render, so there's no need for conditional logic to handle an `undefined` `data`. The seeded data counts as loaded, so [`isLoading`](https://swr.vercel.app/docs/advanced/understanding#combining-with-isloading-and-isvalidating-for-better-ux) stays `false`. A client-side revalidation surfaces as `isValidating` instead, which you can use to show a background-refresh indicator.
 
 |                      | SWR                 | RSC                 | RSC + SWR           |
 | -------------------- | ------------------- | ------------------- | ------------------- |

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -218,7 +218,7 @@ With SWR 2.3.0 (and React 19+), you can gradually adopt server features alongsid
 
 Reach for SWR when you need its client-side features, such as revalidation on focus or interval, [`mutate`](https://swr.vercel.app/docs/mutation), or request deduplication across components. If a Client Component only needs to read server data once, pass a Promise to it and unwrap it with [`use()`](#using-reacts-use-within-a-context-provider) instead. That avoids adding a data-fetching library for data that never revalidates on the client.
 
-To seed the client cache from the server, wrap your application in `<SWRConfig>` and provide a `fallback`:
+To provide server data to SWR on the first render, wrap your application in `<SWRConfig>` and provide a `fallback`:
 
 ```tsx filename="app/layout.tsx" switcher
 import { SWRConfig } from 'swr'
@@ -401,7 +401,7 @@ export function ProjectView({ id }) {
 }
 ```
 
-> **Good to know:** The `fallback` key and the `useSWR` key must match exactly, since SWR looks up the seeded value by key. Nothing warns on a mismatch: the seeded value is never read, `data` starts as `undefined`, and SWR fetches again on the client. When a key is built from dynamic values (route params, search params), derive it in one shared place so the server and client cannot drift apart. To reuse the same request when SWR revalidates after hydration rather than starting a new one, see [`preload`](https://swr.vercel.app/docs/prefetching).
+> **Good to know:** The `fallback` key and the `useSWR` key must match exactly, since SWR looks up the seeded value by key. Nothing warns on a mismatch: the seeded value is never read, `data` starts as `undefined`, and SWR fetches again on the client. When a key is built from dynamic values (route params, search params), derive it in one shared place so the server and client cannot drift apart. `fallback` seeds the first render, not SWR's persistent cache, so use [`preload`](https://swr.vercel.app/docs/prefetching) to fill the cache and reuse the request on revalidation.
 
 See the [live demo](https://next-spa-patterns.labs.vercel.dev/swr) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/swr).
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -93,7 +93,7 @@ The provider forwards the Promise through context:
 ```tsx filename="app/user-provider.tsx" switcher
 'use client'
 
-import { createContext, use, useContext } from 'react'
+import { createContext, useContext } from 'react'
 
 type User = { id: string; name: string }
 
@@ -104,7 +104,7 @@ export function useUser() {
   if (!userPromise) {
     throw new Error('useUser must be used within a UserProvider')
   }
-  return use(userPromise)
+  return userPromise
 }
 
 export function UserProvider({
@@ -123,7 +123,7 @@ export function UserProvider({
 ```js filename="app/user-provider.js" switcher
 'use client'
 
-import { createContext, use, useContext } from 'react'
+import { createContext, useContext } from 'react'
 
 const UserContext = createContext(null)
 
@@ -132,7 +132,7 @@ export function useUser() {
   if (!userPromise) {
     throw new Error('useUser must be used within a UserProvider')
   }
-  return use(userPromise)
+  return userPromise
 }
 
 export function UserProvider({ children, userPromise }) {
@@ -142,15 +142,17 @@ export function UserProvider({ children, userPromise }) {
 }
 ```
 
-Finally, call the `useUser()` hook in any Client Component. It unwraps the Promise with `use()` internally, so the component suspends until the data is ready:
+Finally, call the `useUser()` hook in any Client Component and unwrap the Promise with `use()`, which suspends the component until the data is ready:
 
 ```tsx filename="app/profile.tsx" switcher
 'use client'
 
+import { use } from 'react'
 import { useUser } from './user-provider'
 
 export function Profile() {
-  const user = useUser()
+  const userPromise = useUser()
+  const user = use(userPromise)
 
   return '...'
 }
@@ -159,14 +161,18 @@ export function Profile() {
 ```jsx filename="app/profile.js" switcher
 'use client'
 
+import { use } from 'react'
 import { useUser } from './user-provider'
 
 export function Profile() {
-  const user = useUser()
+  const userPromise = useUser()
+  const user = use(userPromise)
 
   return '...'
 }
 ```
+
+You can also move the `use()` call into the `useUser` hook so components just call `const user = useUser()`. That reads cleanly, but calling `use()` in the component keeps it clear where the component suspends.
 
 Wrap the consumer in a `<Suspense>` boundary to show a fallback while the Promise resolves:
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -42,13 +42,13 @@ The following examples cover common patterns for building an SPA with Next.js. T
 
 ### Using React’s `use` within a Context Provider
 
-You can use React’s [`use` API](https://react.dev/reference/react/use) to stream data from the server to a Client Component. Fetch the data in a Server Component (a parent or layout) and pass the Promise down; the Client Component unwraps it with `use()`, since it cannot `await` during render.
+You can use React’s [`use` API](https://react.dev/reference/react/use) to stream data from the server to a Client Component. Fetch the data in a Server Component (a parent or layout) and pass the Promise down. The Client Component unwraps it with `use()`, since it cannot `await` during render.
 
 Starting the request on the server, before the rest of the app renders, lets the response stream immediately and avoids client-side request waterfalls.
 
 You can pass a single Promise as a prop and unwrap it with `use()`, or pair it with a React context provider so any Client Component can read the value through a custom hook. A provider isn't always the best fit: often you can read the data in a Server Component, or pass the Promise directly, rather than putting everything in context. For general client-side data fetching, a library like [SWR](#spas-with-swr) can help.
 
-Start the request in your root layout without awaiting it, and pass the Promise to the provider:
+Start the request in a Server Component (here, the root layout) without awaiting it, and pass the Promise to the provider:
 
 ```tsx filename="app/layout.tsx" switcher
 import { UserProvider } from './user-provider'
@@ -84,80 +84,73 @@ export default function RootLayout({ children }) {
 }
 ```
 
-If several components read the same data in one request, wrap `getUser` in React's [`cache`](https://react.dev/reference/react/cache) so they share a single call.
+> **Good to know:** Refetching a Promise set high in the tree re-runs the Server Component that set it, so for data only part of the app needs, place the provider on that subtree instead of the root layout. See React's [caveat on reading a Promise from context](https://react.dev/reference/react/use#reading-a-promise-from-context).
+
+If several components read the same data in one request, wrap `getUser` in React's [`cache`](https://react.dev/reference/react/cache) so they share a single call. See [Reusing data with `React.cache`](/docs/app/getting-started/fetching-data#reusing-data-with-reactcache) for more on this pattern.
 
 The provider forwards the Promise through context:
 
-```ts filename="app/user-provider.ts" switcher
-'use client';
+```tsx filename="app/user-provider.tsx" switcher
+'use client'
 
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, use, useContext } from 'react'
 
-type User = any;
-type UserContextType = {
-  userPromise: Promise<User | null>;
-};
+type User = { id: string; name: string }
 
-const UserContext = createContext<UserContextType | null>(null);
+const UserContext = createContext<Promise<User> | null>(null)
 
-export function useUser(): UserContextType {
-  let context = useContext(UserContext);
-  if (context === null) {
-    throw new Error('useUser must be used within a UserProvider');
+export function useUser() {
+  const userPromise = useContext(UserContext)
+  if (!userPromise) {
+    throw new Error('useUser must be used within a UserProvider')
   }
-  return context;
+  return use(userPromise)
 }
 
 export function UserProvider({
   children,
-  userPromise
+  userPromise,
 }: {
-  children: ReactNode;
-  userPromise: Promise<User | null>;
+  children: React.ReactNode
+  userPromise: Promise<User>
 }) {
   return (
-    <UserContext.Provider value={{ userPromise }}>
-      {children}
-    </UserContext.Provider>
-  );
+    <UserContext.Provider value={userPromise}>{children}</UserContext.Provider>
+  )
 }
 ```
 
 ```js filename="app/user-provider.js" switcher
 'use client'
 
-import { createContext, useContext, ReactNode } from 'react'
+import { createContext, use, useContext } from 'react'
 
 const UserContext = createContext(null)
 
 export function useUser() {
-  let context = useContext(UserContext)
-  if (context === null) {
+  const userPromise = useContext(UserContext)
+  if (!userPromise) {
     throw new Error('useUser must be used within a UserProvider')
   }
-  return context
+  return use(userPromise)
 }
 
 export function UserProvider({ children, userPromise }) {
   return (
-    <UserContext.Provider value={{ userPromise }}>
-      {children}
-    </UserContext.Provider>
+    <UserContext.Provider value={userPromise}>{children}</UserContext.Provider>
   )
 }
 ```
 
-Finally, you can call the `useUser()` custom hook in any Client Component and unwrap the Promise:
+Finally, call the `useUser()` hook in any Client Component. It unwraps the Promise with `use()` internally, so the component suspends until the data is ready:
 
 ```tsx filename="app/profile.tsx" switcher
 'use client'
 
-import { use } from 'react'
 import { useUser } from './user-provider'
 
 export function Profile() {
-  const { userPromise } = useUser()
-  const user = use(userPromise)
+  const user = useUser()
 
   return '...'
 }
@@ -166,14 +159,40 @@ export function Profile() {
 ```jsx filename="app/profile.js" switcher
 'use client'
 
-import { use } from 'react'
 import { useUser } from './user-provider'
 
 export function Profile() {
-  const { userPromise } = useUser()
-  const user = use(userPromise)
+  const user = useUser()
 
   return '...'
+}
+```
+
+Wrap the consumer in a `<Suspense>` boundary to show a fallback while the Promise resolves:
+
+```tsx filename="app/page.tsx" switcher
+import { Suspense } from 'react'
+import { Profile } from './profile'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <Profile />
+    </Suspense>
+  )
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { Suspense } from 'react'
+import { Profile } from './profile'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <Profile />
+    </Suspense>
+  )
 }
 ```
 
@@ -265,7 +284,7 @@ export function Profile() {
 
 The `fallback` data can be prerendered and included in the initial HTML response, then immediately read in the child components using `useSWR`. SWR’s polling, revalidation, and caching still run **client-side only**, so it preserves all the interactivity you rely on for an SPA.
 
-Because Next.js seeds the `fallback` on the server, `useSWR` has data on first render, so there's no need for conditional logic to handle an `undefined` `data`. By default, `useSWR` returns `isLoading` and `error` for you to render during client revalidation; enable SWR's [Suspense mode](https://swr.vercel.app/docs/suspense) if you would rather suspend at the closest `<Suspense>` boundary instead.
+Because Next.js seeds the `fallback` on the server, `useSWR` has data on first render, so there's no need for conditional logic to handle an `undefined` `data`. Note that `isLoading` still flips to `true` while SWR revalidates on the client, even though the seeded `data` is present, so avoid gating the whole render on `isLoading`. To suspend at the closest `<Suspense>` boundary instead, enable SWR's [Suspense mode](https://swr.vercel.app/docs/suspense).
 
 |                      | SWR                 | RSC                 | RSC + SWR           |
 | -------------------- | ------------------- | ------------------- | ------------------- |
@@ -276,7 +295,7 @@ Because Next.js seeds the `fallback` on the server, `useSWR` has data on first r
 
 #### Scoping server data to the components that use it
 
-`<SWRConfig>` can live in any Server Component, not only the root layout. Placing it on the route segment that owns the data keeps the `fallback` close to where it is read, keeps unrelated keys out of a global config, and lets each segment start its own server-side requests:
+`<SWRConfig>` can live in any Server Component, not only the root layout. Placing it on the route segment that owns the data keeps the `fallback` close to where it is read, keeps unrelated keys out of a global config, and lets each segment start its own server-side requests. Nested `<SWRConfig>` providers merge their fallbacks, so a page-level config extends the keys seeded by a parent layout rather than replacing them:
 
 ```tsx filename="app/projects/[id]/page.tsx" switcher
 import { Suspense } from 'react'
@@ -344,7 +363,7 @@ function ProjectData({ id }) {
 
 Inside `<Suspense>`, `params.then()` resolves the `id` and passes it to `ProjectData`, which seeds the `fallback` with the `getProject(id)` promise. Only that subtree suspends while the data loads.
 
-The Client Component reads the data with `useSWR` using the same key:
+The Client Component reads the data with `useSWR` using the same key. Passing `suspense: true` opts into SWR's [Suspense mode](https://swr.vercel.app/docs/suspense), so it suspends at the boundary above until the seeded Promise resolves and `data` is always defined:
 
 ```tsx filename="app/projects/[id]/project-view.tsx" switcher
 'use client'
@@ -355,7 +374,7 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
 export function ProjectView({ id }: { id: string }) {
   // This key must match the `fallback` key exactly.
-  const { data } = useSWR(`/api/projects/${id}`, fetcher)
+  const { data } = useSWR(`/api/projects/${id}`, fetcher, { suspense: true })
 
   return <h1>{data.name}</h1>
 }
@@ -370,7 +389,7 @@ const fetcher = (url) => fetch(url).then((res) => res.json())
 
 export function ProjectView({ id }) {
   // This key must match the `fallback` key exactly.
-  const { data } = useSWR(`/api/projects/${id}`, fetcher)
+  const { data } = useSWR(`/api/projects/${id}`, fetcher, { suspense: true })
 
   return <h1>{data.name}</h1>
 }
@@ -458,7 +477,7 @@ function ProjectData({ id }) {
 
 As with SWR, `params.then()` resolves the `id` inside `<Suspense>`, and `ProjectData` prefetches below the boundary.
 
-The Client Component reads the data with the same query key. Use `useSuspenseQuery` when a `<Suspense>` boundary handles loading and you want `data` to always be defined; use `useQuery` when you would rather render its `isPending` and `error` states inline:
+The Client Component reads the data with the same query key. Use `useSuspenseQuery` when a `<Suspense>` boundary handles loading and you want `data` to always be defined. Use `useQuery` when you would rather render its `isPending` and `error` states inline:
 
 ```tsx filename="app/projects/[id]/project-view.tsx" switcher
 'use client'
@@ -574,7 +593,7 @@ See the [live demo](https://next-spa-patterns.labs.vercel.dev/shallow-routing) a
 
 ### Mutating data with Server Actions
 
-The sections above seed client-side data-fetching libraries from the server, which handle reads. Interactivity means writing data, and that usually happens outside those libraries: a Client Component calls a [Server Action](/docs/app/guides/server-actions) to run the mutation on the server. If you already use SWR or TanStack Query, you can instead write through an API route and revalidate with SWR's [`mutate`](https://swr.vercel.app/docs/mutation) or TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations); the rest of this section uses Server Actions directly.
+The sections above seed client-side data-fetching libraries from the server, which handle reads. Interactivity means writing data, and that usually happens outside those libraries: a Client Component calls a [Server Action](/docs/app/guides/server-actions) to run the mutation on the server. If you already use SWR or TanStack Query, you can instead write through an API route and revalidate with SWR's [`mutate`](https://swr.vercel.app/docs/mutation) or TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations). The rest of this section uses Server Actions directly.
 
 A Server Action takes time and can fail. React has useful tools to keep the UI responsive while it runs, so a mutation can feel as instant as a client-rendered SPA: [transitions](https://react.dev/reference/react/useTransition), [`useOptimistic`](https://react.dev/reference/react/useOptimistic), [`useActionState`](https://react.dev/reference/react/useActionState), and [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus).
 
@@ -645,6 +664,8 @@ export function applyAction(todos: Todo[], action: TodoAction): Todo[] {
       )
     case 'delete':
       return todos.filter((todo) => todo.id !== action.id)
+    default:
+      return todos
   }
 }
 ```
@@ -664,6 +685,8 @@ export function applyAction(todos, action) {
       )
     case 'delete':
       return todos.filter((todo) => todo.id !== action.id)
+    default:
+      return todos
   }
 }
 ```

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -2,6 +2,13 @@
 title: How to build single-page applications with Next.js
 nav_title: SPAs
 description: Next.js fully supports building Single-Page Applications (SPAs).
+related:
+  description: Learn more about the features used in this guide.
+  links:
+    - app/guides/interactive-apps
+    - app/guides/streaming
+    - app/api-reference/components/link
+    - app/guides/static-exports
 ---
 
 Next.js fully supports building Single-Page Applications (SPAs).
@@ -29,9 +36,11 @@ Next.js can start as a static site or even a strict SPA where everything is rend
 
 ## Examples
 
-Let's explore common patterns used to build SPAs and how Next.js solves them.
+The following examples cover common patterns for building an SPA with Next.js. The companion [demo](https://next-spa-patterns.labs.vercel.dev) ([source](https://github.com/vercel-labs/next-spa-patterns)) shows each pattern in action.
 
 ### Using React’s `use` within a Context Provider
+
+[**Live demo**](https://next-spa-patterns.labs.vercel.dev/use-context) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/use-context))
 
 We recommend fetching data in a parent component (or layout), returning the Promise, and then unwrapping the value in a Client Component with React’s [`use` API](https://react.dev/reference/react/use).
 
@@ -174,7 +183,11 @@ export function Profile() {
 
 The component that consumes the Promise (e.g. `Profile` above) will be suspended. This enables partial hydration. You can see the streamed and prerendered HTML before JavaScript has finished loading.
 
+> **Good to know:** Wrap the server-side function (`getUser`) in React's [`cache`](https://react.dev/reference/react/cache) so repeated calls in the same request share one Promise instead of starting a new request. For more on this pattern, see the React docs on [reading a Promise from context](https://react.dev/reference/react/use#reading-a-promise-from-context).
+
 ### SPAs with SWR
+
+[**Live demo**](https://next-spa-patterns.labs.vercel.dev/swr) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/swr))
 
 [SWR](https://swr.vercel.app) is a popular React library for data fetching.
 
@@ -184,7 +197,7 @@ With SWR 2.3.0 (and React 19+), you can gradually adopt server features alongsid
 - **Server-only:** `useSWR(key)` + RSC-provided data
 - **Mixed:** `useSWR(key, fetcher)` + RSC-provided data
 
-> **Good to know:** Reach for SWR when you need its client-side features, such as revalidation on focus or interval, [`mutate`](https://swr.vercel.app/docs/mutation), or request deduplication across components. If a Client Component only needs to read server data once, pass a Promise to it and unwrap it with [`use()`](#using-reacts-use-within-a-context-provider) instead. That avoids adding a data-fetching library for data that never revalidates on the client.
+Reach for SWR when you need its client-side features, such as revalidation on focus or interval, [`mutate`](https://swr.vercel.app/docs/mutation), or request deduplication across components. If a Client Component only needs to read server data once, pass a Promise to it and unwrap it with [`use()`](#using-reacts-use-within-a-context-provider) instead. That avoids adding a data-fetching library for data that never revalidates on the client.
 
 For example, wrap your application with `<SWRConfig>` and a `fallback`:
 
@@ -201,8 +214,7 @@ export default function RootLayout({
     <SWRConfig
       value={{
         fallback: {
-          // We do NOT await getUser() here
-          // Only components that read this data will suspend
+          // Do not await: only components that read this data suspend
           '/api/user': getUser(),
         },
       }}
@@ -222,8 +234,7 @@ export default function RootLayout({ children }) {
     <SWRConfig
       value={{
         fallback: {
-          // We do NOT await getUser() here
-          // Only components that read this data will suspend
+          // Do not await: only components that read this data suspend
           '/api/user': getUser(),
         },
       }}
@@ -242,8 +253,7 @@ Because this is a Server Component, `getUser()` can securely read cookies, heade
 import useSWR from 'swr'
 
 export function Profile() {
-  const fetcher = (url) => fetch(url).then((res) => res.json())
-  // The same SWR pattern you already know
+  const fetcher = (url: string) => fetch(url).then((res) => res.json())
   const { data, error } = useSWR('/api/user', fetcher)
 
   return '...'
@@ -257,7 +267,6 @@ import useSWR from 'swr'
 
 export function Profile() {
   const fetcher = (url) => fetch(url).then((res) => res.json())
-  // The same SWR pattern you already know
   const { data, error } = useSWR('/api/user', fetcher)
 
   return '...'
@@ -280,23 +289,27 @@ Since the initial `fallback` data is automatically handled by Next.js, you can n
 `<SWRConfig>` can live in any Server Component, not only the root layout. Placing it on the route segment that owns the data keeps the `fallback` close to where it is read, keeps unrelated keys out of a global config, and lets each segment start its own server-side requests:
 
 ```tsx filename="app/projects/[id]/page.tsx" switcher
+import { Suspense } from 'react'
 import { SWRConfig } from 'swr'
 import { getProject } from './data' // some server-side function
 import { ProjectView } from './project-view'
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>
-}) {
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <ProjectData params={params} />
+    </Suspense>
+  )
+}
+
+async function ProjectData({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 
   return (
     <SWRConfig
       value={{
         fallback: {
-          // Start the request on the server without awaiting it.
-          // Only components that read this key will suspend.
+          // Not awaited: only components that read this key suspend
           [`/api/projects/${id}`]: getProject(id),
         },
       }}
@@ -308,19 +321,27 @@ export default async function Page({
 ```
 
 ```jsx filename="app/projects/[id]/page.js" switcher
+import { Suspense } from 'react'
 import { SWRConfig } from 'swr'
 import { getProject } from './data' // some server-side function
 import { ProjectView } from './project-view'
 
-export default async function Page({ params }) {
+export default function Page({ params }) {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <ProjectData params={params} />
+    </Suspense>
+  )
+}
+
+async function ProjectData({ params }) {
   const { id } = await params
 
   return (
     <SWRConfig
       value={{
         fallback: {
-          // Start the request on the server without awaiting it.
-          // Only components that read this key will suspend.
+          // Not awaited: only components that read this key suspend
           [`/api/projects/${id}`]: getProject(id),
         },
       }}
@@ -330,6 +351,8 @@ export default async function Page({ params }) {
   )
 }
 ```
+
+Resolving `params` in a child component keeps the dynamic read below `<Suspense>`, so the rest of the page streams instead of blocking on it.
 
 The Client Component reads the data with `useSWR` using the same key:
 
@@ -341,8 +364,7 @@ import useSWR from 'swr'
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
 export function ProjectView({ id }: { id: string }) {
-  // This key must match the `fallback` key exactly. If it does not, the
-  // server data is ignored and SWR fetches again on the client.
+  // This key must match the `fallback` key exactly.
   const { data } = useSWR(`/api/projects/${id}`, fetcher)
 
   return <h1>{data.name}</h1>
@@ -357,8 +379,7 @@ import useSWR from 'swr'
 const fetcher = (url) => fetch(url).then((res) => res.json())
 
 export function ProjectView({ id }) {
-  // This key must match the `fallback` key exactly. If it does not, the
-  // server data is ignored and SWR fetches again on the client.
+  // This key must match the `fallback` key exactly.
   const { data } = useSWR(`/api/projects/${id}`, fetcher)
 
   return <h1>{data.name}</h1>
@@ -367,28 +388,36 @@ export function ProjectView({ id }) {
 
 > **Good to know:** The `fallback` key and the `useSWR` key must match exactly, since SWR looks up the seeded value by key. Nothing warns on a mismatch: the seeded value is never read, `data` starts as `undefined`, and SWR fetches again on the client. When a key is built from dynamic values (route params, search params), derive it in one shared place so the server and client cannot drift apart. To reuse the same request when SWR revalidates after hydration rather than starting a new one, see [`preload`](https://swr.vercel.app/docs/prefetching).
 
-### SPAs with React Query
+### SPAs with TanStack Query
 
-You can use React Query with Next.js on the client and the server, and seed its cache from a Server Component the same way as [SWR](#spas-with-swr): prefetch on the server, hand the cache to the client, and let React Query own revalidation from there.
+[**Live demo**](https://next-spa-patterns.labs.vercel.dev/react-query) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/react-query))
+
+You can use [TanStack Query](https://tanstack.com/query) (formerly React Query) with Next.js on the client and the server, and seed its cache from a Server Component the same way as [SWR](#spas-with-swr): prefetch on the server, hand the cache to the client, and let it own revalidation from there.
+
+TanStack Query needs a one-time setup, including a `getQueryClient` (new per request on the server, a singleton in the browser), a `<QueryClientProvider>`, and a client configured to dehydrate pending queries. TanStack Query owns this integration, so follow [its App Router guide](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr) for the full setup and current APIs.
 
 A Server Component starts the request with `prefetchQuery` **without awaiting it**, then serializes the cache into the streamed HTML with `<HydrationBoundary>`:
 
 ```tsx filename="app/projects/[id]/page.tsx" switcher
+import { Suspense } from 'react'
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { getQueryClient } from '@/app/get-query-client'
 import { getProject } from './data' // runs on the server and the client
 import { ProjectView } from './project-view'
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>
-}) {
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <ProjectData params={params} />
+    </Suspense>
+  )
+}
+
+async function ProjectData({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const queryClient = getQueryClient()
 
-  // Start the request on the server without awaiting it, so rendering is
-  // not blocked. Only components that read this query will suspend.
+  // Not awaited, so rendering is not blocked.
   queryClient.prefetchQuery({
     queryKey: ['project', id],
     queryFn: () => getProject(id),
@@ -403,17 +432,25 @@ export default async function Page({
 ```
 
 ```jsx filename="app/projects/[id]/page.js" switcher
+import { Suspense } from 'react'
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { getQueryClient } from '@/app/get-query-client'
 import { getProject } from './data' // runs on the server and the client
 import { ProjectView } from './project-view'
 
-export default async function Page({ params }) {
+export default function Page({ params }) {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <ProjectData params={params} />
+    </Suspense>
+  )
+}
+
+async function ProjectData({ params }) {
   const { id } = await params
   const queryClient = getQueryClient()
 
-  // Start the request on the server without awaiting it, so rendering is
-  // not blocked. Only components that read this query will suspend.
+  // Not awaited, so rendering is not blocked.
   queryClient.prefetchQuery({
     queryKey: ['project', id],
     queryFn: () => getProject(id),
@@ -436,8 +473,7 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { getProject } from './data'
 
 export function ProjectView({ id }: { id: string }) {
-  // This query key must match the server prefetch, or the hydrated cache
-  // is ignored and React Query fetches again on the client.
+  // This query key must match the server prefetch.
   const { data } = useSuspenseQuery({
     queryKey: ['project', id],
     queryFn: () => getProject(id),
@@ -454,8 +490,7 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { getProject } from './data'
 
 export function ProjectView({ id }) {
-  // This query key must match the server prefetch, or the hydrated cache
-  // is ignored and React Query fetches again on the client.
+  // This query key must match the server prefetch.
   const { data } = useSuspenseQuery({
     queryKey: ['project', id],
     queryFn: () => getProject(id),
@@ -467,9 +502,9 @@ export function ProjectView({ id }) {
 
 The query key connects the two sides, the same way the matching `fallback` and `useSWR` keys do above.
 
-> **Good to know:** This example assumes the one-time setup React Query requires: a shared `getQueryClient` (a new instance per request on the server, a singleton in the browser), a `<QueryClientProvider>` Client Component wrapping your app, and the client configured to dehydrate pending queries so data can stream. React Query also ships an experimental `@tanstack/react-query-next-experimental` package that streams without an explicit prefetch, at the cost of reintroducing request waterfalls on navigation. Because React Query owns and continues to evolve this integration, follow the [React Query App Router guide](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr) for the full setup and current APIs.
-
 ### Rendering components only in the browser
+
+[**Live demo**](https://next-spa-patterns.labs.vercel.dev/browser-only) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only))
 
 Client components are [prerendered](https://github.com/reactwg/server-components/discussions/4) during `next build`. If you want to disable prerendering for a Client Component and only load it in the browser environment, you can use [`next/dynamic`](/docs/app/guides/lazy-loading#nextdynamic):
 
@@ -485,13 +520,15 @@ This can be useful for third-party libraries that rely on browser APIs like `win
 
 ### Shallow routing on the client
 
+[**Live demo**](https://next-spa-patterns.labs.vercel.dev/shallow-routing) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/shallow-routing))
+
 If you are migrating from a strict SPA like [Create React App](/docs/app/guides/migrating/from-create-react-app) or [Vite](/docs/app/guides/migrating/from-vite), you might have existing code which shallow routes to update the URL state. This can be useful for manual transitions between views in your application _without_ using the default Next.js file-system routing.
 
 Next.js allows you to use the native [`window.history.pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) and [`window.history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) methods to update the browser's history stack without reloading the page.
 
 `pushState` and `replaceState` calls integrate into the Next.js Router, allowing you to sync with [`usePathname`](/docs/app/api-reference/functions/use-pathname) and [`useSearchParams`](/docs/app/api-reference/functions/use-search-params).
 
-```tsx fileName="app/ui/sort-products.tsx" switcher
+```tsx filename="app/ui/sort-products.tsx" switcher
 'use client'
 
 import { useSearchParams } from 'next/navigation'
@@ -514,7 +551,7 @@ export default function SortProducts() {
 }
 ```
 
-```jsx fileName="app/ui/sort-products.js" switcher
+```jsx filename="app/ui/sort-products.js" switcher
 'use client'
 
 import { useSearchParams } from 'next/navigation'
@@ -539,47 +576,272 @@ export default function SortProducts() {
 
 Learn more about how [routing and navigation](/docs/app/getting-started/linking-and-navigating#how-navigation-works) work in Next.js.
 
-### Using Server Actions in Client Components
+### Adding interactivity
 
-You can progressively adopt Server Actions while still using Client Components. This allows you to remove boilerplate code to call an API route, and instead use React features like `useActionState` to handle loading and error states. See the [Building interactive apps](/docs/app/guides/interactive-apps) guide for a deeper walkthrough, including pending feedback, optimistic UI, transitions, and error handling.
+[**Live demo**](https://next-spa-patterns.labs.vercel.dev/mutations) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/mutations))
 
-For example, create your first Server Action:
+An interactive SPA changes data on the server, not just reads it. That work takes time and can fail, so the UI stays responsive while it runs. You mutate by calling a [Server Action](/docs/app/guides/server-actions) from a Client Component, and React's feedback primitives handle the waiting states, such as optimistic updates ([`useOptimistic`](https://react.dev/reference/react/useOptimistic)), transitions ([`useTransition`](https://react.dev/reference/react/useTransition)), and streaming ([`<Suspense>`](https://react.dev/reference/react/Suspense), see the [Streaming](/docs/app/guides/streaming) guide). These patterns aren't unique to SPAs, but a responsive SPA depends on them.
 
-```tsx filename="app/actions.ts" switcher
+How you apply them depends on the rest of your setup. With a fetching library, write through an API route and revalidate with SWR's [`mutate`](https://swr.vercel.app/docs/mutation) or TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations). Otherwise, run the Server Action through [`useActionState`](https://react.dev/reference/react/useActionState) as an async reducer that returns the next list, paired with `useOptimistic` for instant feedback.
+
+The example below is a to-do list that takes the second approach. One Server Action handles add, toggle, edit, and delete, persisting each change and returning the next list:
+
+```ts filename="app/actions.ts" switcher
 'use server'
 
-export async function create() {}
+import { db } from './db'
+
+export type Todo = { id: string; text: string; done: boolean }
+
+export type TodoAction =
+  | { type: 'add'; id: string; text: string }
+  | { type: 'toggle'; id: string }
+  | { type: 'edit'; id: string; text: string }
+  | { type: 'delete'; id: string }
+
+export async function todosReducer(
+  todos: Todo[],
+  action: TodoAction
+): Promise<Todo[]> {
+  switch (action.type) {
+    case 'add': {
+      const todo = { id: action.id, text: action.text, done: false }
+      await db.todo.create(todo)
+      return [...todos, todo]
+    }
+    case 'toggle': {
+      await db.todo.toggle(action.id)
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, done: !todo.done } : todo
+      )
+    }
+    case 'edit': {
+      await db.todo.update(action.id, action.text)
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, text: action.text } : todo
+      )
+    }
+    case 'delete': {
+      await db.todo.delete(action.id)
+      return todos.filter((todo) => todo.id !== action.id)
+    }
+  }
+}
 ```
 
 ```js filename="app/actions.js" switcher
 'use server'
 
-export async function create() {}
-```
+import { db } from './db'
 
-You can import and use a Server Action from the client, similar to calling a JavaScript function. You do not need to create an API endpoint manually:
-
-```tsx filename="app/button.tsx" switcher
-'use client'
-
-import { create } from './actions'
-
-export function Button() {
-  return <button onClick={() => create()}>Create</button>
+export async function todosReducer(todos, action) {
+  switch (action.type) {
+    case 'add': {
+      const todo = { id: action.id, text: action.text, done: false }
+      await db.todo.create(todo)
+      return [...todos, todo]
+    }
+    case 'toggle': {
+      await db.todo.toggle(action.id)
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, done: !todo.done } : todo
+      )
+    }
+    case 'edit': {
+      await db.todo.update(action.id, action.text)
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, text: action.text } : todo
+      )
+    }
+    case 'delete': {
+      await db.todo.delete(action.id)
+      return todos.filter((todo) => todo.id !== action.id)
+    }
+  }
 }
 ```
 
-```jsx filename="app/button.js" switcher
+The client mirrors the reducer with `useOptimistic`, then a shared `act` helper applies the optimistic change and dispatches the Server Action in one transition. Each add, toggle, edit, and delete shows immediately:
+
+```tsx filename="app/todo-list.tsx" switcher
 'use client'
 
-import { create } from './actions'
+import { useActionState, useOptimistic, useTransition } from 'react'
+import { todosReducer, type Todo, type TodoAction } from './actions'
 
-export function Button() {
-  return <button onClick={() => create()}>Create</button>
+function applyOptimistic(todos: Todo[], action: TodoAction): Todo[] {
+  switch (action.type) {
+    case 'add':
+      return [...todos, { id: action.id, text: action.text, done: false }]
+    case 'toggle':
+      return todos.map((t) =>
+        t.id === action.id ? { ...t, done: !t.done } : t
+      )
+    case 'edit':
+      return todos.map((t) =>
+        t.id === action.id ? { ...t, text: action.text } : t
+      )
+    case 'delete':
+      return todos.filter((t) => t.id !== action.id)
+  }
+}
+
+export function TodoList({ initialTodos }: { initialTodos: Todo[] }) {
+  const [todos, dispatch, isPending] = useActionState(
+    todosReducer,
+    initialTodos
+  )
+  const [optimisticTodos, addOptimistic] = useOptimistic(todos, applyOptimistic)
+  const [, startTransition] = useTransition()
+
+  function act(action: TodoAction) {
+    startTransition(() => {
+      addOptimistic(action)
+      dispatch(action)
+    })
+  }
+
+  return (
+    <>
+      <form
+        action={(f) =>
+          act({
+            type: 'add',
+            id: crypto.randomUUID(),
+            text: String(f.get('text')),
+          })
+        }
+      >
+        <input name="text" />
+        <button>Add</button>
+      </form>
+      <ul>
+        {optimisticTodos.map((todo) => (
+          <li key={todo.id}>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => act({ type: 'toggle', id: todo.id })}
+            />
+            <span
+              style={{ textDecoration: todo.done ? 'line-through' : 'none' }}
+            >
+              {todo.text}
+            </span>
+            <button
+              onClick={() =>
+                act({
+                  type: 'edit',
+                  id: todo.id,
+                  text: `${todo.text} (edited)`,
+                })
+              }
+            >
+              Edit
+            </button>
+            <button onClick={() => act({ type: 'delete', id: todo.id })}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      {isPending && <p>Syncing to server…</p>}
+    </>
+  )
 }
 ```
 
-Learn more about [mutating data with Server Actions](/docs/app/getting-started/mutating-data).
+```jsx filename="app/todo-list.js" switcher
+'use client'
+
+import { useActionState, useOptimistic, useTransition } from 'react'
+import { todosReducer } from './actions'
+
+function applyOptimistic(todos, action) {
+  switch (action.type) {
+    case 'add':
+      return [...todos, { id: action.id, text: action.text, done: false }]
+    case 'toggle':
+      return todos.map((t) =>
+        t.id === action.id ? { ...t, done: !t.done } : t
+      )
+    case 'edit':
+      return todos.map((t) =>
+        t.id === action.id ? { ...t, text: action.text } : t
+      )
+    case 'delete':
+      return todos.filter((t) => t.id !== action.id)
+  }
+}
+
+export function TodoList({ initialTodos }) {
+  const [todos, dispatch, isPending] = useActionState(
+    todosReducer,
+    initialTodos
+  )
+  const [optimisticTodos, addOptimistic] = useOptimistic(todos, applyOptimistic)
+  const [, startTransition] = useTransition()
+
+  function act(action) {
+    startTransition(() => {
+      addOptimistic(action)
+      dispatch(action)
+    })
+  }
+
+  return (
+    <>
+      <form
+        action={(f) =>
+          act({
+            type: 'add',
+            id: crypto.randomUUID(),
+            text: String(f.get('text')),
+          })
+        }
+      >
+        <input name="text" />
+        <button>Add</button>
+      </form>
+      <ul>
+        {optimisticTodos.map((todo) => (
+          <li key={todo.id}>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => act({ type: 'toggle', id: todo.id })}
+            />
+            <span
+              style={{ textDecoration: todo.done ? 'line-through' : 'none' }}
+            >
+              {todo.text}
+            </span>
+            <button
+              onClick={() =>
+                act({
+                  type: 'edit',
+                  id: todo.id,
+                  text: `${todo.text} (edited)`,
+                })
+              }
+            >
+              Edit
+            </button>
+            <button onClick={() => act({ type: 'delete', id: todo.id })}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+      {isPending && <p>Syncing to server…</p>}
+    </>
+  )
+}
+```
+
+The optimistic state updates instantly, but each change still runs on the server. `useActionState` returns a pending flag alongside the state, so you can show a subtle indicator (such as `Syncing to server…`) while the Server Action runs, without blocking the UI.
+
+For these interactivity patterns applied across a full example, see the [Building interactive apps](/docs/app/guides/interactive-apps) guide and its runnable demo.
 
 ## Static export (optional)
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -521,6 +521,8 @@ export function ProjectView({ id }) {
 
 The query key connects the two sides, the same way the matching `fallback` and `useSWR` keys do above.
 
+> **Good to know:** When you cache this data with [Cache Components](/docs/app/getting-started/caching), add [`"use cache"`](/docs/app/api-reference/directives/use-cache) to the data function (such as `getProject`), not around `dehydrate()`. Caching the dehydrated state also caches TanStack Query metadata such as timestamps, which can serve stale data on later requests.
+
 See the [live demo](https://next-spa-patterns.labs.vercel.dev/react-query) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/react-query).
 
 ### Rendering components only in the browser

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -369,7 +369,7 @@ function ProjectData({ id }) {
 
 Inside `<Suspense>`, `params.then()` resolves the `id` and passes it to `ProjectData`, which seeds the `fallback` with the `getProject(id)` promise. Only that subtree suspends while the data loads.
 
-The Client Component reads the data with `useSWR` using the same key. Passing `suspense: true` opts into SWR's [Suspense mode](https://swr.vercel.app/docs/suspense), so it suspends at the boundary above until the seeded Promise resolves and `data` is always defined:
+The Client Component reads the data with `useSWR` using the same key:
 
 ```tsx filename="app/projects/[id]/project-view.tsx" switcher
 'use client'
@@ -380,9 +380,9 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
 export function ProjectView({ id }: { id: string }) {
   // This key must match the `fallback` key exactly.
-  const { data } = useSWR(`/api/projects/${id}`, fetcher, { suspense: true })
+  const { data } = useSWR(`/api/projects/${id}`, fetcher)
 
-  return <h1>{data.name}</h1>
+  return <h1>{data?.name}</h1>
 }
 ```
 
@@ -395,9 +395,9 @@ const fetcher = (url) => fetch(url).then((res) => res.json())
 
 export function ProjectView({ id }) {
   // This key must match the `fallback` key exactly.
-  const { data } = useSWR(`/api/projects/${id}`, fetcher, { suspense: true })
+  const { data } = useSWR(`/api/projects/${id}`, fetcher)
 
-  return <h1>{data.name}</h1>
+  return <h1>{data?.name}</h1>
 }
 ```
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -3,9 +3,11 @@ title: How to build single-page applications with Next.js
 nav_title: SPAs
 description: Next.js fully supports building Single-Page Applications (SPAs).
 related:
-  description: Learn more about the features used in this guide.
+  description: Related guides and references.
   links:
     - app/guides/interactive-apps
+    - app/guides/server-actions
+    - app/guides/forms
     - app/guides/streaming
     - app/api-reference/components/link
     - app/guides/static-exports
@@ -40,25 +42,19 @@ The following examples cover common patterns for building an SPA with Next.js. T
 
 ### Using React’s `use` within a Context Provider
 
-[**Live demo**](https://next-spa-patterns.labs.vercel.dev/use-context) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/use-context))
+You can use React’s [`use` API](https://react.dev/reference/react/use) to stream data from the server to a Client Component. Fetch the data in a Server Component (a parent or layout) and pass the Promise down; the Client Component unwraps it with `use()`, since it cannot `await` during render.
 
-We recommend fetching data in a parent component (or layout), returning the Promise, and then unwrapping the value in a Client Component with React’s [`use` API](https://react.dev/reference/react/use).
+Starting the request on the server, before the rest of the app renders, lets the response stream immediately and avoids client-side request waterfalls.
 
-Next.js can start data fetching early on the server. In this example, that’s the root layout, the entry point to your application. The server can immediately begin streaming a response to the client.
+You can pass a single Promise as a prop and unwrap it with `use()`, or pair it with a React context provider so any Client Component can read the value through a custom hook. A provider isn't always the best fit: often you can read the data in a Server Component, or pass the Promise directly, rather than putting everything in context. For general client-side data fetching, a library like [SWR](#spas-with-swr) can help.
 
-By “hoisting” your data fetching to the root layout, Next.js starts the specified requests on the server early before any other components in your application. This eliminates client waterfalls and prevents having multiple roundtrips between client and server. It can also significantly improve performance, as your server is closer (and ideally colocated) to where your database is located.
-
-For example, update your root layout to call the Promise, but do _not_ await it.
+Start the request in your root layout without awaiting it, and pass the Promise to the provider:
 
 ```tsx filename="app/layout.tsx" switcher
 import { UserProvider } from './user-provider'
 import { getUser } from './user' // some server-side function
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: LayoutProps<'/'>) {
   let userPromise = getUser() // do NOT await
 
   return (
@@ -88,9 +84,9 @@ export default function RootLayout({ children }) {
 }
 ```
 
-While you can [defer and pass a single Promise](/docs/app/getting-started/fetching-data#streaming-data-with-the-use-api) as a prop to a Client Component, we generally see this pattern paired with a React context provider. This enables easier access from Client Components with a custom React Hook.
+If several components read the same data in one request, wrap `getUser` in React's [`cache`](https://react.dev/reference/react/cache) so they share a single call.
 
-You can forward a Promise to the React context provider:
+The provider forwards the Promise through context:
 
 ```ts filename="app/user-provider.ts" switcher
 'use client';
@@ -181,13 +177,11 @@ export function Profile() {
 }
 ```
 
-The component that consumes the Promise (e.g. `Profile` above) will be suspended. This enables partial hydration. You can see the streamed and prerendered HTML before JavaScript has finished loading.
+The component that consumes the Promise (e.g. `Profile` above) suspends while the Promise resolves, so you see the streamed, prerendered HTML before JavaScript has finished loading.
 
-> **Good to know:** Wrap the server-side function (`getUser`) in React's [`cache`](https://react.dev/reference/react/cache) so repeated calls in the same request share one Promise instead of starting a new request. For more on this pattern, see the React docs on [reading a Promise from context](https://react.dev/reference/react/use#reading-a-promise-from-context).
+See the [live demo](https://next-spa-patterns.labs.vercel.dev/use-context) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/use-context).
 
 ### SPAs with SWR
-
-[**Live demo**](https://next-spa-patterns.labs.vercel.dev/swr) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/swr))
 
 [SWR](https://swr.vercel.app) is a popular React library for data fetching.
 
@@ -199,22 +193,18 @@ With SWR 2.3.0 (and React 19+), you can gradually adopt server features alongsid
 
 Reach for SWR when you need its client-side features, such as revalidation on focus or interval, [`mutate`](https://swr.vercel.app/docs/mutation), or request deduplication across components. If a Client Component only needs to read server data once, pass a Promise to it and unwrap it with [`use()`](#using-reacts-use-within-a-context-provider) instead. That avoids adding a data-fetching library for data that never revalidates on the client.
 
-For example, wrap your application with `<SWRConfig>` and a `fallback`:
+To seed the client cache from the server, wrap your application in `<SWRConfig>` and provide a `fallback`:
 
 ```tsx filename="app/layout.tsx" switcher
 import { SWRConfig } from 'swr'
 import { getUser } from './user' // some server-side function
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: LayoutProps<'/'>) {
   return (
     <SWRConfig
       value={{
         fallback: {
-          // Do not await: only components that read this data suspend
+          // Not awaited: only components that read this key suspend
           '/api/user': getUser(),
         },
       }}
@@ -234,7 +224,7 @@ export default function RootLayout({ children }) {
     <SWRConfig
       value={{
         fallback: {
-          // Do not await: only components that read this data suspend
+          // Not awaited: only components that read this key suspend
           '/api/user': getUser(),
         },
       }}
@@ -275,7 +265,7 @@ export function Profile() {
 
 The `fallback` data can be prerendered and included in the initial HTML response, then immediately read in the child components using `useSWR`. SWR’s polling, revalidation, and caching still run **client-side only**, so it preserves all the interactivity you rely on for an SPA.
 
-Since the initial `fallback` data is automatically handled by Next.js, you can now delete any conditional logic previously needed to check if `data` was `undefined`. When the data is loading, the closest `<Suspense>` boundary will be suspended.
+Because Next.js seeds the `fallback` on the server, `useSWR` has data on first render, so there's no need for conditional logic to handle an `undefined` `data`. By default, `useSWR` returns `isLoading` and `error` for you to render during client revalidation; enable SWR's [Suspense mode](https://swr.vercel.app/docs/suspense) if you would rather suspend at the closest `<Suspense>` boundary instead.
 
 |                      | SWR                 | RSC                 | RSC + SWR           |
 | -------------------- | ------------------- | ------------------- | ------------------- |
@@ -294,17 +284,17 @@ import { SWRConfig } from 'swr'
 import { getProject } from './data' // some server-side function
 import { ProjectView } from './project-view'
 
-export default function Page({ params }: { params: Promise<{ id: string }> }) {
+export default function Page({ params }: PageProps<'/projects/[id]'>) {
   return (
     <Suspense fallback={<p>Loading…</p>}>
-      <ProjectData params={params} />
+      {params.then(({ id }) => (
+        <ProjectData id={id} />
+      ))}
     </Suspense>
   )
 }
 
-async function ProjectData({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-
+function ProjectData({ id }: { id: string }) {
   return (
     <SWRConfig
       value={{
@@ -329,14 +319,14 @@ import { ProjectView } from './project-view'
 export default function Page({ params }) {
   return (
     <Suspense fallback={<p>Loading…</p>}>
-      <ProjectData params={params} />
+      {params.then(({ id }) => (
+        <ProjectData id={id} />
+      ))}
     </Suspense>
   )
 }
 
-async function ProjectData({ params }) {
-  const { id } = await params
-
+function ProjectData({ id }) {
   return (
     <SWRConfig
       value={{
@@ -352,7 +342,7 @@ async function ProjectData({ params }) {
 }
 ```
 
-Resolving `params` in a child component keeps the dynamic read below `<Suspense>`, so the rest of the page streams instead of blocking on it.
+Inside `<Suspense>`, `params.then()` resolves the `id` and passes it to `ProjectData`, which seeds the `fallback` with the `getProject(id)` promise. Only that subtree suspends while the data loads.
 
 The Client Component reads the data with `useSWR` using the same key:
 
@@ -388,13 +378,13 @@ export function ProjectView({ id }) {
 
 > **Good to know:** The `fallback` key and the `useSWR` key must match exactly, since SWR looks up the seeded value by key. Nothing warns on a mismatch: the seeded value is never read, `data` starts as `undefined`, and SWR fetches again on the client. When a key is built from dynamic values (route params, search params), derive it in one shared place so the server and client cannot drift apart. To reuse the same request when SWR revalidates after hydration rather than starting a new one, see [`preload`](https://swr.vercel.app/docs/prefetching).
 
-### SPAs with TanStack Query
+See the [live demo](https://next-spa-patterns.labs.vercel.dev/swr) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/swr).
 
-[**Live demo**](https://next-spa-patterns.labs.vercel.dev/react-query) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/react-query))
+### SPAs with TanStack Query
 
 You can use [TanStack Query](https://tanstack.com/query) (formerly React Query) with Next.js on the client and the server, and seed its cache from a Server Component the same way as [SWR](#spas-with-swr): prefetch on the server, hand the cache to the client, and let it own revalidation from there.
 
-TanStack Query needs a one-time setup, including a `getQueryClient` (new per request on the server, a singleton in the browser), a `<QueryClientProvider>`, and a client configured to dehydrate pending queries. TanStack Query owns this integration, so follow [its App Router guide](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr) for the full setup and current APIs.
+TanStack Query needs a one-time setup, including a `getQueryClient` (new per request on the server, a singleton in the browser), a `<QueryClientProvider>`, and a client configured to dehydrate pending queries. TanStack Query owns this integration, so follow [its Advanced SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr) for the full setup and current APIs.
 
 A Server Component starts the request with `prefetchQuery` **without awaiting it**, then serializes the cache into the streamed HTML with `<HydrationBoundary>`:
 
@@ -405,16 +395,17 @@ import { getQueryClient } from '@/app/get-query-client'
 import { getProject } from './data' // runs on the server and the client
 import { ProjectView } from './project-view'
 
-export default function Page({ params }: { params: Promise<{ id: string }> }) {
+export default function Page({ params }: PageProps<'/projects/[id]'>) {
   return (
     <Suspense fallback={<p>Loading…</p>}>
-      <ProjectData params={params} />
+      {params.then(({ id }) => (
+        <ProjectData id={id} />
+      ))}
     </Suspense>
   )
 }
 
-async function ProjectData({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
+function ProjectData({ id }: { id: string }) {
   const queryClient = getQueryClient()
 
   // Not awaited, so rendering is not blocked.
@@ -441,13 +432,14 @@ import { ProjectView } from './project-view'
 export default function Page({ params }) {
   return (
     <Suspense fallback={<p>Loading…</p>}>
-      <ProjectData params={params} />
+      {params.then(({ id }) => (
+        <ProjectData id={id} />
+      ))}
     </Suspense>
   )
 }
 
-async function ProjectData({ params }) {
-  const { id } = await params
+function ProjectData({ id }) {
   const queryClient = getQueryClient()
 
   // Not awaited, so rendering is not blocked.
@@ -464,7 +456,9 @@ async function ProjectData({ params }) {
 }
 ```
 
-The Client Component reads the data with `useSuspenseQuery` (or `useQuery`) using the same query key:
+As with SWR, `params.then()` resolves the `id` inside `<Suspense>`, and `ProjectData` prefetches below the boundary.
+
+The Client Component reads the data with the same query key. Use `useSuspenseQuery` when a `<Suspense>` boundary handles loading and you want `data` to always be defined; use `useQuery` when you would rather render its `isPending` and `error` states inline:
 
 ```tsx filename="app/projects/[id]/project-view.tsx" switcher
 'use client'
@@ -502,9 +496,9 @@ export function ProjectView({ id }) {
 
 The query key connects the two sides, the same way the matching `fallback` and `useSWR` keys do above.
 
-### Rendering components only in the browser
+See the [live demo](https://next-spa-patterns.labs.vercel.dev/react-query) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/react-query).
 
-[**Live demo**](https://next-spa-patterns.labs.vercel.dev/browser-only) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only))
+### Rendering components only in the browser
 
 Client components are [prerendered](https://github.com/reactwg/server-components/discussions/4) during `next build`. If you want to disable prerendering for a Client Component and only load it in the browser environment, you can use [`next/dynamic`](/docs/app/guides/lazy-loading#nextdynamic):
 
@@ -518,9 +512,9 @@ const ClientOnlyComponent = dynamic(() => import('./component'), {
 
 This can be useful for third-party libraries that rely on browser APIs like `window` or `document`. You can also add a `useEffect` that checks for the existence of these APIs, and if they do not exist, return `null` or a loading state which would be prerendered.
 
-### Shallow routing on the client
+See the [live demo](https://next-spa-patterns.labs.vercel.dev/browser-only) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only).
 
-[**Live demo**](https://next-spa-patterns.labs.vercel.dev/shallow-routing) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/shallow-routing))
+### Shallow routing on the client
 
 If you are migrating from a strict SPA like [Create React App](/docs/app/guides/migrating/from-create-react-app) or [Vite](/docs/app/guides/migrating/from-vite), you might have existing code which shallow routes to update the URL state. This can be useful for manual transitions between views in your application _without_ using the default Next.js file-system routing.
 
@@ -576,21 +570,59 @@ export default function SortProducts() {
 
 Learn more about how [routing and navigation](/docs/app/getting-started/linking-and-navigating#how-navigation-works) work in Next.js.
 
-### Adding interactivity
+See the [live demo](https://next-spa-patterns.labs.vercel.dev/shallow-routing) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/shallow-routing).
 
-[**Live demo**](https://next-spa-patterns.labs.vercel.dev/mutations) ([source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/mutations))
+### Mutating data with Server Actions
 
-An interactive SPA changes data on the server, not just reads it. That work takes time and can fail, so the UI stays responsive while it runs. You mutate by calling a [Server Action](/docs/app/guides/server-actions) from a Client Component, and React's feedback primitives handle the waiting states, such as optimistic updates ([`useOptimistic`](https://react.dev/reference/react/useOptimistic)), transitions ([`useTransition`](https://react.dev/reference/react/useTransition)), and streaming ([`<Suspense>`](https://react.dev/reference/react/Suspense), see the [Streaming](/docs/app/guides/streaming) guide). These patterns aren't unique to SPAs, but a responsive SPA depends on them.
+The sections above seed client-side data-fetching libraries from the server, which handle reads. Interactivity means writing data, and that usually happens outside those libraries: a Client Component calls a [Server Action](/docs/app/guides/server-actions) to run the mutation on the server. If you already use SWR or TanStack Query, you can instead write through an API route and revalidate with SWR's [`mutate`](https://swr.vercel.app/docs/mutation) or TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations); the rest of this section uses Server Actions directly.
 
-How you apply them depends on the rest of your setup. With a fetching library, write through an API route and revalidate with SWR's [`mutate`](https://swr.vercel.app/docs/mutation) or TanStack Query's [`invalidateQueries`](https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations). Otherwise, run the Server Action through [`useActionState`](https://react.dev/reference/react/useActionState) as an async reducer that returns the next list, paired with `useOptimistic` for instant feedback.
+A Server Action takes time and can fail. React has useful tools to keep the UI responsive while it runs, so a mutation can feel as instant as a client-rendered SPA: [transitions](https://react.dev/reference/react/useTransition), [`useOptimistic`](https://react.dev/reference/react/useOptimistic), [`useActionState`](https://react.dev/reference/react/useActionState), and [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus).
 
-The example below is a to-do list that takes the second approach. One Server Action handles add, toggle, edit, and delete, persisting each change and returning the next list:
+At its simplest, a Client Component calls a Server Action inside a transition and uses the pending state for feedback:
 
-```ts filename="app/actions.ts" switcher
-'use server'
+```tsx filename="app/delete-post.tsx" switcher
+'use client'
 
-import { db } from './db'
+import { useTransition } from 'react'
+import { deletePost } from './actions'
 
+export function DeletePost({ id }: { id: string }) {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <button
+      disabled={isPending}
+      onClick={() => startTransition(() => deletePost(id))}
+    >
+      {isPending ? 'Deleting…' : 'Delete'}
+    </button>
+  )
+}
+```
+
+```jsx filename="app/delete-post.js" switcher
+'use client'
+
+import { useTransition } from 'react'
+import { deletePost } from './actions'
+
+export function DeletePost({ id }) {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <button
+      disabled={isPending}
+      onClick={() => startTransition(() => deletePost(id))}
+    >
+      {isPending ? 'Deleting…' : 'Delete'}
+    </button>
+  )
+}
+```
+
+For list-like state where each change should appear instantly, you can combine `useActionState` with `useOptimistic`. The example below is a to-do list: a pure reducer defines how each action changes the list, so the client and server share one copy of that logic:
+
+```ts filename="app/reducer.ts" switcher
 export type Todo = { id: string; text: string; done: boolean }
 
 export type TodoAction =
@@ -599,33 +631,58 @@ export type TodoAction =
   | { type: 'edit'; id: string; text: string }
   | { type: 'delete'; id: string }
 
+export function applyAction(todos: Todo[], action: TodoAction): Todo[] {
+  switch (action.type) {
+    case 'add':
+      return [...todos, { id: action.id, text: action.text, done: false }]
+    case 'toggle':
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, done: !todo.done } : todo
+      )
+    case 'edit':
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, text: action.text } : todo
+      )
+    case 'delete':
+      return todos.filter((todo) => todo.id !== action.id)
+  }
+}
+```
+
+```js filename="app/reducer.js" switcher
+export function applyAction(todos, action) {
+  switch (action.type) {
+    case 'add':
+      return [...todos, { id: action.id, text: action.text, done: false }]
+    case 'toggle':
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, done: !todo.done } : todo
+      )
+    case 'edit':
+      return todos.map((todo) =>
+        todo.id === action.id ? { ...todo, text: action.text } : todo
+      )
+    case 'delete':
+      return todos.filter((todo) => todo.id !== action.id)
+  }
+}
+```
+
+The Server Action applies the reducer, persists the result, and returns the next list:
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+import { db } from './db'
+import { applyAction, type Todo, type TodoAction } from './reducer'
+
 export async function todosReducer(
   todos: Todo[],
   action: TodoAction
 ): Promise<Todo[]> {
-  switch (action.type) {
-    case 'add': {
-      const todo = { id: action.id, text: action.text, done: false }
-      await db.todo.create(todo)
-      return [...todos, todo]
-    }
-    case 'toggle': {
-      await db.todo.toggle(action.id)
-      return todos.map((todo) =>
-        todo.id === action.id ? { ...todo, done: !todo.done } : todo
-      )
-    }
-    case 'edit': {
-      await db.todo.update(action.id, action.text)
-      return todos.map((todo) =>
-        todo.id === action.id ? { ...todo, text: action.text } : todo
-      )
-    }
-    case 'delete': {
-      await db.todo.delete(action.id)
-      return todos.filter((todo) => todo.id !== action.id)
-    }
-  }
+  const next = applyAction(todos, action)
+  await db.saveTodos(next)
+  return next
 }
 ```
 
@@ -633,68 +690,32 @@ export async function todosReducer(
 'use server'
 
 import { db } from './db'
+import { applyAction } from './reducer'
 
 export async function todosReducer(todos, action) {
-  switch (action.type) {
-    case 'add': {
-      const todo = { id: action.id, text: action.text, done: false }
-      await db.todo.create(todo)
-      return [...todos, todo]
-    }
-    case 'toggle': {
-      await db.todo.toggle(action.id)
-      return todos.map((todo) =>
-        todo.id === action.id ? { ...todo, done: !todo.done } : todo
-      )
-    }
-    case 'edit': {
-      await db.todo.update(action.id, action.text)
-      return todos.map((todo) =>
-        todo.id === action.id ? { ...todo, text: action.text } : todo
-      )
-    }
-    case 'delete': {
-      await db.todo.delete(action.id)
-      return todos.filter((todo) => todo.id !== action.id)
-    }
-  }
+  const next = applyAction(todos, action)
+  await db.saveTodos(next)
+  return next
 }
 ```
 
-The client mirrors the reducer with `useOptimistic`, then a shared `act` helper applies the optimistic change and dispatches the Server Action in one transition. Each add, toggle, edit, and delete shows immediately:
+The client passes the same reducer to `useOptimistic`, so the optimistic update and the server compute the next state identically. A `runAction` helper applies the optimistic change and dispatches the Server Action in the same transition, so every change shows immediately:
 
 ```tsx filename="app/todo-list.tsx" switcher
 'use client'
 
-import { useActionState, useOptimistic, useTransition } from 'react'
-import { todosReducer, type Todo, type TodoAction } from './actions'
-
-function applyOptimistic(todos: Todo[], action: TodoAction): Todo[] {
-  switch (action.type) {
-    case 'add':
-      return [...todos, { id: action.id, text: action.text, done: false }]
-    case 'toggle':
-      return todos.map((t) =>
-        t.id === action.id ? { ...t, done: !t.done } : t
-      )
-    case 'edit':
-      return todos.map((t) =>
-        t.id === action.id ? { ...t, text: action.text } : t
-      )
-    case 'delete':
-      return todos.filter((t) => t.id !== action.id)
-  }
-}
+import { useActionState, useOptimistic, startTransition } from 'react'
+import { todosReducer } from './actions'
+import { applyAction, type Todo, type TodoAction } from './reducer'
 
 export function TodoList({ initialTodos }: { initialTodos: Todo[] }) {
   const [todos, dispatch, isPending] = useActionState(
     todosReducer,
     initialTodos
   )
-  const [optimisticTodos, addOptimistic] = useOptimistic(todos, applyOptimistic)
-  const [, startTransition] = useTransition()
+  const [optimisticTodos, addOptimistic] = useOptimistic(todos, applyAction)
 
-  function act(action: TodoAction) {
+  function runAction(action: TodoAction) {
     startTransition(() => {
       addOptimistic(action)
       dispatch(action)
@@ -704,11 +725,11 @@ export function TodoList({ initialTodos }: { initialTodos: Todo[] }) {
   return (
     <>
       <form
-        action={(f) =>
-          act({
+        action={(formData) =>
+          runAction({
             type: 'add',
             id: crypto.randomUUID(),
-            text: String(f.get('text')),
+            text: String(formData.get('text')),
           })
         }
       >
@@ -721,25 +742,14 @@ export function TodoList({ initialTodos }: { initialTodos: Todo[] }) {
             <input
               type="checkbox"
               checked={todo.done}
-              onChange={() => act({ type: 'toggle', id: todo.id })}
+              onChange={() => runAction({ type: 'toggle', id: todo.id })}
             />
             <span
               style={{ textDecoration: todo.done ? 'line-through' : 'none' }}
             >
               {todo.text}
             </span>
-            <button
-              onClick={() =>
-                act({
-                  type: 'edit',
-                  id: todo.id,
-                  text: `${todo.text} (edited)`,
-                })
-              }
-            >
-              Edit
-            </button>
-            <button onClick={() => act({ type: 'delete', id: todo.id })}>
+            <button onClick={() => runAction({ type: 'delete', id: todo.id })}>
               Delete
             </button>
           </li>
@@ -754,35 +764,18 @@ export function TodoList({ initialTodos }: { initialTodos: Todo[] }) {
 ```jsx filename="app/todo-list.js" switcher
 'use client'
 
-import { useActionState, useOptimistic, useTransition } from 'react'
+import { useActionState, useOptimistic, startTransition } from 'react'
 import { todosReducer } from './actions'
-
-function applyOptimistic(todos, action) {
-  switch (action.type) {
-    case 'add':
-      return [...todos, { id: action.id, text: action.text, done: false }]
-    case 'toggle':
-      return todos.map((t) =>
-        t.id === action.id ? { ...t, done: !t.done } : t
-      )
-    case 'edit':
-      return todos.map((t) =>
-        t.id === action.id ? { ...t, text: action.text } : t
-      )
-    case 'delete':
-      return todos.filter((t) => t.id !== action.id)
-  }
-}
+import { applyAction } from './reducer'
 
 export function TodoList({ initialTodos }) {
   const [todos, dispatch, isPending] = useActionState(
     todosReducer,
     initialTodos
   )
-  const [optimisticTodos, addOptimistic] = useOptimistic(todos, applyOptimistic)
-  const [, startTransition] = useTransition()
+  const [optimisticTodos, addOptimistic] = useOptimistic(todos, applyAction)
 
-  function act(action) {
+  function runAction(action) {
     startTransition(() => {
       addOptimistic(action)
       dispatch(action)
@@ -792,11 +785,11 @@ export function TodoList({ initialTodos }) {
   return (
     <>
       <form
-        action={(f) =>
-          act({
+        action={(formData) =>
+          runAction({
             type: 'add',
             id: crypto.randomUUID(),
-            text: String(f.get('text')),
+            text: String(formData.get('text')),
           })
         }
       >
@@ -809,25 +802,14 @@ export function TodoList({ initialTodos }) {
             <input
               type="checkbox"
               checked={todo.done}
-              onChange={() => act({ type: 'toggle', id: todo.id })}
+              onChange={() => runAction({ type: 'toggle', id: todo.id })}
             />
             <span
               style={{ textDecoration: todo.done ? 'line-through' : 'none' }}
             >
               {todo.text}
             </span>
-            <button
-              onClick={() =>
-                act({
-                  type: 'edit',
-                  id: todo.id,
-                  text: `${todo.text} (edited)`,
-                })
-              }
-            >
-              Edit
-            </button>
-            <button onClick={() => act({ type: 'delete', id: todo.id })}>
+            <button onClick={() => runAction({ type: 'delete', id: todo.id })}>
               Delete
             </button>
           </li>
@@ -839,9 +821,11 @@ export function TodoList({ initialTodos }) {
 }
 ```
 
-The optimistic state updates instantly, but each change still runs on the server. `useActionState` returns a pending flag alongside the state, so you can show a subtle indicator (such as `Syncing to server…`) while the Server Action runs, without blocking the UI.
+The optimistic update shows instantly, while `useActionState`'s pending flag lets you display a subtle indicator (such as `Syncing to server…`) until the Server Action resolves.
 
-For these interactivity patterns applied across a full example, see the [Building interactive apps](/docs/app/guides/interactive-apps) guide and its runnable demo.
+See the [live demo](https://next-spa-patterns.labs.vercel.dev/mutations) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/mutations).
+
+To learn more about adding interactivity on top of server-rendered apps so they feel like SPAs, see the [Building interactive apps](/docs/app/guides/interactive-apps) guide and its runnable demo.
 
 ## Static export (optional)
 

--- a/docs/01-app/02-guides/streaming.mdx
+++ b/docs/01-app/02-guides/streaming.mdx
@@ -477,7 +477,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 }
 ```
 
-See [Sharing data with context and React.cache](/docs/app/getting-started/fetching-data#sharing-data-with-context-and-reactcache) for the full pattern including the provider and consumer components.
+See [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider) for the full pattern.
 
 ## Streaming in Route Handlers
 


### PR DESCRIPTION
## What

Expands the [Single-Page Applications guide](https://nextjs.org/docs/app/guides/single-page-applications):

- Adds a full **TanStack Query** section (server prefetch + `dehydrate` + client read), alongside the existing SWR and `use()` + Context patterns
- Makes this guide the **canonical home for the `use()` + Context pattern**, so it is no longer duplicated across the docs (fetching-data keeps only the `React.cache` reuse and links here)
- Rewrites the mutations section around one shared reducer with `useActionState` + `useOptimistic`
- Links a companion runnable demo for every example, and modernizes the examples (typed `PageProps`/`LayoutProps`, `useSuspenseQuery` vs `useQuery` guidance, forms/server-actions related guides)

## Why

The guide was outdated and thin on runnable examples, had no real TanStack Query coverage, and the context + `use()` pattern was duplicated across several guides.

## How

Each section maps to a runnable demo route. The context pattern is centralized here as the single source of truth, with fetching-data, streaming, and authentication linking to it.

Docs-only.
