### PR TITLE
fix: wire experimental.webVitalsAttribution into useReportWebVitals

### DIFF
--- a/packages/next/src/client/web-vitals.ts
+++ b/packages/next/src/client/web-vitals.ts
@@ -1,23 +1,40 @@
 import { useEffect } from 'react'
-import {
-  onLCP,
-  onFID,
-  onCLS,
-  onINP,
-  onFCP,
-  onTTFB,
-} from 'next/dist/compiled/web-vitals'
 import type { Metric } from 'next/dist/compiled/web-vitals'
 
-export function useReportWebVitals(
-  reportWebVitalsFn: (metric: Metric) => void
-) {
+// copied to prevent pulling in un-necessary utils
+const WEB_VITALS = ['CLS', 'FID', 'LCP', 'INP', 'FCP', 'TTFB'] as const
+
+type ReportWebVitalsCallback = (
+  metric: Metric & { attribution?: Record<string, unknown> }
+) => void
+
+function trackWebVitals(reportWebVitalsFn: ReportWebVitalsCallback) {
+  const attributions: string[] | undefined = process.env
+    .__NEXT_WEB_VITALS_ATTRIBUTION as any
+
+  for (const webVital of WEB_VITALS) {
+    try {
+      let mod: any
+      if (process.env.__NEXT_HAS_WEB_VITALS_ATTRIBUTION) {
+        if (attributions?.includes(webVital)) {
+          mod =
+            require('next/dist/compiled/web-vitals-attribution') as typeof import('next/dist/compiled/web-vitals-attribution')
+        }
+      }
+      if (!mod) {
+        mod =
+          require('next/dist/compiled/web-vitals') as typeof import('next/dist/compiled/web-vitals')
+      }
+      mod[`on${webVital}`](reportWebVitalsFn)
+    } catch (err) {
+      // Do nothing if the module fails to load
+      console.warn(`Failed to track ${webVital} web-vital`, err)
+    }
+  }
+}
+
+export function useReportWebVitals(reportWebVitalsFn: ReportWebVitalsCallback) {
   useEffect(() => {
-    onCLS(reportWebVitalsFn)
-    onFID(reportWebVitalsFn)
-    onLCP(reportWebVitalsFn)
-    onINP(reportWebVitalsFn)
-    onFCP(reportWebVitalsFn)
-    onTTFB(reportWebVitalsFn)
+    trackWebVitals(reportWebVitalsFn)
   }, [reportWebVitalsFn])
 }

--- a/test/e2e/app-dir/web-vitals-attribution/app/layout.tsx
+++ b/test/e2e/app-dir/web-vitals-attribution/app/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+import { WebVitalsReporter } from './web-vitals-reporter'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <WebVitalsReporter />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/web-vitals-attribution/app/page.tsx
+++ b/test/e2e/app-dir/web-vitals-attribution/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/web-vitals-attribution/app/web-vitals-reporter.tsx
+++ b/test/e2e/app-dir/web-vitals-attribution/app/web-vitals-reporter.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useReportWebVitals } from 'next/web-vitals'
+
+declare global {
+  interface Window {
+    __metrics: Array<{ name: string; attributionKeys: string[] | null }>
+  }
+}
+
+export function WebVitalsReporter() {
+  useReportWebVitals((metric) => {
+    window.__metrics = window.__metrics || []
+    window.__metrics.push({
+      name: metric.name,
+      attributionKeys: metric.attribution
+        ? Object.keys(metric.attribution)
+        : null,
+    })
+  })
+  return null
+}

--- a/test/e2e/app-dir/web-vitals-attribution/next.config.js
+++ b/test/e2e/app-dir/web-vitals-attribution/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    webVitalsAttribution: ['FCP'],
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/web-vitals-attribution/web-vitals-attribution.test.ts
+++ b/test/e2e/app-dir/web-vitals-attribution/web-vitals-attribution.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('web-vitals-attribution', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should include attribution for metrics listed in experimental.webVitalsAttribution', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const metrics: Array<{ name: string; attributionKeys: string[] | null }> =
+        await browser.eval('window.__metrics || []')
+      const fcp = metrics.find((metric) => metric.name === 'FCP')
+      expect(fcp).toBeDefined()
+      expect(fcp.attributionKeys).not.toBeNull()
+      expect(fcp.attributionKeys.length).toBeGreaterThan(0)
+    }, 10000)
+  })
+
+  it('should not include attribution for metrics not listed in experimental.webVitalsAttribution', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const metrics: Array<{ name: string; attributionKeys: string[] | null }> =
+        await browser.eval('window.__metrics || []')
+      const ttfb = metrics.find((metric) => metric.name === 'TTFB')
+      expect(ttfb).toBeDefined()
+      expect(ttfb.attributionKeys).toBeNull()
+    }, 10000)
+  })
+})


### PR DESCRIPTION
### What?

Pass `experimental.webVitalsAttribution` through to `useReportWebVitals`.

### Why?

The option currently has no effect on the hook. Fixes #95919

### How?

Made the hook behave like the previous v14 `performance-relayer` pattern ([reference](https://github.com/vercel/next.js/blob/v14.2.15/packages/next/src/client/performance-relayer.ts#L71-L102)): the `web-vitals` bundle is selected per metric, using the attribution build for metrics listed in the option.

Added an e2e test covering metrics listed and not listed in the option.

<!-- NEXT_JS_LLM -->