### PR TITLE
fix(agent-rules): pad managed AGENTS.md block with blank lines

### DIFF
--- a/packages/create-next-app/helpers/generate-agent-files.ts
+++ b/packages/create-next-app/helpers/generate-agent-files.ts
@@ -7,11 +7,13 @@ import path from 'path'
  */
 export function generateAgentFiles(root: string): void {
   const agentsMdContent = `<!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` (resolved from this file's directory; in monorepos the \`next\` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
 This block is written and re-added by \`next dev\` — verify at \`node_modules/next/dist/server/lib/generate-agent-files.js\`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 <!-- END:nextjs-agent-rules -->
 `
 

--- a/packages/next/src/server/lib/generate-agent-files.ts
+++ b/packages/next/src/server/lib/generate-agent-files.ts
@@ -23,11 +23,13 @@ const LEGACY_AGENT_RULES_END_MARKER = '<!-- NEXT-AGENTS-MD-END -->'
 
 function buildAgentRulesBlock(): string {
   return `${AGENT_RULES_START_MARKER}
+
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` (resolved from this file's directory; in monorepos the \`next\` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
 This block is written and re-added by \`next dev\` — verify at \`node_modules/next/dist/server/lib/generate-agent-files.js\`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 ${AGENT_RULES_END_MARKER}`
 }
 


### PR DESCRIPTION
### What

The generated `nextjs-agent-rules` block in `AGENTS.md` glued the `<!-- BEGIN:nextjs-agent-rules -->` / `<!-- END:nextjs-agent-rules -->` comment markers directly against the `#` heading and the surrounding paragraphs:

```md
<!-- BEGIN:nextjs-agent-rules -->
# This is NOT the Next.js you know
...
<!-- END:nextjs-agent-rules -->
```

Markdown formatters (Prettier, and CommonMark tooling in general) treat block-level HTML comments as needing surrounding blank lines, so formatting an `AGENTS.md` reflows the block:

```md
<!-- BEGIN:nextjs-agent-rules -->

# This is NOT the Next.js you know
...

<!-- END:nextjs-agent-rules -->
```

On the next `next dev`, the generator detects the block as non-current and rewrites it back to the glued form. For any project that runs Prettier over `AGENTS.md`, this produces churn on every commit — the opposite of what the block's own "commit it to keep the tree clean" note promises.

### Change

Emit blank lines around the markers so the generated block is formatter-stable. Both generators are updated together:

- `packages/next/src/server/lib/generate-agent-files.ts` (`next dev` writer)
- `packages/create-next-app/helpers/generate-agent-files.ts`

The `next-codemod` `agents-md` refresh delegates to the installed package's generator, so it needs no change. The docs sample in `ai-agents.mdx` and this repo's own `packages/next/AGENTS.md` already use the blank-line shape, so they now match what's generated.

### Notes

- Existing projects get a one-time block rewrite on their next `next dev` (expected — the block is described as re-added by `next dev`), after which it stays stable under formatting.
- The `agent-rules-auto-generate` test asserts against the live generator output, so it tracks the new shape automatically.
