### PR TITLE
Segment cache: add shell byte boundary to per-segment prefetch responses

### DIFF
--- a/REWINDABLE_SEGMENT_PREFETCH_PLAN.md
+++ b/REWINDABLE_SEGMENT_PREFETCH_PLAN.md
@@ -1,0 +1,273 @@
+# Plan: shell-extractable ("rewindable") per-segment PPR prefetches
+
+> Handoff planning doc. Self-contained — assumes no prior conversation context.
+> Written for a fresh session to start implementing from.
+
+## TL;DR
+
+Give each per-segment prefetch response a **shell byte boundary** — a segment-level
+analogue of the whole-route `a` field — so the client can truncate a segment's
+buffered response and re-decode the prefix into an **intra-segment shell variant**
+(the param-dependent content *within* a single segment reduced to `Fallback`). This
+mirrors, at the segment grain, the shell-extraction the whole-route/navigation path
+already does via `resolveShellStageData` + `decodeStageUntilBoundary`.
+
+The load-bearing difficulty lives in
+`packages/next/src/server/app-render/collect-segment-data.tsx`
+(function `renderSegmentPrefetch`).
+
+## Environment / base branch
+
+- This worktree is based on **`origin/canary`** (the repo default branch).
+- The original feature branch this task was spun off from,
+  `worktree-navlock-shell-restriction` (PR **#95150**, "instant(): Only render
+  shell, unless prefetch prop is set"), is **already MERGED** into canary and its
+  remote branch was deleted. Do **not** base new work on it. Everything this plan
+  mirrors is present in canary.
+- `origin` is HTTPS (`github.com/vercel/next.js`). There is also an `acdlite` SSH
+  remote — if any git op fails with an SSH `publickey`/agent error, stop and ask the
+  user to unlock their SSH key provider (per repo AGENTS.md); do not switch remotes.
+
+## Scope (confirmed with the user)
+
+- **In scope:** the *capability* to extract a shell from a static PPR per-segment
+  prefetch — i.e. produce the per-segment boundary on the server and a decode path
+  on the client.
+- **Out of scope:** wiring the derived shell to any consumer. In particular, ignore
+  the shell-restricted-navigation / navigation-testing-lock work
+  (`shouldRestrictNavigationToShell`, `getShellSegmentVaryPath`) — that was a
+  *separate* task this was split off from. We are not replacing the runtime shell
+  render (`FetchStrategy.RuntimeShell`); we are adding a static-derived shell.
+- **Chosen definition of "shell":** option **B — intra-segment byte prefix.** A
+  segment's shell is that segment's own output with its param-dependent parts
+  reduced to `Fallback`, expressed as a decodable *prefix* of the segment's
+  serialized bytes. (The rejected alternative, option A, was whole-segment grain:
+  "a segment is either entirely shell or not," reusing the existing `varyParams`
+  signal. The user explicitly wants intra-segment prefixes — that is the point of
+  this task.)
+
+## Background: how the whole-route shell mechanism works (the thing to mirror)
+
+Verified in canary. Symbol names are the reliable anchors (line numbers drift).
+
+**Server** (`packages/next/src/server/app-render/app-render.tsx`):
+- The page render is *staged* via `StagedRenderingController`
+  (`packages/next/src/server/app-render/staged-rendering.ts`). Content serializes in
+  temporal stage order: `ShellStatic` → `Static` → `Dynamic`, where the `Shell*`
+  stages are the param-independent App Shell.
+- `renderToNodeFlightStream` produces one source stream; it is wrapped in
+  `ReplayableNodeStream` and two replay streams are taken — one is the actual
+  response, the other is fed to `countShellAndStaticStageBytes`.
+- `countShellAndStaticStageBytes` → `countStageBytesUntilAbortNode` iterates chunks
+  and attributes each chunk's byte length to `stageController.currentStage` (and all
+  later stages, since later stages include earlier). The stage is advanced in
+  lockstep by `runInSequentialTasks(() => advanceStage(ShellStatic), () =>
+  advanceStage(Static), ..., () => advanceStage(Dynamic))`.
+- Cumulative bytes at end-of-`ShellStatic` resolve the response's **`a`** field;
+  end-of-`Static` resolves **`l`**. `a` may resolve to `null`, meaning "shell ==
+  full response" (no separate prefix).
+
+**Client** (`packages/next/src/client/components/router-reducer/fetch-server-response.ts`):
+- `resolveShellStageData(cacheData, flightResponse, headers)`: if `flightResponse.a`
+  is a number, truncate `cacheData.shellBodyClone` at that byte offset and decode the
+  prefix. `a === undefined` → server emitted nothing; `a === null` → shell == full.
+- `resolveStaticStageData(...)` is the analogous helper for the `l` (static) boundary.
+- Both call `decodeStageUntilBoundary(clone, byteLength, headers)`, which buffers the
+  truncated clone (`createNonTaskyPrefetchResponseStream`) and decodes it with
+  `createFromNextReadableStream(..., { allowPartialStream: true })`.
+- The **clone** (`shellBodyClone` / `staticBodyClone`) is what makes it "rewindable":
+  the same response bytes are decoded more than once, at different truncation points.
+- Consumer example: `cache.ts` navigation path calls `resolveShellStageData` and,
+  for a `RuntimeShell` prefetch, fulfills entries with the shell while also caching
+  the full response.
+
+Field type decls: `NavigationFlightResponse` / `InitialRSCPayload` in
+`packages/next/src/shared/lib/app-router-types.ts` carry `a?: Promise<number | null>`
+(shell byte length) and `l?: Promise<number>` (static byte length).
+
+## The crux (why this is hard for segments)
+
+`collect-segment-data.tsx` does **not** stage. Flow today:
+1. `collectSegmentData(...)` (exported; called from `app-render.tsx` via
+   `ComponentMod.collectSegmentData`) receives only the final whole-page Flight
+   buffer `fullPageDataBuffer` (params already **concrete**), warms the module cache
+   by decoding it once, then `prerender(<PrefetchTreeData .../>)` walks the route tree
+   (`FlightRouterState` + `CacheNodeSeedData`) and spawns one task per segment.
+2. `renderSegmentPrefetch(...)` builds a `SegmentPrefetchResponse`
+   (`{ buildId, data: Array<SegmentPrefetch | null> }`, where
+   `SegmentPrefetch = { rsc, isPartial, staleTime, varyParams }`), `prerender`s it to
+   a single prelude stream, and drains it into **one `Buffer`** via `streamToBuffer`.
+   The abort controller fires after `waitAtLeastOneReactRenderTask()` (one microtask);
+   anything not yet emitted is dynamic and encoded as never-resolving references via
+   `createUnclosingPrefetchStream`. `isPartial` is detected by a *separate*
+   abort-on-microtask prerender in `isPartialRSCData`.
+3. Results collected into `Map<SegmentRequestKey, Buffer>`, including special keys
+   `/_tree`, `/_full`, `/_index`. Inlined ancestor segments are carried on a
+   `SegmentBundleNode` linked list and flattened into `data[]` at serialization time.
+
+Because the re-encode works from **decoded concrete data**, the shell/static layering
+that the *source* render produced is already collapsed. A naive re-encode therefore
+**cannot** yield a shell prefix — the prefix property is a product of React PPR staged
+rendering of *source* components, not recoverable from decoded concrete values.
+`collectSegmentData` also runs in **both build and edge runtimes**
+(`process.env.NEXT_RUNTIME === 'edge'` is checked at its call site in `app-render.tsx`).
+
+## Enabling insight
+
+The **whole-page buffer already contains a shell prefix**: its first `a` bytes
+(the page-level shell boundary) decode to a shell-form `InitialRSCPayload` in which
+every segment's content is the `Fallback`/shell version. So if we pass the **page
+shell byte length** into `collectSegmentData`, it can decode the page buffer **twice**:
+
+- full buffer → concrete per-segment `rsc` (as today), and
+- buffer truncated at page-`a` → shell-form per-segment `rsc` (params → `Fallback`).
+
+Walking both decoded trees in parallel gives, per segment, both a `concreteRsc` and a
+`shellRsc`, using only existing primitives (`streamFromBuffer` + `subarray`/truncation
++ `createFromReadableStream`).
+
+The remaining open risk is re-emitting, **per segment**, a *single* Flight stream
+whose first `a_seg` bytes decode to `shellRsc` and whose full bytes decode to
+`concreteRsc`.
+
+## Plan
+
+### Phase 0 — de-risk the per-segment staged re-emission (DO THIS FIRST)
+
+Prove out how to produce a segment stream with a shell prefix from the two decoded
+trees. Nothing else should be built until this is settled, because it determines the
+whole shape.
+
+Candidate techniques, in order of preference:
+
+1. **Staged segment re-encode.** Drive the segment `prerender` with a
+   `StagedRenderingController` + replayable clone + `countShellAndStaticStageBytes`,
+   using a wrapper node that yields `shellRsc` during `ShellStatic` and upgrades to
+   `concreteRsc` during `Static` — analogous to the `useDeferredValue(dynamic,
+   static)` override the segment cache already relies on. Record the `ShellStatic`
+   byte length as `a_seg`.
+   - Note the edge constraint: `ReplayableNodeStream` throws on edge. Segments are
+     already `Buffer`s, so use buffer-based cloning, not a Node tee.
+2. If (1) can't be driven from decoded data: compute per-segment boundaries **in the
+   original staged page render** and carry them down (bigger change; see Phase 1
+   open question), or — last resort — store the shell as a separate representation
+   (diverges from the `a` byte-prefix pattern).
+
+**Exit criteria:** a segment buffer where truncating at the recorded `a_seg` decodes
+to `Fallback` params, and the full buffer decodes to concrete; `isPartial` detection
+still correct. Prototype with a single simple dynamic-param route.
+
+### Phase 1 — server plumbing (after Phase 0 picks a technique)
+
+- Thread the **page shell byte length** into `collectSegmentData`.
+  - OPEN: confirm it is available at the call site. The *streamed response* render
+    computes it as `shellByteLengthDeferred` and attaches it as `a`. The
+    prerender/build path that produces `fullPageDataBuffer` (feeding
+    `collectSegmentData`) needs checking — it may already be computed and just needs
+    passing through, or may need to be captured/stored. Since `a` is a byte offset
+    *into the whole-page buffer* and `collectSegmentData` already has that buffer,
+    passing the single number is sufficient (truncate + decode locally).
+- Double-decode the page buffer (full + truncated-at-page-`a`). Walk the shell and
+  concrete trees in parallel with the existing `FlightRouterState` / `CacheNodeSeedData`
+  traversal in `PrefetchTreeData` → `collectSegmentDataImpl`.
+- Carry `shellRsc` alongside `rsc` through the traversal **and** the `SegmentBundleNode`
+  linked list — each inlined ancestor segment needs its own boundary.
+- `renderSegmentPrefetch`: produce `a_seg` and add it to the serialized response.
+  - Granularity decision: one boundary per `SegmentPrefetchResponse` vs one per
+    `SegmentPrefetch` element in `data[]`. Bundles inline multiple segments into one
+    response, so **per-element** is likely required.
+- Preserve `isPartialRSCData` semantics and the `createUnclosingPrefetchStream` /
+  abort-on-microtask behavior.
+- Edge runtime: buffer-based cloning only.
+
+### Phase 2 — client
+
+- In `packages/next/src/client/components/segment-cache/cache.ts`, the segment fetch
+  path decodes the response via
+  `createFromNextReadableStream<SegmentPrefetchResponse>(..., { allowPartialStream: true })`.
+  The response is already buffered, so add a segment-level shell decode mirroring
+  `decodeStageUntilBoundary` (clone the segment body, truncate at `a_seg`, re-decode).
+- Since no consumer is in scope, deliver the **capability**: the boundary field on the
+  response + a decode path that yields the shell variant. Do not wire it into
+  navigation/vary-path keying.
+
+### Phase 3 — interactions / correctness
+
+- `collectPrefetchHints` (build-time size-measurement pass) also calls
+  `renderSegmentPrefetch` — make sure the added work doesn't break or skew size
+  measurement.
+- `/_tree`, `/_full`, `/_index` special keys: define their shell semantics or
+  explicitly no-op them.
+- Bundle inlining/flattening must preserve per-segment boundaries.
+
+## Verification
+
+- Types: `pnpm --filter=next types` (~10s).
+- Build core: `pnpm --filter=next build`. Full `pnpm build-all` after branch switch /
+  bootstrap or if Rust/Turbopack is touched. Start `pnpm --filter=next dev` (watch)
+  before iterating.
+- e2e must run under cache-components (PPR codepaths):
+  `__NEXT_CACHE_COMPONENTS=true`. Generate any new test with
+  `pnpm new-test -- --args true <name> e2e` (mandatory).
+- Targeted unit-style assertions: truncating a segment buffer at `a_seg` decodes to
+  `Fallback` params; full buffer decodes to concrete; `isPartial` unchanged.
+- Capture test output to a file once and analyze; don't re-run with different greps.
+- NOTE on the user's `nxt` wrapper (Next.js framework dev only): use `nxt` for
+  test/build, never prefix with env vars, never pipe/redirect; use `--tee <file>` to
+  capture. E.g. `nxt test-start-turbo <path> --tee /tmp/out.log`.
+
+## Open questions to resolve while implementing
+
+1. Phase 0 technique feasibility — can a staged re-encode of decoded data emit a
+   valid shell-prefix stream? (The crux.)
+2. Is the page shell byte length already available at the `collectSegmentData` call
+   site for the prerender/build path, or must it be captured/stored?
+3. Boundary granularity: one `a` per `SegmentPrefetchResponse` vs per `SegmentPrefetch`
+   element (bundles argue for per-element).
+4. Client: derive the shell on demand vs eagerly; where to hold it given no consumer
+   is in scope.
+
+## Key code anchors (symbol names; grep these)
+
+- `packages/next/src/server/app-render/collect-segment-data.tsx`:
+  `collectSegmentData`, `PrefetchTreeData`, `collectSegmentDataImpl`,
+  `renderSegmentPrefetch`, `isPartialRSCData`, `createUnclosingPrefetchStream`,
+  types `SegmentPrefetchResponse` / `SegmentPrefetch`, `SegmentBundleNode`,
+  keys `/_tree` `/_full` `/_index`.
+- `packages/next/src/server/app-render/app-render.tsx`:
+  `collectSegmentData` wrapper + `ComponentMod.collectSegmentData` call site,
+  `countShellAndStaticStageBytes`, `countStageBytesUntilAbortNode`,
+  `runInSequentialTasks`, `shellByteLengthDeferred`, `renderToNodeFlightStream`.
+- `packages/next/src/server/app-render/staged-rendering.ts`:
+  `StagedRenderingController`, `RenderStage`, `RENDER_STAGE_ADVANCE_ORDER`.
+- `packages/next/src/client/components/router-reducer/fetch-server-response.ts`:
+  `resolveShellStageData`, `resolveStaticStageData`, `decodeStageUntilBoundary`.
+- `packages/next/src/server/app-render/app-render-prerender-utils.ts`:
+  `ReplayableNodeStream` / `createReplayStream` (throws on edge — do not use there).
+- `packages/next/src/server/stream-utils/node-web-streams-helper.ts`:
+  `streamFromBuffer`, `streamToBuffer`.
+- `packages/next/src/shared/lib/app-router-types.ts`: `a` / `l` field decls.
+
+## Constraints / gotchas
+
+- `collect-segment-data.tsx` runs inside `prerender` with abort-on-microtask. Do NOT
+  introduce real async work into the hot path after `onCompletedProcessingRouteTree()`
+  — it will be treated as a dynamic-data hang.
+- Edge runtime can't tee/replay Node Readables (`ReplayableNodeStream` throws).
+  Account for both runtimes; segments are already `Buffer`s so prefer buffer clones.
+- This file is bundled by the user's bundler via `entry-base.ts`; require internal
+  modules only through `entryBase.*` exports, not relative `require()`. It uses
+  vendored `react-server-dom-webpack/{static,client}` imports (see `$react-vendoring`).
+- Do not break `isPartial` detection or the `collectPrefetchHints` size pass.
+- Cache-components enables PPR by default; test with `__NEXT_CACHE_COMPONENTS=true`
+  rather than the mostly-skipped dedicated `ppr/` suites.
+
+## Suggested first steps for the implementing session
+
+1. Read `renderSegmentPrefetch` and `PrefetchTreeData`/`collectSegmentDataImpl` end to
+   end in `collect-segment-data.tsx`.
+2. Read `resolveShellStageData` + `decodeStageUntilBoundary` and the staged-render
+   byte-counting (`countShellAndStaticStageBytes`) to internalize the pattern.
+3. Start Phase 0 as a throwaway spike on one dynamic-param route: get `shellRsc` +
+   `concreteRsc` per segment (double-decode via page `a`), then try technique (1) and
+   check the exit criteria before building anything durable.

