### PR TITLE
examples: add with-next-i18next (App Router)

### DIFF
--- a/examples/with-next-i18next/.gitignore
+++ b/examples/with-next-i18next/.gitignore
@@ -1,0 +1,40 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/with-next-i18next/README.md
+++ b/examples/with-next-i18next/README.md
@@ -1,0 +1,39 @@
+# next-i18next example
+
+This example shows how to internationalize a Next.js App Router application with [next-i18next](https://github.com/i18next/next-i18next) — the Next.js integration of [i18next](https://www.i18next.com) and [react-i18next](https://react.i18next.com). Since v16, next-i18next supports both the App Router (Server Components, Client Components, and proxy-based locale routing — shown in this example) and the Pages Router approach.
+
+The example demonstrates:
+
+- Locale-prefixed routing (`/en`, `/de`) and language detection (cookie → `Accept-Language` → fallback), handled by `proxy.ts`
+- Translations in Server Components via `getT` — including translated metadata in `generateMetadata`
+- Translations in Client Components via `useT`, including i18next pluralization
+- The `Trans` component for translations with inline markup
+- A language switcher that swaps the locale segment while keeping the current page
+- `generateStaticParams` wiring for the `[lng]` segment via `generateI18nStaticParams`
+- Serverless-safe translation loading (`resourceLoader` with bundler-traceable dynamic imports), so the example works on Vercel out of the box
+
+next-i18next also supports cookie-based language selection without locale prefixes (no-locale-path mode), hiding the default locale prefix, the Pages Router, and mixed App Router + Pages Router setups — see the [next-i18next README](https://github.com/i18next/next-i18next) for those variants.
+
+## Deploy your own
+
+Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-next-i18next&project-name=with-next-i18next&repository-name=with-next-i18next)
+
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
+
+```bash
+npx create-next-app --example with-next-i18next with-next-i18next-app
+```
+
+```bash
+yarn create next-app --example with-next-i18next with-next-i18next-app
+```
+
+```bash
+pnpm create next-app --example with-next-i18next with-next-i18next-app
+```
+
+Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-next-i18next/app/[lng]/about/page.tsx
+++ b/examples/with-next-i18next/app/[lng]/about/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { getT } from "next-i18next/server";
+import { LanguageSwitcher } from "../components/language-switcher";
+import i18nConfig from "../../../i18n.config";
+
+export default async function About() {
+  const { t, lng } = await getT();
+
+  return (
+    <main>
+      <h1>{t("about_title")}</h1>
+      <p>{t("about_text")}</p>
+      <p>
+        <Link href={`/${lng}`}>{t("back_home")}</Link>
+      </p>
+      <LanguageSwitcher supportedLngs={i18nConfig.supportedLngs} />
+    </main>
+  );
+}

--- a/examples/with-next-i18next/app/[lng]/components/counter.tsx
+++ b/examples/with-next-i18next/app/[lng]/components/counter.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState } from "react";
+import { useT } from "next-i18next/client";
+
+export function Counter() {
+  const { t } = useT();
+  const [count, setCount] = useState(0);
+
+  return (
+    <p>
+      <button type="button" onClick={() => setCount((c) => c + 1)}>
+        {t("clicked", { count })}
+      </button>{" "}
+      <button type="button" onClick={() => setCount(0)}>
+        {t("reset")}
+      </button>
+    </p>
+  );
+}

--- a/examples/with-next-i18next/app/[lng]/components/language-switcher.tsx
+++ b/examples/with-next-i18next/app/[lng]/components/language-switcher.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useT } from "next-i18next/client";
+
+export function LanguageSwitcher({
+  supportedLngs,
+}: {
+  supportedLngs: string[];
+}) {
+  const { t, i18n } = useT();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const switchTo = (lng: string) => {
+    const segments = pathname.split("/");
+    segments[1] = lng;
+    router.push(segments.join("/"));
+  };
+
+  return (
+    <p>
+      {t("switch_language")}{" "}
+      {supportedLngs.map((lng) => (
+        <button
+          key={lng}
+          type="button"
+          disabled={lng === i18n.resolvedLanguage}
+          onClick={() => switchTo(lng)}
+        >
+          {lng}
+        </button>
+      ))}
+    </p>
+  );
+}

--- a/examples/with-next-i18next/app/[lng]/layout.tsx
+++ b/examples/with-next-i18next/app/[lng]/layout.tsx
@@ -1,0 +1,42 @@
+import { dir } from "i18next";
+import {
+  initServerI18next,
+  getT,
+  getResources,
+  generateI18nStaticParams,
+} from "next-i18next/server";
+import { I18nProvider } from "next-i18next/client";
+import i18nConfig from "../../i18n.config";
+
+initServerI18next(i18nConfig);
+
+export async function generateStaticParams() {
+  return generateI18nStaticParams();
+}
+
+export async function generateMetadata() {
+  const { t } = await getT();
+  return { title: t("title") };
+}
+
+export default async function RootLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ lng: string }>;
+}) {
+  const { lng } = await params;
+  const { i18n } = await getT();
+  const resources = getResources(i18n);
+
+  return (
+    <html lang={lng} dir={dir(lng)}>
+      <body>
+        <I18nProvider language={lng} resources={resources}>
+          {children}
+        </I18nProvider>
+      </body>
+    </html>
+  );
+}

