### PR TITLE
[turbopack] Reduce macOS HMR latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10193,6 +10193,8 @@ dependencies = [
  "include_dir",
  "indexmap 2.13.0",
  "jsonc-parser",
+ "kqueue-sys",
+ "libc",
  "mime",
  "notify",
  "parking_lot",

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -65,8 +65,8 @@ use crate::{
             AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext,
             CleanupOldEdgesOperation, ConnectChildOperation, ExecuteContext, ExecuteContextImpl,
             LeafDistanceUpdateQueue, Operation, OutdatedEdge, TaskGuard, TaskType, TaskTypeRef,
-            connect_children, get_aggregation_number, get_uppers, make_task_dirty_internal,
-            prepare_new_children,
+            connect_children, get_aggregation_number, get_uppers, is_root_node,
+            make_task_dirty_internal, prepare_new_children,
         },
         snapshot_coordinator::{OperationGuard, SnapshotCoordinator},
         storage::Storage,
@@ -1516,6 +1516,12 @@ impl TurboTasksBackend {
             raw_get_in_shard(shard, hash, |k| k.eq_components(native_fn, this, arg_ref))
         {
             self.track_cache_hit_by_fn(native_fn);
+            if parent_task.is_none() {
+                let task = ctx.task(task_id, TaskDataCategory::Meta);
+                if is_root_node(get_aggregation_number(&task)) && task.has_output() {
+                    return task_id;
+                }
+            }
             operation::ConnectChildOperation::run(parent_task, task_id, ctx);
             return task_id;
         }

--- a/turbopack/crates/turbo-tasks-backend/tests/basic.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/basic.rs
@@ -2,11 +2,14 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, State, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
+static CACHED_TOP_LEVEL_EXECUTIONS: AtomicUsize = AtomicUsize::new(0);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_basic() {
@@ -18,6 +21,46 @@ async fn test_basic() {
     })
     .await
     .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dirty_top_level_cached_root() {
+    CACHED_TOP_LEVEL_EXECUTIONS.store(0, Ordering::SeqCst);
+    let instance = REGISTRATION.create_turbo_tasks("dirty_top_level_cached_root", true);
+    let tt = instance.tt;
+
+    let input = turbo_tasks::run(tt.clone(), async {
+        Ok(create_cached_top_level_input()
+            .resolve()
+            .strongly_consistent()
+            .await?)
+    })
+    .await
+    .unwrap();
+
+    let value = turbo_tasks::run(tt.clone(), async move {
+        Ok(cached_top_level_value(*input)
+            .strongly_consistent()
+            .await?
+            .value)
+    })
+    .await
+    .unwrap();
+    assert_eq!(value, 7);
+
+    let value = turbo_tasks::run(tt.clone(), async move {
+        input.await?.state.set(9);
+        Ok(cached_top_level_value(*input)
+            .strongly_consistent()
+            .await?
+            .value)
+    })
+    .await
+    .unwrap();
+    assert_eq!(value, 9);
+
+    assert_eq!(CACHED_TOP_LEVEL_EXECUTIONS.load(Ordering::SeqCst), 2);
+    tt.stop_and_wait().await;
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -47,6 +90,26 @@ async fn test_basic_operation(nonce: u32) -> Result<Vc<()>> {
 #[derive(Clone, Debug)]
 struct Value {
     value: u32,
+}
+
+#[turbo_tasks::value]
+struct CachedTopLevelInput {
+    state: State<u32>,
+}
+
+#[turbo_tasks::function(operation, root)]
+fn create_cached_top_level_input() -> Vc<CachedTopLevelInput> {
+    CachedTopLevelInput {
+        state: State::new(7),
+    }
+    .cell()
+}
+
+#[turbo_tasks::function(root)]
+async fn cached_top_level_value(input: ResolvedVc<CachedTopLevelInput>) -> Result<Vc<Value>> {
+    CACHED_TOP_LEVEL_EXECUTIONS.fetch_add(1, Ordering::SeqCst);
+    let value = *input.await?.state.get();
+    Ok(Value { value }.cell())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -55,6 +55,10 @@ turbo-tasks-hash = { workspace = true }
 turbo-unix-path = { workspace = true }
 urlencoding = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+kqueue-sys = "1.0.4"
+libc = "0.2.177"
+
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 rand = { workspace = true }
@@ -63,4 +67,3 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }
-

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -10,12 +10,25 @@ use std::{
     },
     time::Duration,
 };
+#[cfg(target_os = "macos")]
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Read, Write},
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::net::UnixStream,
+    },
+    path::Component,
+};
 
 use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
+#[cfg(target_os = "macos")]
+use kqueue_sys::{EventFilter, EventFlag, FilterFlag, kevent, kqueue};
 use notify::{
     Config, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher,
-    event::{MetadataKind, ModifyKind, RenameMode},
+    event::{DataChange, MetadataKind, ModifyKind, RemoveKind, RenameMode},
 };
 use rustc_hash::FxHashSet;
 use tokio::sync::{RwLock, RwLockWriteGuard};
