### PR TITLE
Track whether runtime data is accessed during prefetch

### DIFF
--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -855,10 +855,15 @@ function pingRootRouteTree(
             // opt-in because the Shell for a given route is reusable across
             // all given params, by definition. So it does not lead to an
             // explosion in prefetching costs.
-            // TODO: In the future, the server could emit a hint to tell us
-            // *not* to prefetch via a runtime request, via build-time
-            // heuristics, like if no `cookies()` call was detected. We'll
-            // leave this optimization for later.
+            // TODO: The server now emits signals for skipping unnecessary
+            // runtime prefetch requests: an advisory
+            // PrefetchHint.ShouldAttemptStaticPrefetch bit on the route
+            // tree, and a load-bearing response-level `needsRuntimeRequest`
+            // promise on the static segment responses (fulfilled `true`
+            // visible in the decode means a runtime request would return
+            // more; rewindable at the shell boundary; combined with each
+            // segment's `isPartial`). They aren't consumed yet; wiring them
+            // up is left for a follow-up.
             task.phase === PrefetchPhase.Shell
           ) {
             const runtimeStrategy =
@@ -1139,6 +1144,10 @@ function pingNewPartOfCacheComponentsTree(
   // runtime shell request. For fully static pages, it doesn't matter since
   // server will respond to even a runtime request with a static response. For
   // a partially static page, we can send down a hint from the server.
+  // The server-side hints for this now exist
+  // (PrefetchHint.ShouldAttemptStaticPrefetch on the route tree, the
+  // `needsRuntimeRequest` promise + per-segment `isPartial` on static
+  // segment responses) but aren't consumed yet.
 
   if (
     task.phase === PrefetchPhase.Speculative &&

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -23,6 +23,7 @@ import type {
   InstantValidationSamples,
   PrerenderStoreModernClient,
   PrerenderStoreModernRuntime,
+  PrerenderStoreModernServer,
   RequestStore,
   ValidationStoreClient,
   WorkUnitStore,
@@ -8420,6 +8421,9 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
+        runtimeDataAccessed: null,
+        shouldAttemptStaticPrefetch: null,
+        isFallbackUpgradeable: renderOpts.isFallbackUpgradeable === true,
       }
 
       // We're not going to use the result of this render because the only time it could be used
@@ -8454,6 +8458,9 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
+        runtimeDataAccessed: null,
+        shouldAttemptStaticPrefetch: null,
+        isFallbackUpgradeable: renderOpts.isFallbackUpgradeable === true,
       })
 
       const initialPrerenderOptions = {
@@ -8678,7 +8685,27 @@ async function prerenderToStream(
         finalStage: RenderStage.Static,
       })
 
-      const finalServerPayloadPrerenderStore: PrerenderStore = {
+      // Records runtime data accesses from the payload and render stores
+      // below into the RSC payload (as `u`), resolved `true` at the moment
+      // of first access so the fulfillment row is serialized at the stream
+      // position where it happened. Used when generating per-segment
+      // prefetch responses. Request data props (params, searchParams) are
+      // created while the RSC payload is constructed, under the payload
+      // store; both stores share the same promise so it observes accesses
+      // from both.
+      const runtimeDataAccessed = createPromiseWithResolvers<boolean>()
+
+      // Companion cell holding this prerender's static-prefetch measurement
+      // directly — the value that becomes the route's build-constant hint:
+      // starts true, and a disqualifying runtime-data access flips it false
+      // — fallback-param accesses on an upgradeable route don't (see
+      // trackRuntimeDataAccessed, which applies the rule at access time).
+      // Read after the prerender settles by
+      // collectSegmentData below. Shared between both stores for the same
+      // reason as the promise.
+      const shouldAttemptStaticPrefetch = { current: true }
+
+      const finalServerPayloadPrerenderStore: PrerenderStoreModernServer = {
         type: 'prerender',
         phase: 'render',
         rootParams,
@@ -8704,6 +8731,9 @@ async function prerenderToStream(
         resumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator,
+        runtimeDataAccessed,
+        shouldAttemptStaticPrefetch,
+        isFallbackUpgradeable: renderOpts.isFallbackUpgradeable === true,
       }
 
       const shellByteLengthDeferred = createPromiseWithResolvers<
@@ -8725,6 +8755,13 @@ async function prerenderToStream(
       if (cachedNavigations) {
         staleTimeIterable = new StaleTimeIterable()
         finalServerPayload.s = staleTimeIterable
+      }
+
+      if (shouldGenerateStaticFlightData(workStore)) {
+        // Embed the runtime data access tracking in the payload so
+        // collectSegmentData can replay it per stage. Only needed when the
+        // Flight data will be decomposed into segment prefetches below.
+        finalServerPayload.u = runtimeDataAccessed.promise
       }
 
       const serverDynamicTracking = createDynamicTrackingState(
@@ -8751,6 +8788,9 @@ async function prerenderToStream(
         resumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator,
+        runtimeDataAccessed,
+        shouldAttemptStaticPrefetch,
+        isFallbackUpgradeable: renderOpts.isFallbackUpgradeable === true,
       })
 
       if (staleTimeIterable !== undefined) {
@@ -8801,11 +8841,12 @@ async function prerenderToStream(
 
         // FIXME(NAR-810): If we're already aborted due to Sync IO, there should be no need to
         // finish the accumulators. However, it seems like in `--debug-prerender`
-        // the stream will stay open if we don't close the iterables here.
+        // the stream will stay open if we don't settle these here.
         if (process.env.NODE_ENV === 'development') {
           if (staleTimeIterable !== undefined) {
             staleTimeIterable.close()
           }
+          runtimeDataAccessed.resolve(false)
           finishAccumulatingVaryParams(varyParamsAccumulator)
         }
       }
@@ -8893,6 +8934,9 @@ async function prerenderToStream(
           if (staleTimeIterable !== undefined) {
             staleTimeIterable.close()
           }
+          // Idempotent: a no-op if a runtime data access already resolved it
+          // `true`. The `false` row lands here, after all stage content.
+          runtimeDataAccessed.resolve(false)
           finishAccumulatingVaryParams(varyParamsAccumulator)
 
           shellByteLengthDeferred.resolve(
@@ -9688,6 +9732,9 @@ async function prerenderToStream(
         resumeDataCache: originalResumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator: null,
+        runtimeDataAccessed: null,
+        shouldAttemptStaticPrefetch: null,
+        isFallbackUpgradeable: renderOpts.isFallbackUpgradeable === true,
       }
 
       const errorRSCPayload = await workUnitAsyncStorage.run(
@@ -10327,33 +10374,69 @@ async function collectSegmentData(
 
   // Resolve prefetch hints. At runtime (next start / ISR), the precomputed
   // hints are already loaded from the prefetch-hints.json manifest. During
-  // build, compute them by measuring segment gzip sizes and write them to
-  // metadata so the build pipeline can persist them to the manifest.
+  // build, compute them and write them to metadata so the build pipeline
+  // can persist them to the manifest. Like every other hint bit, the
+  // static-prefetch-attempt hint is computed once here and stays constant
+  // for the entire build — it must reach every response that carries
+  // prefetch hints (dynamic navigations included), which only the manifest
+  // flow can guarantee.
+  //
+  // The manifest isn't just a cache of this work — for some responses it's
+  // the only possible source. A response's FlightRouterState is built early
+  // in its render, before the runtime-data tracking has settled, so it can't
+  // read a finished measurement even when one is coming; and a dynamic
+  // navigation has no prerender to measure in the first place. Recomputing
+  // per render would therefore leave those responses with no hint at all,
+  // which is worse than an occasionally-stale one: the client would deopt
+  // straight to runtime prefetches instead of attempting static.
   let hints: PrefetchHints | null
   const prefetchInlining = renderOpts.experimental.prefetchInlining
-  if (!prefetchInlining) {
-    hints = null
-  } else if (renderOpts.isBuildTimePrerendering) {
-    // Build time: compute fresh hints and store in metadata for the manifest.
-    hints = await ComponentMod.collectPrefetchHints(
-      fullPageDataBuffer,
-      staleTime,
-      clientModules,
-      serverConsumerManifest,
-      prefetchInlining.maxSize,
-      prefetchInlining.maxBundleSize
-    )
-    metadata.prefetchHints = hints
+  if (renderOpts.isBuildTimePrerendering) {
+    // Whether the client should attempt a static prefetch for this route
+    // (PrefetchHint.ShouldAttemptStaticPrefetch): the prerender store's
+    // cell holds the hint value directly — true iff the build-time
+    // prerender accessed no runtime data that disqualifies a static
+    // attempt. The fallback-param upgradeability rule is applied at access
+    // time — see trackRuntimeDataAccessed — so only the settled value is
+    // read here. Only the modern (cacheComponents) prerender tracks
+    // accesses; legacy prerenders conservatively never set the hint.
+    const hintCell =
+      prerenderStore.type === 'prerender'
+        ? prerenderStore.shouldAttemptStaticPrefetch
+        : null
+    const shouldAttemptStaticPrefetch = hintCell !== null && hintCell.current
+    if (prefetchInlining || shouldAttemptStaticPrefetch) {
+      // Build time: compute fresh hints and store in metadata for the
+      // manifest. When prefetch inlining is disabled there are no sizes to
+      // measure, but the static-prefetch hint still rides the manifest —
+      // collectPrefetchHints then only builds the tree shape carrying it.
+      hints = await ComponentMod.collectPrefetchHints(
+        fullPageDataBuffer,
+        staleTime,
+        clientModules,
+        serverConsumerManifest,
+        prefetchInlining,
+        shouldAttemptStaticPrefetch
+      )
+      metadata.prefetchHints = hints
+    } else {
+      // Inlining is disabled and the hint didn't qualify — there's nothing
+      // to record, so don't write a manifest entry for this route.
+      hints = null
+    }
   } else {
     // Runtime: use hints from the manifest. Never compute fresh hints
     // during ISR/revalidation.
     const manifestHints = renderOpts.prefetchHints?.[pagePath]
     if (manifestHints === undefined) {
-      if (!renderOpts.cacheComponents) {
+      if (!prefetchInlining || !renderOpts.cacheComponents) {
         // Without cacheComponents, dynamic pages have no static shell
-        // and therefore no prerender pass to compute hints. This is
-        // expected — just skip the hint system for this route and let
-        // prefetching proceed normally without inlining decisions.
+        // and therefore no prerender pass to compute hints; and with
+        // inlining disabled, a missing entry just means the route didn't
+        // qualify for the static-prefetch hint at build. Either way this
+        // is expected — skip the hint system for this route and let
+        // prefetching proceed normally without inlining decisions (the
+        // client goes straight to runtime prefetches where it matters).
         hints = null
       } else {
         // TODO(#91407): No hints found for this route. This currently
@@ -10362,9 +10445,12 @@ async function collectSegmentData(
         // manifest to be unavailable at runtime.
         //
         // Fall back to a hint tree that marks everything as
-        // unprefetchable. Once the instant:false bug is fixed, this
-        // should become an error — the manifest should always have an
-        // entry for every route that reaches collectSegmentData.
+        // unprefetchable. This also swallows the static-prefetch-attempt
+        // hint — such routes never carry it, so the client goes straight
+        // to a runtime prefetch, which is safe (just less cacheable).
+        // Once the instant:false bug is fixed, this should become an
+        // error — the manifest should always have an entry for every
+        // route that reaches collectSegmentData.
         hints = {
           hints: PrefetchHint.PrefetchDisabled,
           slots: null,

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -129,6 +129,42 @@ export type SegmentPrefetchResponse = {
    * back in via `readVaryParams`.
    */
   rootVaryParams: VaryParamsIterable | null
+  /**
+   * The page's runtime-data-access flag (the page payload's `u`), forwarded
+   * from the staged decode of the page data: whether the prerender accessed
+   * a data source that would have resolved during a runtime prerender
+   * (cookies, headers, fallback params, searchParams, ...). The flag is
+   * monotonic (false → true, at most once), so a promise suffices; the
+   * client takes the settled value visible in its decode. Fulfilled `true`
+   * means a runtime prefetch would return more than this static response;
+   * pending or fulfilled `false` means it wouldn't. The answer is rewindable
+   * because the fulfillment row lands on the same side of the shell byte
+   * boundary (`a`) as the access it records: a decode truncated at `a` reads
+   * pending for a post-shell access, i.e. `false` for the shell variant.
+   *
+   * Tracking is page-global, so this lives on the response envelope, not on
+   * each segment. (A pending promise also costs Flight no abort listener on
+   * the render, unlike an async iterable, which holds one for as long as
+   * it's open.) Per-segment granularity comes from combining it with each
+   * segment's `isPartial`:
+   *
+   *   needsRuntimeRequest(segment) = (settled true) && (isPartial pending)
+   *
+   * A segment whose `isPartial` promise fulfilled is fully static, and a
+   * fully static segment gains nothing from a runtime request no matter what
+   * the page accessed. Conversely, a partial segment on a page that accessed
+   * no runtime data also reads `false`: its holes come from sources that hang
+   * in a runtime prerender too (`io()`, `connection()`, uncached IO), and are
+   * only filled by the navigation-time dynamic request.
+   *
+   * The derived value must never falsely claim that no runtime request is
+   * needed, so every fallback is conservative: pages that carry no `u`
+   * (legacy render paths) forward an already-resolved `true`. Unlike the
+   * build-constant prefetch hints (including the tree-level
+   * ShouldAttemptStaticPrefetch), this is computed per render and may change
+   * between responses for the same build — it reflects THIS response.
+   */
+  needsRuntimeRequest: Promise<boolean>
 }
 
 export type SegmentPrefetch = {
@@ -140,6 +176,10 @@ export type SegmentPrefetch = {
    * pending `isPartial` as "partial". The fulfillment row, when there is one,
    * flushes past the shell boundary, so a truncated shell decode also reads
    * as partial: correct, since a shell has holes by construction.
+   *
+   * This monotonic pending → fulfilled encoding also serves as the
+   * per-segment half of the needs-runtime-request derivation — see
+   * `SegmentPrefetchResponse['needsRuntimeRequest']`.
    */
   isPartial: Promise<void>
   /**
@@ -254,7 +294,13 @@ export async function collectSegmentData(
   // `a` field): a byte offset into fullPageDataBuffer marking the end of the
   // page's shell stage, null if the shell is identical to the full static
   // response, or undefined if the render wasn't staged (no shell exists).
+  //
+  // And it tells us whether the render accessed runtime data (cookies,
+  // headers, fallback params, searchParams, ...): the settled value of the
+  // page's embedded access flag (its `u` field). Conservatively true when
+  // the page carries no flag (legacy render paths) or the decode fails.
   let pageShellByteLength: number | null | undefined = undefined
+  let runtimeDataAccessed = true
   try {
     const pagePayload: InitialRSCPayload = await createFromReadableStream(
       // Use a stream that never closes so pending references (dynamic
@@ -270,6 +316,9 @@ export async function collectSegmentData(
     // it resolves. undefined means the render wasn't staged (no shell).
     if (pagePayload.a !== undefined) {
       pageShellByteLength = await pagePayload.a
+    }
+    if (pagePayload.u !== undefined) {
+      runtimeDataAccessed = readRuntimeDataAccessed(pagePayload.u)
     }
   } catch {}
 
@@ -343,6 +392,7 @@ export async function collectSegmentData(
         prefetchInlining={prefetchInlining}
         hints={hints}
         isUpgradeableISRFallback={isUpgradeableISRFallback}
+        runtimeDataAccessed={runtimeDataAccessed}
         shellStageRelease={release.promise}
       />,
       clientModules,
@@ -420,14 +470,27 @@ export async function collectSegmentData(
  * This is a separate pass from collectSegmentData so that the inlining
  * decisions can be fed back into collectSegmentData to control which segments
  * are output as separate entries vs. inlined into their parent.
+ *
+ * `shouldAttemptStaticPrefetch` (computed by the caller from the prerender's
+ * runtime-data tracking) is folded onto every node of the result, so the
+ * manifest delivers it to every response like the other hint bits. It's
+ * independent of the inlining feature: when `inlining` is false the sizing
+ * pass is skipped entirely — no inlining bits are emitted — and only the
+ * tree shape carrying the static-prefetch hint is built.
+ *
+ * Both kinds of hint have the same structure and the same lifetime — one
+ * bitmask per node of the route tree, measured once per build and constant
+ * for the deployment. They differ only in what they're derived from: the
+ * inlining bits from the size of each segment's encoded response, the
+ * static-prefetch bit from what the decoded body turned out to access.
  */
 export async function collectPrefetchHints(
   fullPageDataBuffer: Buffer,
   staleTime: number,
   clientModules: ManifestNode,
   serverConsumerManifest: any,
-  maxSize: number,
-  maxBundleSize: number
+  inlining: { maxSize: number; maxBundleSize: number } | false,
+  shouldAttemptStaticPrefetch: boolean
 ): Promise<PrefetchHints> {
   // Warm up the module cache, same as collectSegmentData.
   try {
@@ -453,6 +516,23 @@ export async function collectPrefetchHints(
   }
   const { buildId, flightRouterState, seedData, head } = flightData
 
+  // The hints every node starts from. The static-prefetch-attempt hint is
+  // page-global (the tracking that feeds it is), so it goes on every node,
+  // non-propagating — the client reads it per segment, and the runtime
+  // hint merging walks the manifest tree node-by-node.
+  const baseHints = shouldAttemptStaticPrefetch
+    ? PrefetchHint.ShouldAttemptStaticPrefetch
+    : 0
+
+  if (inlining === false) {
+    // Prefetch inlining is disabled: nothing to measure, and no inlining
+    // bits may be emitted (the client would act on them even though the
+    // responses aren't bundled). Just mirror the route tree's shape with
+    // the base hints on every node.
+    return createUniformHintTree(flightRouterState, baseHints)
+  }
+  const { maxSize, maxBundleSize } = inlining
+
   // Root params are forwarded once at the top level of each segment
   // response, same as the page response's own root vary params; the client
   // unions them into each segment's set at read time.
@@ -462,6 +542,12 @@ export async function collectPrefetchHints(
   // Cache Components is off the page carries no `s`, so wrap the eager value.
   const staleTimeIterable =
     initialRSCPayload.s ?? createStaleTimeIterable(staleTime)
+
+  // The page's runtime-data-access flag, forwarded into each segment
+  // response's `needsRuntimeRequest`. This pass only measures sizes, so a
+  // conservative already-resolved `true` stands in when the page carries
+  // no `u`.
+  const needsRuntimeRequest = initialRSCPayload.u ?? Promise.resolve(true)
 
   // This pass only measures gzip sizes for inlining hints, so nothing is
   // staged (each response's `a` falls out as the no-shell sentinel, 0), but
@@ -482,6 +568,7 @@ export async function collectPrefetchHints(
     null,
     // Fallback-ness doesn't affect size, so pass false.
     false,
+    needsRuntimeRequest,
     shellStageRelease
   )
   const headGzipSize = await getGzipSize(headBuffer)
@@ -506,12 +593,14 @@ export async function collectPrefetchHints(
     clientModules,
     ROOT_SEGMENT_REQUEST_KEY,
     null, // root has no parent to inline
+    baseHints,
     maxSize,
     maxBundleSize,
     headGzipSize,
     headInlineState,
     subtreeHasRuntimePrefetch,
     rootVaryParamsIterable,
+    needsRuntimeRequest,
     shellStageRelease
   )
 
@@ -561,12 +650,16 @@ async function collectPrefetchHintsImpl(
   // segment-manifest.json, since it would contain more than just hints.
   requestKey: SegmentRequestKey,
   parentGzipSize: number | null,
+  // Hints every node starts from (the page-global static-prefetch-attempt
+  // hint); the inlining bits computed here are OR'd on top.
+  baseHints: number,
   maxSize: number,
   maxBundleSize: number,
   headGzipSize: number,
   headInlineState: { inlined: boolean },
   routeHasRuntimePrefetch: boolean,
   rootVaryParamsIterable: VaryParamsIterable | null,
+  needsRuntimeRequest: Promise<boolean>,
   shellStageRelease: Promise<boolean>
 ): Promise<{
   node: PrefetchHints
@@ -599,6 +692,7 @@ async function collectPrefetchHintsImpl(
       null,
       // Size-measurement pass only; fallback-ness is irrelevant here.
       false,
+      needsRuntimeRequest,
       shellStageRelease
     )
     currentGzipSize = await getGzipSize(buffer)
@@ -665,12 +759,14 @@ async function collectPrefetchHintsImpl(
       childRequestKey,
       // Once a child has accepted us, stop offering to remaining siblings.
       didInlineIntoChild ? null : sizeToOfferChild,
+      baseHints,
       maxSize,
       maxBundleSize,
       headGzipSize,
       headInlineState,
       routeHasRuntimePrefetch,
       rootVaryParamsIterable,
+      needsRuntimeRequest,
       shellStageRelease
     )
 
@@ -702,7 +798,7 @@ async function collectPrefetchHintsImpl(
   // Mark this segment as InlinedIntoChild if one of its children accepted.
   // This means this segment doesn't need its own prefetch response — its
   // data is included in the accepting child's response instead.
-  let hints = 0
+  let hints = baseHints
   if (didInlineIntoChild) {
     hints |= PrefetchHint.InlinedIntoChild
   }
@@ -792,6 +888,31 @@ async function collectPrefetchHintsImpl(
   }
 }
 
+// Mirrors the route tree's shape with the same hints on every node. Used by
+// collectPrefetchHints when prefetch inlining is disabled: there are no sizes
+// to measure, but the static-prefetch-attempt hint still needs a manifest
+// tree — the client reads the bit per node, and the runtime hint merging
+// (createFlightRouterStateFromLoaderTree) walks the manifest tree in parallel
+// with the loader tree, so a bit that's missing from a node never reaches the
+// corresponding segment.
+function createUniformHintTree(
+  route: FlightRouterState,
+  hints: number
+): PrefetchHints {
+  let slots: Record<string, PrefetchHints> | null = null
+  const children = route[1]
+  for (const parallelRouteKey in children) {
+    if (slots === null) {
+      slots = {}
+    }
+    slots[parallelRouteKey] = createUniformHintTree(
+      children[parallelRouteKey],
+      hints
+    )
+  }
+  return { hints, slots }
+}
+
 // We use gzip size rather than raw size because it better reflects the actual
 // transfer cost. The inlining trade-off is about whether the overhead of an
 // additional HTTP request (connection setup, headers, round trip) is worth
@@ -818,6 +939,7 @@ async function PrefetchTreeData({
   prefetchInlining,
   hints,
   isUpgradeableISRFallback,
+  runtimeDataAccessed,
   shellStageRelease,
 }: {
   isClientParamParsingEnabled: boolean
@@ -830,6 +952,7 @@ async function PrefetchTreeData({
   prefetchInlining: boolean
   hints: PrefetchHints | null
   isUpgradeableISRFallback: boolean
+  runtimeDataAccessed: boolean
   shellStageRelease: Promise<boolean>
 }): Promise<RootTreePrefetch | null> {
   // We're currently rendering a Flight response for the route tree prefetch.
@@ -867,6 +990,13 @@ async function PrefetchTreeData({
   const staleTimeIterable =
     initialRSCPayload.s ?? createStaleTimeIterable(staleTime)
 
+  // The page's runtime-data-access flag, forwarded into each segment
+  // response's `needsRuntimeRequest`. When the page carries no `u` (e.g.
+  // legacy render paths), wrap the flag the caller read from the warm-up
+  // decode in an already-resolved promise.
+  const needsRuntimeRequest =
+    initialRSCPayload.u ?? Promise.resolve(runtimeDataAccessed)
+
   // Only applies when prefetch inlining is enabled — the client doesn't
   // know to look for the head inside a page's response otherwise.
   const headIsInlined =
@@ -896,6 +1026,7 @@ async function PrefetchTreeData({
     headBundle,
     rootVaryParamsIterable,
     isUpgradeableISRFallback,
+    needsRuntimeRequest,
     shellStageRelease
   )
 
@@ -914,6 +1045,7 @@ async function PrefetchTreeData({
           clientModules,
           null,
           isUpgradeableISRFallback,
+          needsRuntimeRequest,
           shellStageRelease
         )
       )
@@ -951,6 +1083,7 @@ function collectSegmentDataImpl(
   headBundle: SegmentBundleNode | null,
   rootVaryParamsIterable: VaryParamsIterable | null,
   isUpgradeableISRFallback: boolean,
+  needsRuntimeRequest: Promise<boolean>,
   shellStageRelease: Promise<boolean>
 ): TreePrefetch {
   // Union the hints already embedded in the FlightRouterState with the
@@ -1028,6 +1161,7 @@ function collectSegmentDataImpl(
             clientModules,
             bundle,
             isUpgradeableISRFallback,
+            needsRuntimeRequest,
             shellStageRelease
           )
         )
@@ -1074,6 +1208,7 @@ function collectSegmentDataImpl(
       headBundle,
       rootVaryParamsIterable,
       isUpgradeableISRFallback,
+      needsRuntimeRequest,
       shellStageRelease
     )
     if (slotMetadata === null) {
@@ -1136,6 +1271,7 @@ async function renderSegmentPrefetch(
   clientModules: ManifestNode,
   bundle: SegmentBundleNode | null,
   isUpgradeableISRFallback: boolean,
+  needsRuntimeRequest: Promise<boolean>,
   shellStageRelease: Promise<boolean>
 ): Promise<[SegmentRequestKey, Buffer]> {
   const streamInfoStage = createPromiseWithResolvers<void>()
@@ -1153,27 +1289,28 @@ async function renderSegmentPrefetch(
       // list, which skips a cache entry for the slot.
       data.push(null)
     } else {
+      // We can determine if a segment contains only partial data if it takes
+      // longer than a task to encode, because dynamic data is encoded as an
+      // infinite promise. We must do this in a separate Flight prerender from
+      // the one that actually generates the prefetch stream because we need
+      // to include the result in the stream itself.
+      const contentIsComplete = new Promise<void>(async (resolve) => {
+        // Wait for the input stream to be fully unblocked before checking if
+        // the data can be decoded synchronously.
+        await streamInfoStage.promise
+
+        // If the data is fully static, this will resolve synchronously.
+        // Otherwise, the promise stays unresolved forever, and so does
+        // whatever field it's encoded into in the outer response.
+        await prerender(elementRsc, clientModules, {
+          filterStackFrame,
+          onError() {},
+        })
+        resolve()
+      })
       data.push({
         rsc: elementRsc,
-        // We can determine if a segment contains only partial data if it takes
-        // longer than a task to encode, because dynamic data is encoded as an
-        // infinite promise. We must do this in a separate Flight prerender from
-        // the one that actually generates the prefetch stream because we need
-        // to include `isPartial` in the stream itself.
-        isPartial: new Promise(async (resolve) => {
-          // Wait for the input stream to be fully unblocked before checking if
-          // the data can be decoded synchronously.
-          await streamInfoStage.promise
-
-          // If the data is fully static, this will resolve synchronously.
-          // Otherwise, `isPartial` will be encoded as an unresolved promise in
-          // the outer response, which the client will interpret as partial.
-          await prerender(elementRsc, clientModules, {
-            filterStackFrame,
-            onError() {},
-          })
-          resolve()
-        }),
+        isPartial: contentIsComplete,
         staleTime,
         varyParams: node.varyParams,
       })
@@ -1199,6 +1336,7 @@ async function renderSegmentPrefetch(
     isUpgradeableISRFallback,
     a: shellByteOffset.promise,
     rootVaryParams,
+    needsRuntimeRequest,
   }
 
   const abortController = new AbortController()
@@ -1258,24 +1396,31 @@ async function renderSegmentPrefetch(
   // enqueues it into the input decode, the render has emitted all of it.
   await waitAtLeastOneReactRenderTask()
 
-  // Resolve `a`: null when the shell is the whole response — either the page
-  // said so (shellIsFullResponse), or no bytes flushed after the shell stage,
-  // which is the same thing at the segment grain. Otherwise it's the boundary
-  // offset. (A numeric boundary is always a strict prefix, never == total.)
-  if (shellIsFullResponse || byteLengthAfterShellStage === totalByteLength) {
+  // Resolve `a`: null when the page said its shell is the whole response
+  // (shellIsFullResponse) — then so is every segment's. Otherwise resolve the
+  // measured boundary, even if no segment *content* follows it: the
+  // stage-dependent metadata (`staleTime`, `needsRuntimeRequest`) always
+  // lands its post-shell values and completion rows after this point, so a
+  // truncated decode is meaningful for every segment of a staged page. When
+  // the page wasn't staged at all, the release resolved before any bytes
+  // flushed and the measured boundary falls out as 0, the "no shell"
+  // sentinel.
+  if (shellIsFullResponse) {
     shellByteOffset.resolve(null)
   } else {
     shellByteOffset.resolve(byteLengthAfterShellStage)
   }
 
-  // Now write the stream metadata (`a` and the `isPartial` promises). This is
-  // gated behind streamInfoStage so it lands strictly after the boundary
-  // measurement above — metadata bytes must not count as segment data.
+  // Now write the stream metadata (`a`, the `isPartial` promises, and a
+  // post-shell `needsRuntimeRequest` resolution). This is gated behind
+  // streamInfoStage so it lands strictly after the boundary measurement
+  // above — the post-shell values must not count as (or leak into) the
+  // shell prefix.
   streamInfoStage.resolve()
 
   // Wait for the metadata rows to flush before halting — two macrotasks,
   // each a distinct hop:
-  //   1. streamInfoStage unblocks the isPartial probe renders; a static
+  //   1. streamInfoStage unblocks the completeness probe renders; a static
   //      segment's probe resolves within this task (a partial one never does,
   //      which is how it stays pending → read as partial).
   //   2. those resolutions (and the already-resolved `a`) ping the render,
@@ -1288,6 +1433,43 @@ async function renderSegmentPrefetch(
   abortController.abort()
   return [responseKey, Buffer.concat(await chunksPromise)]
 }
+
+/**
+ * Reads the page's runtime-data-access flag (the payload's `u`) from a decode
+ * of the fully-settled page buffer. Because every byte is present, the
+ * promise's row (if the render emitted one) is already visible on its
+ * thenable status, so this never blocks — the same trick the client cache
+ * uses to read staleTime from a buffered response.
+ *
+ * - fulfilled: the recorded flag.
+ * - pending: `false`. A successful render always settles the flag (prerender
+ *   completion resolves `false`), so a pending row can only appear in an
+ *   aborted render's buffer, where it means no access was recorded before
+ *   the abort.
+ * - rejected: `true`, conservatively — an abort errors rows that were still
+ *   pending when it happened.
+ */
+function readRuntimeDataAccessed(
+  runtimeDataAccessed: Promise<boolean>
+): boolean {
+  const promise = runtimeDataAccessed as Promise<boolean> & {
+    status?: string
+    value?: boolean
+  }
+  // Force Flight to unwrap a received-but-not-yet-settled row.
+  promise.then(ignoreChunk, ignoreChunk)
+  switch (promise.status) {
+    case 'fulfilled':
+      return promise.value === true
+    case 'rejected':
+      return true
+    case undefined:
+    default:
+      return false
+  }
+}
+
+function ignoreChunk() {}
 
 // Wraps a known staleTime value in the same async-iterable shape as the page
 // response's `s`, so segment responses carry staleTime uniformly (and

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -44,6 +44,7 @@ import {
   ClientHookDynamicError,
   isClientHookDynamicError,
   makeClientHookHangingPromise,
+  trackRuntimeDataAccessed,
 } from '../dynamic-rendering-utils'
 import {
   METADATA_BOUNDARY_NAME,
@@ -361,6 +362,15 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
   errorWithStack: Error,
   prerenderStore: PrerenderStoreModern
 ): never {
+  // The synchronously accessed request data would have been available during
+  // a runtime prerender, which would have rendered past this point instead of
+  // aborting — so a runtime prefetch would produce more content than this
+  // render. Record that, same as when request data access creates a hanging
+  // promise (see makeRuntimeHangingPromise). Unlike
+  // `abortOnSynchronousPlatformIOAccess`, which aborts a runtime prerender
+  // all the same and therefore must not record anything.
+  trackRuntimeDataAccessed(prerenderStore)
+
   const prerenderSignal = prerenderStore.controller.signal
   if (prerenderSignal.aborted === false) {
     // TODO it would be better to move this aborted check into the callsite so we can avoid making

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -307,7 +307,7 @@ export class StagedRenderingController {
           )
         : stagePromise.then(() => resolvedValue)
 
-    // Analogously to `makeHangingPromise`, we might reject this promise if the signal is invoked.
+    // Analogously to `makeDynamicHangingPromise`, we might reject this promise if the signal is invoked.
     // (e.g. in the case where we don't want want the render to proceed to the dynamic stage and abort it).
     // We shouldn't consider this an unhandled rejection, so we attach a noop catch handler here to suppress this warning.
     if (this.abortSignal) {

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -152,6 +152,56 @@ export interface PrerenderStoreModernServer
   readonly type: 'prerender'
 
   readonly stagedRendering: StagedRenderingController | null
+
+  /**
+   * When not null, records whether the render has accessed a data source
+   * that hangs during a static prerender but would resolve during a runtime
+   * prerender — cookies, headers, fallback params, searchParams, and cache
+   * entries excluded only from static prerenders. Call sites go through
+   * `trackRuntimeDataAccessed`, which resolves the promise `true` on the
+   * first access; it's resolved `false` when the prerender completes without
+   * one. Promise resolution is idempotent, so the flag is monotonic with no
+   * extra state.
+   *
+   * The promise is embedded in the RSC payload (`InitialRSCPayload['u']`)
+   * so the fulfillment row's stream position records the stage the access
+   * happened in; the per-segment prefetch encoding (`collectSegmentData`)
+   * extracts it from the page data to tell the client whether a runtime
+   * prefetch request could be skipped. Tracking is page-global: an access
+   * anywhere in the page poisons all segments (per-segment granularity is
+   * recovered downstream for segments whose content is provably complete).
+   * Shared between the payload prerender store and the render store because
+   * request-data props are created during payload construction, before the
+   * render store exists. Null for warmup, route-handler, and error prerender
+   * stores.
+   */
+  readonly runtimeDataAccessed: PromiseWithResolvers<boolean> | null
+
+  /**
+   * Mutable single-boolean companion to `runtimeDataAccessed`, holding this
+   * prerender's `PrefetchHint.ShouldAttemptStaticPrefetch` measurement
+   * directly — the value that becomes the route's build-constant hint:
+   * starts `true`, and a disqualifying runtime-data access flips it to
+   * `false`. Not every access that resolves the promise disqualifies —
+   * fallback-param accesses on a fallback-upgradeable route are transient
+   * and leave the hint intact (see `trackRuntimeDataAccessed`, which applies
+   * the rule at access time using `isFallbackUpgradeable` below). A plain
+   * boolean suffices because the hint needs no stream positioning: unlike
+   * `runtimeDataAccessed`, whose fulfillment position encodes which stage
+   * the access happened in, this is read once after the prerender settles.
+   * Held in a cell so it can be shared. Same sharing and null rules as
+   * `runtimeDataAccessed`.
+   */
+  readonly shouldAttemptStaticPrefetch: { current: boolean } | null
+
+  /**
+   * Whether a fallback shell produced by this prerender could later be
+   * upgraded to a concrete prerender (`renderOpts.isFallbackUpgradeable`:
+   * at least one fallback param is a `generateStaticParams` candidate).
+   * Consulted by `trackRuntimeDataAccessed` to decide whether a
+   * fallback-param access disqualifies the static-prefetch hint.
+   */
+  readonly isFallbackUpgradeable: boolean
 }
 
 export interface PrerenderStoreModernRuntime

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -2,7 +2,10 @@ import {
   RenderStage,
   type AdvanceableRenderStage,
 } from './app-render/staged-rendering'
-import type { RequestStore } from './app-render/work-unit-async-storage.external'
+import type {
+  RequestStore,
+  WorkUnitStore,
+} from './app-render/work-unit-async-storage.external'
 import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
 import { getServerReact, getClientReact } from './runtime-reacts.external'
 
@@ -62,13 +65,22 @@ type AbortListeners = Array<() => void>
 const abortListenersBySignal = new WeakMap<AbortSignal, AbortListeners>()
 
 /**
- * This function constructs a promise that will never resolve. This is primarily
- * useful for cacheComponents where we use promise resolution timing to determine which
- * parts of a render can be included in a prerender.
+ * Constructs a promise that never resolves, standing in for *dynamic* data:
+ * data that is only available during a real dynamic request and hangs in
+ * every kind of prerender — `io()`, `connection()`, uncached `fetch()`.
+ *
+ * This is primarily useful for cacheComponents where we use promise
+ * resolution timing to determine which parts of a render can be included in a
+ * prerender.
+ *
+ * Records nothing on the prerender store: the promise's holes are only ever
+ * filled by a real dynamic request, so a runtime prefetch response would have
+ * the same holes as the static one. If the data source would resolve during a
+ * runtime prerender, use `makeRuntimeHangingPromise` instead.
  *
  * @internal
  */
-export function makeHangingPromise<T>(
+export function makeDynamicHangingPromise<T>(
   signal: AbortSignal,
   route: string,
   expression: string
@@ -77,6 +89,195 @@ export function makeHangingPromise<T>(
     signal,
     new HangingPromiseRejectionError(route, expression)
   )
+}
+
+/**
+ * Constructs a promise that never resolves, standing in for *runtime* data:
+ * data that hangs during a static prerender but is available during a runtime
+ * prerender (the kind that backs a runtime prefetch request: request data
+ * like cookies and headers is available, but the render is still not a real
+ * dynamic request). Examples: cookies, headers, fallback params,
+ * searchParams, and cache entries that are excluded only from static
+ * prerenders.
+ *
+ * Creating one of these during a static prerender records on the prerender
+ * store that a runtime prefetch would produce more content than the static
+ * response (`runtimeDataAccessed`), which the segment prefetch encoding uses
+ * to tell the client whether a runtime prefetch request could be skipped.
+ *
+ * When unsure whether data is dynamic or runtime, prefer this method — the
+ * cost of over-recording is a redundant runtime prefetch request; the cost of
+ * under-recording is a permanently missing one.
+ *
+ * `workUnitStore` may be null ONLY when the caller tracks the access itself
+ * at observation time instead of creation time. This is for promises the
+ * framework creates eagerly whether or not anything reads them (e.g. the
+ * `searchParams` prop constructed for every page): recording at creation
+ * would mark every render. Such a caller MUST call `trackRuntimeDataAccessed`
+ * from every path that observes the promise (e.g. the proxy traps for
+ * `then`/`status`), against the work unit store active at access time.
+ *
+ * For fallback-param data — data a concrete (ISR-upgraded) prerender would
+ * resolve — use `makeFallbackParamsHangingPromise` instead, so the access
+ * is recorded with the right effect on the static-prefetch hint.
+ *
+ * @internal
+ */
+export function makeRuntimeHangingPromise<T>(
+  signal: AbortSignal,
+  route: string,
+  expression: string,
+  workUnitStore: WorkUnitStore | null
+): Promise<T> {
+  if (workUnitStore !== null) {
+    trackRuntimeDataAccessed(workUnitStore)
+  }
+  return makeHangingPromiseWithError(
+    signal,
+    new HangingPromiseRejectionError(route, expression)
+  )
+}
+
+/**
+ * Variant of `makeRuntimeHangingPromise` for *fallback-param* data: fallback
+ * route params and values derived solely from them (`params`, `rootParams`,
+ * `pathname` during a fallback prerender). Like every runtime data access it
+ * records the access on the prerender store's response-level flag, but its
+ * effect on the build-time static-prefetch hint differs — on a
+ * fallback-upgradeable route the access is transient (a concrete prerender
+ * resolves it), so it leaves the hint intact. See
+ * `trackFallbackParamsAccessed`.
+ *
+ * As with `makeRuntimeHangingPromise`, `workUnitStore` may be null ONLY when
+ * the caller tracks the access itself at observation time instead of creation
+ * time, by calling `trackFallbackParamsAccessed` from every path that
+ * observes the promise.
+ *
+ * @internal
+ */
+export function makeFallbackParamsHangingPromise<T>(
+  signal: AbortSignal,
+  route: string,
+  expression: string,
+  workUnitStore: WorkUnitStore | null
+): Promise<T> {
+  if (workUnitStore !== null) {
+    trackFallbackParamsAccessed(workUnitStore)
+  }
+  return makeHangingPromiseWithError(
+    signal,
+    new HangingPromiseRejectionError(route, expression)
+  )
+}
+
+/**
+ * Constructs a promise that never resolves, standing in for data that is only
+ * accessible in a later *stage* of rendering than this render reaches — e.g.
+ * a prefetchable short-stale cache entry that's excluded from shells when the
+ * render ends at the shell stage, or params during a runtime-prefetch render
+ * that stops before the stage where params resolve.
+ *
+ * A render that runs through the later stage would include the data; in
+ * particular a runtime prefetch renders through its later stages, so on a
+ * static prerender store this records `runtimeDataAccessed`, same as
+ * `makeRuntimeHangingPromise`.
+ *
+ * @internal
+ */
+export function makeStageHangingPromise<T>(
+  signal: AbortSignal,
+  route: string,
+  expression: string,
+  workUnitStore: WorkUnitStore
+): Promise<T> {
+  trackRuntimeDataAccessed(workUnitStore)
+  return makeHangingPromiseWithError(
+    signal,
+    new HangingPromiseRejectionError(route, expression)
+  )
+}
+
+/**
+ * Records on a static prerender store that the render accessed a data source
+ * which would have resolved during a runtime prerender. No-op for all other
+ * store types.
+ *
+ * `makeRuntimeHangingPromise` and `makeStageHangingPromise` call this
+ * automatically; call it directly only where the access is observed
+ * separately from the promise's creation (see the null `workUnitStore` case
+ * of `makeRuntimeHangingPromise`), or where the prerender is aborted
+ * synchronously instead of hanging.
+ *
+ * For fallback-param data, use `trackFallbackParamsAccessed` instead. When
+ * unsure, this is the conservative choice: it unconditionally clears the
+ * static-prefetch hint.
+ */
+export function trackRuntimeDataAccessed(workUnitStore: WorkUnitStore): void {
+  trackRuntimeDataAccessedImpl(workUnitStore, false)
+}
+
+/**
+ * Fallback-param variant of `trackRuntimeDataAccessed`, for accesses of
+ * fallback route params and values derived solely from them. It records the
+ * response-level flag all the same, but only clears the build-time
+ * static-prefetch hint when the route is not fallback-upgradeable — on an
+ * upgradeable route the access is transient, since ISR later produces a
+ * concrete prerender that resolves it.
+ */
+export function trackFallbackParamsAccessed(
+  workUnitStore: WorkUnitStore
+): void {
+  trackRuntimeDataAccessedImpl(workUnitStore, true)
+}
+
+function trackRuntimeDataAccessedImpl(
+  workUnitStore: WorkUnitStore,
+  isFallbackParamAccess: boolean
+): void {
+  switch (workUnitStore.type) {
+    case 'prerender': {
+      // Response-level flag (the payload's `u`, forwarded to segment
+      // responses as `needsRuntimeRequest`): resolved for every kind of
+      // access — a pre-upgrade fallback response must keep reporting that
+      // a runtime request would return more. The fulfillment row lands at
+      // the current position in the Flight stream, which is what makes the
+      // value rewindable per stage. Promise resolution is idempotent, so
+      // repeated accesses are free.
+      workUnitStore.runtimeDataAccessed?.resolve(true)
+
+      // Hint cell (holds the build-constant
+      // PrefetchHint.ShouldAttemptStaticPrefetch value directly): a
+      // fallback-param access is transient when the route is
+      // fallback-upgradeable — ISR later produces the concrete prerender a
+      // static prefetch attempt would hit — so it leaves the hint intact.
+      // (Until that upgrade, the response-level flag above keeps directing
+      // the client to a runtime fallback; the hint only costs a wasted
+      // static attempt in the interim.) Every other access clears it.
+      const hintCell = workUnitStore.shouldAttemptStaticPrefetch
+      if (
+        hintCell !== null &&
+        (!isFallbackParamAccess || !workUnitStore.isFallbackUpgradeable)
+      ) {
+        hintCell.current = false
+      }
+      break
+    }
+    case 'prerender-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'prerender-runtime':
+    case 'validation-client':
+    case 'request':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      // Only the modern server prerender tracks this; see the field docs on
+      // PrerenderStoreModernServer.
+      break
+    default:
+      workUnitStore satisfies never
+  }
 }
 
 export function makeClientHookHangingPromise<T>(

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -16,7 +16,7 @@ import {
   NEXT_CACHE_TAG_MAX_LENGTH,
 } from '../../lib/constants'
 import { markCurrentScopeAsDynamic } from '../app-render/dynamic-rendering'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { makeDynamicHangingPromise } from '../dynamic-rendering-utils'
 import type { FetchMetric } from '../base-http'
 import { createDedupeFetch } from './dedupe-fetch'
 import {
@@ -612,7 +612,7 @@ export function createPatchedFetcher(
                 cacheSignal = null
               }
 
-              return makeHangingPromise<Response>(
+              return makeDynamicHangingPromise<Response>(
                 workUnitStore.renderSignal,
                 workStore.route,
                 'fetch()'
@@ -747,7 +747,7 @@ export function createPatchedFetcher(
                     cacheSignal.endRead()
                     cacheSignal = null
                   }
-                  return makeHangingPromise<Response>(
+                  return makeDynamicHangingPromise<Response>(
                     workUnitStore.renderSignal,
                     workStore.route,
                     'fetch()'
@@ -1161,7 +1161,7 @@ export function createPatchedFetcher(
                     cacheSignal.endRead()
                     cacheSignal = null
                   }
-                  return makeHangingPromise<Response>(
+                  return makeDynamicHangingPromise<Response>(
                     workUnitStore.renderSignal,
                     workStore.route,
                     'fetch()'
@@ -1213,7 +1213,7 @@ export function createPatchedFetcher(
                   case 'prerender-client':
                   case 'prerender-runtime':
                   case 'validation-client':
-                    return makeHangingPromise<Response>(
+                    return makeDynamicHangingPromise<Response>(
                       workUnitStore.renderSignal,
                       workStore.route,
                       'fetch()'

--- a/packages/next/src/server/og/cache-image-response.ts
+++ b/packages/next/src/server/og/cache-image-response.ts
@@ -5,7 +5,7 @@ import { InvariantError } from '../../shared/lib/invariant-error'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import { createHangingInputAbortSignal } from '../app-render/dynamic-rendering'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { makeDynamicHangingPromise } from '../dynamic-rendering-utils'
 import {
   getClientReferenceManifest,
   getServerModuleMap,
@@ -192,7 +192,12 @@ async function getCachedImageResponseArrayBuffer(
       // `fetch`), so the image can't be produced statically. Return a hanging
       // promise: the body never resolves, and the final prerender's macrotask
       // budget then classifies the route as dynamic.
-      return makeHangingPromise<ArrayBuffer>(
+      // Whatever dynamic input made the element partial already classified
+      // itself when it created its own hanging promise (cookies() creates a
+      // runtime hanging promise, an uncached fetch creates a dynamic one,
+      // ...), so this wrapper adds no new information and can use the
+      // non-recording dynamic variant.
+      return makeDynamicHangingPromise<ArrayBuffer>(
         renderSignal,
         workStore.route,
         'dynamic `ImageResponse`'

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -10,7 +10,7 @@ import {
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
-  makeHangingPromise,
+  makeDynamicHangingPromise,
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
 import { isRequestApiAllowedInCurrentPhase } from './utils'
@@ -83,7 +83,7 @@ export function connection(): Promise<void> {
         case 'prerender-runtime':
           // We return a promise that never resolves to allow the prerender to
           // stall at this point.
-          return makeHangingPromise(
+          return makeDynamicHangingPromise(
             workUnitStore.renderSignal,
             workStore.route,
             '`connection()`'

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -22,7 +22,7 @@ import {
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
   makeDevtoolsIOAwarePromise,
-  makeHangingPromise,
+  makeRuntimeHangingPromise,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -174,10 +174,11 @@ function makeHangingCookies(
     return cachedPromise
   }
 
-  const promise = makeHangingPromise<ReadonlyRequestCookies>(
+  const promise = makeRuntimeHangingPromise<ReadonlyRequestCookies>(
     prerenderStore.renderSignal,
     workStore.route,
-    '`cookies()`'
+    '`cookies()`',
+    prerenderStore
   )
   CachedCookies.set(prerenderStore, promise)
 

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -20,7 +20,7 @@ import {
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
   makeDevtoolsIOAwarePromise,
-  makeHangingPromise,
+  makeRuntimeHangingPromise,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -181,10 +181,11 @@ function makeHangingHeaders(
     return cachedHeaders
   }
 
-  const promise = makeHangingPromise<ReadonlyHeaders>(
+  const promise = makeRuntimeHangingPromise<ReadonlyHeaders>(
     prerenderStore.renderSignal,
     workStore.route,
-    '`headers()`'
+    '`headers()`',
+    prerenderStore
   )
   CachedHeaders.set(prerenderStore, promise)
 

--- a/packages/next/src/server/request/io.ts
+++ b/packages/next/src/server/request/io.ts
@@ -1,7 +1,7 @@
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
-  makeHangingPromise,
+  makeDynamicHangingPromise,
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
 import { RenderStage } from '../app-render/staged-rendering'
@@ -62,7 +62,7 @@ export function io(): Promise<void> {
         // When prerendering with Cache Components we consider `io()` to be
         // actual IO if not in a cache scope and we can avoid actually executing
         // anything after it by making it return a hanging promise.
-        return makeHangingPromise(
+        return makeDynamicHangingPromise(
           workUnitStore.renderSignal,
           workStore.route,
           '`io()`'

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -33,8 +33,9 @@ import {
 } from '../../shared/lib/utils/reflect-utils'
 import {
   makeDevtoolsIOAwarePromise,
-  makeHangingPromise,
+  makeFallbackParamsHangingPromise,
   makePromiseFromTrigger,
+  trackFallbackParamsAccessed,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -287,10 +288,11 @@ export function createPrerenderParamsForClientSegment(
               // to consider the awaiting of this params object "dynamic". Since
               // we are in cacheComponents mode we encode this as a promise that never
               // resolves.
-              return makeHangingPromise(
+              return makeFallbackParamsHangingPromise(
                 workUnitStore.renderSignal,
                 workStore.route,
-                '`params`'
+                '`params`',
+                workUnitStore
               )
             }
           }
@@ -693,6 +695,15 @@ const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
 
       return {
         [prop]: (...args: unknown[]) => {
+          // Record against the store that's active at access time: the
+          // hanging promise is cached by params object across prerender
+          // stores, so the store that created it may not be the one that's
+          // rendering when it's finally awaited.
+          const workUnitStore = workUnitAsyncStorage.getStore()
+          if (workUnitStore !== undefined) {
+            trackFallbackParamsAccessed(workUnitStore)
+          }
+
           const store = dynamicAccessAsyncStorage.getStore()
 
           if (store) {
@@ -724,10 +735,14 @@ function makeHangingParams(
   }
 
   const promise = new Proxy(
-    makeHangingPromise<Params>(
+    makeFallbackParamsHangingPromise<Params>(
       prerenderStore.renderSignal,
       workStore.route,
-      '`params`'
+      '`params`',
+      // This promise is created for every segment on a fallback route whether
+      // or not it reads params, so recording the access at creation would mark
+      // every render. The access is tracked in the proxy traps instead.
+      null
     ),
     fallbackParamsProxyHandler
   )

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -16,7 +16,8 @@ import {
   type PrerenderStorePPR,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  makeHangingPromise,
+  makeDynamicHangingPromise,
+  makeFallbackParamsHangingPromise,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -72,7 +73,7 @@ export function createServerPathnameForMetadata(
           )
         } else {
           if (workUnitStore.isSessionShell) {
-            return makeHangingPromise<string>(
+            return makeDynamicHangingPromise<string>(
               workUnitStore.renderSignal,
               workStore.route,
               '`pathname`'
@@ -104,10 +105,14 @@ function createPrerenderPathname(
     case 'prerender': {
       const fallbackParams = prerenderStore.fallbackRouteParams
       if (fallbackParams && fallbackParams.size > 0) {
-        return makeHangingPromise<string>(
+        // The pathname only hangs when there are fallback params, and a
+        // concrete (ISR-upgraded) prerender resolves it — so this access is
+        // fallback-param data for the static-prefetch hint.
+        return makeFallbackParamsHangingPromise<string>(
           prerenderStore.renderSignal,
           workStore.route,
-          '`pathname`'
+          '`pathname`',
+          prerenderStore
         )
       }
       break

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -13,7 +13,7 @@ import {
   type PrerenderStoreModernServer,
   type PrerenderStorePPR,
 } from '../app-render/work-unit-async-storage.external'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { makeFallbackParamsHangingPromise } from '../dynamic-rendering-utils'
 import type { ParamValue } from './params'
 import { describeStringPropertyAccess } from '../../shared/lib/utils/reflect-utils'
 import { actionAsyncStorage } from '../app-render/action-async-storage.external'
@@ -162,10 +162,11 @@ function createPrerenderRootParamPromise(
         prerenderStore.fallbackRouteParams &&
         prerenderStore.fallbackRouteParams.has(paramName)
       ) {
-        return makeHangingPromise<ParamValue>(
+        return makeFallbackParamsHangingPromise<ParamValue>(
           prerenderStore.renderSignal,
           workStore.route,
-          apiName
+          apiName,
+          prerenderStore
         )
       }
       break

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -30,8 +30,9 @@ import {
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   makeDevtoolsIOAwarePromise,
-  makeHangingPromise,
+  makeRuntimeHangingPromise,
   makePromiseFromTrigger,
+  trackRuntimeDataAccessed,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -178,10 +179,11 @@ export function createPrerenderSearchParamsForClientPage(): Promise<SearchParams
       case 'prerender-client':
         // We're prerendering in a mode that aborts (cacheComponents) and should stall
         // the promise to ensure the RSC side is considered dynamic
-        return makeHangingPromise(
+        return makeRuntimeHangingPromise(
           workUnitStore.renderSignal,
           workStore.route,
-          '`searchParams`'
+          '`searchParams`',
+          workUnitStore
         )
       case 'validation-client':
         throw new InvariantError(
@@ -382,11 +384,23 @@ function makeHangingSearchParams(
     return cachedSearchParams
   }
 
-  const promise = makeHangingPromise<SearchParams>(
+  const promise = makeRuntimeHangingPromise<SearchParams>(
     prerenderStore.renderSignal,
     workStore.route,
-    '`searchParams`'
+    '`searchParams`',
+    // This promise is created for every page whether or not it reads search
+    // params, so recording the access at creation would mark every render.
+    // The access is tracked in the proxy traps below instead.
+    null
   )
+
+  const trackSearchParamsAccessed = () => {
+    // Record against the store that's active at access time: the promise is
+    // created while the RSC payload is constructed, but typically accessed
+    // later, during the render, under a different store.
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    trackRuntimeDataAccessed(workUnitStore ?? prerenderStore)
+  }
 
   const proxyHandler: ProxyHandler<Promise<SearchParams>> = {
     get(target, prop, receiver) {
@@ -406,6 +420,7 @@ function makeHangingSearchParams(
             [prop]: (...args: unknown[]) => {
               const expression =
                 '`await searchParams`, `searchParams.then`, or similar'
+              trackSearchParamsAccessed()
               annotateDynamicAccess(expression, prerenderStore)
               // Mirror `makeHangingParams`: when this never-resolving promise
               // is awaited while a `use cache` key is being encoded
@@ -428,6 +443,7 @@ function makeHangingSearchParams(
         case 'status': {
           const expression =
             '`use(searchParams)`, `searchParams.status`, or similar'
+          trackSearchParamsAccessed()
           annotateDynamicAccess(expression, prerenderStore)
           return ReflectAdapter.get(target, prop, receiver)
         }

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -479,6 +479,9 @@ export class AppRouteRouteModule extends RouteModule<
               resumeDataCache: prerenderResumeDataCache,
               hmrRefreshHash: undefined,
               varyParamsAccumulator: null,
+              runtimeDataAccessed: null,
+              shouldAttemptStaticPrefetch: null,
+              isFallbackUpgradeable: false,
             })
 
           let prospectiveResult
@@ -575,6 +578,9 @@ export class AppRouteRouteModule extends RouteModule<
             resumeDataCache: prerenderResumeDataCache,
             hmrRefreshHash: undefined,
             varyParamsAccumulator: null,
+            runtimeDataAccessed: null,
+            shouldAttemptStaticPrefetch: null,
+            isFallbackUpgradeable: false,
           })
 
           let responseHandled = false

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -39,7 +39,9 @@ import {
 import {
   applyOwnerStack,
   makeDevtoolsIOAwarePromise,
-  makeHangingPromise,
+  makeDynamicHangingPromise,
+  makeRuntimeHangingPromise,
+  makeStageHangingPromise,
   RENDER_STAGES_BY_DATA_KIND,
 } from '../dynamic-rendering-utils'
 
@@ -1329,10 +1331,12 @@ async function generateCacheEntryImpl(
         // If the prerender is aborted because of dynamic access (e.g. reading
         // fallback params), we return a hanging promise. This essentially makes
         // the "use cache" function dynamic.
-        const hangingPromise = makeHangingPromise<never>(
+        // The dynamic access is a fallback params read, which is runtime data.
+        const hangingPromise = makeRuntimeHangingPromise<never>(
           outerWorkUnitStore.renderSignal,
           workStore.route,
-          'dynamic "use cache"'
+          'dynamic "use cache"',
+          outerWorkUnitStore
         )
 
         if (outerWorkUnitStore.cacheSignal) {
@@ -1714,10 +1718,12 @@ export async function cache(
     switch (workUnitStore.type) {
       // "use cache: private" is dynamic in prerendering contexts.
       case 'prerender':
-        return makeHangingPromise(
+        // Private caches can read request data, which is runtime data.
+        return makeRuntimeHangingPromise(
           workUnitStore.renderSignal,
           workStore.route,
-          expression
+          expression,
+          workUnitStore
         )
       case 'prerender-ppr':
         return postponeWithTracking(
@@ -2054,10 +2060,13 @@ export async function cache(
         )
 
         if (dynamicAccessAbortController.signal.aborted) {
-          return makeHangingPromise(
+          // The dynamic access is a fallback params read, which is runtime
+          // data.
+          return makeRuntimeHangingPromise(
             workUnitStore.renderSignal,
             workStore.route,
-            'dynamic "use cache"'
+            'dynamic "use cache"',
+            workUnitStore
           )
         }
         break
@@ -2197,10 +2206,13 @@ export async function cache(
       switch (workUnitStore.type) {
         case 'prerender':
         case 'prerender-runtime':
-          return makeHangingPromise(
+          // The cache key was marked dynamic because it depends on fallback
+          // params, which are runtime data.
+          return makeRuntimeHangingPromise(
             workUnitStore.renderSignal,
             workStore.route,
-            'dynamic "use cache"'
+            'dynamic "use cache"',
+            workUnitStore
           )
         case 'prerender-ppr':
         case 'prerender-legacy':
@@ -2308,10 +2320,14 @@ export async function cache(
               if (cacheSignal) {
                 cacheSignal.endRead()
               }
-              return makeHangingPromise(
+              // The entry is only excluded from *static* prerenders — the
+              // 'prerender-runtime' case below serves it — so a runtime
+              // prefetch would include this content.
+              return makeRuntimeHangingPromise(
                 workUnitStore.renderSignal,
                 workStore.route,
-                'dynamic "use cache"'
+                'dynamic "use cache"',
+                workUnitStore
               )
             case 'prerender-runtime': {
               // In the final phase of a runtime prerender, we have to make
@@ -2426,7 +2442,20 @@ export async function cache(
                 if (cacheSignal) {
                   cacheSignal.endRead()
                 }
-                return makeHangingPromise(
+                if (isPrefetchable) {
+                  // The entry was omitted only because this render ends
+                  // before the post-shell stage; a render that reaches its
+                  // post-shell stage would serve it.
+                  return makeStageHangingPromise(
+                    prerenderStore.renderSignal,
+                    workStore.route,
+                    'dynamic "use cache"',
+                    prerenderStore
+                  )
+                }
+                // An unprefetchable entry (stale < MIN_PREFETCHABLE_STALE) is
+                // excluded from runtime prerenders too.
+                return makeDynamicHangingPromise(
                   prerenderStore.renderSignal,
                   workStore.route,
                   'dynamic "use cache"'
@@ -2558,10 +2587,13 @@ export async function cache(
             // also do here, this covers the case where params are transformed
             // with an async function before being passed into the "use cache"
             // function, which escapes the instrumentation.
-            return makeHangingPromise(
+            // The cache key depends on fallback params, which are runtime
+            // data.
+            return makeRuntimeHangingPromise(
               workUnitStore.renderSignal,
               workStore.route,
-              'dynamic "use cache"'
+              'dynamic "use cache"',
+              workUnitStore
             )
           }
         // fallthrough
@@ -2580,10 +2612,15 @@ export async function cache(
                 `Unexpected cache miss after cache warming phase during prerendering. This is likely caused by non-deterministic arguments that differ between the cache warming phase and the final prerender phase (e.g. unstable array order). Ensure that arguments passed to cached functions are deterministic.`
               )
             )
-            return makeHangingPromise(
+            // This is an anomaly (non-deterministic cache key), so we can't
+            // know whether a runtime prerender would resolve it. Treat it as
+            // runtime data, conservatively: the cost is at most a redundant
+            // runtime prefetch request.
+            return makeRuntimeHangingPromise(
               workUnitStore.renderSignal,
               workStore.route,
-              'dynamic "use cache"'
+              'dynamic "use cache"',
+              workUnitStore
             )
           }
           break
@@ -2913,10 +2950,14 @@ export async function cache(
                 cacheSignal.endRead()
               }
 
-              const hangingPromise = makeHangingPromise<never>(
+              // The entry is only excluded from *static* prerenders — the
+              // 'prerender-runtime' case below serves it — so a runtime
+              // prefetch would include this content.
+              const hangingPromise = makeRuntimeHangingPromise<never>(
                 workUnitStore.renderSignal,
                 workStore.route,
-                'dynamic "use cache"'
+                'dynamic "use cache"',
+                workUnitStore
               )
               debug?.('leader resolved as prerender-dynamic', cacheHandlerKey)
               resolvableSharedCacheResult.resolve({

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -237,6 +237,28 @@ export const enum PrefetchHint {
   // `<Link prefetch={true}>` warning — unlike PrefetchDisabled, it has no effect
   // on the actual prefetch behavior.
   SubtreeHasInstantFalse = 0b10000000000000,
+  // The client should attempt a static prefetch for this route: the
+  // build-time prerender did not access any runtime data (cookies, headers,
+  // searchParams, ...), so a static prefetch is expected to be as complete
+  // as a runtime one. A fallback-param access only unsets the bit when the
+  // route can never be upgraded from a fallback to a concrete prerender —
+  // on an upgradeable route, ISR later produces the concrete prerender a
+  // static attempt would hit (until then, the static responses' own
+  // signal reports the insufficiency per response). Purely advisory, and
+  // both error directions are safe: if set when a runtime request is
+  // actually needed, that same response-level signal (the load-bearing
+  // `needsRuntimeRequest` promise combined with each segment's `isPartial`)
+  // directs the client to follow up — the cost is a wasted static attempt.
+  // If unset when static would have sufficed, the client goes straight to a
+  // runtime prefetch, which is a superset of the static response — the cost
+  // is only reduced cacheability. Like the other bits, this one is computed
+  // once per build and stays constant for the build's lifetime; it rides
+  // the prefetch-hints manifest into every response that carries hints —
+  // `/_tree` prefetch responses and the FlightRouterState of dynamic
+  // navigations alike. (Routes missing from the manifest — see the #91407
+  // fallbacks — simply never carry it.) Set on every node of the tree, but
+  // does not propagate.
+  ShouldAttemptStaticPrefetch = 0b100000000000000,
 }
 
 /**
@@ -434,6 +456,27 @@ export type InitialRSCPayload = {
   r?: VaryParamsIterable
   /** staleTime in seconds - Only present when Cache Components is enabled. */
   s?: AsyncIterable<number>
+  /**
+   * runtimeDataAccessed — whether the render has accessed a data source that
+   * hangs during a static prerender but would resolve during a runtime
+   * prerender (cookies, headers, fallback params, searchParams, ...). The
+   * flag is monotonic (false → true, at most once), so it's encoded as a
+   * promise: resolved `true` at the moment of first access — the fulfillment
+   * row's position in the stream records the stage the access happened in —
+   * or resolved `false` when the prerender completes without one, a row that
+   * lands past every stage boundary. A truncated (shell) decode therefore
+   * reads the answer as of the shell stage: fulfilled `true` iff the access
+   * happened during a stage it includes, pending (⇒ no access) otherwise.
+   * Unlike an async iterable, a pending promise costs Flight no abort
+   * listener on the render. Used when generating per-segment prefetch
+   * responses (forwarded as the response-level `needsRuntimeRequest`).
+   * The build-constant `PrefetchHint.ShouldAttemptStaticPrefetch` is
+   * tracked directly on the prerender store instead (its
+   * `shouldAttemptStaticPrefetch` cell) — it needs neither stream
+   * positioning nor this flag's param/non-param blindness. Only present
+   * for static prerenders when Cache Components is enabled.
+   */
+  u?: Promise<boolean>
   /** staticStageByteLength - Resolves when the static stage ends. */
   l?: Promise<number>
   /**

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -318,13 +318,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSearchParams (webpack:///<next-src>)
                      at UseSearchParams (webpack:///app/client-hook-abort-reasons/client.tsx:27:18)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-search-params/[id]/page.tsx:8:7)
-                   718 |       return
-                   719 |     case 'prerender-client': {
-                 > 720 |       React.use(
+                   728 |       return
+                   729 |     case 'prerender-client': {
+                 > 730 |       React.use(
                        |             ^
-                   721 |         makeClientHookHangingPromise(
-                   722 |           workUnitStore.renderSignal,
-                   723 |           new ClientHookDynamicError(workStore.route, expression) {
+                   731 |         makeClientHookHangingPromise(
+                   732 |           workUnitStore.renderSignal,
+                   733 |           new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-search-params/[id]" in your browser to investigate the error.
@@ -608,13 +608,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at usePathname (webpack:///<next-src>)
                      at UsePathname (webpack:///app/client-hook-abort-reasons/client.tsx:22:14)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-pathname/[id]/page.tsx:7:7)
-                   647 |           // hang here and never resolve. This will cause the currently
-                   648 |           // rendering component to effectively be a dynamic hole.
-                 > 649 |           React.use(
+                   657 |           // hang here and never resolve. This will cause the currently
+                   658 |           // rendering component to effectively be a dynamic hole.
+                 > 659 |           React.use(
                        |                 ^
-                   650 |             makeClientHookHangingPromise(
-                   651 |               workUnitStore.renderSignal,
-                   652 |               new ClientHookDynamicError(workStore.route, expression) {
+                   660 |             makeClientHookHangingPromise(
+                   661 |               workUnitStore.renderSignal,
+                   662 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-pathname/[id]" in your browser to investigate the error.
@@ -898,13 +898,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-params/[id]/page.tsx:8:7)
-                   647 |           // hang here and never resolve. This will cause the currently
-                   648 |           // rendering component to effectively be a dynamic hole.
-                 > 649 |           React.use(
+                   657 |           // hang here and never resolve. This will cause the currently
+                   658 |           // rendering component to effectively be a dynamic hole.
+                 > 659 |           React.use(
                        |                 ^
-                   650 |             makeClientHookHangingPromise(
-                   651 |               workUnitStore.renderSignal,
-                   652 |               new ClientHookDynamicError(workStore.route, expression) {
+                   660 |             makeClientHookHangingPromise(
+                   661 |               workUnitStore.renderSignal,
+                   662 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-params/[id]" in your browser to investigate the error.
@@ -1188,13 +1188,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegments (webpack:///<next-src>)
                      at UseSelectedLayoutSegments (webpack:///app/client-hook-abort-reasons/client.tsx:37:28)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]/page.tsx:7:7)
-                   647 |           // hang here and never resolve. This will cause the currently
-                   648 |           // rendering component to effectively be a dynamic hole.
-                 > 649 |           React.use(
+                   657 |           // hang here and never resolve. This will cause the currently
+                   658 |           // rendering component to effectively be a dynamic hole.
+                 > 659 |           React.use(
                        |                 ^
-                   650 |             makeClientHookHangingPromise(
-                   651 |               workUnitStore.renderSignal,
-                   652 |               new ClientHookDynamicError(workStore.route, expression) {
+                   660 |             makeClientHookHangingPromise(
+                   661 |               workUnitStore.renderSignal,
+                   662 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]" in your browser to investigate the error.
@@ -1478,13 +1478,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   647 |           // hang here and never resolve. This will cause the currently
-                   648 |           // rendering component to effectively be a dynamic hole.
-                 > 649 |           React.use(
+                   657 |           // hang here and never resolve. This will cause the currently
+                   658 |           // rendering component to effectively be a dynamic hole.
+                 > 659 |           React.use(
                        |                 ^
-                   650 |             makeClientHookHangingPromise(
-                   651 |               workUnitStore.renderSignal,
-                   652 |               new ClientHookDynamicError(workStore.route, expression) {
+                   660 |             makeClientHookHangingPromise(
+                   661 |               workUnitStore.renderSignal,
+                   662 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]" in your browser to investigate the error.
@@ -2198,13 +2198,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-params/[id]/page.tsx:7:7)
-                   647 |           // hang here and never resolve. This will cause the currently
-                   648 |           // rendering component to effectively be a dynamic hole.
-                 > 649 |           React.use(
+                   657 |           // hang here and never resolve. This will cause the currently
+                   658 |           // rendering component to effectively be a dynamic hole.
+                 > 659 |           React.use(
                        |                 ^
-                   650 |             makeClientHookHangingPromise(
-                   651 |               workUnitStore.renderSignal,
-                   652 |               new ClientHookDynamicError(workStore.route, expression) {
+                   660 |             makeClientHookHangingPromise(
+                   661 |               workUnitStore.renderSignal,
+                   662 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-params/[id]" in your browser to investigate the error.
@@ -2697,13 +2697,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   647 |           // hang here and never resolve. This will cause the currently
-                   648 |           // rendering component to effectively be a dynamic hole.
-                 > 649 |           React.use(
+                   657 |           // hang here and never resolve. This will cause the currently
+                   658 |           // rendering component to effectively be a dynamic hole.
+                 > 659 |           React.use(
                        |                 ^
-                   650 |             makeClientHookHangingPromise(
-                   651 |               workUnitStore.renderSignal,
-                   652 |               new ClientHookDynamicError(workStore.route, expression) {
+                   660 |             makeClientHookHangingPromise(
+                   661 |               workUnitStore.renderSignal,
+                   662 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]" in your browser to investigate the error.


### PR DESCRIPTION
Adds a server-computed signal to static per-segment prefetch responses that tells the client whether a runtime prefetch request would return more content than the static response already contains.

The signal is computed by tracking whether the prerender accessed any data source that hangs during a static prerender but would resolve during a runtime prerender. For example: cookies, headers, fallback params, and search params.

The information is encoded two places:

- As a prefetch hint called ShouldAttemptStaticPrefetch. This tells the client that it's worth attempting to do a static prefetch instead of a runtime one. It's only an optimization, though: if the static response ends up being insufficient, the client will follow it up with a runtime request. It's semantically OK if there are false positives.
- Embedded in the static segment response. This tells the client whether the static response is missing data that would have been included in a runtime response. Unlike the prefetch hint, this value must never falsely claim that no runtime request is needed.

A follow-up will update the client to skip the runtime request using this information. This commit only encodes the signal into the response.