--- a/examples/with-next-i18next/app/[lng]/page.tsx
+++ b/examples/with-next-i18next/app/[lng]/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { Trans } from "react-i18next/TransWithoutContext";
+import { getT } from "next-i18next/server";
+import { Counter } from "./components/counter";
+import { LanguageSwitcher } from "./components/language-switcher";
+import i18nConfig from "../../i18n.config";
+
+export default async function Home() {
+  const { t, i18n, lng } = await getT();
+
+  return (
+    <main>
+      <h1>{t("title")}</h1>
+      <p>
+        <Trans t={t} i18n={i18n} i18nKey="intro">
+          This page is a <strong>Server Component</strong>. Its text is
+          translated on the server with getT.
+        </Trans>
+      </p>
+      <Counter />
+      <p>
+        <Link href={`/${lng}/about`}>{t("about_link")}</Link>
+      </p>
+      <LanguageSwitcher supportedLngs={i18nConfig.supportedLngs} />
+    </main>
+  );
+}

--- a/examples/with-next-i18next/app/i18n/locales/de/common.json
+++ b/examples/with-next-i18next/app/i18n/locales/de/common.json
@@ -1,0 +1,12 @@
+{
+  "title": "next-i18next mit dem Next.js App Router",
+  "intro": "Diese Seite ist eine <strong>Server Component</strong>. Ihr Text wird auf dem Server mit getT übersetzt.",
+  "clicked_one": "Du hast {{count}} Mal geklickt",
+  "clicked_other": "Du hast {{count}} Mal geklickt",
+  "reset": "Zurücksetzen",
+  "about_link": "Zur About-Seite",
+  "about_title": "Über",
+  "about_text": "Beim Sprachwechsel bleibst du auf dieser Seite — nur das Locale-Segment der URL ändert sich.",
+  "back_home": "Zurück zur Startseite",
+  "switch_language": "Sprache wechseln:"
+}

--- a/examples/with-next-i18next/app/i18n/locales/en/common.json
+++ b/examples/with-next-i18next/app/i18n/locales/en/common.json
@@ -1,0 +1,12 @@
+{
+  "title": "next-i18next with the Next.js App Router",
+  "intro": "This page is a <strong>Server Component</strong>. Its text is translated on the server with getT.",
+  "clicked_one": "You clicked {{count}} time",
+  "clicked_other": "You clicked {{count}} times",
+  "reset": "Reset",
+  "about_link": "Go to the about page",
+  "about_title": "About",
+  "about_text": "Switching the language keeps you on this page — only the locale segment of the URL changes.",
+  "back_home": "Back to the home page",
+  "switch_language": "Switch language:"
+}

--- a/examples/with-next-i18next/i18n.config.ts
+++ b/examples/with-next-i18next/i18n.config.ts
@@ -1,0 +1,15 @@
+import type { I18nConfig } from "next-i18next/proxy";
+
+const i18nConfig: I18nConfig = {
+  supportedLngs: ["en", "de"],
+  fallbackLng: "en",
+  defaultNS: "common",
+  ns: ["common"],
+  // Bundler-traceable dynamic import, so translation files are included in
+  // serverless deployments (Vercel etc.). See the next-i18next README for a
+  // variant with full hot-reloading of translation files in development.
+  resourceLoader: (language, namespace) =>
+    import(`./app/i18n/locales/${language}/${namespace}.json`),
+};
+
+export default i18nConfig;

--- a/examples/with-next-i18next/package.json
+++ b/examples/with-next-i18next/package.json
@@ -1,0 +1,22 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "i18next": "^26.3.6",
+    "next": "latest",
+    "next-i18next": "^16.0.8",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-i18next": "^17.0.10"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/with-next-i18next/proxy.ts
+++ b/examples/with-next-i18next/proxy.ts
@@ -1,0 +1,8 @@
+import { createProxy } from "next-i18next/proxy";
+import i18nConfig from "./i18n.config";
+
+export const proxy = createProxy(i18nConfig);
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};

--- a/examples/with-next-i18next/tsconfig.json
+++ b/examples/with-next-i18next/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### What?

App Router example for next-i18next v16: en/de with `proxy.ts` detection.
next-i18next v16 works with both the App Router and the Pages Router approach.

It shows:
- locale-prefixed routing (`/en`, `/de`) with detection in `proxy.ts`
- `getT` in Server Components incl. `generateMetadata`
- `useT` in Client Components incl. pluralization
- a `Trans` example
- a language switcher that keeps the current page
- bundler-traceable dynamic imports, so the example deploys to Vercel as-is

### Why?

Until v16, next-i18next supported only the Pages Router approach, because it
was relatively easy to use i18next and react-i18next directly — but it seems
this confused developers, so v16 fixed that. It shows everything important to
know about how to use next-i18next.

The examples directory covers next-intl, lingui, react-intl, next-translate
and rosetta, but none of the i18next family (i18next ~19.9 M, react-i18next
~13.9 M weekly npm downloads).

Related docs PR: #94744.

### How?

I built next-i18next on my own and tested it across various examples and also
on real Next.js projects.

This example: structure modeled on `with-ably`; `next build` passes on
Next.js 16.2.10; `next start` smoke test: `Accept-Language: de`
redirects `/` → `/de/`, server-translated content and metadata in both
locales; prettier-clean against the repo config.
