### PR TITLE
docs: add 'Set up your editor' to the installation guide

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -348,6 +348,39 @@ You can enable the plugin in VS Code by:
 
 See the [TypeScript reference](/docs/app/api-reference/config/typescript) page for more information.
 
+<AppOnly>
+
+## Set up your editor
+
+The App Router names files by convention, like `page.tsx`, `layout.tsx`, and `route.ts`, so your editor quickly fills with same-named tabs. Label each tab with its enclosing folders, like `blog/[id]`, so you can tell them apart.
+
+In VS Code 1.88+ or Cursor, add [custom editor labels](https://code.visualstudio.com/updates/v1_88#_customize-editor-labels) to `.vscode/settings.json`. Labeling two folders deep keeps dynamic routes like `blog/[id]/page.tsx` from all collapsing to the same `[id]` label:
+
+```json filename=".vscode/settings.json"
+{
+  "workbench.editor.customLabels.patterns": {
+    "**/app/**/page.tsx": "${dirname(1)}/${dirname} - page.tsx",
+    "**/app/**/layout.tsx": "${dirname(1)}/${dirname} - layout.tsx",
+    "**/app/**/loading.tsx": "${dirname(1)}/${dirname} - loading.tsx",
+    "**/app/**/error.tsx": "${dirname(1)}/${dirname} - error.tsx",
+    "**/app/**/not-found.tsx": "${dirname(1)}/${dirname} - not-found.tsx",
+    "**/app/**/template.tsx": "${dirname(1)}/${dirname} - template.tsx",
+    "**/app/**/default.tsx": "${dirname(1)}/${dirname} - default.tsx",
+    "**/app/**/route.ts": "${dirname(1)}/${dirname} - route.ts"
+  }
+}
+```
+
+Or copy this prompt to have your coding agent set it up:
+
+```prompt
+Set up custom editor labels so my Next.js App Router files are easy to tell apart. Read https://nextjs.org/docs/app/getting-started/installation#set-up-your-editor and add the workbench.editor.customLabels.patterns config shown there to my .vscode/settings.json, creating the file if it doesn't exist. Adjust the labels to taste. If I use a different editor, apply the equivalent setting or tell me it's automatic, and leave my other settings untouched.
+```
+
+> **Good to know:** JetBrains IDEs (WebStorm, IntelliJ) show the folder for same-named files automatically, so no setup is needed.
+
+</AppOnly>
+
 ## Set up linting
 
 Next.js supports linting with either ESLint or Biome. Choose a linter and run it directly via `package.json` scripts.


### PR DESCRIPTION
## Summary

<img width="1304" height="1546" alt="CleanShot 2026-07-19 at 01 07 57@2x" src="https://github.com/user-attachments/assets/b9a6a7c9-dc95-42d5-9cce-f29e6d869d92" />


Adds a "Set up your editor" section to the App Router installation guide. The App Router names files by convention (`page.tsx`, `layout.tsx`, `route.ts`), so an editor quickly fills with same-named tabs. This section shows how to tell them apart with VS Code / Cursor custom editor labels, labeled two folders deep so dynamic routes like `blog/[id]/page.tsx` do not all collapse to the same `[id]` label. It includes:

- A copy-paste `.vscode/settings.json` config (`workbench.editor.customLabels.patterns`) for setting it up by hand.
- A copyable prompt that points a coding agent back at this section to apply the config, including adapting it to other editors.
- A good-to-know that JetBrains IDEs (WebStorm, IntelliJ) do this automatically.

## Verification

- Previewed locally against the docs site: the section renders (HTTP 200), with the config block, the prompt card, and the good-to-know all rendering correctly.

<!-- NEXT_JS_LLM_PR -->