### PR TITLE
Fix loopback middleware rewrites behind TLS proxies

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -14,7 +14,10 @@ import { getCloneableBody } from '../../body-streams'
 import { filterReqHeaders, ipcForbiddenHeaders } from '../server-ipc/utils'
 import { stringifyQuery } from '../../server-route-utils'
 import { formatHostname } from '../format-hostname'
-import { toNodeOutgoingHttpHeaders } from '../../web/utils'
+import {
+  normalizeLoopbackHostname,
+  toNodeOutgoingHttpHeaders,
+} from '../../web/utils'
 import { isAbortError } from '../../pipe-readable'
 import { getHostname } from '../../../shared/lib/get-hostname'
 import {
@@ -171,12 +174,13 @@ export function getResolveRoutes(
         : 'http'
 
     // When there are hostname and port we build an absolute URL
+    const initHostname = formatHostname(
+      normalizeLoopbackHostname(opts.hostname || 'localhost')
+    )
     const initUrl = (config.experimental as any).trustHostHeader
       ? `https://${req.headers.host || 'localhost'}${req.url}`
       : opts.port
-        ? `${protocol}://${formatHostname(opts.hostname || 'localhost')}:${
-            opts.port
-          }${req.url}`
+        ? `${protocol}://${initHostname}:${opts.port}${req.url}`
         : req.url || ''
 
     addRequestMeta(req, 'initURL', initUrl)

--- a/packages/next/src/server/web/next-url.ts
+++ b/packages/next/src/server/web/next-url.ts
@@ -6,6 +6,7 @@ import { detectDomainLocale } from '../../shared/lib/i18n/detect-domain-locale'
 import { formatNextPathnameInfo } from '../../shared/lib/router/utils/format-next-pathname-info'
 import { getHostname } from '../../shared/lib/get-hostname'
 import { getNextPathnameInfo } from '../../shared/lib/router/utils/get-next-pathname-info'
+import { normalizeLoopbackHostname } from './utils'
 
 interface Options {
   base?: string | URL
@@ -19,14 +20,9 @@ interface Options {
   i18nProvider?: I18NProvider
 }
 
-const REGEX_LOCALHOST_HOSTNAME =
-  /^(?:127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}|\[::1\]|localhost)$/
-
 function parseURL(url: string | URL, base?: string | URL) {
   const parsed = new URL(String(url), base && String(base))
-  if (REGEX_LOCALHOST_HOSTNAME.test(parsed.hostname)) {
-    parsed.hostname = 'localhost'
-  }
+  parsed.hostname = normalizeLoopbackHostname(parsed.hostname)
   return parsed
 }
 

--- a/packages/next/src/server/web/utils.test.ts
+++ b/packages/next/src/server/web/utils.test.ts
@@ -1,4 +1,20 @@
-import { toNodeOutgoingHttpHeaders } from './utils'
+import { normalizeLoopbackHostname, toNodeOutgoingHttpHeaders } from './utils'
+
+describe('normalizeLoopbackHostname', () => {
+  it.each([
+    ['localhost', 'localhost'],
+    ['LOCALHOST', 'localhost'],
+    ['127.0.0.1', 'localhost'],
+    ['127.255.255.255', 'localhost'],
+    ['::1', 'localhost'],
+    ['[::1]', 'localhost'],
+    ['127.0.0.256', '127.0.0.256'],
+    ['192.168.0.1', '192.168.0.1'],
+    ['example.com', 'example.com'],
+  ])('normalizes %s to %s', (hostname, expected) => {
+    expect(normalizeLoopbackHostname(hostname)).toBe(expected)
+  })
+})
 
 describe('toNodeHeaders', () => {
   it('should handle multiple set-cookie headers correctly', () => {

--- a/packages/next/src/server/web/utils.ts
+++ b/packages/next/src/server/web/utils.ts
@@ -4,6 +4,13 @@ import {
   NEXT_QUERY_PARAM_PREFIX,
 } from '../../lib/constants'
 
+const LOOPBACK_HOSTNAME_REGEX =
+  /^(?:127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}|\[::1\]|::1|localhost)$/i
+
+export function normalizeLoopbackHostname(hostname: string): string {
+  return LOOPBACK_HOSTNAME_REGEX.test(hostname) ? 'localhost' : hostname
+}
+
 /**
  * Converts a Node.js IncomingHttpHeaders object to a Headers object. Any
  * headers with multiple values will be joined with a comma and space. Any

--- a/test/production/middleware-rewrite-loopback-hostname/middleware-rewrite-loopback-hostname.test.ts
+++ b/test/production/middleware-rewrite-loopback-hostname/middleware-rewrite-loopback-hostname.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('middleware rewrite with a loopback hostname', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    startArgs: ['-H', '127.0.0.1'],
+  })
+
+  it('keeps the rewrite internal when HTTPS is forwarded', async () => {
+    const res = await next.fetch('/a', {
+      headers: {
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('rewritten-b')
+    expect(next.cliOutput).not.toContain('Failed to proxy')
+  })
+})

--- a/test/production/middleware-rewrite-loopback-hostname/middleware.ts
+++ b/test/production/middleware-rewrite-loopback-hostname/middleware.ts
@@ -1,0 +1,7 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === '/a') {
+    return NextResponse.rewrite(new URL('/b', request.url))
+  }
+}

--- a/test/production/middleware-rewrite-loopback-hostname/pages/a.tsx
+++ b/test/production/middleware-rewrite-loopback-hostname/pages/a.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>original-a</p>
+}

--- a/test/production/middleware-rewrite-loopback-hostname/pages/b.tsx
+++ b/test/production/middleware-rewrite-loopback-hostname/pages/b.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>rewritten-b</p>
+}


### PR DESCRIPTION
### What?

Keep middleware rewrites internal when Next.js is started with an explicit loopback hostname.

### Why?

Loopback hosts are normalized by `NextURL`, but `resolve-routes.ts` constructs `initUrl` using the literal hostname. With `127.0.0.1` or `[::1]`, the origin mismatch causes an internal middleware rewrite to be treated as an external proxy, producing `EPROTO`.

### How?

- Share the loopback hostname normalization used by `NextURL`.
- Normalize the configured hostname before constructing `initUrl`.
- Add a production regression test for `next start -H 127.0.0.1` with `X-Forwarded-Proto: https`.

Fixes #94745

### Tests

- `pnpm exec jest packages/next/src/server/web/utils.test.ts --runInBand`
- `pnpm exec jest test/unit/web-runtime/next-url.test.ts --runInBand`
- `pnpm --filter=next types`
- `pnpm test-start-webpack test/production/middleware-rewrite-loopback-hostname/middleware-rewrite-loopback-hostname.test.ts`
- `pnpm test-start-turbo test/production/middleware-rewrite-loopback-hostname/middleware-rewrite-loopback-hostname.test.ts`
