### PR TITLE
Attach the disallowed-dynamic reason to StaticGenBailoutError

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1467,5 +1467,7 @@
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1468": "Missing workUnitStore in createComponentTree",
-  "1469": "The payload's transport tree is missing a slot that exists in the loader tree: %s"
+  "1469": "The payload's transport tree is missing a slot that exists in the loader tree: %s",
+  "1470": "Route \"%s\" did not produce a static shell and Next.js was unable to determine a reason. This is a bug in Next.js.",
+  "1471": "Route \"%s\" did not produce a static shell while rendering its error page."
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2886,7 +2886,10 @@ async function prerenderAppPage({
   // prerendering phase and the build.
   if (workStore.invalidDynamicUsageError) {
     logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
-    throw new StaticGenBailoutError()
+    throw new StaticGenBailoutError(
+      workStore.invalidDynamicUsageError.message,
+      { cause: workStore.invalidDynamicUsageError }
+    )
   }
   if (response.digestErrorsMap.size) {
     const buildFailingError = response.digestErrorsMap.values().next().value
@@ -7955,8 +7958,9 @@ async function validateInstantConfigsInBuild(
       success = false
     }
     if (!success) {
-      console.error('Stopping prerender due to instant validation errors.')
-      throw new StaticGenBailoutError()
+      const message = 'Stopping prerender due to instant validation errors.'
+      console.error(message)
+      throw new StaticGenBailoutError(message)
     }
   }
 
@@ -8817,7 +8821,10 @@ async function prerenderToStream(
       // detected invalid dynamic usage in the initial prerender phase.
       if (workStore.invalidDynamicUsageError) {
         logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
-        throw new StaticGenBailoutError()
+        throw new StaticGenBailoutError(
+          workStore.invalidDynamicUsageError.message,
+          { cause: workStore.invalidDynamicUsageError }
+        )
       }
 
       let initialServerResult
@@ -10175,9 +10182,8 @@ async function prerenderToStream(
         )
 
         if (preludeIsEmpty) {
-          console.error(
-            `Route "${workStore.route}" did not produce a static shell while rendering its error page.`
-          )
+          const message = `Route "${workStore.route}" did not produce a static shell while rendering its error page.`
+          console.error(message)
           throwIfDisallowedDynamic(
             workStore,
             PreludeState.Empty,
@@ -10185,7 +10191,7 @@ async function prerenderToStream(
             errorServerDynamicTracking,
             false
           )
-          throw new StaticGenBailoutError()
+          throw new StaticGenBailoutError(message)
         }
 
         const getServerInsertedHTML = makeGetServerInsertedHTML({

--- a/packages/next/src/server/app-render/dynamic-rendering.test.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.test.ts
@@ -1,0 +1,102 @@
+import {
+  PreludeState,
+  createDynamicTrackingState,
+  createDynamicValidationState,
+  throwIfDisallowedDynamic,
+  throwIfSyncIOUsed,
+} from './dynamic-rendering'
+import {
+  StaticGenBailoutError,
+  isStaticGenBailoutError,
+} from '../../client/components/static-generation-bailout'
+import type { WorkStore } from './work-async-storage.external'
+
+function catchThrown(fn: () => void): unknown {
+  try {
+    fn()
+  } catch (err) {
+    return err
+  }
+  throw new Error('expected the function to throw')
+}
+
+describe('dynamic-rendering bailout errors', () => {
+  const workStore = { route: '/test' } as WorkStore
+
+  let consoleErrorSpy: jest.SpyInstance
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  describe('throwIfSyncIOUsed', () => {
+    it('does not throw when no sync IO error was recorded', () => {
+      const serverDynamic = createDynamicTrackingState(undefined)
+
+      expect(() => throwIfSyncIOUsed(workStore, serverDynamic)).not.toThrow()
+    })
+
+    it('throws a StaticGenBailoutError carrying the recorded sync IO error', () => {
+      const syncIOError = new Error(
+        'Route "/test" used `Date.now()` before accessing uncached data.'
+      )
+      const serverDynamic = createDynamicTrackingState(undefined)
+      serverDynamic.syncDynamicErrorWithStack = syncIOError
+
+      const thrown = catchThrown(() =>
+        throwIfSyncIOUsed(workStore, serverDynamic)
+      )
+
+      expect(isStaticGenBailoutError(thrown)).toBe(true)
+      expect(thrown).toBeInstanceOf(StaticGenBailoutError)
+      expect((thrown as Error).message).toBe(syncIOError.message)
+      expect((thrown as Error).cause).toBe(syncIOError)
+    })
+  })
+
+  describe('throwIfDisallowedDynamic', () => {
+    it('throws a StaticGenBailoutError carrying the first disallowed dynamic error', () => {
+      const firstError = new Error(
+        'Route "/test" used a blocking API without a Suspense boundary above it.'
+      )
+      const secondError = new Error(
+        'Route "/test" used another blocking API without a Suspense boundary above it.'
+      )
+      const dynamicValidation = createDynamicValidationState()
+      dynamicValidation.dynamicErrors.push(firstError, secondError)
+
+      const thrown = catchThrown(() =>
+        throwIfDisallowedDynamic(
+          workStore,
+          PreludeState.Empty,
+          dynamicValidation,
+          createDynamicTrackingState(undefined),
+          false
+        )
+      )
+
+      expect(isStaticGenBailoutError(thrown)).toBe(true)
+      expect((thrown as Error).message).toBe(firstError.message)
+      expect((thrown as Error).cause).toBe(firstError)
+    })
+
+    it('throws a StaticGenBailoutError with a message when the shell is empty for an unknown reason', () => {
+      const thrown = catchThrown(() =>
+        throwIfDisallowedDynamic(
+          workStore,
+          PreludeState.Empty,
+          createDynamicValidationState(),
+          createDynamicTrackingState(undefined),
+          false
+        )
+      )
+
+      expect(isStaticGenBailoutError(thrown)).toBe(true)
+      expect((thrown as Error).message).toContain(
+        'did not produce a static shell'
+      )
+    })
+  })
+})

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -1335,7 +1335,10 @@ export function throwIfSyncIOUsed(
       workStore,
       serverDynamic.syncDynamicErrorWithStack
     )
-    throw new StaticGenBailoutError()
+    throw new StaticGenBailoutError(
+      serverDynamic.syncDynamicErrorWithStack.message,
+      { cause: serverDynamic.syncDynamicErrorWithStack }
+    )
   }
 }
 
@@ -1358,8 +1361,9 @@ export function throwIfDisallowedDynamic(
     dynamicValidation.hasAllowedDynamic === false &&
     dynamicValidation.hasDynamicMetadata
   ) {
-    console.error(createDynamicOrRuntimeMetadataError(workStore.route).message)
-    throw new StaticGenBailoutError()
+    const metadataError = createDynamicOrRuntimeMetadataError(workStore.route)
+    console.error(metadataError.message)
+    throw new StaticGenBailoutError(metadataError.message)
   }
 
   // Either flag expresses "this shell is allowed to be empty/blocking":
@@ -1382,7 +1386,9 @@ export function throwIfDisallowedDynamic(
         logDisallowedDynamicError(workStore, dynamicErrors[i])
       }
 
-      throw new StaticGenBailoutError()
+      throw new StaticGenBailoutError(dynamicErrors[0].message, {
+        cause: dynamicErrors[0],
+      })
     }
 
     // If we got this far then the only other thing that could be blocking
@@ -1390,20 +1396,18 @@ export function throwIfDisallowedDynamic(
     // you need to opt into that by adding a Suspense boundary above the body
     // to indicate your are ok with fully dynamic rendering.
     if (dynamicValidation.hasDynamicViewport) {
-      console.error(
-        createDynamicOrRuntimeViewportError(workStore.route).message
-      )
-      throw new StaticGenBailoutError()
+      const viewportError = createDynamicOrRuntimeViewportError(workStore.route)
+      console.error(viewportError.message)
+      throw new StaticGenBailoutError(viewportError.message)
     }
 
     if (prelude === PreludeState.Empty) {
       // If we ever get this far then we messed up the tracking of invalid dynamic.
       // We still adhere to the constraint that you must produce a shell but invite the
       // user to report this as a bug in Next.js.
-      console.error(
-        `Route "${workStore.route}" did not produce a static shell and Next.js was unable to determine a reason. This is a bug in Next.js.`
-      )
-      throw new StaticGenBailoutError()
+      const message = `Route "${workStore.route}" did not produce a static shell and Next.js was unable to determine a reason. This is a bug in Next.js.`
+      console.error(message)
+      throw new StaticGenBailoutError(message)
     }
   }
 }

--- a/test/e2e/app-dir/cache-components-errors/client.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client.test.ts
@@ -132,6 +132,16 @@ describe('Cache Components Errors - Client Components', () => {
                  9 |
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-awaited-io": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                > Export encountered errors on 1 path:
                	/client-awaited-io/page: /client-awaited-io"
@@ -162,6 +172,16 @@ describe('Cache Components Errors - Client Components', () => {
                  - Start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-awaited-io": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                Export encountered an error on /client-awaited-io/page: /client-awaited-io, exiting the build."
               `)
             }
@@ -189,6 +209,16 @@ describe('Cache Components Errors - Client Components', () => {
                  9 |
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-awaited-io": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                > Export encountered errors on 1 path:
                	/client-awaited-io/page: /client-awaited-io"
@@ -233,6 +263,16 @@ describe('Cache Components Errors - Client Components', () => {
                  - Start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-awaited-io": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                Export encountered an error on /client-awaited-io/page: /client-awaited-io, exiting the build."
               `)
             }
@@ -302,6 +342,15 @@ describe('Cache Components Errors - Client Components', () => {
                }
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-use-search-params" in your browser to investigate the error.
                Error occurred prerendering page "/client-use-search-params". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-use-search-params": Next.js encountered URL data \`useSearchParams()\` in a Client Component outside of \`<Suspense>\`.
+
+               This blocks prerendering because the value is only available at runtime.
+
+               Ways to fix this:
+                 - [stream] Wrap the component in \`<Suspense fallback={...}>\` so the hook value streams in after prerendering
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
 
                > Export encountered errors on 1 path:
                	/client-use-search-params/page: /client-use-search-params"
@@ -333,6 +382,15 @@ describe('Cache Components Errors - Client Components', () => {
                  - Start the app in development mode by running \`next dev\`, then open "/client-use-search-params" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/client-use-search-params". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-use-search-params": Next.js encountered URL data \`useSearchParams()\` in a Client Component outside of \`<Suspense>\`.
+
+               This blocks prerendering because the value is only available at runtime.
+
+               Ways to fix this:
+                 - [stream] Wrap the component in \`<Suspense fallback={...}>\` so the hook value streams in after prerendering
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
                Export encountered an error on /client-use-search-params/page: /client-use-search-params, exiting the build."
               `)
             }
@@ -381,6 +439,15 @@ describe('Cache Components Errors - Client Components', () => {
                  - Start the app in development mode by running \`next dev\`, then open "/client-use-search-params" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/client-use-search-params". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-use-search-params": Next.js encountered URL data \`useSearchParams()\` in a Client Component outside of \`<Suspense>\`.
+
+               This blocks prerendering because the value is only available at runtime.
+
+               Ways to fix this:
+                 - [stream] Wrap the component in \`<Suspense fallback={...}>\` so the hook value streams in after prerendering
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
                Export encountered an error on /client-use-search-params/page: /client-use-search-params, exiting the build."
               `)
             }
@@ -451,6 +518,15 @@ describe('Cache Components Errors - Client Components', () => {
                }
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-use-pathname/[id]" in your browser to investigate the error.
                Error occurred prerendering page "/client-use-pathname/[id]". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-use-pathname/[id]": Next.js encountered URL data \`usePathname()\` in a Client Component outside of \`<Suspense>\`.
+
+               This blocks prerendering because the value is only available at runtime.
+
+               Ways to fix this:
+                 - [stream] Wrap the component in \`<Suspense fallback={...}>\` so the hook value streams in after prerendering
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
 
                > Export encountered errors on 1 path:
                	/client-use-pathname/[id]/page: /client-use-pathname/[id]"
@@ -482,6 +558,15 @@ describe('Cache Components Errors - Client Components', () => {
                  - Start the app in development mode by running \`next dev\`, then open "/client-use-pathname/[id]" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/client-use-pathname/[id]". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-use-pathname/[id]": Next.js encountered URL data \`usePathname()\` in a Client Component outside of \`<Suspense>\`.
+
+               This blocks prerendering because the value is only available at runtime.
+
+               Ways to fix this:
+                 - [stream] Wrap the component in \`<Suspense fallback={...}>\` so the hook value streams in after prerendering
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
                Export encountered an error on /client-use-pathname/[id]/page: /client-use-pathname/[id], exiting the build."
               `)
             }
@@ -540,6 +625,15 @@ describe('Cache Components Errors - Client Components', () => {
                  - Start the app in development mode by running \`next dev\`, then open "/client-use-pathname/[id]" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/client-use-pathname/[id]". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/client-use-pathname/[id]": Next.js encountered URL data \`usePathname()\` in a Client Component outside of \`<Suspense>\`.
+
+               This blocks prerendering because the value is only available at runtime.
+
+               Ways to fix this:
+                 - [stream] Wrap the component in \`<Suspense fallback={...}>\` so the hook value streams in after prerendering
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
                Export encountered an error on /client-use-pathname/[id]/page: /client-use-pathname/[id], exiting the build."
               `)
             }

--- a/test/e2e/app-dir/cache-components-errors/dynamic-root-and-boundary.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/dynamic-root-and-boundary.util.ts
@@ -131,6 +131,16 @@ export function registerDynamicRootAndBoundaryTests(
                65 |   )
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
              Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-root": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
              > Export encountered errors on 1 path:
              	/dynamic-root/page: /dynamic-root"
@@ -178,6 +188,16 @@ export function registerDynamicRootAndBoundaryTests(
                - Start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-root": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
              Export encountered an error on /dynamic-root/page: /dynamic-root, exiting the build."
             `)
           }
@@ -227,6 +247,16 @@ export function registerDynamicRootAndBoundaryTests(
                65 |   )
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
              Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-root": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
              > Export encountered errors on 1 path:
              	/dynamic-root/page: /dynamic-root"
@@ -309,6 +339,16 @@ export function registerDynamicRootAndBoundaryTests(
                - Start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-root": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
              Export encountered an error on /dynamic-root/page: /dynamic-root, exiting the build."
             `)
           }

--- a/test/e2e/app-dir/cache-components-errors/error-attribution.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/error-attribution.util.ts
@@ -107,6 +107,16 @@ export function registerErrorAttributionTests(
                  8 |     <main>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/guarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
 
                > Export encountered errors on 1 path:
                	/sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync"
@@ -134,6 +144,16 @@ export function registerErrorAttributionTests(
                  8 |     <main>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/guarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
 
                > Export encountered errors on 1 path:
                	/sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync"
@@ -164,6 +184,16 @@ export function registerErrorAttributionTests(
                  - Start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/guarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
                Export encountered an error on /sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync, exiting the build."
               `)
             } else {
@@ -183,6 +213,16 @@ export function registerErrorAttributionTests(
                  - Start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/guarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
                Export encountered an error on /sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync, exiting the build."
               `)
             }
@@ -255,6 +295,16 @@ export function registerErrorAttributionTests(
                  37 |       <h2>Request Data Access</h2>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                > Export encountered errors on 1 path:
                	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
@@ -280,6 +330,16 @@ export function registerErrorAttributionTests(
                  - Start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                Export encountered an error on /sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync, exiting the build."
               `)
             }
@@ -307,6 +367,16 @@ export function registerErrorAttributionTests(
                  37 |       <h2>Request Data Access</h2>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                > Export encountered errors on 1 path:
                	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
@@ -432,6 +502,16 @@ export function registerErrorAttributionTests(
                  8 |     <main>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
 
                > Export encountered errors on 1 path:
                	/sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync"
@@ -459,6 +539,16 @@ export function registerErrorAttributionTests(
                  8 |     <main>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
 
                > Export encountered errors on 1 path:
                	/sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync"
@@ -489,6 +579,16 @@ export function registerErrorAttributionTests(
                  - Start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
                Export encountered an error on /sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync, exiting the build."
               `)
             } else {
@@ -508,6 +608,16 @@ export function registerErrorAttributionTests(
                  - Start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-attribution/unguarded-async-unguarded-clientsync": Next.js encountered the unstable value \`new Date()\` in a Client Component.
+
+               This value would be evaluated during the prerender, instead of recomputed on each visit.
+
+               Ways to fix this:
+                 - [stream] Wrap the Client Component in \`<Suspense fallback={...}>\`
+                 - [defer] Move the read into a \`useEffect\` or event handler
+                 - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time-client
                Export encountered an error on /sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync, exiting the build."
               `)
             }

--- a/test/e2e/app-dir/cache-components-errors/metadata-and-viewport.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/metadata-and-viewport.util.ts
@@ -61,6 +61,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-route": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
 
            > Export encountered errors on 1 path:
            	/dynamic-metadata-static-route/page: /dynamic-metadata-static-route"
@@ -78,6 +88,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-route": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Export encountered an error on /dynamic-metadata-static-route/page: /dynamic-metadata-static-route, exiting the build."
           `)
         }
@@ -146,6 +166,16 @@ export function registerMetadataAndViewportTests(
                23 | }
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
              Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-metadata-error-route": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
              > Export encountered errors on 1 path:
              	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
@@ -169,6 +199,16 @@ export function registerMetadataAndViewportTests(
                - Start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-metadata-error-route": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
              Export encountered an error on /dynamic-metadata-error-route/page: /dynamic-metadata-error-route, exiting the build."
             `)
           }
