### PR TITLE
Add with-email-local-smtp example

### DIFF
--- a/examples/with-email-local-smtp/.env.example
+++ b/examples/with-email-local-smtp/.env.example
@@ -1,0 +1,9 @@
+# Connection string for the Postgres service in docker-compose.yml
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/app
+
+# SMTP connection for the local Mailtrap Local catcher in docker-compose.yml
+EMAIL_SERVER=smtp://localhost:3535
+EMAIL_FROM=onboarding@example.com
+
+# Used to encrypt the session. Generate one with: npx auth secret
+AUTH_SECRET= # https://generate-secret.vercel.app/32

--- a/examples/with-email-local-smtp/.gitignore
+++ b/examples/with-email-local-smtp/.gitignore
@@ -1,0 +1,40 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-email-local-smtp/README.md
+++ b/examples/with-email-local-smtp/README.md
@@ -1,0 +1,74 @@
+# Email authentication with a local SMTP catcher
+
+This example shows a Next.js app with [Auth.js](https://authjs.dev) magic-link (email) sign in,
+using [Mailtrap Local](https://github.com/mailtrap/mailtrap-local) as the local SMTP server so you can read the login
+emails during development without sending anything to a real inbox.
+
+Mailtrap Local is a single-binary, MIT-licensed SMTP catcher with a web UI —
+minimal setup for a Next.js dev who needs to test email locally. It listens for
+SMTP on port `3535` and serves a web UI on [http://localhost:3550](http://localhost:3550).
+
+Because the Email provider stores magic-link verification tokens in a database,
+this example also starts a Postgres container (wired up with the
+[Auth.js PostgreSQL adapter](https://authjs.dev/getting-started/adapters/pg)).
+Both services are defined in `docker-compose.yml`.
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), [pnpm](https://pnpm.io), or [Bun](https://bun.sh/docs/cli/bunx) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-email-local-smtp with-email-local-smtp-app
+```
+
+```bash
+yarn create next-app --example with-email-local-smtp with-email-local-smtp-app
+```
+
+```bash
+pnpm create next-app --example with-email-local-smtp with-email-local-smtp-app
+```
+
+```bash
+bunx create-next-app --example with-email-local-smtp with-email-local-smtp-app
+```
+
+### 1. Start the mail catcher and database
+
+`docker-compose.yml` starts Mailtrap Local and Postgres:
+
+```bash
+docker compose up
+```
+
+Leave it running. The Postgres schema required by Auth.js is created
+automatically from `init.sql` on first start.
+
+### 2. Configure environment variables
+
+Copy the example env file and append a generated auth secret to it:
+
+```bash
+cp .env.example .env.local
+echo "AUTH_SECRET=$(curl -s https://generate-secret.vercel.app/32)" >> .env.local
+```
+
+The `echo` line writes a real value into `.env.local`, overriding the empty
+`AUTH_SECRET=` placeholder (Auth.js throws `MissingSecret` if it is left empty).
+
+The other defaults already point at the local services:
+
+- `EMAIL_SERVER=smtp://localhost:3535` — the Mailtrap Local SMTP catcher
+- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/app` — the Postgres container
+
+### 3. Run the app
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000), enter any email address, and
+submit the form. Then open the Mailtrap Local web UI at
+[http://localhost:3550](http://localhost:3550) to read the sign-in email and
+click the magic link to complete authentication.

--- a/examples/with-email-local-smtp/actions.ts
+++ b/examples/with-email-local-smtp/actions.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import nodemailer from "nodemailer";
+
+export async function sendTestEmail(formData: FormData) {
+  const message =
+    (formData.get("message") || "").toString().trim() ||
+    "Hello from Mailtrap Local!";
+
+  const transport = nodemailer.createTransport(
+    process.env.EMAIL_SERVER || "smtp://localhost:3535",
+  );
+
+  await transport.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: "test@example.com",
+    subject: "Test email from Next.js",
+    text: message,
+  });
+}

--- a/examples/with-email-local-smtp/app/api/auth/[...nextauth]/route.ts
+++ b/examples/with-email-local-smtp/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/auth";

--- a/examples/with-email-local-smtp/app/globals.css
+++ b/examples/with-email-local-smtp/app/globals.css
@@ -1,0 +1,5 @@
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}

--- a/examples/with-email-local-smtp/app/layout.tsx
+++ b/examples/with-email-local-smtp/app/layout.tsx
@@ -1,0 +1,18 @@
+import "./globals.css";
+
+export const metadata = {
+  title: "Next.js Email Auth with Local SMTP",
+  description: "Magic-link sign in with Auth.js and Mailtrap Local",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/with-email-local-smtp/app/page.tsx
+++ b/examples/with-email-local-smtp/app/page.tsx
@@ -1,0 +1,68 @@
+import { auth, signIn, signOut } from "@/auth";
+import { sendTestEmail } from "@/actions";
+
+function SignIn() {
+  return (
+    <form
+      action={async (formData) => {
+        "use server";
+        await signIn("nodemailer", formData);
+      }}
+    >
+      <p>Sign in with a magic link sent to your email.</p>
+      <input type="email" name="email" placeholder="you@example.com" required />
+      <button type="submit">Send magic link</button>
+      <p>
+        The email is caught by Mailtrap Local — open{" "}
+        <a href="http://localhost:3550">http://localhost:3550</a> to read it and
+        click the link.
+      </p>
+    </form>
+  );
+}
+
+function SignOut({ children }: { children: React.ReactNode }) {
+  return (
+    <form
+      action={async () => {
+        "use server";
+        await signOut();
+      }}
+    >
+      <p>{children}</p>
+      <button type="submit">Sign out</button>
+    </form>
+  );
+}
+
+function SendTestEmail() {
+  return (
+    <form action={sendTestEmail}>
+      <h2>Send a test email</h2>
+      <p>
+        Send an email straight to Mailtrap Local, then read it at{" "}
+        <a href="http://localhost:3550">http://localhost:3550</a>.
+      </p>
+      <textarea
+        name="message"
+        rows={3}
+        placeholder="Optional message body (defaults to a greeting)"
+      />
+      <button type="submit">Send test email</button>
+    </form>
+  );
+}
+
+export default async function Page() {
+  const session = await auth();
+  const user = session?.user?.email;
+
+  return (
+    <section>
+      <h1>Home</h1>
+      <div>{user ? <SignOut>{`Welcome ${user}`}</SignOut> : <SignIn />}</div>
+      <hr />
+      <SendTestEmail />
+    </section>
+  );
+}

--- a/examples/with-email-local-smtp/auth.ts
+++ b/examples/with-email-local-smtp/auth.ts
@@ -1,0 +1,23 @@
+import NextAuth from "next-auth";
+import Nodemailer from "next-auth/providers/nodemailer";
+import PostgresAdapter from "@auth/pg-adapter";
+import { Pool } from "pg";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const {
+  handlers: { GET, POST },
+  auth,
+  signIn,
+  signOut,
+} = NextAuth({
+  adapter: PostgresAdapter(pool),
+  providers: [
+    Nodemailer({
+      server: process.env.EMAIL_SERVER,
+      from: process.env.EMAIL_FROM,
+    }),
+  ],
+});

--- a/examples/with-email-local-smtp/docker-compose.yml
+++ b/examples/with-email-local-smtp/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  mailtrap-local:
+    image: mailtrap/mailtrap-local:latest
+    ports:
+      - "3535:3535" # SMTP
+      - "3550:3550" # web ui - http://localhost:3550
+    volumes:
+      - mailtrap-local:/var/lib/mailtrap-local
+
+  # Auth.js stores magic-link verification tokens in a database, so the Email provider needs one.
+  # The schema in init.sql is loaded automatically on the first start.
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+
+volumes:
+  mailtrap-local:

--- a/examples/with-email-local-smtp/init.sql
+++ b/examples/with-email-local-smtp/init.sql
@@ -1,0 +1,29 @@
+-- https://authjs.dev/getting-started/adapters/pg
+-- Schema for magic-link (email) auth with the Auth.js PostgreSQL adapter.
+-- Loaded automatically by the postgres container on first start.
+-- The `accounts` table from the full adapter schema is omitted because it is only needed for OAuth providers, not the email flow shown here.
+
+
+CREATE TABLE verification_token (
+  identifier TEXT NOT NULL,
+  expires TIMESTAMPTZ NOT NULL,
+  token TEXT NOT NULL,
+  PRIMARY KEY (identifier, token)
+);
+
+CREATE TABLE users (
+  id SERIAL,
+  name VARCHAR(255),
+  email VARCHAR(255),
+  "emailVerified" TIMESTAMPTZ,
+  image TEXT,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE sessions (
+  id SERIAL,
+  "userId" INTEGER NOT NULL,
+  expires TIMESTAMPTZ NOT NULL,
+  "sessionToken" VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/examples/with-email-local-smtp/package.json
+++ b/examples/with-email-local-smtp/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "email": "docker compose up"
+  },
+  "dependencies": {
+    "@auth/pg-adapter": "^1.7.0",
+    "next": "latest",
+    "next-auth": "^5.0.0-beta.4",
+    "nodemailer": "^7.0.7",
+    "pg": "^8.11.0",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/nodemailer": "^6.4.17",
+    "@types/pg": "^8.11.0",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "typescript": "latest"
+  }
+}

--- a/examples/with-email-local-smtp/tsconfig.json
+++ b/examples/with-email-local-smtp/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### What?

Adds a new example demonstrating [Mailtrap Local](https://github.com/mailtrap/mailtrap-local) as the local SMTP catcher with Auth.js (NextAuth) to send a magic-link email sign-in.

### Why?

There are many email providers, and if you are working on something before actually using it, you might either run out of free credits or have to start spending money just so that you can test your work. With this local setup it is easy and free to test your emails on your local machine.


### How?

- auth.ts configures NextAuth with PosgresAdapter and Nodemailer.
- using docker-compose to spin up local services, including Mailtrap local and PostgreSQL.
- init.sql taken from Auth.js documentation to provide necessary set-up for magic links.
- README.md provides a step-by-step guide that I've tested myself.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
