### PR TITLE
fix(static-paths): improve error message for invalid path type in getStaticPaths

### DIFF
--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -129,7 +129,15 @@ export async function buildPagesStaticPaths({
     }
     // For the object-provided path, we must make sure it specifies all
     // required keys.
-    else {
+    else if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new Error(
+      `Invalid path "${String(entry)}" returned from \`getStaticPaths\` in ${page}.\n` +
+      `Each path must be a string or an object of shape { params: { [key: string]: string } }.\n` +
+      `Received: ${typeof entry}${entry !== null ? ` (${JSON.stringify(entry)})` : ''}.\n` +
+      `Did you forget to convert a number to a string? e.g. params: { id: String(id) }`
+    )
+  } 
+  else {
       const invalidKeys = Object.keys(entry).filter(
         (key) => key !== 'params' && key !== 'locale'
       )


### PR DESCRIPTION
### What?
Added a type check in `buildPagesStaticPaths` to catch when a non-string, 
non-object value (e.g. a number) is returned as a path entry in the `paths` 
array from `getStaticPaths`.

### Why?
When a developer forgets to convert a value to a string (e.g. returning a 
number from pagination data), the error thrown was confusing and didn't 
explain how to fix it. This change throws a clear, actionable error message 
pointing to the exact problem.

### How?
Added an `else if` branch in the `toPrerender.forEach` loop in 
`packages/next/src/build/static-paths/pages.ts` that checks if an entry 
is neither a string nor a valid object, and throws a descriptive error 
with a hint to convert the value to a string.

Fixes #41281