### PR TITLE
docs: clarify updateTag vs revalidateTag for passive updates

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
@@ -69,7 +69,7 @@ async function getData() {
 
 ## Examples
 
-The following examples demonstrate how to use `revalidateTag` in different contexts. In both cases, we're using `profile="max"` to mark data as stale and use stale-while-revalidate semantics, which is the recommended approach for most use cases.
+The following examples demonstrate how to use `revalidateTag` in different contexts. In each case, we're using `profile="max"` to mark data as stale and use stale-while-revalidate semantics, which is the recommended approach for most use cases.
 
 ### Server Action
 
@@ -133,6 +133,44 @@ export async function GET(request) {
     now: Date.now(),
     message: 'Missing tag to revalidate',
   })
+}
+```
+
+### Passive update that shouldn't block
+
+When a mutation is a side effect of visiting a page rather than a change the user is waiting to see, run it from a Route Handler and call `revalidateTag(tag, 'max')`, then call the handler fire-and-forget from the client. The request runs outside the Server Action queue, and the next read is served from cache and refreshed in the background, so the update blocks neither navigation nor the user's other actions.
+
+```ts filename="app/api/notifications/read/route.ts" switcher
+import { revalidateTag } from 'next/cache'
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const userId = await getCurrentUserId()
+  await db.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  })
+
+  // Background refresh, not read-your-own-write
+  revalidateTag(`notifications:${userId}`, 'max')
+  return new NextResponse(null, { status: 204 })
+}
+```
+
+```js filename="app/api/notifications/read/route.js" switcher
+import { revalidateTag } from 'next/cache'
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const userId = await getCurrentUserId()
+  await db.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  })
+
+  // Background refresh, not read-your-own-write
+  revalidateTag(`notifications:${userId}`, 'max')
+  return new NextResponse(null, { status: 204 })
 }
 ```
 

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -59,6 +59,7 @@ While both `updateTag` and `revalidateTag` invalidate cached data, they serve di
 - **`revalidateTag`**:
   - Can be used in Server Actions and Route Handlers
   - With `profile="max"` (recommended): Serves cached data while fetching fresh data in the background (stale-while-revalidate)
+  - With `{ expire: 0 }`: Expires immediately so the next read is a blocking cache miss. This is the `updateTag` equivalent for a Route Handler, where `updateTag` is not available
   - With custom profile: Can be configured to any cache life profile for advanced usage
   - Without profile: legacy behavior which is equivalent to `updateTag`
 
@@ -118,6 +119,42 @@ export async function createPost(formData) {
 }
 ```
 
+### Passive update that shouldn't block
+
+When a mutation is a side effect of visiting a page rather than a change the user is waiting to see, use `revalidateTag(tag, 'max')` instead of `updateTag`. The next read is served from cache and refreshed in the background, so the update never blocks a navigation.
+
+```ts filename="app/notifications/actions.ts" switcher
+'use server'
+
+import { revalidateTag } from 'next/cache'
+
+export async function markNotificationsRead(userId: string) {
+  await db.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  })
+
+  // Background refresh, not read-your-own-write, so the next visit is never blocked
+  revalidateTag(`notifications:${userId}`, 'max')
+}
+```
+
+```js filename="app/notifications/actions.js" switcher
+'use server'
+
+import { revalidateTag } from 'next/cache'
+
+export async function markNotificationsRead(userId) {
+  await db.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  })
+
+  // Background refresh, not read-your-own-write, so the next visit is never blocked
+  revalidateTag(`notifications:${userId}`, 'max')
+}
+```
+
 ### Error when used outside Server Actions
 
 ```ts filename="app/api/posts/route.ts" switcher
@@ -146,6 +183,7 @@ Use `revalidateTag` instead when:
 - You're in a Route Handler or other non-action context
 - You want stale-while-revalidate semantics
 - You're building a webhook or API endpoint for cache invalidation
+- The update is a passive side-effect rather than a change the user is waiting to see. A blocking refetch stalls the next navigation, so use `revalidateTag(tag, 'max')`
 
 ## Related
 

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -119,42 +119,6 @@ export async function createPost(formData) {
 }
 ```
 
