### PR TITLE
docs: sync redirect and permanentRedirect JSDoc with current docs

### DIFF
--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -19,12 +19,13 @@ export function getRedirectError(
 
 /**
  * This function allows you to redirect the user to another URL. It can be used in
- * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
- * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components),
+ * [Route Handlers](https://nextjs.org/docs/app/api-reference/file-conventions/route), and
+ * [Server Functions](https://nextjs.org/docs/app/getting-started/mutating-data).
  *
- * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
- * - In a Route Handler or Server Action, it will serve a 307/303 to the caller.
+ * - When used in a streaming context, this will insert a meta tag to emit the redirect on the client side.
+ * - When used in a Server Action, it will serve a 303 HTTP redirect response to the caller.
+ * - Otherwise, it will serve a 307 HTTP redirect response to the caller.
  * - In a Server Action, type defaults to 'push' and 'replace' elsewhere.
  *
  * Read more: [Next.js Docs: `redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect)
@@ -41,14 +42,15 @@ export function redirect(
 
 /**
  * This function allows you to redirect the user to another URL. It can be used in
- * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
- * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components),
+ * [Route Handlers](https://nextjs.org/docs/app/api-reference/file-conventions/route), and
+ * [Server Functions](https://nextjs.org/docs/app/getting-started/mutating-data).
  *
- * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
- * - In a Route Handler or Server Action, it will serve a 308/303 to the caller.
+ * - When used in a streaming context, this will insert a meta tag to emit the redirect on the client side.
+ * - When used in a Server Action, it will serve a 303 HTTP redirect response to the caller.
+ * - Otherwise, it will serve a 308 (Permanent) HTTP redirect response to the caller.
  *
- * Read more: [Next.js Docs: `redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect)
+ * Read more: [Next.js Docs: `permanentRedirect`](https://nextjs.org/docs/app/api-reference/functions/permanentRedirect)
  */
 export function permanentRedirect(
   /** The URL to redirect to */


### PR DESCRIPTION
Fixes #83099

The JSDoc comments on `redirect` and `permanentRedirect` in `packages/next/src/client/components/redirect.ts` had drifted from the website docs:

- They still linked to the old `building-your-application/...` doc paths, which have since moved to `getting-started/...` and `api-reference/file-conventions/route`.
- They said the functions can be used in Server Components, but the current docs say Server **and Client** Components.
- They referred to Server Actions where the docs now say Server Functions.
- The behavior notes used the ambiguous "307/303" / "308/303" shorthand; this rewords them to match the docs pages, which spell out the streaming-context meta tag, the 303 for Server Actions, and the 307/308 response otherwise.
- `permanentRedirect`'s "Read more" link pointed at the `redirect` docs page instead of its own.

This only touches comments — no runtime changes. Wording is taken from the current `redirect.mdx` and `permanentRedirect.mdx` pages so the editor hover text and the website agree.

All four linked URLs return 200.