@@ -196,6 +236,16 @@ export function registerMetadataAndViewportTests(
                23 | }
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
              Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-metadata-error-route": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
              > Export encountered errors on 1 path:
              	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
@@ -240,6 +290,16 @@ export function registerMetadataAndViewportTests(
                - Start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/dynamic-metadata-error-route": Next.js encountered uncached or runtime data during prerendering.
+
+             \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+             Ways to fix this:
+               - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+               - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+               - [block] Set \`export const instant = false\` to allow a blocking route
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
              Export encountered an error on /dynamic-metadata-error-route/page: /dynamic-metadata-error-route, exiting the build."
             `)
           }
@@ -296,6 +356,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-with-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-with-suspense": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
 
            > Export encountered errors on 1 path:
            	/dynamic-metadata-static-with-suspense/page: /dynamic-metadata-static-with-suspense"
@@ -313,6 +383,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-with-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-with-suspense": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Export encountered an error on /dynamic-metadata-static-with-suspense/page: /dynamic-metadata-static-with-suspense, exiting the build."
           `)
         }
@@ -368,6 +448,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-with-suspense-above-body". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-with-suspense-above-body": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
 
            > Export encountered errors on 1 path:
            	/dynamic-metadata-static-with-suspense-above-body/page: /dynamic-metadata-static-with-suspense-above-body"
@@ -385,6 +475,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-with-suspense-above-body". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-with-suspense-above-body": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Export encountered an error on /dynamic-metadata-static-with-suspense-above-body/page: /dynamic-metadata-static-with-suspense-above-body, exiting the build."
           `)
         }
