### PR TITLE
Avoid duplicate cached redirect headers

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1856,18 +1856,19 @@ export function createAppPageEntrypoint({
             delete headers[NEXT_CACHE_TAGS_HEADER]
           }
 
+          const nextRes = new NodeNextResponse(res)
           for (let [key, value] of Object.entries(headers)) {
             if (typeof value === 'undefined') continue
 
             if (Array.isArray(value)) {
               for (const v of value) {
-                res.appendHeader(key, v)
+                nextRes.appendHeader(key, v)
               }
             } else if (typeof value === 'number') {
               value = value.toString()
-              res.appendHeader(key, value)
+              nextRes.appendHeader(key, value)
             } else {
-              res.appendHeader(key, value)
+              nextRes.appendHeader(key, value)
             }
           }
         }

--- a/test/production/app-dir/cached-redirect-headers/app/[...slug]/page.tsx
+++ b/test/production/app-dir/cached-redirect-headers/app/[...slug]/page.tsx
@@ -1,7 +1,17 @@
-import { permanentRedirect } from 'next/navigation'
+import { permanentRedirect, redirect } from 'next/navigation'
 
 export const dynamic = 'force-static'
 
-export default function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+
+  if (slug[0] === 'temporary') {
+    redirect('/destination')
+  }
+
   permanentRedirect('/destination')
 }

--- a/test/production/app-dir/cached-redirect-headers/app/[...slug]/page.tsx
+++ b/test/production/app-dir/cached-redirect-headers/app/[...slug]/page.tsx
@@ -1,0 +1,7 @@
+import { permanentRedirect } from 'next/navigation'
+
+export const dynamic = 'force-static'
+
+export default function Page() {
+  permanentRedirect('/destination')
+}

--- a/test/production/app-dir/cached-redirect-headers/app/destination/page.tsx
+++ b/test/production/app-dir/cached-redirect-headers/app/destination/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>destination</p>
+}

--- a/test/production/app-dir/cached-redirect-headers/app/isr/[slug]/page.tsx
+++ b/test/production/app-dir/cached-redirect-headers/app/isr/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import { permanentRedirect } from 'next/navigation'
+
+export const revalidate = 1
+
+export function generateStaticParams() {
+  return [{ slug: 'prerendered' }]
+}
+
+export default function Page() {
+  permanentRedirect('/destination')
+}

--- a/test/production/app-dir/cached-redirect-headers/app/layout.tsx
+++ b/test/production/app-dir/cached-redirect-headers/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/cached-redirect-headers/cached-redirect-headers.test.ts
+++ b/test/production/app-dir/cached-redirect-headers/cached-redirect-headers.test.ts
@@ -2,6 +2,8 @@ import { once } from 'node:events'
 import http from 'node:http'
 import { nextTestSetup } from 'e2e-utils'
 
