### PR TITLE
[Dev] Detect module-scoped state leaking across requests

### DIFF
--- a/packages/next/src/server/node-environment-extensions/cross-request-state-detector.test.ts
+++ b/packages/next/src/server/node-environment-extensions/cross-request-state-detector.test.ts
@@ -1,0 +1,121 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import {
+  installCrossRequestStateDetector,
+  type WorkUnitStoreLike,
+} from './cross-request-state-detector'
+
+type FakeStore = { type: string; url: { pathname: string } }
+
+function setup() {
+  const als = new AsyncLocalStorage<FakeStore>()
+  const warnings: string[] = []
+  const uninstall = installCrossRequestStateDetector({
+    getStore: () => als.getStore() as WorkUnitStoreLike | undefined,
+    warn: (m) => warnings.push(m),
+  })
+  // fresh object per request => distinct identity, like a real RequestStore
+  const request = <T>(pathname: string, fn: () => Promise<T>): Promise<T> =>
+    als.run({ type: 'request', url: { pathname } }, fn)
+  return { warnings, uninstall, request }
+}
+
+async function fetchUserSidebar(user: string): Promise<string> {
+  return `sidebar-data-for-${user}`
+}
+
+describe('cross-request state detector', () => {
+  it('warns AND reproduces the leak: a module-scoped Map<useId, Promise>', async () => {
+    const { warnings, uninstall, request } = setup()
+    try {
+      const sidebarPromises = new Map<string, Promise<string>>() // module scope
+      const renderSidebar = (user: string) => {
+        const id = '_r_0_' // deterministic useId(), identical across requests
+        if (!sidebarPromises.has(id)) {
+          sidebarPromises.set(id, fetchUserSidebar(user))
+        }
+        return sidebarPromises.get(id)!
+      }
+
+      const aliceSaw = await request('/chat/alice', () =>
+        renderSidebar('alice')
+      )
+      const bobSaw = await request('/chat/bob', () => renderSidebar('bob'))
+
+      expect(aliceSaw).toBe('sidebar-data-for-alice')
+      // the actual production bug: bob is served alice's data
+      expect(bobSaw).toBe('sidebar-data-for-alice')
+
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]).toContain('Cross-request state leak detected')
+      expect(warnings[0]).toContain('/chat/alice')
+      expect(warnings[0]).toContain('/chat/bob')
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('warns for a module-scoped WeakSet<Promise> observed across requests', async () => {
+    const { warnings, uninstall, request } = setup()
+    try {
+      const consumed = new WeakSet<Promise<unknown>>() // module scope
+      const shared = fetchUserSidebar('alice')
+      await request('/chat/alice', async () => {
+        consumed.add(shared)
+      })
+      const bobSawIt = await request('/chat/bob', async () =>
+        consumed.has(shared)
+      )
+      expect(bobSawIt).toBe(true)
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]).toContain('WeakSet')
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('does not warn for a per-request container (React.cache-style)', async () => {
+    const { warnings, uninstall, request } = setup()
+    try {
+      const renderScoped = (user: string) => {
+        const cache = new Map<string, Promise<string>>() // per-request
+        const id = '_r_0_'
+        if (!cache.has(id)) cache.set(id, fetchUserSidebar(user))
+        return cache.get(id)!
+      }
+      await request('/chat/alice', () => renderScoped('alice'))
+      const bobSaw = await request('/chat/bob', () => renderScoped('bob'))
+      expect(bobSaw).toBe('sidebar-data-for-bob')
+      expect(warnings).toHaveLength(0)
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('does not warn for a module cache of plain (non-thenable) data', async () => {
+    const { warnings, uninstall, request } = setup()
+    try {
+      const config = new Map<string, string>() // module scope
+      config.set('theme', 'dark') // plain value, set at module load
+      await request('/a', async () => config.get('theme'))
+      await request('/b', async () => config.get('theme'))
+      expect(warnings).toHaveLength(0)
+    } finally {
+      uninstall()
+    }
+  })
+
+  it('does not warn when the same request reads its own promise twice', async () => {
+    const { warnings, uninstall, request } = setup()
+    try {
+      const m = new Map<string, Promise<string>>()
+      await request('/x', async () => {
+        m.set('k', fetchUserSidebar('x'))
+        await m.get('k')!
+        await m.get('k')!
+      })
+      expect(warnings).toHaveLength(0)
+    } finally {
+      uninstall()
+    }
+  })
+})

--- a/packages/next/src/server/node-environment-extensions/cross-request-state-detector.ts
+++ b/packages/next/src/server/node-environment-extensions/cross-request-state-detector.ts
@@ -1,0 +1,372 @@
+/**
+ * DEV-ONLY cross-request state leak detector (prototype).
+ *
+ * Catches the class of bug that hit v0 in production: a module-scoped mutable
+ * container (`const cache = new Map()` at top level) that stores a per-request
+ * `Promise` and — because the container outlives a single request in a reused
+ * server function instance — hands that Promise to a *different* request. When
+ * the cache key is deterministic (e.g. `useId()`), request B reads request A's
+ * in-flight/resolved data. See v0 incident writeup
+ * `chat/app/lib/server-query-swr/state-lifetime-history.md`.
+ *
+ * The unwrap itself (native `await` / React `use()` on an already-settled
+ * promise) is invisible at the JS layer — `await` bypasses a patched
+ * `Promise.prototype.then`, and async_hooks does not expose the promise object
+ * or a cross-store consume event. So instead of tagging the thenable, we tag
+ * the *container entry*: when a Promise is stored under request A's store and
+ * later retrieved under request B's store, we warn.
+ *
+ * We only ever track entries whose value is a thenable. Ordinary module-scoped
+ * caches of plain data (config lookups, compiled-route tables) are never
+ * tracked, which keeps false positives near zero: caching a Promise so it can
+ * be shared across requests is essentially always a bug.
+ *
+ * The core is dependency-injected (no Next imports) so it can be exercised by a
+ * standalone harness. The real extension passes `workUnitAsyncStorage`.
+ */
+
+/* eslint-disable no-extend-native -- this module deliberately instruments the
+   global Map/Set/WeakMap/WeakSet prototypes to observe cross-request reuse,
+   the same way date.tsx/random.tsx instrument Date and Math.random. */
+
+/** Minimal shape we read off a work-unit store. */
+export interface WorkUnitStoreLike {
+  readonly type?: string
+  readonly url?: { readonly pathname?: string }
+}
+
+export interface DetectorHost {
+  /** The currently-active work-unit store, or undefined outside a render. */
+  getStore(): WorkUnitStoreLike | undefined
+  /** Emit a warning (console.error in the real extension). */
+  warn(message: string): void
+}
+
+interface OwnerRecord {
+  /** The request store object — compared by identity to detect crossing. */
+  readonly store: object
+  /** Human-readable label for the warning. */
+  readonly label: string
+}
+
+type ContainerKind = 'Map' | 'WeakMap' | 'Set' | 'WeakSet'
+
+function isThenable(v: unknown): v is PromiseLike<unknown> {
+  return (
+    v != null &&
+    (typeof v === 'object' || typeof v === 'function') &&
+    typeof (v as { then?: unknown }).then === 'function'
+  )
+}
+
+export function installCrossRequestStateDetector(
+  host: DetectorHost
+): () => void {
+  // Capture originals BEFORE patching. All internal bookkeeping goes through
+  // these so the detector never re-enters its own patched methods (which would
+  // recurse infinitely, since we store metadata in Maps/WeakMaps).
+  const O = {
+    mapGet: Map.prototype.get,
+    mapSet: Map.prototype.set,
+    setAdd: Set.prototype.add,
+    setHas: Set.prototype.has,
+    wmGet: WeakMap.prototype.get,
+    wmSet: WeakMap.prototype.set,
+    wsAdd: WeakSet.prototype.add,
+    wsHas: WeakSet.prototype.has,
+  }
+
+  // container -> (entryKeyOrValue -> owner). For Map/WeakMap the sub-key is the
+  // entry key; for Set/WeakSet the sub-key is the value itself.
+  const owners = new WeakMap<
+    object,
+    WeakMap<object, OwnerRecord> | Map<unknown, OwnerRecord>
+  >()
+  // container -> set of already-warned entry keys/values (dedupe noise).
+  const warned = new WeakMap<object, Set<unknown> | WeakSet<object>>()
+  const requestLabels = new WeakMap<object, string>()
+  let nextRequestId = 1
+  let inDetector = false
+
+  function currentRequest(): OwnerRecord | undefined {
+    const store = host.getStore()
+    if (!store || store.type !== 'request') return undefined
+    const s = store as unknown as object
+    let label = O.wmGet.call(requestLabels, s) as string | undefined
+    if (label === undefined) {
+      const path = store.url?.pathname ?? '?'
+      label = `request#${nextRequestId++} (${path})`
+      O.wmSet.call(requestLabels, s, label)
+    }
+    return { store: s, label }
+  }
+
+  /** Record that `subKey` in `container` now holds a request-owned promise. */
+  function recordOwner(
+    container: object,
+    subKey: unknown,
+    weak: boolean,
+    req: OwnerRecord
+  ): void {
+    let table = O.wmGet.call(owners, container) as
+      | WeakMap<object, OwnerRecord>
+      | Map<unknown, OwnerRecord>
+      | undefined
+    if (table === undefined) {
+      table = weak
+        ? new WeakMap<object, OwnerRecord>()
+        : new Map<unknown, OwnerRecord>()
+      O.wmSet.call(owners, container, table)
+    }
+    if (weak) {
+      O.wmSet.call(table as WeakMap<object, OwnerRecord>, subKey as object, req)
+    } else {
+      O.mapSet.call(table as Map<unknown, OwnerRecord>, subKey, req)
+    }
+  }
+
+  /** Look up the owner previously recorded for `subKey`, if any. */
+  function lookupOwner(
+    container: object,
+    subKey: unknown,
+    weak: boolean
+  ): OwnerRecord | undefined {
+    const table = O.wmGet.call(owners, container) as
+      | WeakMap<object, OwnerRecord>
+      | Map<unknown, OwnerRecord>
+      | undefined
+    if (table === undefined) return undefined
+    return weak
+      ? (O.wmGet.call(
+          table as WeakMap<object, OwnerRecord>,
+          subKey as object
+        ) as OwnerRecord | undefined)
+      : (O.mapGet.call(table as Map<unknown, OwnerRecord>, subKey) as
+          | OwnerRecord
+          | undefined)
+  }
+
+  function alreadyWarned(
+    container: object,
+    subKey: unknown,
+    weak: boolean
+  ): boolean {
+    let set = O.wmGet.call(warned, container) as
+      | Set<unknown>
+      | WeakSet<object>
+      | undefined
+    if (set === undefined) {
+      set = weak ? new WeakSet<object>() : new Set<unknown>()
+      O.wmSet.call(warned, container, set)
+    }
+    if (weak) {
+      const ws = set as WeakSet<object>
+      if (O.wsHas.call(ws, subKey as object)) return true
+      O.wsAdd.call(ws, subKey as object)
+      return false
+    }
+    const s = set as Set<unknown>
+    if (O.setHas.call(s, subKey)) return true
+    O.setAdd.call(s, subKey)
+    return false
+  }
+
+  function report(
+    kind: ContainerKind,
+    ownerLabel: string,
+    readerLabel: string,
+    subKey: unknown
+  ): void {
+    const keyDesc =
+      kind === 'Set' || kind === 'WeakSet'
+        ? ''
+        : `\n  Entry key: ${describeKey(subKey)}`
+    host.warn(
+      `Cross-request state leak detected.\n` +
+        `  A Promise stored in a module-scoped \`${kind}\` during ${ownerLabel}\n` +
+        `  was just read during ${readerLabel}.\n` +
+        `  Because the container outlives a single request, one user's in-flight or\n` +
+        `  resolved data can be served to another user.` +
+        keyDesc +
+        `\n  Fix: don't keep per-request Promises in module scope. Use \`React.cache()\`\n` +
+        `  for per-request dedupe, or own the state in a React provider created per render.`
+    )
+  }
+
+  function describeKey(k: unknown): string {
+    if (typeof k === 'string') return JSON.stringify(k)
+    if (typeof k === 'number' || typeof k === 'boolean' || k == null)
+      return String(k)
+    return Object.prototype.toString.call(k)
+  }
+
+  // ---- patches -----------------------------------------------------------
+
+  Map.prototype.set = function set(this: Map<unknown, unknown>, key, value) {
+    const result = O.mapSet.call(this, key, value)
+    if (!inDetector && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        if (req) recordOwner(this, key, false, req)
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return result as Map<unknown, unknown>
+  }
+
+  Map.prototype.get = function get(this: Map<unknown, unknown>, key) {
+    const value = O.mapGet.call(this, key)
+    if (!inDetector && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        const owner = lookupOwner(this, key, false)
+        if (
+          req &&
+          owner &&
+          owner.store !== req.store &&
+          !alreadyWarned(this, key, false)
+        ) {
+          report('Map', owner.label, req.label, key)
+        }
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return value
+  }
+
+  WeakMap.prototype.set = function set(
+    this: WeakMap<object, unknown>,
+    key,
+    value
+  ) {
+    const result = O.wmSet.call(this, key, value)
+    if (!inDetector && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        if (req) recordOwner(this, key, false, req)
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return result as WeakMap<object, unknown>
+  }
+
+  WeakMap.prototype.get = function get(this: WeakMap<object, unknown>, key) {
+    const value = O.wmGet.call(this, key)
+    if (!inDetector && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        const owner = lookupOwner(this, key, false)
+        if (
+          req &&
+          owner &&
+          owner.store !== req.store &&
+          !alreadyWarned(this, key, false)
+        ) {
+          report('WeakMap', owner.label, req.label, key)
+        }
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return value
+  }
+
+  Set.prototype.add = function add(this: Set<unknown>, value) {
+    const result = O.setAdd.call(this, value)
+    if (!inDetector && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        if (req) recordOwner(this, value, true, req)
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return result as Set<unknown>
+  }
+
+  Set.prototype.has = function has(this: Set<unknown>, value) {
+    const present = O.setHas.call(this, value)
+    if (!inDetector && present && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        const owner = lookupOwner(this, value, true)
+        if (
+          req &&
+          owner &&
+          owner.store !== req.store &&
+          !alreadyWarned(this, value, true)
+        ) {
+          report('Set', owner.label, req.label, value)
+        }
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return present
+  }
+
+  WeakSet.prototype.add = function add(this: WeakSet<object>, value) {
+    const result = O.wsAdd.call(this, value)
+    if (!inDetector && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        if (req) recordOwner(this, value, true, req)
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return result as WeakSet<object>
+  }
+
+  WeakSet.prototype.has = function has(this: WeakSet<object>, value) {
+    const present = O.wsHas.call(this, value)
+    if (!inDetector && present && isThenable(value)) {
+      inDetector = true
+      try {
+        const req = currentRequest()
+        const owner = lookupOwner(this, value, true)
+        if (
+          req &&
+          owner &&
+          owner.store !== req.store &&
+          !alreadyWarned(this, value, true)
+        ) {
+          report('WeakSet', owner.label, req.label, value)
+        }
+      } catch {
+      } finally {
+        inDetector = false
+      }
+    }
+    return present
+  }
+
+  // uninstall (for tests)
+  return function uninstall() {
+    Map.prototype.get = O.mapGet
+    Map.prototype.set = O.mapSet
+    Set.prototype.add = O.setAdd
+    Set.prototype.has = O.setHas
+    WeakMap.prototype.get = O.wmGet
+    WeakMap.prototype.set = O.wmSet
+    WeakSet.prototype.add = O.wsAdd
+    WeakSet.prototype.has = O.wsHas
+  }
+}

--- a/packages/next/src/server/node-environment-extensions/cross-request-state.tsx
+++ b/packages/next/src/server/node-environment-extensions/cross-request-state.tsx
@@ -1,0 +1,37 @@
+/**
+ * DEV-ONLY guardrail for the "module-scoped state leaks across requests" bug.
+ *
+ * When a reused server function instance keeps a top-level mutable container
+ * (`const cache = new Map()`) that stores a per-request `Promise`, and the
+ * cache key is deterministic across requests (e.g. `useId()`), one request can
+ * read another request's in-flight/resolved data. This is the v0 incident:
+ * a `useId()`-keyed module Map served one user's sidebar chats to another.
+ *
+ * We can't observe the unwrap — native `await` (and React `use()` on an
+ * already-settled promise) bypass `Promise.prototype.then`, and async_hooks
+ * exposes no cross-store consume event. So we watch the container instead:
+ * when a Promise stored under one request's store is retrieved under a
+ * different request's store, we warn.
+ *
+ * This is opt-in via `__NEXT_DETECT_CROSS_REQUEST_STATE` because it patches the
+ * global `Map`/`Set`/`WeakMap`/`WeakSet` prototypes. It is also gated to the
+ * dev server (`__NEXT_DEV_SERVER`) so it is never installed during
+ * `next build`, prerender, or `next start`.
+ */
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { installCrossRequestStateDetector } from './cross-request-state-detector'
+
+if (
+  process.env.NODE_ENV !== 'production' &&
+  process.env.__NEXT_DEV_SERVER &&
+  process.env.__NEXT_DETECT_CROSS_REQUEST_STATE
+) {
+  try {
+    installCrossRequestStateDetector({
+      getStore: () => workUnitAsyncStorage.getStore(),
+      warn: (message) => console.error('\n' + message + '\n'),
+    })
+  } catch {
+    console.error('Failed to install the cross-request state detector.')
+  }
+}

--- a/packages/next/src/server/node-environment.ts
+++ b/packages/next/src/server/node-environment.ts
@@ -18,3 +18,7 @@ import './node-environment-extensions/date'
 import './node-environment-extensions/web-crypto'
 import './node-environment-extensions/node-crypto'
 import './node-environment-extensions/fast-set-immediate.external'
+
+// DEV-only, opt-in (`__NEXT_DETECT_CROSS_REQUEST_STATE`): warns when a
+// module-scoped container leaks a per-request Promise into another request.
+import './node-environment-extensions/cross-request-state'


### PR DESCRIPTION
Prototype/RFC for the guardrail asked for in [this thread](https://vercel.slack.com/archives/C0BGEL6UDPW/p1783638263690289?thread_ts=1783624971.544149&cid=C0BGEL6UDPW). A reused server function instance that keeps a top-level mutable container (`const cache = new Map()`) holding a per-request `Promise`, keyed deterministically (e.g. `useId()`), can serve one request's data to another. This is the v0 incident: a `useId()`-keyed module `Map` returned one user's sidebar chats to another (writeup: `chat/app/lib/server-query-swr/state-lifetime-history.md`).

The unwrap can't be intercepted, so the detector watches the container instead. `await` on a settled promise bypasses a patched `Promise.prototype.then`, and async_hooks exposes no cross-store consume event:

```
patch Promise.prototype.then; await Promise.resolve(42)
  → then() call count: 0            # await bypasses the JS-level then
B awaits A's already-settled promise, under async_hooks
  → before / promiseResolve fire only for B's own promises; no A→B signal
```

So `installCrossRequestStateDetector` (dev-only) patches `Map`/`Set`/`WeakMap`/`WeakSet`: a `Promise` stored under request A's `workUnitAsyncStorage` store and later read under request B's store warns. Only thenable-valued entries are ever tracked, so ordinary module caches of plain data never warn. Trace against the v0 shape:

```
const m = new Map()                                        # module scope
request A (/chat/alice): m.set('_r_0_', fetchSidebar('alice'))  # entry owner = A
request B (/chat/bob):   m.get('_r_0_') → alice's promise       # owner A != reader B -> WARN
```

Opt-in via `__NEXT_DETECT_CROSS_REQUEST_STATE` and gated to `__NEXT_DEV_SERVER`, because it patches global prototypes — never installed during `next build`, prerender, or `next start`. Detection is wrapped so a detector bug can never break user code, and internal bookkeeping uses pre-patch prototype methods to avoid re-entering the patches. The colocated unit test covers the leak (Map + `WeakSet<Promise>`), the `React.cache()`-style per-request container, a plain-data module cache, and same-request re-read.

Not yet validated against a real `next dev` process or burned in on a large app; global `Map`/`Set` patching in the server has a perf and false-positive surface worth measuring before this moves off opt-in.

<!-- NEXT_JS_LLM_PR -->