@@ -440,6 +540,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-with-instant-false". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-with-instant-false": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
 
            > Export encountered errors on 1 path:
            	/dynamic-metadata-static-with-instant-false/page: /dynamic-metadata-static-with-instant-false"
@@ -457,6 +567,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Error occurred prerendering page "/dynamic-metadata-static-with-instant-false". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-metadata-static-with-instant-false": Next.js encountered uncached or runtime data in \`generateMetadata()\`.
+
+           This route's metadata is blocked, but the rest of its content can be prerendered.
+
+           Ways to fix this:
+             - [static] Use a static metadata export instead of \`generateMetadata()\`
+             - [cache] Cache the metadata with \`"use cache"\` in \`generateMetadata()\` (does not apply to \`connection()\`)
+             - [dynamic] Render a marker component that calls \`await connection()\` inside \`<Suspense>\` on the page
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime
            Export encountered an error on /dynamic-metadata-static-with-instant-false/page: /dynamic-metadata-static-with-instant-false, exiting the build."
           `)
         }
@@ -537,6 +657,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
            Error occurred prerendering page "/dynamic-viewport-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-viewport-static-route": Next.js encountered uncached or runtime data in \`generateViewport()\`.
+
+           This prevents the page from being prerendered, leading to a slower user experience. Unlike metadata, viewport cannot be streamed behind \`<Suspense>\` because it affects the initial page load.
+
+           Ways to fix this:
+             - [static] Use a static viewport export instead of \`generateViewport()\`
+             - [cache] For uncached data (\`fetch\`, database calls): cache the viewport with \`"use cache"\` in \`generateViewport()\` (does not apply to \`connection()\`)
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
 
            > Export encountered errors on 1 path:
            	/dynamic-viewport-static-route/page: /dynamic-viewport-static-route"
@@ -554,6 +684,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
            Error occurred prerendering page "/dynamic-viewport-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-viewport-static-route": Next.js encountered uncached or runtime data in \`generateViewport()\`.
+
+           This prevents the page from being prerendered, leading to a slower user experience. Unlike metadata, viewport cannot be streamed behind \`<Suspense>\` because it affects the initial page load.
+
+           Ways to fix this:
+             - [static] Use a static viewport export instead of \`generateViewport()\`
+             - [cache] For uncached data (\`fetch\`, database calls): cache the viewport with \`"use cache"\` in \`generateViewport()\` (does not apply to \`connection()\`)
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
            Export encountered an error on /dynamic-viewport-static-route/page: /dynamic-viewport-static-route, exiting the build."
           `)
         }
@@ -647,6 +787,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
            Error occurred prerendering page "/dynamic-viewport-dynamic-route". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-viewport-dynamic-route": Next.js encountered uncached or runtime data in \`generateViewport()\`.
+
+           This prevents the page from being prerendered, leading to a slower user experience. Unlike metadata, viewport cannot be streamed behind \`<Suspense>\` because it affects the initial page load.
+
+           Ways to fix this:
+             - [static] Use a static viewport export instead of \`generateViewport()\`
+             - [cache] For uncached data (\`fetch\`, database calls): cache the viewport with \`"use cache"\` in \`generateViewport()\` (does not apply to \`connection()\`)
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
 
            > Export encountered errors on 1 path:
            	/dynamic-viewport-dynamic-route/page: /dynamic-viewport-dynamic-route"
@@ -664,6 +814,16 @@ export function registerMetadataAndViewportTests(
 
            Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
            Error occurred prerendering page "/dynamic-viewport-dynamic-route". Read more: https://nextjs.org/docs/messages/prerender-error
+           Error: Route "/dynamic-viewport-dynamic-route": Next.js encountered uncached or runtime data in \`generateViewport()\`.
+
+           This prevents the page from being prerendered, leading to a slower user experience. Unlike metadata, viewport cannot be streamed behind \`<Suspense>\` because it affects the initial page load.
+
+           Ways to fix this:
+             - [static] Use a static viewport export instead of \`generateViewport()\`
+             - [cache] For uncached data (\`fetch\`, database calls): cache the viewport with \`"use cache"\` in \`generateViewport()\` (does not apply to \`connection()\`)
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-viewport-runtime
            Export encountered an error on /dynamic-viewport-dynamic-route/page: /dynamic-viewport-dynamic-route, exiting the build."
           `)
         }

--- a/test/e2e/app-dir/cache-components-errors/sync-dynamic.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-dynamic.util.ts
@@ -76,6 +76,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  40 |       <span id="rand">{random}</span>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-with-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
                > Export encountered errors on 1 path:
                	/sync-random-with-fallback/page: /sync-random-with-fallback"
@@ -103,6 +113,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  40 |       <span id="rand">{random}</span>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-with-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
                > Export encountered errors on 1 path:
                	/sync-random-with-fallback/page: /sync-random-with-fallback"
@@ -133,6 +153,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  - Start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-with-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
                Export encountered an error on /sync-random-with-fallback/page: /sync-random-with-fallback, exiting the build."
               `)
             } else {
@@ -152,6 +182,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  - Start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-with-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
                Export encountered an error on /sync-random-with-fallback/page: /sync-random-with-fallback, exiting the build."
               `)
             }
@@ -226,6 +266,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  35 | function RandomReadingComponent() {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-without-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
                > Export encountered errors on 1 path:
                	/sync-random-without-fallback/page: /sync-random-without-fallback"
@@ -254,6 +304,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  35 | function RandomReadingComponent() {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-without-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
                > Export encountered errors on 1 path:
                	/sync-random-without-fallback/page: /sync-random-without-fallback"
@@ -284,6 +344,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  - Start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-without-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
                Export encountered an error on /sync-random-without-fallback/page: /sync-random-without-fallback, exiting the build."
               `)
             } else {
@@ -303,6 +373,16 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
                  - Start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/sync-random-without-fallback": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+               This value can change between renders, so it must be either prerendered or computed later.
+
+               Ways to fix this:
+                 - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+                 - [cache] Prerender and cache the value with \`"use cache"\`
+                 - [client] Render the value on the client with \`"use client"\`
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
                Export encountered an error on /sync-random-without-fallback/page: /sync-random-without-fallback, exiting the build."
               `)
             }

--- a/test/e2e/app-dir/cache-components-errors/sync-io-node-crypto.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-io-node-crypto.util.ts
@@ -90,6 +90,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-pair-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeyPairSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync"
@@ -118,6 +128,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-pair-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeyPairSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync, exiting the build."
             `)
           }
@@ -145,6 +165,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-pair-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeyPairSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync"
@@ -166,6 +196,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-pair-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeyPairSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync, exiting the build."
             `)
           }
@@ -252,6 +292,16 @@ export function registerSyncIoNodeCryptoTests(
                24 |     .export()
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeySync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync"
@@ -280,6 +330,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeySync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync, exiting the build."
             `)
           }
@@ -307,6 +367,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |     })
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeySync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync"
@@ -328,6 +398,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-key-sync": Next.js encountered the unstable value \`require('node:crypto').generateKeySync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync, exiting the build."
             `)
           }
