### PR TITLE
Add e2e test for stale use cache content served to cookieless requests in dev

### DIFF
--- a/test/e2e/app-dir/use-cache-dev/use-cache-dev.test.ts
+++ b/test/e2e/app-dir/use-cache-dev/use-cache-dev.test.ts
@@ -139,6 +139,64 @@ describe('use-cache-dev', () => {
       expect(softReloadContent).toEqual(hardReloadContent)
     })
 
+    it('should serve stale content to cookieless requests after an edit until a hard reload revalidates it', async () => {
+      // Establish the cookieless cache entry.
+      let $ = await next.render$('/')
+      expect($('#text').text()).toBe('foo')
+
+      await next.patchFile(
+        'app/page.tsx',
+        (content) => content.replace('foo', 'baz'),
+        async () => {
+          // Once compiled, a request with an HMR refresh hash cookie
+          // (normally set by the HMR client) uses a new cache key and is
+          // rendered fresh. Using a unique hash per attempt to avoid
+          // caching a pre-edit render under the tested key.
+          await retry(async () => {
+            const $ = await next.render$(
+              '/',
+              {},
+              {
+                headers: {
+                  cookie: `__next_hmr_refresh_hash__=${Math.random()}`,
+                },
+              }
+            )
+
+            expect($('#text').text()).toBe('baz')
+          })
+
+          // The edit did not evict the cookieless cache entry; it still
+          // serves the pre-edit content.
+          $ = await next.render$('/')
+          expect($('#text').text()).toBe('foo')
+
+          // A hard reload (cache-control: no-cache) renders fresh...
+          $ = await next.render$(
+            '/',
+            {},
+            { headers: { 'cache-control': 'no-cache' } }
+          )
+
+          expect($('#text').text()).toBe('baz')
+
+          // ...and overwrites the cookieless cache entry.
+          $ = await next.render$('/')
+          expect($('#text').text()).toBe('baz')
+        }
+      )
+
+      // Re-sync the cookieless cache entry with the reverted file content
+      // for subsequent tests.
+      $ = await next.render$(
+        '/',
+        {},
+        { headers: { 'cache-control': 'no-cache' } }
+      )
+
+      expect($('#text').text()).toBe('foo')
+    })
+
     it('should successfully finish compilation when "use cache" directive is added/removed', async () => {
       await next.browser('/')
       let cliOutputLength = next.cliOutput.length


### PR DESCRIPTION
### What?

Adds a fourth dev-mode case to the `use-cache-dev` e2e suite. It proves that `next dev` keeps serving pre-edit `use cache` content to requests that carry no HMR refresh hash cookie, and that a hard reload is what repairs the entry.

### Why?

In dev, editing a file does not evict existing `use cache` entries. Invalidation works by re-keying: the HMR client stores each server component change hash in a `__next_hmr_refresh_hash__` cookie, and requests that carry the cookie use a new cache key. A client without the cookie (curl, a fresh browser profile, any plain HTTP request) keeps reading the old entry until it expires.

The suite covers the browser side of this (HMR updates, soft reload, hard reload) but had no coverage for what a cookieless client sees after an edit. That gap is easy to mistake for a bug: compilation is clean and the connected browser shows the edit, yet `curl http://localhost:3000/` still returns the old HTML.

### How?

The test drives the scenario with plain HTTP requests against the existing fixture, whose cached page renders the string `foo`:

1. A request without any cookie renders `foo` and creates the cache entry keyed without an HMR refresh hash.
2. `next.patchFile` replaces `foo` with `baz` in `app/page.tsx`.
3. A request with the header `cookie: __next_hmr_refresh_hash__=<random>` renders `baz` once compilation finishes. Each retry attempt uses a fresh random value; a fixed value would cache a pre-edit render under that key on the first attempt and never converge. This request is also the compile barrier, so the next assertion cannot race.
4. A plain request still renders `foo`. This is the staleness claim: the edit did not evict the cookieless entry.
5. A request with the header `Cache-Control: no-cache` (what a browser hard reload sends) renders `baz` and writes the fresh result back.
6. A final plain request renders `baz`. The entry is repaired for every client from here on.

After the patch auto-reverts, one more `Cache-Control: no-cache` request re-syncs the entry to `foo` so later tests in the suite start from a clean state.

Passes with both `pnpm test-dev-turbo` and `pnpm test-dev-webpack`. The existing `should successfully finish compilation when "use cache" directive is added/removed` case fails on my machine on unmodified canary as well, so that failure is unrelated to this change.