@@ -112,6 +125,8 @@ enum RecursiveState {
     Watching {
         /// Hold onto the watcher: When this is dropped, it will cause the channel to disconnect
         _notify_watcher: NotifyWatcher,
+        #[cfg(target_os = "macos")]
+        fast_file_watcher: Option<FastFileWatcher>,
     },
 }
 
@@ -140,6 +155,187 @@ struct NonRecursiveWatchingState {
 enum NotifyWatcher {
     Recommended(RecommendedWatcher),
     Polling(PollWatcher),
+}
+
+#[cfg(target_os = "macos")]
+const FAST_FILE_WATCHER_LIMIT: usize = 2048;
+
+/// A low-latency supplement to FSEvents for files that are likely to be edited directly.
+///
+/// FSEvents remains the authoritative recursive watcher. This sidecar deliberately watches only
+/// individual project files and is bounded so it cannot exhaust file descriptors on dependency
+/// trees. Events from either watcher enter the same invalidation channel.
+#[cfg(target_os = "macos")]
+struct FastFileWatcher {
+    tx: std::sync::mpsc::Sender<PathBuf>,
+    wakeup: UnixStream,
+}
+
+#[cfg(target_os = "macos")]
+impl FastFileWatcher {
+    fn new(event_tx: std::sync::mpsc::Sender<notify::Result<notify::Event>>) -> Option<Self> {
+        let (tx, rx) = channel();
+        let (wakeup, wakeup_rx) = UnixStream::pair().ok()?;
+        wakeup.set_nonblocking(true).ok()?;
+        wakeup_rx.set_nonblocking(true).ok()?;
+        spawn_thread(move || run_fast_file_watcher(rx, event_tx, wakeup_rx));
+        Some(Self { tx, wakeup })
+    }
+
+    fn watch(&self, path: &Path) {
+        if self.tx.send(path.to_owned()).is_ok() {
+            let _ = (&self.wakeup).write(&[0]);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn should_fast_watch(path: &Path, root_path: &Path) -> bool {
+    let Ok(relative_path) = path.strip_prefix(root_path) else {
+        return false;
+    };
+
+    !relative_path.components().any(|component| {
+        matches!(
+            component,
+            Component::Normal(name)
+                if name == "node_modules" || name == ".git" || name == ".next"
+        )
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn run_fast_file_watcher(
+    rx: Receiver<PathBuf>,
+    event_tx: std::sync::mpsc::Sender<notify::Result<notify::Event>>,
+    mut wakeup: UnixStream,
+) {
+    let queue = unsafe { kqueue() };
+    if queue < 0 {
+        return;
+    }
+
+    let wakeup_fd = wakeup.as_raw_fd();
+    let wakeup_change = kevent::new(
+        wakeup_fd as usize,
+        EventFilter::EVFILT_READ,
+        EventFlag::EV_ADD | EventFlag::EV_ENABLE | EventFlag::EV_CLEAR,
+        FilterFlag::empty(),
+    );
+    let wakeup_result = unsafe {
+        kevent(
+            queue,
+            &wakeup_change,
+            1,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null(),
+        )
+    };
+    if wakeup_result != 0 {
+        unsafe {
+            libc::close(queue);
+        }
+        return;
+    }
+
+    let mut files = HashMap::<PathBuf, File>::new();
+    let mut paths_by_fd = HashMap::<RawFd, PathBuf>::new();
+
+    'watching: loop {
+        let mut event = kevent::new(
+            0,
+            EventFilter::EVFILT_VNODE,
+            EventFlag::empty(),
+            FilterFlag::empty(),
+        );
+        let count = unsafe { kevent(queue, std::ptr::null(), 0, &mut event, 1, std::ptr::null()) };
+        if count != 1 {
+            continue;
+        }
+        if event.flags.contains(EventFlag::EV_ERROR) {
+            break;
+        }
+
+        let fd = event.ident as RawFd;
+        if fd == wakeup_fd {
+            let mut buffer = [0; 256];
+            loop {
+                match wakeup.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(_) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(_) => break,
+                }
+            }
+
+            loop {
+                match rx.try_recv() {
+                    Ok(path) => {
+                        if files.contains_key(&path) || files.len() >= FAST_FILE_WATCHER_LIMIT {
+                            continue;
+                        }
+                        let Ok(file) = File::open(&path) else {
+                            continue;
+                        };
+                        let fd = file.as_raw_fd();
+                        let change = kevent::new(
+                            fd as usize,
+                            EventFilter::EVFILT_VNODE,
+                            EventFlag::EV_ADD | EventFlag::EV_ENABLE | EventFlag::EV_CLEAR,
+                            FilterFlag::NOTE_DELETE
+                                | FilterFlag::NOTE_WRITE
+                                | FilterFlag::NOTE_EXTEND
+                                | FilterFlag::NOTE_ATTRIB
+                                | FilterFlag::NOTE_RENAME
+                                | FilterFlag::NOTE_REVOKE,
+                        );
+                        let result = unsafe {
+                            kevent(queue, &change, 1, std::ptr::null_mut(), 0, std::ptr::null())
+                        };
+                        if result == 0 {
+                            paths_by_fd.insert(fd, path.clone());
+                            files.insert(path, file);
+                        }
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => break 'watching,
+                }
+            }
+            continue;
+        }
+
+        let Some(path) = paths_by_fd.get(&fd).cloned() else {
+            continue;
+        };
+        let remove_watch = event.fflags.intersects(
+            FilterFlag::NOTE_DELETE | FilterFlag::NOTE_RENAME | FilterFlag::NOTE_REVOKE,
+        );
+        let kind = if event
+            .fflags
+            .intersects(FilterFlag::NOTE_DELETE | FilterFlag::NOTE_REVOKE)
+        {
+            EventKind::Remove(RemoveKind::Any)
+        } else if event.fflags.contains(FilterFlag::NOTE_RENAME) {
+            EventKind::Modify(ModifyKind::Name(RenameMode::Any))
+        } else if event.fflags.contains(FilterFlag::NOTE_ATTRIB) {
+            EventKind::Modify(ModifyKind::Metadata(MetadataKind::Any))
+        } else {
+            EventKind::Modify(ModifyKind::Data(DataChange::Any))
+        };
+
+        let _ = event_tx.send(Ok(notify::Event::new(kind).add_path(path.clone())));
+
+        if remove_watch {
+            paths_by_fd.remove(&fd);
+            files.remove(&path);
+        }
+    }
+
+    unsafe {
+        libc::close(queue);
+    }
 }
 
 impl NotifyWatcher {
@@ -388,9 +584,9 @@ impl DiskWatcher {
 
         let mut notify_watcher = if let Some(poll_interval) = poll_interval {
             let config = config.with_poll_interval(poll_interval);
-            NotifyWatcher::Polling(PollWatcher::new(tx, config)?)
+            NotifyWatcher::Polling(PollWatcher::new(tx.clone(), config)?)
         } else {
-            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?)
+            NotifyWatcher::Recommended(RecommendedWatcher::new(tx.clone(), config)?)
         };
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the
@@ -400,6 +596,13 @@ impl DiskWatcher {
             StateWriteGuard::Recursive(_) => RecursiveMode::Recursive,
             StateWriteGuard::NonRecursive(_) => RecursiveMode::NonRecursive,
         };
+        #[cfg(target_os = "macos")]
+        let fast_file_watcher =
+            if matches!(&state_guard, StateWriteGuard::Recursive(_)) && poll_interval.is_none() {
+                FastFileWatcher::new(tx)
+            } else {
+                None
+            };
         notify_watcher.watch(root_path, recursive_mode)?;
 
         // We need to invalidate all reads or writes that happened before watching. As a
@@ -449,6 +652,8 @@ impl DiskWatcher {
             StateWriteGuard::Recursive(mut recursive) => {
                 *recursive = RecursiveState::Watching {
                     _notify_watcher: notify_watcher,
+                    #[cfg(target_os = "macos")]
+                    fast_file_watcher,
                 }
             }
             StateWriteGuard::NonRecursive(mut non_recursive) => {
@@ -744,6 +949,17 @@ impl DiskWatcher {
     }
 
     pub async fn ensure_watched_file(&self, path: &Path, root_path: &Path) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        if let State::Recursive(recursive) = &self.state
+            && should_fast_watch(path, root_path)
+            && let RecursiveState::Watching {
+                fast_file_watcher: Some(fast_file_watcher),
+                ..
+            } = &*recursive.read().await
+        {
+            fast_file_watcher.watch(path);
+        }
+
         // Watch the parent directory instead of the specified file, since directories also track
         // their immediate children (even in non-recursive mode), and we need to watch all the
         // parents anyways.
@@ -859,5 +1075,36 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use std::path::Path;
+
+    use super::should_fast_watch;
+
+    #[test]
+    fn fast_file_watcher_is_limited_to_project_files() {
+        let root = Path::new("/project");
+
+        assert!(should_fast_watch(Path::new("/project/app/page.tsx"), root));
+        assert!(should_fast_watch(
+            Path::new("/project/src/node_modules-helper.ts"),
+            root
+        ));
+        assert!(!should_fast_watch(
+            Path::new("/project/node_modules/package/index.js"),
+            root
+        ));
+        assert!(!should_fast_watch(Path::new("/project/.git/index"), root));
+        assert!(!should_fast_watch(
+            Path::new("/project/.next/server/app.js"),
+            root
+        ));
+        assert!(!should_fast_watch(
+            Path::new("/other-project/app/page.tsx"),
+            root
+        ));
     }
 }

--- a/turbopack/crates/turbo-tasks/FORMATTING.md
+++ b/turbopack/crates/turbo-tasks/FORMATTING.md
@@ -9,12 +9,20 @@ read. These macros handle that automatically.
 Returns `Result<RcStr>` after resolving all arguments asynchronously.
 
 ```rust
+# use anyhow::Result;
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::{Vc, turbofmt};
+# struct Asset;
+# impl Asset { fn ident(&self) -> &'static str { "asset" } }
+# async fn example(asset: Asset, base_path: &str, some_vc: Vc<RcStr>) -> Result<()> {
 // Positional arguments
 let msg = turbofmt!("asset {} in path {}", asset.ident(), base_path).await?;
 
 // Captured variables
 let name = some_vc;
 let msg = turbofmt!("hello {name}").await?;
+# Ok(())
+# }
 ```
 
 Arguments can be `Vc<T>`, `ResolvedVc<T>`, `ReadRef<T>`, or any type
@@ -29,7 +37,13 @@ Same as `turbofmt!`, but calls `anyhow::bail!()` with the formatted message.
 Has implicit `.await` and return flow.
 
 ```rust
+# use anyhow::Result;
+# use turbo_tasks::turbobail;
+# struct Asset;
+# impl Asset { fn ident(&self) -> &'static str { "asset" } }
+# async fn example(asset: Asset, base_path: &str) -> Result<()> {
 turbobail!("asset {} is not in path {}", asset.ident(), base_path);
+# }
 ```
 
 ## `#[derive(ValueToString)]`
@@ -41,29 +55,49 @@ and `ResolvedVc<T>` fields work directly in format strings.
 **No attribute** — delegates to `Display::to_string()`:
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use std::fmt;
+# use turbo_tasks::ValueToString;
+# #[turbo_tasks::value]
 #[derive(ValueToString)]
-struct Foo { ... } // requires Display impl
+struct Foo; // requires Display impl
+# impl fmt::Display for Foo {
+#     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("foo") }
+# }
 ```
 
 **Format string with field references** — fields are resolved async:
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::{ResolvedVc, ValueToString};
+# #[turbo_tasks::value]
 #[derive(ValueToString)]
 #[value_to_string("[{fs}]/{path}")]
-struct FileSystemPath { fs: ResolvedVc<...>, path: RcStr }
+struct FileSystemPath { fs: ResolvedVc<RcStr>, path: RcStr }
 ```
 
 **Format string with explicit expressions:**
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::ValueToString;
+# #[turbo_tasks::value]
 #[derive(ValueToString)]
 #[value_to_string("{}", self.name())]
-struct Bar { ... }
+struct Bar { name: RcStr }
+# impl Bar { fn name(&self) -> &str { &self.name } }
 ```
 
 **Direct expression:**
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::ValueToString;
+# #[turbo_tasks::value]
 #[derive(ValueToString)]
 #[value_to_string(self.inner)]
 struct Wrapper { inner: RcStr }
@@ -72,6 +106,10 @@ struct Wrapper { inner: RcStr }
 **Enums** — variants without an attribute default to their name:
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::{ResolvedVc, ValueToString};
+# #[turbo_tasks::value]
 #[derive(ValueToString)]
 enum Kind {
     Foo,                                    // → "Foo"
@@ -88,8 +126,12 @@ The underlying async trait. You rarely need to implement this manually —
 prefer `#[derive(ValueToString)]` instead.
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::Vc;
 #[turbo_tasks::value_trait]
 pub trait ValueToString {
+    #[turbo_tasks::function]
     fn to_string(self: Vc<Self>) -> Vc<RcStr>;
 }
 ```

--- a/turbopack/crates/turbo-tasks/function.md
+++ b/turbopack/crates/turbo-tasks/function.md
@@ -1,9 +1,13 @@
 Tasks are created by defining a Rust function annotated with the `#[turbo_tasks::function]` macro and calling it with arguments. Each unique combination of function and arguments create a new task at runtime. Tasks are the fundamental units of work within the build system.
 
 ```rust
+# use turbo_tasks::Vc;
+# #[turbo_tasks::value]
+# struct Something;
 #[turbo_tasks::function]
 fn add(a: i32, b: i32) -> Vc<Something> {
     // Task implementation goes here...
+#   Something.cell()
 }
 ```
 
@@ -66,6 +70,11 @@ async fn foo(
 will have an external signature of
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_tasks::Vc;
+# #[turbo_tasks::value_trait]
+# trait Example {
+# #[turbo_tasks::function]
 fn foo(
     self: Vc<Self>,           // was: &self
     a: i32,
@@ -73,6 +82,7 @@ fn foo(
     c: Vc<i32>,               // was: ResolvedVc<i32>
     d: Option<Vec<Vc<i32>>>,  // was: Option<Vec<ResolvedVc<i32>>>
 ) -> Vc<i32>;                 // was: impl Future<Output = Result<ResolvedVc<i32>>>
+# }
 ```
 
 ## Attributes
@@ -81,9 +91,15 @@ The `#[turbo_tasks::function]` macro accepts optional attributes that modify the
 task. Multiple attributes can be combined by separating them with commas.
 
 ```rust
+# use anyhow::Result;
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::Vc;
+# #[turbo_tasks::value]
+# struct FileContent;
 #[turbo_tasks::function(fs, session_dependent)]
 async fn read_file(path: RcStr) -> Result<Vc<FileContent>> {
     // ...
+#   Ok(FileContent.cell())
 }
 ```
 
@@ -156,28 +172,36 @@ Tasks can be methods associated with a value or a trait implementation using the
 ### Inherent Implementations
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use anyhow::Result;
+# use turbo_tasks::{ResolvedVc, Vc};
+# #[turbo_tasks::value]
+# struct Something { some_field: i32 }
+# #[turbo_tasks::value]
+# struct SomethingElse(i32);
+# impl SomethingElse { fn new(value: i32, a: i32) -> Self { Self(value + a) } }
 #[turbo_tasks::value_impl]
 impl Something {
     #[turbo_tasks::function]
-    fn method(self: Vc<Self>, a: i32) -> Vc<SomethingElse> {
+    async fn method(self: Vc<Self>, a: i32) -> Result<Vc<SomethingElse>> {
         // Receives the full `Vc<Self>` type, which we must `.await` to get a
         // `ReadRef<Self>`.
-        vdbg!(self.await?.some_field);
+        let some_field = self.await?.some_field;
 
         // The `Vc` type is useful for calling other methods declared on
         // `Vc<Self>`, e.g.:
-        self.method_resolved(a)
+        Ok(self.method_resolved(a))
     }
 
     #[turbo_tasks::function]
-    fn method_resolved(self: ResolvedVc<Self>, a: i32) -> Vc<SomethingElse> {
+    async fn method_resolved(self: ResolvedVc<Self>, a: i32) -> Result<Vc<SomethingElse>> {
         // Same as above, but receives a `ResolvedVc`, which can be `.await`ed
         // to a `ReadRef` or dereferenced (implicitly or with `*`) to `Vc`.
-        vdbg!(self.await?.some_field);
+        let some_field = self.await?.some_field;
 
         // The `ResolvedVc<Self>` type can be used to call other methods
         // declared on `Vc<Self>`, e.g.:
-        self.method_ref(a)
+        Ok(self.method_ref(a))
     }
 
     #[turbo_tasks::function]
@@ -188,7 +212,7 @@ impl Something {
         // It can access fields on the struct/enum and call methods declared on
         // `Self`, but it cannot call other methods declared on `Vc<Self>`
         // (without cloning the value and re-wrapping it in a `Vc`).
-        Vc::cell(SomethingElse::new(self.some_field, a))
+        SomethingElse::new(self.some_field, a).cell()
     }
 }
 ```
@@ -202,6 +226,17 @@ impl Something {
 ### Trait Implementations
 
 ```rust
+# #![feature(arbitrary_self_types_pointers)]
+# use turbo_tasks::Vc;
+# #[turbo_tasks::value]
+# struct Something;
+# #[turbo_tasks::value]
+# struct SomethingElse;
+# #[turbo_tasks::value_trait]
+# trait Trait {
+#     #[turbo_tasks::function]
+#     fn method(self: Vc<Self>, a: i32) -> Vc<SomethingElse>;
+# }
 #[turbo_tasks::value_impl]
 impl Trait for Something {
     #[turbo_tasks::function]
@@ -209,6 +244,7 @@ impl Trait for Something {
         // Trait method implementation...
         //
         // `self: ResolvedVc<Self>` and `&self` are also valid argument types!
+#       SomethingElse.cell()
     }
 }
 ```

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -266,7 +266,9 @@ impl EffectStateStorage {
 /// # #![feature(arbitrary_self_types_pointers)]
 /// #
 /// # use anyhow::Result;
-/// # use turbo_tasks::{Effects, ReadRef, Vc, run_once, take_effects};
+/// # use turbo_tasks::{
+/// #     Effects, ReadRef, Vc, read_strongly_consistent_and_apply_effects, take_effects,
+/// # };
 /// #
 /// # async fn _wrapper() -> Result<()> {
 /// # type Example = ();
@@ -292,13 +294,12 @@ impl EffectStateStorage {
 ///     Ok(OutputWithEffects { output, effects }.cell())
 /// }
 ///
-/// // every operation must be read with strong consistency at the top-level
-/// let result_with_effects = some_turbo_tasks_operation_with_effects(args)
-///     .read_strongly_consistent()
-///     .await?;
-///
-/// // apply the effects once outside of a turbo_tasks::function at the top-level (e.g. `run_once`)
-/// result_with_effects.effects.apply().await?;
+/// // At the top level, strongly read the operation and apply its effects in one retrying helper.
+/// let result_with_effects = read_strongly_consistent_and_apply_effects(
+///     some_turbo_tasks_operation_with_effects(args),
+///     |value| &value.effects,
+/// )
+/// .await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1985,9 +1985,9 @@ impl CurrentCellRef {
     /// struct Wrapper(Vec<u32>);
     ///
     /// impl PartialEq for Wrapper {
-    ///     fn eq(&self, other: Wrapper) {
+    ///     fn eq(&self, other: &Self) -> bool {
     ///         // Example: order doesn't matter for equality
-    ///         let (mut this, mut other) = (self.clone(), other.clone());
+    ///         let (mut this, mut other) = (self.0.clone(), other.0.clone());
     ///         this.sort_unstable();
     ///         other.sort_unstable();
     ///         this == other

--- a/turbopack/crates/turbo-tasks/src/message_queue.rs
+++ b/turbopack/crates/turbo-tasks/src/message_queue.rs
@@ -163,6 +163,9 @@ pub struct TimingEvent {
     ///
     /// Example:
     /// ```rust
+    /// use std::time::Duration;
+    /// use turbo_tasks::message_queue::{CompilationEvent, TimingEvent};
+    ///
     /// let event = TimingEvent::new("Compiled successfully".to_string(), Duration::from_millis(100));
     /// let message = event.message();
     /// assert_eq!(message, "Compiled successfully in 100ms");

--- a/turbopack/crates/turbo-tasks/src/priority_runner.rs
+++ b/turbopack/crates/turbo-tasks/src/priority_runner.rs
@@ -38,6 +38,12 @@ struct HeapItem<P, T> {
     task: T,
 }
 
+#[cfg(test)]
+struct GraceWindowHook {
+    entered: std::sync::mpsc::Sender<()>,
+    proceed: std::sync::mpsc::Receiver<()>,
+}
+
 impl<P: Eq, T> PartialEq for HeapItem<P, T> {
     fn eq(&self, other: &Self) -> bool {
         self.priority == other.priority
@@ -69,8 +75,12 @@ pub struct PriorityRunner<
     target_workers: usize,
     /// The queue of tasks to execute. These tasks are not scheduled yet.
     queue: Mutex<BinaryHeap<HeapItem<P, T>>>,
+    #[cfg(test)]
+    grace_window_hook: Mutex<Option<GraceWindowHook>>,
     /// The number of active workers currently polling tasks.
-    /// Workers that responded with Poll::Pending are not counted until they are polled again.
+    /// Workers whose current task returned `Poll::Pending` are not counted until they are polled
+    /// again. Workers that self-yield after completing a task remain counted while they check for
+    /// follow-up work.
     active_workers: AtomicUsize,
     phantom: std::marker::PhantomData<C>,
 }
@@ -87,6 +97,8 @@ impl<
             executor,
             target_workers: tokio::runtime::Handle::current().metrics().num_workers(),
             queue: Mutex::new(BinaryHeap::new()),
+            #[cfg(test)]
+            grace_window_hook: Mutex::new(None),
             active_workers: AtomicUsize::new(0),
             phantom: std::marker::PhantomData,
         }
@@ -161,6 +173,32 @@ impl<
         }
     }
 
+    /// On a single-worker runtime, after the worker has already yielded once, briefly release the
+    /// OS thread between queue checks so a concurrent producer can enqueue a sequential follow-up
+    /// without busy-waiting. Multi-worker runtimes can rely on another worker for that handoff.
+    fn pop_future_from_worker_after_yield(&self, execute_context: &Arc<C>) -> Option<E::Future> {
+        const FOLLOW_UP_YIELDS: usize = 16;
+
+        if self.target_workers > 1 {
+            return self.pop_future_from_worker(execute_context);
+        }
+
+        #[cfg(test)]
+        if let Some(hook) = self.grace_window_hook.lock().take() {
+            hook.entered.send(()).unwrap();
+            hook.proceed
+                .recv_timeout(Duration::from_secs(1))
+                .expect("test should enqueue follow-up work before releasing the grace window");
+        }
+        for _ in 0..FOLLOW_UP_YIELDS {
+            std::thread::yield_now();
+            if let Some(future) = self.pop_future_from_worker(execute_context) {
+                return Some(future);
+            }
+        }
+        None
+    }
+
     fn spawn_worker_if_work_available(
         self: &Arc<Self>,
         execute_context: &Arc<C>,
@@ -199,6 +237,7 @@ enum WorkerState {
     UnfinishedFuture,
     PendingFuture,
     Done,
+    Yielded,
     Closed,
 }
 
@@ -286,7 +325,7 @@ impl<
                         }
                     }
                 }
-                WorkerState::Done => {
+                WorkerState::Done | WorkerState::Yielded => {
                     let active_workers = this.runner.active_workers.load(Ordering::Relaxed);
                     if active_workers > this.runner.target_workers {
                         // There are more active workers than target, so we should end this
@@ -298,9 +337,13 @@ impl<
 
                     // This future is done, we need to check the queue for more tasks,
                     // so we can continue working on a new future in this worker.
-                    if let Some(new_future) =
+                    let new_future = if matches!(this.state, WorkerState::Yielded) {
+                        this.runner
+                            .pop_future_from_worker_after_yield(this.execute_context)
+                    } else {
                         this.runner.pop_future_from_worker(this.execute_context)
-                    {
+                    };
+                    if let Some(new_future) = new_future {
                         // We are replacing the future with a new one, but the current future is
                         // pinned. So we need to drop the future in place
                         // and replace it with the new future, which becomes
@@ -314,11 +357,15 @@ impl<
                         }
                         *this.state = WorkerState::UnfinishedFuture;
                     } else {
-                        // No more tasks to execute
-                        // This worker ends here
-                        this.runner.decrease_active_workers(this.execute_context);
-                        *this.state = WorkerState::Closed;
-                        return Poll::Ready(());
+                        if matches!(this.state, WorkerState::Done) {
+                            cx.waker().wake_by_ref();
+                            *this.state = WorkerState::Yielded;
+                            return Poll::Pending;
+                        } else {
+                            this.runner.decrease_active_workers(this.execute_context);
+                            *this.state = WorkerState::Closed;
+                            return Poll::Ready(());
+                        }
                     }
                 }
             }
@@ -329,12 +376,121 @@ impl<
 #[cfg(test)]
 mod tests {
     use std::{
+        future::ready,
         sync::{Arc, Barrier},
         thread::sleep,
         time::Duration,
     };
 
     use super::*;
+
+    #[test]
+    fn test_sequential_follow_ups_finish_cleanly() {
+        struct TestContext {
+            completed: AtomicUsize,
+            completed_event: tokio::sync::Notify,
+        }
+
+        struct ExecutorImpl;
+
+        impl Executor<TestContext, usize, usize> for ExecutorImpl {
+            type Future = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+            fn execute(
+                &self,
+                ctx: &Arc<TestContext>,
+                _task: usize,
+                _priority: usize,
+            ) -> Self::Future {
+                let ctx = ctx.clone();
+                Box::pin(async move {
+                    ctx.completed.fetch_add(1, Ordering::Release);
+                    ctx.completed_event.notify_one();
+                })
+            }
+        }
+
+        const TASKS: usize = 32;
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .disable_lifo_slot()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let runner = Arc::new(PriorityRunner::new(ExecutorImpl));
+                let ctx = Arc::new(TestContext {
+                    completed: AtomicUsize::new(0),
+                    completed_event: tokio::sync::Notify::new(),
+                });
+
+                for task in 0..TASKS {
+                    let completed = ctx.completed_event.notified();
+                    runner.schedule(&ctx, task, task);
+                    if ctx.completed.load(Ordering::Acquire) <= task {
+                        completed.await;
+                    }
+                }
+
+                tokio::time::timeout(Duration::from_secs(1), async {
+                    while runner.active_workers.load(Ordering::Acquire) != 0 {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("worker should leave the grace window and finish");
+
+                assert_eq!(ctx.completed.load(Ordering::Acquire), TASKS);
+                assert!(runner.queue.lock().is_empty());
+            });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_single_worker_consumes_concurrent_follow_up_during_grace_window() {
+        struct ExecutorImpl;
+
+        impl Executor<(), usize, usize> for ExecutorImpl {
+            type Future = std::future::Ready<()>;
+
+            fn execute(&self, _ctx: &Arc<()>, _task: usize, _priority: usize) -> Self::Future {
+                ready(())
+            }
+        }
+
+        let runner = Arc::new(PriorityRunner::new(ExecutorImpl));
+        let ctx = Arc::new(());
+        runner
+            .active_workers
+            .store(runner.target_workers, Ordering::Release);
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (proceed_tx, proceed_rx) = std::sync::mpsc::channel();
+        *runner.grace_window_hook.lock() = Some(GraceWindowHook {
+            entered: entered_tx,
+            proceed: proceed_rx,
+        });
+
+        let consumer_runner = runner.clone();
+        let consumer_ctx = ctx.clone();
+        let consumer = std::thread::spawn(move || {
+            consumer_runner.pop_future_from_worker_after_yield(&consumer_ctx)
+        });
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("consumer should enter the grace window with an empty queue");
+        runner.schedule(&ctx, 0, 0);
+        proceed_tx.send(()).unwrap();
+
+        let future = consumer
+            .join()
+            .expect("consumer thread should not panic")
+            .expect("yielded worker should observe the concurrent follow-up");
+        future.await;
+        assert!(runner.queue.lock().is_empty());
+
+        // No WorkerFuture owns the synthetic active count used to force `schedule` to queue.
+        runner.active_workers.store(0, Ordering::Release);
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_cpu_bound_tasks() {

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -90,7 +90,10 @@ impl<'a, T> Unpin for CloneReady<'a, T> {}
 /// Structs or enums can be made into task inputs by deriving `TaskInput`:
 ///
 /// ```rust
+/// # use bincode::{Decode, Encode};
+/// # use turbo_tasks::trace::TraceRawVcs;
 /// #[turbo_tasks::task_input]
+/// #[derive(Clone, Debug, PartialEq, Eq, Hash, Encode, Decode, TraceRawVcs)]
 /// struct MyStruct {
 ///     // Fields go here...
 /// }

--- a/turbopack/crates/turbo-tasks/src/vc/README.md
+++ b/turbopack/crates/turbo-tasks/src/vc/README.md
@@ -2,10 +2,16 @@
 
 In order to get a reference to the pointed value, you need to `.await` the [`Vc<T>`] to get a [`ReadRef<T>`][`ReadRef`]:
 
-```
-let some_vc: Vc<T>;
-let some_ref: ReadRef<T> = some_vc.await?;
-some_ref.some_method_on_t();
+```rust
+# use anyhow::Result;
+# use turbo_rcstr::RcStr;
+# use turbo_tasks::{ReadRef, Vc};
+# async fn read_value(some_vc: Vc<RcStr>) -> Result<()> {
+let some_ref: ReadRef<RcStr> = some_vc.await?;
+let value: &RcStr = &some_ref;
+# assert_eq!(value, &*some_ref);
+# Ok(())
+# }
 ```
 
 The returned [`ReadRef<T>`][`ReadRef`] represents a [reference-counted][triomphe::Arc] snapshot of a cell's value at a given point in time.

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -393,9 +393,18 @@ where
     ///
     /// # Example
     /// ```rust
+    /// # #![feature(arbitrary_self_types_pointers)]
+    /// # use turbo_tasks::{ResolvedVc, Upcast, Vc};
+    /// # #[turbo_tasks::value]
+    /// # struct Foo;
+    /// # #[turbo_tasks::value_trait]
+    /// # trait MyTrait {
+    /// #     #[turbo_tasks::function]
+    /// #     fn do_something(self: Vc<Self>) -> Vc<Foo>;
+    /// # }
     /// // In generic code where T might be the same as K
     /// fn process_foo(vc: ResolvedVc<impl Upcast<Box<dyn MyTrait>>>) -> Vc<Foo> {
-    ///    let my_trait: ResolvedVc<Box<dyn MyTrait>> = Vc::upcast_non_strict(vc);
+    ///    let my_trait: ResolvedVc<Box<dyn MyTrait>> = ResolvedVc::upcast_non_strict(vc);
     ///    my_trait.do_something()
     /// }
     /// ```


### PR DESCRIPTION
## Summary

- supplement macOS FSEvents with a bounded per-file `kqueue` watcher for project files that Turbo Tasks has actually read, while keeping FSEvents as the authoritative recursive watcher
- reduce intrinsic Turbo Tasks overhead by reusing the existing worker for sequential follow-up work on single-worker runtimes and by skipping redundant child-connection bookkeeping for materialized top-level cached roots
- add scheduler, cached-root invalidation, and watcher coverage; make all active `turbo-tasks` doctests compile as part of the exact crate test

The macOS watcher sidecar excludes `.git`, `.next`, and `node_modules`, is capped at 2,048 files, and feeds the existing invalidation channel. The scheduler grace period is also deliberately bounded: after one normal self-wake it performs at most 16 unlocked OS yields, and only when the runtime has one worker. Multi-worker runtimes retain the immediate queue-pop path.

## Findings

macOS sampling of the unchanged `task_overhead` benchmark showed that minimal task latency was dominated by orchestration rather than task-body work: `Runtime::block_on`, worker creation and handoff, Tokio remote-queue pushes, parked-worker notification, wake/unpark, cache lookup, and connect-child aggregation were the recurring hotspots.

The retained implementation addresses two of those costs without weakening bookkeeping:

1. Sequential single-worker chains get a short opportunity to enqueue their next task onto the same pinned `WorkerFuture`, avoiding a teardown/spawn/wake cycle.
2. A cache hit for a top-level task that is already an aggregation root and already has output returns directly instead of running a redundant `ConnectChildOperation`. Dirty roots still take the normal execution path.

Fifty measured candidates covered scheduling/wakes, allocation and initialization, registration/lookup, hashing/maps, locks/refcounts, aggregation, and completion state. Two tempting alternatives were rejected: an atomic busy-spin occupied a Tokio worker, and applying the yield grace to multi-worker runtimes regressed `turbo-uncached-parallel/1` by 6.372% with a 95% CI of `[+5.410%, +11.502%]`. Moving work onto a coordinator was faster in isolation but unsafe because it changed task-local, `LocalSet`, cancellation, and lifetime behavior.

## Benchmark results

The benchmark source and configuration were unchanged. The primary metric was Criterion slope `E = turbo-uncached/1 - direct/1`; lower is better. The frozen baseline executable was compared adjacently with the candidate in alternating order in independent Linux sandbox sessions.

| Validation | Baseline E | Candidate E | Reduction | 95% bootstrap CI for C/B | Candidate U wins | Max control drift |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Batch A | 18,121.549 ns | 14,276.488 ns | 21.218% | `[0.785446, 0.869037]` | 5/5 | D 0.603%, Tokio 0.714% |
| Batch B | 21,421.499 ns | 15,333.384 ns | 28.421% | `[0.701792, 0.746936]` | 5/5 | D 0.931%, Tokio 0.861% |
| Combined median | 19,418.916 ns | 14,903.762 ns | 23.251% | `[0.711160, 0.802896]` | 10/10 | D 0.931%, Tokio 0.861% |

Combined medians were:

- baseline: D 1,056.735 ns, U 20,474.332 ns, E 19,418.916 ns
- candidate: D 1,058.013 ns, U 15,963.206 ns, E 14,903.762 ns

The complete guardrail benchmark showed `turbo-cached-same-keys` improving by 35-49% and `turbo-cached-different-keys` improving or remaining neutral across durations. `turbo-uncached-parallel` was noisy, but no fixed duration produced a reproducible statistically significant regression larger than 3%. Focused repeats were -0.319% for duration 1 with CI `[-2.795%, +2.232%]` and +2.735% for duration 10 with CI `[-0.875%, +6.372%]`.

These are production paths, not benchmark special cases: the benchmark source, runtime construction, task bodies, worker counts, toolchain, profiles, and feature flags are unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p turbo-tasks` (79 unit tests and 31 active doctests passed; 12 pre-existing intentional doctest ignores remain)
- `cargo test -p turbo-tasks-backend`
- `cargo test -p turbo-tasks-fs` (111 tests passed)
- `cargo bench -p turbo-tasks-backend --bench mod --no-run --message-format=json-render-diagnostics`
- two independent five-pair final validation batches plus the complete `task_overhead` guardrail benchmark
- pre-commit `prettier` and `rustfmt` checks
- independent pre-ship review by two reviewers, with no findings
- Not run: `pnpm --filter=next dev` (Rust-only Turbo Tasks scheduler/backend/filesystem changes; Cargo tests and benchmarks are the authoritative checks)

<!-- NEXT_JS_LLM -->