@@ -414,6 +494,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-prime-sync": Next.js encountered the unstable value \`require('node:crypto').generatePrimeSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync"
@@ -442,6 +532,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-prime-sync": Next.js encountered the unstable value \`require('node:crypto').generatePrimeSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync, exiting the build."
             `)
           }
@@ -469,6 +569,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-prime-sync": Next.js encountered the unstable value \`require('node:crypto').generatePrimeSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync"
@@ -490,6 +600,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/generate-prime-sync": Next.js encountered the unstable value \`require('node:crypto').generatePrimeSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync, exiting the build."
             `)
           }
@@ -576,6 +696,16 @@ export function registerSyncIoNodeCryptoTests(
                24 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/get-random-values": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values"
@@ -604,6 +734,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/get-random-values": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
              Export encountered an error on /sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values, exiting the build."
             `)
           }
@@ -631,6 +771,16 @@ export function registerSyncIoNodeCryptoTests(
                24 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/get-random-values": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values"
@@ -652,6 +802,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/get-random-values": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
              Export encountered an error on /sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values, exiting the build."
             `)
           }
@@ -738,6 +898,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-bytes": Next.js encountered the unstable value \`require('node:crypto').randomBytes(size)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes"
@@ -766,6 +936,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-bytes": Next.js encountered the unstable value \`require('node:crypto').randomBytes(size)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes, exiting the build."
             `)
           }
@@ -793,6 +973,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-bytes": Next.js encountered the unstable value \`require('node:crypto').randomBytes(size)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes"
@@ -814,6 +1004,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-bytes": Next.js encountered the unstable value \`require('node:crypto').randomBytes(size)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes, exiting the build."
             `)
           }
@@ -900,6 +1100,16 @@ export function registerSyncIoNodeCryptoTests(
                24 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-fill-sync": Next.js encountered the unstable value \`require('node:crypto').randomFillSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync"
@@ -928,6 +1138,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-fill-sync": Next.js encountered the unstable value \`require('node:crypto').randomFillSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync, exiting the build."
             `)
           }
@@ -955,6 +1175,16 @@ export function registerSyncIoNodeCryptoTests(
                24 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-fill-sync": Next.js encountered the unstable value \`require('node:crypto').randomFillSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync"
@@ -976,6 +1206,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-fill-sync": Next.js encountered the unstable value \`require('node:crypto').randomFillSync(...)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync, exiting the build."
             `)
           }
@@ -1062,6 +1302,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-between": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between"
@@ -1090,6 +1340,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-between": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between, exiting the build."
             `)
           }
@@ -1117,6 +1377,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-between": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between"
@@ -1138,6 +1408,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-between": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between, exiting the build."
             `)
           }
@@ -1224,6 +1504,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-up-to": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to"
@@ -1252,6 +1542,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-up-to": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to, exiting the build."
             `)
           }
@@ -1279,6 +1579,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-up-to": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to"
@@ -1300,6 +1610,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-int-up-to": Next.js encountered the unstable value \`require('node:crypto').randomInt(min, max)\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to, exiting the build."
             `)
           }
@@ -1386,6 +1706,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-uuid": Next.js encountered the unstable value \`require('node:crypto').randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid"
@@ -1414,6 +1744,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-uuid": Next.js encountered the unstable value \`require('node:crypto').randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid, exiting the build."
             `)
           }
@@ -1441,6 +1781,16 @@ export function registerSyncIoNodeCryptoTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-uuid": Next.js encountered the unstable value \`require('node:crypto').randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid"
@@ -1462,6 +1812,16 @@ export function registerSyncIoNodeCryptoTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-node-crypto/random-uuid": Next.js encountered the unstable value \`require('node:crypto').randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid, exiting the build."
             `)
           }

--- a/test/e2e/app-dir/cache-components-errors/sync-io-time-and-random.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-io-time-and-random.util.ts
@@ -72,6 +72,17 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date": Next.js encountered the unstable value \`Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
 
              > Export encountered errors on 1 path:
              	/sync-io-current-time/date/page: /sync-io-current-time/date"
@@ -99,6 +110,17 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date": Next.js encountered the unstable value \`Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
 
              > Export encountered errors on 1 path:
              	/sync-io-current-time/date/page: /sync-io-current-time/date"
@@ -129,6 +151,17 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date": Next.js encountered the unstable value \`Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
              Export encountered an error on /sync-io-current-time/date/page: /sync-io-current-time/date, exiting the build."
             `)
           } else {
@@ -149,6 +182,17 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date": Next.js encountered the unstable value \`Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
              Export encountered an error on /sync-io-current-time/date/page: /sync-io-current-time/date, exiting the build."
             `)
           }
@@ -217,6 +261,17 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date-now": Next.js encountered the unstable value \`Date.now()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
 
              > Export encountered errors on 1 path:
              	/sync-io-current-time/date-now/page: /sync-io-current-time/date-now"
@@ -244,6 +299,17 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date-now": Next.js encountered the unstable value \`Date.now()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
 
              > Export encountered errors on 1 path:
              	/sync-io-current-time/date-now/page: /sync-io-current-time/date-now"
@@ -274,6 +340,17 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date-now": Next.js encountered the unstable value \`Date.now()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
              Export encountered an error on /sync-io-current-time/date-now/page: /sync-io-current-time/date-now, exiting the build."
             `)
           } else {
@@ -294,6 +371,17 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/date-now": Next.js encountered the unstable value \`Date.now()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
              Export encountered an error on /sync-io-current-time/date-now/page: /sync-io-current-time/date-now, exiting the build."
             `)
           }
@@ -362,6 +450,17 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/new-date": Next.js encountered the unstable value \`new Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
 
              > Export encountered errors on 1 path:
              	/sync-io-current-time/new-date/page: /sync-io-current-time/new-date"
@@ -389,6 +488,17 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/new-date": Next.js encountered the unstable value \`new Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
 
              > Export encountered errors on 1 path:
              	/sync-io-current-time/new-date/page: /sync-io-current-time/new-date"
@@ -419,6 +529,17 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/new-date": Next.js encountered the unstable value \`new Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
              Export encountered an error on /sync-io-current-time/new-date/page: /sync-io-current-time/new-date, exiting the build."
             `)
           } else {
@@ -439,6 +560,17 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-current-time/new-date": Next.js encountered the unstable value \`new Date()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+               - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
              Export encountered an error on /sync-io-current-time/new-date/page: /sync-io-current-time/new-date, exiting the build."
             `)
           }
@@ -506,6 +638,16 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-random/math-random": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-random/math-random/page: /sync-io-random/math-random"
@@ -532,6 +674,16 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-random/math-random": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
 
              > Export encountered errors on 1 path:
              	/sync-io-random/math-random/page: /sync-io-random/math-random"
@@ -561,6 +713,16 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-random/math-random": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-random/math-random/page: /sync-io-random/math-random, exiting the build."
             `)
           } else {
@@ -580,6 +742,16 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-random/math-random": Next.js encountered the unstable value \`Math.random()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-random
              Export encountered an error on /sync-io-random/math-random/page: /sync-io-random/math-random, exiting the build."
             `)
           }
@@ -648,6 +820,16 @@ export function registerSyncIoTimeAndRandomTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/get-random-value": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
 
              > Export encountered errors on 1 path:
              	/sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value"
@@ -675,6 +857,16 @@ export function registerSyncIoTimeAndRandomTests(
                23 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/get-random-value": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
 
              > Export encountered errors on 1 path:
              	/sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value"
@@ -705,6 +897,16 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/get-random-value": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
              Export encountered an error on /sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value, exiting the build."
             `)
           } else {
@@ -724,6 +926,16 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/get-random-value": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
              Export encountered an error on /sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value, exiting the build."
             `)
           }
@@ -791,6 +1003,16 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/random-uuid": Next.js encountered the unstable value \`crypto.randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
 
              > Export encountered errors on 1 path:
              	/sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid"
@@ -817,6 +1039,16 @@ export function registerSyncIoTimeAndRandomTests(
                21 |
              To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
              Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/random-uuid": Next.js encountered the unstable value \`crypto.randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
 
              > Export encountered errors on 1 path:
              	/sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid"
@@ -846,6 +1078,16 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/random-uuid": Next.js encountered the unstable value \`crypto.randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
              Export encountered an error on /sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid, exiting the build."
             `)
           } else {
@@ -865,6 +1107,16 @@ export function registerSyncIoTimeAndRandomTests(
                - Start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
                - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
              Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
+             Error: Route "/sync-io-web-crypto/random-uuid": Next.js encountered the unstable value \`crypto.randomUUID()\` while prerendering.
+
+             This value can change between renders, so it must be either prerendered or computed later.
+
+             Ways to fix this:
+               - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+               - [cache] Prerender and cache the value with \`"use cache"\`
+               - [client] Render the value on the client with \`"use client"\`
+
+             Learn more: https://nextjs.org/docs/messages/blocking-prerender-crypto
              Export encountered an error on /sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid, exiting the build."
             `)
           }

