### PR TITLE
Package skills/ as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "nextjs",
+  "description": "Official Claude Code plugin marketplace for Next.js, serving the skills that ship in the vercel/next.js repository.",
+  "owner": {
+    "name": "Vercel",
+    "url": "https://vercel.com"
+  },
+  "plugins": [
+    {
+      "name": "nextjs",
+      "source": "./skills",
+      "description": "Official Next.js skills: adopt and optimize Cache Components, adopt Partial Prefetching, and verify runtime behavior against a running dev server."
+    }
+  ]
+}

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "nextjs",
+  "version": "0.1.0",
+  "description": "Official Next.js skills: adopt and optimize Cache Components, adopt Partial Prefetching, and verify runtime behavior against a running dev server.",
+  "author": {
+    "name": "Next.js Team",
+    "url": "https://nextjs.org"
+  },
+  "homepage": "https://nextjs.org/docs",
+  "repository": "https://github.com/vercel/next.js",
+  "license": "MIT",
+  "keywords": [
+    "nextjs",
+    "react",
+    "cache-components",
+    "partial-prerendering",
+    "partial-prefetching",
+    "skills"
+  ],
+  "skills": ["./"]
+}


### PR DESCRIPTION
#94877 removed the embedded plugin marketplace because its plugin carried copies of skills that drifted from `skills/`. This re-adds plugin packaging without duplicating any content: `skills/` itself is the plugin root. `skills/.claude-plugin/plugin.json` sets `"skills": ["./"]` so the four skills at `skills/*/SKILL.md` are discovered in place, and the root `.claude-plugin/marketplace.json` points its single entry at `./skills`. External catalogs can reference the plugin with a `git-subdir` source (`path: "skills"`), which sparse-clones only that directory instead of the whole repo.

`claude plugin validate` passes on both manifests. `claude --plugin-dir ./skills` discovers all four skills (`nextjs:next-cache-components-adoption`, `nextjs:next-cache-components-optimizer`, `nextjs:next-dev-loop`, `nextjs:next-partial-prefetching-adoption`).