+const destination = '/destination'
+
 function getRawHeaderValues(rawHeaders: string[], name: string) {
   const values: string[] = []
 
@@ -14,27 +16,56 @@ function getRawHeaderValues(rawHeaders: string[], name: string) {
   return values
 }
 
+async function getRawResponse(url: URL): Promise<http.IncomingMessage> {
+  const response = await new Promise<http.IncomingMessage>(
+    (resolve, reject) => {
+      http.get(url, resolve).on('error', reject)
+    }
+  )
+
+  response.resume()
+  await once(response, 'end')
+  return response
+}
+
+function expectSingleRedirect(
+  response: http.IncomingMessage,
+  statusCode: 307 | 308
+) {
+  expect(response.statusCode).toBe(statusCode)
+  expect(getRawHeaderValues(response.rawHeaders, 'location')).toEqual([
+    destination,
+  ])
+  expect(
+    getRawHeaderValues(response.rawHeaders, 'x-nextjs-stale-time')
+  ).toHaveLength(1)
+}
+
 describe('cached redirect headers', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
-  it('does not duplicate cached redirect headers', async () => {
-    const response = await new Promise<http.IncomingMessage>(
-      (resolve, reject) => {
-        http.get(new URL('/test', next.url), resolve).on('error', reject)
-      }
-    )
+  it.each([
+    { pathname: '/permanent', statusCode: 308 as const },
+    { pathname: '/temporary', statusCode: 307 as const },
+  ])(
+    'does not duplicate force-static $statusCode redirect headers',
+    async ({ pathname, statusCode }) => {
+      const response = await getRawResponse(new URL(pathname, next.url))
 
-    response.resume()
-    await once(response, 'end')
+      expectSingleRedirect(response, statusCode)
+    }
+  )
 
-    expect(response.statusCode).toBe(308)
-    expect(getRawHeaderValues(response.rawHeaders, 'location')).toEqual([
-      '/destination',
-    ])
-    expect(
-      getRawHeaderValues(response.rawHeaders, 'x-nextjs-stale-time')
-    ).toHaveLength(1)
+  it('does not duplicate ISR fallback redirect headers', async () => {
+    const url = new URL('/isr/fallback', next.url)
+
+    expectSingleRedirect(await getRawResponse(url), 308)
+    expectSingleRedirect(await getRawResponse(url), 308)
+
+    await new Promise((resolve) => setTimeout(resolve, 1_100))
+
+    expectSingleRedirect(await getRawResponse(url), 308)
   })
 })

--- a/test/production/app-dir/cached-redirect-headers/cached-redirect-headers.test.ts
+++ b/test/production/app-dir/cached-redirect-headers/cached-redirect-headers.test.ts
@@ -1,0 +1,40 @@
+import { once } from 'node:events'
+import http from 'node:http'
+import { nextTestSetup } from 'e2e-utils'
+
+function getRawHeaderValues(rawHeaders: string[], name: string) {
+  const values: string[] = []
+
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    if (rawHeaders[index].toLowerCase() === name.toLowerCase()) {
+      values.push(rawHeaders[index + 1])
+    }
+  }
+
+  return values
+}
+
+describe('cached redirect headers', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('does not duplicate cached redirect headers', async () => {
+    const response = await new Promise<http.IncomingMessage>(
+      (resolve, reject) => {
+        http.get(new URL('/test', next.url), resolve).on('error', reject)
+      }
+    )
+
+    response.resume()
+    await once(response, 'end')
+
+    expect(response.statusCode).toBe(308)
+    expect(getRawHeaderValues(response.rawHeaders, 'location')).toEqual([
+      '/destination',
+    ])
+    expect(
+      getRawHeaderValues(response.rawHeaders, 'x-nextjs-stale-time')
+    ).toHaveLength(1)
+  })
+})

--- a/test/production/app-dir/cached-redirect-headers/next.config.js
+++ b/test/production/app-dir/cached-redirect-headers/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
**Summary**

Fix duplicate headers when a cached App Router redirect response is replayed.

**Root cause**

Cached response headers were appended directly to the native Node response. This bypassed the duplicate-value protection already implemented by `NodeNextResponse.appendHeader`.

As a result, headers such as `Location` and `x-nextjs-stale-time` could be emitted twice. Intermediaries that combine repeated `Location` headers could then produce an invalid value such as `/destination, /destination`.

**Changes**

- Replay cached headers through `NodeNextResponse.appendHeader`.
- Avoid appending identical values that are already present.
- Preserve distinct values for legitimate multi-value headers.

**Regression coverage**

The production fixture inspects raw Node response headers and covers:

- `dynamic = 'force-static'` with `permanentRedirect()` (`308`).
- `dynamic = 'force-static'` with `redirect()` (`307`).
- ISR fallback generation for a dynamic route whose requested parameter was not returned by `generateStaticParams()`.
- The ISR response on initial generation, cache reuse, and after the revalidation window.
- A single `Location` value and a single `x-nextjs-stale-time` value for every cached redirect response.

The expanded tests fail against the previous implementation with two raw `Location` values and pass with this fix.

**Additional validation**

- Reproduced the original issue's catch-all `force-static` example.
- Reproduced the reported Next.js 16.1.6 `cacheComponents: true` case using a cached, revalidatable dynamic fallback route. Its first response emitted two `Location` headers before this change and one after applying the same header-replay fix.
- Verified the response directly from `next start`, without a proxy. Emitting one raw `Location` header also prevents Cloudflare/Datadome-style comma merging and the malformed redirect observed by crawlers.

**Validation completed on current canary**

- Next.js package build and type generation.
- Webpack production test.
- Turbopack production test.
- Focused ESLint.
- Prettier.
- Signed commit and pre-commit hooks.

Fixes #82117