--- a/test/e2e/app-dir/cache-components-errors/use-cache-private.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/use-cache-private.util.ts
@@ -70,22 +70,23 @@ export function registerUseCachePrivateTests(
           if (isDebugPrerender) {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within \`unstable_cache()\`.
-                     at <unknown> (app/use-cache-private-in-unstable-cache/page.tsx:21:38)
-                     at async ComponentWithCachedData (app/use-cache-private-in-unstable-cache/page.tsx:16:16)
-                   19 | }
-                   20 |
-                 > 21 | const getCachedData = unstable_cache(async () => {
-                      |                                      ^
-                   22 |   'use cache: private'
-                   23 |
-                   24 |   return fetch('https://next-data-api-endpoint.vercel.app/api/random').then(
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: "use cache: private" must not be used within \`unstable_cache()\`.
+                   at <unknown> (app/use-cache-private-in-unstable-cache/page.tsx:21:38)
+                   at async ComponentWithCachedData (app/use-cache-private-in-unstable-cache/page.tsx:16:16)
+                 19 | }
+                 20 |
+               > 21 | const getCachedData = unstable_cache(async () => {
+                    |                                      ^
+                 22 |   'use cache: private'
+                 23 |
+                 24 |   return fetch('https://next-data-api-endpoint.vercel.app/api/random').then(
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within \`unstable_cache()\`.
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: "use cache: private" must not be used within \`unstable_cache()\`.
@@ -100,6 +101,7 @@ export function registerUseCachePrivateTests(
                  24 |   return fetch('https://next-data-api-endpoint.vercel.app/api/random').then(
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
                Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within \`unstable_cache()\`.
 
                > Export encountered errors on 1 path:
                	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
@@ -108,34 +110,36 @@ export function registerUseCachePrivateTests(
           } else {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within \`unstable_cache()\`.
-                     at <unknown> (app/use-cache-private-in-unstable-cache/page.tsx:21:38)
-                     at async g (app/use-cache-private-in-unstable-cache/page.tsx:16:16)
-                   19 | }
-                   20 |
-                 > 21 | const getCachedData = unstable_cache(async () => {
-                      |                                      ^
-                   22 |   'use cache: private'
-                   23 |
-                   24 |   return fetch('https://next-data-api-endpoint.vercel.app/api/random').then(
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache, exiting the build."
-                `)
+               "Error: "use cache: private" must not be used within \`unstable_cache()\`.
+                   at <unknown> (app/use-cache-private-in-unstable-cache/page.tsx:21:38)
+                   at async g (app/use-cache-private-in-unstable-cache/page.tsx:16:16)
+                 19 | }
+                 20 |
+               > 21 | const getCachedData = unstable_cache(async () => {
+                    |                                      ^
+                 22 |   'use cache: private'
+                 23 |
+                 24 |   return fetch('https://next-data-api-endpoint.vercel.app/api/random').then(
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within \`unstable_cache()\`.
+               Export encountered an error on /use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache, exiting the build."
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within \`unstable_cache()\`.
-                     at a (<next-dist-dir>)
-                     at b (<next-dist-dir>)
-                     at c (<next-dist-dir>)
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache, exiting the build."
-                `)
+               "Error: "use cache: private" must not be used within \`unstable_cache()\`.
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+                   at c (<next-dist-dir>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within \`unstable_cache()\`.
+               Export encountered an error on /use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache, exiting the build."
+              `)
             }
           }
         })
@@ -179,89 +183,93 @@ export function registerUseCachePrivateTests(
           if (isDebugPrerender) {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at Private (app/use-cache-private-in-use-cache/page.tsx:15:1)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p> {
-                   digest: '<error-digest>'
-                 }
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                   at Private (app/use-cache-private-in-use-cache/page.tsx:15:1)
+                 13 | }
+                 14 |
+               > 15 | async function Private() {
+                    | ^
+                 16 |   'use cache: private'
+                 17 |
+                 18 |   return <p>Private</p> {
+                 digest: '<error-digest>'
+               }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
+              `)
             } else
               expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at Private (webpack:///app/use-cache-private-in-use-cache/page.tsx:15:1)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p> {
-                   digest: '<error-digest>'
-                 }
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                   at Private (webpack:///app/use-cache-private-in-use-cache/page.tsx:15:1)
+                 13 | }
+                 14 |
+               > 15 | async function Private() {
+                    | ^
+                 16 |   'use cache: private'
+                 17 |
+                 18 |   return <p>Private</p> {
+                 digest: '<error-digest>'
+               }
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
+              `)
           } else {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
-                 "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p> {
-                   digest: '<error-digest>'
-                 }
-                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p> {
-                   digest: '<error-digest>'
-                 }
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache, exiting the build."
-                `)
+               "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                   at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
+                 13 | }
+                 14 |
+               > 15 | async function Private() {
+                    | ^
+                 16 |   'use cache: private'
+                 17 |
+                 18 |   return <p>Private</p> {
+                 digest: '<error-digest>'
+               }
+               Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                   at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
+                 13 | }
+                 14 |
+               > 15 | async function Private() {
+                    | ^
+                 16 |   'use cache: private'
+                 17 |
+                 18 |   return <p>Private</p> {
+                 digest: '<error-digest>'
+               }
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+               Export encountered an error on /use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache, exiting the build."
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at a (<next-dist-dir>) {
-                   digest: '<error-digest>'
-                 }
-                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at b (<next-dist-dir>) {
-                   digest: '<error-digest>'
-                 }
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache, exiting the build."
-                `)
+               "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                   at a (<next-dist-dir>) {
+                 digest: '<error-digest>'
+               }
+               Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                   at b (<next-dist-dir>) {
+                 digest: '<error-digest>'
+               }
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+               Export encountered an error on /use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache, exiting the build."
+              `)
             }
           }
         })
@@ -328,6 +336,16 @@ export function registerUseCachePrivateTests(
                  18 |   return <p>Private</p>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/use-cache-private-without-suspense": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                > Export encountered errors on 1 path:
                	/use-cache-private-without-suspense/page: /use-cache-private-without-suspense"
@@ -351,6 +369,16 @@ export function registerUseCachePrivateTests(
                  - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/use-cache-private-without-suspense": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                Export encountered an error on /use-cache-private-without-suspense/page: /use-cache-private-without-suspense, exiting the build."
               `)
             }
