### PR TITLE
Add next/nav-link for active-aware navigation links

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -198,6 +198,14 @@ pub async fn get_next_client_import_map(
             );
             insert_exact_alias_or_js(
                 &mut import_map,
+                rcstr!("next/nav-link"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    rcstr!("next/dist/client/app-dir/nav-link"),
+                ),
+            );
+            insert_exact_alias_or_js(
+                &mut import_map,
                 rcstr!("next/form"),
                 request_to_import_mapping(
                     project_path.clone(),
@@ -352,6 +360,14 @@ pub async fn get_next_server_import_map(
             );
             insert_exact_alias_or_js(
                 &mut import_map,
+                rcstr!("next/nav-link"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    rcstr!("next/dist/client/app-dir/nav-link"),
+                ),
+            );
+            insert_exact_alias_or_js(
+                &mut import_map,
                 rcstr!("next/form"),
                 request_to_import_mapping(
                     project_path.clone(),
@@ -415,6 +431,7 @@ pub async fn get_next_edge_import_map(
         rcstr!("next/headers") => rcstr!("next/dist/api/headers"),
         rcstr!("next/image") => rcstr!("next/dist/api/image"),
         rcstr!("next/link") => rcstr!("next/dist/api/link"),
+        rcstr!("next/nav-link") => rcstr!("next/dist/api/nav-link"),
         rcstr!("next/navigation") => rcstr!("next/dist/api/navigation"),
         rcstr!("next/router") => rcstr!("next/dist/api/router"),
         rcstr!("next/script") => rcstr!("next/dist/api/script"),
@@ -475,6 +492,14 @@ pub async fn get_next_edge_import_map(
                 request_to_import_mapping(
                     project_path.clone(),
                     rcstr!("next/dist/client/app-dir/link"),
+                ),
+            );
+            insert_exact_alias_or_js(
+                &mut import_map,
+                rcstr!("next/nav-link"),
+                request_to_import_mapping(
+                    project_path.clone(),
+                    rcstr!("next/dist/client/app-dir/nav-link"),
                 ),
             );
         }
@@ -987,7 +1012,8 @@ async fn apply_vendored_react_aliases_server(
         alias.extend(
             fxindexmap! {rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
             rcstr!("next/navigation") => rcstr!("next/dist/api/navigation.react-server"),
-            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),},
+            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),
+            rcstr!("next/nav-link") => rcstr!("next/dist/client/app-dir/nav-link.react-server"),},
         );
     }
 
@@ -1018,7 +1044,8 @@ async fn rsc_aliases(
         alias.extend(
             fxindexmap! {rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
             rcstr!("next/navigation") => rcstr!("next/dist/api/navigation.react-server"),
-            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),},
+            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),
+            rcstr!("next/nav-link") => rcstr!("next/dist/client/app-dir/nav-link.react-server"),},
         );
     }
 

--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -4,6 +4,7 @@ description: Learn how the built-in navigation optimizations work, including pre
 related:
   links:
     - app/api-reference/components/link
