### PR TITLE
[test] Run the navigation e2e suite under cacheComponents

### DIFF
--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -205,7 +205,6 @@
       "test/e2e/app-dir/metadata/metadata.test.ts",
       "test/e2e/app-dir/middleware-rewrite-dynamic/middleware-rewrite-dynamic.test.ts",
       "test/e2e/app-dir/middleware-sitemap/no-matcher/index.test.ts",
-      "test/e2e/app-dir/navigation/navigation.test.ts",
       "test/e2e/app-dir/next-after-app-api-usage/index.test.ts",
       "test/e2e/app-dir/next-after-app-deploy/index.test.ts",
       "test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts",

--- a/test/e2e/app-dir/navigation/app/redirect/result/page.js
+++ b/test/e2e/app-dir/navigation/app/redirect/result/page.js
@@ -1,4 +1,7 @@
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   return (
     <div>
       <h1 id="result-page">Result Page</h1>


### PR DESCRIPTION
This test suite used to be disabled in CC runs, which feels like a bit of a hazard for developing CC.

Let's enable it.