--- a/REWINDABLE_SEGMENT_PREFETCH_PLAN.md
+++ b/REWINDABLE_SEGMENT_PREFETCH_PLAN.md
@@ -3,12 +3,17 @@
 > Handoff planning doc. Self-contained — assumes no prior conversation context.
 > Written for a fresh session to start implementing from.
 
+## STATUS: IMPLEMENTED (see "Implementation notes" at the bottom)
+
+All phases below are done on this branch. The "Implementation notes" section
+records how the open questions were resolved and where the plan was refined.
+
 ## TL;DR
 
 Give each per-segment prefetch response a **shell byte boundary** — a segment-level
 analogue of the whole-route `a` field — so the client can truncate a segment's
 buffered response and re-decode the prefix into an **intra-segment shell variant**
-(the param-dependent content *within* a single segment reduced to `Fallback`). This
+(the param-dependent content _within_ a single segment reduced to `Fallback`). This
 mirrors, at the segment grain, the shell-extraction the whole-route/navigation path
 already does via `resolveShellStageData` + `decodeStageUntilBoundary`.
 
@@ -30,17 +35,17 @@ The load-bearing difficulty lives in
 
 ## Scope (confirmed with the user)
 
-- **In scope:** the *capability* to extract a shell from a static PPR per-segment
+- **In scope:** the _capability_ to extract a shell from a static PPR per-segment
   prefetch — i.e. produce the per-segment boundary on the server and a decode path
   on the client.
 - **Out of scope:** wiring the derived shell to any consumer. In particular, ignore
   the shell-restricted-navigation / navigation-testing-lock work
   (`shouldRestrictNavigationToShell`, `getShellSegmentVaryPath`) — that was a