@@ -411,6 +439,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                  - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/use-cache-private-without-suspense": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                Export encountered an error on /use-cache-private-without-suspense/page: /use-cache-private-without-suspense, exiting the build."
               `)
             }

--- a/test/e2e/app-dir/cache-components-errors/use-cache.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/use-cache.util.ts
@@ -51,39 +51,41 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at CookiesReadingComponent (app/use-cache-cookies/page.tsx:22:18)
-                     at Page (app/use-cache-cookies/page.tsx:10:7)
-                   20 |   // in userland.
-                   21 |   try {
-                 > 22 |     await cookies()
-                      |                  ^
-                   23 |   } catch {}
-                   24 |
-                   25 |   return null
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at CookiesReadingComponent (app/use-cache-cookies/page.tsx:22:18)
+                   at Page (app/use-cache-cookies/page.tsx:10:7)
+                 20 |   // in userland.
+                 21 |   try {
+               > 22 |     await cookies()
+                    |                  ^
+                 23 |   } catch {}
+                 24 |
+                 25 |   return null
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-cookies/page: /use-cache-cookies"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-cookies/page: /use-cache-cookies"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (app/use-cache-cookies/page.tsx:22:11)
-                   20 |   // in userland.
-                   21 |   try {
-                 > 22 |     await cookies()
-                      |           ^
-                   23 |   } catch {}
-                   24 |
-                   25 |   return null
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-cookies/page: /use-cache-cookies, exiting the build."
-                `)
+               "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (app/use-cache-cookies/page.tsx:22:11)
+                 20 |   // in userland.
+                 21 |   try {
+               > 22 |     await cookies()
+                    |           ^
+                 23 |   } catch {}
+                 24 |
+                 25 |   return null
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-cookies/page: /use-cache-cookies, exiting the build."
+              `)
             }
           } else {
             if (isDebugPrerender) {
@@ -100,21 +102,23 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
                  25 |   return null
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
                Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
                > Export encountered errors on 1 path:
                	/use-cache-cookies/page: /use-cache-cookies"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (<next-dist-dir>)
-                     at b (<next-dist-dir>)
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-cookies/page: /use-cache-cookies, exiting the build."
-                `)
+               "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-cookies/page: /use-cache-cookies, exiting the build."
+              `)
             }
           }
         })
@@ -160,69 +164,73 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
           if (isDebugPrerender) {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at DraftModeEnablingComponent (app/use-cache-draft-mode/page.tsx:20:26)
-                     at Page (app/use-cache-draft-mode/page.tsx:9:7)
-                   18 |   // here to ensure that this error is shown even when it's caught in userland.
-                   19 |   try {
-                 > 20 |     ;(await draftMode()).enable()
-                      |                          ^
-                   21 |   } catch {}
-                   22 |
-                   23 |   return null
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at DraftModeEnablingComponent (app/use-cache-draft-mode/page.tsx:20:26)
+                   at Page (app/use-cache-draft-mode/page.tsx:9:7)
+                 18 |   // here to ensure that this error is shown even when it's caught in userland.
+                 19 |   try {
+               > 20 |     ;(await draftMode()).enable()
+                    |                          ^
+                 21 |   } catch {}
+                 22 |
+                 23 |   return null
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-draft-mode/page: /use-cache-draft-mode"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-draft-mode/page: /use-cache-draft-mode"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at DraftModeEnablingComponent (webpack:///app/use-cache-draft-mode/page.tsx:20:26)
-                     at Page (webpack:///app/use-cache-draft-mode/page.tsx:9:7)
-                   18 |   // here to ensure that this error is shown even when it's caught in userland.
-                   19 |   try {
-                 > 20 |     ;(await draftMode()).enable()
-                      |                          ^
-                   21 |   } catch {}
-                   22 |
-                   23 |   return null
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at DraftModeEnablingComponent (webpack:///app/use-cache-draft-mode/page.tsx:20:26)
+                   at Page (webpack:///app/use-cache-draft-mode/page.tsx:9:7)
+                 18 |   // here to ensure that this error is shown even when it's caught in userland.
+                 19 |   try {
+               > 20 |     ;(await draftMode()).enable()
+                    |                          ^
+                 21 |   } catch {}
+                 22 |
+                 23 |   return null
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-draft-mode/page: /use-cache-draft-mode"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-draft-mode/page: /use-cache-draft-mode"
+              `)
             }
           } else {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (app/use-cache-draft-mode/page.tsx:20:26)
-                   18 |   // here to ensure that this error is shown even when it's caught in userland.
-                   19 |   try {
-                 > 20 |     ;(await draftMode()).enable()
-                      |                          ^
-                   21 |   } catch {}
-                   22 |
-                   23 |   return null
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-draft-mode/page: /use-cache-draft-mode, exiting the build."
-                `)
+               "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (app/use-cache-draft-mode/page.tsx:20:26)
+                 18 |   // here to ensure that this error is shown even when it's caught in userland.
+                 19 |   try {
+               > 20 |     ;(await draftMode()).enable()
+                    |                          ^
+                 21 |   } catch {}
+                 22 |
+                 23 |   return null
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-draft-mode/page: /use-cache-draft-mode, exiting the build."
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (<next-dist-dir>)
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-draft-mode/page: /use-cache-draft-mode, exiting the build."
-                `)
+               "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (<next-dist-dir>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-draft-mode/page: /use-cache-draft-mode, exiting the build."
+              `)
             }
           }
         })
@@ -268,39 +276,41 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at HeadersReadingComponent (app/use-cache-headers/page.tsx:21:18)
-                     at Page (app/use-cache-headers/page.tsx:10:7)
-                   19 |   // to ensure that this error is shown even when it's caught in userland.
-                   20 |   try {
-                 > 21 |     await headers()
-                      |                  ^
-                   22 |   } catch {}
-                   23 |
-                   24 |   return null
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at HeadersReadingComponent (app/use-cache-headers/page.tsx:21:18)
+                   at Page (app/use-cache-headers/page.tsx:10:7)
+                 19 |   // to ensure that this error is shown even when it's caught in userland.
+                 20 |   try {
+               > 21 |     await headers()
+                    |                  ^
+                 22 |   } catch {}
+                 23 |
+                 24 |   return null
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-headers/page: /use-cache-headers"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-headers/page: /use-cache-headers"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (app/use-cache-headers/page.tsx:21:11)
-                   19 |   // to ensure that this error is shown even when it's caught in userland.
-                   20 |   try {
-                 > 21 |     await headers()
-                      |           ^
-                   22 |   } catch {}
-                   23 |
-                   24 |   return null
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-headers/page: /use-cache-headers, exiting the build."
-                `)
+               "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (app/use-cache-headers/page.tsx:21:11)
+                 19 |   // to ensure that this error is shown even when it's caught in userland.
+                 20 |   try {
+               > 21 |     await headers()
+                    |           ^
+                 22 |   } catch {}
+                 23 |
+                 24 |   return null
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-headers/page: /use-cache-headers, exiting the build."
+              `)
             }
           } else {
             if (isDebugPrerender) {
@@ -317,21 +327,23 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
                  24 |   return null
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
                Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
                > Export encountered errors on 1 path:
                	/use-cache-headers/page: /use-cache-headers"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (<next-dist-dir>)
-                     at b (<next-dist-dir>)
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-headers/page: /use-cache-headers, exiting the build."
-                `)
+               "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-headers/page: /use-cache-headers, exiting the build."
+              `)
             }
           }
         })
@@ -375,39 +387,41 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at ConnectionCallingComponent (app/use-cache-connection/page.tsx:21:21)
-                     at Page (app/use-cache-connection/page.tsx:10:7)
-                   19 |   // here to ensure that this error is shown even when it's caught in userland.
-                   20 |   try {
-                 > 21 |     await connection()
-                      |                     ^
-                   22 |   } catch {}
-                   23 |
-                   24 |   return null
-                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
-                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+               "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at ConnectionCallingComponent (app/use-cache-connection/page.tsx:21:21)
+                   at Page (app/use-cache-connection/page.tsx:10:7)
+                 19 |   // here to ensure that this error is shown even when it's caught in userland.
+                 20 |   try {
+               > 21 |     await connection()
+                    |                     ^
+                 22 |   } catch {}
+                 23 |
+                 24 |   return null
+               To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+               Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                 > Export encountered errors on 1 path:
-                 	/use-cache-connection/page: /use-cache-connection"
-                `)
+               > Export encountered errors on 1 path:
+               	/use-cache-connection/page: /use-cache-connection"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (app/use-cache-connection/page.tsx:21:11)
-                   19 |   // here to ensure that this error is shown even when it's caught in userland.
-                   20 |   try {
-                 > 21 |     await connection()
-                      |           ^
-                   22 |   } catch {}
-                   23 |
-                   24 |   return null
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-connection/page: /use-cache-connection, exiting the build."
-                `)
+               "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (app/use-cache-connection/page.tsx:21:11)
+                 19 |   // here to ensure that this error is shown even when it's caught in userland.
+                 20 |   try {
+               > 21 |     await connection()
+                    |           ^
+                 22 |   } catch {}
+                 23 |
+                 24 |   return null
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-connection/page: /use-cache-connection, exiting the build."
+              `)
             }
           } else {
             if (isDebugPrerender) {
@@ -424,21 +438,23 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
                  24 |   return null
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
                Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
                > Export encountered errors on 1 path:
                	/use-cache-connection/page: /use-cache-connection"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                     at a (<next-dist-dir>)
-                     at b (<next-dist-dir>)
-                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
-                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
-                 Export encountered an error on /use-cache-connection/page: /use-cache-connection, exiting the build."
-                `)
+               "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>)
+               To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                 - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+                 - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+               Export encountered an error on /use-cache-connection/page: /use-cache-connection, exiting the build."
+              `)
             }
           }
         })
@@ -502,6 +518,16 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
                    6 |   cacheLife({ expire: 299 }) // 1 second below the threshold of 5 minutes
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-low-expire/fast": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                  > Export encountered errors on 1 path:
                  	/use-cache-low-expire/fast/page: /use-cache-low-expire/fast"
@@ -525,6 +551,16 @@ export function registerUseCacheTests(ctx: CacheComponentsErrorsContext) {
                    - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                    - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                  Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-low-expire/fast": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                  Export encountered an error on /use-cache-low-expire/fast/page: /use-cache-low-expire/fast, exiting the build."
                 `)
               }
@@ -620,6 +656,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    6 |   cacheLife({ expire: 299 }) // 1 second below the threshold of 5 minutes
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-low-expire/slow": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                  > Export encountered errors on 1 path:
                  	/use-cache-low-expire/slow/page: /use-cache-low-expire/slow"
@@ -643,6 +689,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                    - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                  Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-low-expire/slow": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                  Export encountered an error on /use-cache-low-expire/slow/page: /use-cache-low-expire/slow, exiting the build."
                 `)
               }
