### PR TITLE
[ci] Match the test job summary style to the PR test report comment

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -13,6 +13,7 @@ const glob = promisify(_glob)
 const exec = promisify(execOrig)
 const core = require('@actions/core')
 const { getTestFilter } = require('./test/get-test-filter')
+const { buildTestReport } = require('./scripts/test-report')
 
 // --- Test profile and result caching via actions cache ---
 // On CI retry attempts, skip tests that already passed on this commit.
@@ -250,48 +251,80 @@ const configuredTestTypes = Object.values(testFilters)
 /** @type {Map<string, { output: string, failedCases: string[] }>} */
 const errorsPerTests = new Map()
 
+// GitHub drops the whole job summary of a step if it exceeds 1MiB:
+// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+const MAX_SUMMARY_BYTES = 1024 * 1024
+const SUMMARY_TRUNCATION_NOTICE =
+  '\n\n... truncated to fit the job summary size limit ...'
+
+// Strip terminal color/control codes before writing output to the job
+// summary. Mirrors `scripts/pr-ci-comment.mjs`.
+const ANSI_RE =
+  // eslint-disable-next-line no-control-regex
+  /(?:\u001B\][\s\S]*?(?:\u0007|\u001B\\|\u009C))|(?:[\u001B\u009B][[\]()#;?]*(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g
+
+// The head commit of this CI run. `GITHUB_SHA` is the merge commit for
+// pull requests, but Datadog test runs and the PR test report comment use
+// the PR head commit, so prefer that when available.
+function getHeadSha() {
+  if (process.env.GITHUB_EVENT_PATH) {
+    try {
+      const event = JSON.parse(
+        fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')
+      )
+      const headSha = event.pull_request?.head?.sha
+      if (headSha) {
+        return headSha
+      }
+    } catch (err) {
+      console.log('Failed to read the head SHA from the event payload', err)
+    }
+  }
+  return process.env.GITHUB_SHA ?? null
+}
+
+// Write a job summary using the same printer as the PR test report comment
+// (`scripts/pr-ci-comment.mjs`), so a truncated comment can refer to the job
+// summary for the full report.
 async function maybeLogSummary() {
   if (process.env.CI && errorsPerTests.size > 0) {
-    const outputTemplate = `
-${Array.from(errorsPerTests.entries())
-  .map(([test, { output }]) => {
-    return `
-<details>
-<summary>${test}</summary>
+    const sha = getHeadSha()
+    const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '').split('/')
 
-\`\`\`
-${output}
-\`\`\`
-
-</details>
-`
-  })
-  .join('\n')}`
-
-    // Build table rows with one row per failed test case
-    const tableRows = []
-    for (const [test, { failedCases }] of errorsPerTests.entries()) {
-      const testLink = `<a href="https://github.com/vercel/next.js/blob/canary/${test}">${test}</a>`
-      if (failedCases.length === 0) {
-        tableRows.push(['Unknown', testLink])
-      } else {
-        for (const caseName of failedCases) {
-          tableRows.push([caseName, testLink])
-        }
+    const suites = [...errorsPerTests.keys()].sort().map((test) => {
+      const { output, failedCases } = errorsPerTests.get(test)
+      return {
+        testPath: test,
+        mode: process.env.NEXT_TEST_MODE,
+        isTurbopack: !!process.env.IS_TURBOPACK_TEST,
+        isRspack: !!process.env.NEXT_RSPACK,
+        isExperimental: process.env.__NEXT_CACHE_COMPONENTS === 'true',
+        isPPR: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
+        failedCases,
+        resultMessage: ['```', output.replace(ANSI_RE, ''), '```'].join('\n'),
       }
+    })
+
+    let summary = buildTestReport({
+      owner,
+      repo,
+      sha,
+      suites,
+    })
+
+    if (Buffer.byteLength(summary, 'utf8') > MAX_SUMMARY_BYTES) {
+      const truncated = Buffer.from(summary, 'utf8')
+        .subarray(
+          0,
+          MAX_SUMMARY_BYTES - Buffer.byteLength(SUMMARY_TRUNCATION_NOTICE)
+        )
+        .toString('utf8')
+        // A multi-byte character cut at the boundary decodes to U+FFFD.
+        .replace(/�$/, '')
+      summary = truncated + SUMMARY_TRUNCATION_NOTICE
     }
 
-    await core.summary
-      .addHeading('Tests failures')
-      .addTable([
-        [
-          { data: 'Test Name', header: true },
-          { data: 'Test Path', header: true },
-        ],
-        ...tableRows,
-      ])
-      .addRaw(outputTemplate)
-      .write()
+    await core.summary.addRaw(summary).write()
   }
 }
 
@@ -905,6 +938,9 @@ ${ENDGROUP}`)
 
     if (passed) {
       recordPassed(test.file)
+      // The test may have failed on an earlier attempt; don't report tests
+      // that ultimately passed in the job summary.
+      errorsPerTests.delete(test.file)
     }
 
     if (!passed) {

--- a/scripts/pr-ci-comment.mjs
+++ b/scripts/pr-ci-comment.mjs
@@ -3,11 +3,10 @@
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
+import { buildTestReport } from './test-report.js'
 
 const TEST_COMMENT_MARKER = '<!-- __NEXT_TEST_REPORT_COMMENT__ -->'
 const STATS_COMMENT_MARKER = '<!-- __NEXT_STATS_COMMENT__ -->'
-const CONTRIBUTING_URL =
-  'https://github.com/vercel/next.js/blob/canary/contributing.md'
 const MAX_COMMENT_LENGTH = 62_000
 const MAX_RESULT_MESSAGE_LENGTH = 12_000
 
@@ -634,11 +633,7 @@ async function handleBuildAndTestWorkflow({
       return
     }
 
-    const parsedSuites = parseFailedSuitesFromLogs(logs, job, {
-      owner,
-      repo,
-      sha: pr.headSha || workflowRun.head_sha,
-    })
+    const parsedSuites = parseFailedSuitesFromLogs(logs, job)
 
     if (parsedSuites.length === 0) {
       otherFailures.push({ job })
@@ -650,6 +645,8 @@ async function handleBuildAndTestWorkflow({
   const body = buildTestReportComment({
     failedSuites,
     otherFailures,
+    owner,
+    repo,
     sha: pr.headSha || workflowRun.head_sha,
   })
 
@@ -659,7 +656,7 @@ async function handleBuildAndTestWorkflow({
   ])
 }
 
-function parseFailedSuitesFromLogs(logs, job, { owner, repo, sha }) {
+function parseFailedSuitesFromLogs(logs, job) {
   const blocks = extractJsonBlocks(logs)
   const failedSuites = []
 
@@ -696,9 +693,6 @@ function parseFailedSuitesFromLogs(logs, job, { owner, repo, sha }) {
           MAX_RESULT_MESSAGE_LENGTH
         ),
         groups: groupedFails,
-        owner,
-        repo,
-        sha,
       })
     }
   }
@@ -737,137 +731,57 @@ function extractDelimitedBlock(logs, start, end) {
   return logs.slice(contentStart, endIndex).trim()
 }
 
-function buildTestReportComment({ failedSuites, otherFailures, sha }) {
-  const heading =
-    failedSuites.length > 0 ? '## Failing test suites' : '## Failing CI jobs'
-  const lines = [
-    TEST_COMMENT_MARKER,
-    heading,
-    '',
-    `Commit: ${sha} | [About building and testing Next.js](${CONTRIBUTING_URL})`,
-    '',
-  ]
-
-  for (const suite of failedSuites.sort((a, b) =>
-    `${a.job.name}:${a.testPath}`.localeCompare(`${b.job.name}:${b.testPath}`)
-  )) {
-    const jobMarker = getJobMarker(suite.job.name)
-    lines.push(jobMarker.start)
-    lines.push(
-      `\`${getTestCommand(suite)}\`${getJobTags(suite.job.name)} ([job](${suite.job.html_url}))`
+function buildTestReportComment({
+  failedSuites,
+  otherFailures,
+  owner,
+  repo,
+  sha,
+}) {
+  const suites = failedSuites
+    .sort((a, b) =>
+      `${a.job.name}:${a.testPath}`.localeCompare(`${b.job.name}:${b.testPath}`)
     )
+    .map((suite) => {
+      // Unlike `run-tests.js`, which reads them from its environment, the
+      // suite properties have to be derived from the CI job name here.
+      const jobName = suite.job.name.toLowerCase()
+      const isCacheComponents = jobName.includes('cache components')
 
-    const sortedGroups = [...suite.groups.keys()].sort()
-    for (const group of sortedGroups) {
-      const fails = suite.groups.get(group)
-      lines.push(
-        `- ${fails
-          .map((fail) => formatFailureLine(suite, group, fail))
-          .join('\n- ')}`
-      )
-    }
-
-    if (suite.resultMessage) {
-      lines.push('')
-      lines.push('<details>')
-      lines.push('<summary>Expand output</summary>')
-      lines.push('')
-      lines.push(suite.resultMessage)
-      lines.push('</details>')
-    }
-
-    lines.push(jobMarker.end)
-    lines.push('')
-  }
-
-  if (otherFailures.length > 0) {
-    if (failedSuites.length > 0) {
-      lines.push('### Other failing CI jobs')
-      lines.push('')
-    }
-
-    for (const { job, reason } of otherFailures.sort((a, b) =>
-      a.job.name.localeCompare(b.job.name)
-    )) {
-      lines.push(
-        `- [${job.name}](${job.html_url})${reason ? `: ${reason}` : ''}`
-      )
-    }
-  }
-
-  return lines.join('\n')
-}
-
-function formatFailureLine(suite, group, fail) {
-  const testName = `${group ? `${group} > ` : ''}${fail.title}`
-  const jobName = suite.job.name.toLowerCase()
-  if (jobName.includes('rspack')) {
-    return testName
-  }
-
-  const query = datadogSearchQuery({
-    '@git.repository.id': `github.com/${suite.owner}/${suite.repo}`,
-    '@git.commit.head_sha': suite.sha,
-    '@test.name': testName.replace(/ > /g, ' '),
-    '@test.type': jobName.includes('turbopack') ? 'turbopack' : 'nextjs',
-    '@test.status': 'fail',
-  })
-  const linkUrl = new URL('https://app.datadoghq.com/ci/test/runs')
-  linkUrl.searchParams.set('query', query)
-  return `${testName} ([DD](${linkUrl.href}))`
-}
-
-function datadogSearchQuery(values) {
-  return Object.entries(values)
-    .map(([key, value]) => {
-      const escapedValue = value.replace(/"/g, '\\"')
-      return `${key}:"${escapedValue}"`
+      return {
+        jobName: suite.job.name,
+        jobUrl: suite.job.html_url,
+        mode: suite.mode,
+        testPath: suite.testPath,
+        isTurbopack: jobName.includes('turbopack') || isCacheComponents,
+        isRspack: jobName.includes('rspack'),
+        isExperimental: jobName.includes('experimental') || isCacheComponents,
+        isPPR: jobName.includes('ppr'),
+        failedCases: [...suite.groups.keys()]
+          .sort()
+          .flatMap((group) =>
+            suite.groups
+              .get(group)
+              .map((fail) => `${group ? `${group} > ` : ''}${fail.title}`)
+          ),
+        resultMessage: suite.resultMessage,
+      }
     })
-    .join(' ')
-}
 
-function getTestCommand(suite) {
-  const jobName = suite.job.name.toLowerCase()
-  const isCacheComponents = jobName.includes('cache components')
-  const isTurbopack = jobName.includes('turbopack') || isCacheComponents
-  const isRspack = jobName.includes('rspack')
-  const isExperimental = jobName.includes('experimental') || isCacheComponents
-  const isPPR = jobName.includes('ppr')
-  const script = suite.mode
-    ? `test-${suite.mode}${isExperimental ? '-experimental' : ''}${
-        isTurbopack ? '-turbo' : isRspack ? '-rspack' : ''
-      }`
-    : 'test'
-  const commandPrefix = isPPR ? '__NEXT_EXPERIMENTAL_PPR=true ' : ''
-
-  return `${commandPrefix}pnpm ${script} ${suite.testPath}`
-}
-
-function getJobTags(jobName) {
-  const lowerJobName = jobName.toLowerCase()
-  let tags = ''
-
-  if (lowerJobName.includes('turbopack')) {
-    tags += ' (turbopack)'
-  } else if (lowerJobName.includes('rspack')) {
-    tags += ' (rspack)'
-  }
-
-  if (lowerJobName.includes('experimental')) {
-    tags += ' (Experimental)'
-  } else if (lowerJobName.includes('ppr')) {
-    tags += ' (PPR)'
-  }
-
-  return tags
-}
-
-function getJobMarker(jobName) {
-  const safeName = jobName.replaceAll('-->', '')
-  return {
-    start: `<!-- J"${safeName}" -->`,
-    end: `<!-- /J"${safeName}" -->`,
-  }
+  return buildTestReport({
+    marker: TEST_COMMENT_MARKER,
+    owner,
+    repo,
+    sha,
+    suites,
+    otherFailures: otherFailures
+      .sort((a, b) => a.job.name.localeCompare(b.job.name))
+      .map(({ job, reason }) => ({
+        name: job.name,
+        url: job.html_url,
+        reason,
+      })),
+  })
 }
 
 function normalizeTestPath(testName) {

--- a/scripts/test-report.js
+++ b/scripts/test-report.js
@@ -1,0 +1,183 @@
+// Shared printer for test failure reports. Renders the markdown used by both
+// the PR test report comment (`scripts/pr-ci-comment.mjs`) and the GitHub job
+// summary (`run-tests.js`), so both read the same way. Callers only provide
+// data (commit, test mode, bundler flags, failed case names); all rendering
+// decisions live here. Size limits are the caller's responsibility: GitHub
+// comments and job summaries have different maximum sizes.
+
+const CONTRIBUTING_URL =
+  'https://github.com/vercel/next.js/blob/canary/contributing.md'
+
+function getJobMarker(jobName) {
+  const safeName = jobName.replaceAll('-->', '')
+  return {
+    start: `<!-- J"${safeName}" -->`,
+    end: `<!-- /J"${safeName}" -->`,
+  }
+}
+
+/**
+ * @typedef {object} FailedSuite
+ * @property {string} testPath Repo-relative path of the test file.
+ * @property {string} [mode] `NEXT_TEST_MODE` the suite ran with, e.g. `dev`
+ *   or `start`. Without it the command is rendered as plain `pnpm test`.
+ * @property {boolean} [isTurbopack]
+ * @property {boolean} [isRspack]
+ * @property {boolean} [isExperimental]
+ * @property {boolean} [isPPR]
+ * @property {string} [jobName] Emits HTML comment markers around the suite so
+ *   tooling can locate per-job sections.
+ * @property {string} [jobUrl] Rendered as a link to the CI job.
+ * @property {string[]} failedCases Failed test case names with ancestor
+ *   titles joined by ` > `. Rendered as a bullet list with Datadog links.
+ * @property {string} [resultMessage] Rendered in a collapsed "Expand output"
+ *   section.
+ */
+
+// The `pnpm test-*` command that reproduces the suite run.
+function buildTestCommand(suite) {
+  const script = suite.mode
+    ? `test-${suite.mode}${suite.isExperimental ? '-experimental' : ''}${
+        suite.isTurbopack ? '-turbo' : suite.isRspack ? '-rspack' : ''
+      }`
+    : 'test'
+  const commandPrefix = suite.isPPR ? '__NEXT_EXPERIMENTAL_PPR=true ' : ''
+
+  return `${commandPrefix}pnpm ${script} ${suite.testPath}`
+}
+
+function buildJobTags(suite) {
+  let tags = ''
+
+  if (suite.isTurbopack) {
+    tags += ' (turbopack)'
+  } else if (suite.isRspack) {
+    tags += ' (rspack)'
+  }
+
+  if (suite.isExperimental) {
+    tags += ' (Experimental)'
+  } else if (suite.isPPR) {
+    tags += ' (PPR)'
+  }
+
+  return tags
+}
+
+// Link to the Datadog CI test runs of a failed test case, matching how
+// `datadog-ci junit upload` tags the runs in CI.
+function datadogTestRunUrl({ owner, repo, sha, testName, testType }) {
+  const query = Object.entries({
+    '@git.repository.id': `github.com/${owner}/${repo}`,
+    '@git.commit.head_sha': sha,
+    '@test.name': testName,
+    '@test.type': testType,
+    '@test.status': 'fail',
+  })
+    .map(([key, value]) => `${key}:"${value.replace(/"/g, '\\"')}"`)
+    .join(' ')
+
+  const url = new URL('https://app.datadoghq.com/ci/test/runs')
+  url.searchParams.set('query', query)
+  return url.href
+}
+
+function formatFailureLine(suite, { owner, repo, sha }, testName) {
+  // Rspack test runs are not ingested into Datadog.
+  if (suite.isRspack || !owner || !repo || !sha) {
+    return testName
+  }
+
+  const linkUrl = datadogTestRunUrl({
+    owner,
+    repo,
+    sha,
+    testName: testName.replace(/ > /g, ' '),
+    testType: suite.isTurbopack ? 'turbopack' : 'nextjs',
+  })
+  return `${testName} ([DD](${linkUrl}))`
+}
+
+/**
+ * @param {object} options
+ * @param {string} [options.marker] Leading HTML comment marker identifying the
+ *   report, e.g. for finding an existing PR comment. Omitted from job summaries.
+ * @param {string} [options.owner] Repository owner, used for Datadog links.
+ * @param {string} [options.repo] Repository name, used for Datadog links.
+ * @param {string} [options.sha] The head commit of the run (for pull requests,
+ *   the PR head, not the merge commit). Used for the commit line and Datadog
+ *   links; both are skipped when absent.
+ * @param {FailedSuite[]} options.suites One entry per failing test suite.
+ * @param {Array<{ name: string, url: string, reason?: string }>} [options.otherFailures]
+ *   Failing CI jobs without parseable test results.
+ * @returns {string} The rendered markdown report.
+ */
+function buildTestReport({
+  marker,
+  owner,
+  repo,
+  sha,
+  suites,
+  otherFailures = [],
+}) {
+  const heading =
+    suites.length > 0 ? '## Failing test suites' : '## Failing CI jobs'
+  const lines = []
+  if (marker) {
+    lines.push(marker)
+  }
+  lines.push(heading, '')
+  if (sha) {
+    lines.push(
+      `Commit: ${sha} | [About building and testing Next.js](${CONTRIBUTING_URL})`,
+      ''
+    )
+  }
+
+  for (const suite of suites) {
+    const jobMarker = suite.jobName ? getJobMarker(suite.jobName) : null
+    if (jobMarker) {
+      lines.push(jobMarker.start)
+    }
+    lines.push(
+      `\`${buildTestCommand(suite)}\`${buildJobTags(suite)}${
+        suite.jobUrl ? ` ([job](${suite.jobUrl}))` : ''
+      }`
+    )
+
+    for (const testName of suite.failedCases) {
+      lines.push(
+        `- ${formatFailureLine(suite, { owner, repo, sha }, testName)}`
+      )
+    }
+
+    if (suite.resultMessage) {
+      lines.push('')
+      lines.push('<details>')
+      lines.push('<summary>Expand output</summary>')
+      lines.push('')
+      lines.push(suite.resultMessage)
+      lines.push('</details>')
+    }
+
+    if (jobMarker) {
+      lines.push(jobMarker.end)
+    }
+    lines.push('')
+  }
+
+  if (otherFailures.length > 0) {
+    if (suites.length > 0) {
+      lines.push('### Other failing CI jobs')
+      lines.push('')
+    }
+
+    for (const { name, url, reason } of otherFailures) {
+      lines.push(`- [${name}](${url})${reason ? `: ${reason}` : ''}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+module.exports = { buildTestReport }

--- a/test/e2e/app-dir/hello-world/hello-world.test.ts
+++ b/test/e2e/app-dir/hello-world/hello-world.test.ts
@@ -8,7 +8,7 @@ describe('hello-world', () => {
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   it('should work using cheerio', async () => {
     const $ = await next.render$('/')
-    expect($('p').text()).toBe('hello world')
+    expect($('p').text()).toBe('goodbye world')
   })
 
   // Recommended for tests that need a full browser.

--- a/test/e2e/app-dir/hello-world/hello-world.test.ts
+++ b/test/e2e/app-dir/hello-world/hello-world.test.ts
@@ -8,7 +8,7 @@ describe('hello-world', () => {
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   it('should work using cheerio', async () => {
     const $ = await next.render$('/')
-    expect($('p').text()).toBe('goodbye world')
+    expect($('p').text()).toBe('hello world')
   })
 
   // Recommended for tests that need a full browser.


### PR DESCRIPTION
The GitHub job summary written by `run-tests.js` for failing tests previously used its own format (a "Tests failures" heading with a test-name/test-path table and raw output blocks). It now renders the same report as the PR test report comment, so a truncated comment can refer to the job summary for the full output.


First commit will extract the existing printer into a shared util. The following commits will use the same printer for the GH summary.

Size limits are decided by each caller of the printer: the comment script keeps its existing 62KB comment limit, while the job summary caps the whole rendered summary at 1MiB because [GitHub drops a step's job summary entirely above that](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary).

## test plan
- [x] [no summaries with green CI](https://github.com/vercel/next.js/actions/runs/29821227701?pr=95882)
- [x] [summaries like the test comment with failing CI](https://github.com/vercel/next.js/actions/runs/29822852344?pr=95882)