-  *separate* task this was split off from. We are not replacing the runtime shell
+  _separate_ task this was split off from. We are not replacing the runtime shell
   render (`FetchStrategy.RuntimeShell`); we are adding a static-derived shell.
 - **Chosen definition of "shell":** option **B — intra-segment byte prefix.** A
   segment's shell is that segment's own output with its param-dependent parts
-  reduced to `Fallback`, expressed as a decodable *prefix* of the segment's
+  reduced to `Fallback`, expressed as a decodable _prefix_ of the segment's
   serialized bytes. (The rejected alternative, option A, was whole-segment grain:
   "a segment is either entirely shell or not," reusing the existing `varyParams`
   signal. The user explicitly wants intra-segment prefixes — that is the point of
@@ -51,7 +56,8 @@ The load-bearing difficulty lives in
 Verified in canary. Symbol names are the reliable anchors (line numbers drift).
 
 **Server** (`packages/next/src/server/app-render/app-render.tsx`):
-- The page render is *staged* via `StagedRenderingController`
+
+- The page render is _staged_ via `StagedRenderingController`
   (`packages/next/src/server/app-render/staged-rendering.ts`). Content serializes in
   temporal stage order: `ShellStatic` → `Static` → `Dynamic`, where the `Shell*`
   stages are the param-independent App Shell.
@@ -62,12 +68,13 @@ Verified in canary. Symbol names are the reliable anchors (line numbers drift).
   and attributes each chunk's byte length to `stageController.currentStage` (and all
   later stages, since later stages include earlier). The stage is advanced in
   lockstep by `runInSequentialTasks(() => advanceStage(ShellStatic), () =>
-  advanceStage(Static), ..., () => advanceStage(Dynamic))`.
+advanceStage(Static), ..., () => advanceStage(Dynamic))`.
 - Cumulative bytes at end-of-`ShellStatic` resolve the response's **`a`** field;
   end-of-`Static` resolves **`l`**. `a` may resolve to `null`, meaning "shell ==
   full response" (no separate prefix).
 
 **Client** (`packages/next/src/client/components/router-reducer/fetch-server-response.ts`):
+
 - `resolveShellStageData(cacheData, flightResponse, headers)`: if `flightResponse.a`
   is a number, truncate `cacheData.shellBodyClone` at that byte offset and decode the
   prefix. `a === undefined` → server emitted nothing; `a === null` → shell == full.
@@ -88,6 +95,7 @@ Field type decls: `NavigationFlightResponse` / `InitialRSCPayload` in
 ## The crux (why this is hard for segments)
 
 `collect-segment-data.tsx` does **not** stage. Flow today:
+
 1. `collectSegmentData(...)` (exported; called from `app-render.tsx` via
    `ComponentMod.collectSegmentData`) receives only the final whole-page Flight
    buffer `fullPageDataBuffer` (params already **concrete**), warms the module cache
@@ -99,16 +107,16 @@ Field type decls: `NavigationFlightResponse` / `InitialRSCPayload` in
    a single prelude stream, and drains it into **one `Buffer`** via `streamToBuffer`.
    The abort controller fires after `waitAtLeastOneReactRenderTask()` (one microtask);
    anything not yet emitted is dynamic and encoded as never-resolving references via
-   `createUnclosingPrefetchStream`. `isPartial` is detected by a *separate*
+   `createUnclosingPrefetchStream`. `isPartial` is detected by a _separate_
    abort-on-microtask prerender in `isPartialRSCData`.
 3. Results collected into `Map<SegmentRequestKey, Buffer>`, including special keys
    `/_tree`, `/_full`, `/_index`. Inlined ancestor segments are carried on a
    `SegmentBundleNode` linked list and flattened into `data[]` at serialization time.
 
 Because the re-encode works from **decoded concrete data**, the shell/static layering
-that the *source* render produced is already collapsed. A naive re-encode therefore
+that the _source_ render produced is already collapsed. A naive re-encode therefore
 **cannot** yield a shell prefix — the prefix property is a product of React PPR staged
-rendering of *source* components, not recoverable from decoded concrete values.
+rendering of _source_ components, not recoverable from decoded concrete values.
 `collectSegmentData` also runs in **both build and edge runtimes**
 (`process.env.NEXT_RUNTIME === 'edge'` is checked at its call site in `app-render.tsx`).
 
@@ -124,9 +132,10 @@ shell byte length** into `collectSegmentData`, it can decode the page buffer **t
 
 Walking both decoded trees in parallel gives, per segment, both a `concreteRsc` and a
 `shellRsc`, using only existing primitives (`streamFromBuffer` + `subarray`/truncation
-+ `createFromReadableStream`).
 
-The remaining open risk is re-emitting, **per segment**, a *single* Flight stream
+- `createFromReadableStream`).
+
+The remaining open risk is re-emitting, **per segment**, a _single_ Flight stream
 whose first `a_seg` bytes decode to `shellRsc` and whose full bytes decode to
 `concreteRsc`.
 
@@ -144,7 +153,7 @@ Candidate techniques, in order of preference:
    `StagedRenderingController` + replayable clone + `countShellAndStaticStageBytes`,
    using a wrapper node that yields `shellRsc` during `ShellStatic` and upgrades to
    `concreteRsc` during `Static` — analogous to the `useDeferredValue(dynamic,
-   static)` override the segment cache already relies on. Record the `ShellStatic`
+static)` override the segment cache already relies on. Record the `ShellStatic`
    byte length as `a_seg`.
    - Note the edge constraint: `ReplayableNodeStream` throws on edge. Segments are
      already `Buffer`s, so use buffer-based cloning, not a Node tee.
@@ -160,12 +169,12 @@ still correct. Prototype with a single simple dynamic-param route.
 ### Phase 1 — server plumbing (after Phase 0 picks a technique)
 
 - Thread the **page shell byte length** into `collectSegmentData`.
-  - OPEN: confirm it is available at the call site. The *streamed response* render
+  - OPEN: confirm it is available at the call site. The _streamed response_ render
     computes it as `shellByteLengthDeferred` and attaches it as `a`. The
     prerender/build path that produces `fullPageDataBuffer` (feeding
     `collectSegmentData`) needs checking — it may already be computed and just needs
     passing through, or may need to be captured/stored. Since `a` is a byte offset
-    *into the whole-page buffer* and `collectSegmentData` already has that buffer,
+    _into the whole-page buffer_ and `collectSegmentData` already has that buffer,
     passing the single number is sufficient (truncate + decode locally).
 - Double-decode the page buffer (full + truncated-at-page-`a`). Walk the shell and
   concrete trees in parallel with the existing `FlightRouterState` / `CacheNodeSeedData`
@@ -271,3 +280,113 @@ still correct. Prototype with a single simple dynamic-param route.
 3. Start Phase 0 as a throwaway spike on one dynamic-param route: get `shellRsc` +
    `concreteRsc` per segment (double-decode via page `a`), then try technique (1) and
    check the exit criteria before building anything durable.
