### PR TITLE
test(instant-validation): failing fixtures for navigation signals in a parent layout

### DIFF
--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -1,18 +1,33 @@
 ---
 title: Error Handling
-description: Learn how to display expected errors and handle uncaught exceptions.
+description: Learn how to display expected errors, render 404 and auth UI, and recover from uncaught exceptions.
 related:
   title: API Reference
   description: Learn more about the features mentioned in this page by reading the API Reference.
   links:
     - app/api-reference/functions/redirect
+    - app/api-reference/config/next-config-js/authInterrupts
+    - app/api-reference/functions/unauthorized
+    - app/api-reference/functions/forbidden
     - app/api-reference/file-conventions/error
     - app/api-reference/functions/catchError
     - app/api-reference/functions/not-found
     - app/api-reference/file-conventions/not-found
 ---
 
-Errors can be divided into two categories: [expected errors](#handling-expected-errors) and [uncaught exceptions](#handling-uncaught-exceptions). This page will walk you through how you can handle these errors in your Next.js application.
+Errors can be divided into two categories: [expected errors](#handling-expected-errors) and [uncaught exceptions](#handling-uncaught-exceptions). This page will walk you through how to handle these errors in your Next.js application.
+
+Use the smallest boundary that matches what happened. Expected errors should stay in the UI that caused them. Framework interrupts should change the route response. Uncaught exceptions should render an error boundary.
+
+| What happened                                     | Handle it with                                                                                                                                                                                                                         |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A form field failed validation                    | Return an error value from the Server Function and show an inline message with [`useActionState`](https://react.dev/reference/react/useActionState).                                                                                   |
+| A mutation failed but the user can keep working   | Return an error value and show a toast or local message from the Client Component that invoked the action.                                                                                                                             |
+| A resource does not exist                         | Call [`notFound()`](/docs/app/api-reference/functions/not-found) and render a [`not-found.js`](/docs/app/api-reference/file-conventions/not-found) file.                                                                               |
+| A user is not signed in or does not have access   | Enable [`authInterrupts`](/docs/app/api-reference/config/next-config-js/authInterrupts), then call [`unauthorized()`](/docs/app/api-reference/functions/unauthorized) or [`forbidden()`](/docs/app/api-reference/functions/forbidden). |
+| A route segment throws an unexpected error        | Throw the error and recover with [`error.js`](/docs/app/api-reference/file-conventions/error).                                                                                                                                         |
+| A smaller Server Component subtree needs recovery | Wrap that subtree with [`catchError`](/docs/app/api-reference/functions/catchError).                                                                                                                                                   |
+| The root layout throws an unexpected error        | Recover with [`global-error.js`](/docs/app/api-reference/file-conventions/error#global-error).                                                                                                                                         |
 
 ## Handling expected errors
 
@@ -22,7 +37,7 @@ Expected errors are those that can occur during the normal operation of the appl
 
 You can use the [`useActionState`](https://react.dev/reference/react/useActionState) hook to handle expected errors in [Server Functions](https://react.dev/reference/rsc/server-functions).
 
-For these errors, avoid using `try`/`catch` blocks and throw errors. Instead, model expected errors as return values.
+For these errors, avoid using `try`/`catch` blocks to throw errors. Instead, model expected errors as return values.
 
 ```ts filename="app/actions.ts" switcher
 'use server'
@@ -116,6 +131,108 @@ export function Form() {
 }
 ```
 
+Use an inline message when the error blocks the current interaction, such as a missing required field or invalid input. Use a toast or another local notification when the action failed but the user can keep working, such as a save failure in a toolbar button.
+
+For example, a Client Component can call a Server Function from an event handler and show a toast from the returned value:
+
+```tsx filename="app/ui/save-button.tsx" switcher
+'use client'
+
+import { useTransition } from 'react'
+import { savePost } from '@/app/actions'
+import { toast } from '@/app/ui/toast'
+
+export function SaveButton({ postId }: { postId: string }) {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <button
+      disabled={isPending}
+      onClick={() => {
+        startTransition(async () => {
+          const result = await savePost(postId)
+
+          if (result?.error) {
+            toast.error(result.error)
+            return
+          }
+
+          toast.success('Post saved')
+        })
+      }}
+    >
+      Save
+    </button>
+  )
+}
+```
+
+```jsx filename="app/ui/save-button.js" switcher
+'use client'
+
+import { useTransition } from 'react'
+import { savePost } from '@/app/actions'
+import { toast } from '@/app/ui/toast'
+
+export function SaveButton({ postId }) {
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <button
+      disabled={isPending}
+      onClick={() => {
+        startTransition(async () => {
+          const result = await savePost(postId)
+
+          if (result?.error) {
+            toast.error(result.error)
+            return
+          }
+
+          toast.success('Post saved')
+        })
+      }}
+    >
+      Save
+    </button>
+  )
+}
+```
+
+The Server Function still returns a value instead of throwing:
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+export async function savePost(postId: string) {
+  const res = await fetch(`https://api.vercel.app/posts/${postId}`, {
+    method: 'PATCH',
+  })
+
+  if (!res.ok) {
+    return { error: 'Failed to save post' }
+  }
+
+  return { error: null }
+}
+```
+
+```js filename="app/actions.js" switcher
+'use server'
+
+export async function savePost(postId) {
+  const res = await fetch(`https://api.vercel.app/posts/${postId}`, {
+    method: 'PATCH',
+  })
+
+  if (!res.ok) {
+    return { error: 'Failed to save post' }
+  }
+
+  return { error: null }
+}
+```
+
 ### Server Components
 
 When fetching data inside of a Server Component, you can use the response to conditionally render an error message or [`redirect`](/docs/app/api-reference/functions/redirect).
@@ -198,6 +315,98 @@ export default function NotFound() {
 }
 ```
 
+### Auth interrupts
+
+When a route should render login or access-denied UI, use the `unauthorized()` and `forbidden()` functions instead of returning a local error message. These functions require the experimental [`authInterrupts`](/docs/app/api-reference/config/next-config-js/authInterrupts) option:
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    authInterrupts: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+module.exports = {
+  experimental: {
+    authInterrupts: true,
+  },
+}
+```
+
+Then call [`unauthorized()`](/docs/app/api-reference/functions/unauthorized) when the user needs to sign in, or [`forbidden()`](/docs/app/api-reference/functions/forbidden) when the user is signed in but lacks permission:
+
+```tsx filename="app/admin/page.tsx" switcher
+import { forbidden, unauthorized } from 'next/navigation'
+import { verifySession } from '@/app/lib/dal'
+
+export default async function AdminPage() {
+  const session = await verifySession()
+
+  if (!session) {
+    unauthorized()
+  }
+
+  if (session.role !== 'admin') {
+    forbidden()
+  }
+
+  return <h1>Admin</h1>
+}
+```
+
+```jsx filename="app/admin/page.js" switcher
+import { forbidden, unauthorized } from 'next/navigation'
+import { verifySession } from '@/app/lib/dal'
+
+export default async function AdminPage() {
+  const session = await verifySession()
+
+  if (!session) {
+    unauthorized()
+  }
+
+  if (session.role !== 'admin') {
+    forbidden()
+  }
+
+  return <h1>Admin</h1>
+}
+```
+
+Create the matching UI files for the route:
+
+```tsx filename="app/admin/unauthorized.tsx" switcher
+export default function Unauthorized() {
+  return <h1>Please sign in to continue</h1>
+}
+```
+
+```jsx filename="app/admin/unauthorized.js" switcher
+export default function Unauthorized() {
+  return <h1>Please sign in to continue</h1>
+}
+```
+
+```tsx filename="app/admin/forbidden.tsx" switcher
+export default function Forbidden() {
+  return <h1>You do not have access to this page</h1>
+}
+```
+
+```jsx filename="app/admin/forbidden.js" switcher
+export default function Forbidden() {
+  return <h1>You do not have access to this page</h1>
+}
+```
+
+Use auth interrupts when authentication or authorization should change the route UI and status. Use a returned value or toast when the user can stay in the same workflow.
+
 ## Handling uncaught exceptions
 
 Uncaught exceptions are unexpected errors that indicate bugs or issues that should not occur during the normal flow of your application. These should be handled by throwing errors, which will then be caught by error boundaries.
@@ -278,7 +487,7 @@ Errors will bubble up to the nearest parent error boundary. This allows for gran
   height="687"
 />
 
-For component-level error recovery, the [`catchError`](/docs/app/api-reference/functions/catchError) function lets you create error boundaries that can wrap any part of your component tree:
+For component-level error recovery, the [`catchError`](/docs/app/api-reference/functions/catchError) function lets you create error boundaries that can wrap any part of your component tree. Use `catchError` when a smaller Server Component subtree can fail and recover without replacing the whole route segment.
 
 ```tsx filename="app/custom-error-boundary.tsx" switcher
 'use client'
@@ -333,6 +542,8 @@ export default function Component({ children }) {
   return <ErrorBoundary title="Dashboard Error">{children}</ErrorBoundary>
 }
 ```
+
+Both `error.js` and `catchError` receive a `retry()` function. When called, `retry()` re-fetches and re-renders the boundary's children. If the render succeeds, the fallback is replaced with the recovered UI.
 
 Error boundaries don't catch errors inside event handlers. They're designed to catch errors [during rendering](https://react.dev/reference/react/Component#static-getderivedstatefromerror) to show a **fallback UI** instead of crashing the whole app.
 

--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -5,6 +5,7 @@ description: API Reference for the next/root-params module that provides access 
 related:
   description: Related API references and conventions.
   links:
+    - app/guides/internationalization
     - app/api-reference/file-conventions/layout
     - app/api-reference/functions/generate-static-params
     - app/api-reference/directives/use-cache

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/forbidden-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/forbidden-blocks-children/layout.tsx
@@ -1,0 +1,28 @@
+import { Suspense, type ReactNode } from 'react'
+import { connection } from 'next/server'
+import { forbidden } from 'next/navigation'
+
+export const instant = false
+
+// See not-found-blocks-children: `forbidden()` throws an HTTP-access-fallback
+// signal (403), the same family as notFound(). It must not be reported as an
+// instant-validation failure. Requires `experimental.authInterrupts`.
+function Bail() {
+  forbidden()
+}
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  await connection()
+  return (
+    <>
+      <p>
+        This layout calls forbidden() inside a Suspense boundary that also wraps
+        the children slot, preventing the instant page from rendering.
+      </p>
+      <Suspense>
+        <Bail />
+        {children}
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/forbidden-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/forbidden-blocks-children/page.tsx
@@ -1,0 +1,12 @@
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return (
+    <main>
+      <p>
+        This page has instant validation but a forbidden() signal in the parent
+        layout bails before it renders.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/not-found-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/not-found-blocks-children/layout.tsx
@@ -1,0 +1,29 @@
+import { Suspense, type ReactNode } from 'react'
+import { connection } from 'next/server'
+import { notFound } from 'next/navigation'
+
+export const instant = false
+
+// A parent layout that bails with a framework navigation signal (here
+// `notFound()`) must NOT be reported as an instant-validation failure. The
+// signal is an intentional bail, not "an error prevented the target segment
+// from rendering", so no "Could not validate `instant`" wrapper should appear.
+function Bail() {
+  notFound()
+}
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  await connection()
+  return (
+    <>
+      <p>
+        This layout calls notFound() inside a Suspense boundary that also wraps
+        the children slot, preventing the instant page from rendering.
+      </p>
+      <Suspense>
+        <Bail />
+        {children}
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/not-found-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/not-found-blocks-children/page.tsx
@@ -1,0 +1,12 @@
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return (
+    <main>
+      <p>
+        This page has instant validation but a notFound() signal in the parent
+        layout bails before it renders.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/redirect-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/redirect-blocks-children/layout.tsx
@@ -1,0 +1,28 @@
+import { Suspense, type ReactNode } from 'react'
+import { connection } from 'next/server'
+import { redirect } from 'next/navigation'
+
+export const instant = false
+
+// See not-found-blocks-children: `redirect()` is a navigation signal, not a
+// validation failure. It goes through `isRedirectError`, the other branch of
+// the skip in the validation onError handler.
+function Bail() {
+  redirect('/suspense-in-root')
+}
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  await connection()
+  return (
+    <>
+      <p>
+        This layout calls redirect() inside a Suspense boundary that also wraps
+        the children slot, preventing the instant page from rendering.
+      </p>
+      <Suspense>
+        <Bail />
+        {children}
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/redirect-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/redirect-blocks-children/page.tsx
@@ -1,0 +1,12 @@
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return (
+    <main>
+      <p>
+        This page has instant validation but a redirect() signal in the parent
+        layout bails before it renders.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/unauthorized-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/unauthorized-blocks-children/layout.tsx
@@ -1,0 +1,28 @@
+import { Suspense, type ReactNode } from 'react'
+import { connection } from 'next/server'
+import { unauthorized } from 'next/navigation'
+
+export const instant = false
+
+// See not-found-blocks-children: `unauthorized()` throws an HTTP-access-fallback
+// signal (401), the same family as notFound()/forbidden(). It must not be
+// reported as an instant-validation failure. Requires `experimental.authInterrupts`.
+function Bail() {
+  unauthorized()
+}
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  await connection()
+  return (
+    <>
+      <p>
+        This layout calls unauthorized() inside a Suspense boundary that also
+        wraps the children slot, preventing the instant page from rendering.
+      </p>
+      <Suspense>
+        <Bail />
+        {children}
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/unauthorized-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/unauthorized-blocks-children/page.tsx
@@ -1,0 +1,12 @@
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return (
+    <main>
+      <p>
+        This page has instant validation but an unauthorized() signal in the
+        parent layout bails before it renders.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/next.config.ts
+++ b/test/e2e/app-dir/instant-validation/next.config.ts
@@ -3,6 +3,8 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
+    // Needed for the forbidden()/unauthorized() navigation-signal fixtures.
+    authInterrupts: true,
     instantInsights: {
       validationLevel: 'manual-warning',
     },

--- a/test/e2e/app-dir/instant-validation/server-errors.test.ts
+++ b/test/e2e/app-dir/instant-validation/server-errors.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import {
   extractBuildValidationError,
+  getDevCliValidationOutput,
   waitForValidation,
 } from 'e2e-utils/instant-validation'
 import { retry, waitForRedbox } from '../../../lib/next-test-utils'
@@ -184,6 +185,64 @@ describe('instant validation - server errors', () => {
       }
     })
   })
+
+  // Bug witness: a navigation signal — notFound(), redirect(), forbidden(),
+  // unauthorized() — in a parent layout intentionally prevents the target
+  // segment from rendering. That is control flow, not a failure to validate
+  // instant UI, so it should NOT surface a "Could not validate `instant`"
+  // error. Today it does: the target boundary never renders, so validation
+  // reports the segment as unrendered / prevented-from-rendering.
+  //
+  // The correct fix (Josh Story) gates validation on the segments the *real*
+  // render actually produced, so a signalled bail is never "required" and no
+  // false positive is raised. Detecting the signal inside the validation pass
+  // is not enough — the validation render is separate from the real render and
+  // can't reliably tell an intentional bail from a divergent render. When the
+  // rendered-segment-set fix lands, `it.failing` will itself fail — flip to
+  // `it`.
+  const navigationSignals = [
+    {
+      name: 'notFound',
+      path: '/suspense-in-root/static/not-found-blocks-children',
+    },
+    {
+      name: 'redirect',
+      path: '/suspense-in-root/static/redirect-blocks-children',
+    },
+    {
+      name: 'forbidden',
+      path: '/suspense-in-root/static/forbidden-blocks-children',
+    },
+    {
+      name: 'unauthorized',
+      path: '/suspense-in-root/static/unauthorized-blocks-children',
+    },
+  ]
+
+  describe.each(cases)(
+    '$description - navigation signals',
+    ({ isClientNav }) => {
+      /* eslint-disable jest/no-standalone-expect */
+      for (const { name, path } of navigationSignals) {
+        // Only dev initial load reproduces the false positive deterministically;
+        // client nav to a redirect changes the URL, and build handles the signal
+        // as a normal response.
+        ;(isNextDev && !isClientNav ? it.failing : it)(
+          `${name}() in a parent layout is control flow, not a validation failure`,
+          async () => {
+            if (!isNextDev || isClientNav) return
+            await next.browser(path)
+            const output = await getDevCliValidationOutput(
+              next.url + path,
+              getCliOutputSinceMark
+            )
+            expect(output).not.toContain('Could not validate')
+          }
+        )
+      }
+      /* eslint-enable jest/no-standalone-expect */
+    }
+  )
 
   async function navigateViaClientNav(href: string): Promise<Playwright> {
     const browser = await next.browser('/suspense-in-root')


### PR DESCRIPTION
Bug-witness `it.failing` tests for a false positive in instant validation.

## The bug

A navigation signal — `notFound()`, `redirect()`, `forbidden()`, `unauthorized()` — in a **parent layout** intentionally prevents the target segment from rendering. That's control flow, not a failure to validate instant UI, but today it surfaces a `Could not validate \`instant\`` error: the target boundary never renders, so validation reports the segment as unrendered / prevented-from-rendering.

Repro shape (per fixture): a parent layout bails with the signal while wrapping the instant child; the child page has `instant = { level: 'experimental-error' }`.

## What's here

- Four fixtures under `app/suspense-in-root/static/{not-found,redirect,forbidden,unauthorized}-blocks-children`.
- `experimental.authInterrupts` enabled in the suite config (needed for `forbidden()`/`unauthorized()`).
- Tests assert the dev validation output does **not** contain `Could not validate`.

The tests fail today, so they're marked `it.failing`, scoped to dev initial load where the false positive reproduces deterministically (client nav to a redirect changes the URL; build handles the signal as a normal response). Uses `getDevCliValidationOutput` + a plain `not.toContain` assertion (not inline snapshots) to avoid the `it.failing` + snapshot issue.

## Why not just fix it here

Detecting the signal inside the validation pass is not enough — the validation render is separate from the real render and can't reliably tell an intentional bail from a divergent render (an RSC-only pass doesn't know what SSR will/won't render). The correct fix (@Josh Story) gates validation on the segments the *real* render actually produced, so a signalled bail is never "required." **When that lands, `it.failing` will itself fail — flip to `it`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)