### PR TITLE
Fix repeated navigations while the Instant Navigation lock is held

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -12,7 +12,6 @@ import {
   NOT_FOUND_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
-import type { NavigationLockState } from '../segment-cache/navigation-testing-lock'
 import { createHrefFromUrl } from './create-href-from-url'
 import { fetchServerResponse } from './fetch-server-response'
 import { dispatchAppRouterAction } from '../use-action-queue'
@@ -142,7 +141,15 @@ export type NavigationRequestAccumulation = {
   scrollRef: ScrollRef | null
 }
 
-export type NavigationLock = NavigationLockState | null
+/**
+ * A locked navigation's withheld-data gate, for the Instant Navigation Testing
+ * API. Captured — as an immutable promise — when the navigation begins (via
+ * `beginLockedNavigation`) or when router work spawns a dynamic write outside
+ * a navigation (via `getCurrentNavigationLock`), and threaded to the write,
+ * which awaits it before applying dynamic data. Resolves when a newer locked
+ * navigation begins or the lock is released.
+ */
+export type NavigationLock = Promise<void>
 
 const noop = () => {}
 
@@ -1416,7 +1423,7 @@ export function spawnDynamicRequests(
   // server-patch retry logic so it can inherit the intent if the original
   // transition hasn't committed yet.
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock,
+  navigationLock: NavigationLock | null,
   signal: AbortSignal | undefined
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
@@ -1774,7 +1781,7 @@ async function fetchMissingDynamicData(
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
   routeCacheEntry: FulfilledRouteCacheEntry | null,
-  navigationLock: NavigationLock,
+  navigationLock: NavigationLock | null,
   signal: AbortSignal | undefined
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
@@ -1812,8 +1819,8 @@ async function fetchMissingDynamicData(
     // If the navigation lock is active, wait for it to be released before
     // writing the dynamic data. This allows tests to assert on the prefetched
     // UI state.
-    if (process.env.__NEXT_EXPOSE_TESTING_API) {
-      await waitForNavigationLock(navigationLock)
+    if (process.env.__NEXT_EXPOSE_TESTING_API && navigationLock !== null) {
+      await navigationLock
     }
 
     // TODO: Implement Shell extraction as part of Cached Navigations.
@@ -2300,25 +2307,36 @@ function createDeferredRsc<
 }
 
 /**
- * Helper for the Instant Navigation Testing API. Snapshots the lock that is
- * active when a navigation starts, so the navigation can wait for the same lock
- * even if another lock is acquired before its dynamic response is applied.
+ * Helper for the Instant Navigation Testing API. Captures the withheld-data
+ * gate of the locked navigation that is current when router work spawns a
+ * dynamic write, so the write awaits that same gate even if a newer locked
+ * navigation rolls the lock over before its response is applied.
  *
  * Not exposed in production builds by default.
  */
-export function getCurrentNavigationLock(): NavigationLock {
+export function getCurrentNavigationLock(): NavigationLock | null {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    const { getCurrentNavigationLock: getCurrentLock } =
+    const { getCurrentNavigationGate } =
       require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
-    return getCurrentLock()
+    return getCurrentNavigationGate()
   }
   return null
 }
 
-async function waitForNavigationLock(lock: NavigationLock): Promise<void> {
+/**
+ * Helper for the Instant Navigation Testing API. Signals that a new locked
+ * navigation is beginning: force-resolves the previous locked navigation's
+ * withheld-data gate (without ending the scope) and returns a fresh gate for
+ * this navigation, which the caller threads to its dynamic-data write. See
+ * `beginLockedNavigation` in `navigation-testing-lock`.
+ *
+ * Not exposed in production builds by default.
+ */
+export function beginLockedNavigation(): NavigationLock | null {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    const { waitForNavigationLockIfActive } =
+    const { beginLockedNavigation: begin } =
       require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
-    await waitForNavigationLockIfActive(lock)
+    return begin()
   }
+  return null
 }

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
@@ -61,13 +61,17 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
   return null
 }
 
+export function beginLockedNavigation(): Promise<void> | null {
+  return null
+}
+
+export function getCurrentNavigationGate(): Promise<void> | null {
+  return null
+}
+
 export function shouldRestrictNavigationToShell(
   _rootPrefetchHints: number,
   _linkFetchStrategy: FetchStrategy
 ): boolean {
   return false
 }
-
-export async function waitForNavigationLockIfActive(
-  _lock: NavigationLockState | null = null
-): Promise<void> {}

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -119,9 +119,10 @@ export type NavigationLockPrefetch = {
 }
 
 export type NavigationLockState = {
-  // Resolves when the lock is released (the testing scope ends). The dynamic-
-  // data write during a locked navigation waits on this; see
-  // `getCurrentNavigationLock` and `waitForNavigationLockIfActive`.
+  // Resolves when the lock is released (the testing scope ends). Out-of-band
+  // user fetches blocked by `globalFetchOverride` wait on this so they dispatch
+  // only once the scope ends. (A locked navigation's *withheld dynamic write*
+  // waits on `currentNavigation` instead — see below.)
   released: Promise<void>
   resolveReleased: () => void
   // The pre-lock `window.fetch`, captured at `acquireLock` time and
@@ -140,6 +141,20 @@ export type NavigationLockState = {
   // entry left in the cache by an earlier navigation or prefetch. See
   // `readSegmentCacheEntryForNavigation`.
   ownedEntries: Set<SegmentCacheEntry>
+  // The withheld-data gate for the current locked navigation. A locked
+  // navigation's dynamic write waits on this rather than on the scope-wide
+  // `released`. Each navigation captures the promise when it begins (via
+  // `beginLockedNavigation` or `getCurrentNavigationGate`) and awaits that
+  // immutable snapshot, never this mutable field. `beginLockedNavigation`
+  // rolls the field over on each new locked navigation: it resolves the
+  // current promise — so the *previous* navigation's withheld data is written
+  // out and the cache nodes it produced stop holding pending deferred promises
+  // that a reused shared segment would otherwise suspend on — then installs a
+  // fresh one. `releaseLock` resolves it too. Net effect: only the most recent
+  // navigation's data stays withheld; a new navigation always releases the
+  // previous one.
+  currentNavigation: Promise<void>
+  resolveCurrentNavigation: () => void
 }
 
 let lockState: NavigationLockState | null = null
@@ -250,12 +265,18 @@ function acquireLock(): void {
   const released = new Promise<void>((r) => {
     resolveReleased = r
   })
+  let resolveCurrentNavigation: () => void
+  const currentNavigation = new Promise<void>((r) => {
+    resolveCurrentNavigation = r
+  })
   lockState = {
     released,
     resolveReleased: resolveReleased!,
     fetch: window.fetch,
     activePrefetches: new Set(),
     ownedEntries: new Set(),
+    currentNavigation,
+    resolveCurrentNavigation: resolveCurrentNavigation!,
   }
 
   // Install the fetch blocker. We only intercept `window.fetch` for the
@@ -271,15 +292,51 @@ function releaseLock(): void {
   // Restore the pre-lock `window.fetch` before resolving the lock promise
   // so any fetches queued on the promise see the restored fetch.
   window.fetch = lockState.fetch
-  const { resolveReleased, activePrefetches } = lockState
+  const { resolveReleased, activePrefetches, resolveCurrentNavigation } =
+    lockState
   lockState = null
   // Force-resolve every prefetch that hasn't finished, so a navigation still
   // waiting on one doesn't hang now that the scope is ending.
   for (const prefetch of activePrefetches) {
     prefetch.resolve()
   }
-  // Resolve the release promise so a gated dynamic write unblocks too.
+  // Resolve the current locked navigation's withheld-data gate, so its gated
+  // dynamic write unblocks now that the scope is ending.
+  resolveCurrentNavigation()
+  // Resolve the release promise so blocked out-of-band fetches dispatch too.
   resolveReleased()
+}
+
+/**
+ * Called when a new locked navigation begins (from `navigate` while the lock is
+ * held). Rolls over the lock's withheld-data gate: it resolves the current
+ * `currentNavigation` promise — so the *previous* locked navigation's withheld
+ * dynamic write proceeds and the cache nodes it produced stop holding pending
+ * deferred `rsc` promises that a reused shared segment in this navigation would
+ * otherwise suspend on — then installs a fresh promise for this navigation.
+ * Only the most recent navigation's data stays withheld; a new navigation
+ * always releases the previous one. Returns this navigation's gate — the
+ * immutable promise its dynamic write awaits — or null when no lock is held.
+ *
+ * This is the testing-lock behavior for repeated navigations while paused. It
+ * is not a principled fix for the underlying `useDeferredValue`/reuse-suspend
+ * behavior; it just ensures that, under the lock, a reused segment never
+ * carries a still-pending deferred `rsc` from an earlier navigation.
+ */
+export function beginLockedNavigation(): Promise<void> | null {
+  if (lockState === null) {
+    return null
+  }
+  // Release the previous locked navigation's withheld data, then roll over to a
+  // fresh gate for this navigation — all without ending the scope.
+  lockState.resolveCurrentNavigation()
+  let resolveCurrentNavigation: () => void
+  const currentNavigation = new Promise<void>((r) => {
+    resolveCurrentNavigation = r
+  })
+  lockState.currentNavigation = currentNavigation
+  lockState.resolveCurrentNavigation = resolveCurrentNavigation!
+  return currentNavigation
 }
 
 /**
@@ -451,6 +508,18 @@ export function getCurrentNavigationLock(): NavigationLockState | null {
 }
 
 /**
+ * Returns the current locked navigation's withheld-data gate — the same
+ * immutable promise `beginLockedNavigation` handed that navigation — or null
+ * when no lock is held. For router work that spawns a dynamic write without
+ * beginning a navigation of its own (refreshes, server actions, server
+ * patches): it gates behind the navigation that is current when it spawns, so
+ * the next locked navigation (or unlock) releases it.
+ */
+export function getCurrentNavigationGate(): Promise<void> | null {
+  return lockState !== null ? lockState.currentNavigation : null
+}
+
+/**
  * Decides whether segment reads during a navigation should be restricted to
  * shell entries (every param substituted with Fallback) rather than matching
  * entries that vary on concrete route params.
@@ -475,16 +544,4 @@ export function shouldRestrictNavigationToShell(
     (rootPrefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) !== 0 &&
     !subtreeHasSpeculativePrefetch(linkFetchStrategy, rootPrefetchHints)
   )
-}
-
-/**
- * Waits for the navigation lock to be released, if it's currently held.
- * No-op if the lock is not acquired.
- */
-export async function waitForNavigationLockIfActive(
-  lock: NavigationLockState | null = getCurrentNavigationLock()
-): Promise<void> {
-  if (lock !== null) {
-    await lock.released
-  }
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -17,7 +17,7 @@ import {
   startPPRNavigation,
   spawnDynamicRequests,
   FreshnessPolicy,
-  getCurrentNavigationLock,
+  beginLockedNavigation,
   type NavigationLock,
   type NavigationRequestAccumulation,
 } from '../router-reducer/ppr-navigations'
@@ -68,7 +68,7 @@ export function navigate(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
-  let navigationLock: NavigationLock = null
+  let navigationLock: NavigationLock | null = null
 
   // Instant Navigation Testing API: when the lock is active, ensure a
   // prefetch task has been initiated before proceeding with the navigation.
@@ -80,7 +80,11 @@ export function navigate(
     const { isNavigationLocked } =
       require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
     if (isNavigationLocked()) {
-      navigationLock = getCurrentNavigationLock()
+      // Signal that a new locked navigation is starting. This force-resolves the
+      // previous locked navigation's withheld data (so a reused shared segment
+      // no longer carries a pending deferred rsc) and returns this navigation's
+      // own withheld-data gate.
+      navigationLock = beginLockedNavigation()
       return ensurePrefetchThenNavigate(
         state,
         url,
@@ -123,7 +127,7 @@ function navigateImpl(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock | null
 ): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
   const href = url.href
@@ -226,7 +230,7 @@ export function navigateToKnownRoute(
   nextUrl: string | null,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock,
+  navigationLock: NavigationLock | null,
   debugInfo: Array<unknown> | null,
   // The route cache entry used for this navigation, if it came from route
   // prediction. Passed through so it can be marked as having a dynamic rewrite
@@ -388,7 +392,7 @@ function navigateUsingPrefetchedRouteTree(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
   route: FulfilledRouteCacheEntry,
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock | null
 ): AppRouterState {
   const routeTree = route.tree
   const canonicalUrl = route.canonicalUrl + url.hash
@@ -447,7 +451,7 @@ async function navigateToUnknownRoute(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock | null
 ): Promise<AppRouterState> {
   // Runs when a navigation happens but there's no cached prefetch we can use.
   // Don't bother to wait for a prefetch response; go straight to a full
@@ -1070,7 +1074,7 @@ async function ensurePrefetchThenNavigate(
   freshnessPolicy: FreshnessPolicy,
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
-  navigationLock: NavigationLock
+  navigationLock: NavigationLock | null
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
   const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/layout.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/layout.tsx
@@ -1,4 +1,6 @@
+import Link from 'next/link'
 import { ReactNode } from 'react'
+import { HydrationMarker } from './hydration-marker'
 
 export default function Root({ children }: { children: ReactNode }) {
   return (
@@ -14,6 +16,18 @@ export default function Root({ children }: { children: ReactNode }) {
           color: '#111',
         }}
       >
+        <HydrationMarker />
+        <nav style={{ display: 'flex', gap: 12, marginBottom: '1rem' }}>
+          <Link href="/" id="link-to-home">
+            Home
+          </Link>
+          <Link href="/post/1" id="link-to-post-1">
+            Post 1
+          </Link>
+          <Link href="/post/2" id="link-to-post-2">
+            Post 2
+          </Link>
+        </nav>
         {children}
       </body>
     </html>

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/page.tsx
@@ -1,11 +1,9 @@
 import Link from 'next/link'
-import { HydrationMarker } from './hydration-marker'
 import { ErrorTrigger } from './error-trigger'
 
 export default function Page() {
   return (
     <div>
-      <HydrationMarker />
       <h1 data-testid="home-title">Instant Navigation Mode Demo</h1>
       <ErrorTrigger />
       <p>

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/post/[slug]/loading.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/post/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p data-testid="post-loading">Loading post...</p>
+}

--- a/test/development/app-dir/instant-navs-devtools/app/(main)/post/[slug]/page.tsx
+++ b/test/development/app-dir/instant-navs-devtools/app/(main)/post/[slug]/page.tsx
@@ -1,0 +1,9 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return <p data-testid="post">Post {slug}</p>
+}

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -607,6 +607,54 @@ describe('instant-nav-panel', () => {
       await clearInstantModeCookie(browser)
     })
 
+    async function expectPostLoadingAt(pathname: string, browser: Playwright) {
+      await retry(
+        async () => {
+          expect(new URL(await browser.url()).pathname).toBe(pathname)
+        },
+        3_000,
+        100
+      )
+
+      await browser
+        .locator('[data-testid="post-loading"]')
+        .first()
+        .waitFor({ state: 'visible' })
+    }
+
+    it('should continue capturing loading navigations when starting on a dynamic route', async () => {
+      const browser = await next.browser('/post/1')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="post"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      await clickLink(browser, '/post/2')
+      await expectSpaPanel(browser)
+      await expectPostLoadingAt('/post/2', browser)
+
+      await clickLink(browser, '/post/1')
+      await expectPostLoadingAt('/post/1', browser)
+    })
+
+    it('should continue capturing loading navigations after starting on the home route', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      await clickLink(browser, '/post/1')
+      await expectSpaPanel(browser)
+      await expectPostLoadingAt('/post/1', browser)
+
+      await clickLink(browser, '/post/2')
+      await expectPostLoadingAt('/post/2', browser)
+    })
+
     it('should reset the panel and app when pressing the close button from captured SPA state', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 


### PR DESCRIPTION
With the Instant Navigation Testing lock held (the Navigation Inspector paused), repeated client navigations between pages that share a layout could sometimes get stuck without ever resolving.

The root cause turned out to be a subtle problem with the client router's use of `useDeferredValue` to switch between the cached UI and the final UI. The mechanism only works as we intend when mounting a new part of the tree. When updating an existing part of the tree, like a shared layout, React will skip the cached UI entirely.

We were already aware of this issue with the `useDeferredValue` approach. The plan is to instead model cached navigation as an optimistic update followed by a transition update. Before we can make such a change, though, we need to make a change in React to allow optimistic updates to suspend (currently, optimistic updates act like sync updates, and can trigger existing Suspense boundaries to switch back to their fallback state).

To workaround this issue when using the Navigation Inspector, we're going to change how the inspector works when multiple navigations are performed during the same "lock". Instead of keeping the entire sequence blocked until the end, we will instead only block the most recent one. This more closely matches what the inspector UI implies, anyway: it doesn't show a stack of pending navigations, only the most recent one.

This doesn't absolve us from needing to switch to using an optimistic update. That's needed regardless to address similar behavior in production. But this sidesteps the issue for now, and we were planning to make this change to the Navigation Inspector regardless.