+
+## Implementation notes (written after implementing)
+
+### How the open questions resolved
+
+1. **Phase 0 technique.** A refinement of technique (1) worked, with less
+   machinery than a `StagedRenderingController`: a **gated decode**. Each
+   segment response performs its own extra decode of the page buffer through a
+   stream that enqueues the first `pageShellByteLength` bytes immediately and
+   the remainder only when a gate promise resolves (never closing, like
+   `createUnclosingPrefetchStream`). The decoded per-segment `rsc` then has
+   pending references (React Lazy at ReactNode positions) exactly at the
+   param-dependent holes. Serializing the response while gated emits the shell
+   rows; releasing the gate makes the concrete rows flow into the same stream.
+   No tree splicing or `useDeferredValue`-style wrapper needed — the decode
+   itself is the staging mechanism.
+
+   Byte measurement can NOT use `prerender`: its prelude only becomes readable
+   after the render completes/aborts (verified in the vendored build — the
+   promise resolves in the all-ready callback). So the boundary render uses the
+   streaming `renderToReadableStream` (imported from
+   `react-server-dom-webpack/server`, works in node + edge; the build
+   prerender itself uses it via `ComponentMod.renderToReadableStream`), with
+   task choreography: start render + count consumed bytes → **wait until the
+   stream is quiet** (two consecutive tasks with no new bytes) → snapshot
+   `a_seg`, resolve the payload's `a` promise, release the gate → wait until
+   quiet again → abort and **drop post-abort chunks** (the same halt
+   simulation the page render uses for `flightData`; render-mode abort emits
+   error rows, prerender-mode halt emits nothing — verified). Quiescence
+   rather than a fixed task count is load-bearing: each wave can need
+   multiple rounds because re-rendering pinged tasks can outline further
+   nested lazy references from the decode, one round per nesting level — a
+   fixed window truncated deep trees (caught by segment-cache/
+   prefetch-inlining "hints are based on concrete params"). Attribution can
+   only under-count the shell (safe direction): the concrete wave physically
+   cannot start before the gate is released, which happens after the
+   snapshot.
+
+2. **Page shell byte length at the call site.** Available at the staged
+   build-time path in `app-render.tsx`: captured where
+   `shellByteLengthDeferred` is resolved (the `collectedChunksByStage.
+shellStaticChunks` byte sum when `didLinkDataUnblockNewContent`, else
+   null). `shellStaticChunks` is a strict byte prefix of the full flight
+   buffer (the stage accumulator appends each chunk to all stages >= current).
+   The three legacy `collectSegmentData` call sites (non-staged PPR, legacy
+   prerender, error page) pass `undefined` → no `a` emitted there. The
+   `cachedNavigations` marker byte is stripped before `collectSegmentData`, so
+   the offset needs no adjustment.
+
+3. **Boundary granularity: per-response.** A single stream has a single
+   truncation point; all bundled elements share the gate and go shell-form
+   together. Per-element boundaries are meaningless for one stream. The `a`
+   field lives on `SegmentPrefetchResponse`, typed like the route-level one
+   (`a?: Promise<number | null>`; null = shell == full response, undefined =
+   server didn't emit).
+
+4. **Client capability.** `createNonTaskyPrefetchResponseStream` already
+   buffers the whole response into one contiguous `Uint8Array`; it now also
+   returns that buffer, which doubles as the rewindable clone (no tee needed).
+   `resolveSegmentShellResponse(responseBuffer, serverResponse, headers)` in
+   `segment-cache/cache.ts` mirrors `resolveShellStageData` (undefined/null/
+   covers-whole-response → null, number → re-decode the subarray prefix as a
+   single chunk with `allowPartialStream`). `fetchSegmentsOnCacheMissImpl`
+   returns `responseBuffer` so a future consumer has it at the decision point.
+   Nothing is wired into navigation.
+
+### Safety properties / degraded modes
+
+- Navigation of the gated (shell-form) tree is **synchronous-only**: it
+  follows the same parallel-route-key path used by the concrete walk
+  (`SegmentSeedPath`, threaded through the traversal and `SegmentBundleNode`;
+  `'head'` addresses the head). If any element's path hits a pending thenable
+  or a mismatch, the whole response falls back to the legacy `prerender` path
+  with no `a` — every emitted response is either boundary-enhanced or exactly
+  as before. (Holes at ReactNode positions decode as React Lazy and pass
+  through fine; only holes at data positions — seed tuples/children maps —
+  trigger the bail, so the common cases all get boundaries.)
+- The gated decode root is raced against one render task and errors are
+  caught → bail to legacy path; a malformed prefix can't hang the build.
+- `isPartial`, `varyParams`, `staleTime` are always computed from the
+  concrete decode, as before.
+- `collectPrefetchHints` (size pass) passes no boundary → byte-identical
+  behavior to before.
+- `/_tree` unchanged; `/_full` already carries the page-level `a`; `/_index`
+  gets a boundary like any segment; the page-level `/_shell` special key is
+  unrelated and unchanged.
+
+### Verified
+
+- Types pass; fixture build (cache components, turbopack) emits, for a
+  param-reading page: envelope `"a":"$@f"`, boundary row `f:<offset>` exactly
+  on a row edge, all param-independent content (page static content, layouts,
+  Suspense fallback, bundled head) before the boundary, the param row after
+  it; static routes resolve `a` → null; ISR fallback-shell renders resolve
+  `a` → null (they are already shells; params never unblocked content).
+- New e2e: `test/e2e/app-dir/segment-prefetch-shell-boundary` (start mode).
+- Regression suites run in start mode: segment-cache `basic`,
+  `prefetch-inlining`, `prefetch-app-shell`.
+
+### Possible follow-ups (not in scope)
+
+- One gated decode per response is O(responses × page size) per
+  build/revalidation of a param-varying route. Could be optimized to a single
+  shared gated decode with a barrier that releases the gate after every
+  response has snapshotted its boundary.
+- The deferred-concrete fallback (serialize concrete data gated behind the
+  gate promise when the shell tree can't be navigated) was considered and
+  rejected for now because it changes the decoded shape of `rsc` to a promise.
+- A dev-mode assertion that decodes the truncated prefix server-side and
+  verifies it resolves.

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2223,6 +2223,12 @@ async function fetchSegmentsOnCacheMissImpl(
 ): Promise<{
   serverResponse: SegmentPrefetchResponse
   responseSize: number
+  /**
+   * The raw response bytes. A shell variant of the response can be derived
+   * from these with resolveSegmentShellResponse, when the response carries a
+   * shell byte boundary (the `a` field).
+   */
+  responseBuffer: Uint8Array
   closed: Promise<void>
 } | null> {
   // Use the canonical URL to request the segment, not the original URL. These
@@ -2282,8 +2288,11 @@ async function fetchSegmentsOnCacheMissImpl(
   // buffered prefetch paths.
   const closed = createPromiseWithResolvers<void>()
 
-  const { stream: prefetchStream, size: responseSize } =
-    await createNonTaskyPrefetchResponseStream(response.body)
+  const {
+    stream: prefetchStream,
+    size: responseSize,
+    buffer: responseBuffer,
+  } = await createNonTaskyPrefetchResponseStream(response.body)
   closed.resolve()
 
   // Parse the response. Always a SegmentPrefetchResponse with a build ID and a
@@ -2308,7 +2317,12 @@ async function fetchSegmentsOnCacheMissImpl(
     return null
   }
 
-  return { serverResponse, responseSize, closed: closed.promise }
+  return {
+    serverResponse,
+    responseSize,
+    responseBuffer,
+    closed: closed.promise,
+  }
 }
 
 /**
@@ -3268,7 +3282,15 @@ async function fetchPrefetchResponse<T>(
 export async function createNonTaskyPrefetchResponseStream(
   body: ReadableStream<Uint8Array>,
   byteLimit?: number
-): Promise<{ stream: ReadableStream<Uint8Array>; size: number }> {
+): Promise<{
+  stream: ReadableStream<Uint8Array>
+  size: number
+  // The buffered response bytes. Because the response is fully buffered
+  // anyway, this doubles as a rewindable copy: a prefix of it can be decoded
+  // again at a byte boundary (see resolveSegmentShellResponse) without
+  // teeing the original body.
+  buffer: Uint8Array
+}> {
   // Buffer the entire response before passing it to the Flight client. This
   // ensures that when Flight processes the stream, all model data is available
   // synchronously. This is important for readVaryParams, which synchronously
@@ -3329,7 +3351,58 @@ export async function createNonTaskyPrefetchResponseStream(
       controller.close()
     },
   })
-  return { stream, size }
+  return { stream, size, buffer }
+}
+
+/**
+ * Decodes the shell variant of a segment prefetch response: the response's
+ * own output with all param-dependent content reduced to pending references
+ * (which suspend during render, i.e. act as the param fallback). This is the
+ * segment-level analogue of `resolveShellStageData` for route-level
+ * responses.
+ *
+ * The server encodes the shell as a byte prefix: the response's `a` field
+ * resolves to a byte offset such that re-decoding the response body truncated
+ * at that offset yields the shell variant of every segment in the response.
+ *
+ * Returns null when no separate decode is needed:
+ * - `a === undefined`: the server didn't emit a shell boundary (e.g. the page
+ *   wasn't rendered with staged rendering).
+ * - `a` resolves to `null`, or to a boundary covering the entire response:
+ *   the shell IS the full response — the caller can reuse the already-decoded
+ *   response if it needs a shell variant.
+ */
+export async function resolveSegmentShellResponse(
+  responseBuffer: Uint8Array,
+  serverResponse: SegmentPrefetchResponse,
+  headers: RequestHeaders | undefined
+): Promise<SegmentPrefetchResponse | null> {
+  if (serverResponse.a === undefined) {
+    return null
+  }
+  const shellByteLength = await serverResponse.a
+  if (
+    shellByteLength === null ||
+    shellByteLength >= responseBuffer.byteLength
+  ) {
+    // Shell == full response — caller reuses the existing decoded response.
+    return null
+  }
+  // Enqueue the truncated prefix as a single chunk, for the same reason
+  // createNonTaskyPrefetchResponseStream buffers the response: all model data
+  // must be available synchronously when Flight processes the stream.
+  const prefix = responseBuffer.subarray(0, shellByteLength)
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(prefix)
+      controller.close()
+    },
+  })
+  return createFromNextReadableStream<SegmentPrefetchResponse>(
+    stream,
+    headers,
+    { allowPartialStream: true }
+  )
 }
 
 /**

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -8338,6 +8338,11 @@ async function prerenderToStream(
       const collectedChunksByStage = appShells
         ? createStageChunksAccumulator()
         : null
+      // The page-level shell byte boundary, captured when the shell stage
+      // completes. Resolves shellByteLengthDeferred and is also passed to
+      // collectSegmentData so each per-segment response can derive its own
+      // shell boundary from it. Stays undefined when appShells is off.
+      let pageShellByteLength: number | null | undefined = undefined
       const collectChunk = (chunk: Uint8Array) => {
         collectPrerenderChunk(
           collectedChunks,
@@ -8474,14 +8479,13 @@ async function prerenderToStream(
           finishAccumulatingVaryParams(varyParamsAccumulator)
 
           if (shellByteLengthDeferred && collectedChunksByStage) {
-            shellByteLengthDeferred.resolve(
-              didLinkDataUnblockNewContent
-                ? collectedChunksByStage.shellStaticChunks.reduce(
-                    (acc, chunk) => acc + chunk.byteLength,
-                    0
-                  )
-                : null
-            )
+            pageShellByteLength = didLinkDataUnblockNewContent
+              ? collectedChunksByStage.shellStaticChunks.reduce(
+                  (acc, chunk) => acc + chunk.byteLength,
+                  0
+                )
+              : null
+            shellByteLengthDeferred.resolve(pageShellByteLength)
           }
         },
         () => {
@@ -8524,12 +8528,15 @@ async function prerenderToStream(
         )
 
         // collectSegmentData needs the raw flight data without the marker byte.
+        // Note pageShellByteLength is an offset into these raw chunks, so it
+        // doesn't need adjusting for the marker byte.
         const flightData = cachedNavigations
           ? metadata.flightData.subarray(1)
           : metadata.flightData
 
         await collectSegmentData(
           flightData,
+          pageShellByteLength,
           finalServerPrerenderStore,
           ComponentMod,
           renderOpts,
@@ -8882,6 +8889,8 @@ async function prerenderToStream(
         metadata.flightData = flightData
         await collectSegmentData(
           flightData,
+          // Not a staged render; no shell boundary exists.
+          undefined,
           ssrPrerenderStore,
           ComponentMod,
           renderOpts,
@@ -9095,6 +9104,8 @@ async function prerenderToStream(
         metadata.flightData = flightData
         await collectSegmentData(
           flightData,
+          // Not a staged render; no shell boundary exists.
+          undefined,
           prerenderLegacyStore,
           ComponentMod,
           renderOpts,
@@ -9638,6 +9649,8 @@ async function prerenderToStream(
         metadata.flightData = flightData
         await collectSegmentData(
           flightData,
+          // Not a staged render; no shell boundary exists.
+          undefined,
           prerenderLegacyStore,
           ComponentMod,
           renderOpts,
@@ -9880,6 +9893,11 @@ const getGlobalErrorStyles = async (
 
 async function collectSegmentData(
   fullPageDataBuffer: Buffer,
+  // Byte offset into fullPageDataBuffer marking the end of the page's shell
+  // stage (null: shell == full static response), when produced by staged
+  // rendering; undefined otherwise. Used to derive per-segment shell
+  // boundaries.
+  pageShellByteLength: number | null | undefined,
   prerenderStore: PrerenderStore,
   ComponentMod: AppPageModule,
   renderOpts: RenderOpts,
@@ -9999,7 +10017,8 @@ async function collectSegmentData(
     serverConsumerManifest,
     Boolean(renderOpts.experimental.prefetchInlining),
     hints,
-    isUpgradeableISRFallback
+    isUpgradeableISRFallback,
+    pageShellByteLength
   )
 }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -21,6 +21,8 @@ import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-p
 import { createFromReadableStream } from 'react-server-dom-webpack/client'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { prerender } from 'react-server-dom-webpack/static'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { renderToReadableStream } from 'react-server-dom-webpack/server'
 
 import {
   streamFromBuffer,
@@ -28,6 +30,8 @@ import {
 } from '../stream-utils/node-web-streams-helper'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
+import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
+import { isThenable } from '../../shared/lib/is-thenable'
 import {
   type SegmentRequestKey,
   createSegmentRequestKeyPart,
@@ -107,6 +111,19 @@ export type SegmentPrefetchResponse = {
    * more complete *static* version may become available.
    */
   isUpgradeableISRFallback: boolean
