### PR TITLE
[test] Add source-mapping coverage of React's fake stack frame scripts in `use cache`

### DIFF
--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -95,6 +95,17 @@ describe('Cache Components Dev Errors', () => {
     expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
       'https://nextjs.org/docs/messages/blocking-prerender-dynamic'
     )
+    // The logged error's stack is built from React's fake stack frame
+    // functions for the Prerender environment, and must be source-mapped
+    // with a codeframe like any other frame.
+    expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
+      '\n    at Page (app/no-accessed-data/page.js:2:9)' +
+        '\n  1 | export default async function Page() {' +
+        '\n> 2 |   await new Promise((r) => setTimeout(r, 200))' +
+        '\n    |         ^' +
+        '\n  3 |   return <p>Page</p>' +
+        '\n  4 | }'
+    )
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -95,9 +95,6 @@ describe('Cache Components Dev Errors', () => {
     expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
       'https://nextjs.org/docs/messages/blocking-prerender-dynamic'
     )
-    // The logged error's stack is built from React's fake stack frame
-    // functions for the Prerender environment, and must be source-mapped
-    // with a codeframe like any other frame.
     expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
       '\n    at Page (app/no-accessed-data/page.js:2:9)' +
         '\n  1 | export default async function Page() {' +

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -1,0 +1,368 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import * as url from 'url'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import WebSocket from 'ws'
+// Next.js' vendored synchronous source-map fork. Its type declarations
+// forward to the `source-map` package, which only resolves from within
+// packages/next, not from the test tsconfig — hence `require`.
+const {
+  SourceMapConsumer: SyncSourceMapConsumer,
+} = require('next/dist/compiled/source-map')
+
+interface InspectorTarget {
+  title: string
+  url: string
+  webSocketDebuggerUrl: string
+}
+
+/** Minimal Chrome DevTools Protocol client on top of `ws`. */
+class CDPSession {
+  private ws: WebSocket
+  private lastId = 0
+  private pending = new Map<
+    number,
+    { resolve: (result: any) => void; reject: (error: Error) => void }
+  >()
+  onEvent: ((method: string, params: any) => void) | null = null
+
+  private constructor(ws: WebSocket) {
+    this.ws = ws
+    ws.on('message', (data) => {
+      const message = JSON.parse(data.toString())
+      if (message.id !== undefined && this.pending.has(message.id)) {
+        const { resolve, reject } = this.pending.get(message.id)!
+        this.pending.delete(message.id)
+        if (message.error) {
+          reject(new Error(message.error.message))
+        } else {
+          resolve(message.result)
+        }
+      } else if (message.method && this.onEvent) {
+        this.onEvent(message.method, message.params)
+      }
+    })
+  }
+
+  static async connect(url: string): Promise<CDPSession> {
+    const ws = new WebSocket(url)
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve())
+      ws.once('error', reject)
+    })
+    return new CDPSession(ws)
+  }
+
+  send(method: string, params: Record<string, any> = {}): Promise<any> {
+    const id = ++this.lastId
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      this.ws.send(JSON.stringify({ id, method, params }))
+    })
+  }
+
+  close(): void {
+    this.ws.close()
+  }
+}
+
+/**
+ * Resolves a script's source map the way a debugger frontend can:
+ * - a self-contained `data:` URL,
+ * - a URL resolved against the script's location and read from disk
+ *   (`file:`/relative, like the references emitted into build output),
+ * - or served by the debugged target via `Network.loadNetworkResource`.
+ * Debugger frontends cannot be assumed to fetch arbitrary http(s) URLs
+ * themselves; the dedicated Chrome DevTools frontend for Node.js targets
+ * does not.
+ */
+/** CJS script "URLs" from the inspector are plain file paths. */
+function scriptURLToFileURL(scriptURL: string): string {
+  return scriptURL.startsWith('file://')
+    ? scriptURL
+    : url.pathToFileURL(scriptURL).href
+}
+
+async function resolveSourceMapLikeADebugger(
+  session: CDPSession,
+  scriptURL: string,
+  sourceMapURL: string
+): Promise<{ sourceMap: any; mapURL: URL | null }> {
+  const dataPrefix = 'data:application/json;base64,'
+  if (sourceMapURL.startsWith(dataPrefix)) {
+    return {
+      sourceMap: JSON.parse(
+        Buffer.from(sourceMapURL.slice(dataPrefix.length), 'base64').toString(
+          'utf8'
+        )
+      ),
+      mapURL: null,
+    }
+  }
+
+  if (!/^https?:/.test(sourceMapURL)) {
+    const mapURL = new URL(sourceMapURL, scriptURLToFileURL(scriptURL))
+    expect(mapURL.protocol).toBe('file:')
+    return {
+      sourceMap: JSON.parse(fs.readFileSync(url.fileURLToPath(mapURL), 'utf8')),
+      mapURL,
+    }
+  }
+
+  const { resource } = await session.send('Network.loadNetworkResource', {
+    url: sourceMapURL,
+    options: { disableCache: false, includeCredentials: false },
+  })
+  if (!resource.success) {
+    throw new Error(
+      `Unable to load source map through the debugged target: ${sourceMapURL}`
+    )
+  }
+  let data = ''
+  while (true) {
+    const chunk = await session.send('IO.read', {
+      handle: resource.stream,
+      size: 1024 * 1024,
+    })
+    data += chunk.base64Encoded
+      ? Buffer.from(chunk.data, 'base64').toString('utf8')
+      : chunk.data
+    if (chunk.eof) break
+  }
+  return { sourceMap: JSON.parse(data), mapURL: null }
+}
+
+describe('app-dir - server source maps - fake frame source maps', () => {
+  const dependencies = {
+    // `link:` simulates a package in a monorepo
+    'internal-pkg': `link:./internal-pkg`,
+    'external-pkg': `file:./external-pkg`,
+  }
+  const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
+    dependencies,
+    files: path.join(__dirname, 'fixtures/default'),
+    skipDeployment: true,
+    // Expose the inspector on a random port so that the test can observe
+    // the server's scripts the same way an attached debugger would.
+    startArgs: ['--inspect=0'],
+  })
+
+  if (skipped) return
+
+  async function findServerInspectorTarget(): Promise<InspectorTarget> {
+    const ports = [
+      ...new Set(
+        [
+          ...next.cliOutput.matchAll(
+            /Debugger listening on ws:\/\/127\.0\.0\.1:(\d+)\//g
+          ),
+        ].map((match) => match[1])
+      ),
+    ]
+    expect(ports.length).toBeGreaterThan(0)
+
+    const targets: InspectorTarget[] = []
+    for (const port of ports) {
+      try {
+        targets.push(
+          ...(await (await fetch(`http://127.0.0.1:${port}/json/list`)).json())
+        )
+      } catch {
+        // The process may have exited or the port may be gone after a
+        // restart.
+        continue
+      }
+    }
+    // The process running the server code, as opposed to e.g. the `next dev`
+    // CLI wrapper.
+    const serverTarget = targets.find((target) =>
+      /next-server|start-server\.js|next start/.test(
+        `${target.title} ${target.url}`
+      )
+    )
+    if (serverTarget !== undefined) {
+      return serverTarget
+    }
+    if (targets.length === 1) {
+      return targets[0]
+    }
+    throw new Error(
+      `Unable to find the server inspector target among ${JSON.stringify(targets.map((target) => target.title))}`
+    )
+  }
+
+  function expectWellFormedSource(source: string): void {
+    // Sources must be proper URLs. Guards against mangled concatenations
+    // like `file:/cwd-relative/path` that substring assertions would hide.
+    expect(source).toMatch(/^(file:\/\/\/|turbopack:\/\/|webpack:\/\/)/)
+  }
+
+  if (isNextDev) {
+    it('fake stack frame source maps are resolvable by an attached debugger', async () => {
+      // Render an RSC page so that React materializes fake stack frame
+      // functions for the Server Components debug info.
+      await next.render('/rsc-error-log')
+
+      const target = await findServerInspectorTarget()
+      const session = await CDPSession.connect(target.webSocketDebuggerUrl)
+      try {
+        const fakeScripts: {
+          scriptId: string
+          url: string
+          sourceMapURL: string
+        }[] = []
+        session.onEvent = (method, params) => {
+          if (
+            method === 'Debugger.scriptParsed' &&
+            typeof params.url === 'string' &&
+            params.url.startsWith('about://React/')
+          ) {
+            fakeScripts.push({
+              scriptId: params.scriptId,
+              url: params.url,
+              sourceMapURL: params.sourceMapURL ?? '',
+            })
+          }
+        }
+        // Enabling the debugger emits `Debugger.scriptParsed` for every
+        // script that is still alive, including the already-evaled fake
+        // frame scripts.
+        await session.send('Debugger.enable', { maxScriptsCacheSize: 1 })
+
+        await retry(async () => {
+          expect(fakeScripts.length).toBeGreaterThan(0)
+        })
+
+        // Every fake frame script must carry a source map so that debuggers
+        // can reveal the original callsite of Server Components stack
+        // frames.
+        for (const script of fakeScripts) {
+          expect({
+            url: script.url,
+            hasSourceMap: script.sourceMapURL !== '',
+          }).toEqual({ url: script.url, hasSourceMap: true })
+        }
+
+        // Resolve each source map like a debugger frontend and map the
+        // padded `_()` call position of each fake function back to its
+        // original source, like clicking the frame in a debugger would.
+        const sourceMapsByURL = new Map<string, any>()
+        const mappedSources = new Set<string>()
+        for (const script of fakeScripts) {
+          let resolved = sourceMapsByURL.get(script.sourceMapURL)
+          if (resolved === undefined) {
+            resolved = await resolveSourceMapLikeADebugger(
+              session,
+              script.url,
+              script.sourceMapURL
+            )
+            expect(resolved.sourceMap).toHaveProperty('version', 3)
+            sourceMapsByURL.set(script.sourceMapURL, resolved)
+          }
+          const { sourceMap, mapURL } = resolved
+
+          const { scriptSource } = await session.send(
+            'Debugger.getScriptSource',
+            { scriptId: script.scriptId }
+          )
+          const callIndex = scriptSource.indexOf('_()')
+          if (callIndex === -1) continue
+          const line = scriptSource.slice(0, callIndex).split('\n').length
+          const column =
+            callIndex - (scriptSource.lastIndexOf('\n', callIndex) + 1)
+
+          const consumer = new SyncSourceMapConsumer(sourceMap)
+          const original = consumer.originalPositionFor({ line, column })
+          if (original.source !== null) {
+            // Relative sources resolve against the map's own URL. Sources in
+            // `data:` maps are already absolute.
+            mappedSources.add(
+              mapURL === null
+                ? original.source
+                : new URL(original.source, mapURL).href
+            )
+          }
+        }
+
+        for (const source of mappedSources) {
+          expectWellFormedSource(source)
+        }
+
+        // The rendered page's own Server Component frames must resolve
+        // exactly to its original source file.
+        const testDirURL = url.pathToFileURL(fs.realpathSync(next.testDir))
+        expect([...mappedSources]).toContain(
+          `${testDirURL.href}/app/rsc-error-log/page.js`
+        )
+      } finally {
+        session.close()
+      }
+    })
+  } else {
+    it('server chunk source maps are resolvable by an attached debugger', async () => {
+      await next.render('/rsc-error-log')
+
+      const target = await findServerInspectorTarget()
+      const session = await CDPSession.connect(target.webSocketDebuggerUrl)
+      try {
+        const serverScripts: { url: string; sourceMapURL: string }[] = []
+        session.onEvent = (method, params) => {
+          if (
+            method === 'Debugger.scriptParsed' &&
+            typeof params.url === 'string' &&
+            params.url.includes(`${path.sep}.next${path.sep}server${path.sep}`)
+          ) {
+            serverScripts.push({
+              url: params.url,
+              sourceMapURL: params.sourceMapURL ?? '',
+            })
+          }
+        }
+        await session.send('Debugger.enable', { maxScriptsCacheSize: 1 })
+
+        await retry(async () => {
+          expect(serverScripts.length).toBeGreaterThan(0)
+        })
+
+        // Every declared source map reference of the build output must
+        // resolve, like clicking a frame in a debugger would. Sources in
+        // these maps are relative and resolve against the map's own URL.
+        const resolvedSources = new Set<string>()
+        const mappedScripts: typeof serverScripts = []
+        for (const script of serverScripts) {
+          if (script.sourceMapURL === '') continue
+          const { sourceMap } = await resolveSourceMapLikeADebugger(
+            session,
+            script.url,
+            script.sourceMapURL
+          )
+          expect(sourceMap).toHaveProperty('version', 3)
+          const mapURL = new URL(
+            script.sourceMapURL,
+            scriptURLToFileURL(script.url)
+          )
+          for (const source of sourceMap.sources as string[]) {
+            const resolved = new URL(source, mapURL).href
+            expectWellFormedSource(resolved)
+            resolvedSources.add(resolved)
+          }
+          mappedScripts.push(script)
+        }
+
+        // The build output must reference source maps at all
+        // (`serverSourceMaps` is enabled in the fixture), and the rendered
+        // page's original source file must be resolvable from them.
+        expect(mappedScripts.length).toBeGreaterThan(0)
+        const testDirURL = url.pathToFileURL(fs.realpathSync(next.testDir))
+        expect([...resolvedSources]).toContain(
+          isTurbopack
+            ? `${testDirURL.href}/app/rsc-error-log/page.js`
+            : 'webpack:///app/rsc-error-log/page.js'
+        )
+      } finally {
+        session.close()
+      }
+    })
+  }
+})

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -1,15 +1,10 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as url from 'url'
+import { SourceMap } from 'module'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import WebSocket from 'ws'
-// Next.js' vendored synchronous source-map fork. Its type declarations
-// forward to the `source-map` package, which only resolves from within
-// packages/next, not from the test tsconfig — hence `require`.
-const {
-  SourceMapConsumer: SyncSourceMapConsumer,
-} = require('next/dist/compiled/source-map')
 
 interface InspectorTarget {
   title: string
@@ -272,15 +267,15 @@ describe('app-dir - server source maps - fake frame source maps', () => {
           const column =
             callIndex - (scriptSource.lastIndexOf('\n', callIndex) + 1)
 
-          const consumer = new SyncSourceMapConsumer(sourceMap)
-          const original = consumer.originalPositionFor({ line, column })
-          if (original.source !== null) {
+          const consumer = new SourceMap(sourceMap)
+          const original = consumer.findEntry(line - 1, column)
+          if (original.originalSource !== undefined) {
             // Relative sources resolve against the map's own URL. Sources in
             // `data:` maps are already absolute.
             mappedSources.add(
               mapURL === null
-                ? original.source
-                : new URL(original.source, mapURL).href
+                ? original.originalSource
+                : new URL(original.originalSource, mapURL).href
             )
           }
         }

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -12,7 +12,6 @@ interface InspectorTarget {
   webSocketDebuggerUrl: string
 }
 
-/** Minimal Chrome DevTools Protocol client on top of `ws`. */
 class CDPSession {
   private ws: WebSocket
   private lastId = 0
@@ -62,16 +61,6 @@ class CDPSession {
   }
 }
 
-/**
- * Resolves a script's source map the way a debugger frontend can:
- * - a self-contained `data:` URL,
- * - a URL resolved against the script's location and read from disk
- *   (`file:`/relative, like the references emitted into build output),
- * - or served by the debugged target via `Network.loadNetworkResource`.
- * Debugger frontends cannot be assumed to fetch arbitrary http(s) URLs
- * themselves; the dedicated Chrome DevTools frontend for Node.js targets
- * does not.
- */
 /** CJS script "URLs" from the inspector are plain file paths. */
 function scriptURLToFileURL(scriptURL: string): string {
   return scriptURL.startsWith('file://')
@@ -79,6 +68,11 @@ function scriptURLToFileURL(scriptURL: string): string {
     : url.pathToFileURL(scriptURL).href
 }
 
+/**
+ * Debugger frontends cannot be assumed to fetch arbitrary http(s) URLs
+ * themselves (the dedicated Chrome DevTools frontend for Node.js targets
+ * does not), so http(s) maps are loaded through the debugged target.
+ */
 async function resolveSourceMapLikeADebugger(
   session: CDPSession,
   scriptURL: string,
@@ -138,8 +132,7 @@ describe('app-dir - server source maps - fake frame source maps', () => {
     dependencies,
     files: path.join(__dirname, 'fixtures/default'),
     skipDeployment: true,
-    // Expose the inspector on a random port so that the test can observe
-    // the server's scripts the same way an attached debugger would.
+    // Expose the inspector on a random port.
     startArgs: ['--inspect=0'],
   })
 
@@ -188,8 +181,8 @@ describe('app-dir - server source maps - fake frame source maps', () => {
   }
 
   function expectWellFormedSource(source: string): void {
-    // Sources must be proper URLs. Guards against mangled concatenations
-    // like `file:/cwd-relative/path` that substring assertions would hide.
+    // Guards against mangled concatenations like `file:/cwd-relative/path`
+    // that substring assertions would hide.
     expect(source).toMatch(/^(file:\/\/\/|turbopack:\/\/|webpack:\/\/)/)
   }
 
@@ -229,9 +222,6 @@ describe('app-dir - server source maps - fake frame source maps', () => {
           expect(fakeScripts.length).toBeGreaterThan(0)
         })
 
-        // Every fake frame script must carry a source map so that debuggers
-        // can reveal the original callsite of Server Components stack
-        // frames.
         for (const script of fakeScripts) {
           expect({
             url: script.url,
@@ -284,8 +274,6 @@ describe('app-dir - server source maps - fake frame source maps', () => {
           expectWellFormedSource(source)
         }
 
-        // The rendered page's own Server Component frames must resolve
-        // exactly to its original source file.
         const testDirURL = url.pathToFileURL(fs.realpathSync(next.testDir))
         expect([...mappedSources]).toContain(
           `${testDirURL.href}/app/rsc-error-log/page.js`
@@ -320,9 +308,8 @@ describe('app-dir - server source maps - fake frame source maps', () => {
           expect(serverScripts.length).toBeGreaterThan(0)
         })
 
-        // Every declared source map reference of the build output must
-        // resolve, like clicking a frame in a debugger would. Sources in
-        // these maps are relative and resolve against the map's own URL.
+        // Sources in these maps are relative and resolve against the map's
+        // own URL.
         const resolvedSources = new Set<string>()
         const mappedScripts: typeof serverScripts = []
         for (const script of serverScripts) {
@@ -346,8 +333,7 @@ describe('app-dir - server source maps - fake frame source maps', () => {
         }
 
         // The build output must reference source maps at all
-        // (`serverSourceMaps` is enabled in the fixture), and the rendered
-        // page's original source file must be resolvable from them.
+        // (`serverSourceMaps` is enabled in the fixture).
         expect(mappedScripts.length).toBeGreaterThan(0)
         const testDirURL = url.pathToFileURL(fs.realpathSync(next.testDir))
         expect([...resolvedSources]).toContain(

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-throw-cached/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-throw-cached/page.js
@@ -1,0 +1,12 @@
+import { connection } from 'next/server'
+
+async function throwsInCache() {
+  'use cache'
+  throw new Error('rsc-error-throw-cached')
+}
+
+export default async function Page() {
+  await connection()
+  await throwsInCache()
+  return null
+}

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -537,6 +537,53 @@ describe('app-dir - server source maps', () => {
     }
   })
 
+  it('thrown errors from "use cache" have a sourcemapped stack with a codeframe', async () => {
+    // Errors thrown inside "use cache" functions cross a Flight boundary:
+    // the logged error object is deserialized by the consuming Flight client,
+    // and its stack is rebuilt through React's eval'd fake frame functions
+    // (`about://React/Cache/...` sourceURLs). This covers sourcemapping of
+    // fake stack frames.
+    if (isNextDev) {
+      const outputIndex = next.cliOutput.length
+      await next.render('/rsc-error-throw-cached')
+
+      await retry(() => {
+        expect(next.cliOutput.slice(outputIndex)).toContain(
+          'Error: rsc-error-throw-cached'
+        )
+      })
+      const cliOutput = normalizeCliOutput(next.cliOutput.slice(outputIndex))
+      expect(cliOutput).toContain(
+        'Error: rsc-error-throw-cached' +
+          '\n    at throwsInCache (app/rsc-error-throw-cached/page.js:5:9)' +
+          '\n  3 | async function throwsInCache() {' +
+          "\n  4 |   'use cache'" +
+          "\n> 5 |   throw new Error('rsc-error-throw-cached')" +
+          '\n    |         ^' +
+          '\n  6 | }' +
+          '\n  7 |' +
+          '\n  8 | export default async function Page() {'
+      )
+      // The logged error is the one revived by the consuming Flight client,
+      // not the original from the cache environment.
+      expect(cliOutput).toContain("environmentName: 'Cache'")
+    } else {
+      const outputIndex = next.cliOutput.length
+      await next.render('/rsc-error-throw-cached')
+
+      await retry(() => {
+        expect(next.cliOutput.slice(outputIndex)).toContain(
+          'Error: rsc-error-throw-cached'
+        )
+      })
+      // Runtime stacks are not sourcemapped in production, but fake frames
+      // must not leak virtual `about://React/` URLs into logged stacks.
+      expect(
+        normalizeCliOutput(next.cliOutput.slice(outputIndex))
+      ).not.toContain('about://React/')
+    }
+  })
+
   it('logged errors preserve their name', async () => {
     let cliOutput = next.cliOutput
     if (isNextDev) {

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -538,11 +538,6 @@ describe('app-dir - server source maps', () => {
   })
 
   it('thrown errors from "use cache" have a sourcemapped stack with a codeframe', async () => {
-    // Errors thrown inside "use cache" functions cross a Flight boundary:
-    // the logged error object is deserialized by the consuming Flight client,
-    // and its stack is rebuilt through React's eval'd fake frame functions
-    // (`about://React/Cache/...` sourceURLs). This covers sourcemapping of
-    // fake stack frames.
     if (isNextDev) {
       const outputIndex = next.cliOutput.length
       await next.render('/rsc-error-throw-cached')

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -571,8 +571,7 @@ describe('app-dir - server source maps', () => {
           'Error: rsc-error-throw-cached'
         )
       })
-      // Runtime stacks are not sourcemapped in production, but fake frames
-      // must not leak virtual `about://React/` URLs into logged stacks.
+      // React only creates fake stack frames in development.
       expect(
         normalizeCliOutput(next.cliOutput.slice(outputIndex))
       ).not.toContain('about://React/')


### PR DESCRIPTION
Adds tests verifying that`use cache` stacks get symbolicated.

We noticed insufficient coverage in https://github.com/vercel/next.js/pull/95936, which should have failed the tests (it broke symbolication) but tests passed. So this restores the missing stack assertions. This also adds some new coverage that specifically verifies that symbolicating via CDP also works.

---

<details>

### What

Test-only. Server Components debug stacks are materialized as eval'd fake frame functions (`about://React/<env>/<file>?<idx>` scripts) whose `//# sourceMappingURL=` is consumed by several parties: Node.js' source map cache, `patch-error-inspect` for terminal stacks, and attached debuggers. Nothing asserted that these maps stay resolvable or that fake frames keep printing source-mapped stacks — regressions here only surfaced when manually attaching a debugger (see the discussion in #95936).

- **`fake-frame-source-maps.test.ts` (new):** starts the server with the first-class `--inspect=0` flag (works for `next dev` and `next start`), attaches over CDP, and resolves script source maps the way a debugger frontend can — self-contained `data:` URL, a `file:`/relative reference read from disk, or served by the debugged target via `Network.loadNetworkResource`. In dev it maps each fake frame script's padded position back to its original source (exact `file://` URL match against the test dir, with a well-formedness check on every mapped source to catch mangled path concatenations). In `next start` it verifies the build output's declared source map references all resolve and that the rendered page's original source is resolvable from them (per-bundler exact match).
- **`rsc-error-throw-cached` fixture + test:** an error thrown inside `"use cache"` crosses a Flight boundary, so the logged error's stack is rebuilt through fake frames (`resolveErrorDev`); asserts the full source-mapped stack with a codeframe, plus that prod logs don't leak `about://React/` URLs.
- **`cache-components-dev-errors.test.ts`:** restores the CLI stack + codeframe assertion for blocking-route validation errors (reduced to a message-only check in 782d04db1f). Those stacks flow through Prerender-environment fake frames.

### Verification

Green on this branch in all four local mode/bundler combinations (`next dev` and `next start` × Turbopack and webpack). Ran against #95936's branch to confirm they catch the breakage discussed there:

- the CDP test fails with `Unable to load source map through the debugged target` / `Network resource loading is not enabled…` — the same failure an attached debugger hits,
- the `use cache` test fails on unnormalized fake frame paths (`at throwsInCache (file:/private/var/...)`, sometimes `../`-prefixed),
- the restored validation-error assertion fails on frames in bracket-named chunks leaking raw `about://React/...%5Broot-of-the-server%5D...` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>


