### PR TITLE
Fix Flight payload chunk list duplication

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -62,6 +62,7 @@ type FlightSegment =
   | [isNotBootstrap: 1, responsePartial: string]
   | [isFormState: 2, formState: any]
   | [isBinary: 3, responseBase64Partial: string]
+  | [isChunksDict: 4, chunksDict: Record<string, string[]>]
 
 type NextFlight = Omit<Array<FlightSegment>, 'push'> & {
   push: (seg: FlightSegment) => void
@@ -108,6 +109,11 @@ function nextServerDataCallback(seg: FlightSegment): void {
     } else {
       initialServerDataBuffer.push(decodedChunk)
     }
+  } else if (seg[0] === 4) {
+    ;(self as any).__next_f_chunks_dict = Object.assign(
+      (self as any).__next_f_chunks_dict || {},
+      seg[1]
+    )
   }
 }
 
@@ -183,11 +189,94 @@ nextServerDataLoadingGlobal.length = 0
 // Patch its push method so subsequent chunks are handled (but not actually pushed to the array).
 nextServerDataLoadingGlobal.push = nextServerDataCallback
 
+function replaceChunks(line: string): string {
+  const dict = (self as any).__next_f_chunks_dict
+  if (!dict) return line
+  return line.replace(/:I\[([^,]+),("c\d+"),/g, (match, moduleId, quotedId) => {
+    const id = quotedId.slice(1, -1)
+    const chunks = dict[id]
+    if (chunks) {
+      return `:I[${moduleId},${JSON.stringify(chunks)},`
+    }
+    return match
+  })
+}
+
+function transformRSCStream(
+  stream: ReadableStream<Uint8Array>
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          if (buffer) {
+            controller.enqueue(encoder.encode(replaceChunks(buffer)))
+          }
+          controller.close()
+          return
+        }
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (let line of lines) {
+          const match = line.match(/^__next_chunks_dict__:(.*)$/)
+          if (match) {
+            try {
+              ;(self as any).__next_f_chunks_dict = Object.assign(
+                (self as any).__next_f_chunks_dict || {},
+                JSON.parse(match[1])
+              )
+            } catch (e) {
+              // ignore
+            }
+          } else {
+            controller.enqueue(encoder.encode(replaceChunks(line) + '\n'))
+          }
+        }
+        if (lines.length > 0) {
+          return
+        }
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+}
+
+if (typeof window !== 'undefined') {
+  const originalFetch = window.fetch
+  window.fetch = function (input, init) {
+    return originalFetch.call(this, input, init).then((response) => {
+      const contentType = response.headers.get('content-type')
+      if (
+        contentType &&
+        contentType.includes('text/x-component') &&
+        response.body
+      ) {
+        const transformedBody = transformRSCStream(response.body)
+        return new Response(transformedBody, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        })
+      }
+      return response
+    })
+  }
+}
+
 let readable: ReadableStream<Uint8Array> = new ReadableStream({
   start(controller) {
     nextServerDataRegisterWriter(controller)
   },
 })
+readable = transformRSCStream(readable)
 if (process.env.NODE_ENV !== 'production') {
   // @ts-expect-error
   readable.name = 'hydration'

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -29,6 +29,10 @@ import { getDeploymentId } from '../shared/lib/deployment-id'
 import { setNavigationBuildId } from './navigation-build-id'
 import type { ClientInstrumentationModules } from './router-transition-types'
 import { initializeRouterTransitionModules } from './components/router-transition'
+import {
+  decodeFlightChunkLists,
+  decodeFlightResponse,
+} from '../shared/lib/flight-chunk-list-deduplication'
 
 /// <reference types="react-dom/experimental" />
 
@@ -56,13 +60,14 @@ let initialServerDataLoaded = false
 let initialServerDataFlushed = false
 
 let initialFormStateData: null | any = null
+let initialChunksDictionary: Record<string, string[]> | undefined
 
 type FlightSegment =
   | [isBootStrap: 0]
   | [isNotBootstrap: 1, responsePartial: string]
   | [isFormState: 2, formState: any]
   | [isBinary: 3, responseBase64Partial: string]
-  | [isChunksDict: 4, chunksDict: Record<string, string[]>]
+  | [isChunksDictionary: 4, chunksDictionary: Record<string, string[]>]
 
 type NextFlight = Omit<Array<FlightSegment>, 'push'> & {
   push: (seg: FlightSegment) => void
@@ -110,10 +115,7 @@ function nextServerDataCallback(seg: FlightSegment): void {
       initialServerDataBuffer.push(decodedChunk)
     }
   } else if (seg[0] === 4) {
-    ;(self as any).__next_f_chunks_dict = Object.assign(
-      (self as any).__next_f_chunks_dict || {},
-      seg[1]
-    )
+    initialChunksDictionary = seg[1]
   }
 }
 
@@ -189,94 +191,12 @@ nextServerDataLoadingGlobal.length = 0
 // Patch its push method so subsequent chunks are handled (but not actually pushed to the array).
 nextServerDataLoadingGlobal.push = nextServerDataCallback
 
