### PR TITLE
Emit Cache Components route trees as static files

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -529,6 +529,7 @@ export async function handleBuildComplete({
       prerenders: [],
       staticFiles: [],
     }
+    let hasStaticRootTreePrefetch = false
 
     if (config.output === 'export') {
       // collect export assets and provide as static files
@@ -1160,10 +1161,28 @@ export async function handleBuildComplete({
 
           for (const segmentPath of meta.segmentPaths) {
             const outputSegmentPath =
-              path.join(
+              path.posix.join(
                 normalizedRoute + prefetchSegmentDirSuffix,
                 segmentPath
               ) + prefetchSegmentSuffix
+
+            if (
+              routesManifest.rsc.clientParamParsing &&
+              segmentPath === '/_tree'
+            ) {
+              hasStaticRootTreePrefetch = true
+              outputs.staticFiles.push({
+                id: outputSegmentPath,
+                pathname: outputSegmentPath,
+                type: AdapterOutputType.STATIC_FILE,
+                filePath: path.join(
+                  segmentsDir,
+                  segmentPath + prefetchSegmentSuffix
+                ),
+                immutableHash: undefined,
+              })
+              continue
+            }
 
             // Only use the fallback value when the allowQuery is defined and
             // either: (1) it is empty, meaning segments do not vary by params,
@@ -2112,6 +2131,22 @@ export async function handleBuildComplete({
               },
             },
             ...onMatchHeaders,
+            ...(hasStaticRootTreePrefetch
+              ? [
+                  {
+                    sourceRegex: `^${escapeStringRegexp(
+                      config.basePath || ''
+                    )}/.+${escapeStringRegexp(
+                      `${routesManifest.rsc.prefetchSegmentDirSuffix}/_tree${routesManifest.rsc.prefetchSegmentSuffix}`
+                    )}(?:/)?$`,
+                    headers: {
+                      vary: routesManifest.rsc.varyHeader,
+                      'content-type': routesManifest.rsc.contentTypeHeader,
+                      [routesManifest.rsc.didPostponeHeader]: '2',
+                    },
+                  } satisfies Route,
+                ]
+              : []),
           ],
           fallback: rewrites.fallback,
           shouldNormalizeNextData: !!needsMiddlewareResolveRoutes,

--- a/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
+++ b/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import { resolveRoutes } from '../../../../packages/next-routing/src'
 import { nextTestSetup } from 'e2e-utils'
 import type { NextAdapter } from 'next'
 
@@ -7,63 +9,63 @@ describe('adapter-partial-fallback', () => {
   })
 
   it('should emit partial fallback metadata when infra can upgrade the shell', async () => {
-    const { outputs }: Parameters<NextAdapter['onBuildComplete']>[0] =
-      await next.readJSON('build-complete.json')
+    const {
+      outputs,
+      routing,
+      buildId,
+      config,
+    }: Parameters<NextAdapter['onBuildComplete']>[0] = await next.readJSON(
+      'build-complete.json'
+    )
+    const basePath = '/docs'
+    expect(config.basePath).toBe(basePath)
 
     const withGspPrerender = outputs.prerenders.find(
-      (output) => output.pathname === '/with-gsp/[slug]'
-    )
-    const withGspRouteTreePrerender = outputs.prerenders.find(
-      (output) =>
-        output.pathname === '/with-gsp/[slug].segments/_tree.segment.rsc'
+      (output) => output.pathname === `${basePath}/with-gsp/[slug]`
     )
     const withGspOtherSegmentPrerenders = outputs.prerenders.filter(
       (output) =>
-        output.pathname.startsWith('/with-gsp/[slug].segments/') &&
-        output.pathname !== '/with-gsp/[slug].segments/_tree.segment.rsc'
+        output.pathname.startsWith(`${basePath}/with-gsp/[slug].segments/`) &&
+        output.pathname !==
+          `${basePath}/with-gsp/[slug].segments/_tree.segment.rsc`
     )
     const withoutGspPrerender = outputs.prerenders.find(
-      (output) => output.pathname === '/without-gsp/[slug]'
-    )
-    const withoutGspRouteTreePrerender = outputs.prerenders.find(
-      (output) =>
-        output.pathname === '/without-gsp/[slug].segments/_tree.segment.rsc'
+      (output) => output.pathname === `${basePath}/without-gsp/[slug]`
     )
     const withoutGspOtherSegmentPrerenders = outputs.prerenders.filter(
       (output) =>
-        output.pathname.startsWith('/without-gsp/[slug].segments/') &&
-        output.pathname !== '/without-gsp/[slug].segments/_tree.segment.rsc'
+        output.pathname.startsWith(
+          `${basePath}/without-gsp/[slug].segments/`
+        ) &&
+        output.pathname !==
+          `${basePath}/without-gsp/[slug].segments/_tree.segment.rsc`
     )
     const genericPrefixPrerender = outputs.prerenders.find(
-      (output) => output.pathname === '/prefix/[one]/[two]'
-    )
-    const genericPrefixRouteTreePrerender = outputs.prerenders.find(
-      (output) =>
-        output.pathname === '/prefix/[one]/[two].segments/_tree.segment.rsc'
+      (output) => output.pathname === `${basePath}/prefix/[one]/[two]`
     )
     const genericPrefixOtherSegmentPrerenders = outputs.prerenders.filter(
       (output) =>
-        output.pathname.startsWith('/prefix/[one]/[two].segments/') &&
-        output.pathname !== '/prefix/[one]/[two].segments/_tree.segment.rsc'
+        output.pathname.startsWith(
+          `${basePath}/prefix/[one]/[two].segments/`
+        ) &&
+        output.pathname !==
+          `${basePath}/prefix/[one]/[two].segments/_tree.segment.rsc`
     )
     const generatedPrefixPrerender = outputs.prerenders.find(
-      (output) => output.pathname === '/prefix/b/[two]'
+      (output) => output.pathname === `${basePath}/prefix/b/[two]`
     )
     const genericDashedPrerender = outputs.prerenders.find(
-      (output) => output.pathname === '/dashed/[my-slug]/[two]'
+      (output) => output.pathname === `${basePath}/dashed/[my-slug]/[two]`
     )
     const generatedDashedPrerender = outputs.prerenders.find(
-      (output) => output.pathname === '/dashed/b/[two]'
+      (output) => output.pathname === `${basePath}/dashed/b/[two]`
     )
 
     expect(withGspPrerender).toBeDefined()
-    expect(withGspRouteTreePrerender).toBeDefined()
     expect(withGspOtherSegmentPrerenders.length).toBeGreaterThan(0)
     expect(withoutGspPrerender).toBeDefined()
-    expect(withoutGspRouteTreePrerender).toBeDefined()
     expect(withoutGspOtherSegmentPrerenders.length).toBeGreaterThan(0)
     expect(genericPrefixPrerender).toBeDefined()
-    expect(genericPrefixRouteTreePrerender).toBeDefined()
     expect(genericPrefixOtherSegmentPrerenders.length).toBeGreaterThan(0)
     expect(generatedPrefixPrerender).toBeDefined()
     expect(genericDashedPrerender).toBeDefined()
@@ -71,8 +73,6 @@ describe('adapter-partial-fallback', () => {
 
     expect(withGspPrerender.config.partialFallback).toBe(true)
     expect(withGspPrerender.config.allowQuery).toEqual(['nxtPslug'])
-    expect(withGspRouteTreePrerender.config.partialFallback).toBe(true)
-    expect(withGspRouteTreePrerender.config.allowQuery).toEqual(['nxtPslug'])
     for (const output of withGspOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBe(true)
       expect(output.config.allowQuery).toEqual(['nxtPslug'])
@@ -80,8 +80,6 @@ describe('adapter-partial-fallback', () => {
 
     expect(withoutGspPrerender.config.partialFallback).toBeUndefined()
     expect(withoutGspPrerender.config.allowQuery).toEqual([])
-    expect(withoutGspRouteTreePrerender.config.partialFallback).toBeUndefined()
-    expect(withoutGspRouteTreePrerender.config.allowQuery).toEqual([])
     for (const output of withoutGspOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBeUndefined()
       expect(output.config.allowQuery).toEqual([])
@@ -89,10 +87,6 @@ describe('adapter-partial-fallback', () => {
 
     expect(genericPrefixPrerender.config.partialFallback).toBe(true)
     expect(genericPrefixPrerender.config.allowQuery).toEqual(['nxtPone'])
-    expect(genericPrefixRouteTreePrerender.config.partialFallback).toBe(true)
-    expect(genericPrefixRouteTreePrerender.config.allowQuery).toEqual([
-      'nxtPone',
-    ])
     for (const output of genericPrefixOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBe(true)
       expect(output.config.allowQuery).toEqual(['nxtPone'])
@@ -106,5 +100,102 @@ describe('adapter-partial-fallback', () => {
 
     expect(generatedDashedPrerender.config.partialFallback).toBeUndefined()
     expect(generatedDashedPrerender.config.allowQuery).toEqual([])
+
+    const routeTreeSuffix = '.segments/_tree.segment.rsc'
+    expect(
+      outputs.prerenders.filter((output) =>
+        output.pathname.endsWith(routeTreeSuffix)
+      )
+    ).toEqual([])
+
+    const routeTreeStaticOutputs = outputs.staticFiles.filter((output) =>
+      output.pathname.endsWith(routeTreeSuffix)
+    )
+    const expectedRouteTrees = [
+      '/with-gsp/one.segments/_tree.segment.rsc',
+      '/with-gsp/[slug].segments/_tree.segment.rsc',
+      '/without-gsp/[slug].segments/_tree.segment.rsc',
+      '/prefix/[one]/[two].segments/_tree.segment.rsc',
+    ]
+
+    for (const id of expectedRouteTrees) {
+      const pathname = `${basePath}${id}`
+      const matchingOutputs = routeTreeStaticOutputs.filter(
+        (output) => output.pathname === pathname
+      )
+      expect(matchingOutputs).toHaveLength(1)
+      expect(matchingOutputs[0]).toEqual(
+        expect.objectContaining({
+          id,
+          pathname,
+          type: 'STATIC_FILE',
+        })
+      )
+      expect(matchingOutputs[0].immutableHash).toBeUndefined()
+    }
+
+    for (const output of routeTreeStaticOutputs) {
+      expect(output.filePath).toMatch(/\.segments[/\\]_tree\.segment\.rsc$/)
+      expect((await fs.promises.stat(output.filePath)).isFile()).toBe(true)
+    }
+
+    const routeTreeOnMatch = routing.onMatch[routing.onMatch.length - 1]
+    expect(routeTreeOnMatch.headers).toEqual({
+      vary: routing.rsc.varyHeader,
+      'content-type': routing.rsc.contentTypeHeader,
+      [routing.rsc.didPostponeHeader]: '2',
+    })
+
+    const routeTreeRegex = new RegExp(routeTreeOnMatch.sourceRegex)
+    expect(
+      routeTreeRegex.test(`${basePath}/with-gsp/one.segments/_tree.segment.rsc`)
+    ).toBe(true)
+    expect(
+      routeTreeRegex.test('/with-gsp/one.segments/_tree.segment.rsc')
+    ).toBe(false)
+    expect(
+      routeTreeRegex.test(
+        `${basePath}/with-gsp/two.segments/__PAGE__.segment.rsc`
+      )
+    ).toBe(false)
+
+    const concreteTreePathname = `${basePath}/with-gsp/two.segments/_tree.segment.rsc`
+    const resolvedTreeRoute = await resolveRoutes({
+      url: new URL(`https://example.com${concreteTreePathname}`),
+      buildId,
+      basePath,
+      requestBody: new ReadableStream({
+        start(controller) {
+          controller.close()
+        },
+      }),
+      headers: new Headers(),
+      pathnames: [
+        ...outputs.pages,
+        ...outputs.pagesApi,
+        ...outputs.appPages,
+        ...outputs.appRoutes,
+        ...outputs.prerenders,
+        ...outputs.staticFiles,
+      ].map((output) => output.pathname),
+      routes: routing,
+      invokeMiddleware: async () => ({}),
+    })
+
+    expect(resolvedTreeRoute.resolvedPathname).toBe(
+      `${basePath}/with-gsp/[slug].segments/_tree.segment.rsc`
+    )
+    expect(resolvedTreeRoute.invocationTarget?.pathname).toBe(
+      concreteTreePathname
+    )
+    expect(
+      resolvedTreeRoute.resolvedHeaders?.get(routing.rsc.didPostponeHeader)
+    ).toBe('2')
+    expect(resolvedTreeRoute.resolvedHeaders?.get('content-type')).toBe(
+      routing.rsc.contentTypeHeader
+    )
+    expect(resolvedTreeRoute.resolvedHeaders?.get('vary')).toBe(
+      routing.rsc.varyHeader
+    )
   })
 })

--- a/test/production/app-dir/adapter-partial-fallback/next.config.js
+++ b/test/production/app-dir/adapter-partial-fallback/next.config.js
@@ -2,6 +2,7 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
+  basePath: '/docs',
   cacheComponents: true,
   adapterPath: require.resolve('./my-adapter.mjs'),
 }


### PR DESCRIPTION
## Summary

- Emit Cache Components `/_tree` prefetch segments as static adapter outputs for both concrete and dynamic fallback routes.
- Preserve the required RSC response headers through a basePath-aware `onMatch` rule.
- Keep non-tree segment prerenders and their partial-fallback upgrade metadata unchanged.

## Verification

- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-turbo test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-webpack test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-webpack test/production/adapter-config/adapter-config.test.ts`

<!-- NEXT_JS_LLM -->