### PR TITLE
fix(examples): correct preview message typo across examples

### DIFF
--- a/examples/cms-agilitycms/components/alert.tsx
+++ b/examples/cms-agilitycms/components/alert.tsx
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-datocms/components/alert.js
+++ b/examples/cms-datocms/components/alert.js
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-dotcms/components/alert.tsx
+++ b/examples/cms-dotcms/components/alert.tsx
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-ghost/components/alert.js
+++ b/examples/cms-ghost/components/alert.js
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-prepr/components/alert.js
+++ b/examples/cms-prepr/components/alert.js
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-prismic/components/alert.tsx
+++ b/examples/cms-prismic/components/alert.tsx
@@ -20,7 +20,7 @@ export default function Alert({ preview }: AlertProps) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-storyblok/components/alert.js
+++ b/examples/cms-storyblok/components/alert.js
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"

--- a/examples/cms-takeshape/components/alert.js
+++ b/examples/cms-takeshape/components/alert.js
@@ -14,7 +14,7 @@ export default function Alert({ preview }) {
         <div className="py-2 text-center text-sm">
           {preview ? (
             <>
-              This is page is a preview.{" "}
+              This page is a preview.{" "}
               <a
                 href="/api/exit-preview"
                 className="underline hover:text-cyan duration-200 transition-colors"


### PR DESCRIPTION
## Summary

This PR corrects the same grammatical typo in the preview banner across multiple examples.

### Changes

Updated the preview message from:

> `This is page is a preview.`

to:

> `This page is a preview.`

This change applies the same correction consistently across all affected example `Alert` components.

### Testing

* Verified that the updated preview message renders correctly in the affected examples.