-function replaceChunks(line: string): string {
-  const dict = (self as any).__next_f_chunks_dict
-  if (!dict) return line
-  return line.replace(/:I\[([^,]+),("c\d+"),/g, (match, moduleId, quotedId) => {
-    const id = quotedId.slice(1, -1)
-    const chunks = dict[id]
-    if (chunks) {
-      return `:I[${moduleId},${JSON.stringify(chunks)},`
-    }
-    return match
-  })
-}
-
-function transformRSCStream(
-  stream: ReadableStream<Uint8Array>
-): ReadableStream<Uint8Array> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) {
-          if (buffer) {
-            controller.enqueue(encoder.encode(replaceChunks(buffer)))
-          }
-          controller.close()
-          return
-        }
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() || ''
-        for (let line of lines) {
-          const match = line.match(/^__next_chunks_dict__:(.*)$/)
-          if (match) {
-            try {
-              ;(self as any).__next_f_chunks_dict = Object.assign(
-                (self as any).__next_f_chunks_dict || {},
-                JSON.parse(match[1])
-              )
-            } catch (e) {
-              // ignore
-            }
-          } else {
-            controller.enqueue(encoder.encode(replaceChunks(line) + '\n'))
-          }
-        }
-        if (lines.length > 0) {
-          return
-        }
-      }
-    },
-    cancel(reason) {
-      return reader.cancel(reason)
-    },
-  })
-}
-
-if (typeof window !== 'undefined') {
-  const originalFetch = window.fetch
-  window.fetch = function (input, init) {
-    return originalFetch.call(this, input, init).then((response) => {
-      const contentType = response.headers.get('content-type')
-      if (
-        contentType &&
-        contentType.includes('text/x-component') &&
-        response.body
-      ) {
-        const transformedBody = transformRSCStream(response.body)
-        return new Response(transformedBody, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: response.headers,
-        })
-      }
-      return response
-    })
-  }
-}
-
 let readable: ReadableStream<Uint8Array> = new ReadableStream({
   start(controller) {
     nextServerDataRegisterWriter(controller)
   },
 })
