### PR TITLE
Fix Rust doctest failures

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -206,20 +206,24 @@ struct PlainDirectoryTree {
 ///
 /// For example, given this directory structure:
 ///
-///     app/
-///     ├── (group1)/
-///     │   └── products/
-///     │       └── sale/
-///     └── (group2)/
-///         └── products/
-///             └── [id]/
+/// ```text
+/// app/
+/// ├── (group1)/
+/// │   └── products/
+/// │       └── sale/
+/// └── (group2)/
+///     └── products/
+///         └── [id]/
+/// ```
 ///
 /// The UrlSegmentTree would be:
 ///
-///     (root)
-///     └── products/
-///         ├── sale/
-///         └── [id]/
+/// ```text
+/// (root)
+/// └── products/
+///     ├── sale/
+///     └── [id]/
+/// ```
 ///
 /// This makes it easy to find all siblings at a given URL level.
 #[derive(Clone, Debug, Default, PartialEq, Eq, TraceRawVcs, NonLocalValue, Encode, Decode)]

--- a/turbopack/crates/turbo-prehash/src/lib.rs
+++ b/turbopack/crates/turbo-prehash/src/lib.rs
@@ -10,9 +10,8 @@
 //! # Example
 //!
 //! ```
-//! use std::hash::{BuildHasherDefault, RandomState, Hash};
+//! use std::{collections::HashMap, hash::{Hash, RandomState}};
 //!
-//! use rustc_hash::FxHashMap;
 //! use turbo_prehash::{BuildHasherExt, PreHashed};
 //!
 //! /// hash a key, returning a prehashed value
@@ -21,7 +20,7 @@
 //! }
 //!
 //! // create hashmap to hold pre-hashed values
-//! let mut map: FxHashMap<PreHashed<String>, String> = FxHashMap::default();
+//! let mut map: HashMap<PreHashed<String>, String> = HashMap::default();
 //!
 //! // insert a prehashed value
 //! let hashed_key = hash_key("hello".to_string());

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -20,7 +20,7 @@ use crate::{
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
 /// use turbo_tasks::{Vc};
 ///
 /// #[turbo_tasks::function(fs)]

--- a/turbopack/crates/turbo-tasks/FORMATTING.md
+++ b/turbopack/crates/turbo-tasks/FORMATTING.md
@@ -8,7 +8,7 @@ read. These macros handle that automatically.
 
 Returns `Result<RcStr>` after resolving all arguments asynchronously.
 
-```rust
+```ignore
 // Positional arguments
 let msg = turbofmt!("asset {} in path {}", asset.ident(), base_path).await?;
 
@@ -28,7 +28,7 @@ formatting directly and are **not** resolved asynchronously.
 Same as `turbofmt!`, but calls `anyhow::bail!()` with the formatted message.
 Has implicit `.await` and return flow.
 
-```rust
+```ignore
 turbobail!("asset {} is not in path {}", asset.ident(), base_path);
 ```
 
@@ -40,14 +40,14 @@ and `ResolvedVc<T>` fields work directly in format strings.
 
 **No attribute** — delegates to `Display::to_string()`:
 
-```rust
+```ignore
 #[derive(ValueToString)]
 struct Foo { ... } // requires Display impl
 ```
 
 **Format string with field references** — fields are resolved async:
 
-```rust
+```ignore
 #[derive(ValueToString)]
 #[value_to_string("[{fs}]/{path}")]
 struct FileSystemPath { fs: ResolvedVc<...>, path: RcStr }
@@ -55,7 +55,7 @@ struct FileSystemPath { fs: ResolvedVc<...>, path: RcStr }
 
 **Format string with explicit expressions:**
 
-```rust
+```ignore
 #[derive(ValueToString)]
 #[value_to_string("{}", self.name())]
 struct Bar { ... }
@@ -63,7 +63,7 @@ struct Bar { ... }
 
 **Direct expression:**
 
-```rust
+```ignore
 #[derive(ValueToString)]
 #[value_to_string(self.inner)]
 struct Wrapper { inner: RcStr }
@@ -71,7 +71,7 @@ struct Wrapper { inner: RcStr }
 
 **Enums** — variants without an attribute default to their name:
 
-```rust
+```ignore
 #[derive(ValueToString)]
 enum Kind {
     Foo,                                    // → "Foo"
@@ -87,7 +87,7 @@ enum Kind {
 The underlying async trait. You rarely need to implement this manually —
 prefer `#[derive(ValueToString)]` instead.
 
-```rust
+```ignore
 #[turbo_tasks::value_trait]
 pub trait ValueToString {
     fn to_string(self: Vc<Self>) -> Vc<RcStr>;

--- a/turbopack/crates/turbo-tasks/function.md
+++ b/turbopack/crates/turbo-tasks/function.md
@@ -1,6 +1,6 @@
 Tasks are created by defining a Rust function annotated with the `#[turbo_tasks::function]` macro and calling it with arguments. Each unique combination of function and arguments create a new task at runtime. Tasks are the fundamental units of work within the build system.
 
-```rust
+```ignore
 #[turbo_tasks::function]
 fn add(a: i32, b: i32) -> Vc<Something> {
     // Task implementation goes here...
@@ -65,7 +65,7 @@ async fn foo(
 
 will have an external signature of
 
-```rust
+```ignore
 fn foo(
     self: Vc<Self>,           // was: &self
     a: i32,
@@ -80,7 +80,7 @@ fn foo(
 The `#[turbo_tasks::function]` macro accepts optional attributes that modify the behavior of the
 task. Multiple attributes can be combined by separating them with commas.
 
-```rust
+```ignore
 #[turbo_tasks::function(fs, session_dependent)]
 async fn read_file(path: RcStr) -> Result<Vc<FileContent>> {
     // ...
@@ -155,7 +155,7 @@ Tasks can be methods associated with a value or a trait implementation using the
 
 ### Inherent Implementations
 
-```rust
+```ignore
 #[turbo_tasks::value_impl]
 impl Something {
     #[turbo_tasks::function]
@@ -201,7 +201,7 @@ impl Something {
 
 ### Trait Implementations
 
-```rust
+```ignore
 #[turbo_tasks::value_impl]
 impl Trait for Something {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -266,7 +266,9 @@ impl EffectStateStorage {
 /// # #![feature(arbitrary_self_types_pointers)]
 /// #
 /// # use anyhow::Result;
-/// # use turbo_tasks::{Effects, ReadRef, Vc, run_once, take_effects};
+/// # use turbo_tasks::{
+/// #     Effects, ReadRef, Vc, read_strongly_consistent_and_apply_effects, take_effects,
+/// # };
 /// #
 /// # async fn _wrapper() -> Result<()> {
 /// # type Example = ();
@@ -292,13 +294,13 @@ impl EffectStateStorage {
 ///     Ok(OutputWithEffects { output, effects }.cell())
 /// }
 ///
-/// // every operation must be read with strong consistency at the top-level
-/// let result_with_effects = some_turbo_tasks_operation_with_effects(args)
-///     .read_strongly_consistent()
-///     .await?;
-///
-/// // apply the effects once outside of a turbo_tasks::function at the top-level (e.g. `run_once`)
-/// result_with_effects.effects.apply().await?;
+/// // read with strong consistency and apply the effects once at the top-level
+/// // (e.g. in a `run_once` closure)
+/// let _result_with_effects = read_strongly_consistent_and_apply_effects(
+///     some_turbo_tasks_operation_with_effects(args),
+///     |result| &result.effects,
+/// )
+/// .await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1982,12 +1982,13 @@ impl CurrentCellRef {
     ///
     /// ```
     /// #[turbo_tasks::value(transparent, eq = "manual")]
+    /// #[derive(Clone)]
     /// struct Wrapper(Vec<u32>);
     ///
     /// impl PartialEq for Wrapper {
-    ///     fn eq(&self, other: Wrapper) {
+    ///     fn eq(&self, other: &Wrapper) -> bool {
     ///         // Example: order doesn't matter for equality
-    ///         let (mut this, mut other) = (self.clone(), other.clone());
+    ///         let (mut this, mut other) = (self.0.clone(), other.0.clone());
     ///         this.sort_unstable();
     ///         other.sort_unstable();
     ///         this == other

--- a/turbopack/crates/turbo-tasks/src/message_queue.rs
+++ b/turbopack/crates/turbo-tasks/src/message_queue.rs
@@ -163,6 +163,9 @@ pub struct TimingEvent {
     ///
     /// Example:
     /// ```rust
+    /// use std::time::Duration;
+    /// use turbo_tasks::message_queue::{CompilationEvent, TimingEvent};
+    ///
     /// let event = TimingEvent::new("Compiled successfully".to_string(), Duration::from_millis(100));
     /// let message = event.message();
     /// assert_eq!(message, "Compiled successfully in 100ms");

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -90,7 +90,12 @@ impl<'a, T> Unpin for CloneReady<'a, T> {}
 /// Structs or enums can be made into task inputs by deriving `TaskInput`:
 ///
 /// ```rust
+/// # use turbo_tasks::{
+/// #     macro_helpers::bincode::{Decode, Encode},
+/// #     trace::TraceRawVcs,
+/// # };
 /// #[turbo_tasks::task_input]
+/// #[derive(Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Encode, Decode)]
 /// struct MyStruct {
 ///     // Fields go here...
 /// }

--- a/turbopack/crates/turbo-tasks/src/vc/README.md
+++ b/turbopack/crates/turbo-tasks/src/vc/README.md
@@ -2,7 +2,7 @@
 
 In order to get a reference to the pointed value, you need to `.await` the [`Vc<T>`] to get a [`ReadRef<T>`][`ReadRef`]:
 
-```
+```ignore
 let some_vc: Vc<T>;
 let some_ref: ReadRef<T> = some_vc.await?;
 some_ref.some_method_on_t();

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -392,7 +392,7 @@ where
     /// usecases.
     ///
     /// # Example
-    /// ```rust
+    /// ```ignore
     /// // In generic code where T might be the same as K
     /// fn process_foo(vc: ResolvedVc<impl Upcast<Box<dyn MyTrait>>>) -> Vc<Foo> {
     ///    let my_trait: ResolvedVc<Box<dyn MyTrait>> = Vc::upcast_non_strict(vc);


### PR DESCRIPTION
## Summary

- Fix Rust documentation examples so workspace doctests compile successfully.
- Mark incomplete illustrative snippets as ignored while keeping runnable examples checked.
- Update stale imports and API usage, and classify directory trees as text.

## Verification

- cargo fmt --all -- --check
- cargo test --workspace --doc --no-fail-fast
- autoreview --mode local --stream-engine-output (Codex + Claude: 0 findings)

<!-- NEXT_JS_LLM -->