### PR TITLE
docs: note the `:has()` scaling limit in the Interactive apps guide

### DIFF
--- a/docs/01-app/02-guides/interactive-apps.mdx
+++ b/docs/01-app/02-guides/interactive-apps.mdx
@@ -285,6 +285,8 @@ The consumer passes a callback (`changeAction`), and the design component runs i
 
 The `data-pending` attribute on the `ChipGroup` root element lets ancestor components react through CSS without any coordination. The board on the home page uses `group-has-data-pending:opacity-50` to dim while the transition runs, without replacing the board with a skeleton. Because `ChipGroup` renders inside the `group` element, the attribute is available to any ancestor for styling.
 
+> **Good to know:** `group-has-data-pending:` and `has-data-pending:` compile to the CSS [`:has()`](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) selector, which the browser re-evaluates over the anchored subtree whenever `data-pending` toggles. That stays cheap here because the board toggles it only twice per filter, and dragging (Step 5) deliberately skips it. Reach for client state instead when a broad `:has()` anchor toggles on a high-frequency interaction like dragging or scrolling, where repeated recalculation over a large subtree adds up.
+
 The "Frontend" chip now highlights on the current frame. The board dims while the filtered data loads, then updates with the filtered tasks.
 
 ### Step 4: Add comments with instant feedback


### PR DESCRIPTION
### What?

Adds a "Good to know" to the Interactive apps guide explaining that the `data-pending` + `group-has-data-pending:`/`has-data-pending:` pattern compiles to the CSS `:has()` selector, and when to reach for client state instead.

### Why?

`:has()` is re-evaluated over the anchored subtree whenever the attribute toggles, so a broad anchor (like the whole board) combined with a high-frequency interaction can add up. The guide taught the pattern without noting that scaling limit, so a reader could copy the board-wide dim into a per-frame interaction and hit style-recalc cost.

### How?

Documentation only. One callout in Step 3, calibrated so the guide's own board usage stays fine (it toggles only per filter, and dragging deliberately skips it), and pointing to client state for the high-frequency case.
