### PR TITLE
Back/forward set the Nav Inspector back to pending

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -147,7 +147,10 @@ export type NavigationRequestAccumulation = {
  * `beginLockedNavigation`) or when router work spawns a dynamic write outside
  * a navigation (via `getCurrentNavigationLock`), and threaded to the write,
  * which awaits it before applying dynamic data. Resolves when a newer locked
- * navigation begins or the lock is released.
+ * navigation begins or the lock is released. Because the capture happens at
+ * spawn time, a newer navigation's rollover releases this write rather than
+ * re-gating it. Threaded as `NavigationLock | null`; null whenever the testing
+ * API is not active.
  */
 export type NavigationLock = Promise<void>
 
@@ -2339,4 +2342,18 @@ export function beginLockedNavigation(): NavigationLock | null {
     return begin()
   }
   return null
+}
+
+/**
+ * Helper for the Instant Navigation Testing API. Called during a history
+ * traversal: resets the testing lock to a fresh pending scope, releasing any
+ * withheld data from prior navigations. See `resetNavigationLockToPending` in
+ * `navigation-testing-lock`.
+ */
+export function resetNavigationLockToPending(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    const { resetNavigationLockToPending: reset } =
+      require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
+    reset()
+  }
 }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -6,7 +6,7 @@ import type {
 import { extractPathFromFlightRouterState } from '../compute-changed-path'
 import {
   FreshnessPolicy,
-  getCurrentNavigationLock,
+  resetNavigationLockToPending,
   spawnDynamicRequests,
   startPPRNavigation,
   type NavigationRequestAccumulation,
@@ -44,7 +44,6 @@ export function restoreReducer(
   const restoredUrl = action.url
   const restoredNextUrl =
     extractPathFromFlightRouterState(treeToRestore) ?? restoredUrl.pathname
-  const navigationLock = getCurrentNavigationLock()
 
   const now = Date.now()
   // TODO: Store the dynamic stale time on the top-level state so it's known
@@ -94,10 +93,18 @@ export function restoreReducer(
     null,
     // History traversal always uses 'replace'.
     'replace',
-    navigationLock,
+    // Instant Navigation Testing API: a traversal is not a capture. Spawn its
+    // dynamic requests ungated (null lock) so they render from cache or fetch
+    // normally rather than being withheld behind the lock.
+    null,
     // Not an HMR refresh, so there's no request generation to cancel.
     undefined
   )
+  // Instant Navigation Testing API: a traversal resets the lock to a fresh
+  // pending scope — releasing any data withheld by prior forward navigations and
+  // returning the panel to "awaiting" — without ending the testing session.
+  // No-op when the testing API is disabled or no lock is held.
+  resetNavigationLockToPending()
   return completeTraverseNavigation(
     state,
     restoredUrl,

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
@@ -69,6 +69,8 @@ export function getCurrentNavigationGate(): Promise<void> | null {
   return null
 }
 
+export function resetNavigationLockToPending(): void {}
+
 export function shouldRestrictNavigationToShell(
   _rootPrefetchHints: number,
   _linkFetchStrategy: FetchStrategy

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -340,6 +340,31 @@ export function beginLockedNavigation(): Promise<void> | null {
 }
 
 /**
+ * Called when the router applies a history traversal (Back/Forward restore) while
+ * the testing lock is active. A traversal is not a capture — the mental model is
+ * that history entries are already cached — so it must not participate in the
+ * current capture. Instead it resets the lock to a fresh pending scope:
+ *
+ * - `releaseLock` flushes every still-withheld write from prior forward
+ *   navigations, so the pages you navigated away from finish streaming.
+ * - `acquireLock` immediately re-arms a fresh pending scope (no gap where the
+ *   lock or fetch blocker is down).
+ * - the cookie flips from the captured state back to pending.
+ *
+ * The traversal's own dynamic requests are spawned ungated by the caller (see
+ * `restore-reducer`), so they render from cache or fetch normally rather than
+ * being withheld.
+ */
+export function resetNavigationLockToPending(): void {
+  if (lockState === null || typeof document === 'undefined') {
+    return
+  }
+  releaseLock()
+  acquireLock()
+  writeCookieValue([0, `c${Math.random()}`])
+}
+
+/**
  * Global fetch override
  *
  * While the navigation lock is active, we install this as `window.fetch` so

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -323,6 +323,30 @@ describe('instant-nav-panel', () => {
       .waitFor({ state: 'visible', timeout: 30000 })
   }
 
+  async function expectPostLoadingAt(pathname: string, browser: Playwright) {
+    await retry(
+      async () => {
+        expect(new URL(await browser.url()).pathname).toBe(pathname)
+      },
+      3_000,
+      100
+    )
+
+    await browser
+      .locator('[data-testid="post-loading"]')
+      .first()
+      .waitFor({ state: 'visible' })
+  }
+
+  async function expectPostRenderedAt(pathname: string, browser: Playwright) {
+    await retry(async () => {
+      expect(new URL(await browser.url()).pathname).toBe(pathname)
+      expect(await browser.elementByCss('[data-testid="post"]').text()).toBe(
+        `Post ${pathname.split('/').pop()}`
+      )
+    })
+  }
+
   async function expectAwaitConnectionPageLoading(browser: Playwright) {
     await retry(
       async () => {
@@ -607,21 +631,6 @@ describe('instant-nav-panel', () => {
       await clearInstantModeCookie(browser)
     })
 
-    async function expectPostLoadingAt(pathname: string, browser: Playwright) {
-      await retry(
-        async () => {
-          expect(new URL(await browser.url()).pathname).toBe(pathname)
-        },
-        3_000,
-        100
-      )
-
-      await browser
-        .locator('[data-testid="post-loading"]')
-        .first()
-        .waitFor({ state: 'visible' })
-    }
-
     it('should continue capturing loading navigations when starting on a dynamic route', async () => {
       const browser = await next.browser('/post/1')
       await clearInstantModeCookie(browser)
@@ -774,6 +783,123 @@ describe('instant-nav-panel', () => {
 
       await expectMpaPanel(browser)
       await expectTargetPageMpaShell(browser)
+    })
+  })
+
+  describe('history traversals', () => {
+    it('re-arms the capture when navigating back from a captured SPA navigation', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await expectTargetPageSpaShell(browser)
+
+      // The SPA capture is recorded as soon as the prefetch resolves, which
+      // can be before the navigation commits the new URL. Wait for the URL to
+      // change before traversing so back() returns to home.
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      await browser.back()
+
+      // The traversal restores home with its real content.
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await retry(async () => {
+        expect(await browser.url()).not.toContain('/target-page')
+      })
+
+      // The capture no longer corresponds to what's on screen, so the panel
+      // returns to awaiting the next navigation, with the cookie still set.
+      await expectPendingPanel(browser)
+      await waitForInstantModeCookie(browser)
+
+      // The next navigation is captured again. (The revisited route renders
+      // from the navigation cache rather than showing the shell — same as a
+      // recapture after Resume.)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+    })
+
+    it('shows real content on forward after back while awaiting navigation', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await expectTargetPageSpaShell(browser)
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      await browser.back()
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await expectPendingPanel(browser)
+
+      // The re-arm released the captured scope, so the target page's dynamic
+      // data finished streaming in. Forward restores it with real content and
+      // does not start a new capture.
+      await browser.forward()
+      await expectTargetPageRendered(browser)
+      await expectPendingPanel(browser)
+    })
+
+    it('returns the panel to pending when navigating back after repeated captured navigations', async () => {
+      const browser = await next.browser('/post/1')
+      await clearInstantModeCookie(browser)
+      await browser.waitForElementByCss('[data-testid="post"]')
+      await waitForAppHydration(browser)
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await expectPendingPanel(browser)
+
+      // Two captured navigations in a row. The second navigation takes over
+      // the capture, releasing the first navigation's withheld data.
+      await clickLink(browser, '/post/2')
+      await expectSpaPanel(browser)
+      await expectPostLoadingAt('/post/2', browser)
+
+      await clickLink(browser, '/post/1')
+      await expectPostLoadingAt('/post/1', browser)
+
+      // Traversals are not captured, so going back resets the panel to
+      // awaiting the next navigation, with the cookie still set. The revisited
+      // page shows real content — its data was released when the second
+      // navigation took over the capture.
+      await browser.back()
+      await expectPostRenderedAt('/post/2', browser)
+      await expectPendingPanel(browser)
+      await waitForInstantModeCookie(browser)
+
+      // The traversal also released the current capture's withheld data, so
+      // forward restores real content too and does not start a new capture.
+      await browser.forward()
+      await expectPostRenderedAt('/post/1', browser)
+      await expectPendingPanel(browser)
+    })
+
+    it('captures a page load when reloading after back', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(browser, '/target-page/my-post?search=foo')
+      await expectSpaPanel(browser)
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      await browser.back()
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+      await expectPendingPanel(browser)
+
+      await browser.refresh()
+      await getInstantNavPanel(browser)
+      await expectMpaPanel(browser)
     })
   })
 


### PR DESCRIPTION
A back/forward (history traversal) navigation should not be captured by the Nav Inspector, because it's not the same as a regular navigation: it reads the entire navigation from cache, rather than fetching new data. It might be the case that data in the bfcache is missing for some reason, but in the normal case all the data will be available and the navigation will be instant. So that's how we should model it in the Nav Inspector.

In the future we may want to update the Nav Inspector UI to show that the current screen was the result of a back/forward navigation, but for now we will just reset the Nav Inspector back to the pending ("Waiting for navigation...") state.

Includes the regression tests from #95793.
