### PR TITLE
Run Rust doctests in CI

### DIFF
--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -19,7 +19,7 @@
     "rust-check-doc": "RUSTDOCFLAGS='-Zunstable-options --output-format=json' cargo doc --no-deps --workspace",
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-napi": "cargo check -p next-napi-bindings",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-napi-bindings --exclude turbo-tasks-macros --cargo-profile release-with-assertions --no-fail-fast"
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-napi-bindings --exclude turbo-tasks-macros --cargo-profile release-with-assertions --no-fail-fast && cargo test --workspace --doc --profile=release-with-assertions --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",


### PR DESCRIPTION
## Summary

Run all Rust workspace doctests as part of the existing Turbo-cached cargo unit test task so future documentation regressions fail CI without adding an uncached workspace build.

## Verification

- `cargo test --workspace --doc --profile=release-with-assertions --no-fail-fast`
- Not run: `pnpm --filter=@next/swc test-cargo-unit` (`cargo-nextest` is installed in CI but unavailable locally; the new doctest suffix passed independently)

<!-- NEXT_JS_LLM -->