### PR TITLE
Add Instant Insights pipeline spans

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -77,26 +77,51 @@ describe('request insights trace viewer', () => {
     ).toBe(false)
   })
 
-  it('shows the Instant Insights root span in the default trace', () => {
+  it('shows the Instant Insights pipeline in the default trace', () => {
     const request = createRequest({
       kind: 'instant-insights',
       spans: [
         {
           name: 'Instant Insights',
+          spanId: 'root',
           startTime: 100,
           durationMs: 50,
           attributes: {
             'next.span_type': 'AppRender.instantInsights',
           },
         },
+        {
+          name: 'Prepare validation inputs',
+          spanId: 'prepare',
+          parentSpanId: 'root',
+          startTime: 105,
+          durationMs: 20,
+          attributes: {
+            'next.span_type': 'AppRender.instantInsights.prepareValidation',
+          },
+        },
+        {
+          name: 'Run validation',
+          spanId: 'validate',
+          parentSpanId: 'root',
+          startTime: 125,
+          durationMs: 20,
+          attributes: {
+            'next.span_type': 'AppRender.instantInsights.runValidation',
+          },
+        },
       ],
     })
 
-    expect(getTraceItems(request, false)).toEqual([
-      expect.objectContaining({
-        label: 'Instant Insights',
-        spanType: 'AppRender.instantInsights',
-      }),
+    expect(
+      getTraceItems(request, false).map(({ label, depth }) => ({
+        label,
+        depth,
+      }))
+    ).toEqual([
+      { label: 'Instant Insights', depth: 0 },
+      { label: 'Prepare validation inputs', depth: 1 },
+      { label: 'Run validation', depth: 1 },
     ])
   })
 

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -43,6 +43,8 @@ const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'AppRender.renderToNodeFizzStream',
   'AppRender.waitForHTMLCompletion',
   'AppRender.instantInsights',
+  'AppRender.instantInsights.prepareValidation',
+  'AppRender.instantInsights.runValidation',
   FETCH_SPAN_TYPE,
   'NextNodeServer.waitForFirstResponseChunk',
   'NextNodeServer.startResponse',

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -112,11 +112,8 @@ import {
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
-import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
-import {
-  createLocalSpan,
-  withLocalSpan,
-} from '../lib/trace/local-span-recorder'
+import { getTracer, SpanStatusCode, type Span } from '../lib/trace/tracer'
+import { createLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
 import {
@@ -4528,37 +4525,47 @@ function runDevValidationInBackground(
         return
       }
 
-      return runInstantInsightsWithTracing(ctx, async () => {
+      return runInstantInsightsWithTracing(ctx, async (instantInsightsSpan) => {
         // Read whether the streamed render errored only now that it has fully
         // settled.
         const devRenderDidError = getDevRenderDidError()
 
-        const lazyInputs = await prepareValidationInputs(
-          prefetchMode,
-          navigationKind,
-          result,
-          requestStore,
-          validationDebugChannel,
-          ctx,
-          prerenderResumeDataCache,
-          createRequestStore,
-          getPayload,
-          onError,
-          validationAbortSignal
-        )
+        const [instantInputs, staticInputs] = await getTracer().trace(
+          AppRenderSpan.instantInsightsPrepareValidation,
+          {
+            spanName: 'Prepare validation inputs',
+            parentSpan: instantInsightsSpan,
+          },
+          async () => {
+            const lazyInputs = await prepareValidationInputs(
+              prefetchMode,
+              navigationKind,
+              result,
+              requestStore,
+              validationDebugChannel,
+              ctx,
+              prerenderResumeDataCache,
+              createRequestStore,
+              getPayload,
+              onError,
+              validationAbortSignal
+            )
 
-        // If we need to do multiple renders, do them in parallel.
-        // `runValidationInDev` currently needs `instantInputs` eagerly
-        // right before using `staticInputs` for static shell validation,
-        // so there's no point delaying one of the renders.
-        // We bail out (after logging an error during `resolveLazyDevValidationInputs`)
-        // if sync IO or invalid dynamic errors happen in either.
-        const [instantInputs, staticInputs] = await Promise.all([
-          lazyInputs.instantInputs
-            ? resolveLazyDevValidationInputs(lazyInputs.instantInputs, ctx)
-            : null,
-          resolveLazyDevValidationInputs(lazyInputs.staticInputs, ctx),
-        ])
+            // If we need to do multiple renders, do them in parallel.
+            // `runValidationInDev` currently needs `instantInputs` eagerly
+            // right before using `staticInputs` for static shell validation,
+            // so there's no point delaying one of the renders.
+            // We bail out (after logging an error during
+            // `resolveLazyDevValidationInputs`) if sync IO or invalid dynamic
+            // errors happen in either.
+            return Promise.all([
+              lazyInputs.instantInputs
+                ? resolveLazyDevValidationInputs(lazyInputs.instantInputs, ctx)
+                : null,
+              resolveLazyDevValidationInputs(lazyInputs.staticInputs, ctx),
+            ])
+          }
+        )
         if (
           instantInputs === VALIDATION_BAILOUT ||
           staticInputs === VALIDATION_BAILOUT
@@ -4573,74 +4580,87 @@ function runDevValidationInBackground(
           return
         }
 
-        // Hand the whole validation to the worker when one is installed. It runs
-        // on a worker thread (off the main thread), emits its own lifecycle
-        // markers, logs code frames on its piped stdio, and returns the overlay
-        // Flight bytes for the main thread to forward. The worker is absent when
-        // `experimental.devValidationWorker` is false, and validation runs
-        // in-process instead.
-        const devValidationWorker = getDevValidationWorker()
+        return getTracer().trace(
+          AppRenderSpan.instantInsightsRunValidation,
+          {
+            spanName: 'Run validation',
+            parentSpan: instantInsightsSpan,
+          },
+          async () => {
+            // Hand the whole validation to the worker when one is installed. It
+            // runs on a worker thread (off the main thread), emits its own
+            // lifecycle markers, logs code frames on its piped stdio, and
+            // returns the overlay Flight bytes for the main thread to forward.
+            // The worker is absent when `experimental.devValidationWorker` is
+            // false, and validation runs in-process instead.
+            const devValidationWorker = getDevValidationWorker()
 
-        if (devValidationWorker) {
-          const snapshot = await buildDevValidationSnapshot(
-            ctx,
-            instantInputs,
-            staticInputs,
-            prefetchMode,
-            fallbackRouteParams,
-            devRenderDidError
-          )
-
-          const chunks = await devValidationWorker(
-            snapshot,
-            validationAbortSignal
-          )
-
-          // A newer navigation may have superseded this validation while the
-          // worker ran; don't surface stale insights for a page the user left.
-          if (chunks && !validationAbortSignal.aborted) {
-            const { sendErrorsToBrowser } = ctx.renderOpts
-            if (!sendErrorsToBrowser) {
-              throw new InvariantError(
-                'Expected `sendErrorsToBrowser` to be defined in renderOpts.'
-              )
-            }
-            sendErrorsToBrowser(
-              createNodeStreamFromChunks(chunks),
-              ctx.htmlRequestId
-            )
-          }
-        } else {
-          // In-process path, taken when `experimental.devValidationWorker` is
-          // false or no worker is installed (e.g. during a build). Validation
-          // computes the errors; the caller delivers them to the dev overlay.
-          // `runWithDevValidationLogging` encloses both the render and the
-          // delivery in the test-mode lifecycle markers so tests that assert the
-          // delivered error between `validation_start` and `validation_end`
-          // capture it.
-          await runWithDevValidationLogging(
-            ctx,
-            validationAbortSignal,
-            async () => {
-              const validationErrors = await runValidationInDev(
-                prefetchMode,
+            if (devValidationWorker) {
+              const snapshot = await buildDevValidationSnapshot(
+                ctx,
                 instantInputs,
                 staticInputs,
-                toValidationRenderContext(ctx),
+                prefetchMode,
                 fallbackRouteParams,
-                devRenderDidError,
+                devRenderDidError
+              )
+
+              const chunks = await devValidationWorker(
+                snapshot,
                 validationAbortSignal
               )
 
-              if (
-                validationErrors !== undefined &&
-                !validationAbortSignal.aborted
-              ) {
-                await logMessagesAndSendErrorsToBrowser(validationErrors, ctx)
+              // A newer navigation may have superseded this validation while
+              // the worker ran; don't surface stale insights for a page the user
+              // left.
+              if (chunks && !validationAbortSignal.aborted) {
+                const { sendErrorsToBrowser } = ctx.renderOpts
+                if (!sendErrorsToBrowser) {
+                  throw new InvariantError(
+                    'Expected `sendErrorsToBrowser` to be defined in renderOpts.'
+                  )
+                }
+                sendErrorsToBrowser(
+                  createNodeStreamFromChunks(chunks),
+                  ctx.htmlRequestId
+                )
               }
+            } else {
+              // In-process path, taken when `experimental.devValidationWorker`
+              // is false or no worker is installed (e.g. during a build).
+              // Validation computes the errors; the caller delivers them to the
+              // dev overlay. `runWithDevValidationLogging` encloses both the
+              // render and the delivery in the test-mode lifecycle markers so
+              // tests that assert the delivered error between
+              // `validation_start` and `validation_end` capture it.
+              await runWithDevValidationLogging(
+                ctx,
+                validationAbortSignal,
+                async () => {
+                  const validationErrors = await runValidationInDev(
+                    prefetchMode,
+                    instantInputs,
+                    staticInputs,
+                    toValidationRenderContext(ctx),
+                    fallbackRouteParams,
+                    devRenderDidError,
+                    validationAbortSignal
+                  )
+
+                  if (
+                    validationErrors !== undefined &&
+                    !validationAbortSignal.aborted
+                  ) {
+                    await logMessagesAndSendErrorsToBrowser(
+                      validationErrors,
+                      ctx
+                    )
+                  }
+                }
+              )
             }
-          )
-        }
+          }
+        )
       })
     })
     // The catch keeps a failed render, or anything thrown inside validation,
@@ -4662,7 +4682,7 @@ function runDevValidationInBackground(
 
 async function runInstantInsightsWithTracing<T>(
   ctx: AppRenderContext,
-  fn: () => Promise<T>
+  fn: (span?: Span) => Promise<T>
 ): Promise<T> {
   if (!isRequestInsightsEnabled()) {
     return fn()
@@ -4686,9 +4706,9 @@ async function runInstantInsightsWithTracing<T>(
         },
       })
 
-      return withLocalSpan(span, async () => {
+      return getTracer().withSpan(span, async () => {
         try {
-          return await fn()
+          return await fn(span)
         } catch (err) {
           span.recordException(err as Error)
           span.setStatus({ code: SpanStatusCode.ERROR })

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -112,8 +112,8 @@ import {
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
-import { getTracer, SpanStatusCode, type Span } from '../lib/trace/tracer'
-import { createLocalSpan } from '../lib/trace/local-span-recorder'
+import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
+import { traceLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
 import {
@@ -4525,17 +4525,14 @@ function runDevValidationInBackground(
         return
       }
 
-      return runInstantInsightsWithTracing(ctx, async (instantInsightsSpan) => {
+      return runInstantInsightsWithTracing(ctx, async (runSpan) => {
         // Read whether the streamed render errored only now that it has fully
         // settled.
         const devRenderDidError = getDevRenderDidError()
 
-        const [instantInputs, staticInputs] = await getTracer().trace(
+        const [instantInputs, staticInputs] = await runSpan(
           AppRenderSpan.instantInsightsPrepareValidation,
-          {
-            spanName: 'Prepare validation inputs',
-            parentSpan: instantInsightsSpan,
-          },
+          'Prepare validation inputs',
           async () => {
             const lazyInputs = await prepareValidationInputs(
               prefetchMode,
@@ -4580,12 +4577,9 @@ function runDevValidationInBackground(
           return
         }
 
-        return getTracer().trace(
+        return runSpan(
           AppRenderSpan.instantInsightsRunValidation,
-          {
-            spanName: 'Run validation',
-            parentSpan: instantInsightsSpan,
-          },
+          'Run validation',
           async () => {
             // Hand the whole validation to the worker when one is installed. It
             // runs on a worker thread (off the main thread), emits its own
@@ -4680,12 +4674,44 @@ function runDevValidationInBackground(
     .finally(() => validationGeneration.finish())
 }
 
+type RunInstantInsightsSpan = <T>(
+  spanType: AppRenderSpan,
+  spanName: string,
+  fn: () => Promise<T>
+) => Promise<T>
+
+function runInstantInsightsSpan<T>(
+  spanType: AppRenderSpan,
+  spanName: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  return traceLocalSpan(
+    {
+      name: spanName,
+      attributes: {
+        'next.span_category': 'nextjs',
+        'next.span_name': spanName,
+        'next.span_type': spanType,
+      },
+    },
+    fn
+  )
+}
+
+function runWithoutInstantInsightsSpan<T>(
+  _spanType: AppRenderSpan,
+  _spanName: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  return fn()
+}
+
 async function runInstantInsightsWithTracing<T>(
   ctx: AppRenderContext,
-  fn: (span?: Span) => Promise<T>
+  fn: (runSpan: RunInstantInsightsSpan) => Promise<T>
 ): Promise<T> {
   if (!isRequestInsightsEnabled()) {
-    return fn()
+    return fn(runWithoutInstantInsightsSpan)
   }
 
   return runWithRequestInsightsIdentity(
@@ -4695,29 +4721,20 @@ async function runInstantInsightsWithTracing<T>(
       htmlRequestId: ctx.htmlRequestId,
       url: ctx.url.href,
     },
-    () => {
-      const span = createLocalSpan({
-        name: 'Instant Insights',
-        attributes: {
-          'next.span_category': 'nextjs',
-          'next.span_name': 'Instant Insights',
-          'next.span_type': AppRenderSpan.instantInsights,
-          'next.route': ctx.pagePath,
+    () =>
+      traceLocalSpan(
+        {
+          name: 'Instant Insights',
+          parentSpan: null,
+          attributes: {
+            'next.span_category': 'nextjs',
+            'next.span_name': 'Instant Insights',
+            'next.span_type': AppRenderSpan.instantInsights,
+            'next.route': ctx.pagePath,
+          },
         },
-      })
-
-      return getTracer().withSpan(span, async () => {
-        try {
-          return await fn(span)
-        } catch (err) {
-          span.recordException(err as Error)
-          span.setStatus({ code: SpanStatusCode.ERROR })
-          throw err
-        } finally {
-          span.end()
-        }
-      })
-    }
+        () => fn(runInstantInsightsSpan)
+      )
   )
 }
 

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -90,6 +90,8 @@ enum AppRenderSpan {
   waitShellReady = 'AppRender.waitShellReady',
   renderToNodeFizzStream = 'AppRender.renderToNodeFizzStream',
   instantInsights = 'AppRender.instantInsights',
+  instantInsightsPrepareValidation = 'AppRender.instantInsights.prepareValidation',
+  instantInsightsRunValidation = 'AppRender.instantInsights.runValidation',
 }
 
 enum RouterSpan {

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -184,6 +184,9 @@ describe('request insights', () => {
           span.name === 'Instant Insights'
       )
       expect(rootSpans?.length).toBeGreaterThan(0)
+      for (const rootSpan of rootSpans ?? []) {
+        expect(rootSpan.parentSpanId).toBeUndefined()
+      }
 
       const pipelineSpanTypes = [
         'AppRender.instantInsights.prepareValidation',

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -12,6 +12,8 @@ type RequestInsight = {
   status: 'ok'
   spans: Array<{
     name?: string
+    spanId?: string
+    parentSpanId?: string
     attributes?: Record<string, string | number | boolean>
   }>
   fetches: Array<{
@@ -176,17 +178,43 @@ describe('request insights', () => {
         })
       )
       expect(instantInsights?.htmlRequestId).toBe(request?.htmlRequestId)
-      expect(
-        instantInsights?.spans.some(
-          (span) =>
-            span.attributes?.['next.span_type'] ===
-              'AppRender.instantInsights' && span.name === 'Instant Insights'
+      const rootSpans = instantInsights?.spans.filter(
+        (span) =>
+          span.attributes?.['next.span_type'] === 'AppRender.instantInsights' &&
+          span.name === 'Instant Insights'
+      )
+      expect(rootSpans?.length).toBeGreaterThan(0)
+
+      const pipelineSpanTypes = [
+        'AppRender.instantInsights.prepareValidation',
+        'AppRender.instantInsights.runValidation',
+      ]
+      const pipelineSpans = instantInsights?.spans.filter((span) =>
+        pipelineSpanTypes.includes(
+          span.attributes?.['next.span_type'] as string
         )
-      ).toBe(true)
+      )
+      expect(
+        pipelineSpans?.map((span) => span.attributes?.['next.span_type'])
+      ).toEqual(
+        expect.arrayContaining([
+          'AppRender.instantInsights.prepareValidation',
+          'AppRender.instantInsights.runValidation',
+        ])
+      )
+      for (const span of pipelineSpans ?? []) {
+        expect(
+          rootSpans?.some((rootSpan) => rootSpan.spanId === span.parentSpanId)
+        ).toBe(true)
+      }
       expect(
         request?.spans.some(
           (span) =>
-            span.attributes?.['next.span_type'] === 'AppRender.instantInsights'
+            span.attributes?.['next.span_type'] ===
+              'AppRender.instantInsights' ||
+            pipelineSpanTypes.includes(
+              span.attributes?.['next.span_type'] as string
+            )
         )
       ).toBe(false)
     })


### PR DESCRIPTION
## Summary

- Adds a detached `Instant Insights` root span.
- Surfaces `Prepare validation inputs` and `Run validation` as child phases.
- Covers both the validation worker and Webpack’s in-process path.
- Stores these spans separately from the foreground request.
- Preserves scheduling, cancellation, and concurrent-document behavior.

## Verification

```bash
pnpm build-all
pnpm --filter=next types
pnpm --filter=next build
pnpm test-unit --runTestsByPath packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts
pnpm test-dev-webpack test/development/app-dir/request-insights/request-insights.test.ts
pnpm test-dev-turbo test/development/app-dir/instant-validation-scheduling/instant-validation-scheduling.test.ts
```

<!-- NEXT_JS_LLM -->