-### Passive update that shouldn't block
-
-When a mutation is a side effect of visiting a page rather than a change the user is waiting to see, use `revalidateTag(tag, 'max')` instead of `updateTag`. The next read is served from cache and refreshed in the background, so the update never blocks a navigation.
-
-```ts filename="app/notifications/actions.ts" switcher
-'use server'
-
-import { revalidateTag } from 'next/cache'
-
-export async function markNotificationsRead(userId: string) {
-  await db.notification.updateMany({
-    where: { userId, readAt: null },
-    data: { readAt: new Date() },
-  })
-
-  // Background refresh, not read-your-own-write, so the next visit is never blocked
-  revalidateTag(`notifications:${userId}`, 'max')
-}
-```
-
-```js filename="app/notifications/actions.js" switcher
-'use server'
-
-import { revalidateTag } from 'next/cache'
-
-export async function markNotificationsRead(userId) {
-  await db.notification.updateMany({
-    where: { userId, readAt: null },
-    data: { readAt: new Date() },
-  })
-
-  // Background refresh, not read-your-own-write, so the next visit is never blocked
-  revalidateTag(`notifications:${userId}`, 'max')
-}
-```
-
 ### Error when used outside Server Actions
 
 ```ts filename="app/api/posts/route.ts" switcher
@@ -183,7 +147,7 @@ Use `revalidateTag` instead when:
 - You're in a Route Handler or other non-action context
 - You want stale-while-revalidate semantics
 - You're building a webhook or API endpoint for cache invalidation
-- The update is a passive, background side-effect rather than a change the user is waiting to see. Use `revalidateTag(tag, 'max')` so it does not block a read. Because Server Actions run one at a time, move a frequent background update to a Route Handler so it does not queue behind the user's other actions
+- The update is a passive, background side-effect rather than a change the user is waiting to see. Use `revalidateTag(tag, 'max')` so it does not block a read. Because Server Actions run one at a time, move a frequent background update to a Route Handler so it does not queue behind the user's other actions. See [Passive update that shouldn't block](/docs/app/api-reference/functions/revalidateTag#passive-update-that-shouldnt-block)
 
 ## Related
 

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -183,7 +183,7 @@ Use `revalidateTag` instead when:
 - You're in a Route Handler or other non-action context
 - You want stale-while-revalidate semantics
 - You're building a webhook or API endpoint for cache invalidation
-- The update is a passive side-effect rather than a change the user is waiting to see. A blocking refetch stalls the next navigation, so use `revalidateTag(tag, 'max')`
+- The update is a passive, background side-effect rather than a change the user is waiting to see. Use `revalidateTag(tag, 'max')` so it does not block a read. Because Server Actions run one at a time, move a frequent background update to a Route Handler so it does not queue behind the user's other actions
 
 ## Related
 


### PR DESCRIPTION
### What?

Adds guidance to the `updateTag` reference for choosing between `updateTag` and `revalidateTag` when an update is a passive side effect rather than a change the user is waiting to see.

- A "Passive update that shouldn't block" example that uses `revalidateTag(tag, 'max')`.
- A `revalidateTag(tag, { expire: 0 })` row in the "Differences from revalidateTag" list, documenting the blocking equivalent for a Route Handler where `updateTag` is not available.
- A "when to use `revalidateTag` instead" bullet for passive side effects.

### Why?

`updateTag` makes the next read block on fresh data, which is correct for read-your-own-writes but stalls the next navigation when the update is passive (for example marking items read on visit). The reference did not warn about this or point to the non-blocking alternative, so it was an easy mistake to make.

### How?

Documentation only. The example prose stays generalized and the concrete case lives in the code sample.
