### PR TITLE
Fix root pathname hydration mismatch during minimal-mode ISR

### DIFF
--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -1,7 +1,12 @@
 import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
 import type RenderResult from '../../render-result'
 import type { RenderOpts } from '../../app-render/types'
-import { addRequestMeta, type NextParsedUrlQuery } from '../../request-meta'
+import { MATCHED_PATH_HEADER } from '../../../lib/constants'
+import {
+  addRequestMeta,
+  getRequestMeta,
+  type NextParsedUrlQuery,
+} from '../../request-meta'
 import type { LoaderTree } from '../../lib/app-dir-module'
 import type { PrerenderManifest } from '../../../build'
 
@@ -144,6 +149,19 @@ export class AppPageRouteModule extends RouteModule<
       req.headers[RSC_HEADER] = '1'
     } else {
       super.normalizeUrl(req, parsedUrl)
+    }
+
+    // A matched root path identifies `/index` as a platform-internal alias.
+    // Without it, `/index` may be a public rewrite source that must remain
+    // available when route preparation applies user rewrites below.
+    if (
+      getRequestMeta(req, 'minimalMode') &&
+      !getRequestMeta(req, 'rewrittenPathname') &&
+      req.headers[MATCHED_PATH_HEADER] === '/' &&
+      this.definition.pathname === '/' &&
+      parsedUrl.pathname === '/index'
+    ) {
+      parsedUrl.pathname = '/'
     }
 
     // Minimal adapters can bypass base-server request normalization and invoke

--- a/test/production/app-dir/root-pathname-isr-minimal-mode/app/layout.tsx
+++ b/test/production/app-dir/root-pathname-isr-minimal-mode/app/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+import { Pathname } from './pathname'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Pathname />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/production/app-dir/root-pathname-isr-minimal-mode/app/page.tsx
+++ b/test/production/app-dir/root-pathname-isr-minimal-mode/app/page.tsx
@@ -1,0 +1,6 @@
+// Make the root page ISR-enabled so the test exercises regeneration.
+export const revalidate = 1
+
+export default function Page() {
+  return <p id="page">hello world</p>
+}

--- a/test/production/app-dir/root-pathname-isr-minimal-mode/app/pathname.tsx
+++ b/test/production/app-dir/root-pathname-isr-minimal-mode/app/pathname.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+export function Pathname() {
+  return <p id="pathname">{usePathname()}</p>
+}

--- a/test/production/app-dir/root-pathname-isr-minimal-mode/next.config.js
+++ b/test/production/app-dir/root-pathname-isr-minimal-mode/next.config.js
@@ -1,0 +1,36 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // This fixture exercises legacy ISR through `revalidate`. CI also runs it
+  // with Cache Components and Cached Navigations enabled through environment
+  // variables, so explicitly keep both incompatible features disabled.
+  cacheComponents: false,
+  experimental: {
+    cachedNavigations: false,
+  },
+  // Root-path normalization must distinguish the platform's internal `/index`
+  // alias from a real user rewrite whose public source remains `/index`. Gate
+  // this rewrite by a header so the primary ISR reproduction is unchanged.
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: '/index',
+          has: [
+            {
+              type: 'header',
+              key: 'x-test-index-rewrite',
+              value: '1',
+            },
+          ],
+          destination: '/',
+        },
+      ],
+      afterFiles: [],
+      fallback: [],
+    }
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/root-pathname-isr-minimal-mode/root-pathname-isr-minimal-mode.test.ts
+++ b/test/production/app-dir/root-pathname-isr-minimal-mode/root-pathname-isr-minimal-mode.test.ts
@@ -1,0 +1,73 @@
+import cheerio from 'cheerio'
+import { nextTestSetup } from 'e2e-utils'
+import { withInvocationId } from 'next-test-utils'
+
+describe('root pathname during minimal-mode ISR', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: {
+      // Reproduce the platform's minimal-mode request path locally.
+      NEXT_PRIVATE_MINIMAL_MODE: '1',
+      // Keep x-matched-path from being stripped as an external-only header.
+      NEXT_PRIVATE_TEST_HEADERS: '1',
+    },
+  })
+
+  it('keeps the root pathname when ISR is invoked through /index', async () => {
+    const initial$ = await next.render$('/')
+    expect(initial$('#pathname').text()).toBe('/')
+
+    // The platform invokes root ISR through its internal `/index` path while
+    // `x-matched-path` identifies the public route as `/`. Minimal-mode
+    // responses are scoped by invocation, so this generates a fresh response.
+    const invocation = withInvocationId({
+      redirect: 'manual',
+      headers: {
+        'x-matched-path': '/',
+      },
+    })
+    const response = await next.fetch('/index', invocation)
+    const regeneratedHtml = await response.text()
+    const regenerated$ = cheerio.load(regeneratedHtml)
+
+    // Reuse the invocation so `/` hydrates the response generated through
+    // `/index`, matching how the platform serves the regenerated entry.
+    const browser = await next.browser('/', {
+      pushErrorAsConsoleLog: true,
+      extraHTTPHeaders: {
+        'x-invocation-id': (invocation.headers as Record<string, string>)[
+          'x-invocation-id'
+        ],
+      },
+    })
+    const browserLogs = await browser.log()
+
+    expect(response.status).toBe(200)
+    expect(regenerated$('#page').text()).toBe('hello world')
+    expect(browserLogs).not.toContainEqual(
+      expect.objectContaining({
+        source: 'error',
+        message: expect.stringContaining('Minified React error #418'),
+      })
+    )
+    expect(regenerated$('#pathname').text()).toBe('/')
+  })
+
+  // A real user rewrite can produce the same root route and `/index` request
+  // shape as the platform's internal alias. Only the internal alias should be
+  // normalized; the rewrite must retain its browser-visible source pathname.
+  it('keeps the source pathname when /index is rewritten to the root', async () => {
+    const invocation = withInvocationId({
+      headers: {
+        'x-test-index-rewrite': '1',
+      },
+    })
+    const response = await next.fetch('/index', invocation)
+    const html = await response.text()
+    const $ = cheerio.load(html)
+
+    expect(response.status).toBe(200)
+    expect($('#page').text()).toBe('hello world')
+    expect($('#pathname').text()).toBe('/index')
+  })
+})


### PR DESCRIPTION
### Why?

Minimal-mode ISR can regenerate the App Router root through the internal `/index` pathname even though `x-matched-path` identifies the public route as `/`. The regenerated response then renders `usePathname()` as `/index`, while the browser hydrates at `/`, causing React error `#418`.

Current behavior: https://github.com/vercel/next.js/actions/runs/29773240589/job/88456779708?pr=95973#step:32:280

A real user rewrite from `/index` to `/` must continue exposing `/index` as its browser-visible pathname.

### How?

- Normalize `/index` to `/` only for minimal-mode requests targeting the root App Page.
- Preserve `/index` when rewrite metadata identifies it as the public source pathname.
- Add production coverage for the failing ISR hydration path and the user-rewrite preservation case.

Fixes #95648

<!-- NEXT_JS_LLM -->