+  /**
+   * Shell byte boundary for this response — the segment-level analogue of the
+   * `a` field on the route-level response. Resolves to the byte offset such
+   * that truncating the response body at that offset and re-decoding the
+   * prefix yields a shell variant of every segment in the response: the
+   * segment's own output with its param-dependent content reduced to pending
+   * references (which suspend, i.e. render as the param fallback).
+   *
+   * Only emitted for pages rendered with staged rendering (appShells).
+   * Resolves to null when the shell is identical to the full response, in
+   * which case no separate decode is needed.
+   */
+  a?: Promise<number | null>
 }
 
 export type SegmentPrefetch = {
@@ -134,7 +151,35 @@ export type SegmentPrefetch = {
 type SegmentBundleNode = {
   rsc: React.ReactNode
   varyParams: Set<string> | null
+  seedPath: SegmentSeedPath
   next: SegmentBundleNode | null
+}
+
+/**
+ * Identifies a segment's position in the page payload: the chain of parallel
+ * route keys leading to its CacheNodeSeedData, or 'head' for the head. Used
+ * to locate the segment's data in a second, shell-truncated decode of the
+ * page buffer. That tree can't be walked ahead of time alongside the main
+ * traversal because each response performs its own gated decode (see
+ * renderSegmentPrefetchWithShellBoundary), so segments are addressed by path
+ * instead of by value.
+ */
+type SegmentSeedPath = readonly string[] | 'head'
+
+/**
+ * Everything needed to derive per-segment shell byte boundaries from the
+ * whole-page Flight buffer. Only available when the page was produced by
+ * staged rendering (appShells). `pageShellByteLength` is the page-level shell
+ * boundary — the same value the route-level `a` field resolves to; the first
+ * `pageShellByteLength` bytes of `fullPageDataBuffer` decode to the shell
+ * variant of the page. null means the page's shell is identical to its full
+ * static response (route-level `a: null`), and therefore the same is true of
+ * every segment.
+ */
+type ShellBoundaryContext = {
+  pageShellByteLength: number | null
+  fullPageDataBuffer: Buffer
+  serverConsumerManifest: any
 }
 
 const filterStackFrame =
@@ -201,9 +246,20 @@ export async function collectSegmentData(
   serverConsumerManifest: any,
   prefetchInlining: boolean,
   hints: PrefetchHints | null,
-  isUpgradeableISRFallback: boolean
+  isUpgradeableISRFallback: boolean,
+  // The page-level shell byte boundary, when the page was produced by staged
+  // rendering: a byte offset into fullPageDataBuffer, or null if the page's
+  // shell is identical to its full static response. undefined when the render
+  // wasn't staged (no shell exists), in which case segment responses don't
+  // get a shell boundary.
+  pageShellByteLength?: number | null
 ): Promise<Map<SegmentRequestKey, Buffer>> {
   // Traverse the router tree and generate a prefetch response for each segment.
+
+  const shellBoundary: ShellBoundaryContext | null =
+    pageShellByteLength !== undefined
+      ? { pageShellByteLength, fullPageDataBuffer, serverConsumerManifest }
+      : null
 
   // A mutable map to collect the results as we traverse the route tree.
   const resultMap = new Map<SegmentRequestKey, Buffer>()
@@ -252,6 +308,7 @@ export async function collectSegmentData(
       prefetchInlining={prefetchInlining}
       hints={hints}
       isUpgradeableISRFallback={isUpgradeableISRFallback}
+      shellBoundary={shellBoundary}
     />,
     clientModules,
     {
@@ -361,7 +418,11 @@ export async function collectPrefetchHints(
     null,
     // This pass only measures gzip sizes for inlining hints; fallback-ness
     // doesn't affect size, so pass false.
-    false
+    false,
+    'head',
+    // No shell boundary in the size-measurement pass — a shell prefix
+    // wouldn't meaningfully change the gzip size.
+    null
   )
   const headGzipSize = await getGzipSize(headBuffer)
 
@@ -476,7 +537,11 @@ async function collectPrefetchHintsImpl(
       clientModules,
       null,
       // Size-measurement pass only; fallback-ness is irrelevant here.
-      false
+      false,
+      // The seed path is only used when a shell boundary is requested, which
+      // this pass never does.
+      [],
+      null
     )
     currentGzipSize = await getGzipSize(buffer)
   }
@@ -694,6 +759,7 @@ async function PrefetchTreeData({
   prefetchInlining,
   hints,
   isUpgradeableISRFallback,
+  shellBoundary,
 }: {
   isClientParamParsingEnabled: boolean
   fullPageDataBuffer: Buffer
@@ -705,6 +771,7 @@ async function PrefetchTreeData({
   prefetchInlining: boolean
   hints: PrefetchHints | null
   isUpgradeableISRFallback: boolean
+  shellBoundary: ShellBoundaryContext | null
 }): Promise<RootTreePrefetch | null> {
   // We're currently rendering a Flight response for the route tree prefetch.
   // Inside this component, decode the Flight stream for the whole page. This is
@@ -749,7 +816,7 @@ async function PrefetchTreeData({
   // each segment. When prefetch inlining is enabled, small segments are bundled
   // into their children's responses based on the hint bits.
   const headBundle: SegmentBundleNode | null = headIsInlined
-    ? { rsc: head, varyParams: headVaryParams, next: null }
+    ? { rsc: head, varyParams: headVaryParams, seedPath: 'head', next: null }
     : null
   const tree = collectSegmentDataImpl(
     isClientParamParsingEnabled,
@@ -765,7 +832,9 @@ async function PrefetchTreeData({
     null,
     headBundle,
     rootVaryParamsIterable,
-    isUpgradeableISRFallback
+    isUpgradeableISRFallback,
+    [],
+    shellBoundary
   )
 
   // Spawn a task to produce a prefetch response for the "head" segment,
@@ -781,7 +850,9 @@ async function PrefetchTreeData({
           headVaryParams,
           clientModules,
           null,
-          isUpgradeableISRFallback
+          isUpgradeableISRFallback,
+          'head',
+          shellBoundary
         )
       )
     )
@@ -817,7 +888,9 @@ function collectSegmentDataImpl(
   parentBundle: SegmentBundleNode | null,
   headBundle: SegmentBundleNode | null,
   rootVaryParamsIterable: VaryParamsIterable | null,
-  isUpgradeableISRFallback: boolean
+  isUpgradeableISRFallback: boolean,
+  seedPath: readonly string[],
+  shellBoundary: ShellBoundaryContext | null
 ): TreePrefetch {
   // Union the hints already embedded in the FlightRouterState with the
   // separately-computed build-time hints. During the initial build, the
@@ -863,6 +936,7 @@ function collectSegmentDataImpl(
       childBundle = {
         rsc,
         varyParams,
+        seedPath,
         next: parentBundle,
       }
     }
@@ -895,7 +969,9 @@ function collectSegmentDataImpl(
             varyParams,
             clientModules,
             bundle,
-            isUpgradeableISRFallback
+            isUpgradeableISRFallback,
+            seedPath,
+            shellBoundary
           )
         )
       )
@@ -940,7 +1016,9 @@ function collectSegmentDataImpl(
       childBundle,
       headBundle,
       rootVaryParamsIterable,
-      isUpgradeableISRFallback
+      isUpgradeableISRFallback,
+      [...seedPath, parallelRouteKey],
+      shellBoundary
     )
     if (slotMetadata === null) {
       slotMetadata = {}
@@ -983,7 +1061,9 @@ async function renderSegmentPrefetch(
   varyParams: Set<string> | null,
   clientModules: ManifestNode,
   bundle: SegmentBundleNode | null,
-  isUpgradeableISRFallback: boolean
+  isUpgradeableISRFallback: boolean,
+  seedPath: SegmentSeedPath,
+  shellBoundary: ShellBoundaryContext | null
 ): Promise<[SegmentRequestKey, Buffer]> {
   // Build the SegmentPrefetch for the terminal (requested) segment.
   // The terminal always has non-null rsc data — disabled segments are
@@ -995,8 +1075,12 @@ async function renderSegmentPrefetch(
     varyParams,
   }
 
-  // Build the data array. Always an array, even for a single segment.
+  // Build the data array. Always an array, even for a single segment. Track
+  // each element's seed path in a parallel array; the shell boundary render
+  // uses it to locate the same segments in a shell-truncated decode of the
+  // page buffer.
   const data: Array<SegmentPrefetch | null> = [selfPrefetch]
+  const seedPaths: Array<SegmentSeedPath | null> = [seedPath]
   if (bundle !== null) {
     // Walk the bundle linked list and append each entry to the array.
     let node: SegmentBundleNode | null = bundle
@@ -1008,15 +1092,45 @@ async function renderSegmentPrefetch(
           staleTime,
           varyParams: node.varyParams,
         })
+        seedPaths.push(node.seedPath)
       } else {
         // This segment has static prefetching disabled (runtime prefetch
         // or instant = false). Emit null as a placeholder so the array
         // indices stay aligned with the client's SegmentBundle linked
         // list. The client will skip creating a cache entry for this slot.
         data.push(null)
+        seedPaths.push(null)
       }
       node = node.next
     }
+  }
+
+  const responseKey =
+    requestKey === ROOT_SEGMENT_REQUEST_KEY
+      ? ('/_index' as SegmentRequestKey)
+      : requestKey
+
+  if (shellBoundary !== null && shellBoundary.pageShellByteLength !== null) {
+    // The page has a shell that is a strict byte prefix of its static
+    // response. Derive a per-response shell boundary by re-encoding the
+    // segment data in two waves — shell content first, then the
+    // param-dependent remainder — and measuring the boundary between them.
+    const segmentBuffer = await renderSegmentPrefetchWithShellBoundary(
+      buildId,
+      data,
+      seedPaths,
+      clientModules,
+      isUpgradeableISRFallback,
+      shellBoundary.fullPageDataBuffer,
+      shellBoundary.pageShellByteLength,
+      shellBoundary.serverConsumerManifest
+    )
+    if (segmentBuffer !== null) {
+      return [responseKey, segmentBuffer]
+    }
+    // The shell-truncated decode didn't pan out (e.g. this segment's data
+    // isn't reachable in the page's shell prefix). Fall through and emit a
+    // regular response with no shell boundary.
   }
 
   // Wrap in the response envelope with the build ID at the top level.
@@ -1027,6 +1141,12 @@ async function renderSegmentPrefetch(
     buildId: buildId ?? '',
     data,
     isUpgradeableISRFallback,
+  }
+  if (shellBoundary !== null && shellBoundary.pageShellByteLength === null) {
+    // The page's shell is identical to its full static response, so the same
+    // is true of every segment: the shell variant of this response is the
+    // response itself. Mirrors `a: null` on the route-level response.
+    payload.a = Promise.resolve(null)
   }
   // Since all we're doing is decoding and re-encoding a cached prerender, if
   // it takes longer than a microtask, it must because of hanging promises
@@ -1039,11 +1159,301 @@ async function renderSegmentPrefetch(
     onError: onSegmentPrerenderError,
   })
   const segmentBuffer = await streamToBuffer(segmentStream)
-  if (requestKey === ROOT_SEGMENT_REQUEST_KEY) {
-    return ['/_index' as SegmentRequestKey, segmentBuffer]
-  } else {
-    return [requestKey, segmentBuffer]
+  return [responseKey, segmentBuffer]
+}
+
+/**
+ * Renders a segment prefetch response with an embedded shell byte boundary
+ * (the `a` field): a byte offset such that truncating the response body at
+ * that offset and re-decoding the prefix yields a shell variant of every
+ * segment in the response — the output those segments would have produced
+ * had the route's params been unknown. This mirrors, per segment response,
+ * the route-level `a` field produced by staged rendering.
+ *
+ * The shell layering of the original staged page render is not recoverable
+ * from the decoded concrete values that collectSegmentData normally works
+ * with — it's a temporal property of the page stream, already collapsed by
+ * the time the stream is decoded. But the page buffer's own shell boundary
+ * preserves it: the first `pageShellByteLength` bytes decode to a shell-form
+ * payload in which each segment's param-dependent content is reified as
+ * references that stay pending until more of the stream arrives.
+ *
+ * So the page buffer is decoded again through a gate: the shell prefix is
+ * released immediately, the remainder only after the segment's shell content
+ * has been serialized and measured. Re-encoding the gated tree emits the
+ * response in two waves — first the shell rows, with param-dependent
+ * references still pending, then, once the gate is released, the rows those
+ * references resolve to. The byte count at the moment the gate is released
+ * is the response's shell boundary.
+ *
+ * This uses the streaming Flight renderer rather than `prerender` because the
+ * boundary must be observed while the stream is being emitted, and
+ * `prerender` only exposes its prelude after the render has finished.
+ * Aborting the streaming renderer emits error rows for still-pending
+ * references, so chunks that arrive after the abort are discarded — the same
+ * way the page render halts the stream it stores as `flightData`. A dropped
+ * row reads as a reference that never resolves, which is exactly how
+ * prefetch responses encode dynamic holes.
+ *
+ * Returns null if the segment data can't be located in the shell-form decode;
+ * the caller falls back to a regular response with no shell boundary.
+ */
+async function renderSegmentPrefetchWithShellBoundary(
+  buildId: string | undefined,
+  data: Array<SegmentPrefetch | null>,
+  seedPaths: Array<SegmentSeedPath | null>,
+  clientModules: ManifestNode,
+  isUpgradeableISRFallback: boolean,
+  fullPageDataBuffer: Buffer,
+  pageShellByteLength: number,
+  serverConsumerManifest: any
+): Promise<Buffer | null> {
+  // Decode the page buffer through a gate: the shell prefix immediately, the
+  // remainder when the gate is released.
+  const gate = createPromiseWithResolvers<void>()
+  const gatedStream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(fullPageDataBuffer.subarray(0, pageShellByteLength))
+      await gate.promise
+      controller.enqueue(fullPageDataBuffer.subarray(pageShellByteLength))
+      // Intentionally never closed, for the same reason as
+      // createUnclosingPrefetchStream: the page stream may contain references
+      // that never resolve (dynamic holes), and Flight errors if the stream
+      // closes before all references are resolved.
+    },
+  })
+
+  let gatedPayload: InitialRSCPayload | null = null
+  try {
+    const gatedPayloadPromise: Promise<InitialRSCPayload> =
+      createFromReadableStream(gatedStream, {
+        findSourceMapURL,
+        serverConsumerManifest,
+      })
+    // If we bail out below, the decode may reject later (e.g. on a malformed
+    // prefix); that's not actionable at that point.
+    gatedPayloadPromise.catch(() => {})
+    gatedPayload = await Promise.race([
+      gatedPayloadPromise,
+      // The shell prefix is a fully buffered payload and the module cache is
+      // already warm, so the root of the decoded tree resolves within a
+      // microtask. If it hasn't resolved within a task, the prefix must not
+      // contain the root row; bail out rather than risk hanging.
+      waitAtLeastOneReactRenderTask().then(() => null),
+    ])
+  } catch {
+    gatedPayload = null
   }
+  if (gatedPayload === null) {
+    gate.resolve()
+    return null
+  }
+
+  // Substitute each segment's concrete data with its shell-form counterpart.
+  // The shell-form values contain the same content, but everything that was
+  // serialized after the page's shell boundary is a pending reference that
+  // resolves only once the gate is released.
+  const gatedData: Array<SegmentPrefetch | null> = []
+  for (let i = 0; i < data.length; i++) {
+    const element = data[i]
+    const elementSeedPath = seedPaths[i]
+    if (element === null || elementSeedPath === null) {
+      gatedData.push(null)
+      continue
+    }
+    const gatedRsc = readGatedSegmentData(gatedPayload, elementSeedPath)
+    if (gatedRsc === undefined) {
+      // This segment's data isn't synchronously reachable in the shell-form
+      // tree. Re-encoding an asynchronous replacement would change the shape
+      // of the decoded response (e.g. `rsc` would decode to a promise), so
+      // bail out and let the caller emit a regular response instead.
+      gate.resolve()
+      return null
+    }
+    // Everything except the rsc data (isPartial, varyParams) describes the
+    // full response and is copied from the concrete data — it must not
+    // depend on the gated decode, whose iterables/thenables are pending.
+    gatedData.push({ ...element, rsc: gatedRsc })
+  }
+
+  // The boundary can't be known until the shell wave has been measured, so
+  // like the route-level `a`, it's serialized as a promise and resolved
+  // mid-stream. Its row is emitted after the boundary, as part of the
+  // concrete wave; a client decoding the truncated prefix sees it as pending.
+  const boundary = createPromiseWithResolvers<number | null>()
+  const payload: SegmentPrefetchResponse = {
+    buildId: buildId ?? '',
+    data: gatedData,
+    isUpgradeableISRFallback,
+    a: boundary.promise,
+  }
+
+  const abortController = new AbortController()
+  const segmentStream: ReadableStream<Uint8Array> = renderToReadableStream(
+    payload,
+    clientModules,
+    {
+      filterStackFrame,
+      signal: abortController.signal,
+      onError(error: unknown) {
+        if (abortController.signal.aborted) {
+          // Expected: aborting the render "errors" every reference that is
+          // still pending, i.e. the dynamic holes. The corresponding error
+          // rows are discarded below.
+          return undefined
+        }
+        return onSegmentPrerenderError(error)
+      },
+    }
+  )
+
+  // Consume the stream as it's emitted, counting the bytes of the shell wave.
+  // Because reads settle within a microtask of each enqueue and the waves are
+  // separated by task boundaries, every chunk is attributed to the wave that
+  // emitted it. (If a read were ever delayed past the boundary, the chunk
+  // would be attributed to the concrete wave — which under-counts the shell,
+  // a safe direction: the truncated prefix just resolves less content. The
+  // boundary can never over-count, because the concrete wave doesn't start
+  // until the gate is released, after the boundary is measured.)
+  const reader = segmentStream.getReader()
+  const chunks: Uint8Array[] = []
+  let totalByteLength = 0
+  let shellByteLength = 0
+  let isShellWave = true
+  let fatalError: unknown = null
+  const consumePromise = (async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        if (abortController.signal.aborted) {
+          // Discard the error rows emitted by the abort. This matches the
+          // halting behavior of `prerender`, which emits nothing for tasks
+          // that are still pending when it's aborted.
+          continue
+        }
+        chunks.push(value)
+        totalByteLength += value.byteLength
+        if (isShellWave) {
+          shellByteLength += value.byteLength
+        }
+      }
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        fatalError = err
+      }
+    }
+  })()
+
+  // Each wave can need multiple render tasks to serialize: resolving decoded
+  // data pings the renderer's pending tasks, and re-rendering those can
+  // outline further references (nested lazy nodes from the decode), each of
+  // which needs another round. The number of rounds is bounded by the nesting
+  // depth of the decoded tree, so rather than guess, wait until the stream
+  // goes quiet: proceed only after two consecutive tasks with no new bytes.
+  // (Two, not one, to be robust to the renderer and the stream plumbing
+  // scheduling work with different task primitives.) References that are
+  // still pending once the stream is quiet can't make progress — during the
+  // shell wave that's everything behind the gate, and during the concrete
+  // wave it's the truly-dynamic holes.
+  const waitUntilStreamIsQuiet = async () => {
+    let quietTasks = 0
+    let previousByteLength = totalByteLength
+    while (quietTasks < 2) {
+      await waitAtLeastOneReactRenderTask()
+      if (totalByteLength === previousByteLength) {
+        quietTasks++
+      } else {
+        quietTasks = 0
+        previousByteLength = totalByteLength
+      }
+    }
+  }
+
+  await waitUntilStreamIsQuiet()
+  isShellWave = false
+  boundary.resolve(shellByteLength)
+  gate.resolve()
+  await waitUntilStreamIsQuiet()
+  abortController.abort()
+
+  // The renderer closes the stream after flushing the abort error rows. Don't
+  // rely on it: if the stream hasn't closed within a task, cancel the reader.
+  const consumed = await Promise.race([
+    consumePromise.then(() => true),
+    waitAtLeastOneReactRenderTask().then(() => false),
+  ])
+  if (!consumed) {
+    try {
+      await reader.cancel()
+    } catch {}
+    await consumePromise
+  }
+
+  if (fatalError !== null) {
+    // The streaming render failed before it was aborted. Surface the error —
+    // the regular path would have failed the same way.
+    throw fatalError
+  }
+
+  return Buffer.concat(chunks)
+}
+
+/**
+ * Reads a segment's data from the shell-form decode of the page payload by
+ * following the same path used to reach it in the concrete decode. Returns
+ * undefined if the path can't be followed synchronously — either it doesn't
+ * exist in the shell-form tree, or part of it was serialized after the page's
+ * shell boundary and is still a pending reference. (Holes at ReactNode
+ * positions don't cause this: those decode to React Lazy nodes, which pass
+ * through as regular values and re-encode as pending references, exactly the
+ * shape the shell variant needs.)
+ */
+function readGatedSegmentData(
+  gatedPayload: InitialRSCPayload,
+  seedPath: SegmentSeedPath
+): React.ReactNode | undefined {
+  const flightDataPaths = gatedPayload.f
+  if (
+    !Array.isArray(flightDataPaths) ||
+    flightDataPaths.length !== 1 ||
+    !Array.isArray(flightDataPaths[0])
+  ) {
+    return undefined
+  }
+  // FlightDataPath for a full-page render: [FlightRouterState,
+  // CacheNodeSeedData, HeadData].
+  const flightDataPath = flightDataPaths[0]
+  if (seedPath === 'head') {
+    const head = flightDataPath[2]
+    return head == null || isThenable(head) ? undefined : head
+  }
+  let seedData: unknown = flightDataPath[1]
+  for (let i = 0; i < seedPath.length; i++) {
+    if (seedData == null || isThenable(seedData) || !Array.isArray(seedData)) {
+      return undefined
+    }
+    const children = (seedData as CacheNodeSeedData)[1]
+    if (
+      children == null ||
+      typeof children !== 'object' ||
+      isThenable(children)
+    ) {
+      return undefined
+    }
+    seedData = children[seedPath[i]]
+  }
+  if (seedData == null || isThenable(seedData) || !Array.isArray(seedData)) {
+    return undefined
+  }
+  const rsc = (seedData as CacheNodeSeedData)[0]
+  // The caller only requests segments whose concrete rsc is non-null, so a
+  // null here means the shell-form tree doesn't match. A pending reference at
+  // this position would decode differently than the concrete response
+  // (a promise instead of the node itself), so bail on that too.
+  return rsc == null || isThenable(rsc) ? undefined : rsc
 }
 
 async function isPartialRSCData(

--- a/test/e2e/app-dir/segment-prefetch-shell-boundary/app/blog/[slug]/layout.tsx
+++ b/test/e2e/app-dir/segment-prefetch-shell-boundary/app/blog/[slug]/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <h1 id="blog-layout-heading">Blog layout heading</h1>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-prefetch-shell-boundary/app/blog/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-prefetch-shell-boundary/app/blog/[slug]/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+
+async function ParamContent({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  return <p id="param-content">Param value: {slug}</p>
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <>
+      <p id="static-content">Static page content</p>
+      <Suspense fallback={<p id="param-fallback">Loading param...</p>}>
+        <ParamContent params={params} />
+      </Suspense>
+    </>
+  )
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'param-marker-alpha' }]
+}

