### PR TITLE
Throw for empty or incomplete generateStaticParams results with output: export

### DIFF
--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Invalid `generateStaticParams` Value'
+title: '`generateStaticParams` Error'
 ---
 
 ## Why This Error Occurred
@@ -23,6 +23,16 @@ export function generateStaticParams() {
 
 See the [`generateStaticParams` return value documentation](/docs/app/api-reference/functions/generate-static-params#returns) for the expected shape.
 
+## Using `output: 'export'`
+
+When your application uses `output: 'export'`, every [Dynamic Route](/docs/app/api-reference/file-conventions/dynamic-routes), such as `app/blog/[slug]/page.tsx`, must be rendered at build time.
+
+This error also occurs when a dynamic route does not export a `generateStaticParams` function.
+
+Export `generateStaticParams` from every dynamic route. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
+
 ## Useful Links
 
 - [`generateStaticParams` documentation](/docs/app/api-reference/functions/generate-static-params)
+- [Static Exports documentation](/docs/app/guides/static-exports)
+- [Dynamic Routes documentation](/docs/app/api-reference/file-conventions/dynamic-routes)

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -27,9 +27,12 @@ See the [`generateStaticParams` return value documentation](/docs/app/api-refere
 
 When your application uses `output: 'export'`, every [Dynamic Route](/docs/app/api-reference/file-conventions/dynamic-routes), such as `app/blog/[slug]/page.tsx`, must be rendered at build time.
 
-This error also occurs when a dynamic route does not export a `generateStaticParams` function.
+This error also occurs when a dynamic route:
 
-Export `generateStaticParams` from every dynamic route. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
+- does not export a `generateStaticParams` function, or
+- returns an empty array from `generateStaticParams`.
+
+Export `generateStaticParams` from every dynamic route and return at least one params object. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
 
 ## Useful Links
 

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -29,10 +29,13 @@ When your application uses `output: 'export'`, every [Dynamic Route](/docs/app/a
 
 This error also occurs when a dynamic route:
 
-- does not export a `generateStaticParams` function, or
-- returns an empty array from `generateStaticParams`.
+- does not export a `generateStaticParams` function,
+- returns an empty array from `generateStaticParams`, or
+- generates a route without every dynamic route parameter. For example, `{ slug: 'first' }` does not provide the `id` value for a route using an `[id]` segment.
 
-Export `generateStaticParams` from every dynamic route and return at least one params object. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
+When multiple route segments export `generateStaticParams`, Next.js combines the params returned by each parent and child function before generating routes.
+
+Export `generateStaticParams` from every dynamic route and make sure the combined params include all dynamic route parameters for every generated route. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
 
 ## Useful Links
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1451,5 +1451,6 @@
   "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1452,5 +1452,6 @@
   "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1455": "Page \"%s\" returned incomplete params from \"generateStaticParams()\". With \"output: export\", every params object must include all dynamic route parameters. Missing: %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1449,5 +1449,7 @@
   "1448": "Error in the \"%s\" app-route HMR subscription",
   "1449": "Accessed `searchParams` during prerendering.",
   "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2439,7 +2439,7 @@ export default async function build(
                               !hasGenerateStaticParams
                             ) {
                               throw new Error(
-                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params`
                               )
                             }
 

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -965,7 +965,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -981,7 +982,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -996,7 +998,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ id: '1' }, { id: '2' }])
     })
@@ -1018,7 +1021,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { category: 'tech', slug: 'tech-post-1' },
@@ -1043,7 +1047,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
@@ -1065,7 +1070,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en', slug: 'en-slug' }])
     })
@@ -1080,7 +1086,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -1096,7 +1103,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en' }])
     })
@@ -1114,7 +1122,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
@@ -1136,7 +1145,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(store.fetchCache).toBe('force-cache')
     })
@@ -1151,7 +1161,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(store.fetchCache).toBe('force-cache')
     })
@@ -1171,7 +1182,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       // Should have the last fetchCache value
       expect(store.fetchCache).toBe('default-cache')
@@ -1192,7 +1204,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ slug: ['a', 'b'] }, { slug: ['c', 'd', 'e'] }])
     })
@@ -1210,7 +1223,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en', slug: ['en', 'post'] }])
     })
@@ -1230,7 +1244,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ a: '1', b: '1-2', c: '1-2-3', d: '1-2-3-4' }])
     })
@@ -1247,7 +1262,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { x: '1', y: 'a', z: 'i' },
@@ -1276,7 +1292,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           false,
-          []
+          [],
+          false
         )
       ).rejects.toThrow('Test error')
     })
@@ -1294,7 +1311,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           false,
-          []
+          [],
+          false
         )
       ).rejects.toThrow('Async error')
     })
@@ -1306,7 +1324,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1319,7 +1337,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1332,7 +1350,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1346,7 +1364,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1359,7 +1377,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1372,7 +1390,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type string. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1385,7 +1403,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type array. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1398,7 +1416,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1411,7 +1429,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type number. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1424,7 +1442,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1439,7 +1457,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1454,7 +1472,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1467,7 +1485,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1482,7 +1500,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1501,7 +1519,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1517,7 +1535,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1531,7 +1549,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1542,7 +1560,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).resolves.toEqual([{}])
     })
 
@@ -1563,9 +1581,35 @@ describe('generateRouteStaticParams', () => {
           store,
 
           false,
-          []
+          [],
+          false
         )
       ).rejects.toThrow('Tech not allowed')
+    })
+
+    it('should reject an empty array in export mode', async () => {
+      const segments: TestAppSegment[] = [createMockSegment(async () => [])]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [], true)
+      ).rejects.toThrow(
+        'Page "/test-page" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject an empty array from a nested generateStaticParams in export mode', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(async () => []),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [], true)
+      ).rejects.toThrow(
+        'Page "/test-page" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
     })
 
     it('should throw error when generateStaticParams returns empty array with isRoutePPREnabled=true', async () => {
@@ -1580,7 +1624,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           true,
-          []
+          [],
+          false
         )
       ).rejects.toThrow(
         'When using Cache Components, all `generateStaticParams` functions must return at least one result'
@@ -1598,7 +1643,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           true,
-          []
+          [],
+          false
         )
       ).rejects.toThrow(
         'When using Cache Components, all `generateStaticParams` functions must return at least one result'
@@ -1616,7 +1662,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en' }])
     })
@@ -1631,7 +1678,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -1660,7 +1708,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toHaveLength(12) // 3 langs × 2 categories × 2 slugs
       expect(result).toContainEqual({
@@ -1698,7 +1747,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         {
@@ -1739,7 +1789,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toHaveLength(8) // 2 years × 2 months × 2 slug variations
       expect(result).toContainEqual({
@@ -1765,7 +1816,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toHaveLength(1)
       expect(Object.keys(result[0])).toHaveLength(5000)

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -614,7 +614,8 @@ async function callGenerateStaticParams(
   generateStaticParams: NonNullable<AppSegment['generateStaticParams']>,
   parentParams: Params,
   rootParamKeys: readonly string[],
-  implicitTags: ImplicitTags
+  implicitTags: ImplicitTags,
+  isStaticExport: boolean
 ): Promise<Params[]> {
   const rootParams: Params = {}
   for (const key of rootParamKeys) {
@@ -642,6 +643,12 @@ async function callGenerateStaticParams(
     )
   }
 
+  if (isStaticExport && generatedParams.length === 0) {
+    throw new Error(
+      `Page "${page}" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params`
+    )
+  }
+
   for (const [index, params] of generatedParams.entries()) {
     if (!isPlainObject(params)) {
       throw new Error(
@@ -663,6 +670,7 @@ async function callGenerateStaticParams(
  * @param store - Work store for tracking fetch cache configuration
  * @param isRoutePPREnabled - Whether PPR is enabled for this route
  * @param rootParamKeys - The keys identifying which params are root params
+ * @param isStaticExport - Whether the route is built with output: export
  * @returns Promise that resolves to an array of all parameter combinations
  */
 export async function generateRouteStaticParams(
@@ -676,7 +684,8 @@ export async function generateRouteStaticParams(
   >,
   store: Pick<WorkStore, 'fetchCache' | 'page'>,
   isRoutePPREnabled: boolean,
-  rootParamKeys: readonly string[]
+  rootParamKeys: readonly string[],
+  isStaticExport: boolean
 ): Promise<Params[]> {
   // Early return if no segments to process
   if (segments.length === 0) return []
@@ -725,7 +734,8 @@ export async function generateRouteStaticParams(
           current.generateStaticParams,
           parentParams,
           rootParamKeys,
-          implicitTags
+          implicitTags,
+          isStaticExport
         )
 
         if (result.length > 0) {
@@ -747,7 +757,8 @@ export async function generateRouteStaticParams(
         current.generateStaticParams,
         {},
         rootParamKeys,
-        implicitTags
+        implicitTags,
+        isStaticExport
       )
       if (result.length === 0 && isRoutePPREnabled) {
         throwEmptyGenerateStaticParamsError(current.createEmptyParamsError)
@@ -915,7 +926,8 @@ export async function buildAppStaticPaths({
     segments,
     store,
     isRoutePPREnabled,
-    rootParamKeys
+    rootParamKeys,
+    nextConfigOutput === 'export'
   )
   const generatedParamNames = new Set<string>()
   for (const params of routeParams) {

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -977,17 +977,29 @@ export async function buildAppStaticPaths({
     }
   }
 
+  const missingParamNames: string[] = []
+  if (routeParams.length > 0) {
+    for (const { paramName } of pathnameRouteParamSegments) {
+      if (routeParams.some((params) => !(paramName in params))) {
+        missingParamNames.push(paramName)
+      }
+    }
+  }
+
   // Determine if all the segments have had their parameters provided.
   const hadAllParamsGenerated =
     pathnameRouteParamSegments.length === 0 ||
-    (routeParams.length > 0 &&
-      routeParams.every((params) => {
-        for (const { paramName } of pathnameRouteParamSegments) {
-          if (paramName in params) continue
-          return false
-        }
-        return true
-      }))
+    (routeParams.length > 0 && missingParamNames.length === 0)
+
+  if (
+    nextConfigOutput === 'export' &&
+    routeParams.length > 0 &&
+    !hadAllParamsGenerated
+  ) {
+    throw new Error(
+      `Page "${page}" returned incomplete params from "generateStaticParams()". With "output: export", every params object must include all dynamic route parameters. Missing: ${missingParamNames.map((name) => `"${name}"`).join(', ')}. See more info here: https://nextjs.org/docs/messages/generate-static-params`
+    )
+  }
 
   // TODO: dynamic params should be allowed to be granular per segment but
   // we need additional information stored/leveraged in the prerender

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -857,7 +857,7 @@ export default class DevServer extends Server {
           if (this.nextConfig.output === 'export') {
             if (!prerenderedRoutes) {
               throw new Error(
-                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config.`
+                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params`
               )
             }
 

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -39,6 +39,24 @@ describe('app dir - with output export - dynamic missing gsp', () => {
     })
   })
 
+  describe('should error when generateStaticParams returns incomplete params', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set wrong param',
+      expectedErrMsg:
+        'Page "/another/[slug]" returned incomplete params from "generateStaticParams()". With "output: export", every params object must include all dynamic route parameters. Missing: "slug". See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
+  describe('should error when one of the generated params is incomplete', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set mixed params',
+      expectedErrMsg:
+        'Page "/another/[slug]" returned incomplete params from "generateStaticParams()". With "output: export", every params object must include all dynamic route parameters. Missing: "slug". See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
   describe('should error when client component has generateStaticParams', () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? 'App pages cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -30,6 +30,15 @@ describe('app dir - with output export - dynamic missing gsp', () => {
     })
   })
 
+  describe('should error when generateStaticParams returns an empty array', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set empty',
+      expectedErrMsg:
+        'Page "/another/[slug]" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
   describe('should error when client component has generateStaticParams', () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? 'App pages cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -7,8 +7,8 @@ describe('app dir - with output export - dynamic missing gsp', () => {
       dynamicPage: 'undefined',
       generateStaticParamsOpt: 'set noop',
       expectedErrMsg: isNextDev
-        ? 'Page "/another/[slug]/page" is missing exported function "generateStaticParams()", which is required with "output: export" config.'
-        : 'Page "/another/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.',
+        ? 'Page "/another/[slug]/page" is missing exported function "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+        : 'Page "/another/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params',
     })
   })
 

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -222,7 +222,9 @@ export function runTests({
     | 'set client'
     | 'set empty'
     | 'set invalid entry'
+    | 'set mixed params'
     | 'set non-array'
+    | 'set wrong param'
   expectedErrMsg?: string | RegExp
 }) {
   let { next, skipped, isNextDev } = nextTestSetup({
@@ -300,6 +302,20 @@ export function runTests({
         content.replace(
           `return [{ slug: 'first' }, { slug: 'second' }]`,
           'return []'
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set wrong param') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          `return [{ id: 'first' }]`
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set mixed params') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          `return [{ slug: 'first' }, { id: 'second' }]`
         )
       )
     }

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -220,6 +220,7 @@ export function runTests({
   generateStaticParamsOpt?:
     | 'set noop'
     | 'set client'
+    | 'set empty'
     | 'set invalid entry'
     | 'set non-array'
   expectedErrMsg?: string | RegExp
@@ -292,6 +293,13 @@ export function runTests({
         content.replace(
           `return [{ slug: 'first' }, { slug: 'second' }]`,
           `return [null]`
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set empty') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          'return []'
         )
       )
     }


### PR DESCRIPTION
> [!TIP]
> This PR is best reviewed commit by commit.

### Why?

With `output: 'export'`, an empty array or incomplete params can be reported as a missing `generateStaticParams` function, even when the function exists.

### How?

- Throw when any `generateStaticParams` invocation returns `[]`.
- Throw when any composed parent and child params object omits a dynamic route parameter.
- Extend the troubleshooting page added in #95968 with the export-specific cases.

Stacked on #95968.

Supersedes #95388.

<!-- NEXT_JS_LLM -->

Co-authored-by: SukkaW <isukkaw@gmail.com>
