### PR TITLE
test(instant-validation): witness the throw-site vs mount-site call-stack labelling gap

### DIFF
--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/mount-site-not-labelled/app-sidebar.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/mount-site-not-labelled/app-sidebar.tsx
@@ -1,0 +1,14 @@
+import { DynamicBreadcrumb } from './dynamic-breadcrumb'
+
+// Mount site: <DynamicBreadcrumb /> is rendered here with no <Suspense> around
+// it. THIS is where the fix goes — but the dev-overlay call stack lists this
+// frame identically to the throw site, with nothing marking it as the mount
+// site / where the <Suspense> boundary belongs.
+export function AppSideBar() {
+  return (
+    <aside>
+      <h2>Sidebar</h2>
+      <DynamicBreadcrumb />
+    </aside>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/mount-site-not-labelled/dynamic-breadcrumb.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/mount-site-not-labelled/dynamic-breadcrumb.tsx
@@ -1,0 +1,11 @@
+import { cookies } from 'next/headers'
+
+// Throw site: the runtime data access. The instant-validation error's code
+// frame correctly points here — but wrapping THIS component in <Suspense>
+// does not fix it. The boundary has to go around the mount site (see
+// app-sidebar.tsx), one frame up.
+export async function DynamicBreadcrumb() {
+  const cookieStore = await cookies()
+  const theme = cookieStore.get('theme')?.value ?? 'system'
+  return <nav>Theme: {theme}</nav>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/mount-site-not-labelled/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/mount-site-not-labelled/page.tsx
@@ -1,0 +1,15 @@
+import { AppSideBar } from './app-sidebar'
+
+export const instant = { level: 'experimental-error' }
+
+// The runtime data access lives in dynamic-breadcrumb.tsx (throw site), mounted
+// by app-sidebar.tsx (mount site). The dev-overlay call stack contains both
+// frames but does not label which is which, so a reader following "wrap the
+// data access in <Suspense>" edits the throw site instead of the mount site.
+export default function Page() {
+  return (
+    <main>
+      <AppSideBar />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/mount-site-labelling.test.ts
+++ b/test/e2e/app-dir/instant-validation/mount-site-labelling.test.ts
@@ -1,0 +1,81 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  openRedbox,
+  getRedboxCallStack,
+  getRedboxSource,
+} from '../../../lib/next-test-utils'
+
+// Bug witness for the "throw site vs mount site" call-stack gap.
+//
+// A runtime data access lives in a leaf component (the *throw site*,
+// `dynamic-breadcrumb.tsx`), mounted by a parent (the *mount site*,
+// `app-sidebar.tsx`). The `<Suspense>` fix has to go around the mount site —
+// wrapping the throw site itself does nothing, because Suspense must be above
+// the suspending component.
+//
+// The dev overlay already surfaces both frames in the Call Stack, and the code
+// frame correctly points at the throw site. What's missing is any labelling
+// that tells the reader which frame is the throw site and which is the mount
+// site (where the `<Suspense>` edit belongs). So a reader/agent following
+// "wrap the data access in <Suspense>" edits the throw site and the error
+// persists.
+//
+// See reproductions/cases/mounting-call-site-not-in-stack.
+describe('instant validation - mount-site labelling', () => {
+  const { next, skipped, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+    },
+  })
+  if (skipped) return
+  if (!isNextDev) {
+    // The call-stack labelling is a dev-overlay concern only.
+    it('dev-only', () => {})
+    return
+  }
+
+  const ROUTE = '/suspense-in-root/static/mount-site-not-labelled'
+
+  it('code frame points at the throw site (correct — must not be repointed)', async () => {
+    const browser = await next.browser(ROUTE)
+    await openRedbox(browser)
+    const source = await getRedboxSource(browser)
+    // The throw site is the correct code-frame target. The fix for the gap
+    // below is to label the mount frame, NOT to move this caret.
+    expect(source).toContain('dynamic-breadcrumb.tsx')
+    expect(source).toContain('await cookies()')
+  })
+
+  it('call stack contains both the throw site and the mount site', async () => {
+    const browser = await next.browser(ROUTE)
+    await openRedbox(browser)
+    const stack = (await getRedboxCallStack(browser)) ?? []
+    const joined = stack.join('\n')
+    // The data is already there — the mount site is not "missing" from the stack.
+    expect(joined).toContain('dynamic-breadcrumb.tsx') // throw site
+    expect(joined).toContain('app-sidebar.tsx') // mount site
+  })
+
+  // The gap: today both frames render identically (`Name file (line:col)`), with
+  // nothing marking which is the throw site and which is the mount site where
+  // the `<Suspense>` boundary goes. This asserts the desired distinction; it
+  // fails today, so it's `it.failing`. When the overlay labels the frames,
+  // this flips — change `it.failing` to `it` (and tighten the matcher to the
+  // exact label wording that ships).
+  it.failing(
+    'call stack labels the mount site distinctly from the throw site',
+    async () => {
+      const browser = await next.browser(ROUTE)
+      await openRedbox(browser)
+      const stack = (await getRedboxCallStack(browser)) ?? []
+      const hasMountLabel = stack.some((frame) =>
+        /mounted by|mount site|suspending component|wrap (in )?<?suspense|<suspense>/i.test(
+          frame
+        )
+      )
+      expect(hasMountLabel).toBe(true)
+    }
+  )
+})


### PR DESCRIPTION
Bug-witness `it.failing` test for the Call Stack throw-site/mount-site labelling gap (NAR / Instant-Insights stack-trace gaps).

## The gap

When a runtime data access lives in a leaf component (the **throw site**) that's mounted by a parent (the **mount site**), the `<Suspense>` fix has to wrap the **mount site** — wrapping the throw site does nothing, because Suspense must be *above* the suspending component.

The dev-overlay already has the data:
- the **code frame** correctly points at the throw site (`dynamic-breadcrumb.tsx`, the `await cookies()` line), and
- the **Call Stack** contains both frames:

```
DynamicBreadcrumb  …/dynamic-breadcrumb.tsx (8:36)   ← throw site
AppSideBar         …/app-sidebar.tsx (11:7)          ← mount site (where <Suspense> goes)
Page               …/page.tsx (12:7)
```

What's missing is any **labelling** of which frame is the throw site vs the mount site. Both render identically (`Name file (line:col)`), so a reader/agent following "wrap the data access in `<Suspense>`" edits the throw site and the error persists.

## What's here

Fixture: `mount-site-not-labelled` — leaf `dynamic-breadcrumb.tsx` reads `cookies()`, mounted by `app-sidebar.tsx`, on a route with `instant = { level: 'experimental-error' }`, no Suspense.

Three tests:
- **code frame points at the throw site** (regular `it`) — guards against "fixing" this by moving the caret; the throw-site code frame is correct.
- **call stack contains both the throw site and the mount site** (regular `it`) — the mount frame is *not* missing; the data is there.
- **call stack labels the mount site distinctly** (`it.failing`) — the actual gap. Fails today (frames are unlabelled).

Mirrors `reproductions/cases/mounting-call-site-not-in-stack`.

## Note on the fix shape

The fix is a dev-overlay **framing** change (label the throw vs mount frames, e.g. "Suspending component" / "Mounted by"), **not** repointing the code frame. When it lands, flip `it.failing` → `it` and tighten the matcher to the shipped label wording.

Verified locally (12/12 for the sibling nav-signal suite; 3/3 here) with `NEXT_SKIP_ISOLATE=1` against a fresh `pnpm --filter next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)