### PR TITLE
fix(examples): correct preview message typo in cms-agilitycms alert

### DIFF
--- a/examples/cms-agilitycms/components/alert.tsx
+++ b/examples/cms-agilitycms/components/alert.tsx
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"


### PR DESCRIPTION
## Summary

This PR fixes a grammatical typo in the `cms-agilitycms` example's `Alert` component.

### Changes

* Corrected the preview message:

  * **Before:** `This is page is a preview.`
  * **After:** `This page is a preview.`

### Testing

* Verified the updated preview message renders correctly in the `cms-agilitycms` example.
