### PR TITLE
[sourcemaps] Use file: sourcemaps for Turbopack to improve dev performance

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -84,6 +84,7 @@ import type { ModernSourceMapPayload } from '../lib/source-maps'
 import { isDeferredEntry } from '../../build/entries'
 import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 import { setBundlerFindSourceMapImplementation } from '../patch-error-inspect'
+import { setBundlerFindSourceMapURLImplementation } from '../lib/source-maps'
 import { getNextErrorFeedbackMiddleware } from '../../next-devtools/server/get-next-error-feedback-middleware'
 import {
   formatIssue,
@@ -279,6 +280,18 @@ function getSourceMapFromTurbopack(
   }
 }
 
+function getSourceMapURLFromTurbopack(
+  project: Project,
+  sourceURL: string
+): string | null {
+  let sourceMapFilePath: string | null = null
+  try {
+    sourceMapFilePath = project.getSourceMapFilePathSync(sourceURL)
+  } catch (err) {}
+
+  return sourceMapFilePath
+}
+
 export async function createHotReloaderTurbopack(
   opts: SetupOpts & { isSrcDir: boolean },
   serverFields: ServerFields,
@@ -409,6 +422,9 @@ export async function createHotReloaderTurbopack(
   setBundlerFindSourceMapImplementation(
     getSourceMapFromTurbopack.bind(null, project)
   )
+  setBundlerFindSourceMapURLImplementation(
+    getSourceMapURLFromTurbopack.bind(null, project)
+  )
 
   // Set up code frame renderer using native bindings
   const { installCodeFrameSupport } =
@@ -417,6 +433,7 @@ export async function createHotReloaderTurbopack(
 
   opts.onDevServerCleanup?.(async () => {
     setBundlerFindSourceMapImplementation(() => undefined)
+    setBundlerFindSourceMapURLImplementation(() => null)
     await project.onExit()
     await lockfile?.unlock()
   })

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1,7 +1,9 @@
 import type { Socket } from 'net'
 import { mkdir, writeFile } from 'fs/promises'
+import { realpathSync } from 'fs'
 import * as inspector from 'inspector'
-import { join, extname, relative } from 'path'
+import { join, extname, relative, isAbsolute } from 'path'
+import { pathToFileURL } from 'url'
 
 import ws from 'next/dist/compiled/ws'
 
@@ -281,15 +283,34 @@ function getSourceMapFromTurbopack(
 }
 
 function getSourceMapURLFromTurbopack(
-  project: Project,
-  sourceURL: string
+  distDir: string,
+  scriptNameOrSourceURL: string
 ): string | null {
-  let sourceMapFilePath: string | null = null
-  try {
-    sourceMapFilePath = project.getSourceMapFilePathSync(sourceURL)
-  } catch (err) {}
+  // React invokes this with the raw stack-frame filename, which for the server
+  // chunks we can source-map is the script's `getScriptNameOrSourceURL()`, i.e.
+  // an absolute filesystem path (React only wraps it into a `file:`/
+  // `about://React/...` URL for the fake script's own `//# sourceURL`, after
+  // this lookup). Anything else (`webpack-internal://`, `node:internal/...`,
+  // `<anonymous>`, ...) is not something we have an emitted source map for.
+  if (!isAbsolute(scriptNameOrSourceURL)) {
+    return null
+  }
 
-  return sourceMapFilePath
+  // Only chunks emitted into `distDir` have an on-disk source map to point at.
+  const relativePath = relative(distDir, scriptNameOrSourceURL)
+  if (
+    relativePath.startsWith('..') ||
+    // On Windows an absolute path on a different drive is returned unchanged
+    // rather than as a `..`-prefixed relative path.
+    isAbsolute(relativePath)
+  ) {
+    return null
+  }
+
+  // The emitted source map lives next to its chunk with a `.map` suffix (see
+  // `SourceMapAsset::path`). Encode through `pathToFileURL` so any special
+  // characters in the path are escaped into a well-formed `file:` URL.
+  return pathToFileURL(scriptNameOrSourceURL + '.map').href
 }
 
 export async function createHotReloaderTurbopack(
@@ -422,8 +443,13 @@ export async function createHotReloaderTurbopack(
   setBundlerFindSourceMapImplementation(
     getSourceMapFromTurbopack.bind(null, project)
   )
+
+  let canonicalDistDir = distDir
+  try {
+    canonicalDistDir = realpathSync(distDir)
+  } catch {}
   setBundlerFindSourceMapURLImplementation(
-    getSourceMapURLFromTurbopack.bind(null, project)
+    getSourceMapURLFromTurbopack.bind(null, canonicalDistDir)
   )
 
   // Set up code frame renderer using native bindings

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'fs/promises'
 import { realpathSync } from 'fs'
 import * as inspector from 'inspector'
 import { join, extname, relative, isAbsolute } from 'path'
-import { pathToFileURL } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 import ws from 'next/dist/compiled/ws'
 
@@ -286,18 +286,28 @@ function getSourceMapURLFromTurbopack(
   distDir: string,
   scriptNameOrSourceURL: string
 ): string | null {
-  // React invokes this with the raw stack-frame filename, which for the server
-  // chunks we can source-map is the script's `getScriptNameOrSourceURL()`, i.e.
-  // an absolute filesystem path (React only wraps it into a `file:`/
-  // `about://React/...` URL for the fake script's own `//# sourceURL`, after
-  // this lookup). Anything else (`webpack-internal://`, `node:internal/...`,
-  // `<anonymous>`, ...) is not something we have an emitted source map for.
-  if (!isAbsolute(scriptNameOrSourceURL)) {
+  // React invokes this with the raw stack-frame filename, which arrives
+  // either as an absolute filesystem path or as a `file:` URL. Anything else
+  // (`file:` URLs with a query are eval'd server HMR modules carrying inline
+  // source maps, `webpack-internal://`, `node:internal/...`, `<anonymous>`,
+  // ...) is not something we have an emitted source map for.
+  let scriptPath = scriptNameOrSourceURL
+  if (scriptNameOrSourceURL.startsWith('file://')) {
+    if (scriptNameOrSourceURL.includes('?')) {
+      return null
+    }
+    try {
+      scriptPath = fileURLToPath(scriptNameOrSourceURL)
+    } catch {
+      return null
+    }
+  }
+  if (!isAbsolute(scriptPath)) {
     return null
   }
 
   // Only chunks emitted into `distDir` have an on-disk source map to point at.
-  const relativePath = relative(distDir, scriptNameOrSourceURL)
+  const relativePath = relative(distDir, scriptPath)
   if (
     relativePath.startsWith('..') ||
     // On Windows an absolute path on a different drive is returned unchanged
@@ -310,7 +320,7 @@ function getSourceMapURLFromTurbopack(
   // The emitted source map lives next to its chunk with a `.map` suffix (see
   // `SourceMapAsset::path`). Encode through `pathToFileURL` so any special
   // characters in the path are escaped into a well-formed `file:` URL.
-  return pathToFileURL(scriptNameOrSourceURL + '.map').href
+  return pathToFileURL(scriptPath + '.map').href
 }
 
 export async function createHotReloaderTurbopack(

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -158,6 +158,30 @@ export function filterStackFrameDEV(
   }
 }
 
+type FindSourceMapURL = (sourceURL: string) => string | null
+// Find the URL of a source map using the bundler's API.
+// Shared via `globalThis` because this module is compiled both into the server
+// runtime bundles (which call `findSourceMapURLDEV`) and into `next/dist/server`
+// (where the dev server registers the implementation), and each copy has its own
+// module state.
+const bundlerFindSourceMapURLSymbol = Symbol.for(
+  'next.server.bundlerFindSourceMapURL'
+)
+
+export function setBundlerFindSourceMapURLImplementation(
+  findSourceMapURLImplementation: FindSourceMapURL
+): void {
+  ;(globalThis as any)[bundlerFindSourceMapURLSymbol] =
+    findSourceMapURLImplementation
+}
+
+function bundlerFindSourceMapURL(sourceURL: string): string | null {
+  const implementation: FindSourceMapURL | undefined = (globalThis as any)[
+    bundlerFindSourceMapURLSymbol
+  ]
+  return implementation === undefined ? null : implementation(sourceURL)
+}
+
 const invalidSourceMap = Symbol('invalid-source-map')
 const sourceMapURLs = new LRUCache<string | typeof invalidSourceMap>(
   512 * 1024 * 1024,
@@ -174,25 +198,37 @@ export function findSourceMapURLDEV(
 ): string | null {
   let sourceMapURL = sourceMapURLs.get(scriptNameOrSourceURL)
   if (sourceMapURL === undefined) {
-    let sourceMapPayload: ModernSourceMapPayload | undefined
     try {
-      sourceMapPayload = findSourceMap(scriptNameOrSourceURL)?.payload
+      sourceMapURL = bundlerFindSourceMapURL(scriptNameOrSourceURL) ?? undefined
     } catch (cause) {
       console.error(
-        `${scriptNameOrSourceURL}: Invalid source map. Only conformant source maps can be used to find the original code. Cause: ${cause}`
+        `${scriptNameOrSourceURL}: Failed to find the source map URL. Cause: ${cause}`
       )
     }
 
-    if (sourceMapPayload === undefined) {
-      sourceMapURL = invalidSourceMap
-    } else {
-      // TODO: Might be more efficient to extract the relevant section from Index Maps.
-      // Unclear if that search is worth the smaller payload we have to stringify.
-      const sourceMapJSON = JSON.stringify(sourceMapPayload)
-      const sourceMapURLData = Buffer.from(sourceMapJSON, 'utf8').toString(
-        'base64'
-      )
-      sourceMapURL = `data:application/json;base64,${sourceMapURLData}`
+    if (sourceMapURL === undefined) {
+      // No bundler implementation (e.g. Webpack): inline the source map
+      // Node.js knows as a `data:` URL.
+      let sourceMapPayload: ModernSourceMapPayload | undefined
+      try {
+        sourceMapPayload = findSourceMap(scriptNameOrSourceURL)?.payload
+      } catch (cause) {
+        console.error(
+          `${scriptNameOrSourceURL}: Invalid source map. Only conformant source maps can be used to find the original code. Cause: ${cause}`
+        )
+      }
+
+      if (sourceMapPayload === undefined) {
+        sourceMapURL = invalidSourceMap
+      } else {
+        // TODO: Might be more efficient to extract the relevant section from Index Maps.
+        // Unclear if that search is worth the smaller payload we have to stringify.
+        const sourceMapJSON = JSON.stringify(sourceMapPayload)
+        const sourceMapURLData = Buffer.from(sourceMapJSON, 'utf8').toString(
+          'base64'
+        )
+        sourceMapURL = `data:application/json;base64,${sourceMapURLData}`
+      }
     }
 
     sourceMapURLs.set(scriptNameOrSourceURL, sourceMapURL)

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -158,7 +158,11 @@ export function filterStackFrameDEV(
   }
 }
 
-type FindSourceMapURL = (sourceURL: string) => string | null
+// `scriptNameOrSourceURL` is what React forwards from the stack frame: the
+// script's `getScriptNameOrSourceURL()`, which for the server chunks we can
+// map is an absolute filesystem path, not a URL. The returned value is the
+// source map's URL (`file:` or `data:`).
+type FindSourceMapURL = (scriptNameOrSourceURL: string) => string | null
 // Find the URL of a source map using the bundler's API.
 // Shared via `globalThis` because this module is compiled both into the server
 // runtime bundles (which call `findSourceMapURLDEV`) and into `next/dist/server`
@@ -175,11 +179,13 @@ export function setBundlerFindSourceMapURLImplementation(
     findSourceMapURLImplementation
 }
 
-function bundlerFindSourceMapURL(sourceURL: string): string | null {
+function bundlerFindSourceMapURL(scriptNameOrSourceURL: string): string | null {
   const implementation: FindSourceMapURL | undefined = (globalThis as any)[
     bundlerFindSourceMapURLSymbol
   ]
-  return implementation === undefined ? null : implementation(sourceURL)
+  return implementation === undefined
+    ? null
+    : implementation(scriptNameOrSourceURL)
 }
 
 const invalidSourceMap = Symbol('invalid-source-map')

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -202,39 +202,40 @@ const sourceMapURLs = new LRUCache<string | typeof invalidSourceMap>(
 export function findSourceMapURLDEV(
   scriptNameOrSourceURL: string
 ): string | null {
+  try {
+    const bundlerSourceMapURL = bundlerFindSourceMapURL(scriptNameOrSourceURL)
+    if (bundlerSourceMapURL !== null) {
+      return bundlerSourceMapURL
+    }
+  } catch (cause) {
+    console.error(
+      `${scriptNameOrSourceURL}: Failed to find the source map URL. Cause: ${cause}`
+    )
+  }
+
+  // No bundler implementation (e.g. Webpack): inline the source map Node.js
+  // knows as a `data:` URL.
   let sourceMapURL = sourceMapURLs.get(scriptNameOrSourceURL)
   if (sourceMapURL === undefined) {
+    let sourceMapPayload: ModernSourceMapPayload | undefined
     try {
-      sourceMapURL = bundlerFindSourceMapURL(scriptNameOrSourceURL) ?? undefined
+      sourceMapPayload = findSourceMap(scriptNameOrSourceURL)?.payload
     } catch (cause) {
       console.error(
-        `${scriptNameOrSourceURL}: Failed to find the source map URL. Cause: ${cause}`
+        `${scriptNameOrSourceURL}: Invalid source map. Only conformant source maps can be used to find the original code. Cause: ${cause}`
       )
     }
 
-    if (sourceMapURL === undefined) {
-      // No bundler implementation (e.g. Webpack): inline the source map
-      // Node.js knows as a `data:` URL.
-      let sourceMapPayload: ModernSourceMapPayload | undefined
-      try {
-        sourceMapPayload = findSourceMap(scriptNameOrSourceURL)?.payload
-      } catch (cause) {
-        console.error(
-          `${scriptNameOrSourceURL}: Invalid source map. Only conformant source maps can be used to find the original code. Cause: ${cause}`
-        )
-      }
-
-      if (sourceMapPayload === undefined) {
-        sourceMapURL = invalidSourceMap
-      } else {
-        // TODO: Might be more efficient to extract the relevant section from Index Maps.
-        // Unclear if that search is worth the smaller payload we have to stringify.
-        const sourceMapJSON = JSON.stringify(sourceMapPayload)
-        const sourceMapURLData = Buffer.from(sourceMapJSON, 'utf8').toString(
-          'base64'
-        )
-        sourceMapURL = `data:application/json;base64,${sourceMapURLData}`
-      }
+    if (sourceMapPayload === undefined) {
+      sourceMapURL = invalidSourceMap
+    } else {
+      // TODO: Might be more efficient to extract the relevant section from Index Maps.
+      // Unclear if that search is worth the smaller payload we have to stringify.
+      const sourceMapJSON = JSON.stringify(sourceMapPayload)
+      const sourceMapURLData = Buffer.from(sourceMapJSON, 'utf8').toString(
+        'base64'
+      )
+      sourceMapURL = `data:application/json;base64,${sourceMapURLData}`
     }
 
     sourceMapURLs.set(scriptNameOrSourceURL, sourceMapURL)

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -177,11 +177,16 @@ function getSourcemappedFrameIfPossible(
   stack: IgnorableStackFrame
   code: string | null
 } {
-  const sourceMapCacheEntry = sourceMapCache.get(frame.file)
+  // React's fake eval'd scripts for Server Component stack frames use virtual
+  // URLs like `about://React/Server/file:///path/to/chunk.js?42` with positions
+  // padded to match the underlying chunk, so they resolve via the real chunk's
+  // source map.
+  const fileKey = devirtualizeReactServerURL(frame.file)
+  const sourceMapCacheEntry = sourceMapCache.get(fileKey)
   let sourceMapConsumer: SyncSourceMapConsumer
   let sourceMapPayload: ModernSourceMapPayload
   if (sourceMapCacheEntry === undefined) {
-    let sourceURL = frame.file
+    let sourceURL = fileKey
     // e.g. "/Users/foo/APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js"
     // or "C:\Users\foo\APP\.next\server\chunks\ssr\[root-of-the-server]__2934a0._.js"
     // will be keyed by Node.js as "file:///APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js".
@@ -189,8 +194,8 @@ function getSourcemappedFrameIfPossible(
     //
     // But frame.file might also be "webpack-internal:///(rsc)/./app/bad-sourcemap/page.js" or
     // "<anonymous>" or "node:internal/process/task_queues" here
-    if (path.isAbsolute(frame.file)) {
-      sourceURL = url.pathToFileURL(frame.file).toString()
+    if (path.isAbsolute(sourceURL)) {
+      sourceURL = url.pathToFileURL(sourceURL).toString()
     }
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined
     try {
@@ -204,7 +209,7 @@ function getSourcemappedFrameIfPossible(
       )
       // If loading fails once, it'll fail every time.
       // So set the cache to avoid duplicate errors.
-      sourceMapCache.set(frame.file, null)
+      sourceMapCache.set(fileKey, null)
       // Don't even fall back to the bundler because it might be not as strict
       // with regards to parsing and then we fail later once we consume the
       // source map payload.
@@ -228,10 +233,9 @@ function getSourcemappedFrameIfPossible(
       // is sufficient to compute relative paths but is actually wrong (the
       // chunk and sourcemap have different content hashes). We are using the
       // node API to read the sourcemap and it doesn't give us access to the
-      // URI. Devirtualize `about://React/Server/file:///path/to/chunk.js?4` to
-      // `file:///path/to/chunk.js` so that relative `sources` in the source map
-      // resolve against the real chunk URL, not the virtual one.
-      const sourceMapURL = devirtualizeReactServerURL(sourceURL) + '.map'
+      // URI. `sourceURL` is already devirtualized so that relative `sources`
+      // resolve against the real chunk URL, not React's virtual one.
+      const sourceMapURL = sourceURL + '.map'
       sourceMapConsumer = new SyncSourceMapConsumer(
         sourceMapPayload,
         // @ts-expect-error: our typings don't include this parameter but it is here.
@@ -245,10 +249,10 @@ function getSourcemappedFrameIfPossible(
       )
       // If creating the consumer fails once, it'll fail every time.
       // So set the cache to avoid duplicate errors.
-      sourceMapCache.set(frame.file, null)
+      sourceMapCache.set(fileKey, null)
       return createUnsourcemappedFrame(frame)
     }
-    sourceMapCache.set(frame.file, {
+    sourceMapCache.set(fileKey, {
       map: sourceMapConsumer,
       payload: sourceMapPayload,
     })

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -177,16 +177,15 @@ function getSourcemappedFrameIfPossible(
   stack: IgnorableStackFrame
   code: string | null
 } {
-  // React's fake eval'd scripts for Server Component stack frames use virtual
-  // URLs like `about://React/Server/file:///path/to/chunk.js?42` with positions
-  // padded to match the underlying chunk, so they resolve via the real chunk's
-  // source map.
-  const fileKey = devirtualizeReactServerURL(frame.file)
-  const sourceMapCacheEntry = sourceMapCache.get(fileKey)
+  const sourceMapCacheEntry = sourceMapCache.get(frame.file)
   let sourceMapConsumer: SyncSourceMapConsumer
   let sourceMapPayload: ModernSourceMapPayload
   if (sourceMapCacheEntry === undefined) {
-    let sourceURL = fileKey
+    // React's fake eval'd scripts for Server Component stack frames use
+    // virtual URLs like `about://React/Server/file:///path/to/chunk.js?42`
+    // with positions padded to match the underlying chunk, so they resolve
+    // via the real chunk's source map.
+    let sourceURL = devirtualizeReactServerURL(frame.file)
     // e.g. "/Users/foo/APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js"
     // or "C:\Users\foo\APP\.next\server\chunks\ssr\[root-of-the-server]__2934a0._.js"
     // will be keyed by Node.js as "file:///APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js".
@@ -209,7 +208,7 @@ function getSourcemappedFrameIfPossible(
       )
       // If loading fails once, it'll fail every time.
       // So set the cache to avoid duplicate errors.
-      sourceMapCache.set(fileKey, null)
+      sourceMapCache.set(frame.file, null)
       // Don't even fall back to the bundler because it might be not as strict
       // with regards to parsing and then we fail later once we consume the
       // source map payload.
@@ -249,10 +248,10 @@ function getSourcemappedFrameIfPossible(
       )
       // If creating the consumer fails once, it'll fail every time.
       // So set the cache to avoid duplicate errors.
-      sourceMapCache.set(fileKey, null)
+      sourceMapCache.set(frame.file, null)
       return createUnsourcemappedFrame(frame)
     }
-    sourceMapCache.set(fileKey, {
+    sourceMapCache.set(frame.file, {
       map: sourceMapConsumer,
       payload: sourceMapPayload,
     })

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -181,10 +181,9 @@ function getSourcemappedFrameIfPossible(
   let sourceMapConsumer: SyncSourceMapConsumer
   let sourceMapPayload: ModernSourceMapPayload
   if (sourceMapCacheEntry === undefined) {
-    // React's fake eval'd scripts for Server Component stack frames use
-    // virtual URLs like `about://React/Server/file:///path/to/chunk.js?42`
-    // with positions padded to match the underlying chunk, so they resolve
-    // via the real chunk's source map.
+    // Fake frame scripts (`about://React/Server/file:///path/to/chunk.js?42`)
+    // have their positions padded to match the underlying chunk, so they
+    // resolve via the chunk's source map.
     let sourceURL = devirtualizeReactServerURL(frame.file)
     // e.g. "/Users/foo/APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js"
     // or "C:\Users\foo\APP\.next\server\chunks\ssr\[root-of-the-server]__2934a0._.js"

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -229,6 +229,23 @@ describe('app-dir - server source maps - fake frame source maps', () => {
           }).toEqual({ url: script.url, hasSourceMap: true })
         }
 
+        if (isTurbopack) {
+          // Turbopack must reference the emitted source map files instead of
+          // inlining a payload copy into every fake script. Guards against
+          // silently degrading to `data:` URLs, e.g. when the bundler
+          // implementation isn't registered in one of the compiled copies of
+          // the resolver.
+          for (const script of fakeScripts) {
+            expect({
+              url: script.url,
+              sourceMapURL: script.sourceMapURL,
+            }).toEqual({
+              url: script.url,
+              sourceMapURL: expect.stringMatching(/^file:/),
+            })
+          }
+        }
+
         // Resolve each source map like a debugger frontend and map the
         // padded `_()` call position of each fake function back to its
         // original source, like clicking the frame in a debugger would.

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -297,6 +297,88 @@ describe('app-dir - server source maps - fake frame source maps', () => {
         session.close()
       }
     })
+
+    it('fake stack frames from nested Flight requests are resolvable by an attached debugger', async () => {
+      // Rendering this page produces fake frame scripts whose frame
+      // filenames are `file:` URLs rather than file paths.
+      await next.render('/rsc-error-throw-cached')
+
+      const target = await findServerInspectorTarget()
+      const session = await CDPSession.connect(target.webSocketDebuggerUrl)
+      try {
+        const evalScripts: {
+          scriptId: string
+          url: string
+          sourceMapURL: string
+        }[] = []
+        session.onEvent = (method, params) => {
+          if (method === 'Debugger.scriptParsed' && params.hasSourceURL) {
+            evalScripts.push({
+              scriptId: params.scriptId,
+              url: params.url,
+              sourceMapURL: params.sourceMapURL ?? '',
+            })
+          }
+        }
+        await session.send('Debugger.enable', { maxScriptsCacheSize: 1 })
+
+        await retry(async () => {
+          expect(
+            evalScripts.filter((script) =>
+              script.url.startsWith('about://React/Cache/')
+            ).length
+          ).toBeGreaterThan(0)
+        })
+
+        // React emits a fake frame script under `about://React/` with a
+        // source map, or, when no source map could be found for it, under
+        // the frame's raw filename without one.
+        const fakeScripts = evalScripts.filter(
+          (script) =>
+            script.url.startsWith('about://React/') ||
+            (script.url.startsWith('file:') && script.sourceMapURL === '')
+        )
+        const mappedSources = new Set<string>()
+        for (const script of fakeScripts) {
+          expect({
+            url: script.url,
+            hasSourceMap: script.sourceMapURL !== '',
+          }).toEqual({ url: script.url, hasSourceMap: true })
+
+          const { sourceMap, mapURL } = await resolveSourceMapLikeADebugger(
+            session,
+            script.url,
+            script.sourceMapURL
+          )
+          const { scriptSource } = await session.send(
+            'Debugger.getScriptSource',
+            { scriptId: script.scriptId }
+          )
+          const callIndex = scriptSource.indexOf('_()')
+          if (callIndex === -1) continue
+          const line = scriptSource.slice(0, callIndex).split('\n').length
+          const column =
+            callIndex - (scriptSource.lastIndexOf('\n', callIndex) + 1)
+
+          const consumer = new SourceMap(sourceMap)
+          const original = consumer.findEntry(line - 1, column)
+          if (original.originalSource !== undefined) {
+            mappedSources.add(
+              mapURL === null
+                ? original.originalSource
+                : new URL(original.originalSource, mapURL).href
+            )
+          }
+        }
+
+        const testDirURL = url.pathToFileURL(fs.realpathSync(next.testDir))
+        expect([...mappedSources]).toContain(
+          `${testDirURL.href}/app/rsc-error-throw-cached/page.js`
+        )
+      } finally {
+        session.close()
+      }
+    })
   } else {
     it('server chunk source maps are resolvable by an attached debugger', async () => {
       await next.render('/rsc-error-log')

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -230,11 +230,9 @@ describe('app-dir - server source maps - fake frame source maps', () => {
         }
 
         if (isTurbopack) {
-          // Turbopack must reference the emitted source map files instead of
-          // inlining a payload copy into every fake script. Guards against
-          // silently degrading to `data:` URLs, e.g. when the bundler
-          // implementation isn't registered in one of the compiled copies of
-          // the resolver.
+          // The resolver silently falls back to inlining `data:` URLs, so a
+          // defect in the `file:` URL derivation keeps all behavior-based
+          // assertions green. Only this assertion catches it.
           for (const script of fakeScripts) {
             expect({
               url: script.url,


### PR DESCRIPTION
Improves development performance when we have a huge file with lots of functions (each of which gets its own copy of the sourcemap).

The issue is due to `data:` sourcemaps, as foreseen in https://github.com/vercel/next.js/pull/81904. Node.js forever retains a parsed copy of a sourcemap per eval'd fake function, keyed by each function's unique `sourceURL`. There's also a bunch of CPU work that gets repeated.

The fix is to switch to `file:` sourcemaps, which we can easily do in Turbopack in dev because all chunks have a `<chunk-name>.map` source map. We'll inject this behavior from `hot-reloader-turbopack.js`.

# Test Plan

That hyper slow example we've seen no longer takes 12s to render first route in dev:

<img width="532" height="268" alt="Screenshot 2026-07-20 at 02 22 24" src="https://github.com/user-attachments/assets/31507ca8-f45c-4fd0-b895-c18f885476e4" />

Also, `vercel-docs` no longer OOMs when slowly navigating across a bunch of routes. (It still OOMs on fast bursts — to be investigated separately.)

I see sourcemaps in:

- Terminal
- Instant Validation
- Server Error
- Client Error
- Cache Error
- Server HMR
- Client HMR

----

<h1 id=wtf> Okay, but seriously, how does it work?</h1>

I'm glad you asked...

While working on this PR, I've learned a lot of trivia about sourcemaps and the tricks we do in React to make them work nicely across environments. I'm afraid I'll forget all of them so I wrote them down here.

## Basics

A stack is made of frames.

Frames can originate in different environments, and can look like `https://example.com/chunk.js` (browser) or `/Users/dan/layout.js` (CJS Node) or `file:///Users/dan/app/layout.js` (ESM Node), or something more exotic (`webpack://bundle.js` etc). You can see them by doing `new Error().stack`.

However, these frames are not necessarily what the user *sees* in the stack. If the relevant script contained a reference to a sourcemap, the displayed frame is whatever the sourcemap says for that position. So this is how `https://example.com/bundle.js:1:2` can show up as `app/Button.tsx:5:10`. It means that `https://example.com/bundle.js` contains a sourcemapping URL to a sourcemap that says "this piece of code is actually from `app/Button.tsx`".

## Fake Frames

Suppose we're in a browser, but the error contains some frames originally from the Server (in the RSC sense).

If we just let the browser display them as is, a `/Users/dan/app/.next/server/chunk.js:1234:56` frame will show up in the browser. Which is fine but it wouldn't be clickable and obviously wouldn't display source code (because why would it).

So we do a little trick. We eval a special empty function that's positioned right where the original frame was in the chunk (e.g. line 1234, char 56) by padding it with newlines and spaces. Inside that eval, we point at the *chunk's* sourcemap — the one that says "the code at 1234:56 is actually a function from `app/layout.js`".

What this achieves is that in the stack you see `app/layout.js` (because the sourcemap says that's what this position is), and when you click on it, the contents of that server file is shown (because the sourcemap includes the original source text). Since our stub sits at exactly the position the real frame had in the chunk, the chunk's sourcemap gives the right answers for it.

**So we've tricked the browser into displaying a frame with the server code.**

(This was the feature that motivates all this.)

Now, for all of this to work, we still need to give some name to the surrounding module during eval. In other words, our "fake" module is not a `file://` or `https://` or whatever. It's just a virtual eval'd thing that exists so that it can "sourcemap" down to the real server file, and we can splice those frames in the current environment's stacks. Let's give this module a URI like `about://React/Server/file:///Users/dan/app/.next/server/chunk.js?1`:

- We want these stubs to be grouped separately away from people's eyes in the Source tab. They're not real code.
- `Server` can be `Cache` or others instead, that's the React environment it represents
- The `file://` part after that is the compiled file whose frame this stub is standing in for
- The `?1` part at the end makes this stub module unique
  - We need that because every distinct frame (function and position) needs its own "empty file with a function" stub, and one file can appear in many frames. So we can't use the same URI or the browser will treat them as the same module.

We'll call this `about://React/Server/file:///Users/dan/app/.next/server/chunk.js?1` thing a "virtualized" URL.

To recap: it's the URI of a virtual eval'd module that is almost completely empty but has an empty function at just the right line, and a sourcemap that says "actually if you click on my frame, display `app/layout.js`".

## Browser Symbolication

For the browser itself, the above is sufficient. The browser sees `about://React/Server/file:///Users/dan/app/.next/server/chunk.js?1` in the stack (spliced by React to mark a frame from another environment). But the user doesn't see this if they have sourcemaps on. This is because the browser loads the sourcemap that this module points to, and that sourcemap "makes it look" like the real `app/layout.js`. Illusion achieved.

## Where Does a Source Map Come From

For the above to work, the virtual module generated by React needs to contain a `//# sourceMappingURL=` which points to the thing that lets it masquerade as the server module.

React can't do this on its own since it shouldn't be reading files and may not have access to them anyway (at least not in the browser). So this is actually injected into React by the framework (the thing being injected is called `findSourceMapURL`). Next.js itself has multiple implementations of `findSourceMapURL`:

- The version for the browser emits
  - `//# sourceMappingURL=<chunk-url>.map` for client sourcemaps
  - `//# sourceMappingURL=/__nextjs_source-map?filename=...` for server sourcemaps which loads it over HTTP

- The version for Node.js emits
  - `//# sourceMappingURL=data:...` URI with the same sourcemap inline.

React doesn't care. It just needs something to put into `//# sourceMappingURL=` of those virtual modules, and then hopefully the surrounding environment is actually able to resolve this.

## Why `data:` for Node.js?

You might wonder why SSR points to sourcemaps with `data:` URIs instead of HTTP like the browser version.

The answer is that we want to support debugging *Node.js process itself* with a Chrome debugger. And Node.js version of Chrome debugger does not load HTTP `sourceMappingURL`. It only supports `file:` or `data:`. Today we use `data:`.

## Terminal Symbolication

What we have above is enough for browsers, where we use HTTP, and for Node.js Chrome debugger, where we currently use `data:`. They'll follow `sourceMappingURL` and grab the sourcemap when they need it.

But we also show error stacks on *our own* surfaces, e.g. in terminal. So we need to replicate what the browser does.

We need to resolve arbitrary frames (whether real ones like `/Users/dan/...` or `file:///Users/dan` — stuff from the current environment captured by V8 — or weird ones like `about://...`, which is stuff from an earlier environment like Server or Cache). We need to resolve them to source files like `app/layout.js` and such.

For the browser (or for Node.js), this is easy because the runtime already "remembers" executing each module, and what the `sourceMappingURL` told it. However, *our own* terminal printing code is unaware of what happened inside Node.js.

So we need to get creative:

1. For real Node.js frames from the current process like `/Users/dan/...` (CJS) and `file:///Users/dan` (ESM), there is no problem. If they have sourcemaps (e.g. Turbopack output), those are relative like `//# sourceMappingURL=foo.js.map`. Node.js reads and caches those when it loads each module, and `require('module').findSourceMap` gives us what it cached.
2. For virtual frames like `about://...`, we need to know what actual file it corresponds to. We could try to parse it out of the virtual frame itself, but actually we don't need to do that. **It turns out that we can simply ask the Node.js inline sourcemap cache: "give me the inline sourcemap you cached when evaluating this frame's module".** This works because Node.js already caches all sourcemaps from modules that have `data:` URIs as source map URL. So we just look into that map under the `about://...` key, and we can treat that `about://` key itself as opaque.

Once we get that sourcemap, we can parse it and symbolicate the frame.

## The Problem

**Okay, now we're finally getting to the point of this PR.**

It turns out that it is actually expensive to use `data:` URIs for this. Worst of all, it's expensive in the happy case (when errors don't show up).

Let's see why this is expensive.

React's fake modules are evaluated not just for thrown errors, but for debug information (component stacks) that travels with JSX. So this has nothing to do with throwing or the cost of displaying an error. We're always materializing those frames. (Can we do that lazily? I'm not sure.)

To materialize these frames, Node evaluates our fake modules — one per distinct frame that shows up in stacks. So a big file with 100 components appearing in stacks means 100 fake modules. Each of them includes the same `//# sourceMappingURL=data:...` URI carrying the entire sourcemap of the chunk that file was compiled into.

So you can see why we have a problem:

1. A big original file with 100 components would produce 100 virtual modules
2. Each of the 100 virtual modules contains an identical `data:` with the sourcemap for the entire chunk
3. Node.js does not dedupe any work between `data:` URIs so they *each* get parsed
4. Worse, Node.js doesn't share memory between identical sourcemaps born from `data:` so they pile up in memory
5. Even worse, this memory is effectively never freed (the cached sourcemaps live as long as the eval'd modules, and React keeps the fake functions in a cache forever)

That's why we saw 12 second slowdown on the start of one demo app with a huge number of icon sprites in one file.

Basically, Node.js didn't anticipate that many different files may include an identical inline sourcemap, and so this case is very badly unoptimized. (We could plausibly send a fix for this but it would only affect those who upgrade.)

So all of this isn't super great, and that's what we're trying to fix.

## The Fix: Just Use Files

To reiterate, the problem we're solving is that a fake module with a huge `//# sourceMappingURL=data:...` has upfront evaluation cost, and we're potentially evaluating a lot of these modules.

The obvious fix is to stop using `data:` URIs.

But what other option do we have for symbolicating on the server? We can't use HTTP (like in the browser) because that would break debugging Node.js with Chrome. Our only options are `data:`... and `file:`.

So let's try `file:`. But for that to work, we need the sourcemap to already exist on the disk.

With webpack, we can't do this because our webpack setup doesn't write sourcemaps to disk (unless we make it, I guess). I'm not touching that in this PR. So webpack stays with suboptimal performance, and this fix doesn't improve it.

But for turbopack, we can do this trivially. In dev, every first-party `chunk.js` compiled by Turbopack in the output already has a `chunk.js.map` next to it. So we just need to point our fake modules at *that* sourcemap that *already exists* on disk. Then Node.js has no per-module work to do at all — it simply ignores `file:` sourcemap URLs on eval'd modules instead of materializing them. Whoever actually needs the sourcemap later (the Chrome debugger, or our own terminal code) resolves it from disk, and all fake modules for one chunk point at the same single file.

In other words, instead of this:

- The version for Node.js emits `//# sourceMappingURL=data:...` URI with the same sourcemap inline.

We want to do this:

- The version for Node.js emits `//# sourceMappingURL=file:...` URI that points at the sourcemap on disk.

**That's the `source-maps.ts` change in this PR.** We ask the bundler for a source map file first, and if the source map file exists, we return that (as a `file:` URI) instead of the `data:` URI.

This fixes the memory issue and the 12 second slowdown.

## The Tricky Bits

With the change above, debugging Node.js via Chrome debugger will "just work". It doesn't care whether the sourcemap is at a `data:` URI or a `file:` URI as long as the sourcemap actually exists.

However, *our own* symbolication of terminal errors will break.

Why is that?

Recall how our terminal logic currently gets the sourcemap for every frame:

>1. For real Node.js frames from the current process like `/Users/dan/...` (CJS) and `file:///Users/dan` (ESM), there is no problem. If they have sourcemaps (e.g. Turbopack output), those are relative like `//# sourceMappingURL=foo.js.map`. Node.js reads and caches those when it loads each module, and `require('module').findSourceMap` gives us what it cached.
>
>2. For virtual frames like `about://...`, we need to know what actual file it corresponds to. We could try to parse it out of the virtual frame itself, but actually we don't need to do that. **It turns out that we can simply ask the Node.js inline sourcemap cache: "give me the inline sourcemap you cached when evaluating this frame's module".** This works because Node.js already caches all sourcemaps from modules that have `data:` URIs as source map URL. So we just look into that map under the `about://...` key, and we can treat that `about://` key itself as opaque.

The first case doesn't change — those keep working like before.

But the second case is now broken. There's no entry corresponding to `about://...` URI in Node.js inline source map cache because *we did not use an inline sourcemap*. That was the whole point of switching to `file:`! It's how we get memory and CPU savings — Node.js no longer materializes them eagerly so they don't exist in any cache yet.

**So we need to change the logic.** We need to treat `about://...` not as an opaque thing but as an encoded filename (it's inside — for example, `about://React/Server/file:///Users/dan/app/.next/chunk.js?1`). This lets us decode the filename out of it (strictly speaking, we get back `file:///Users/dan/app/.next/chunk.js` — React adds a `file://` prefix that decoding doesn't remove; more on that in the follow-ups). And knowing the JS file lets us get the map for it: the chunk itself was loaded by this process at some point, and Node.js read and cached the chunk's own sourcemap back then, so we look it up under the chunk's name. (If the chunk was never loaded in this process, Node.js has nothing, and we ask Turbopack for the map as a fallback.)

**That's the `patch-error-inspect.ts` changes in this PR.**

With this change, the terminal also gets symbolicated stacks after switching to `file:`.

## Follow-ups

There's a couple of things I'm not super happy with:

- It would be nice to fix this for webpack too? But maybe too risky or slow. I haven't tried.
- Caching could be improved. There's no need to do duplicate work per each `?1` `?2` etc of the same file. I think there's a way to place caches so that we can still respect React's contract for "each frame may have its own map".
- For some chunks with special names (e.g. `[root-of-the-server]` ones) whose sourcemaps are already loaded in Node.js memory in the same process (e.g. RSC frames transported into SSR world), we're no longer able to reuse the sourcemaps from Node.js memory, and instead have to fall back to asking Turbopack for them again. This is for two reasons:
  - We're no longer hitting the *inline* source map cache codepath because they're not inline.
  - We can't hit the Node.js *file* source map cache for them because we query them with wrong encoding:
    - Node.js file source map cache keys them with `pathToFileURL` encoding, like `file://...%5Broot-of-the-server%5D...`
    - Whereas devirtualizing `about://` React URL gives us `file://` URL with non-encoded content like `file://...[root-of-the-server]...`
    - The problem here is that `devirtualize(virtualize(absolutePath))` doesn't roundtrip. See https://github.com/react/react/pull/37105.
      - If it roundtripped, we would've gotten plain absolute `/...[root-of-the-server]...` and it would have been fine.
      - We can't fix this purely by tweaking the decoding on our side, because React prepends `file://` only when the filename starts with `/`, so from the decoded string we can't tell whether the original was an absolute path (CJS) that got prefixed or a real `file://` URL (ESM) that didn't. (We could try both interpretations against the cache — there are only two — but that's a follow-up.)
      - There's a related issue where an error travelling multiple layers (e.g. from Cache) gains `file://` on the second pass. I've had to add some defensive coding and a test for that.
    - This is not a huge deal because the Turbopack fallback saves us but I would've liked to fix this.

I don't think they're land-blocking so I'll maybe follow up.