@@ -732,61 +788,63 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
-                       at async Page (app/use-cache-low-expire/nested/page.tsx:20:14)
-                     18 |   let result: number | undefined
-                     19 |   try {
-                   > 20 |     result = await outerCache()
-                        |              ^
-                     21 |   } catch {}
-                     22 |
-                     23 |   return ( {
-                     [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
-                         at innerCache (app/use-cache-low-expire/nested/page.tsx:3:1)
-                         at outerCache (app/use-cache-low-expire/nested/page.tsx:14:10)
-                         at Page (<anonymous>)
-                       1 | import { cacheLife } from 'next/cache'
-                       2 |
-                     > 3 | async function innerCache() {
-                         | ^
-                       4 |   'use cache'
-                       5 |   cacheLife({ expire: 60 }) // 1 minute, under the 5 minute threshold
-                       6 |   return Math.random()
-                   }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                     at async Page (app/use-cache-low-expire/nested/page.tsx:20:14)
+                   18 |   let result: number | undefined
+                   19 |   try {
+                 > 20 |     result = await outerCache()
+                      |              ^
+                   21 |   } catch {}
+                   22 |
+                   23 |   return ( {
+                   [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
+                       at innerCache (app/use-cache-low-expire/nested/page.tsx:3:1)
+                       at outerCache (app/use-cache-low-expire/nested/page.tsx:14:10)
+                       at Page (<anonymous>)
+                     1 | import { cacheLife } from 'next/cache'
+                     2 |
+                   > 3 | async function innerCache() {
+                       | ^
+                     4 |   'use cache'
+                     5 |   cacheLife({ expire: 60 }) // 1 minute, under the 5 minute threshold
+                     6 |   return Math.random()
+                 }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-low-expire/nested/page: /use-cache-low-expire/nested"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-low-expire/nested/page: /use-cache-low-expire/nested"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
-                       at async k (app/use-cache-low-expire/nested/page.tsx:20:14)
-                     18 |   let result: number | undefined
-                     19 |   try {
-                   > 20 |     result = await outerCache()
-                        |              ^
-                     21 |   } catch {}
-                     22 |
-                     23 |   return ( {
-                     [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
-                         at <unknown> (app/use-cache-low-expire/nested/page.tsx:3:1)
-                         at a (app/use-cache-low-expire/nested/page.tsx:3:16)
-                       1 | import { cacheLife } from 'next/cache'
-                       2 |
-                     > 3 | async function innerCache() {
-                         | ^
-                       4 |   'use cache'
-                       5 |   cacheLife({ expire: 60 }) // 1 minute, under the 5 minute threshold
-                       6 |   return Math.random()
-                   }
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-low-expire/nested/page: /use-cache-low-expire/nested, exiting the build."
-                  `)
+                 "Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                     at async k (app/use-cache-low-expire/nested/page.tsx:20:14)
+                   18 |   let result: number | undefined
+                   19 |   try {
+                 > 20 |     result = await outerCache()
+                      |              ^
+                   21 |   } catch {}
+                   22 |
+                   23 |   return ( {
+                   [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
+                       at <unknown> (app/use-cache-low-expire/nested/page.tsx:3:1)
+                       at a (app/use-cache-low-expire/nested/page.tsx:3:16)
+                     1 | import { cacheLife } from 'next/cache'
+                     2 |
+                   > 3 | async function innerCache() {
+                       | ^
+                     4 |   'use cache'
+                     5 |   cacheLife({ expire: 60 }) // 1 minute, under the 5 minute threshold
+                     6 |   return Math.random()
+                 }
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                 Export encountered an error on /use-cache-low-expire/nested/page: /use-cache-low-expire/nested, exiting the build."
+                `)
               }
             } else {
               if (isDebugPrerender) {
@@ -814,25 +872,27 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
 
                  > Export encountered errors on 1 path:
                  	/use-cache-low-expire/nested/page: /use-cache-low-expire/nested"
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
-                       at a (<next-dist-dir>) {
-                     [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
-                         at b (<next-dist-dir>)
-                         at c (<next-dist-dir>)
-                         at d (<next-dist-dir>)
-                   }
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-low-expire/nested/page: /use-cache-low-expire/nested, exiting the build."
-                  `)
+                 "Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                     at a (<next-dist-dir>) {
+                   [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
+                       at b (<next-dist-dir>)
+                       at c (<next-dist-dir>)
+                       at d (<next-dist-dir>)
+                 }
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                 Export encountered an error on /use-cache-low-expire/nested/page: /use-cache-low-expire/nested, exiting the build."
+                `)
               }
             }
           })
@@ -897,6 +957,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    6 |   cacheLife({ revalidate: 0 })
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-revalidate-0/fast": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                  > Export encountered errors on 1 path:
                  	/use-cache-revalidate-0/fast/page: /use-cache-revalidate-0/fast"
@@ -920,6 +990,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                    - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                  Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-revalidate-0/fast": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                  Export encountered an error on /use-cache-revalidate-0/fast/page: /use-cache-revalidate-0/fast, exiting the build."
                 `)
               }
@@ -1015,6 +1095,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    6 |   cacheLife({ revalidate: 0 })
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-revalidate-0/slow": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                  > Export encountered errors on 1 path:
                  	/use-cache-revalidate-0/slow/page: /use-cache-revalidate-0/slow"
@@ -1038,6 +1128,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                    - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                  Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route "/use-cache-revalidate-0/slow": Next.js encountered uncached or runtime data during prerendering.
+
+                 \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+                 Ways to fix this:
+                   - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                   - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                   - [block] Set \`export const instant = false\` to allow a blocking route
+
+                 Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                  Export encountered an error on /use-cache-revalidate-0/slow/page: /use-cache-revalidate-0/slow, exiting the build."
                 `)
               }
@@ -1127,61 +1227,63 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
-                       at async Page (app/use-cache-revalidate-0/nested/page.tsx:20:14)
-                     18 |   let result: number | undefined
-                     19 |   try {
-                   > 20 |     result = await outerCache()
-                        |              ^
-                     21 |   } catch {}
-                     22 |
-                     23 |   return ( {
-                     [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
-                         at innerCache (app/use-cache-revalidate-0/nested/page.tsx:3:1)
-                         at outerCache (app/use-cache-revalidate-0/nested/page.tsx:14:10)
-                         at Page (<anonymous>)
-                       1 | import { cacheLife } from 'next/cache'
-                       2 |
-                     > 3 | async function innerCache() {
-                         | ^
-                       4 |   'use cache'
-                       5 |   cacheLife({ revalidate: 0 })
-                       6 |   return Math.random()
-                   }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                     at async Page (app/use-cache-revalidate-0/nested/page.tsx:20:14)
+                   18 |   let result: number | undefined
+                   19 |   try {
+                 > 20 |     result = await outerCache()
+                      |              ^
+                   21 |   } catch {}
+                   22 |
+                   23 |   return ( {
+                   [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
+                       at innerCache (app/use-cache-revalidate-0/nested/page.tsx:3:1)
+                       at outerCache (app/use-cache-revalidate-0/nested/page.tsx:14:10)
+                       at Page (<anonymous>)
+                     1 | import { cacheLife } from 'next/cache'
+                     2 |
+                   > 3 | async function innerCache() {
+                       | ^
+                     4 |   'use cache'
+                     5 |   cacheLife({ revalidate: 0 })
+                     6 |   return Math.random()
+                 }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
-                       at async k (app/use-cache-revalidate-0/nested/page.tsx:20:14)
-                     18 |   let result: number | undefined
-                     19 |   try {
-                   > 20 |     result = await outerCache()
-                        |              ^
-                     21 |   } catch {}
-                     22 |
-                     23 |   return ( {
-                     [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
-                         at <unknown> (app/use-cache-revalidate-0/nested/page.tsx:3:1)
-                         at a (app/use-cache-revalidate-0/nested/page.tsx:3:16)
-                       1 | import { cacheLife } from 'next/cache'
-                       2 |
-                     > 3 | async function innerCache() {
-                         | ^
-                       4 |   'use cache'
-                       5 |   cacheLife({ revalidate: 0 })
-                       6 |   return Math.random()
-                   }
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested, exiting the build."
-                  `)
+                 "Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                     at async k (app/use-cache-revalidate-0/nested/page.tsx:20:14)
+                   18 |   let result: number | undefined
+                   19 |   try {
+                 > 20 |     result = await outerCache()
+                      |              ^
+                   21 |   } catch {}
+                   22 |
+                   23 |   return ( {
+                   [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
+                       at <unknown> (app/use-cache-revalidate-0/nested/page.tsx:3:1)
+                       at a (app/use-cache-revalidate-0/nested/page.tsx:3:16)
+                     1 | import { cacheLife } from 'next/cache'
+                     2 |
+                   > 3 | async function innerCache() {
+                       | ^
+                     4 |   'use cache'
+                     5 |   cacheLife({ revalidate: 0 })
+                     6 |   return Math.random()
+                 }
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                 Export encountered an error on /use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested, exiting the build."
+                `)
               }
             } else {
               if (isDebugPrerender) {
@@ -1209,25 +1311,27 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
 
                  > Export encountered errors on 1 path:
                  	/use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested"
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
-                       at a (<next-dist-dir>) {
-                     [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
-                         at b (<next-dist-dir>)
-                         at c (<next-dist-dir>)
-                         at d (<next-dist-dir>)
-                   }
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested, exiting the build."
-                  `)
+                 "Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                     at a (<next-dist-dir>) {
+                   [cause]: Nested dynamic "use cache": This "use cache" has a dynamic cache life that was propagated to its parent.
+                       at b (<next-dist-dir>)
+                       at c (<next-dist-dir>)
+                       at d (<next-dist-dir>)
+                 }
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer "use cache" to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife
+                 Export encountered an error on /use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested, exiting the build."
+                `)
               }
             }
           })
@@ -1331,6 +1435,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                  4 |   params: Promise<{ slug: string }>
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
                Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/use-cache-params/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
 
                > Export encountered errors on 1 path:
                	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
@@ -1354,6 +1468,16 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                  - Start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
                Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+               Error: Route "/use-cache-params/[slug]": Next.js encountered uncached or runtime data during prerendering.
+
+               \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+               Ways to fix this:
+                 - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+                 - [cache] For uncached data (\`fetch\`, database calls): cache the access with \`"use cache"\` (does not apply to \`connection()\`)
+                 - [block] Set \`export const instant = false\` to allow a blocking route
+
+               Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
                Export encountered an error on /use-cache-params/[slug]/page: /use-cache-params/[slug], exiting the build."
               `)
             }
@@ -1553,31 +1677,33 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at Page (app/use-cache-cookies-third-party/page.tsx:10:7)
-                      8 |         which triggers an error.
-                      9 |       </p>
-                   > 10 |       <CachedCookiesReader />
-                        |       ^
-                     11 |     </>
-                     12 |   )
-                     13 | }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at Page (app/use-cache-cookies-third-party/page.tsx:10:7)
+                    8 |         which triggers an error.
+                    9 |       </p>
+                 > 10 |       <CachedCookiesReader />
+                      |       ^
+                   11 |     </>
+                   12 |   )
+                   13 | }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-cookies-third-party/page: /use-cache-cookies-third-party"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-cookies-third-party/page: /use-cache-cookies-third-party"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-cookies-third-party/page: /use-cache-cookies-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at ignore-listed frames
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-cookies-third-party/page: /use-cache-cookies-third-party, exiting the build."
+                `)
               }
             } else {
               if (isDebugPrerender) {
@@ -1593,21 +1719,23 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    13 | }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
                  > Export encountered errors on 1 path:
                  	/use-cache-cookies-third-party/page: /use-cache-cookies-third-party"
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at a (<next-dist-dir>)
-                       at b (<next-dist-dir>)
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-cookies-third-party/page: /use-cache-cookies-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-cookies-third-party/page: /use-cache-cookies-third-party, exiting the build."
+                `)
               }
             }
           })
