### PR TITLE
Fix basePath fallback parameter parsing

### DIFF
--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -10,6 +10,8 @@ import {
   NEXT_REWRITTEN_QUERY_HEADER,
   NEXT_RSC_UNION_QUERY,
 } from './components/app-router-headers'
+import { hasBasePath } from './has-base-path'
+import { removeBasePath } from './remove-base-path'
 import type {
   NormalizedPathname,
   NormalizedSearch,
@@ -44,9 +46,14 @@ export function getRenderedPathname(
   // page will be different from the pathname in the request URL. In this case,
   // the response will include a header that gives the rewritten pathname.
   const rewrittenPath = response.headers.get(NEXT_REWRITTEN_PATH_HEADER)
-  return (rewrittenPath ??
-    urlToUrlWithoutFlightMarker(new URL(response.url))
-      .pathname) as NormalizedPathname
+  if (rewrittenPath !== null) {
+    return rewrittenPath as NormalizedPathname
+  }
+
+  const pathname = urlToUrlWithoutFlightMarker(new URL(response.url)).pathname
+  return (
+    hasBasePath(pathname) ? removeBasePath(pathname) : pathname
+  ) as NormalizedPathname
 }
 
 // Pathname parts come from `URL.pathname.split('/')`, so they are already

--- a/test/e2e/app-dir/basepath-fallback-params/app/items/[itemId]/page.tsx
+++ b/test/e2e/app-dir/basepath-fallback-params/app/items/[itemId]/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function Page() {
+  const { itemId } = useParams<{ itemId: string }>()
+
+  return <p id="item-id">{itemId}</p>
+}

--- a/test/e2e/app-dir/basepath-fallback-params/app/layout.tsx
+++ b/test/e2e/app-dir/basepath-fallback-params/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={<p>Loading route parameters...</p>}>
+          {children}
+        </Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/basepath-fallback-params/app/page.tsx
+++ b/test/e2e/app-dir/basepath-fallback-params/app/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return <Link href="/items/expected-id">Open item</Link>
+}

--- a/test/e2e/app-dir/basepath-fallback-params/basepath-fallback-params.test.ts
+++ b/test/e2e/app-dir/basepath-fallback-params/basepath-fallback-params.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('basepath-fallback-params', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('reads fallback params on a direct visit', async () => {
+    const browser = await next.browser('/dashboard/items/expected-id')
+
+    expect(await browser.elementById('item-id').text()).toBe('expected-id')
+  })
+
+  it('reads fallback params after a client navigation', async () => {
+    const browser = await next.browser('/dashboard')
+
+    await browser.elementByCss('a').click()
+
+    expect(await browser.elementById('item-id').text()).toBe('expected-id')
+  })
+})

--- a/test/e2e/app-dir/basepath-fallback-params/next.config.js
+++ b/test/e2e/app-dir/basepath-fallback-params/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  basePath: '/dashboard',
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

- Strip the configured `basePath` from response URL pathnames before reconstructing fallback route parameters on the client.
- Add production regression coverage for both direct hydration and client navigation with Cache Components enabled.

This prevents dynamic parameters from shifting when the response URL includes a base path but the App Router tree does not.

## Verification

- Added production Turbopack E2E coverage for direct visits and client navigation.

<!-- NEXT_JS_LLM_PR -->