### PR TITLE
Mark Cache Components prefetch requests with purpose/prefer headers

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -22,6 +22,30 @@ export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 export const NEXT_INSTANT_TEST_COOKIE =
   'next-instant-navigation-testing' as const
 
+// Headers set on prefetch requests when Cache Components is enabled. Unlike
+// the Next.js-specific headers above, these are standard(-ish) HTTP headers,
+// so that infrastructure sitting in front of the application server (e.g. a
+// CDN or proxy) can use them to decide how to handle a prefetch request
+// without understanding Next.js protocol internals.
+//
+// `purpose: prefetch` marks the request as a prefetch, as opposed to a normal
+// navigation. (Browsers send the same header for speculative loads like
+// <link rel="prefetch">.)
+//
+// The `prefer` header describes what kind of response the client can accept:
+//
+// - `return=minimal`: a minimal response is sufficient. E.g. if only a
+//   partial fallback shell of the page is available, serving it as-is is
+//   fine, and should not trigger regeneration of the full page.
+// - `return=representation`: the client intends to use the response as a
+//   full representation of the page. E.g. if only a partial fallback shell is
+//   available, regeneration of the full page may be triggered.
+export const PURPOSE_HEADER = 'purpose' as const
+export const PURPOSE_PREFETCH = 'prefetch' as const
+export const PREFER_HEADER = 'prefer' as const
+export const PREFER_RETURN_MINIMAL = 'return=minimal' as const
+export const PREFER_RETURN_REPRESENTATION = 'return=representation' as const
+
 export const FLIGHT_HEADERS = [
   RSC_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -27,6 +27,11 @@ import {
   NEXT_DID_POSTPONE_HEADER,
   NEXT_HTML_REQUEST_ID_HEADER,
   NEXT_REQUEST_ID_HEADER,
+  type PURPOSE_HEADER,
+  type PURPOSE_PREFETCH,
+  type PREFER_HEADER,
+  type PREFER_RETURN_MINIMAL,
+  type PREFER_RETURN_REPRESENTATION,
 } from '../app-router-headers'
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
@@ -113,6 +118,13 @@ export type RequestHeaders = {
   [NEXT_URL]?: string
   [NEXT_ROUTER_PREFETCH_HEADER]?: '1' | '2' | '3'
   [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]?: string
+  // Set on prefetch requests when Cache Components is enabled, for
+  // infrastructure in front of the application server (e.g. a CDN or proxy).
+  // See app-router-headers.ts for details.
+  [PURPOSE_HEADER]?: typeof PURPOSE_PREFETCH
+  [PREFER_HEADER]?:
+    | typeof PREFER_RETURN_MINIMAL
+    | typeof PREFER_RETURN_REPRESENTATION
   'x-deployment-id'?: string
   [NEXT_HMR_REFRESH_HEADER]?: '1'
   // A header that is only added in test mode to assert on fetch priority

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -21,6 +21,11 @@ import {
   NEXT_ROUTER_STALE_TIME_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_URL,
+  PREFER_HEADER,
+  PREFER_RETURN_MINIMAL,
+  PREFER_RETURN_REPRESENTATION,
+  PURPOSE_HEADER,
+  PURPOSE_PREFETCH,
   RSC_CONTENT_TYPE_HEADER,
   RSC_HEADER,
 } from '../app-router-headers'
@@ -1816,6 +1821,15 @@ export async function fetchRouteOnCacheMiss(
   if (nextUrl !== null) {
     headers[NEXT_URL] = nextUrl
   }
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    // Mark the request as a prefetch for infrastructure in front of the
+    // application server (e.g. a CDN or proxy). See app-router-headers.ts for
+    // details. The route tree request is never speculative: it fetches a
+    // small, static description of the route's structure, and must not
+    // trigger regeneration of a partial fallback.
+    headers[PURPOSE_HEADER] = PURPOSE_PREFETCH
+    headers[PREFER_HEADER] = PREFER_RETURN_MINIMAL
+  }
 
   try {
     const url = new URL(pathname + search, location.origin)
@@ -2120,7 +2134,8 @@ export async function fetchSegmentsOnCacheMiss(
   routeKey: RouteCacheKey,
   tree: RouteTree,
   segments: SegmentBundle,
-  segmentCount: number
+  segmentCount: number,
+  isSpeculative: boolean
 ): Promise<PrefetchSubtaskResult<null> | null> {
   // This function is allowed to use async/await because it contains the actual
   // fetch that gets issued on a cache miss. Notice it writes the result to the
@@ -2131,7 +2146,12 @@ export async function fetchSegmentsOnCacheMiss(
   // on completion.
   let result
   try {
-    result = await fetchSegmentsOnCacheMissImpl(route, routeKey, tree)
+    result = await fetchSegmentsOnCacheMissImpl(
+      route,
+      routeKey,
+      tree,
+      isSpeculative
+    )
   } catch (error) {
     // The connection failed, or the response couldn't be decoded. Reject the
     // pending entries so they don't stay Pending forever, and get retried once
@@ -2191,7 +2211,8 @@ export async function fetchSegmentsOnCacheMiss(
       routeKey,
       tree,
       segments,
-      segmentCount
+      segmentCount,
+      isSpeculative
     )
   }
 
@@ -2219,7 +2240,8 @@ export async function fetchSegmentsOnCacheMiss(
 async function fetchSegmentsOnCacheMissImpl(
   route: FulfilledRouteCacheEntry,
   routeKey: RouteCacheKey,
-  tree: RouteTree
+  tree: RouteTree,
+  isSpeculative: boolean
 ): Promise<{
   serverResponse: SegmentPrefetchResponse
   responseSize: number
@@ -2251,6 +2273,18 @@ async function fetchSegmentsOnCacheMissImpl(
   }
   if (nextUrl !== null) {
     headers[NEXT_URL] = nextUrl
+  }
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    // Mark the request as a prefetch for infrastructure in front of the
+    // application server (e.g. a CDN or proxy). See app-router-headers.ts
+    // for details. Speculative requests fetch data beyond the route's
+    // reusable shell and may trigger regeneration of a partial fallback
+    // (`return=representation`); shell requests must not
+    // (`return=minimal`). The caller decides which kind this is.
+    headers[PURPOSE_HEADER] = PURPOSE_PREFETCH
+    headers[PREFER_HEADER] = isSpeculative
+      ? PREFER_RETURN_REPRESENTATION
+      : PREFER_RETURN_MINIMAL
   }
 
   const requestUrl = isOutputExportMode
@@ -2430,7 +2464,8 @@ async function retryUpgradeableFallbackPrefetch(
   routeKey: RouteCacheKey,
   tree: RouteTree,
   segments: SegmentBundle,
-  segmentCount: number
+  segmentCount: number,
+  isSpeculative: boolean
 ): Promise<void> {
   for (let attempt = 0; attempt < MAX_FALLBACK_RETRIES; attempt++) {
     await new Promise<void>((resolve) =>
@@ -2442,7 +2477,12 @@ async function retryUpgradeableFallbackPrefetch(
 
     let result
     try {
-      result = await fetchSegmentsOnCacheMissImpl(route, routeKey, tree)
+      result = await fetchSegmentsOnCacheMissImpl(
+        route,
+        routeKey,
+        tree,
+        isSpeculative
+      )
     } catch {
       // A hard failure (connection dropped, or the response couldn't be
       // decoded). Re-issuing the identical request won't fix it, so give up.
@@ -2528,18 +2568,42 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // We omit the prefetch header from a full prefetch because it's essentially
       // just a navigation request that happens ahead of time — it should include
       // all the same data in the response.
+      //
+      // For the same reason, we also omit the Cache Components prefetch
+      // headers (purpose/prefer): a full prefetch only reaches this point on
+      // a route that hasn't opted into Partial Prefetching (the scheduler
+      // coerces full prefetches on opted-in routes to the PPR strategy), so
+      // it's a legacy dynamic prefetch that must be indistinguishable from
+      // the navigation request it stands in for.
       break
     }
     case FetchStrategy.PPRRuntime: {
       headers[NEXT_ROUTER_PREFETCH_HEADER] = '2'
+      if (process.env.__NEXT_CACHE_COMPONENTS) {
+        // A runtime prefetch fetches data beyond the reusable shell, and may
+        // trigger regeneration of a partial fallback. See
+        // app-router-headers.ts for details on these headers.
+        headers[PURPOSE_HEADER] = PURPOSE_PREFETCH
+        headers[PREFER_HEADER] = PREFER_RETURN_REPRESENTATION
+      }
       break
     }
     case FetchStrategy.RuntimeShell: {
       headers[NEXT_ROUTER_PREFETCH_HEADER] = '3'
+      if (process.env.__NEXT_CACHE_COMPONENTS) {
+        // A shell prefetch is satisfiable by a partial fallback shell and
+        // must not trigger regeneration of the full page. See
+        // app-router-headers.ts for details on these headers.
+        headers[PURPOSE_HEADER] = PURPOSE_PREFETCH
+        headers[PREFER_HEADER] = PREFER_RETURN_MINIMAL
+      }
       break
     }
     case FetchStrategy.LoadingBoundary: {
       headers[NEXT_ROUTER_PREFETCH_HEADER] = '1'
+      // No Cache Components prefetch headers: this strategy is only used on
+      // routes that don't support per-segment prefetching, which don't have
+      // partial fallback shells for a proxy to act on.
       break
     }
     default: {

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -1831,6 +1831,16 @@ function pingSegmentBundle(
   if (!needsFetch) {
     return
   }
+  // On a route that opted into Partial Prefetching, per-segment requests
+  // fetch data beyond the reusable shell — they only ever happen during the
+  // Speculative phase (the Shell phase issues a single combined RuntimeShell
+  // request instead; see accumulateSegmentBundle) — so they may trigger
+  // regeneration of a partial fallback. Per-segment requests on routes
+  // without Partial Prefetching only ever fetch the static shell. The hint
+  // propagates to the root of the route tree from any segment that opted in,
+  // same as the strategy coercion in pingRoute.
+  const isSpeculative =
+    (route.tree.prefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) !== 0
   spawnPrefetchSubtask(
     fetchSegmentsOnCacheMiss(
       task,
@@ -1838,7 +1848,8 @@ function pingSegmentBundle(
       routeKey,
       tree,
       segments,
-      segmentCount
+      segmentCount,
+      isSpeculative
     )
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/default/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/default/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// No Partial Prefetching opt-ins. With a default (auto) link, the static
+// parts of this page are prefetched with per-segment requests.
+export default function Page() {
+  return (
+    <main>
+      <p id="default-static">Default route static content</p>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="default-dynamic">{`Default dynamic content: ${cookieValue}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/legacy/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/legacy/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// No Partial Prefetching opt-ins. Targeted by a <Link prefetch={true}>, which
+// performs a legacy "full" dynamic prefetch.
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="legacy-dynamic">{`Legacy dynamic content: ${cookieValue}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/nav-target/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/nav-target/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// Targeted by a <Link prefetch={false}>, so it's only ever requested by an
+// actual navigation.
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="nav-target-dynamic">{`Nav target content: ${cookieValue}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/page.tsx
@@ -1,0 +1,33 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <ul>
+      <li>
+        <LinkAccordion href="/default">
+          Default prefetch to a route without Partial Prefetching
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/pp">
+          Default prefetch to a Partial Prefetching route (instant + eager)
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/runtime" prefetch={true}>
+          Full prefetch to a runtime-prefetchable route (allow-runtime)
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/legacy" prefetch={true}>
+          Full prefetch to a route without Partial Prefetching
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/nav-target" prefetch={false}>
+          Unprefetched link, for testing navigation requests
+        </LinkAccordion>
+      </li>
+    </ul>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/pp/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/pp/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// Opts into Partial Prefetching (`instant`), and into eager prefetching so
+// the per-link Speculative prefetch fires for a default (auto) link.
+export const instant = true
+export const prefetch = 'unstable_eager'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p id="pp-shell">PP app shell</p>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="pp-dynamic">{`PP dynamic content: ${cookieValue}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/app/runtime/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// Opts into runtime prefetching. This page is targeted by a
+// <Link prefetch={true}>: because the route opted into Partial Prefetching,
+// the full prefetch is performed with the Cache Components strategy, and the
+// dynamic parts of the page are prefetched with a runtime request during the
+// Speculative phase.
+export const prefetch = 'allow-runtime'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p id="runtime-shell">Runtime app shell</p>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="runtime-dynamic">{`Runtime dynamic content: ${cookieValue}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-request-headers/prefetch-request-headers.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-request-headers/prefetch-request-headers.test.ts
@@ -1,0 +1,303 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+// This test asserts on the exact headers that the router sends with each
+// prefetch request. Normally we'd avoid asserting on wire-format details like
+// this, but these headers are a contract between Next.js and the
+// infrastructure deployed in front of the application server (e.g. a CDN or
+// proxy), which uses them to decide how to handle prefetch requests. The
+// headers themselves are the behavior under test.
+
+type CapturedRequest = {
+  url: string
+  headers: Record<string, string>
+}
+
+// The router request headers that are part of the contract. A request must
+// send exactly the expected subset of these — a missing expected header and
+// an unexpected extra header are both errors.
+const ROUTER_HEADERS = [
+  'next-router-prefetch',
+  'next-router-segment-prefetch',
+  'purpose',
+  'prefer',
+] as const
+
+function expectRouterHeaders(
+  request: CapturedRequest,
+  expected: Record<string, unknown>
+) {
+  const actual: Record<string, string> = {}
+  for (const name of ROUTER_HEADERS) {
+    const value = request.headers[name]
+    if (value !== undefined) {
+      actual[name] = value
+    }
+  }
+  expect(actual).toEqual(expected)
+}
+
+describe('segment cache (prefetch request headers)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  async function setup() {
+    const captured: Array<CapturedRequest> = []
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page: Playwright.Page) {
+        // Passively record every outgoing router request so we can assert on
+        // its headers. This doesn't interfere with router-act's interception,
+        // which controls response timing.
+        page.on('request', (request) => {
+          const headers = request.headers()
+          if (headers['rsc'] !== undefined) {
+            captured.push({ url: request.url(), headers })
+          }
+        })
+        act = createRouterAct(page, { includeAppShellRequests: true })
+      },
+    })
+    return { browser, act: act!, captured }
+  }
+
+  it(
+    'marks all prefetches of a route without Partial Prefetching as ' +
+      'shell prefetches (return=minimal)',
+    async () => {
+      const { browser, act, captured } = await setup()
+
+      // Reveal the link to /default. The route has no Partial Prefetching
+      // opt-ins, so its static data is prefetched with a route tree request
+      // followed by per-segment requests. None of these requests may trigger
+      // regeneration of a partial fallback, so all of them are marked
+      // `return=minimal`.
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/default"]')
+          .click()
+      })
+
+      let sawTreeRequest = false
+      let sawSegmentRequest = false
+      for (const request of captured) {
+        if (request.headers['next-router-segment-prefetch'] === '/_tree') {
+          // Route tree prefetch
+          sawTreeRequest = true
+          expectRouterHeaders(request, {
+            'next-router-prefetch': '1',
+            'next-router-segment-prefetch': '/_tree',
+            purpose: 'prefetch',
+            prefer: 'return=minimal',
+          })
+        } else {
+          // Static per-segment prefetch
+          sawSegmentRequest = true
+          expectRouterHeaders(request, {
+            'next-router-prefetch': '1',
+            'next-router-segment-prefetch': expect.any(String),
+            purpose: 'prefetch',
+            prefer: 'return=minimal',
+          })
+        }
+      }
+      expect(sawTreeRequest).toBe(true)
+      expect(sawSegmentRequest).toBe(true)
+    }
+  )
+
+  it(
+    'marks Shell-phase prefetches of a Partial Prefetching route as ' +
+      'return=minimal, and Speculative-phase prefetches as ' +
+      'return=representation',
+    async () => {
+      const { browser, act, captured } = await setup()
+
+      // Reveal the link to /pp, which opted into Partial Prefetching
+      // (`instant`) and eager prefetching. The prefetch happens in phases:
+      //
+      // - The route tree request and the App Shell request (Shell phase)
+      //   fetch the route's reusable shell. They must not trigger
+      //   regeneration of a partial fallback, so they're `return=minimal`.
+      // - The per-segment requests (Speculative phase) fetch the full static
+      //   output of the route, and are `return=representation`.
+      await act(async () => {
+        await browser.elementByCss('input[data-link-accordion="/pp"]').click()
+      })
+
+      let sawTreeRequest = false
+      let sawAppShellRequest = false
+      let sawSegmentRequest = false
+      for (const request of captured) {
+        if (request.headers['next-router-segment-prefetch'] === '/_tree') {
+          // Route tree prefetch
+          sawTreeRequest = true
+          expectRouterHeaders(request, {
+            'next-router-prefetch': '1',
+            'next-router-segment-prefetch': '/_tree',
+            purpose: 'prefetch',
+            prefer: 'return=minimal',
+          })
+        } else if (request.headers['next-router-prefetch'] === '3') {
+          // App Shell prefetch
+          sawAppShellRequest = true
+          expectRouterHeaders(request, {
+            'next-router-prefetch': '3',
+            purpose: 'prefetch',
+            prefer: 'return=minimal',
+          })
+        } else {
+          // Static per-segment prefetch
+          sawSegmentRequest = true
+          expectRouterHeaders(request, {
+            'next-router-prefetch': '1',
+            'next-router-segment-prefetch': expect.any(String),
+            purpose: 'prefetch',
+            prefer: 'return=representation',
+          })
+        }
+      }
+      expect(sawTreeRequest).toBe(true)
+      expect(sawAppShellRequest).toBe(true)
+      expect(sawSegmentRequest).toBe(true)
+    }
+  )
+
+  it('marks runtime prefetches as return=representation', async () => {
+    const { browser, act, captured } = await setup()
+
+    // Reveal the link to /runtime, which opted into runtime prefetching
+    // (`prefetch = 'allow-runtime'`). The link is rendered with
+    // prefetch={true}; because the route opted into Partial Prefetching, the
+    // full prefetch is performed with the Cache Components strategy instead
+    // of a legacy dynamic request. During the Speculative phase, the dynamic
+    // parts of the page are prefetched with a runtime request, which may
+    // trigger regeneration of a partial fallback (`return=representation`).
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/runtime"]')
+        .click()
+    })
+
+    let sawTreeRequest = false
+    let sawAppShellRequest = false
+    let sawRuntimeRequest = false
+    for (const request of captured) {
+      if (request.headers['next-router-segment-prefetch'] === '/_tree') {
+        // Route tree prefetch
+        sawTreeRequest = true
+        expectRouterHeaders(request, {
+          'next-router-prefetch': '1',
+          'next-router-segment-prefetch': '/_tree',
+          purpose: 'prefetch',
+          prefer: 'return=minimal',
+        })
+      } else if (request.headers['next-router-prefetch'] === '3') {
+        // App Shell prefetch (Shell phase)
+        sawAppShellRequest = true
+        expectRouterHeaders(request, {
+          'next-router-prefetch': '3',
+          purpose: 'prefetch',
+          prefer: 'return=minimal',
+        })
+      } else if (request.headers['next-router-prefetch'] === '2') {
+        // Runtime prefetch
+        sawRuntimeRequest = true
+        expectRouterHeaders(request, {
+          'next-router-prefetch': '2',
+          purpose: 'prefetch',
+          prefer: 'return=representation',
+        })
+      } else {
+        // Static per-segment prefetch (Speculative phase)
+        expectRouterHeaders(request, {
+          'next-router-prefetch': '1',
+          'next-router-segment-prefetch': expect.any(String),
+          purpose: 'prefetch',
+          prefer: 'return=representation',
+        })
+      }
+    }
+    expect(sawTreeRequest).toBe(true)
+    expect(sawAppShellRequest).toBe(true)
+    expect(sawRuntimeRequest).toBe(true)
+  })
+
+  it(
+    'does not mark a legacy full prefetch (prefetch={true} without ' +
+      'Partial Prefetching)',
+    async () => {
+      const { browser, act, captured } = await setup()
+
+      // Reveal the link to /legacy, which is rendered with prefetch={true}.
+      // The route has no Partial Prefetching opt-ins, so this performs a
+      // legacy "full" dynamic prefetch — essentially a navigation request
+      // that happens ahead of time. Because it must be indistinguishable from
+      // the navigation request it stands in for, it doesn't get the purpose
+      // or prefer headers. (The route tree request that precedes it is a
+      // normal shell prefetch.)
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/legacy"]')
+          .click()
+      })
+
+      let sawTreeRequest = false
+      let sawFullPrefetchRequest = false
+      for (const request of captured) {
+        if (request.headers['next-router-segment-prefetch'] === '/_tree') {
+          // Route tree prefetch
+          sawTreeRequest = true
+          expectRouterHeaders(request, {
+            'next-router-prefetch': '1',
+            'next-router-segment-prefetch': '/_tree',
+            purpose: 'prefetch',
+            prefer: 'return=minimal',
+          })
+        } else {
+          // Legacy full prefetch. Sends no router headers at all.
+          sawFullPrefetchRequest = true
+          expectRouterHeaders(request, {})
+        }
+      }
+      expect(sawTreeRequest).toBe(true)
+      expect(sawFullPrefetchRequest).toBe(true)
+    }
+  )
+
+  it('does not mark navigation requests', async () => {
+    const { browser, act, captured } = await setup()
+
+    // Reveal the link to /nav-target, which is rendered with prefetch={false},
+    // so nothing is prefetched. (Not wrapped in `act` because no requests are
+    // expected.)
+    await browser
+      .elementByCss('input[data-link-accordion="/nav-target"]')
+      .click()
+
+    // Navigate. The navigation request gets neither the purpose nor the
+    // prefer header.
+    captured.length = 0
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/nav-target"]').click()
+      },
+      { includes: 'Nav target content' }
+    )
+    expect(await browser.elementById('nav-target-dynamic').text()).toContain(
+      'Nav target content'
+    )
+
+    expect(captured.length).toBeGreaterThan(0)
+    for (const request of captured) {
+      // Navigation request. Sends no router headers at all.
+      expectRouterHeaders(request, {})
+    }
+  })
+})


### PR DESCRIPTION
Adds two headers to the prefetch requests issued by the Segment Cache, so that infrastructure deployed in front of the application server (e.g. a CDN or proxy) can identify prefetch requests and decide how to handle them:

- `purpose: prefetch` is sent on every Cache Components prefetch request.
- `prefer: return=minimal` is sent on requests that fetch the route's reusable shell and must not trigger regeneration of a partial fallback: the route tree request, the App Shell (RuntimeShell) request, and per-segment requests on routes that haven't opted into Partial Prefetching.
- `prefer: return=representation` is sent on speculative requests that fetch data beyond the reusable shell and may trigger regeneration of a partial fallback: per-segment requests on routes that opted into Partial Prefetching, and runtime prefetch requests.

Legacy "full" prefetches (`prefetch={true}` on a route without Partial Prefetching) don't get either header — by design they must remain indistinguishable from the navigation request they stand in for. Navigation requests are likewise unchanged.