### PR TITLE
Turbopack(napi v3): type subscribe callback args and tighten FunctionRef types

### DIFF
--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -185,7 +185,10 @@ pub fn endpoint_server_changed_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
     issues: bool,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<TurbopackResult<()>, ()>,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult) => void")] func: FunctionRef<
+        TurbopackResult<()>,
+        (),
+    >,
 ) -> napi::Result<External<RootTask>> {
     let turbopack_ctx = endpoint.turbopack_ctx().clone();
     let endpoint = ****endpoint;
@@ -269,7 +272,10 @@ async fn subscribe_issues_and_diags_operation(
 pub fn endpoint_client_changed_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: &External<ExternalEndpoint>,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<TurbopackResult<()>, ()>,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult) => void")] func: FunctionRef<
+        TurbopackResult<()>,
+        (),
+    >,
 ) -> napi::Result<External<RootTask>> {
     let turbopack_ctx = endpoint.turbopack_ctx().clone();
     let endpoint_op = ****endpoint;

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2032,7 +2032,7 @@ pub enum UpdateMessage {
 }
 
 #[napi(object, object_from_js = false)]
-struct NapiUpdateMessage {
+pub struct NapiUpdateMessage {
     pub update_type: &'static str,
     pub value: Option<NapiUpdateInfo>,
 }
@@ -2053,7 +2053,7 @@ impl From<UpdateMessage> for NapiUpdateMessage {
 }
 
 #[napi(object, object_from_js = false)]
-struct NapiUpdateInfo {
+pub struct NapiUpdateInfo {
     pub duration: u32,
     pub tasks: u32,
 }
@@ -2134,7 +2134,7 @@ pub fn project_update_info_subscribe(
 }
 
 #[napi(object, object_from_js = false)]
-struct NapiCompilationEvent {
+pub struct NapiCompilationEvent {
     pub type_name: String,
     pub severity: String,
     pub message: String,

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1739,10 +1739,8 @@ pub async fn project_entrypoints(
 pub fn project_entrypoints_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<
-        TurbopackResult<Option<NapiEntrypoints>>,
-        (),
-    >,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<Partial<NapiEntrypoints>>) => void")]
+    func: FunctionRef<TurbopackResult<Option<NapiEntrypoints>>, ()>,
 ) -> napi::Result<External<RootTask>> {
     let turbopack_ctx = project.turbopack_ctx.clone();
     let container = project.container;
@@ -1843,10 +1841,8 @@ pub fn project_hmr_events(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     chunk_name: RcStr,
     target: String,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<
-        TurbopackResult<Unknown<'static>>,
-        (),
-    >,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<unknown>) => void")]
+    func: FunctionRef<TurbopackResult<Unknown<'static>>, ()>,
 ) -> napi::Result<External<RootTask>> {
     let hmr_target = target
         .parse::<HmrTarget>()
@@ -1986,10 +1982,8 @@ pub fn project_hmr_chunk_names_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     target: String,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<
-        TurbopackResult<HmrChunkNames>,
-        (),
-    >,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<HmrChunkNames>) => void")]
+    func: FunctionRef<TurbopackResult<HmrChunkNames>, ()>,
 ) -> napi::Result<External<RootTask>> {
     let hmr_target = target
         .parse::<HmrTarget>()
@@ -2089,7 +2083,8 @@ pub fn project_update_info_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     aggregation_ms: u32,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<Unknown<'static>, ()>,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<UpdateMessage>) => void")]
+    func: FunctionRef<NapiUpdateMessage, ()>,
 ) -> napi::Result<()> {
     let func: ThreadsafeFunction<UpdateMessage, (), NapiUpdateMessage, Status, true> = func
         .borrow_back(&env)?
@@ -2165,7 +2160,8 @@ impl From<Arc<dyn CompilationEvent>> for NapiCompilationEvent {
 pub fn project_compilation_events_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-    #[napi(ts_arg_type = "(...args: any[]) => any")] func: FunctionRef<Unknown<'static>, ()>,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<CompilationEvent>) => void")]
+    func: FunctionRef<NapiCompilationEvent, ()>,
     event_types: Option<Vec<String>>,
 ) -> napi::Result<()> {
     let tsfn: ThreadsafeFunction<

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -1,6 +1,6 @@
 // Manual additions to make the generated types below work.
 
-import type { TurbopackResult } from './types'
+import type { CompilationEvent, TurbopackResult, UpdateMessage } from './types'
 
 export type TurboTasks = { readonly __tag: unique symbol }
 export type ExternalEndpoint = { readonly __tag: unique symbol }
@@ -67,13 +67,13 @@ export declare function codeFrameColumns(
 
 export declare function endpointClientChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
-  func: (...args: any[]) => any
+  func: (err: Error, value: TurbopackResult) => void
 ): { __napiType: 'RootTask' }
 
 export declare function endpointServerChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
   issues: boolean,
-  func: (...args: any[]) => any
+  func: (err: Error, value: TurbopackResult) => void
 ): { __napiType: 'RootTask' }
 
 export declare function endpointWriteToDisk(endpoint: {
@@ -572,7 +572,7 @@ export declare function parse(
 /** Subscribes to all compilation events that are not cached like timing and progress information. */
 export declare function projectCompilationEventsSubscribe(
   project: { __napiType: 'Project' },
-  func: (...args: any[]) => any,
+  func: (err: Error, value: TurbopackResult<CompilationEvent>) => void,
   eventTypes?: Array<string> | undefined | null
 ): void
 
@@ -582,7 +582,7 @@ export declare function projectEntrypoints(project: {
 
 export declare function projectEntrypointsSubscribe(
   project: { __napiType: 'Project' },
-  func: (...args: any[]) => any
+  func: (err: Error, value: TurbopackResult<Partial<NapiEntrypoints>>) => void
 ): { __napiType: 'RootTask' }
 
 /**
@@ -619,14 +619,14 @@ export declare function projectGetSourceMapSync(
 export declare function projectHmrChunkNamesSubscribe(
   project: { __napiType: 'Project' },
   target: string,
-  func: (...args: any[]) => any
+  func: (err: Error, value: TurbopackResult<HmrChunkNames>) => void
 ): { __napiType: 'RootTask' }
 
 export declare function projectHmrEvents(
   project: { __napiType: 'Project' },
   chunkName: RcStr,
   target: string,
-  func: (...args: any[]) => any
+  func: (err: Error, value: TurbopackResult<unknown>) => void
 ): { __napiType: 'RootTask' }
 
 /**
@@ -635,7 +635,7 @@ export declare function projectHmrEvents(
  */
 export declare function projectInvalidateFileSystemCache(project: {
   __napiType: 'Project'
-}): Promise<undefined>
+}): Promise<void>
 
 export declare function projectNew(
   options: NapiProjectOptions,
@@ -651,7 +651,7 @@ export declare function projectNew(
  */
 export declare function projectOnExit(project: {
   __napiType: 'Project'
-}): Promise<undefined>
+}): Promise<void>
 
 /**
  * Runs `project_on_exit`, and then waits for turbo_tasks to gracefully shut down.
@@ -662,7 +662,7 @@ export declare function projectOnExit(project: {
  */
 export declare function projectShutdown(project: {
   __napiType: 'Project'
-}): Promise<undefined>
+}): Promise<void>
 
 export declare function projectTraceSource(
   project: { __napiType: 'Project' },
@@ -673,7 +673,7 @@ export declare function projectTraceSource(
 export declare function projectUpdate(
   project: { __napiType: 'Project' },
   options: NapiPartialProjectOptions
-): Promise<undefined>
+): Promise<void>
 
 /**
  * Subscribes to lifecycle events of the compilation.
@@ -691,7 +691,7 @@ export declare function projectUpdate(
 export declare function projectUpdateInfoSubscribe(
   project: { __napiType: 'Project' },
   aggregationMs: number,
-  func: (...args: any[]) => any
+  func: (err: Error, value: TurbopackResult<UpdateMessage>) => void
 ): void
 
 export declare function projectWriteAllEntrypointsToDisk(
@@ -835,8 +835,7 @@ export interface TransformOutput {
 /**
  * The JS-facing result of a SWC transform.
  *
- * Optional fields are omitted from the resulting object when `None`, matching
- * the previous manual object construction.
+ * Optional fields are omitted from the resulting object when `None`.
  */
 export interface TransformOutputResult {
   code: string


### PR DESCRIPTION
## Summary

Follow-up to two review comments on #95412:

- **Type the subscribe callbacks.** The seven `*Subscribe` / `*Changed` bindings declared their callback as `(...args: any[]) => any`. They now use error-first typed signatures, e.g. `(err: Error, value: TurbopackResult<UpdateMessage>) => void`. (bgw: _"clean up these typescript `any` types wherever we reasonably can"_.)
- **Tighten the Rust `FunctionRef` value types.** `project_update_info_subscribe` and `project_compilation_events_subscribe` still used `FunctionRef<Unknown<'static>>`; they now use their concrete mapper output (`NapiUpdateMessage` / `NapiCompilationEvent`). `project_hmr_events` intentionally keeps `Unknown` since it emits a dynamic `to_js_value` client/server union. (bgw: _"get rid of `Unknown` here ... that'll involve updating callsites too"_.)

`generated-native.d.ts` was regenerated from these Rust changes via `pnpm swc-build-native`. That regeneration also refreshes a handful of lines that were stale in the committed copy (a few `Promise<undefined>` → `Promise<void>` and one doc comment) — these reflect what the repo's pinned CLI emits today, not hand edits.

## Verification

- `pnpm --filter=next types`

<!-- NEXT_JS_LLM_PR -->