### PR TITLE
Always consult `npm_config_user_agent` first

### DIFF
--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -54,20 +54,30 @@ export function getPnpmMajorVersion(): number | null {
 
 export function getPkgManager(baseDir: string): PackageManager {
   try {
+    const userAgent = process.env.npm_config_user_agent
+    if (userAgent) {
+      if (userAgent.startsWith('yarn')) {
+        return 'yarn'
+      } else if (userAgent.startsWith('pnpm')) {
+        return 'pnpm'
+      } else if (userAgent.startsWith('bun')) {
+        return 'bun'
+      } else if (userAgent.startsWith('npm')) {
+        return 'npm'
+      }
+    }
     const lockFile = findUp.sync(
       [
-        'package-lock.json',
         'yarn.lock',
         'pnpm-lock.yaml',
         'bun.lock',
         'bun.lockb',
+        'package-lock.json',
       ],
       { cwd: baseDir }
     )
     if (lockFile) {
       switch (basename(lockFile)) {
-        case 'package-lock.json':
-          return 'npm'
         case 'yarn.lock':
           return 'yarn'
         case 'pnpm-lock.yaml':
@@ -75,6 +85,8 @@ export function getPkgManager(baseDir: string): PackageManager {
         case 'bun.lock':
         case 'bun.lockb':
           return 'bun'
+        case 'package-lock.json':
+          return 'npm'
         default:
           return 'npm'
       }

--- a/packages/next/src/lib/helpers/get-pkg-manager.ts
+++ b/packages/next/src/lib/helpers/get-pkg-manager.ts
@@ -6,6 +6,16 @@ export type PackageManager = 'npm' | 'pnpm' | 'yarn'
 
 export function getPkgManager(baseDir: string): PackageManager {
   try {
+    const userAgent = process.env.npm_config_user_agent
+    if (userAgent) {
+      if (userAgent.startsWith('yarn')) {
+        return 'yarn'
+      } else if (userAgent.startsWith('pnpm')) {
+        return 'pnpm'
+      } else if (userAgent.startsWith('npm')) {
+        return 'npm'
+      }
+    }
     for (const { lockFile, packageManager } of [
       { lockFile: 'yarn.lock', packageManager: 'yarn' },
       { lockFile: 'pnpm-lock.yaml', packageManager: 'pnpm' },
@@ -13,14 +23,6 @@ export function getPkgManager(baseDir: string): PackageManager {
     ]) {
       if (fs.existsSync(path.join(baseDir, lockFile))) {
         return packageManager as PackageManager
-      }
-    }
-    const userAgent = process.env.npm_config_user_agent
-    if (userAgent) {
-      if (userAgent.startsWith('yarn')) {
-        return 'yarn'
-      } else if (userAgent.startsWith('pnpm')) {
-        return 'pnpm'
       }
     }
     try {


### PR DESCRIPTION
The `getPkgManager` helpers previously consulted the filesystem first for files hinting at the used package manager. Only if none were found did we check `process.env.npm_config_user_agent` and then shelled out to testing which package manager is available.

This change makes all helpers check the `npm_config_user_agent` environment variable first. The variable is set by the package manager that invoked the process, so when present it is both the cheapest and the most direct signal, avoiding filesystem access and subprocess spawns entirely. `create-next-app` already used this user-agent-first approach and is unchanged.

The check order is now consistent across all three implementations: yarn, pnpm, bun, npm for the user agent (the `packages/next` variant has no `bun` in its `PackageManager` type and falls through to lockfile detection there), and the same order for the codemod's lockfile walk, which previously prioritized `package-lock.json`.

Because the invoking package manager now takes precedence over lockfile inference, running `npx next ...` or `npx @next/codemod ...` inside a pnpm or yarn app is now detected as npm. Use `pnpx` (or `pnpm dlx`) and `yarn dlx` instead so the detected package manager matches the project.