@@ -1652,60 +1780,64 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
             if (isDebugPrerender) {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at Page (app/use-cache-draft-mode-third-party/page.tsx:10:7)
-                      8 |         which triggers an error.
-                      9 |       </p>
-                   > 10 |       <CachedDraftModeEnabler />
-                        |       ^
-                     11 |     </>
-                     12 |   )
-                     13 | }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at Page (app/use-cache-draft-mode-third-party/page.tsx:10:7)
+                    8 |         which triggers an error.
+                    9 |       </p>
+                 > 10 |       <CachedDraftModeEnabler />
+                      |       ^
+                   11 |     </>
+                   12 |   )
+                   13 | }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at Page (webpack:///app/use-cache-draft-mode-third-party/page.tsx:10:7)
-                      8 |         which triggers an error.
-                      9 |       </p>
-                   > 10 |       <CachedDraftModeEnabler />
-                        |       ^
-                     11 |     </>
-                     12 |   )
-                     13 | }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at Page (webpack:///app/use-cache-draft-mode-third-party/page.tsx:10:7)
+                    8 |         which triggers an error.
+                    9 |       </p>
+                 > 10 |       <CachedDraftModeEnabler />
+                      |       ^
+                   11 |     </>
+                   12 |   )
+                   13 | }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party"
+                `)
               }
             } else {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at ignore-listed frames
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party, exiting the build."
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at a (<next-dist-dir>)
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at a (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party, exiting the build."
+                `)
               }
             }
           })
@@ -1748,31 +1880,33 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at Page (app/use-cache-headers-third-party/page.tsx:10:7)
-                      8 |         which triggers an error.
-                      9 |       </p>
-                   > 10 |       <CachedHeadersReader />
-                        |       ^
-                     11 |     </>
-                     12 |   )
-                     13 | }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at Page (app/use-cache-headers-third-party/page.tsx:10:7)
+                    8 |         which triggers an error.
+                    9 |       </p>
+                 > 10 |       <CachedHeadersReader />
+                      |       ^
+                   11 |     </>
+                   12 |   )
+                   13 | }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-headers-third-party/page: /use-cache-headers-third-party"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-headers-third-party/page: /use-cache-headers-third-party"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-headers-third-party/page: /use-cache-headers-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at ignore-listed frames
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-headers-third-party/page: /use-cache-headers-third-party, exiting the build."
+                `)
               }
             } else {
               if (isDebugPrerender) {
@@ -1788,21 +1922,23 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    13 | }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
                  > Export encountered errors on 1 path:
                  	/use-cache-headers-third-party/page: /use-cache-headers-third-party"
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at a (<next-dist-dir>)
-                       at b (<next-dist-dir>)
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-headers-third-party/page: /use-cache-headers-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-headers-third-party/page: /use-cache-headers-third-party, exiting the build."
+                `)
               }
             }
           })
@@ -1847,31 +1983,33 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at Page (app/use-cache-connection-third-party/page.tsx:10:7)
-                      8 |         which triggers an error.
-                      9 |       </p>
-                   > 10 |       <CachedConnectionCaller />
-                        |       ^
-                     11 |     </>
-                     12 |   )
-                     13 | }
-                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
-                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at Page (app/use-cache-connection-third-party/page.tsx:10:7)
+                    8 |         which triggers an error.
+                    9 |       </p>
+                 > 10 |       <CachedConnectionCaller />
+                      |       ^
+                   11 |     </>
+                   12 |   )
+                   13 | }
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
-                   > Export encountered errors on 1 path:
-                   	/use-cache-connection-third-party/page: /use-cache-connection-third-party"
-                  `)
+                 > Export encountered errors on 1 path:
+                 	/use-cache-connection-third-party/page: /use-cache-connection-third-party"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-connection-third-party/page: /use-cache-connection-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at ignore-listed frames
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-connection-third-party/page: /use-cache-connection-third-party, exiting the build."
+                `)
               }
             } else {
               if (isDebugPrerender) {
@@ -1887,21 +2025,23 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
                    13 | }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
 
                  > Export encountered errors on 1 path:
                  	/use-cache-connection-third-party/page: /use-cache-connection-third-party"
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at a (<next-dist-dir>)
-                       at b (<next-dist-dir>)
-                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
-                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
-                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
-                   Export encountered an error on /use-cache-connection-third-party/page: /use-cache-connection-third-party, exiting the build."
-                  `)
+                 "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                 Export encountered an error on /use-cache-connection-third-party/page: /use-cache-connection-third-party, exiting the build."
+                `)
               }
             }
           })


### PR DESCRIPTION
### What?

In 9 locations in `packages/next/src/server/app-render/dynamic-rendering.ts` and `app-render.tsx` (including `throwIfDisallowedDynamic` and `throwIfSyncIOUsed`), `StaticGenBailoutError` was being thrown without a reason; this has been changed so that the reason that was already logged via `console.error` right before the throw is now attached as the error's `message` (and, where the original error object exists, as the `cause` as well).

### Why?

When runtime ISR revalidation failed, only an `Error` with an empty message was sent to error trackers via `onRequestError`, making the failure impossible to diagnose.

### Side effects

The reason is now also displayed in the build output when a build fails (because the existing logic in the export worker prints `StaticGenBailoutError` messages when present). The ~130 updated snapshots under `test/e2e/app-dir/cache-components-errors` reflect this new output.

### Testing

Added a new `dynamic-rendering.test.ts` (confirmed to fail without the fix). The `cache-components-errors` suite has been updated and passes in all modes (dev/start × Turbopack/Webpack × with and without debug-prerender).

Fixes #95867