### PR TITLE
Expose a new napi binding for accessing the source map _path_ of a source asset

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -924,6 +924,18 @@ impl ProjectContainer {
         if let Some(map) = self.versioned_content_map {
             map.get_asset(file_path)
         } else {
+            // The `versioned_content_map` is a dev-only path→asset index (see
+            // `Project::versioned_content_map`), so there's no lookup available in production.
+            //
+            // To make this work outside dev we'd need a path→asset index over the emitted output
+            // graph (walk `all_assets_from_entries` keyed by `OutputAsset::path()`), analogous to
+            // `VersionedContentMap` but populated in build mode too. Source maps *are* written to
+            // disk in prod (server maps default-on, client maps behind
+            // `productionBrowserSourceMaps`), and the resolved chunk asset's referenced
+            // `SourceMapAsset::path()` is the authoritative `.map` location in every
+            // mode (it already accounts for content-hashed prod client chunks, whose
+            // map path is derived from the map's own content — not `<chunk>.map`), so
+            // once the chunk asset is resolvable here the file-path lookup works unchanged.
             Vc::cell(None)
         }
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -76,8 +76,8 @@ use turbopack_core::{
         chunk_group_info::{ChunkGroupEntry, EntryHeuristics},
     },
     output::{
-        ExpandOutputAssetsInput, ExpandedOutputAssets, OutputAsset, OutputAssets,
-        expand_output_assets,
+        ExpandOutputAssetsInput, ExpandedOutputAssets, OptionOutputAsset, OutputAsset,
+        OutputAssets, expand_output_assets,
     },
     reference::all_assets_from_entries,
     reference_type::{CommonJsReferenceSubType, ReferenceType},
@@ -914,6 +914,17 @@ impl ProjectContainer {
             map.get_source_map(file_path, section)
         } else {
             FileContent::NotFound.cell()
+        }
+    }
+
+    /// Gets the [`OutputAsset`] that generates the source map for a particular `file_path` (i.e.
+    /// the chunk asset itself). If `dev` mode is disabled, this will always return [`None`].
+    #[turbo_tasks::function]
+    pub fn get_source_map_asset(&self, file_path: FileSystemPath) -> Vc<OptionOutputAsset> {
+        if let Some(map) = self.versioned_content_map {
+            map.get_asset(file_path)
+        } else {
+            Vc::cell(None)
         }
     }
 }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -58,14 +58,15 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::db_invalidation::invalidation_reasons;
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation, util::uri_from_file,
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation, rebase,
+    util::uri_from_file,
 };
 use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
     issue::PlainIssue,
-    output::{OutputAsset, OutputAssets},
-    source_map::{GenerateSourceMap, SourceMap, Token},
+    output::{OutputAsset, OutputAssets, OutputAssetsReference},
+    source_map::{GenerateSourceMap, SourceMap, SourceMapAsset, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
 };
 use turbopack_ecmascript_hmr_protocol::{ClientUpdateInstruction, Issue, ResourceIdentifier};