-readable = transformRSCStream(readable)
+readable = decodeFlightChunkLists(readable, initialChunksDictionary)
 if (process.env.NODE_ENV !== 'production') {
   // @ts-expect-error
   readable.name = 'hydration'
@@ -319,16 +239,19 @@ if (instantTestStaticFetch) {
   // fetch kicked off by an injected <script> tag, instead of the inline
   // Flight data (which is not present in the static shell).
   initialServerResponse = Promise.resolve(
-    createFromFetch<InitialRSCPayload>(instantTestStaticFetch, {
-      callServer,
-      findSourceMapURL,
-      debugChannel,
-      // The static fetch response is a partial stream (static-only Flight
-      // data with no dynamic content). Allow it to close without error so
-      // React treats dynamic holes as still-suspended rather than
-      // triggering error recovery.
-      unstable_allowPartialStream: true,
-    })
+    createFromFetch<InitialRSCPayload>(
+      decodeFlightResponse(instantTestStaticFetch),
+      {
+        callServer,
+        findSourceMapURL,
+        debugChannel,
+        // The static fetch response is a partial stream (static-only Flight
+        // data with no dynamic content). Allow it to close without error so
+        // React treats dynamic holes as still-suspended rather than
+        // triggering error recovery.
+        unstable_allowPartialStream: true,
+      }
+    )
   ).then(async (initialRSCPayload) => {
     return createInitialRSCPayloadFromFallbackPrerender(
       await instantTestStaticFetch,
@@ -343,11 +266,14 @@ if (instantTestStaticFetch) {
     // @ts-expect-error
     window.__NEXT_CLIENT_RESUME
   initialServerResponse = Promise.resolve(
-    createFromFetch<InitialRSCPayload>(clientResumeFetch, {
-      callServer,
-      findSourceMapURL,
-      debugChannel,
-    })
+    createFromFetch<InitialRSCPayload>(
+      decodeFlightResponse(clientResumeFetch),
+      {
+        callServer,
+        findSourceMapURL,
+        debugChannel,
+      }
+    )
   ).then(async (fallbackInitialRSCPayload) =>
     createInitialRSCPayloadFromFallbackPrerender(
       await clientResumeFetch,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -46,6 +46,10 @@ import {
   createNonTaskyPrefetchResponseStream,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
+import {
+  decodeFlightChunkLists,
+  decodeFlightResponse as decodeFlightChunkListResponse,
+} from '../../../shared/lib/flight-chunk-list-deduplication'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -839,7 +843,7 @@ export function createFromNextReadableStream<T>(
   requestHeaders: RequestHeaders | undefined,
   options?: { allowPartialStream?: boolean }
 ): Promise<T> {
-  return createFromReadableStream(flightStream, {
+  return createFromReadableStream(decodeFlightChunkLists(flightStream), {
     callServer,
     findSourceMapURL,
     debugChannel: createDebugChannel && createDebugChannel(requestHeaders),
@@ -851,7 +855,7 @@ function createFromNextFetch<T>(
   promiseForResponse: Promise<Response>,
   requestHeaders: RequestHeaders
 ): Promise<T> & { _debugInfo?: Array<any> } {
-  return createFromFetch(promiseForResponse, {
+  return createFromFetch(decodeFlightChunkListResponse(promiseForResponse), {
     callServer,
     findSourceMapURL,
     debugChannel: createDebugChannel && createDebugChannel(requestHeaders),

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -51,6 +51,7 @@ import { invalidateEntirePrefetchCache } from '../../segment-cache/cache'
 import { startRevalidationCooldown } from '../../segment-cache/scheduler'
 import { getDeploymentId } from '../../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../../navigation-build-id'
+import { decodeFlightResponse } from '../../../../shared/lib/flight-chunk-list-deduplication'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../../lib/constants'
 import {
   completeHardNavigation,
@@ -248,7 +249,7 @@ async function fetchServerAction(
       : Promise.resolve(res)
 
     const response: ActionFlightResponse = await createFromFetch(
-      responsePromise,
+      decodeFlightResponse(responsePromise),
       {
         callServer,
         findSourceMapURL,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -98,7 +98,10 @@ import { getImplicitTags, type ImplicitTags } from '../lib/implicit-tags'
 import { AppRenderSpan, NextNodeServerSpan } from '../lib/trace/constants'
 import { getRequestInsightsIdentity } from '../lib/trace/request-insights-identity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
-import { FlightRenderResult } from './flight-render-result'
+import {
+  FlightRenderResult,
+  prependFlightChunksDictionaryToBuffer,
+} from './flight-render-result'
 import {
   createReactServerErrorHandler,
   createHTMLErrorHandler,
@@ -8475,7 +8478,7 @@ async function prerenderToStream(
       reactServerPrerenderStore = finalServerPrerenderStore
 
       if (shouldGenerateStaticFlightData(workStore)) {
-        metadata.flightData = Buffer.concat(
+        const flightDataWithMarker = Buffer.concat(
           cachedNavigations
             ? prependIsPartialByteToChunks(
                 reactServerResult.asChunks(),
@@ -8486,8 +8489,8 @@ async function prerenderToStream(
 
         // collectSegmentData needs the raw flight data without the marker byte.
         const flightData = cachedNavigations
-          ? metadata.flightData.subarray(1)
-          : metadata.flightData
+          ? flightDataWithMarker.subarray(1)
+          : flightDataWithMarker
 
         await collectSegmentData(
           flightData,
@@ -8497,6 +8500,8 @@ async function prerenderToStream(
           ctx.pagePath,
           metadata
         )
+        metadata.flightData =
+          prependFlightChunksDictionaryToBuffer(flightDataWithMarker)
         // If link data (static params) unblocked new content, then the shell has to be partial.
         // If not, then the shell prerender and the static prerender are the same except for staleTime/varyParams.
         const shellIsPartial = didLinkDataUnblockNewContent
@@ -8838,7 +8843,6 @@ async function prerenderToStream(
       const flightData = await streamToBuffer(reactServerResult.asStream())
 
       if (shouldGenerateStaticFlightData(workStore)) {
-        metadata.flightData = flightData
         await collectSegmentData(
           flightData,
           ssrPrerenderStore,
@@ -8847,6 +8851,7 @@ async function prerenderToStream(
           ctx.pagePath,
           metadata
         )
+        metadata.flightData = prependFlightChunksDictionaryToBuffer(flightData)
       }
 
       const { prelude, preludeIsEmpty } =
@@ -9051,7 +9056,6 @@ async function prerenderToStream(
 
       if (shouldGenerateStaticFlightData(workStore)) {
         const flightData = await streamToBuffer(reactServerResult.asStream())
-        metadata.flightData = flightData
         await collectSegmentData(
           flightData,
           prerenderLegacyStore,
@@ -9060,6 +9064,7 @@ async function prerenderToStream(
           ctx.pagePath,
           metadata
         )
+        metadata.flightData = prependFlightChunksDictionaryToBuffer(flightData)
       }
 
       const getServerInsertedHTML = makeGetServerInsertedHTML({
@@ -9594,7 +9599,6 @@ async function prerenderToStream(
         const flightData = await streamToBuffer(
           reactServerPrerenderResult.asStream()
         )
-        metadata.flightData = flightData
         await collectSegmentData(
           flightData,
           prerenderLegacyStore,
@@ -9603,6 +9607,7 @@ async function prerenderToStream(
           ctx.pagePath,
           metadata
         )
+        metadata.flightData = prependFlightChunksDictionaryToBuffer(flightData)
       }
 
       return {

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,10 +1,7 @@
 import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
 import RenderResult, { type RenderResultMetadata } from '../render-result'
 import type { AnyStream } from './stream-ops'
-import {
-  getClientReferenceManifest,
-  getChunksDictForManifest,
-} from './manifests-singleton'
+import { getCurrentChunksDict } from './manifests-singleton'
 import { PassThrough, Readable } from 'node:stream'
 
 function prependToWebStream(
@@ -54,6 +51,24 @@ function prependToStream(stream: any, prefix: string): any {
   return stream
 }
 
+export function prependFlightChunksDictionaryToBuffer(payload: Buffer): Buffer {
+  const chunksDictionary = getCurrentChunksDict()
+  if (!chunksDictionary || Object.keys(chunksDictionary).length === 0) {
+    return payload
+  }
+
+  const prefix = Buffer.from(
+    `__next_chunks_dict__:${JSON.stringify(chunksDictionary)}\n`
+  )
+  // Cache Components place a completeness marker before the Flight rows.
+  // Keep it as the first byte so both the cache and Flight decoders see the
+  // framing they expect.
+  if (payload[0] === 0x23 || payload[0] === 0x7e) {
+    return Buffer.concat([payload.subarray(0, 1), prefix, payload.subarray(1)])
+  }
+  return Buffer.concat([prefix, payload])
+}
+
 /**
  * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
  */
@@ -65,10 +80,9 @@ export class FlightRenderResult extends RenderResult {
   ) {
     let payload = response
     try {
-      const manifest = getClientReferenceManifest()
-      const dictEntry = getChunksDictForManifest(manifest)
-      if (dictEntry && Object.keys(dictEntry.dict).length > 0) {
-        const prefix = `__next_chunks_dict__:${JSON.stringify(dictEntry.dict)}\n`
+      const chunksDictionary = getCurrentChunksDict()
+      if (chunksDictionary && Object.keys(chunksDictionary).length > 0) {
+        const prefix = `__next_chunks_dict__:${JSON.stringify(chunksDictionary)}\n`
         if (typeof payload === 'string') {
           payload = prefix + payload
         } else {

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,6 +1,58 @@
 import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
 import RenderResult, { type RenderResultMetadata } from '../render-result'
 import type { AnyStream } from './stream-ops'
+import {
+  getClientReferenceManifest,
+  getChunksDictForManifest,
+} from './manifests-singleton'
+import { PassThrough, Readable } from 'node:stream'
+
+function prependToWebStream(
+  stream: ReadableStream<Uint8Array>,
+  prefix: string
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader()
+  const encoder = new TextEncoder()
+  let prefixSent = false
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (!prefixSent) {
+        controller.enqueue(encoder.encode(prefix))
+        prefixSent = true
+        return
+      }
+      const { done, value } = await reader.read()
+      if (done) {
+        controller.close()
+      } else {
+        controller.enqueue(value)
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+}
+
+function prependToNodeStream(stream: Readable, prefix: string): Readable {
+  const pt = new PassThrough()
+  pt.write(Buffer.from(prefix))
+  stream.pipe(pt)
+  return pt
+}
+
+function prependToStream(stream: any, prefix: string): any {
+  if (
+    typeof ReadableStream !== 'undefined' &&
+    stream instanceof ReadableStream
+  ) {
+    return prependToWebStream(stream, prefix)
+  }
+  if (stream instanceof Readable) {
+    return prependToNodeStream(stream as Readable, prefix)
+  }
+  return stream
+}
 
 /**
  * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
@@ -11,7 +63,23 @@ export class FlightRenderResult extends RenderResult {
     metadata: RenderResultMetadata = {},
     waitUntil?: Promise<unknown>
   ) {
-    super(response, {
+    let payload = response
+    try {
+      const manifest = getClientReferenceManifest()
+      const dictEntry = getChunksDictForManifest(manifest)
+      if (dictEntry && Object.keys(dictEntry.dict).length > 0) {
+        const prefix = `__next_chunks_dict__:${JSON.stringify(dictEntry.dict)}\n`
+        if (typeof payload === 'string') {
+          payload = prefix + payload
+        } else {
+          payload = prependToStream(payload, prefix)
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+
+    super(payload, {
       contentType: RSC_CONTENT_TYPE_HEADER,
       metadata,
       waitUntil,

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -44,6 +44,79 @@ type ClientReferenceManifestMappingProp =
 
 const globalThisWithManifests = globalThis as GlobalThisWithManifests
 
+const chunksDicts = new WeakMap<
+  any,
+  {
+    dict: Record<string, string[]>
+    chunksToId: Map<string, string>
+  }
+>()
+
+export function getChunksDictForManifest(
+  manifest: DeepReadonly<ClientReferenceManifest>
+) {
+  let entry = chunksDicts.get(manifest)
+  if (!entry) {
+    const dict: Record<string, string[]> = {}
+    const chunksToId = new Map<string, string>()
+    let idCounter = 1
+
+    const processChunks = (
+      chunks: DeepReadonly<ReadonlyArray<string>> | undefined
+    ) => {
+      if (!chunks || !Array.isArray(chunks)) return
+      const key = JSON.stringify(chunks)
+      if (!chunksToId.has(key)) {
+        const id = `c${idCounter++}`
+        chunksToId.set(key, id)
+        dict[id] = chunks as string[]
+      }
+    }
+
+    if (manifest.clientModules) {
+      for (const key of Object.keys(manifest.clientModules)) {
+        const moduleNode = manifest.clientModules[key]
+        if (moduleNode && typeof moduleNode === 'object') {
+          processChunks(moduleNode.chunks)
+        }
+      }
+    }
+
+    if (manifest.ssrModuleMapping) {
+      for (const key of Object.keys(manifest.ssrModuleMapping)) {
+        const exportsMap = manifest.ssrModuleMapping[key]
+        if (exportsMap && typeof exportsMap === 'object') {
+          for (const exp of Object.keys(exportsMap)) {
+            processChunks(exportsMap[exp]?.chunks)
+          }
+        }
+      }
+    }
+
+    entry = { dict, chunksToId }
+    chunksDicts.set(manifest, entry)
+  }
+  return entry
+}
+
+function wrapClientModulesEntry(entry: any, prop: string, manifest: any) {
+  if (prop === 'clientModules' && entry && typeof entry === 'object') {
+    const entryChunks = entry.chunks
+    if (Array.isArray(entryChunks)) {
+      const dictEntry = getChunksDictForManifest(manifest)
+      const chunksKey = JSON.stringify(entryChunks)
+      const chunkId = dictEntry.chunksToId.get(chunksKey)
+      if (chunkId) {
+        return {
+          ...entry,
+          chunks: chunkId,
+        }
+      }
+    }
+  }
+  return entry
+}
+
 function createProxiedClientReferenceManifest(
   clientReferenceManifestsPerRoute: Map<
     string,
@@ -63,7 +136,11 @@ function createProxiedClientReferenceManifest(
             )
 
             if (currentManifest?.[prop][id]) {
-              return currentManifest[prop][id]
+              return wrapClientModulesEntry(
+                currentManifest[prop][id],
+                prop,
+                currentManifest
+              )
             }
 
             // In development, we also check all other manifests to see if the
@@ -88,7 +165,7 @@ function createProxiedClientReferenceManifest(
                 const entry = manifest[prop][id]
 
                 if (entry !== undefined) {
-                  return entry
+                  return wrapClientModulesEntry(entry, prop, manifest)
                 }
               }
             }
@@ -103,7 +180,7 @@ function createProxiedClientReferenceManifest(
               const entry = manifest[prop][id]
 
               if (entry !== undefined) {
-                return entry
+                return wrapClientModulesEntry(entry, prop, manifest)
               }
             }
           }

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -82,17 +82,6 @@ export function getChunksDictForManifest(
       }
     }
 
-    if (manifest.ssrModuleMapping) {
-      for (const key of Object.keys(manifest.ssrModuleMapping)) {
-        const exportsMap = manifest.ssrModuleMapping[key]
-        if (exportsMap && typeof exportsMap === 'object') {
-          for (const exp of Object.keys(exportsMap)) {
-            processChunks(exportsMap[exp]?.chunks)
-          }
-        }
-      }
-    }
-
     entry = { dict, chunksToId }
     chunksDicts.set(manifest, entry)
   }
@@ -405,6 +394,16 @@ function getManifestsSingleton(): ManifestsSingleton {
 
 export function getClientReferenceManifest(): DeepReadonly<ClientReferenceManifest> {
   return getManifestsSingleton().proxiedClientReferenceManifest
+}
+
+export function getCurrentChunksDict() {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) return undefined
+
+  const manifest = getManifestsSingleton().clientReferenceManifestsPerRoute.get(
+    workStore.route
+  )
+  return manifest ? getChunksDictForManifest(manifest).dict : undefined
 }
 
 export function getServerActionsManifest(): DeepReadonly<ActionManifest> {

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -18,6 +18,10 @@ import { PassThrough, Readable, Transform } from 'node:stream'
 import { isUtf8 } from 'node:buffer'
 
 import {
+  getClientReferenceManifest,
+  getChunksDictForManifest,
+} from './manifests-singleton'
+import {
   continueStaticPrerender as webContinueStaticPrerender,
   continueDynamicPrerender as webContinueDynamicPrerender,
   continueStaticFallbackPrerender as webContinueStaticFallbackPrerender,
@@ -947,6 +951,18 @@ export function createNodeInlinedDataStream(
   let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
     JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
   )})`
+  try {
+    const manifest = getClientReferenceManifest()
+    const dictEntry = getChunksDictForManifest(manifest)
+    if (dictEntry && Object.keys(dictEntry.dict).length > 0) {
+      const line = `__next_chunks_dict__:${JSON.stringify(dictEntry.dict)}\n`
+      scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
+        JSON.stringify([INLINE_FLIGHT_PAYLOAD_DATA, line])
+      )})`
+    }
+  } catch (e) {
+    // ignore
+  }
   if (formState != null) {
     scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
       JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -17,10 +17,7 @@ import { prerender } from 'react-dom/static'
 import { PassThrough, Readable, Transform } from 'node:stream'
 import { isUtf8 } from 'node:buffer'
 
-import {
-  getClientReferenceManifest,
-  getChunksDictForManifest,
-} from './manifests-singleton'
+import { getCurrentChunksDict } from './manifests-singleton'
 import {
   continueStaticPrerender as webContinueStaticPrerender,
   continueDynamicPrerender as webContinueDynamicPrerender,
@@ -952,12 +949,13 @@ export function createNodeInlinedDataStream(
     JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
   )})`
   try {
-    const manifest = getClientReferenceManifest()
-    const dictEntry = getChunksDictForManifest(manifest)
-    if (dictEntry && Object.keys(dictEntry.dict).length > 0) {
-      const line = `__next_chunks_dict__:${JSON.stringify(dictEntry.dict)}\n`
+    const chunksDictionary = getCurrentChunksDict()
+    if (chunksDictionary && Object.keys(chunksDictionary).length > 0) {
       scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
-        JSON.stringify([INLINE_FLIGHT_PAYLOAD_DATA, line])
+        JSON.stringify([
+          INLINE_FLIGHT_PAYLOAD_CHUNKS_DICTIONARY,
+          chunksDictionary,
+        ])
       )})`
     }
   } catch (e) {
@@ -980,6 +978,7 @@ const INLINE_FLIGHT_PAYLOAD_BOOTSTRAP = 0
 const INLINE_FLIGHT_PAYLOAD_DATA = 1
 const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
 const INLINE_FLIGHT_PAYLOAD_BINARY = 3
+const INLINE_FLIGHT_PAYLOAD_CHUNKS_DICTIONARY = 4
 
 async function pullFlightData(
   dataStream: Readable,

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -7,7 +7,10 @@ import {
 } from '../../shared/lib/htmlescape'
 import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
-import { getClientReferenceManifest } from './manifests-singleton'
+import {
+  getClientReferenceManifest,
+  getChunksDictForManifest,
+} from './manifests-singleton'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
@@ -227,6 +230,19 @@ function writeInitialInstructions(
   let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
     JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
   )})`
+
+  try {
+    const manifest = getClientReferenceManifest()
+    const dictEntry = getChunksDictForManifest(manifest)
+    if (dictEntry && Object.keys(dictEntry.dict).length > 0) {
+      const line = `__next_chunks_dict__:${JSON.stringify(dictEntry.dict)}\n`
+      scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
+        JSON.stringify([INLINE_FLIGHT_PAYLOAD_DATA, line])
+      )})`
+    }
+  } catch (e) {
+    // ignore
+  }
 
   if (formState != null) {
     scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -9,8 +9,12 @@ import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   getClientReferenceManifest,
-  getChunksDictForManifest,
+  getCurrentChunksDict,
 } from './manifests-singleton'
+import {
+  decodeFlightChunkLists,
+  FlightChunkListDecoder,
+} from '../../shared/lib/flight-chunk-list-deduplication'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
@@ -18,6 +22,7 @@ const INLINE_FLIGHT_PAYLOAD_BOOTSTRAP = 0
 const INLINE_FLIGHT_PAYLOAD_DATA = 1
 const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
 const INLINE_FLIGHT_PAYLOAD_BINARY = 3
+const INLINE_FLIGHT_PAYLOAD_CHUNKS_DICTIONARY = 4
 
 const flightResponses = new WeakMap<
   Readable | BinaryStreamOf<any>,
@@ -30,6 +35,29 @@ const findSourceMapURL =
     ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
         .findSourceMapURLDEV
     : undefined
+
+function decodeNodeFlightChunkLists(
+  stream: Readable,
+  dictionary: Record<string, string[]> | undefined
+): Readable {
+  const { Transform } = require('node:stream') as typeof import('node:stream')
+  const decoder = new FlightChunkListDecoder(dictionary)
+  const output = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      for (const decodedChunk of decoder.transform(chunk)) {
+        this.push(decodedChunk)
+      }
+      callback()
+    },
+    flush(callback) {
+      for (const decodedChunk of decoder.flush()) this.push(decodedChunk)
+      callback()
+    },
+  })
+  stream.on('error', (error) => output.destroy(error))
+  stream.pipe(output)
+  return output
+}
 
 /**
  * Render Flight stream.
@@ -49,6 +77,7 @@ export function getFlightStream<T>(
 
   const { moduleLoading, edgeSSRModuleMapping, ssrModuleMapping } =
     getClientReferenceManifest()
+  const chunksDictionary = getCurrentChunksDict()
 
   let newResponse: Promise<T>
   if (flightStream instanceof ReadableStream) {
@@ -62,17 +91,20 @@ export function getFlightStream<T>(
       // eslint-disable-next-line import/no-extraneous-dependencies
       require('react-server-dom-webpack/client') as typeof import('react-server-dom-webpack/client')
 
-    newResponse = createFromReadableStream<T>(flightStream, {
-      findSourceMapURL,
-      serverConsumerManifest: {
-        moduleLoading,
-        moduleMap: isEdgeRuntime ? edgeSSRModuleMapping : ssrModuleMapping,
-        serverModuleMap: null,
-      },
-      nonce,
-      debugChannel: debugStream ? { readable: debugStream } : undefined,
-      endTime: debugEndTime,
-    })
+    newResponse = createFromReadableStream<T>(
+      decodeFlightChunkLists(flightStream, chunksDictionary),
+      {
+        findSourceMapURL,
+        serverConsumerManifest: {
+          moduleLoading,
+          moduleMap: isEdgeRuntime ? edgeSSRModuleMapping : ssrModuleMapping,
+          serverModuleMap: null,
+        },
+        nonce,
+        debugChannel: debugStream ? { readable: debugStream } : undefined,
+        endTime: debugEndTime,
+      }
+    )
   } else {
     if (process.env.NEXT_RUNTIME === 'edge') {
       throw new InvariantError(
@@ -101,7 +133,7 @@ export function getFlightStream<T>(
         require('react-server-dom-webpack/client') as typeof import('react-server-dom-webpack/client')
 
       newResponse = createFromNodeStream<T>(
-        flightStream,
+        decodeNodeFlightChunkLists(flightStream, chunksDictionary),
         {
           moduleLoading,
           moduleMap: isEdgeRuntime ? edgeSSRModuleMapping : ssrModuleMapping,
@@ -232,12 +264,13 @@ function writeInitialInstructions(
   )})`
 
   try {
-    const manifest = getClientReferenceManifest()
-    const dictEntry = getChunksDictForManifest(manifest)
-    if (dictEntry && Object.keys(dictEntry.dict).length > 0) {
-      const line = `__next_chunks_dict__:${JSON.stringify(dictEntry.dict)}\n`
+    const chunksDictionary = getCurrentChunksDict()
+    if (chunksDictionary && Object.keys(chunksDictionary).length > 0) {
       scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
-        JSON.stringify([INLINE_FLIGHT_PAYLOAD_DATA, line])
+        JSON.stringify([
+          INLINE_FLIGHT_PAYLOAD_CHUNKS_DICTIONARY,
+          chunksDictionary,
+        ])
       )})`
     }
   } catch (e) {

--- a/packages/next/src/shared/lib/flight-chunk-list-deduplication.test.ts
+++ b/packages/next/src/shared/lib/flight-chunk-list-deduplication.test.ts
@@ -1,0 +1,65 @@
+import {
+  decodeFlightChunkLists,
+  FlightChunkListDecoder,
+} from './flight-chunk-list-deduplication'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+describe('Flight chunk list deduplication', () => {
+  it('expands dictionary references split across stream chunks', async () => {
+    const input =
+      '__next_chunks_dict__:{"c1":["/a.js","/b.js"]}\n' +
+      '1:I[123,"c1","default"]\n' +
+      '0:{"value":"ok"}\n'
+    const bytes = encoder.encode(input)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.subarray(0, 17))
+        controller.enqueue(bytes.subarray(17, 53))
+        controller.enqueue(bytes.subarray(53))
+        controller.close()
+      },
+    })
+
+    const output = await new Response(decodeFlightChunkLists(stream)).text()
+    expect(output).toBe(
+      '1:I[123,["/a.js","/b.js"],"default"]\n0:{"value":"ok"}\n'
+    )
+  })
+
+  it('preserves binary rows and completeness markers byte-for-byte', () => {
+    const flightDecoder = new FlightChunkListDecoder({ c1: ['/a.js'] })
+    const prefix = encoder.encode('~1:T4,')
+    const binary = new Uint8Array([0, 10, 255, 1])
+    const suffix = encoder.encode('2:I[7,"c1","x"]\n')
+    const input = new Uint8Array(prefix.length + binary.length + suffix.length)
+    input.set(prefix)
+    input.set(binary, prefix.length)
+    input.set(suffix, prefix.length + binary.length)
+
+    const chunks = [
+      ...flightDecoder.transform(input.subarray(0, 5)),
+      ...flightDecoder.transform(input.subarray(5, 9)),
+      ...flightDecoder.transform(input.subarray(9)),
+      ...flightDecoder.flush(),
+    ]
+    const output = new Uint8Array(
+      chunks.reduce((total, chunk) => total + chunk.byteLength, 0)
+    )
+    let offset = 0
+    for (const chunk of chunks) {
+      output.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+
+    const expectedSuffix = encoder.encode('2:I[7,["/a.js"],"x"]\n')
+    expect(output.subarray(0, prefix.length)).toEqual(prefix)
+    expect(
+      output.subarray(prefix.length, prefix.length + binary.length)
+    ).toEqual(binary)
+    expect(decoder.decode(output.subarray(prefix.length + binary.length))).toBe(
+      decoder.decode(expectedSuffix)
+    )
+  })
+})

--- a/packages/next/src/shared/lib/flight-chunk-list-deduplication.ts
+++ b/packages/next/src/shared/lib/flight-chunk-list-deduplication.ts
@@ -1,0 +1,242 @@
+const CHUNKS_DICTIONARY_PREFIX = '__next_chunks_dict__:'
+
+// Flight's length-delimited binary row tags. Text rows end in a newline, but
+// binary rows can contain arbitrary bytes (including newlines), so the decoder
+// must frame them before inspecting import rows.
+const BINARY_ROW_TAGS = new Set([
+  84, // T
+  65, // A
+  79, // O
+  111, // o
+  98, // b
+  85, // U
+  83, // S
+  115, // s
+  76, // L
+  108, // l
+  71, // G
+  103, // g
+  77, // M
+  109, // m
+  86, // V
+])
+
+type ChunksDictionary = Record<string, string[]>
+
+const enum RowState {
+  Id,
+  Tag,
+  Length,
+  Text,
+  Binary,
+}
+
+/**
+ * Expands dictionary references in Flight import rows while preserving binary
+ * rows byte-for-byte. A decoder instance is scoped to one Flight response so
+ * dictionary ids from concurrent responses cannot collide.
+ */
+export class FlightChunkListDecoder {
+  private readonly dictionary: ChunksDictionary
+  private readonly textDecoder = new TextDecoder()
+  private readonly textEncoder = new TextEncoder()
+  private rowState = RowState.Id
+  private rowBuffer: number[] = []
+  private rowLength = 0
+  private binaryBytesRemaining = 0
+  private atStart = true
+
+  constructor(initialDictionary?: ChunksDictionary) {
+    this.dictionary = { ...initialDictionary }
+  }
+
+  transform(chunk: Uint8Array): Uint8Array[] {
+    const output: Uint8Array[] = []
+    let offset = 0
+
+    // Cache Components may prepend a completeness marker. It is outside the
+    // Flight row framing and must pass through untouched.
+    if (this.atStart && chunk.byteLength > 0) {
+      this.atStart = false
+      if (chunk[0] === 0x23 || chunk[0] === 0x7e) {
+        output.push(chunk.subarray(0, 1))
+        offset = 1
+      }
+    }
+
+    while (offset < chunk.byteLength) {
+      switch (this.rowState) {
+        case RowState.Id: {
+          const byte = chunk[offset++]
+          this.rowBuffer.push(byte)
+          if (byte === 58) {
+            this.rowState = RowState.Tag
+          }
+          break
+        }
+        case RowState.Tag: {
+          const byte = chunk[offset++]
+          this.rowBuffer.push(byte)
+          if (BINARY_ROW_TAGS.has(byte)) {
+            this.rowLength = 0
+            this.rowState = RowState.Length
+          } else if (byte === 10) {
+            this.flushTextRow(output)
+          } else {
+            this.rowState = RowState.Text
+          }
+          break
+        }
+        case RowState.Length: {
+          const byte = chunk[offset++]
+          this.rowBuffer.push(byte)
+          if (byte === 44) {
+            output.push(Uint8Array.from(this.rowBuffer))
+            this.rowBuffer = []
+            this.binaryBytesRemaining = this.rowLength
+            if (this.binaryBytesRemaining === 0) {
+              this.rowState = RowState.Id
+            } else {
+              this.rowState = RowState.Binary
+            }
+          } else {
+            this.rowLength =
+              (this.rowLength << 4) | (byte > 96 ? byte - 87 : byte - 48)
+          }
+          break
+        }
+        case RowState.Text: {
+          const newline = chunk.indexOf(10, offset)
+          if (newline === -1) {
+            for (; offset < chunk.byteLength; offset++) {
+              this.rowBuffer.push(chunk[offset])
+            }
+          } else {
+            for (; offset <= newline; offset++) {
+              this.rowBuffer.push(chunk[offset])
+            }
+            this.flushTextRow(output)
+          }
+          break
+        }
+        case RowState.Binary: {
+          const available = chunk.byteLength - offset
+          const length = Math.min(available, this.binaryBytesRemaining)
+          output.push(chunk.subarray(offset, offset + length))
+          offset += length
+          this.binaryBytesRemaining -= length
+          if (this.binaryBytesRemaining === 0) {
+            this.rowState = RowState.Id
+          }
+          break
+        }
+        default:
+          this.rowState satisfies never
+      }
+    }
+
+    return output
+  }
+
+  flush(): Uint8Array[] {
+    if (this.rowBuffer.length === 0) return []
+    const remainder = Uint8Array.from(this.rowBuffer)
+    this.rowBuffer = []
+    return [remainder]
+  }
+
+  private flushTextRow(output: Uint8Array[]) {
+    const bytes = Uint8Array.from(this.rowBuffer)
+    this.rowBuffer = []
+    this.rowState = RowState.Id
+
+    const line = this.textDecoder.decode(bytes)
+    if (line.startsWith(CHUNKS_DICTIONARY_PREFIX)) {
+      try {
+        Object.assign(
+          this.dictionary,
+          JSON.parse(
+            line.slice(CHUNKS_DICTIONARY_PREFIX.length).trimEnd()
+          ) as ChunksDictionary
+        )
+      } catch {
+        // Preserve malformed control rows. React will surface the protocol
+        // error instead of silently dropping data.
+        output.push(bytes)
+      }
+      return
+    }
+
+    const match = /^([0-9a-f]+):I(.+)\n$/.exec(line)
+    if (!match) {
+      output.push(bytes)
+      return
+    }
+
+    try {
+      const metadata = JSON.parse(match[2]) as unknown[]
+      const chunksId = metadata[1]
+      if (typeof chunksId !== 'string') {
+        output.push(bytes)
+        return
+      }
+      const chunks = this.dictionary[chunksId]
+      if (!chunks) {
+        output.push(bytes)
+        return
+      }
+      metadata[1] = chunks
+      output.push(
+        this.textEncoder.encode(`${match[1]}:I${JSON.stringify(metadata)}\n`)
+      )
+    } catch {
+      output.push(bytes)
+    }
+  }
+}
+
+export function decodeFlightChunkLists(
+  stream: ReadableStream<Uint8Array>,
+  initialDictionary?: ChunksDictionary
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader()
+  const decoder = new FlightChunkListDecoder(initialDictionary)
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          for (const chunk of decoder.flush()) controller.enqueue(chunk)
+          controller.close()
+          return
+        }
+        const decodedChunks = decoder.transform(value)
+        for (const chunk of decodedChunks) controller.enqueue(chunk)
+        if (decodedChunks.length > 0) return
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+}
+
+export async function decodeFlightResponse(
+  responsePromise: Promise<Response>
+): Promise<Response> {
+  const response = await responsePromise
+  if (!response.body) return response
+
+  const decoded = new Response(decodeFlightChunkLists(response.body), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+  Object.defineProperties(decoded, {
+    redirected: { value: response.redirected },
+    type: { value: response.type },
+    url: { value: response.url },
+  })
+  return decoded
+}


### PR DESCRIPTION
### What?

Fixes duplicate Flight payload chunk URL lists in App Router by dictionary-encoding repeated chunk lists and decoding them wherever Flight/RSC responses are consumed.

### Why?

Issue #95559 reports that App Router Flight payloads repeat the full list of chunk URLs for every client module reference row, which significantly increases SSR HTML size.

### How?

- Adds shared Flight chunk-list dictionary decoding that preserves streamed Flight framing, binary rows, and Cache Components completeness markers.
- Emits chunk-list dictionaries for inline Flight payloads and standalone RSC responses.
- Decodes deduplicated payloads before server React consumption, client inline processing, router fetches, resume fetches, and server action RSC fetches.
- Adds focused tests for split streamed dictionaries and binary row preservation.

Verification against `Adophlidu/next-flight-chunklist-repro`:

- Duplication factor dropped to `1.6x`.
- Chunk URL text dropped to `2.7%` of raw HTML.
- Raw HTML size dropped from `15,869` bytes to `11,696` bytes, a `26.3%` reduction.
- Production hydration passed with no browser errors.
- Standalone `text/x-component` RSC navigation decoded and rendered successfully with no browser errors.

Fixes #95559