--- a/test/e2e/app-dir/segment-prefetch-shell-boundary/app/layout.tsx
+++ b/test/e2e/app-dir/segment-prefetch-shell-boundary/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-prefetch-shell-boundary/app/page.tsx
+++ b/test/e2e/app-dir/segment-prefetch-shell-boundary/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/segment-prefetch-shell-boundary/next.config.js
+++ b/test/e2e/app-dir/segment-prefetch-shell-boundary/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-prefetch-shell-boundary/segment-prefetch-shell-boundary.test.ts
+++ b/test/e2e/app-dir/segment-prefetch-shell-boundary/segment-prefetch-shell-boundary.test.ts
@@ -1,0 +1,85 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// The shell byte boundary (the `a` field on a segment prefetch response) is
+// only produced by build-time prerendering, so the boundary assertions only
+// run in `next start` mode.
+describe('segment-prefetch-shell-boundary', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
+
+  async function fetchSegmentPrefetchBytes(
+    pathname: string,
+    segmentKey: string
+  ): Promise<Buffer> {
+    const res = await next.fetch(pathname, {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': segmentKey,
+      },
+    })
+    expect(res.status).toBe(200)
+    return Buffer.from(await res.arrayBuffer())
+  }
+
+  // Reads the response's shell byte boundary from the raw Flight stream: the
+  // envelope contains `"a":"$@<id>"` and a later row `<id>:<value>` resolves
+  // it to a number (byte offset) or null (shell == full response).
+  function readShellByteBoundary(responseBytes: Buffer): number | null {
+    const text = responseBytes.toString('utf8')
+    const refMatch = text.match(/"a":"\$@([0-9a-f]+)"/)
+    expect(refMatch).not.toBeNull()
+    const rowId = refMatch![1]
+    const rowMatch = text.match(new RegExp(`(?:^|\\n)${rowId}:(null|\\d+)\\n`))
+    expect(rowMatch).not.toBeNull()
+    return rowMatch![1] === 'null' ? null : Number(rowMatch![1])
+  }
+
+  it('renders the param page', async () => {
+    const $ = await next.render$('/blog/param-marker-alpha')
+    expect($('#static-content').text()).toBe('Static page content')
+    expect($('#param-content').text()).toBe('Param value: param-marker-alpha')
+  })
+
+  if (!isNextStart) {
+    it('only runs boundary assertions in start mode', () => {})
+    return
+  }
+
+  it('emits a shell byte boundary that splits param-dependent content out of a segment prefetch response', async () => {
+    const bytes = await fetchSegmentPrefetchBytes(
+      '/blog/param-marker-alpha',
+      '/blog/$d$slug/__PAGE__'
+    )
+    const boundary = readShellByteBoundary(bytes)
+    // The page reads a param, so the shell must be a strict prefix.
+    expect(typeof boundary).toBe('number')
+    expect(boundary).toBeGreaterThan(0)
+    expect(boundary).toBeLessThan(bytes.byteLength)
+
+    const shellPrefix = bytes.subarray(0, boundary as number).toString('utf8')
+    const concreteRemainder = bytes
+      .subarray(boundary as number)
+      .toString('utf8')
+
+    // The shell prefix contains all the param-independent content...
+    expect(shellPrefix).toContain('Static page content')
+    expect(shellPrefix).toContain('Blog layout heading')
+    expect(shellPrefix).toContain('Loading param...')
+    // ...but not the param-dependent content, which is only emitted after
+    // the boundary.
+    expect(shellPrefix).not.toContain('param-marker-alpha')
+    expect(concreteRemainder).toContain('param-marker-alpha')
+
+    // The boundary falls on a Flight row edge: the remainder starts with a
+    // new row (`<hex id>:`).
+    expect(concreteRemainder).toMatch(/^[0-9a-f]+:/)
+  })
+
+  it('resolves the boundary to null on static routes (shell == full response)', async () => {
+    const bytes = await fetchSegmentPrefetchBytes('/', '/__PAGE__')
+    const boundary = readShellByteBoundary(bytes)
+    expect(boundary).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Gives each static per-segment prefetch response a **shell byte boundary** — a segment-level analogue of the whole-route `a` field — so the client can truncate a segment's buffered response at that offset and re-decode the prefix into an **intra-segment shell variant**: the segment's own output with its param-dependent content reduced to pending references (which suspend, i.e. render as the param fallback). This is capability-only: the boundary is produced on the server and a decode path exists on the client, but nothing consumes the derived shell yet.

**Server** (`collect-segment-data.tsx`): The shell layering of the staged page render is a temporal property of the page stream, already collapsed by the time `collectSegmentData` decodes it — but the page buffer's own shell boundary preserves it. Each segment response decodes the page buffer again through a *gate* (shell prefix released immediately, the remainder only after the segment's shell content has been serialized and measured). Re-encoding the gated tree emits the response in two waves — shell rows first, then the rows the pending references resolve to — and the byte count at gate release is the response's boundary, embedded as `a: Promise<number | null>` on `SegmentPrefetchResponse` (`null` = shell == full response; omitted for non-staged renders). The boundary render uses the streaming Flight renderer (the `prerender` prelude is only readable after completion, so it can't be measured mid-stream) and waits for stream quiescence between waves rather than a fixed task count, since nested lazy references need one serialization round per nesting level. If a segment's data isn't synchronously reachable in the shell-form decode, the response falls back to the existing `prerender` path byte-for-byte unchanged. The `collectPrefetchHints` size pass and non-staged call sites are untouched.