+    - app/api-reference/components/nav-link
     - app/api-reference/file-conventions/loading
     - app/guides/prefetching
 ---

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -584,7 +584,9 @@ export default function PostList({ posts }) {
 
 ### Checking active links
 
-You can use [`usePathname()`](/docs/app/api-reference/functions/use-pathname) to determine if a link is active. For example, to add a class to the active link, you can check if the current `pathname` matches the `href` of the link:
+To style a link based on the current route, use [`NavLink`](/docs/app/api-reference/components/nav-link). It sets `aria-current="page"` when active and exposes `{ isActive, isPending }` to a function `className` or `children`, so you do not have to compare the pathname yourself.
+
+You can also use [`usePathname()`](/docs/app/api-reference/functions/use-pathname) to determine if a link is active. For example, to add a class to the active link, you can check if the current `pathname` matches the `href` of the link:
 
 ```tsx filename="app/ui/nav-links.tsx" switcher
 'use client'

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -584,7 +584,7 @@ export default function PostList({ posts }) {
 
 ### Checking active links
 
-To style a link based on the current route, use [`NavLink`](/docs/app/api-reference/components/nav-link). It sets `aria-current="page"` when active and exposes `{ isActive, isPending }` to a function `className` or `children`, so you do not have to compare the pathname yourself.
+To style a link based on the current route, use [`NavLink`](/docs/app/api-reference/components/nav-link). It sets `data-active` for styling and `aria-current="page"` on the exact page, and exposes `{ isActive, isPending }` to a function `className` or `children`, so you do not have to compare the pathname yourself.
 
 You can also use [`usePathname()`](/docs/app/api-reference/functions/use-pathname) to determine if a link is active. For example, to add a class to the active link, you can check if the current `pathname` matches the `href` of the link:
 

--- a/docs/01-app/03-api-reference/02-components/nav-link.mdx
+++ b/docs/01-app/03-api-reference/02-components/nav-link.mdx
@@ -86,23 +86,32 @@ Controls how `href` is compared to the current pathname:
 </NavLink>
 ```
 
-### Query strings
+### `data-active` and `aria-current`
 
-`<NavLink>` matches the pathname and ignores the query string, so `/dashboard?tab=one` and `/dashboard?tab=two` both match `href="/dashboard"`. Query params are request-time data, and matching on them would opt the link out of the static shell that keeps the active state flicker-free.
+`<NavLink>` reflects its state with two attributes on the rendered `<a>`, and you set neither yourself:
 
-For active state that depends on a query param, such as tabs or filters, read [`useSearchParams()`](/docs/app/api-reference/functions/use-search-params) in a Client Component and compare it yourself. The [Interactive apps guide](/docs/app/guides/interactive-apps#step-3-filter-with-pending-feedback) builds this pattern with pending feedback.
+- `data-active` is present whenever the link is active, including an ancestor matched by [prefix](#exact). Use it to [style](#active-styling) the visual active state.
+- `aria-current="page"` is set only on the exact current page. A prefix-matched ancestor is not the current page, so it gets `data-active` but not `aria-current`. An assistive technology never announces two links as the current page at once.
+
+For a `<NavLink href="/blog">`, the rendered `<a>` depends on the route:
+
+```html
+<!-- On /blog (exact match) -->
+<a href="/blog" data-active aria-current="page">Blog</a>
+
+<!-- On /blog/post (prefix match) -->
+<a href="/blog" data-active>Blog</a>
+```
+
+## Examples
 
 ### Active styling
 
-`<NavLink>` sets `data-active` on the active link, including an ancestor matched by [prefix](#exact), so you can style the active state in CSS with no render prop, straight from a Server Component. With Tailwind, use the `data-active:` variant:
+`<NavLink>` sets `data-active` on the active link, including an ancestor matched by [prefix](#exact), so you can style the active state in CSS with no render prop, straight from a Server Component:
 
 ```tsx
-<NavLink href="/blog" className="rounded px-3 data-active:font-bold">
-  Blog
-</NavLink>
+<NavLink href="/blog">Blog</NavLink>
 ```
-
-Or target the attribute directly in plain CSS:
 
 ```css
 a[data-active] {
@@ -110,7 +119,17 @@ a[data-active] {
 }
 ```
 
-Style with `data-active` for the visual state. `aria-current="page"` is set only on the [exact current page](#data-active-and-aria-current), so `aria-[current=page]:` styling turns off on nested routes. Use it when you want the style to match only the exact page.
+`aria-current="page"` is set only on the exact current page, so an `[aria-current='page']` selector matches only the exact page, not nested routes.
+
+#### With Tailwind
+
+Use the `data-active:` variant:
+
+```tsx
+<NavLink href="/blog" className="rounded px-3 data-active:font-bold">
+  Blog
+</NavLink>
+```
 
 ### `className` and `children` as functions
 
@@ -148,7 +167,7 @@ function Spinner() {
 
 export function NavItem() {
   return (
-    <NavLink href="/dashboard" className="aria-[current=page]:font-bold">
+    <NavLink href="/dashboard" className="data-active:font-bold">
       Dashboard <Spinner />
     </NavLink>
   )
@@ -168,25 +187,24 @@ function Spinner() {
 
 export function NavItem() {
   return (
-    <NavLink href="/dashboard" className="aria-[current=page]:font-bold">
+    <NavLink href="/dashboard" className="data-active:font-bold">
       Dashboard <Spinner />
     </NavLink>
   )
 }
 ```
 
-> **Good to know:** The render-prop `isPending` and `useLinkStatus` read the same status. Use the render prop for the link's own `className`/`children`, and `useLinkStatus` for a self-contained nested indicator that does not need the render prop threaded down to it.
-
-### `data-active` and `aria-current`
-
-`<NavLink>` reflects its state with two attributes on the rendered `<a>`, and you set neither yourself:
-
-- `data-active` is present whenever the link is active, including an ancestor matched by [prefix](#exact). Use it to [style](#active-styling) the visual active state.
-- `aria-current="page"` is set only on the [exact current page](#exact). A prefix-matched ancestor is not the current page, so it gets `data-active` but not `aria-current`. An assistive technology never announces two links as the current page at once.
+> **Good to know:** The render-prop `isPending` and `useLinkStatus` read the same status. Use the render prop for the link's own `className`/`children`, and call `useLinkStatus` inside a nested component (like the `Spinner` above) so it reads the pending status directly instead of taking it as a prop.
 
 ## Behavior
 
 `NavLink` resolves its active state from the current pathname on both the server and the client, so the correct `data-active`, `aria-current`, and classes are in the initial HTML.
+
+### Query strings
+
+`<NavLink>` matches the pathname and ignores the query string, so `/dashboard?tab=one` and `/dashboard?tab=two` both match `href="/dashboard"`. Query params are request-time data, and matching on them would opt the link out of the static shell that keeps the active state flicker-free.
+
+For active state that depends on a query param, such as tabs or filters, read [`useSearchParams()`](/docs/app/api-reference/functions/use-search-params) in a Client Component and compare it yourself. The [Interactive apps guide](/docs/app/guides/interactive-apps#step-3-filter-with-pending-feedback) builds this pattern with pending feedback.
 
 ### Cache Components
 

--- a/docs/01-app/03-api-reference/02-components/nav-link.mdx
+++ b/docs/01-app/03-api-reference/02-components/nav-link.mdx
@@ -116,6 +116,52 @@ Pass a function to `className` or `children` to receive `{ isActive, isPending }
 
 > **A function `className` or `children` must be used in a Client Component.** The function cannot be passed to a Client Component from the server, so add the `"use client"` directive to the file that renders the `NavLink`. A string `className` or `activeClassName` works from a Server Component.
 
+### Pending UI with `useLinkStatus`
+
+The render-prop `isPending` covers the link itself. For a pending indicator nested deeper in the link, such as a spinner beside the label, call [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) from a component rendered inside the `NavLink`, the same as with [`Link`](/docs/app/api-reference/components/link). `NavLink` extends `Link`, so the hook works inside it.
+
+```tsx filename="app/ui/nav-item.tsx" switcher
+'use client'
+
+import NavLink from 'next/nav-link'
+import { useLinkStatus } from 'next/link'
+
+function Spinner() {
+  const { pending } = useLinkStatus()
+  return pending ? <span className="spinner" aria-hidden /> : null
+}
+
+export function NavItem() {
+  return (
+    <NavLink href="/dashboard" activeClassName="active">
+      Dashboard <Spinner />
+    </NavLink>
+  )
+}
+```
+
+```jsx filename="app/ui/nav-item.js" switcher
+'use client'
+
+import NavLink from 'next/nav-link'
+import { useLinkStatus } from 'next/link'
+
+function Spinner() {
+  const { pending } = useLinkStatus()
+  return pending ? <span className="spinner" aria-hidden /> : null
+}
+
+export function NavItem() {
+  return (
+    <NavLink href="/dashboard" activeClassName="active">
+      Dashboard <Spinner />
+    </NavLink>
+  )
+}
+```
+
+> **Good to know:** The render-prop `isPending` and `useLinkStatus` read the same status. Use the render prop for the link's own `className`/`children`, and `useLinkStatus` for a self-contained nested indicator that does not need the render prop threaded down to it.
+
 ### `aria-current`
 
 `<NavLink>` sets `aria-current="page"` on the rendered `<a>` when the link is active, keeping the visual state and the assistive-technology state in sync. You do not set it yourself.

--- a/docs/01-app/03-api-reference/02-components/nav-link.mdx
+++ b/docs/01-app/03-api-reference/02-components/nav-link.mdx
@@ -1,0 +1,143 @@
+---
+title: NavLink Component
+description: Enable active-aware navigation links with the built-in `next/nav-link` component.
+related:
+  title: Next Steps
+  description: Learn more about the features mentioned in this page by reading the API Reference.
+  links:
+    - app/api-reference/components/link
+    - app/api-reference/functions/use-link-status
+    - app/api-reference/functions/use-pathname
+    - app/api-reference/functions/use-selected-layout-segment
+---
+
+`<NavLink>` extends [`<Link>`](/docs/app/api-reference/components/link) to know whether it points at the current route. It sets `aria-current="page"` when active and lets `className` and `children` be functions of `{ isActive, isPending }`, so you can style a link or swap its content without wiring up [`usePathname()`](/docs/app/api-reference/functions/use-pathname) yourself.
+
+```tsx filename="app/ui/nav.tsx" switcher
+'use client'
+
+import NavLink from 'next/nav-link'
+
+export function Nav() {
+  return (
+    <nav>
+      <NavLink href="/" activeClassName="active">
+        Home
+      </NavLink>
+      <NavLink
+        href="/blog"
+        className={({ isActive, isPending }) =>
+          `link ${isActive ? 'active' : ''} ${isPending ? 'pending' : ''}`
+        }
+      >
+        {({ isActive }) => (isActive ? 'Blog (current)' : 'Blog')}
+      </NavLink>
+    </nav>
+  )
+}
+```
+
+```jsx filename="app/ui/nav.js" switcher
+'use client'
+
+import NavLink from 'next/nav-link'
+
+export function Nav() {
+  return (
+    <nav>
+      <NavLink href="/" activeClassName="active">
+        Home
+      </NavLink>
+      <NavLink
+        href="/blog"
+        className={({ isActive, isPending }) =>
+          `link ${isActive ? 'active' : ''} ${isPending ? 'pending' : ''}`
+        }
+      >
+        {({ isActive }) => (isActive ? 'Blog (current)' : 'Blog')}
+      </NavLink>
+    </nav>
+  )
+}
+```
+
+> **Good to know:** `<NavLink>` is available in the App Router only.
+
+## Reference
+
+`<NavLink>` accepts every [`<Link>` prop](/docs/app/api-reference/components/link#reference), plus the following:
+
+| Prop              | Example                           | Type                                  | Default |
+| ----------------- | --------------------------------- | ------------------------------------- | ------- |
+| `exact`           | `exact`                           | `boolean`                             | `false` |
+| `activeClassName` | `activeClassName="active"`        | `string`                              | -       |
+| `className`       | `className={({ isActive }) => …}` | `string` or `(state) => string`       | -       |
+| `children`        | `children={({ isActive }) => …}`  | `ReactNode` or `(state) => ReactNode` | -       |
+
+### `exact`
+
+Controls how `href` is compared to the current pathname:
+
+- Default: active on `href` and any nested path, so `/blog` is active on `/blog/post`. `/` stays exact so it is not active on every route.
+- `exact`: active only when the pathname equals `href`. Use it for a link that should not stay active on nested routes, such as a `/blog` overview tab that turns off once you open `/blog/post`.
+
+```tsx
+<NavLink href="/blog" exact>
+  Blog
+</NavLink>
+```
+
+### `activeClassName`
+
+A class appended to `className` when the link is active. Use it for the common case where the active style is a single class:
+
+```tsx
+<NavLink href="/" activeClassName="font-bold">
+  Home
+</NavLink>
+```
+
+### `className` and `children` as functions
+
+Pass a function to `className` or `children` to receive `{ isActive, isPending }` and decide what to render:
+
+```tsx
+<NavLink
+  href="/inbox"
+  className={({ isActive, isPending }) =>
+    `${isActive ? 'text-blue-600' : ''} ${isPending ? 'opacity-50' : ''}`
+  }
+>
+  {({ isActive }) => (isActive ? <InboxFilled /> : <Inbox />)}
+</NavLink>
+```
+
+`isPending` is `true` while a navigation to the link is in progress, the same value provided by [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status).
+
+> **A function `className` or `children` must be used in a Client Component.** The function cannot be passed to a Client Component from the server, so add the `"use client"` directive to the file that renders the `NavLink`. A string `className` or `activeClassName` works from a Server Component.
+
+### `aria-current`
+
+`<NavLink>` sets `aria-current="page"` on the rendered `<a>` when the link is active, keeping the visual state and the assistive-technology state in sync. You do not set it yourself.
+
+## Behavior
+
+`NavLink` resolves its active state from the current pathname on both the server and the client, so the correct `aria-current` and classes are in the initial HTML.
+
+### Cache Components
+
+Under [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents), `NavLink` does not require a [`Suspense`](https://react.dev/reference/react/Suspense) boundary and does not force its layout to render dynamically. It reads the pathname without the dynamic-API check that makes a hand-written [`usePathname`](/docs/app/api-reference/functions/use-pathname) nav hang, so a nav in a static layout stays in the [App Shell](/docs/app/glossary#app-shell).
+
+On a route prerendered with a dynamic param not covered by [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), the pathname is not known at build time. `NavLink` renders inactive in that prerender and applies the active class on the client after hydration. This is a first-paint flicker, not a missing boundary. To apply the class before hydration, set it from an inline script as shown in [Preventing flash before hydration](/docs/app/guides/preventing-flash-before-hydration).
+
+### Rewrites
+
+Matching compares against the pathname in the URL, so `NavLink` reflects the address bar. A statically prerendered page reached through a [rewrite](/docs/app/api-reference/config/next-config-js/rewrites) or [Proxy](/docs/app/api-reference/file-conventions/proxy) can produce a hydration mismatch, the same one [`usePathname`](/docs/app/api-reference/functions/use-pathname#avoid-hydration-mismatch-with-rewrites) has, because the prerender is for the source path rather than the browser path.
+
+This is distinct from the flicker above: the flicker is a missing class that fills in, while a mismatch is a server value that disagrees with the client. To fix it, either base the active state on the matched route with [`useSelectedLayoutSegment`](/docs/app/api-reference/functions/use-selected-layout-segment), or keep matching the URL and defer the active read to the client with the [`usePathname` client-deferred pattern](/docs/app/api-reference/functions/use-pathname#avoid-hydration-mismatch-with-rewrites).
+
+## Version History
+
+| Version   | Changes                     |
+| --------- | --------------------------- |
+| `v16.3.0` | `<NavLink>` was introduced. |

--- a/docs/01-app/03-api-reference/02-components/nav-link.mdx
+++ b/docs/01-app/03-api-reference/02-components/nav-link.mdx
@@ -21,7 +21,7 @@ import NavLink from 'next/nav-link'
 export function Nav() {
   return (
     <nav>
-      <NavLink href="/" activeClassName="active">
+      <NavLink href="/" className="link aria-[current=page]:active">
         Home
       </NavLink>
       <NavLink
@@ -45,7 +45,7 @@ import NavLink from 'next/nav-link'
 export function Nav() {
   return (
     <nav>
-      <NavLink href="/" activeClassName="active">
+      <NavLink href="/" className="link aria-[current=page]:active">
         Home
       </NavLink>
       <NavLink
@@ -67,12 +67,11 @@ export function Nav() {
 
 `<NavLink>` accepts every [`<Link>` prop](/docs/app/api-reference/components/link#reference), plus the following:
 
-| Prop              | Example                           | Type                                  | Default |
-| ----------------- | --------------------------------- | ------------------------------------- | ------- |
-| `exact`           | `exact`                           | `boolean`                             | `false` |
-| `activeClassName` | `activeClassName="active"`        | `string`                              | -       |
-| `className`       | `className={({ isActive }) => …}` | `string` or `(state) => string`       | -       |
-| `children`        | `children={({ isActive }) => …}`  | `ReactNode` or `(state) => ReactNode` | -       |
+| Prop        | Example                           | Type                                  | Default |
+| ----------- | --------------------------------- | ------------------------------------- | ------- |
+| `exact`     | `exact`                           | `boolean`                             | `false` |
+| `className` | `className={({ isActive }) => …}` | `string` or `(state) => string`       | -       |
+| `children`  | `children={({ isActive }) => …}`  | `ReactNode` or `(state) => ReactNode` | -       |
 
 ### `exact`
 
@@ -87,14 +86,22 @@ Controls how `href` is compared to the current pathname:
 </NavLink>
 ```
 
-### `activeClassName`
+### Active styling
 
-A class appended to `className` when the link is active. Use it for the common case where the active style is a single class:
+`<NavLink>` sets `aria-current="page"` on the active link, so you can style the active state in CSS with no render prop, straight from a Server Component. With Tailwind, use the `aria-[current=page]:` variant:
 
 ```tsx
-<NavLink href="/" activeClassName="font-bold">
+<NavLink href="/" className="rounded px-3 aria-[current=page]:font-bold">
   Home
 </NavLink>
+```
+
+Or target the attribute directly in plain CSS:
+
+```css
+a[aria-current='page'] {
+  font-weight: bold;
+}
 ```
 
 ### `className` and `children` as functions
@@ -114,7 +121,7 @@ Pass a function to `className` or `children` to receive `{ isActive, isPending }
 
 `isPending` is `true` while a navigation to the link is in progress, the same value provided by [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status).
 
-> **A function `className` or `children` must be used in a Client Component.** The function cannot be passed to a Client Component from the server, so add the `"use client"` directive to the file that renders the `NavLink`. A string `className` or `activeClassName` works from a Server Component.
+> **A function `className` or `children` must be used in a Client Component.** The function cannot be passed to a Client Component from the server, so add the `"use client"` directive to the file that renders the `NavLink`. A string `className` works from a Server Component.
 
 ### Pending UI with `useLinkStatus`
 

--- a/docs/01-app/03-api-reference/02-components/nav-link.mdx
+++ b/docs/01-app/03-api-reference/02-components/nav-link.mdx
@@ -11,7 +11,7 @@ related:
     - app/api-reference/functions/use-selected-layout-segment
 ---
 
-`<NavLink>` extends [`<Link>`](/docs/app/api-reference/components/link) to know whether it points at the current route. It sets `aria-current="page"` when active and lets `className` and `children` be functions of `{ isActive, isPending }`, so you can style a link or swap its content without wiring up [`usePathname()`](/docs/app/api-reference/functions/use-pathname) yourself.
+`<NavLink>` extends [`<Link>`](/docs/app/api-reference/components/link) to know whether it points at the current route. It sets `data-active` for styling and `aria-current="page"` on the exact page, and lets `className` and `children` be functions of `{ isActive, isPending }`, so you can style a link or swap its content without wiring up [`usePathname()`](/docs/app/api-reference/functions/use-pathname) yourself.
 
 ```tsx filename="app/ui/nav.tsx" switcher
 'use client'
@@ -21,7 +21,7 @@ import NavLink from 'next/nav-link'
 export function Nav() {
   return (
     <nav>
-      <NavLink href="/" className="link aria-[current=page]:active">
+      <NavLink href="/" className="link data-active:active">
         Home
       </NavLink>
       <NavLink
@@ -45,7 +45,7 @@ import NavLink from 'next/nav-link'
 export function Nav() {
   return (
     <nav>
-      <NavLink href="/" className="link aria-[current=page]:active">
+      <NavLink href="/" className="link data-active:active">
         Home
       </NavLink>
       <NavLink
@@ -86,23 +86,31 @@ Controls how `href` is compared to the current pathname:
 </NavLink>
 ```
 
+### Query strings
+
+`<NavLink>` matches the pathname and ignores the query string, so `/dashboard?tab=one` and `/dashboard?tab=two` both match `href="/dashboard"`. Query params are request-time data, and matching on them would opt the link out of the static shell that keeps the active state flicker-free.
+
+For active state that depends on a query param, such as tabs or filters, read [`useSearchParams()`](/docs/app/api-reference/functions/use-search-params) in a Client Component and compare it yourself. The [Interactive apps guide](/docs/app/guides/interactive-apps#step-3-filter-with-pending-feedback) builds this pattern with pending feedback.
+
 ### Active styling
 
-`<NavLink>` sets `aria-current="page"` on the active link, so you can style the active state in CSS with no render prop, straight from a Server Component. With Tailwind, use the `aria-[current=page]:` variant:
+`<NavLink>` sets `data-active` on the active link, including an ancestor matched by [prefix](#exact), so you can style the active state in CSS with no render prop, straight from a Server Component. With Tailwind, use the `data-active:` variant:
 
 ```tsx
-<NavLink href="/" className="rounded px-3 aria-[current=page]:font-bold">
-  Home
+<NavLink href="/blog" className="rounded px-3 data-active:font-bold">
+  Blog
 </NavLink>
 ```
 
 Or target the attribute directly in plain CSS:
 
 ```css
-a[aria-current='page'] {
+a[data-active] {
   font-weight: bold;
 }
 ```
+
+Style with `data-active` for the visual state. `aria-current="page"` is set only on the [exact current page](#data-active-and-aria-current), so `aria-[current=page]:` styling turns off on nested routes. Use it when you want the style to match only the exact page.
 
 ### `className` and `children` as functions
 
@@ -169,13 +177,16 @@ export function NavItem() {
 
 > **Good to know:** The render-prop `isPending` and `useLinkStatus` read the same status. Use the render prop for the link's own `className`/`children`, and `useLinkStatus` for a self-contained nested indicator that does not need the render prop threaded down to it.
 
-### `aria-current`
+### `data-active` and `aria-current`
 
-`<NavLink>` sets `aria-current="page"` on the rendered `<a>` when the link is active, keeping the visual state and the assistive-technology state in sync. You do not set it yourself.
+`<NavLink>` reflects its state with two attributes on the rendered `<a>`, and you set neither yourself:
+
+- `data-active` is present whenever the link is active, including an ancestor matched by [prefix](#exact). Use it to [style](#active-styling) the visual active state.
+- `aria-current="page"` is set only on the [exact current page](#exact). A prefix-matched ancestor is not the current page, so it gets `data-active` but not `aria-current`. An assistive technology never announces two links as the current page at once.
 
 ## Behavior
 
-`NavLink` resolves its active state from the current pathname on both the server and the client, so the correct `aria-current` and classes are in the initial HTML.
+`NavLink` resolves its active state from the current pathname on both the server and the client, so the correct `data-active`, `aria-current`, and classes are in the initial HTML.
 
 ### Cache Components
 

--- a/docs/01-app/03-api-reference/02-components/nav-link.mdx
+++ b/docs/01-app/03-api-reference/02-components/nav-link.mdx
@@ -140,7 +140,7 @@ function Spinner() {
 
 export function NavItem() {
   return (
-    <NavLink href="/dashboard" activeClassName="active">
+    <NavLink href="/dashboard" className="aria-[current=page]:font-bold">
       Dashboard <Spinner />
     </NavLink>
   )
@@ -160,7 +160,7 @@ function Spinner() {
 
 export function NavItem() {
   return (
-    <NavLink href="/dashboard" activeClassName="active">
+    <NavLink href="/dashboard" className="aria-[current=page]:font-bold">
       Dashboard <Spinner />
     </NavLink>
   )

--- a/docs/01-app/03-api-reference/04-functions/use-link-status.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-link-status.mdx
@@ -6,6 +6,7 @@ related:
   description: Learn more about the features mentioned in this page by reading the API Reference.
   links:
     - app/api-reference/components/link
+    - app/api-reference/components/nav-link
     - app/api-reference/file-conventions/loading
 ---
 

--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -1,9 +1,18 @@
 ---
 title: usePathname
 description: API Reference for the usePathname hook.
+related:
+  title: Next Steps
+  description: Learn more about the features mentioned in this page by reading the API Reference.
+  links:
+    - app/api-reference/components/nav-link
+    - app/api-reference/functions/use-selected-layout-segment
+    - app/api-reference/components/link
 ---
 
 `usePathname` is a **Client Component** hook that lets you read the current URL's **pathname**.
+
+> **Good to know:** To style a link based on the active route, use [`NavLink`](/docs/app/api-reference/components/nav-link) instead of comparing `usePathname` by hand.
 
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segment.mdx
@@ -1,11 +1,20 @@
 ---
 title: useSelectedLayoutSegment
 description: API Reference for the useSelectedLayoutSegment hook.
+related:
+  title: Next Steps
+  description: Learn more about the features mentioned in this page by reading the API Reference.
+  links:
+    - app/api-reference/components/nav-link
+    - app/api-reference/functions/use-selected-layout-segments
+    - app/api-reference/functions/use-pathname
 ---
 
 `useSelectedLayoutSegment` is a **Client Component** hook that lets you read the active route segment **one level below** the Layout it is called from.
 
 It is useful for navigation UI, such as tabs inside a parent layout that change style depending on the active child segment.
+
+> **Good to know:** For a single link that styles itself based on the active route, use [`NavLink`](/docs/app/api-reference/components/nav-link). Use `useSelectedLayoutSegment` when you need segment-based active state, such as tabs that stay active across nested routes or under rewrites.
 
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'

--- a/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-selected-layout-segments.mdx
@@ -1,11 +1,20 @@
 ---
 title: useSelectedLayoutSegments
 description: API Reference for the useSelectedLayoutSegments hook.
+related:
+  title: Next Steps
+  description: Learn more about the features mentioned in this page by reading the API Reference.
+  links:
+    - app/api-reference/components/nav-link
+    - app/api-reference/functions/use-selected-layout-segment
+    - app/api-reference/functions/use-pathname
 ---
 
 `useSelectedLayoutSegments` is a **Client Component** hook that lets you read the active route segments **below** the Layout it is called from.
 
 It is useful for creating UI in parent Layouts that need knowledge of active child segments such as breadcrumbs.
+
+> **Good to know:** For a single link that styles itself based on the active route, use [`NavLink`](/docs/app/api-reference/components/nav-link) rather than reading segments by hand.
 
 ```tsx filename="app/example-client-component.tsx" switcher
 'use client'

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1422,5 +1422,5 @@
   "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed.",
   "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE.",
   "1423": "`next/nav-link` is only supported in the App Router (the `app` directory).",
-  "1424": "NavLink \"%s\": A function \\`className\\` or \\`children\\` only works in Client Components. Add the \"use client\" directive at the top of the file that renders it, or pass a string \\`className\\`/\\`activeClassName\\` instead."
+  "1424": "NavLink \"%s\": A function \\`className\\` or \\`children\\` only works in Client Components. Add the \"use client\" directive at the top of the file that renders it, or pass a string \\`className\\` instead."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1421,7 +1421,6 @@
   "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s",
   "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed.",
   "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE.",
-  "1423": "`NavLink` from `next/link` is only supported in the App Router (the `app` directory).",
-  "1424": "A `NavLink` with a function `className` or `children` (render props) must be rendered from a Client Component, because the function cannot be passed to a Client Component from the server. Add the \"use client\" directive to the file that renders this `NavLink`, or pass a string `className`/`activeClassName` instead.",
-  "1425": "`next/nav-link` is only supported in the App Router (the `app` directory)."
+  "1423": "`next/nav-link` is only supported in the App Router (the `app` directory).",
+  "1424": "NavLink \"%s\": A function \\`className\\` or \\`children\\` only works in Client Components. Add the \"use client\" directive at the top of the file that renders it, or pass a string \\`className\\`/\\`activeClassName\\` instead."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1420,5 +1420,8 @@
   "1419": "TypeScript CLI interrupted by %s",
   "1420": "shouldTrackSyncInterrupt allowed a sync IO interrupt in an unexpected stage: %s",
   "1421": "The lazy module is still loading. It must be awaited with `waitUntilLoaded()` before it can be accessed.",
-  "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE."
+  "1422": "MIN_PREFETCHABLE_STALE must not exceed MIN_SHELL_STALE.",
+  "1423": "`NavLink` from `next/link` is only supported in the App Router (the `app` directory).",
+  "1424": "A `NavLink` with a function `className` or `children` (render props) must be rendered from a Client Component, because the function cannot be passed to a Client Component from the server. Add the \"use client\" directive to the file that renders this `NavLink`, or pass a string `className`/`activeClassName` instead.",
+  "1425": "`next/nav-link` is only supported in the App Router (the `app` directory)."
 }

--- a/packages/next/nav-link.d.ts
+++ b/packages/next/nav-link.d.ts
@@ -1,0 +1,3 @@
+import NavLink from './dist/client/nav-link'
+export * from './dist/client/nav-link'
+export default NavLink

--- a/packages/next/nav-link.js
+++ b/packages/next/nav-link.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/client/nav-link')

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -40,6 +40,8 @@
     "image.d.ts",
     "link.js",
     "link.d.ts",
+    "nav-link.js",
+    "nav-link.d.ts",
     "offline.js",
     "offline.d.ts",
     "form.js",

--- a/packages/next/src/api/nav-link.ts
+++ b/packages/next/src/api/nav-link.ts
@@ -1,0 +1,2 @@
+export { default } from '../client/nav-link'
+export * from '../client/nav-link'

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -260,6 +260,7 @@ export function createNextApiEsmAliases() {
     dynamic: 'next/dist/api/dynamic',
     script: 'next/dist/api/script',
     link: 'next/dist/api/link',
+    'nav-link': 'next/dist/api/nav-link',
     form: 'next/dist/api/form',
     navigation: 'next/dist/api/navigation',
     headers: 'next/dist/api/headers',
@@ -284,6 +285,7 @@ export function createAppRouterApiAliases(isServerOnlyLayer: boolean) {
     head: 'next/dist/client/components/noop-head',
     dynamic: 'next/dist/api/app-dynamic',
     link: 'next/dist/client/app-dir/link',
+    'nav-link': 'next/dist/client/app-dir/nav-link',
     form: 'next/dist/client/app-dir/form',
   }
 
@@ -291,6 +293,7 @@ export function createAppRouterApiAliases(isServerOnlyLayer: boolean) {
     mapping['error'] = 'next/dist/api/error.react-server'
     mapping['navigation'] = 'next/dist/api/navigation.react-server'
     mapping['link'] = 'next/dist/client/app-dir/link.react-server'
+    mapping['nav-link'] = 'next/dist/client/app-dir/nav-link.react-server'
   }
 
   const aliasMap: Record<string, string> = {}

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -234,6 +234,14 @@ type InternalLinkProps = {
 // isn't generated yet. It will be replaced when type generation runs.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type LinkProps<RouteInferType = any> = InternalLinkProps
+
+// The active-link state resolved for `className`/`children` when `NavLink`
+// (from `next/nav-link`) sets `__navActive`. Kept internal here.
+type LinkActiveState = {
+  isActive: boolean
+  isPending: boolean
+}
+
 type LinkPropsRequired = RequiredKeys<LinkProps>
 type LinkPropsOptional = OptionalKeys<Omit<InternalLinkProps, 'locale'>>
 
@@ -339,8 +347,11 @@ function formatStringOrUrl(urlObjOrString: UrlObject | string): string {
  */
 export default function LinkComponent(
   props: LinkProps & {
-    children: React.ReactNode
+    children: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)
+    className?: string | ((state: LinkActiveState) => string)
     ref: React.Ref<HTMLAnchorElement>
+    /** @internal Set by `NavLink`. Enables active-aware `className`/`children`. */
+    __navActive?: boolean
   }
 ) {
   const [linkStatus, setOptimisticLinkStatus] = useOptimistic(IDLE_LINK_STATUS)
@@ -366,10 +377,26 @@ export default function LinkComponent(
     transitionTypes,
     ref: forwardedRef,
     unstable_dynamicOnHover,
+    className: classNameProp,
+    __navActive,
     ...restProps
   } = props
 
-  children = childrenProp
+  // Active-link state, populated only by `NavLink`; plain `Link` leaves
+  // `__navActive` undefined. `className` and `children` may each be a function
+  // of this state. Resolving here (inside `Link`) is what lets `className` read
+  // `isPending`, which a userland wrapper around `Link` cannot do.
+  const navState = {
+    isActive: __navActive ?? false,
+    isPending: linkStatus.pending,
+  }
+  const className =
+    typeof classNameProp === 'function'
+      ? classNameProp(navState)
+      : classNameProp
+
+  children =
+    typeof childrenProp === 'function' ? childrenProp(navState) : childrenProp
 
   if (
     legacyBehavior &&
@@ -786,7 +813,7 @@ export default function LinkComponent(
     link = React.cloneElement(child, childProps)
   } else {
     link = (
-      <a {...restProps} {...childProps}>
+      <a {...restProps} {...childProps} className={className}>
         {children}
       </a>
     )

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -381,19 +381,24 @@ export default function LinkComponent(
     ...restProps
   } = props
 
-  // Resolving here (inside `Link`) is what lets a function `className` read
-  // `isPending`, which a userland wrapper around `Link` cannot do.
+  // Resolving function `className`/`children` here (inside `Link`) is what lets
+  // them read `isPending`, which a userland wrapper cannot do. Only `NavLink`
+  // sets `__navActive`, so a plain `Link` never invokes function props and keeps
+  // its original behavior.
+  const isNavLink = __navActive !== undefined
   const navState = {
     isActive: __navActive ?? false,
     isPending: linkStatus.pending,
   }
   const className =
-    typeof classNameProp === 'function'
+    isNavLink && typeof classNameProp === 'function'
       ? classNameProp(navState)
-      : classNameProp
+      : (classNameProp as string | undefined)
 
   children =
-    typeof childrenProp === 'function' ? childrenProp(navState) : childrenProp
+    isNavLink && typeof childrenProp === 'function'
+      ? childrenProp(navState)
+      : (childrenProp as React.ReactNode)
 
   if (
     legacyBehavior &&

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -235,8 +235,7 @@ type InternalLinkProps = {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type LinkProps<RouteInferType = any> = InternalLinkProps
 
-// The active-link state resolved for `className`/`children` when `NavLink`
-// (from `next/nav-link`) sets `__navActive`. Kept internal here.
+// Resolved for `className`/`children` when `NavLink` sets `__navActive`.
 type LinkActiveState = {
   isActive: boolean
   isPending: boolean
@@ -382,9 +381,7 @@ export default function LinkComponent(
     ...restProps
   } = props
 
-  // Active-link state, populated only by `NavLink`; plain `Link` leaves
-  // `__navActive` undefined. `className` and `children` may each be a function
-  // of this state. Resolving here (inside `Link`) is what lets `className` read
+  // Resolving here (inside `Link`) is what lets a function `className` read
   // `isPending`, which a userland wrapper around `Link` cannot do.
   const navState = {
     isActive: __navActive ?? false,

--- a/packages/next/src/client/app-dir/nav-link.react-server.tsx
+++ b/packages/next/src/client/app-dir/nav-link.react-server.tsx
@@ -1,0 +1,24 @@
+import ClientNavLink, {
+  type NavLinkProps,
+  type LinkActiveState,
+} from './nav-link'
+
+// This wrapper runs on the server, so it receives the render-prop functions
+// directly (before React tries to serialize them to the client). That lets us
+// throw a `NavLink`-specific error instead of React's generic "Functions are
+// not valid as a child of Client Components". When `NavLink` is used from a
+// Client Component this wrapper does not run, so there is no false positive.
+export default function NavLink(props: NavLinkProps) {
+  if (
+    typeof props.className === 'function' ||
+    typeof props.children === 'function'
+  ) {
+    throw new Error(
+      'A `NavLink` with a function `className` or `children` (render props) must be rendered from a Client Component, because the function cannot be passed to a Client Component from the server. Add the "use client" directive to the file that renders this `NavLink`, or pass a string `className`/`activeClassName` instead.'
+    )
+  }
+
+  return <ClientNavLink {...props} />
+}
+
+export { type NavLinkProps, type LinkActiveState }

--- a/packages/next/src/client/app-dir/nav-link.react-server.tsx
+++ b/packages/next/src/client/app-dir/nav-link.react-server.tsx
@@ -1,3 +1,4 @@
+import { formatUrl } from '../../shared/lib/router/utils/format-url'
 import ClientNavLink, {
   type NavLinkProps,
   type LinkActiveState,
@@ -13,8 +14,10 @@ export default function NavLink(props: NavLinkProps) {
     typeof props.className === 'function' ||
     typeof props.children === 'function'
   ) {
+    const href =
+      typeof props.href === 'string' ? props.href : formatUrl(props.href)
     throw new Error(
-      'A `NavLink` with a function `className` or `children` (render props) must be rendered from a Client Component, because the function cannot be passed to a Client Component from the server. Add the "use client" directive to the file that renders this `NavLink`, or pass a string `className`/`activeClassName` instead.'
+      `NavLink "${href}": A function \`className\` or \`children\` only works in Client Components. Add the "use client" directive at the top of the file that renders it, or pass a string \`className\`/\`activeClassName\` instead.`
     )
   }
 

--- a/packages/next/src/client/app-dir/nav-link.react-server.tsx
+++ b/packages/next/src/client/app-dir/nav-link.react-server.tsx
@@ -15,7 +15,7 @@ export default function NavLink(props: NavLinkProps) {
     const href =
       typeof props.href === 'string' ? props.href : formatUrl(props.href)
     throw new Error(
-      `NavLink "${href}": A function \`className\` or \`children\` only works in Client Components. Add the "use client" directive at the top of the file that renders it, or pass a string \`className\`/\`activeClassName\` instead.`
+      `NavLink "${href}": A function \`className\` or \`children\` only works in Client Components. Add the "use client" directive at the top of the file that renders it, or pass a string \`className\` instead.`
     )
   }
 

--- a/packages/next/src/client/app-dir/nav-link.react-server.tsx
+++ b/packages/next/src/client/app-dir/nav-link.react-server.tsx
@@ -4,11 +4,9 @@ import ClientNavLink, {
   type LinkActiveState,
 } from './nav-link'
 
-// This wrapper runs on the server, so it receives the render-prop functions
-// directly (before React tries to serialize them to the client). That lets us
-// throw a `NavLink`-specific error instead of React's generic "Functions are
-// not valid as a child of Client Components". When `NavLink` is used from a
-// Client Component this wrapper does not run, so there is no false positive.
+// Runs only on the server boundary, so it can catch a function `className`/
+// `children` and throw a `NavLink`-specific error instead of React's generic
+// "Functions are not valid as a child of Client Components".
 export default function NavLink(props: NavLinkProps) {
   if (
     typeof props.className === 'function' ||

--- a/packages/next/src/client/app-dir/nav-link.tsx
+++ b/packages/next/src/client/app-dir/nav-link.tsx
@@ -6,23 +6,16 @@ import { formatUrl } from '../../shared/lib/router/utils/format-url'
 import { useUntrackedPathname } from '../components/navigation-untracked'
 import LinkComponent, { type LinkProps } from './link'
 
-/** The active state passed to a `NavLink` function `className`/`children`. */
+/** State passed to a `NavLink` function `className`/`children`. */
 export type LinkActiveState = {
-  /** Whether the link's `href` matches the current pathname. */
   isActive: boolean
-  /** Whether a navigation to this link is in progress. */
   isPending: boolean
 }
 
 export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
-  /**
-   * How `href` is compared to the current pathname:
-   * - Default: active on `href` and any nested path (`/blog` matches
-   *   `/blog/post`). `/` stays exact so it is not active everywhere.
-   * - `exact`: active only when the pathname equals `href`.
-   */
+  /** Match nested paths by default; `exact` matches only `href`. `/` is always exact. */
   exact?: boolean
-  /** Class appended when active. Convenience for the common string case. */
+  /** Class appended when active. */
   activeClassName?: string
   className?: string | ((state: LinkActiveState) => string)
   children?: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)
@@ -40,42 +33,31 @@ function stripUrlQueryAndHash(url: string): string {
   return index === -1 ? url : url.slice(0, index)
 }
 
+// Drop a trailing slash (except root) so matching is stable under `trailingSlash`.
+function normalizePathname(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith('/')
+    ? pathname.slice(0, -1)
+    : pathname
+}
+
 function matchNavLink(
   pathname: string,
   target: string,
   exact: boolean
 ): boolean {
-  if (exact || target === '/') {
-    return pathname === target
+  const currentPath = normalizePathname(pathname)
+  const targetPath = normalizePathname(target)
+  if (exact || targetPath === '/') {
+    return currentPath === targetPath
   }
-  return pathname === target || pathname.startsWith(target + '/')
+  return currentPath === targetPath || currentPath.startsWith(targetPath + '/')
 }
 
 /**
- * A `<Link>` that knows whether it points at the current route. It sets
- * `aria-current="page"` when active and lets `className` and `children` be
- * functions of `{ isActive, isPending }`, so a nav item can style or swap its
- * content without wiring up `usePathname()` by hand.
- *
- * ```tsx
- * import NavLink from 'next/nav-link'
- *
- * <NavLink href="/dashboard" activeClassName="font-bold">
- *   Dashboard
- * </NavLink>
- *
- * <NavLink
- *   href="/inbox"
- *   className={({ isActive, isPending }) =>
- *     cn(isActive && 'text-blue-600', isPending && 'opacity-50')}
- * >
- *   {({ isActive }) => (isActive ? <InboxFilled /> : <Inbox />)}
- * </NavLink>
- * ```
- *
- * The active state is computed from the current pathname without opting the
- * link out of the static shell under `cacheComponents`, and it is resolved on
- * the server too, so the correct state is present on first paint.
+ * A `<Link>` that knows whether it points at the current route: it sets
+ * `aria-current="page"` when active and accepts `className`/`children` as
+ * functions of `{ isActive, isPending }`. The active state resolves on the
+ * server without opting the link out of the static shell under `cacheComponents`.
  */
 export default function NavLink(props: NavLinkProps) {
   const {
@@ -92,9 +74,8 @@ export default function NavLink(props: NavLinkProps) {
   const target = stripUrlQueryAndHash(formatStringOrUrl(href))
   const isActive = pathname !== null && matchNavLink(pathname, target, exact)
 
-  // `activeClassName` needs only `isActive`, so fold it into a string here. A
-  // function `className` is passed through and resolved inside `Link`, where
-  // the pending status lives.
+  // A function `className` resolves inside `Link`, where `isPending` lives; a
+  // string is combined with `activeClassName` here.
   const resolvedClassName =
     typeof className === 'function'
       ? className

--- a/packages/next/src/client/app-dir/nav-link.tsx
+++ b/packages/next/src/client/app-dir/nav-link.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import React from 'react'
+import type { UrlObject } from 'url'
+import { formatUrl } from '../../shared/lib/router/utils/format-url'
+import { useUntrackedPathname } from '../components/navigation-untracked'
+import LinkComponent, { type LinkProps } from './link'
+
+/** The active state passed to a `NavLink` function `className`/`children`. */
+export type LinkActiveState = {
+  /** Whether the link's `href` matches the current pathname. */
+  isActive: boolean
+  /** Whether a navigation to this link is in progress. */
+  isPending: boolean
+}
+
+export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
+  /**
+   * How `href` is compared to the current pathname:
+   * - Default: active on `href` and any nested path (`/blog` matches
+   *   `/blog/post`). `/` stays exact so it is not active everywhere.
+   * - `exact`: active only when the pathname equals `href`.
+   */
+  exact?: boolean
+  /** Class appended when active. Convenience for the common string case. */
+  activeClassName?: string
+  className?: string | ((state: LinkActiveState) => string)
+  children?: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)
+  ref?: React.Ref<HTMLAnchorElement>
+}
+
+function formatStringOrUrl(urlObjOrString: UrlObject | string): string {
+  return typeof urlObjOrString === 'string'
+    ? urlObjOrString
+    : formatUrl(urlObjOrString)
+}
+
+function stripUrlQueryAndHash(url: string): string {
+  const index = url.search(/[?#]/)
+  return index === -1 ? url : url.slice(0, index)
+}
+
+function matchNavLink(
+  pathname: string,
+  target: string,
+  exact: boolean
+): boolean {
+  if (exact || target === '/') {
+    return pathname === target
+  }
+  return pathname === target || pathname.startsWith(target + '/')
+}
+
+/**
+ * A `<Link>` that knows whether it points at the current route. It sets
+ * `aria-current="page"` when active and lets `className` and `children` be
+ * functions of `{ isActive, isPending }`, so a nav item can style or swap its
+ * content without wiring up `usePathname()` by hand.
+ *
+ * ```tsx
+ * import NavLink from 'next/nav-link'
+ *
+ * <NavLink href="/dashboard" activeClassName="font-bold">
+ *   Dashboard
+ * </NavLink>
+ *
+ * <NavLink
+ *   href="/inbox"
+ *   className={({ isActive, isPending }) =>
+ *     cn(isActive && 'text-blue-600', isPending && 'opacity-50')}
+ * >
+ *   {({ isActive }) => (isActive ? <InboxFilled /> : <Inbox />)}
+ * </NavLink>
+ * ```
+ *
+ * The active state is computed from the current pathname without opting the
+ * link out of the static shell under `cacheComponents`, and it is resolved on
+ * the server too, so the correct state is present on first paint.
+ */
+export default function NavLink(props: NavLinkProps) {
+  const {
+    href,
+    exact = false,
+    activeClassName,
+    className,
+    children,
+    ref,
+    ...rest
+  } = props
+
+  const pathname = useUntrackedPathname()
+  const target = stripUrlQueryAndHash(formatStringOrUrl(href))
+  const isActive = pathname !== null && matchNavLink(pathname, target, exact)
+
+  // `activeClassName` needs only `isActive`, so fold it into a string here. A
+  // function `className` is passed through and resolved inside `Link`, where
+  // the pending status lives.
+  const resolvedClassName =
+    typeof className === 'function'
+      ? className
+      : [className, isActive && activeClassName ? activeClassName : null]
+          .filter(Boolean)
+          .join(' ') || undefined
+
+  return (
+    <LinkComponent
+      {...rest}
+      href={href}
+      ref={ref ?? null}
+      aria-current={isActive ? 'page' : undefined}
+      className={resolvedClassName}
+      __navActive={isActive}
+    >
+      {children}
+    </LinkComponent>
+  )
+}

--- a/packages/next/src/client/app-dir/nav-link.tsx
+++ b/packages/next/src/client/app-dir/nav-link.tsx
@@ -12,7 +12,10 @@ export type LinkActiveState = {
   isPending: boolean
 }
 
-export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
+export type NavLinkProps = Omit<
+  LinkProps,
+  'children' | 'className' | 'legacyBehavior' | 'passHref'
+> & {
   /** Match nested paths by default; `exact` matches only `href`. `/` is always exact. */
   exact?: boolean
   className?: string | ((state: LinkActiveState) => string)
@@ -56,6 +59,9 @@ function matchNavLink(
  * `aria-current="page"` when active and accepts `className`/`children` as
  * functions of `{ isActive, isPending }`. The active state resolves on the
  * server without opting the link out of the static shell under `cacheComponents`.
+ *
+ * Matching ignores the query string and hash on `href`. `/` is active only on
+ * `/` itself, and `exact` restricts any `href` to its own path.
  */
 export default function NavLink(props: NavLinkProps) {
   const { href, exact = false, className, children, ref, ...rest } = props

--- a/packages/next/src/client/app-dir/nav-link.tsx
+++ b/packages/next/src/client/app-dir/nav-link.tsx
@@ -55,13 +55,19 @@ function matchNavLink(
 }
 
 /**
- * A `<Link>` that knows whether it points at the current route: it sets
- * `aria-current="page"` when active and accepts `className`/`children` as
- * functions of `{ isActive, isPending }`. The active state resolves on the
- * server without opting the link out of the static shell under `cacheComponents`.
+ * A `<Link>` that knows whether it points at the current route: it accepts
+ * `className`/`children` as functions of `{ isActive, isPending }` and sets
+ * `aria-current="page"` on the exact current page. The active state resolves on
+ * the server without opting the link out of the static shell under `cacheComponents`.
  *
  * Matching ignores the query string and hash on `href`. `/` is active only on
  * `/` itself, and `exact` restricts any `href` to its own path.
+ *
+ * Two hooks reflect the state, because they mean different things. `data-active`
+ * is present whenever the link is active (exact or prefix), for styling in CSS.
+ * `aria-current="page"` is set only on an exact match, so an ancestor made active
+ * by prefix matching still carries `data-active` but is not announced as the
+ * current page.
  */
 export default function NavLink(props: NavLinkProps) {
   const { href, exact = false, className, children, ref, ...rest } = props
@@ -69,6 +75,11 @@ export default function NavLink(props: NavLinkProps) {
   const pathname = useUntrackedPathname()
   const target = stripUrlQueryAndHash(formatStringOrUrl(href))
   const isActive = pathname !== null && matchNavLink(pathname, target, exact)
+  // `aria-current="page"` marks the current page itself, so it's set only on an
+  // exact match, not on an ancestor made active by prefix matching.
+  const isCurrentPage =
+    pathname !== null &&
+    normalizePathname(pathname) === normalizePathname(target)
 
   // A string `className` passes through; a function is resolved inside `Link`,
   // where `isPending` lives.
@@ -77,7 +88,8 @@ export default function NavLink(props: NavLinkProps) {
       {...rest}
       href={href}
       ref={ref ?? null}
-      aria-current={isActive ? 'page' : undefined}
+      aria-current={isCurrentPage ? 'page' : undefined}
+      data-active={isActive ? '' : undefined}
       className={className}
       __navActive={isActive}
     >

--- a/packages/next/src/client/app-dir/nav-link.tsx
+++ b/packages/next/src/client/app-dir/nav-link.tsx
@@ -15,8 +15,6 @@ export type LinkActiveState = {
 export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
   /** Match nested paths by default; `exact` matches only `href`. `/` is always exact. */
   exact?: boolean
-  /** Class appended when active. */
-  activeClassName?: string
   className?: string | ((state: LinkActiveState) => string)
   children?: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)
   ref?: React.Ref<HTMLAnchorElement>
@@ -60,36 +58,21 @@ function matchNavLink(
  * server without opting the link out of the static shell under `cacheComponents`.
  */
 export default function NavLink(props: NavLinkProps) {
-  const {
-    href,
-    exact = false,
-    activeClassName,
-    className,
-    children,
-    ref,
-    ...rest
-  } = props
+  const { href, exact = false, className, children, ref, ...rest } = props
 
   const pathname = useUntrackedPathname()
   const target = stripUrlQueryAndHash(formatStringOrUrl(href))
   const isActive = pathname !== null && matchNavLink(pathname, target, exact)
 
-  // A function `className` resolves inside `Link`, where `isPending` lives; a
-  // string is combined with `activeClassName` here.
-  const resolvedClassName =
-    typeof className === 'function'
-      ? className
-      : [className, isActive && activeClassName ? activeClassName : null]
-          .filter(Boolean)
-          .join(' ') || undefined
-
+  // A string `className` passes through; a function is resolved inside `Link`,
+  // where `isPending` lives.
   return (
     <LinkComponent
       {...rest}
       href={href}
       ref={ref ?? null}
       aria-current={isActive ? 'page' : undefined}
-      className={resolvedClassName}
+      className={className}
       __navActive={isActive}
     >
       {children}

--- a/packages/next/src/client/nav-link.tsx
+++ b/packages/next/src/client/nav-link.tsx
@@ -7,7 +7,10 @@ export type LinkActiveState = {
   isPending: boolean
 }
 
-export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
+export type NavLinkProps = Omit<
+  LinkProps,
+  'children' | 'className' | 'legacyBehavior' | 'passHref'
+> & {
   exact?: boolean
   className?: string | ((state: LinkActiveState) => string)
   children?: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)

--- a/packages/next/src/client/nav-link.tsx
+++ b/packages/next/src/client/nav-link.tsx
@@ -9,7 +9,6 @@ export type LinkActiveState = {
 
 export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
   exact?: boolean
-  activeClassName?: string
   className?: string | ((state: LinkActiveState) => string)
   children?: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)
   ref?: React.Ref<HTMLAnchorElement>

--- a/packages/next/src/client/nav-link.tsx
+++ b/packages/next/src/client/nav-link.tsx
@@ -1,0 +1,26 @@
+import type React from 'react'
+import type { LinkProps } from './link'
+
+/** The active state passed to a `NavLink` function `className`/`children`. */
+export type LinkActiveState = {
+  isActive: boolean
+  isPending: boolean
+}
+
+export type NavLinkProps = Omit<LinkProps, 'children' | 'className'> & {
+  exact?: boolean
+  activeClassName?: string
+  className?: string | ((state: LinkActiveState) => string)
+  children?: React.ReactNode | ((state: LinkActiveState) => React.ReactNode)
+  ref?: React.Ref<HTMLAnchorElement>
+}
+
+/**
+ * `NavLink` is only available in the App Router. This Pages Router entry exists
+ * so the `next/nav-link` type surface resolves; calling it throws.
+ */
+export default function NavLink(_props: NavLinkProps): React.JSX.Element {
+  throw new Error(
+    '`next/nav-link` is only supported in the App Router (the `app` directory).'
+  )
+}

--- a/test/e2e/app-dir/navlink/app/about/page.tsx
+++ b/test/e2e/app-dir/navlink/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>About</h1>
+}

--- a/test/e2e/app-dir/navlink/app/blog/[slug]/page.tsx
+++ b/test/e2e/app-dir/navlink/app/blog/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export function generateStaticParams() {
+  return [{ slug: 'first' }]
+}
+
+export default function Page() {
+  return <h1>Post</h1>
+}

--- a/test/e2e/app-dir/navlink/app/blog/page.tsx
+++ b/test/e2e/app-dir/navlink/app/blog/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Blog</h1>
+}

--- a/test/e2e/app-dir/navlink/app/contact/page.tsx
+++ b/test/e2e/app-dir/navlink/app/contact/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Contact</h1>
+}

--- a/test/e2e/app-dir/navlink/app/layout.tsx
+++ b/test/e2e/app-dir/navlink/app/layout.tsx
@@ -1,0 +1,16 @@
+import { Nav } from './nav'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <Nav />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/navlink/app/nav.tsx
+++ b/test/e2e/app-dir/navlink/app/nav.tsx
@@ -5,17 +5,24 @@ import NavLink from 'next/nav-link'
 export function Nav() {
   return (
     <nav>
-      <NavLink href="/" activeClassName="active-home">
+      <NavLink
+        href="/"
+        className={({ isActive }) => (isActive ? 'active-home' : '')}
+      >
         Home
       </NavLink>
-      <NavLink href="/blog" activeClassName="active-blog">
+      <NavLink
+        href="/blog"
+        className={({ isActive }) => (isActive ? 'active-blog' : '')}
+      >
         Blog
       </NavLink>
       <NavLink
         href="/blog"
         exact
-        className="blog-exact"
-        activeClassName="active-blog-exact"
+        className={({ isActive }) =>
+          isActive ? 'blog-exact active-blog-exact' : 'blog-exact'
+        }
       >
         Blog exact
       </NavLink>

--- a/test/e2e/app-dir/navlink/app/nav.tsx
+++ b/test/e2e/app-dir/navlink/app/nav.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import NavLink from 'next/nav-link'
+
+export function Nav() {
+  return (
+    <nav>
+      <NavLink href="/" activeClassName="active-home">
+        Home
+      </NavLink>
+      <NavLink href="/blog" activeClassName="active-blog">
+        Blog
+      </NavLink>
+      <NavLink
+        href="/blog"
+        exact
+        className="blog-exact"
+        activeClassName="active-blog-exact"
+      >
+        Blog exact
+      </NavLink>
+      <NavLink
+        href="/about"
+        className={({ isActive }) => (isActive ? 'fn-active' : 'fn-idle')}
+      >
+        About
+      </NavLink>
+      <NavLink href="/contact">
+        {({ isActive }) => (isActive ? 'Contact-on' : 'Contact-off')}
+      </NavLink>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/navlink/app/page.tsx
+++ b/test/e2e/app-dir/navlink/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir/navlink/navlink.test.ts
+++ b/test/e2e/app-dir/navlink/navlink.test.ts
@@ -6,13 +6,15 @@ describe('navlink', () => {
 
   it('marks the matching link active in the SSR HTML with aria-current (flicker-free)', async () => {
     const $ = await next.render$('/blog')
-    const blog = $('nav a[href="/blog"]')
+    const blog = $('nav a[href="/blog"]').first()
     expect(blog.attr('aria-current')).toBe('page')
+    expect(blog.attr('data-active')).toBe('')
     expect(blog.attr('class')).toContain('active-blog')
 
     // Non-greedy "/": home is not active on another route.
     const home = $('nav a[href="/"]')
     expect(home.attr('aria-current')).toBeUndefined()
+    expect(home.attr('data-active')).toBeUndefined()
     expect(home.attr('class') || '').not.toContain('active-home')
   })
 
@@ -25,11 +27,16 @@ describe('navlink', () => {
     expect(onBlog('nav a[href="/"]').attr('aria-current')).toBeUndefined()
   })
 
-  it('matches nested routes by default (prefix)', async () => {
+  it('matches nested routes by default (prefix) with data-active but not aria-current', async () => {
     const $ = await next.render$('/blog/first')
     const blog = $('nav a[href="/blog"]').first()
-    expect(blog.attr('aria-current')).toBe('page')
+    // The active class and data-active apply to the ancestor via prefix matching...
     expect(blog.attr('class')).toContain('active-blog')
+    expect(blog.attr('data-active')).toBe('')
+    // ...but aria-current="page" is reserved for the exact current page, so an
+    // ancestor link must not claim to be the page.
+    expect(blog.attr('aria-current')).toBeUndefined()
+    expect($('nav a[href="/"]').attr('data-active')).toBeUndefined()
     expect($('nav a[href="/"]').attr('aria-current')).toBeUndefined()
   })
 

--- a/test/e2e/app-dir/navlink/navlink.test.ts
+++ b/test/e2e/app-dir/navlink/navlink.test.ts
@@ -1,0 +1,89 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('navlink', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  it('marks the matching link active in the SSR HTML with aria-current (flicker-free)', async () => {
+    const $ = await next.render$('/blog')
+    const blog = $('nav a[href="/blog"]')
+    expect(blog.attr('aria-current')).toBe('page')
+    expect(blog.attr('class')).toContain('active-blog')
+
+    // Non-greedy "/": home is not active on another route.
+    const home = $('nav a[href="/"]')
+    expect(home.attr('aria-current')).toBeUndefined()
+    expect(home.attr('class') || '').not.toContain('active-home')
+  })
+
+  it('root link stays exact so it is not active everywhere', async () => {
+    const $ = await next.render$('/')
+    expect($('nav a[href="/"]').attr('aria-current')).toBe('page')
+    expect($('nav a[href="/"]').attr('class')).toContain('active-home')
+
+    const onBlog = await next.render$('/blog')
+    expect(onBlog('nav a[href="/"]').attr('aria-current')).toBeUndefined()
+  })
+
+  it('matches nested routes by default (prefix)', async () => {
+    const $ = await next.render$('/blog/first')
+    const blog = $('nav a[href="/blog"]').first()
+    expect(blog.attr('aria-current')).toBe('page')
+    expect(blog.attr('class')).toContain('active-blog')
+    expect($('nav a[href="/"]').attr('aria-current')).toBeUndefined()
+  })
+
+  it('exact restricts matching to the exact path (not nested)', async () => {
+    // On /blog both the default and exact links are active.
+    const onBlog = await next.render$('/blog')
+    expect(onBlog('nav a.blog-exact').attr('aria-current')).toBe('page')
+    expect(onBlog('nav a.blog-exact').attr('class')).toContain(
+      'active-blog-exact'
+    )
+
+    // On a nested route only the default (prefix) link stays active.
+    const onNested = await next.render$('/blog/first')
+    expect(onNested('nav a.blog-exact').attr('aria-current')).toBeUndefined()
+    expect(onNested('nav a.blog-exact').attr('class') || '').not.toContain(
+      'active-blog-exact'
+    )
+  })
+
+  it('resolves a function className with isActive', async () => {
+    const onAbout = await next.render$('/about')
+    expect(onAbout('nav a[href="/about"]').attr('class')).toContain('fn-active')
+
+    const offAbout = await next.render$('/')
+    expect(offAbout('nav a[href="/about"]').attr('class')).toContain('fn-idle')
+  })
+
+  it('resolves function children with isActive', async () => {
+    const onContact = await next.render$('/contact')
+    expect(onContact('nav a[href="/contact"]').text()).toBe('Contact-on')
+
+    const offContact = await next.render$('/')
+    expect(offContact('nav a[href="/contact"]').text()).toBe('Contact-off')
+  })
+
+  it('updates the active link on client navigation', async () => {
+    const browser = await next.browser('/')
+    expect(
+      await browser.elementByCss('nav a[href="/"]').getAttribute('aria-current')
+    ).toBe('page')
+
+    await browser.elementByCss('nav a[href="/blog"]').click()
+
+    await retry(async () => {
+      expect(
+        await browser
+          .elementByCss('nav a[href="/blog"]')
+          .getAttribute('aria-current')
+      ).toBe('page')
+      expect(
+        await browser
+          .elementByCss('nav a[href="/"]')
+          .getAttribute('aria-current')
+      ).toBeNull()
+    })
+  })
+})

--- a/test/e2e/app-dir/navlink/next.config.js
+++ b/test/e2e/app-dir/navlink/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  cacheComponents: true,
+}


### PR DESCRIPTION
### What?

Adds a `NavLink` component, similar to [React Router's `NavLink`](https://reactrouter.com/api/components/NavLink), to simplify a common task.

```tsx
import NavLink from 'next/nav-link'

// 1. String className, styled via the data-active variant — no render prop, works from a Server Component
<NavLink href="/dashboard" className="nav-item data-active:font-bold">
  Dashboard
</NavLink>

// 2. Render-prop className — reads isActive AND isPending (Client Component)
<NavLink
  href="/inbox"
  className={({ isActive, isPending }) =>
    cn(isActive && 'text-blue-600', isPending && 'opacity-50')
  }
>
  Inbox
</NavLink>

// 3. Render-prop children — swap content when active (Client Component)
<NavLink href="/profile">
  {({ isActive }) => (isActive ? <ProfileFilled /> : <ProfileOutline />)}
</NavLink>
```

### Why?

There's a lot of gotchas when doing this yourself, which I have documented here, so it would be great if Next.js could have this built in.  https://aurorascharff.no/posts/building-an-active-navlink-component-in-nextjs/

### How?

- A `<NavLink>` for the App Router that knows when it points at the current route. It sets `data-active` on the active link — including an ancestor matched by prefix — for styling, and `aria-current="page"` only on the exact page, so an ancestor is never announced as the current page.
- Style the active link in CSS via the `data-active:` Tailwind variant (or a `[data-active]` rule), or take full control by passing `className`/`children` as a function of `{ isActive, isPending }`.
- Matches nested routes by default (`/blog` is active on `/blog/post`); add `exact` for an exact-only match. Matching uses the pathname; for query-string state such as tabs, read `useSearchParams()` yourself.
- Active state is worked out on the server, so it's right on first paint and a nav in a static layout stays static under `cacheComponents` — no extra `Suspense`.
- On a route with an unknown dynamic param it can't be resolved at build time, so the active class fills in after hydration (a small flicker); the docs show an inline-script fix.
- A clear, `NavLink`-specific error if you use the function form from a Server Component.
- Ships with a docs page and e2e tests.

<details>
<summary>A `next/nav-link` entry that reuses `Link`, reads the pathname untracked, and resolves the render props inside the anchor.</summary>

**Its own module.** `next/nav-link` is a separate entry (like `next/form`) rather than an overload of `next/link`. Webpack aliases (`create-compiler-aliases.ts`) and the Turbopack import map (`next_import_map.rs`) mirror `next/link` across the base / app-client / react-server conditions; the react-server variant throws the Server-Component error, and the Pages Router entry throws "App Router only".

**Two things a userland wrapper can't do:**

- _Stays in the static shell under `cacheComponents`._ The active read uses `useUntrackedPathname()`, which reads `PathnameContext` directly and skips the dynamic-API guard that makes a hand-written `usePathname()` nav hang on fallback-param prerenders. The context is SSR-seeded, so the active class is already in the initial HTML for static routes.
- _`isPending` reaches `className`, not just `children`._ Both function props are resolved inside the anchor render, where the optimistic link status lives. A userland wrapper sets `className` on `Link` from the outside, so it can only observe pending via `useLinkStatus` inside `children` — never in `className`.

**Two attributes, two meanings.** `data-active` is present on any match (exact or prefix) for styling; `aria-current="page"` is set only on an exact match, so a prefix-matched ancestor gets `data-active` but not `aria-current`.

**Matching.** `exact` → `pathname === href`; default → `pathname === href || pathname.startsWith(href + '/')`, with `/` exact. Trailing slashes are normalized so matching is stable under `trailingSlash`.

</details>