@@ -2181,23 +2182,41 @@ pub struct StackFrame {
 #[derive(Clone)]
 pub struct OptionStackFrame(Option<StackFrame>);
 
-/// The resolved chunk asset that owns the source map for a given `source_url`, along with the
-/// optional module `section` (the `id` query param) and the `chunk_base` (path relative to the dist
-/// dir, in unix form) that were used to resolve it.
+/// The chunk asset that owns the source map for a given `source_url`, along with the referenced
+/// [`SourceMapAsset`] and the optional module `section` (the `id` query param).
 ///
-/// Callers can derive the source map *content* from the asset (via [`GenerateSourceMap`]) or its
-/// *file path* (via [`OutputAsset::path`]).
+/// Callers can derive the source map *content* from `chunk` (via [`GenerateSourceMap`]) or its
+/// *file path* from `source_map`'s [`OutputAsset::path`].
 struct ResolvedSourceMapAsset {
-    asset: ResolvedVc<Box<dyn OutputAsset>>,
+    chunk: ResolvedVc<Box<dyn OutputAsset>>,
+    source_map: ResolvedVc<SourceMapAsset>,
     section: Option<RcStr>,
-    chunk_base_unix: RcStr,
 }
 
-/// Resolves the chunk asset whose generated source map has content for the given `source_url`,
-/// trying the server chunk first and falling back to a client chunk.
+/// Returns the [`SourceMapAsset`] referenced by `chunk` (chunks reference their source map as a
+/// sibling output asset), or `None` if the chunk has no source map.
+async fn source_map_asset_of(
+    chunk: ResolvedVc<Box<dyn OutputAsset>>,
+) -> Result<Option<ResolvedVc<SourceMapAsset>>> {
+    let references = (*chunk).references().await?;
+    for referenced in references.assets.await?.iter() {
+        if let Some(source_map) = ResolvedVc::try_downcast_type::<SourceMapAsset>(*referenced) {
+            return Ok(Some(source_map));
+        }
+    }
+    Ok(None)
+}
+
+/// Resolves the chunk asset that owns the source map for the given `source_url`, trying the server
+/// chunk first and falling back to a client chunk.
 ///
-/// Returns `Ok(None)` when the url is outside the dist dir. `bail`s when the chunk exists in
-/// neither location (i.e. is missing a sourcemap).
+/// The server-vs-client decision is based on whether a chunk asset *exists at that path and
+/// references a [`SourceMapAsset`]* — we deliberately avoid *generating* the source map here
+/// (that's potentially expensive and is only needed by the content getter), so the file-path getter
+/// never pays for source-map codegen.
+///
+/// Returns `Ok(None)` when the url is outside the dist dir. `bail`s when no such chunk exists in
+/// either location (i.e. is missing a sourcemap).
 async fn resolve_source_map_asset(
     container: Vc<ProjectContainer>,
     source_url: &RcStr,
@@ -2240,19 +2259,13 @@ async fn resolve_source_map_asset(
         .await?
         .join(&chunk_base_unix)?;
 
-    // A chunk asset may exist without producing a (non-empty) source map, so the server-vs-client
-    // decision is based on whether the *generated* source map has content, matching the historical
-    // behavior of `get_source_map_rope`.
-    if container
-        .get_source_map(server_path.clone(), module.clone())
-        .await?
-        .is_content()
-        && let Some(asset) = *container.get_source_map_asset(server_path).await?
+    if let Some(chunk) = *container.get_source_map_asset(server_path).await?
+        && let Some(source_map) = source_map_asset_of(chunk).await?
     {
         return Ok(Some(ResolvedSourceMapAsset {
-            asset,
+            chunk,
+            source_map,
             section: module,
-            chunk_base_unix,
         }));
     }
 
@@ -2266,16 +2279,13 @@ async fn resolve_source_map_asset(
         .await?
         .join(&chunk_base_unix)?;
 
-    if container
-        .get_source_map(client_path.clone(), module.clone())
-        .await?
-        .is_content()
-        && let Some(asset) = *container.get_source_map_asset(client_path).await?
+    if let Some(chunk) = *container.get_source_map_asset(client_path).await?
+        && let Some(source_map) = source_map_asset_of(chunk).await?
     {
         return Ok(Some(ResolvedSourceMapAsset {
-            asset,
+            chunk,
+            source_map,
             section: module,
-            chunk_base_unix,
         }));
     }
 
@@ -2287,13 +2297,13 @@ pub async fn get_source_map_rope(
     container: Vc<ProjectContainer>,
     source_url: RcStr,
 ) -> Result<Vc<FileContent>> {
-    let Some(ResolvedSourceMapAsset { asset, section, .. }) =
+    let Some(ResolvedSourceMapAsset { chunk, section, .. }) =
         resolve_source_map_asset(container, &source_url).await?
     else {
         return Ok(FileContent::NotFound.cell());
     };
 
-    let Some(generate_source_map) = ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(asset)
+    let Some(generate_source_map) = ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(chunk)
     else {
         bail!("chunk/module '{}' is missing a sourcemap", source_url);
     };
@@ -2319,19 +2329,41 @@ pub async fn get_source_map_file_path(
     container: Vc<ProjectContainer>,
     source_url: RcStr,
 ) -> Result<Vc<Option<RcStr>>> {
-    let Some(ResolvedSourceMapAsset {
-        chunk_base_unix, ..
-    }) = resolve_source_map_asset(container, &source_url).await?
+    let Some(ResolvedSourceMapAsset { source_map, .. }) =
+        resolve_source_map_asset(container, &source_url).await?
     else {
         return Ok(Vc::cell(None));
     };
 
-    // Both the client (`VirtualFileSystem`) and server chunks physically live under the dist dir
-    // (i.e. `node_root`) on disk, so build the `file://` URL by joining the chunk base onto the
-    // disk-backed `node_root`. This reuses `FileSystemPath::join`/`to_sys_path` normalization
-    // (leading separators, Windows paths) rather than concatenating strings by hand.
-    let node_root = container.project().node_root().owned().await?;
-    let uri = uri_from_file(node_root, Some(&chunk_base_unix)).await?;
+    // Use the `SourceMapAsset`'s own `path()` rather than deriving `<chunk>.map` by string
+    // manipulation: it's authoritative in every mode, whereas the `<chunk>.map` derivation breaks
+    // for content-hashed chunks (prod client), where the map is hashed from the map's own content —
+    // see `SourceMapAsset::path` / `BrowserChunkingContext::chunk_path`.
+    let source_map_path = source_map.path().owned().await?;
+
+    // Server source maps live under `node_root` (a `DiskFileSystem`) and can be turned into a
+    // `file://` URL directly. Client source maps live under `client_relative_path` (a
+    // `VirtualFileSystem`), which is not disk-backed; they are emitted to disk by rebasing onto the
+    // client output path (which is `node_root` in dev — see `Project::emit_all_output_assets`).
+    // Mirror that rebasing so we always hand back the on-disk location.
+    let project = container.project();
+    let node_root = project.node_root().owned().await?;
+    let disk_source_map_path = if source_map_path.is_inside_ref(&node_root) {
+        source_map_path
+    } else {
+        let client_relative_path = project.client_relative_path().owned().await?;
+        if source_map_path.is_inside_ref(&client_relative_path) {
+            rebase(source_map_path, client_relative_path, node_root.clone())
+                .owned()
+                .await?
+        } else {
+            // Not under a known output root (e.g. produced on some other filesystem); we can't map
+            // it to a disk `file://` URL.
+            return Ok(Vc::cell(None));
+        }
+    };
+
+    let uri = uri_from_file(disk_source_map_path, None).await?;
 
     Ok(Vc::cell(Some(RcStr::from(uri))))
 }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -58,14 +58,15 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::db_invalidation::invalidation_reasons;
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation, util::uri_from_file,
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation,
+    util::{uri_from_file, uri_from_path_buf},
 };
 use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
     issue::PlainIssue,
     output::{OutputAsset, OutputAssets},
-    source_map::{SourceMap, Token},
+    source_map::{GenerateSourceMap, SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
 };
 use turbopack_ecmascript_hmr_protocol::{ClientUpdateInstruction, Issue, ResourceIdentifier};
@@ -2181,12 +2182,28 @@ pub struct StackFrame {
 #[derive(Clone)]
 pub struct OptionStackFrame(Option<StackFrame>);
 
-#[turbo_tasks::function]
-pub async fn get_source_map_rope(
+/// The resolved chunk asset that owns the source map for a given `source_url`, along with the
+/// optional module `section` (the `id` query param) and the `chunk_base` (path relative to the dist
+/// dir, in unix form) that were used to resolve it.
+///
+/// Callers can derive the source map *content* from the asset (via [`GenerateSourceMap`]) or its
+/// *file path* (via [`OutputAsset::path`]).
+struct ResolvedSourceMapAsset {
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
+    section: Option<RcStr>,
+    chunk_base_unix: RcStr,
+}
+
+/// Resolves the chunk asset whose generated source map has content for the given `source_url`,
+/// trying the server chunk first and falling back to a client chunk.
+///
+/// Returns `Ok(None)` when the url is outside the dist dir. `bail`s when the chunk exists in
+/// neither location (i.e. is missing a sourcemap).
+async fn resolve_source_map_asset(
     container: Vc<ProjectContainer>,
-    source_url: RcStr,
-) -> Result<Vc<FileContent>> {
-    let (file_path_sys, module) = match Url::parse(&source_url) {
+    source_url: &RcStr,
+) -> Result<Option<ResolvedSourceMapAsset>> {
+    let (file_path_sys, module) = match Url::parse(source_url) {
         Ok(url) => match url.scheme() {
             "file" => {
                 let path = match url.to_file_path() {
@@ -2211,10 +2228,10 @@ pub async fn get_source_map_rope(
 
     let chunk_base_unix =
         match file_path_sys.strip_prefix(container.project().dist_dir_absolute().await?.as_str()) {
-            Some(relative_path) => sys_to_unix(relative_path),
+            Some(relative_path) => RcStr::from(sys_to_unix(relative_path).into_owned()),
             None => {
                 // File doesn't exist within the dist dir
-                return Ok(FileContent::NotFound.cell());
+                return Ok(None);
             }
         };
 
@@ -2224,26 +2241,68 @@ pub async fn get_source_map_rope(
         .await?
         .join(&chunk_base_unix)?;
 
+    // A chunk asset may exist without producing a (non-empty) source map, so the server-vs-client
+    // decision is based on whether the *generated* source map has content, matching the historical
+    // behavior of `get_source_map_rope`.
+    if container
+        .get_source_map(server_path.clone(), module.clone())
+        .await?
+        .is_content()
+        && let Some(asset) = *container.get_source_map_asset(server_path).await?
+    {
+        return Ok(Some(ResolvedSourceMapAsset {
+            asset,
+            section: module,
+            chunk_base_unix,
+        }));
+    }
+
+    // If the chunk doesn't exist as a server chunk, try a client chunk.
+    // TODO: Properly tag all server chunks and use the `isServer` query param.
+    // Currently, this is inaccurate as it does not cover RSC server
+    // chunks.
     let client_path = container
         .project()
         .client_relative_path()
         .await?
         .join(&chunk_base_unix)?;
 
-    let mut map = container.get_source_map(server_path, module.clone());
-
-    if !map.await?.is_content() {
-        // If the chunk doesn't exist as a server chunk, try a client chunk.
-        // TODO: Properly tag all server chunks and use the `isServer` query param.
-        // Currently, this is inaccurate as it does not cover RSC server
-        // chunks.
-        map = container.get_source_map(client_path, module);
-        if !map.await?.is_content() {
-            bail!("chunk/module '{}' is missing a sourcemap", source_url);
-        }
+    if container
+        .get_source_map(client_path.clone(), module.clone())
+        .await?
+        .is_content()
+        && let Some(asset) = *container.get_source_map_asset(client_path).await?
+    {
+        return Ok(Some(ResolvedSourceMapAsset {
+            asset,
+            section: module,
+            chunk_base_unix,
+        }));
     }
 
-    Ok(map)
+    bail!("chunk/module '{}' is missing a sourcemap", source_url);
+}
+
+#[turbo_tasks::function]
+pub async fn get_source_map_rope(
+    container: Vc<ProjectContainer>,
+    source_url: RcStr,
+) -> Result<Vc<FileContent>> {
+    let Some(ResolvedSourceMapAsset { asset, section, .. }) =
+        resolve_source_map_asset(container, &source_url).await?
+    else {
+        return Ok(FileContent::NotFound.cell());
+    };
+
+    let Some(generate_source_map) = ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(asset)
+    else {
+        bail!("chunk/module '{}' is missing a sourcemap", source_url);
+    };
+
+    Ok(match section {
+        Some(section) => generate_source_map.by_section(section),
+        None => generate_source_map.generate_source_map(),
+    })
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -2252,6 +2311,42 @@ pub fn get_source_map_rope_operation(
     file_path: RcStr,
 ) -> Vc<FileContent> {
     get_source_map_rope(*container, file_path)
+}
+
+/// Resolves the `file://` URL of the source map for `source_url` (i.e. the location of the chunk's
+/// `.map`), working for both client and server chunk paths.
+#[turbo_tasks::function]
+pub async fn get_source_map_file_path(
+    container: Vc<ProjectContainer>,
+    source_url: RcStr,
+) -> Result<Vc<Option<RcStr>>> {
+    let Some(ResolvedSourceMapAsset {
+        chunk_base_unix, ..
+    }) = resolve_source_map_asset(container, &source_url).await?
+    else {
+        return Ok(Vc::cell(None));
+    };
+
+    // Both the client (`VirtualFileSystem`) and server chunks live under the dist dir on disk, so
+    // reconstruct the absolute path from the dist dir rather than from the (possibly virtual)
+    // `FileSystemPath` of the asset.
+    let dist_dir_absolute = container.project().dist_dir_absolute().await?;
+    let sys_path = PathBuf::from(format!(
+        "{}{}{}",
+        dist_dir_absolute,
+        std::path::MAIN_SEPARATOR,
+        unix_to_sys(&chunk_base_unix)
+    ));
+
+    Ok(Vc::cell(Some(RcStr::from(uri_from_path_buf(sys_path)))))
+}
+
+#[turbo_tasks::function(operation, root)]
+pub fn get_source_map_file_path_operation(
+    container: ResolvedVc<ProjectContainer>,
+    file_path: RcStr,
+) -> Vc<Option<RcStr>> {
+    get_source_map_file_path(*container, file_path)
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -2439,6 +2534,39 @@ pub fn project_get_source_map_sync(
 ) -> napi::Result<Option<String>> {
     within_runtime_if_available(|| {
         tokio::runtime::Handle::current().block_on(project_get_source_map(project, file_path))
+    })
+}
+
+#[tracing::instrument(level = "info", name = "get SourceMap file path for asset", skip_all)]
+#[napi]
+pub async fn project_get_source_map_file_path(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    file_path: RcStr,
+) -> napi::Result<Option<String>> {
+    let container = project.container;
+    let ctx = &project.turbopack_ctx;
+    ctx.turbo_tasks()
+        .run(async move {
+            let source_map_file_path = get_source_map_file_path_operation(container, file_path)
+                .read_strongly_consistent()
+                .await?;
+            Ok(source_map_file_path.as_ref().map(|s| s.to_string()))
+        })
+        // HACK: Don't use `TurbopackInternalError`, this function is race-condition prone (the
+        // source files may have changed or been deleted), so these probably aren't internal errors?
+        // Ideally we should differentiate.
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
+}
+
+#[napi]
+pub fn project_get_source_map_file_path_sync(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    file_path: RcStr,
+) -> napi::Result<Option<String>> {
+    within_runtime_if_available(|| {
+        tokio::runtime::Handle::current()
+            .block_on(project_get_source_map_file_path(project, file_path))
     })
 }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -58,8 +58,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::db_invalidation::invalidation_reasons;
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation,
-    util::{uri_from_file, uri_from_path_buf},
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation, util::uri_from_file,
 };
 use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
@@ -2327,18 +2326,14 @@ pub async fn get_source_map_file_path(
         return Ok(Vc::cell(None));
     };
 
-    // Both the client (`VirtualFileSystem`) and server chunks live under the dist dir on disk, so
-    // reconstruct the absolute path from the dist dir rather than from the (possibly virtual)
-    // `FileSystemPath` of the asset.
-    let dist_dir_absolute = container.project().dist_dir_absolute().await?;
-    let sys_path = PathBuf::from(format!(
-        "{}{}{}",
-        dist_dir_absolute,
-        std::path::MAIN_SEPARATOR,
-        unix_to_sys(&chunk_base_unix)
-    ));
+    // Both the client (`VirtualFileSystem`) and server chunks physically live under the dist dir
+    // (i.e. `node_root`) on disk, so build the `file://` URL by joining the chunk base onto the
+    // disk-backed `node_root`. This reuses `FileSystemPath::join`/`to_sys_path` normalization
+    // (leading separators, Windows paths) rather than concatenating strings by hand.
+    let node_root = container.project().node_root().owned().await?;
+    let uri = uri_from_file(node_root, Some(&chunk_base_unix)).await?;
 
-    Ok(Vc::cell(Some(RcStr::from(uri_from_path_buf(sys_path)))))
+    Ok(Vc::cell(Some(RcStr::from(uri))))
 }
 
 #[turbo_tasks::function(operation, root)]

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -485,6 +485,14 @@ export declare function projectGetSourceMapSync(
   project: { __napiType: 'Project' },
   filePath: RcStr
 ): string | null
+export declare function projectGetSourceMapFilePath(
+  project: { __napiType: 'Project' },
+  filePath: RcStr
+): Promise<string | null>
+export declare function projectGetSourceMapFilePathSync(
+  project: { __napiType: 'Project' },
+  filePath: RcStr
+): string | null
 export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -821,6 +821,17 @@ function bindingToApi(
       return binding.projectGetSourceMapSync(this._nativeProject, filePath)
     }
 
+    getSourceMapFilePath(filePath: string): Promise<string | null> {
+      return binding.projectGetSourceMapFilePath(this._nativeProject, filePath)
+    }
+
+    getSourceMapFilePathSync(filePath: string): string | null {
+      return binding.projectGetSourceMapFilePathSync(
+        this._nativeProject,
+        filePath
+      )
+    }
+
     updateInfoSubscribe(aggregationMs: number) {
       return subscribe<TurbopackResult<UpdateMessage>>(true, async (callback) =>
         binding.projectUpdateInfoSubscribe(

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -339,6 +339,9 @@ export interface Project {
   getSourceMap(filePath: string): Promise<string | null>
   getSourceMapSync(filePath: string): string | null
 
+  getSourceMapFilePath(filePath: string): Promise<string | null>
+  getSourceMapFilePathSync(filePath: string): string | null
+
   traceSource(
     stackFrame: TurbopackStackFrame,
     currentDirectoryFileUrl: string


### PR DESCRIPTION
Add a new synchronous napi endpoint for computing the sourcemap filename from a source in dev

This can be used by `findSourceMapURLDEV` to create a more efficient solution in the future