**Client** (`segment-cache/cache.ts`): `createNonTaskyPrefetchResponseStream` now also returns the buffered response bytes (the response is fully buffered anyway, so this doubles as a rewindable clone with no extra tee), and `resolveSegmentShellResponse` derives the shell variant by re-decoding the truncated prefix — mirroring `resolveShellStageData` for route-level responses. `fetchSegmentsOnCacheMissImpl` returns the buffer so a future consumer has it at the decision point.

`REWINDABLE_SEGMENT_PREFETCH_PLAN.md` documents the design decisions and safety properties in detail.

## Verification

- New e2e: `pnpm test-start-turbo test/e2e/app-dir/segment-prefetch-shell-boundary` — asserts the boundary splits param-dependent content out of the prefix at a row edge, and that static routes resolve `a` to null
- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/basic`
- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/prefetch-inlining` (caught the fixed-task-count bug during development; now passes 18/18)
- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/prefetch-app-shell`
- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/vary-params` — 3 failures in `vary-params-base-dynamic` (server-action revalidation) reproduce identically on clean canary sources locally, i.e. pre-existing and unrelated
- Byte-level inspection of build output for ISR fallback shells (`a` resolves to null — a fallback shell is already a shell) and bundled (inlined) responses

<!-- NEXT_JS_LLM -->