### PR TITLE
turbo-tasks-backend: add persistence delete/tombstone plumbing for GC

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1244,7 +1244,7 @@ impl TurboTasksBackend {
                 None
             };
 
-            SnapshotItem {
+            SnapshotItem::Put {
                 task_id,
                 meta,
                 data,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -1044,7 +1044,7 @@ mod tests {
         _: &super::TaskStorage,
         _: &mut TurboBincodeBuffer,
     ) -> SnapshotItem {
-        SnapshotItem {
+        SnapshotItem::Put {
             task_id,
             meta: Some(TurboBincodeBuffer::default()),
             data: None,
@@ -1112,7 +1112,7 @@ mod tests {
 
         // The pre-snapshot snapshot copy should have been encoded and returned.
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, task_id);
+        assert_eq!(items[0].task_id(), task_id);
 
         {
             let guard = storage.access_mut(task_id);
@@ -1179,7 +1179,7 @@ mod tests {
             .collect();
 
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, task_id);
+        assert_eq!(items[0].task_id(), task_id);
 
         {
             let guard = storage.access_mut(task_id);
@@ -1227,7 +1227,7 @@ mod tests {
             .collect();
 
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, task_id);
+        assert_eq!(items[0].task_id(), task_id);
 
         // The entry must be gone from the map now that it has been persisted.
         assert!(
@@ -1324,7 +1324,7 @@ mod tests {
             .flat_map(|shard| shard.into_iter())
             .collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].task_id, modified_id);
+        assert_eq!(items[0].task_id(), modified_id);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -8,15 +8,50 @@ use turbo_tasks_hash::Xxh3Hash64Hasher;
 
 pub type TaskTypeHash = [u8; 8];
 
-/// A single item yielded by the snapshot iterator during persistence.
-pub struct SnapshotItem {
+/// A single item yielded by the snapshot iterator during persistence: either a put (persist a
+/// modified task's meta/data + optionally register a new task's type) or a delete (tombstone a
+/// GC-collected task's on-disk copy). Both ride the one streaming iterator `save_snapshot`
+/// consumes, so GC tombstones are applied in the same commit and batch as the puts without a
+/// side-channel that would have to be fully materialized before the put loop.
+pub enum SnapshotItem {
+    Put {
+        task_id: TaskId,
+        /// Serialized task meta data, if modified
+        meta: Option<TurboBincodeBuffer>,
+        /// Serialized task data, if modified
+        data: Option<TurboBincodeBuffer>,
+        /// Task type for new tasks that need to be added to the task cache
+        task_type_hash: Option<TaskTypeHash>,
+    },
+    /// Tombstone a GC-collected task (see [`TaskDeletion`]).
+    ///
+    /// Not yet constructed: this PR lands the persistence-side delete mechanism (the
+    /// `save_snapshot` handling below + its tests). The GC pass that emits `Delete` for
+    /// soft-deleted tasks lands in a later PR in the stack.
+    #[allow(dead_code)]
+    Delete(TaskDeletion),
+}
+
+impl SnapshotItem {
+    /// The task this item persists or tombstones. (Currently only used by tests, which assert on
+    /// the id of items yielded by the snapshot iterator.)
+    #[cfg(test)]
+    pub fn task_id(&self) -> TaskId {
+        match self {
+            SnapshotItem::Put { task_id, .. } => *task_id,
+            SnapshotItem::Delete(TaskDeletion { task_id, .. }) => *task_id,
+        }
+    }
+}
+
+/// A GC-collected task to tombstone from persistent storage, applied in the same commit as the
+/// snapshot. See `save_snapshot` for how the tombstone is applied (the `TaskCache` bucket
+/// re-insertion of hash-colliding survivors lives there).
+pub struct TaskDeletion {
     pub task_id: TaskId,
-    /// Serialized task meta data, if modified
-    pub meta: Option<TurboBincodeBuffer>,
-    /// Serialized task data, if modified
-    pub data: Option<TurboBincodeBuffer>,
-    /// Task type for new tasks that need to be added to the task cache
-    pub task_type_hash: Option<TaskTypeHash>,
+    /// The deleted task's `TaskCache` key. Always present: only persistent tasks are collected,
+    /// and those always have a task type.
+    pub task_type_hash: TaskTypeHash,
 }
 
 /// Computes a deterministic 64-bit hash of a CachedTaskType for use as a TaskCache key.

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -10,9 +10,8 @@ pub type TaskTypeHash = [u8; 8];
 
 /// A single item yielded by the snapshot iterator during persistence: either a put (persist a
 /// modified task's meta/data + optionally register a new task's type) or a delete (tombstone a
-/// GC-collected task's on-disk copy). Both ride the one streaming iterator `save_snapshot`
-/// consumes, so GC tombstones are applied in the same commit and batch as the puts without a
-/// side-channel that would have to be fully materialized before the put loop.
+/// GC-collected task's on-disk copy). Both ride the one iterator `save_snapshot` consumes, so
+/// tombstones are applied in the same commit and batch as the puts.
 pub enum SnapshotItem {
     Put {
         task_id: TaskId,
@@ -23,23 +22,8 @@ pub enum SnapshotItem {
         /// Task type for new tasks that need to be added to the task cache
         task_type_hash: Option<TaskTypeHash>,
     },
-    /// Tombstone a GC-collected task, applied in the same commit as the surrounding puts.
-    ///
-    /// This is identity-only — no copy of the `TaskMeta`/`TaskData` buffers or the full
-    /// `CachedTaskType` behind the hash — because that is all the deletion needs:
-    ///
-    /// - `TaskMeta` and `TaskData` are `SingleValue`, so a key-granular delete is exact.
-    /// - `TaskCache` is `MultiValue` and keyed by the type hash, so deleting the key would also
-    ///   drop any task type that xxh3-collides with this one. The task id is the value in that
-    ///   bucket, so `delete_value` names exactly the one mapping to remove.
-    ///
-    /// Every part of this is a buffered write; nothing is read back at commit time. Compaction
-    /// drops the tombstoned entry the next time it rewrites the key group, and reads filter it out
-    /// until then.
-    ///
-    /// Not yet constructed: this PR lands the persistence-side delete mechanism (the
-    /// `save_snapshot` handling below + its tests). The GC pass that emits `Delete` for
-    /// soft-deleted tasks lands in a later PR in the stack.
+    // Constructed by the GC pass that emits `Delete` for soft-deleted tasks, which lands in a
+    // later PR in the stack.
     #[allow(dead_code)]
     Delete {
         task_id: TaskId,

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -47,6 +47,21 @@ impl SnapshotItem {
 /// A GC-collected task to tombstone from persistent storage, applied in the same commit as the
 /// snapshot. See `save_snapshot` for how the tombstone is applied (the `TaskCache` bucket
 /// re-insertion of hash-colliding survivors lives there).
+///
+/// This is identity-only: the task's id and the hash of its type, with no copy of the value being
+/// deleted (neither the `TaskMeta`/`TaskData` buffers nor the full `CachedTaskType` behind the
+/// hash). That is enough for `TaskMeta` and `TaskData`, which are `SingleValue` key spaces where a
+/// key-granular delete is exact.
+///
+/// It costs us on `TaskCache`, which is `MultiValue`: a delete tombstones the entire hash bucket,
+/// so `save_snapshot` has to read the bucket back and re-insert every id that xxh3-collides with a
+/// deleted one. Carrying the full `CachedTaskType` here would not avoid that read — the underlying
+/// write batch has no delete-one-value-from-a-bucket operation, so removing a single entry from a
+/// `MultiValue` bucket is a read-modify-write no matter what the caller hands us. Doing better
+/// means a new persistence primitive (a value-granular `MultiValue` delete), not a fatter
+/// tombstone, so we keep the tombstone small and pay the read. In practice the read is cheap:
+/// hash collisions are rare, so almost every bucket contains exactly the one id being deleted and
+/// the survivor set is empty.
 pub struct TaskDeletion {
     pub task_id: TaskId,
     /// The deleted task's `TaskCache` key. Always present: only persistent tasks are collected,

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -45,36 +45,20 @@ impl SnapshotItem {
 }
 
 /// A GC-collected task to tombstone from persistent storage, applied in the same commit as the
-/// snapshot. See `save_snapshot` for how the tombstone is applied (the `TaskCache` bucket
-/// re-insertion of hash-colliding survivors lives there).
+/// snapshot. See `save_snapshot` for how the tombstone is applied.
 ///
-/// This is identity-only: the task's id and the hash of its type, with no copy of the value being
-/// deleted (neither the `TaskMeta`/`TaskData` buffers nor the full `CachedTaskType` behind the
-/// hash). That is enough for `TaskMeta` and `TaskData`, which are `SingleValue` key spaces where a
-/// key-granular delete is exact.
+/// This is identity-only: the task's id and the hash of its type, with no copy of the
+/// `TaskMeta`/`TaskData` buffers or the full `CachedTaskType` behind the hash. That is all the
+/// deletion needs:
 ///
-/// It costs us on `TaskCache`, which is `MultiValue`: a tombstone there is value-less, so it can
-/// only mean "drop the whole hash bucket". That forces `save_snapshot` to read the bucket back and
-/// re-insert every id that xxh3-collides with a deleted one, synchronously, on every GC commit.
+/// - `TaskMeta` and `TaskData` are `SingleValue`, so a key-granular delete is exact.
+/// - `TaskCache` is `MultiValue` and keyed by the type hash, so deleting the key would also drop
+///   any task type that xxh3-collides with this one. The task id is the value in that bucket, so
+///   `delete_value` names exactly the one mapping to remove.
 ///
-/// The cleaner design is a *valued* tombstone: record the id being deleted alongside the key, and
-/// let the deletion stay lazy the way the rest of `turbo-persistence` already is. Nothing would
-/// need to be read at commit time — compaction drops the matching entry the next time it rewrites
-/// the key group, and reads filter it out until then. The two places that would change already
-/// inspect tombstones and already have the entry in hand: the `MultiValue` arm of the compaction
-/// merge (which today sets `skip_remaining_for_this_key` on any tombstone) and `get_impl` (which
-/// today stops at the first tombstone). Both would narrow from "skip the group" to "skip entries
-/// matching this value". Tombstones already sort last within a key group, so a filtering pass sees
-/// every value before the tombstone that kills it, and `TaskCache` values are 4-byte task ids,
-/// small enough to ride inline in the tombstone entry.
-///
-/// That is a `turbo-persistence` format change (the on-disk `Deleted` entry type carries no value
-/// bytes today, so old and new tombstones would have to coexist behind a version bump) plus a query
-/// change (reads could no longer return early at the first tombstone; they would have to accumulate
-/// tombstones across all older layers). It is out of scope here and does not change this struct's
-/// shape — `TaskDeletion` already carries exactly the identity such a tombstone needs. Until then
-/// we pay the read, which is cheap in practice: collisions are rare, so almost every bucket holds
-/// only the one id being deleted and the survivor set is empty.
+/// Every part of this is a buffered write; nothing is read back at commit time. Compaction drops
+/// the tombstoned entry the next time it rewrites the key group, and reads filter it out until
+/// then.
 pub struct TaskDeletion {
     pub task_id: TaskId,
     /// The deleted task's `TaskCache` key. Always present: only persistent tasks are collected,

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -53,15 +53,28 @@ impl SnapshotItem {
 /// hash). That is enough for `TaskMeta` and `TaskData`, which are `SingleValue` key spaces where a
 /// key-granular delete is exact.
 ///
-/// It costs us on `TaskCache`, which is `MultiValue`: a delete tombstones the entire hash bucket,
-/// so `save_snapshot` has to read the bucket back and re-insert every id that xxh3-collides with a
-/// deleted one. Carrying the full `CachedTaskType` here would not avoid that read — the underlying
-/// write batch has no delete-one-value-from-a-bucket operation, so removing a single entry from a
-/// `MultiValue` bucket is a read-modify-write no matter what the caller hands us. Doing better
-/// means a new persistence primitive (a value-granular `MultiValue` delete), not a fatter
-/// tombstone, so we keep the tombstone small and pay the read. In practice the read is cheap:
-/// hash collisions are rare, so almost every bucket contains exactly the one id being deleted and
-/// the survivor set is empty.
+/// It costs us on `TaskCache`, which is `MultiValue`: a tombstone there is value-less, so it can
+/// only mean "drop the whole hash bucket". That forces `save_snapshot` to read the bucket back and
+/// re-insert every id that xxh3-collides with a deleted one, synchronously, on every GC commit.
+///
+/// The cleaner design is a *valued* tombstone: record the id being deleted alongside the key, and
+/// let the deletion stay lazy the way the rest of `turbo-persistence` already is. Nothing would
+/// need to be read at commit time — compaction drops the matching entry the next time it rewrites
+/// the key group, and reads filter it out until then. The two places that would change already
+/// inspect tombstones and already have the entry in hand: the `MultiValue` arm of the compaction
+/// merge (which today sets `skip_remaining_for_this_key` on any tombstone) and `get_impl` (which
+/// today stops at the first tombstone). Both would narrow from "skip the group" to "skip entries
+/// matching this value". Tombstones already sort last within a key group, so a filtering pass sees
+/// every value before the tombstone that kills it, and `TaskCache` values are 4-byte task ids,
+/// small enough to ride inline in the tombstone entry.
+///
+/// That is a `turbo-persistence` format change (the on-disk `Deleted` entry type carries no value
+/// bytes today, so old and new tombstones would have to coexist behind a version bump) plus a query
+/// change (reads could no longer return early at the first tombstone; they would have to accumulate
+/// tombstones across all older layers). It is out of scope here and does not change this struct's
+/// shape — `TaskDeletion` already carries exactly the identity such a tombstone needs. Until then
+/// we pay the read, which is cheap in practice: collisions are rare, so almost every bucket holds
+/// only the one id being deleted and the survivor set is empty.
 pub struct TaskDeletion {
     pub task_id: TaskId,
     /// The deleted task's `TaskCache` key. Always present: only persistent tasks are collected,

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -23,13 +23,30 @@ pub enum SnapshotItem {
         /// Task type for new tasks that need to be added to the task cache
         task_type_hash: Option<TaskTypeHash>,
     },
-    /// Tombstone a GC-collected task (see [`TaskDeletion`]).
+    /// Tombstone a GC-collected task, applied in the same commit as the surrounding puts.
+    ///
+    /// This is identity-only — no copy of the `TaskMeta`/`TaskData` buffers or the full
+    /// `CachedTaskType` behind the hash — because that is all the deletion needs:
+    ///
+    /// - `TaskMeta` and `TaskData` are `SingleValue`, so a key-granular delete is exact.
+    /// - `TaskCache` is `MultiValue` and keyed by the type hash, so deleting the key would also
+    ///   drop any task type that xxh3-collides with this one. The task id is the value in that
+    ///   bucket, so `delete_value` names exactly the one mapping to remove.
+    ///
+    /// Every part of this is a buffered write; nothing is read back at commit time. Compaction
+    /// drops the tombstoned entry the next time it rewrites the key group, and reads filter it out
+    /// until then.
     ///
     /// Not yet constructed: this PR lands the persistence-side delete mechanism (the
     /// `save_snapshot` handling below + its tests). The GC pass that emits `Delete` for
     /// soft-deleted tasks lands in a later PR in the stack.
     #[allow(dead_code)]
-    Delete(TaskDeletion),
+    Delete {
+        task_id: TaskId,
+        /// The deleted task's `TaskCache` key. Always present: only persistent tasks are
+        /// collected, and those always have a task type.
+        task_type_hash: TaskTypeHash,
+    },
 }
 
 impl SnapshotItem {
@@ -38,32 +55,9 @@ impl SnapshotItem {
     #[cfg(test)]
     pub fn task_id(&self) -> TaskId {
         match self {
-            SnapshotItem::Put { task_id, .. } => *task_id,
-            SnapshotItem::Delete(TaskDeletion { task_id, .. }) => *task_id,
+            SnapshotItem::Put { task_id, .. } | SnapshotItem::Delete { task_id, .. } => *task_id,
         }
     }
-}
-
-/// A GC-collected task to tombstone from persistent storage, applied in the same commit as the
-/// snapshot. See `save_snapshot` for how the tombstone is applied.
-///
-/// This is identity-only: the task's id and the hash of its type, with no copy of the
-/// `TaskMeta`/`TaskData` buffers or the full `CachedTaskType` behind the hash. That is all the
-/// deletion needs:
-///
-/// - `TaskMeta` and `TaskData` are `SingleValue`, so a key-granular delete is exact.
-/// - `TaskCache` is `MultiValue` and keyed by the type hash, so deleting the key would also drop
-///   any task type that xxh3-collides with this one. The task id is the value in that bucket, so
-///   `delete_value` names exactly the one mapping to remove.
-///
-/// Every part of this is a buffered write; nothing is read back at commit time. Compaction drops
-/// the tombstoned entry the next time it rewrites the key group, and reads filter it out until
-/// then.
-pub struct TaskDeletion {
-    pub task_id: TaskId,
-    /// The deleted task's `TaskCache` key. Always present: only persistent tasks are collected,
-    /// and those always have a task type.
-    pub task_type_hash: TaskTypeHash,
 }
 
 /// Computes a deterministic 64-bit hash of a CachedTaskType for use as a TaskCache key.

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -234,6 +234,17 @@ impl<'a> TurboWriteBatch<'a> {
             .put(key_space as u32, key.into_static(), value.into())
     }
 
+    /// Writes a delete (tombstone) for `key` into the write batch.
+    ///
+    /// For `SingleValue` families (`TaskMeta`, `TaskData`, `Infra`) this erases the key. For the
+    /// `MultiValue` `TaskCache` family this erases *all* values stored under the key (the whole
+    /// hash bucket); to remove a single mapping while keeping colliding entries, re-`put` the
+    /// survivors after the delete in the same batch (see `save_snapshot` in
+    /// `kv_backing_storage.rs`).
+    pub fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
+        self.batch.delete(key_space as u32, key.into_static())
+    }
+
     /// Flushes a key space of the write batch, reducing the amount of buffered memory used.
     /// Does not commit any data persistently.
     ///

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -236,19 +236,13 @@ impl<'a> TurboWriteBatch<'a> {
 
     /// Writes a delete (tombstone) for `key` into the write batch.
     ///
-    /// For `SingleValue` families (`TaskMeta`, `TaskData`, `Infra`) this erases the key. For the
-    /// `MultiValue` `TaskCache` family this erases *all* values stored under the key (the whole
-    /// hash bucket), including task types that merely collide with the intended one — use
-    /// [`Self::delete_value`] to remove a single mapping.
+    /// Use [`Self::delete_value`] to remove a single mapping from a MultiValue KeySpace
     pub fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.batch.delete(key_space as u32, key.into_static())
     }
 
     /// Writes a tombstone for a single `key` -> `value` mapping, leaving other values under `key`
     /// intact. Only valid for `MultiValue` families (`TaskCache`).
-    ///
-    /// Unlike [`Self::delete`], this needs no read of the existing bucket: the tombstone carries
-    /// the value it deletes and is applied lazily by reads and compaction.
     pub fn delete_value(
         &self,
         key_space: KeySpace,

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -238,11 +238,25 @@ impl<'a> TurboWriteBatch<'a> {
     ///
     /// For `SingleValue` families (`TaskMeta`, `TaskData`, `Infra`) this erases the key. For the
     /// `MultiValue` `TaskCache` family this erases *all* values stored under the key (the whole
-    /// hash bucket); to remove a single mapping while keeping colliding entries, re-`put` the
-    /// survivors after the delete in the same batch (see `save_snapshot` in
-    /// `kv_backing_storage.rs`).
+    /// hash bucket), including task types that merely collide with the intended one — use
+    /// [`Self::delete_value`] to remove a single mapping.
     pub fn delete(&self, key_space: KeySpace, key: WriteBuffer<'_>) -> Result<()> {
         self.batch.delete(key_space as u32, key.into_static())
+    }
+
+    /// Writes a tombstone for a single `key` -> `value` mapping, leaving other values under `key`
+    /// intact. Only valid for `MultiValue` families (`TaskCache`).
+    ///
+    /// Unlike [`Self::delete`], this needs no read of the existing bucket: the tombstone carries
+    /// the value it deletes and is applied lazily by reads and compaction.
+    pub fn delete_value(
+        &self,
+        key_space: KeySpace,
+        key: WriteBuffer<'_>,
+        value: WriteBuffer<'_>,
+    ) -> Result<()> {
+        self.batch
+            .delete_value(key_space as u32, key.into_static(), value.into())
     }
 
     /// Flushes a key space of the write batch, reducing the amount of buffered memory used.

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use turbo_bincode::{new_turbo_bincode_decoder, turbo_bincode_decode, turbo_bincode_encode};
 use turbo_persistence::CommitStats;
@@ -19,7 +20,10 @@ use turbo_tasks::{
 use crate::{
     GitVersionInfo,
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
-    backing_storage::{SnapshotItem, SnapshotMeta, compute_task_type_hash_from_components},
+    backing_storage::{
+        SnapshotItem, SnapshotMeta, TaskDeletion, TaskTypeHash,
+        compute_task_type_hash_from_components,
+    },
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
         db_versioning::handle_db_versioning,
@@ -236,20 +240,40 @@ impl TurboBackingStorage {
         let batch = self.inner.database.write_batch()?;
 
         {
-            let _span = tracing::trace_span!("update task data").entered();
-            let mut snapshot_meta =
+            let span = tracing::trace_span!("update task data");
+            // Each `Delete` item's `TaskMeta`/`TaskData` tombstone is applied inline in the
+            // parallel put phase; its `TaskCache` tombstone is deferred (returned in
+            // `shard_deletes`) to the sequential phase below, which merges these with
+            // the caller-supplied deletes.
+            let per_shard =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
+                    let _span = span.clone().entered();
                     let mut max_new_task_id = 0;
                     let mut data_items = 0;
                     let mut meta_items = 0;
                     let mut task_cache_items = 0;
-                    for SnapshotItem {
-                        task_id,
-                        meta,
-                        data,
-                        task_type_hash,
-                    } in shard
-                    {
+                    let mut shard_deletes: Vec<TaskDeletion> = Vec::new();
+                    for item in shard {
+                        let (task_id, meta, data, task_type_hash) = match item {
+                            SnapshotItem::Put {
+                                task_id,
+                                meta,
+                                data,
+                                task_type_hash,
+                            } => (task_id, meta, data, task_type_hash),
+                            SnapshotItem::Delete(deletion) => {
+                                // `TaskMeta`/`TaskData` are SingleValue: tombstone them inline
+                                // here. The `TaskCache` tombstone
+                                // (a MultiValue read-modify-write) is
+                                // carried out in `deletion` for the sequential phase below.
+                                let key = IntKey::new(*deletion.task_id);
+                                let key = key.as_ref();
+                                batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
+                                batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
+                                shard_deletes.push(deletion);
+                                continue;
+                            }
+                        };
                         let key = IntKey::new(*task_id);
                         let key = key.as_ref();
                         if let Some(meta) = meta {
@@ -279,28 +303,58 @@ impl TurboBackingStorage {
                             max_new_task_id = max_new_task_id.max(*task_id);
                         }
                     }
-                    Ok(SnapshotMeta {
-                        data_items,
-                        meta_items,
-                        task_cache_items,
-                        // The on-disk byte totals aren't known until the batch is committed below;
-                        // they're filled in from `CommitStats` after `batch.commit()`.
-                        bytes_written: 0,
-                        bytes_deleted: 0,
-                        max_next_task_id: max_new_task_id,
-                    })
-                })?
-                .into_iter()
-                .reduce(|t1, t2| t1.merge(t2))
-                .unwrap_or_default();
+                    Ok((
+                        SnapshotMeta {
+                            data_items,
+                            meta_items,
+                            task_cache_items,
+                            // The on-disk byte totals aren't known until the batch is committed
+                            // below; they're filled in from `CommitStats` after `batch.commit()`.
+                            bytes_written: 0,
+                            bytes_deleted: 0,
+                            max_next_task_id: max_new_task_id,
+                        },
+                        shard_deletes,
+                    ))
+                })?;
+            // Merge the per-shard snapshot metadata and, in the same pass, group the deleted ids by
+            // their TaskCache hash bucket (their SingleValue TaskMeta/TaskData tombstones were
+            // already applied inline in the parallel phase above). TaskCache is MultiValue and a
+            // tombstone erases the *whole* bucket, so for each distinct hash we must re-insert
+            // every id still living in that bucket (any type that xxh3-collides with a
+            // deleted one). Normally each hash maps to exactly the single id being
+            // deleted, so the survivor set is empty.
+            let mut snapshot_meta = SnapshotMeta::default();
+            let mut deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>> =
+                FxHashMap::default();
+            let mut deleted_count = 0usize;
+            for (meta, shard_deletes) in per_shard {
+                snapshot_meta = snapshot_meta.merge(meta);
+                for deletion in shard_deletes {
+                    deleted_by_hash
+                        .entry(deletion.task_type_hash)
+                        .or_default()
+                        .push(deletion.task_id);
+                    deleted_count += 1;
+                }
+            }
 
-            let span = tracing::trace_span!("flush task data").entered();
+            if !deleted_by_hash.is_empty() {
+                apply_task_cache_deletions(
+                    &self.inner.database,
+                    &batch,
+                    deleted_by_hash,
+                    deleted_count,
+                )?;
+            }
+
+            let span = tracing::trace_span!("flush task data");
             parallel::try_for_each(
                 &[KeySpace::TaskMeta, KeySpace::TaskData, KeySpace::TaskCache],
                 |&key_space| {
                     let _span = span.clone().entered();
-                    // Safety: `map_collect_owned` has returned, so no concurrent `put` or
-                    // `delete` on these key spaces are in-flight.
+                    // Safety: the two loops above have completed so no concurrent `put` or `delete`
+                    // on these key spaces are in-flight.
                     unsafe { batch.flush(key_space) }
                 },
             )?;
@@ -415,6 +469,56 @@ impl TurboBackingStorage {
     pub(crate) fn has_unrecoverable_write_error(&self) -> bool {
         self.inner.database.has_unrecoverable_write_error()
     }
+}
+
+/// Applies the `TaskCache` tombstones for GC-collected tasks, grouped by their hash bucket.
+///
+/// `TaskCache` is MultiValue and a tombstone erases the *whole* bucket, so for each distinct hash
+/// we read the authoritative on-disk bucket and re-insert every id NOT being deleted — any type
+/// that xxh3-collides with a deleted one. Normally each hash maps to exactly the single deleted id,
+/// so the survivor set is empty. (A survivor that is a *new* task added in this same commit is
+/// covered by its own put; new tasks aren't on disk yet, so they can't appear here.)
+///
+/// Runs after all puts (each bucket is a read+delete+reinsert), but the buckets are independent
+/// (distinct hash keys, sharing only the `batch`/`database` refs), so they process in parallel:
+/// `batch.delete`/`batch.put` use the same thread-local collectors the put phase does, and
+/// `get_multiple` is a shared-ref read.
+fn apply_task_cache_deletions(
+    database: &TurboKeyValueDatabase,
+    batch: &TurboWriteBatch<'_>,
+    deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>>,
+    deleted_count: usize,
+) -> Result<()> {
+    let span = tracing::trace_span!("delete tasks", count = deleted_count);
+    // TODO: this would be a good usecase for a batch_get_multiple, that would optimize reading
+    parallel::try_for_each_owned(
+        deleted_by_hash.into_iter().collect::<Vec<_>>(),
+        |(task_type_hash, deleted_ids)| {
+            let _span = span.clone().entered();
+            let bucket = database
+                .get_multiple(KeySpace::TaskCache, &task_type_hash)
+                .with_context(|| {
+                    format!("Reading TaskCache bucket {task_type_hash:?} for GC re-insert")
+                })?;
+            batch.delete(
+                KeySpace::TaskCache,
+                WriteBuffer::Borrowed(&task_type_hash[..]),
+            )?;
+            for bytes in bucket {
+                let id = TaskId::try_from(as_u32(bytes)?)?;
+                if deleted_ids.contains(&id) {
+                    continue;
+                }
+                let survivor_key = IntKey::new(*id);
+                batch.put(
+                    KeySpace::TaskCache,
+                    WriteBuffer::Borrowed(&task_type_hash[..]),
+                    WriteBuffer::Vec(survivor_key.as_ref().to_vec()),
+                )?;
+            }
+            anyhow::Ok(())
+        },
+    )
 }
 
 fn get_next_free_task_id(batch: &TurboWriteBatch<'_>) -> Result<u32, anyhow::Error> {
@@ -587,6 +691,239 @@ mod tests {
             db.shutdown()?;
         }
 
+        Ok(())
+    }
+
+    fn task_data_key(task_id: TaskId) -> [u8; 4] {
+        (*task_id).to_le_bytes()
+    }
+
+    /// GC tombstone path: deleting a task must erase its `TaskMeta` and `TaskData`
+    /// (`SingleValue`) entries and its `TaskCache` (`MultiValue`) mapping, and the deletion must
+    /// survive a reopen. Written first so the persistence-layer semantics the sweep relies on are
+    /// pinned down independently of the mark/sweep logic (Stage 0).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_gc_delete_tombstones_meta_data_and_cache() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
+
+        let hash: u64 = 0xABCD_1234;
+        let task_id = TaskId::try_from(42u32).unwrap();
+
+        // Write the task's meta, data, and cache entries in one committed batch.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let batch = db.write_batch()?;
+            let key = task_data_key(task_id);
+            batch.put(
+                KeySpace::TaskMeta,
+                WriteBuffer::Borrowed(&key),
+                WriteBuffer::Borrowed(b"meta-bytes"),
+            )?;
+            batch.put(
+                KeySpace::TaskData,
+                WriteBuffer::Borrowed(&key),
+                WriteBuffer::Borrowed(b"data-bytes"),
+            )?;
+            batch.put(
+                KeySpace::TaskCache,
+                WriteBuffer::Borrowed(&hash.to_le_bytes()),
+                WriteBuffer::Borrowed(&key),
+            )?;
+            batch.commit()?;
+            db.shutdown()?;
+        }
+
+        // Sanity: everything is present before deletion.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let key = task_data_key(task_id);
+            assert!(db.get(KeySpace::TaskMeta, &key)?.is_some());
+            assert!(db.get(KeySpace::TaskData, &key)?.is_some());
+            assert_eq!(
+                db.get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
+                    .len(),
+                1
+            );
+            db.shutdown()?;
+        }
+
+        // Tombstone the task in a single committed batch (the shape save_snapshot uses for a
+        // delete list with no colliding survivors).
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let batch = db.write_batch()?;
+            let key = task_data_key(task_id);
+            batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(&key))?;
+            batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(&key))?;
+            batch.delete(
+                KeySpace::TaskCache,
+                WriteBuffer::Borrowed(&hash.to_le_bytes()),
+            )?;
+            batch.commit()?;
+            db.shutdown()?;
+        }
+
+        // Reopen: all three entries must be gone.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let key = task_data_key(task_id);
+            assert!(
+                db.get(KeySpace::TaskMeta, &key)?.is_none(),
+                "TaskMeta should be tombstoned"
+            );
+            assert!(
+                db.get(KeySpace::TaskData, &key)?.is_none(),
+                "TaskData should be tombstoned"
+            );
+            assert!(
+                db.get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
+                    .is_empty(),
+                "TaskCache mapping should be tombstoned"
+            );
+            db.shutdown()?;
+        }
+
+        Ok(())
+    }
+
+    /// The load-bearing correctness test for the "whole-key tombstone + re-put survivors" approach
+    /// to deleting one entry from the `MultiValue` `TaskCache`: when two task ids collide in one
+    /// hash bucket and we delete one, tombstoning the whole bucket and re-putting the survivor in
+    /// the *same* committed batch must leave exactly the survivor readable after a reopen.
+    ///
+    /// It also pins down the delete/put ordering question: within one commit the relative order of
+    /// the survivor `put` and the whole-bucket `delete` does **not** matter. `Collector::sorted`
+    /// sorts tombstones last within a key group regardless of insertion order, so the survivor
+    /// (ordered before the tombstone) always survives while older-SST entries for the key are
+    /// erased. We assert both orderings produce the same result.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_gc_delete_task_cache_reput_survivor() -> Result<()> {
+        // `put_before_delete` selects the order the two operations are added to the batch; the
+        // committed outcome must be identical either way.
+        async fn run_case(put_before_delete: bool) -> Result<()> {
+            let tempdir = tempfile::tempdir()?;
+            let path = tempdir.path();
+
+            let collision_hash: u64 = 0xDEAD_DEAD;
+            let deleted_id = TaskId::try_from(111u32).unwrap();
+            let survivor_id = TaskId::try_from(222u32).unwrap();
+
+            // Two ids share one hash bucket (each write is its own SST so both are stored).
+            {
+                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+                write_task_cache_entry(&db, collision_hash, deleted_id)?;
+                write_task_cache_entry(&db, collision_hash, survivor_id)?;
+                let results =
+                    db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+                assert_eq!(results.len(), 2, "both colliding ids should be present");
+                db.shutdown()?;
+            }
+
+            // Delete `deleted_id`: tombstone the whole bucket and re-put the survivor in one batch,
+            // adding the two operations in the order under test.
+            {
+                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+                let batch = db.write_batch()?;
+                let put = |batch: &TurboWriteBatch<'_>| {
+                    batch.put(
+                        KeySpace::TaskCache,
+                        WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
+                        WriteBuffer::Vec(task_data_key(survivor_id).to_vec()),
+                    )
+                };
+                let delete = |batch: &TurboWriteBatch<'_>| {
+                    batch.delete(
+                        KeySpace::TaskCache,
+                        WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
+                    )
+                };
+                if put_before_delete {
+                    put(&batch)?;
+                    delete(&batch)?;
+                } else {
+                    delete(&batch)?;
+                    put(&batch)?;
+                }
+                batch.commit()?;
+                db.shutdown()?;
+            }
+
+            // Reopen: exactly the survivor remains under the bucket.
+            {
+                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+                let results =
+                    db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+                let found_ids: Vec<TaskId> = results
+                    .iter()
+                    .map(|bytes| {
+                        let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
+                        TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
+                    })
+                    .collect();
+                assert_eq!(
+                    found_ids,
+                    vec![survivor_id],
+                    "only the survivor should remain after deleting the colliding id \
+                     (put_before_delete={put_before_delete})"
+                );
+                db.shutdown()?;
+            }
+
+            Ok(())
+        }
+
+        run_case(true).await?;
+        run_case(false).await?;
+        Ok(())
+    }
+
+    /// End-to-end coverage of the survivor path through `save_snapshot`: a `TaskDeletion` must
+    /// tombstone the deleted id's whole `TaskCache` bucket **and** automatically re-insert a
+    /// colliding survivor that exists *only on disk* — i.e. the survivor is resolved by reading the
+    /// on-disk bucket at apply time, not carried on the `TaskDeletion` (the old design) or read
+    /// from the in-memory task cache (which wouldn't know about a disk-only entry).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_save_snapshot_reinserts_disk_only_survivor() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
+
+        let collision_hash: u64 = 0xC0FFEE;
+        let deleted_id = TaskId::try_from(111u32).unwrap();
+        let survivor_id = TaskId::try_from(222u32).unwrap();
+
+        let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+        // Both ids live in the bucket purely on disk; nothing is in an in-memory task cache.
+        write_task_cache_entry(&db, collision_hash, deleted_id)?;
+        write_task_cache_entry(&db, collision_hash, survivor_id)?;
+
+        let storage = TurboBackingStorage::new_in_memory(db);
+
+        // Snapshot with no task data, just the one deletion (carried inline as a delete item).
+        storage.save_snapshot(
+            Vec::new(),
+            vec![vec![SnapshotItem::Delete(TaskDeletion {
+                task_id: deleted_id,
+                task_type_hash: collision_hash.to_le_bytes(),
+            })]],
+        )?;
+
+        // The deleted id is gone; the disk-only survivor was re-inserted automatically.
+        let results = storage
+            .inner
+            .database
+            .get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+        let found_ids: Vec<TaskId> = results
+            .into_iter()
+            .map(|bytes| TaskId::try_from(as_u32(bytes).unwrap()).unwrap())
+            .collect();
+        assert_eq!(
+            found_ids,
+            vec![survivor_id],
+            "save_snapshot should tombstone the deleted id and re-insert the disk-only survivor"
+        );
+
+        storage.inner.database.shutdown()?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -287,13 +287,9 @@ impl TurboBackingStorage {
                             } => {
                                 let key = IntKey::new(*task_id);
                                 let key = key.as_ref();
-                                // TaskMeta/TaskData are SingleValue, so a key-granular delete is
-                                // exact.
                                 batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
                                 batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
-                                // TaskCache is MultiValue and keyed by a hash, so a whole-key
-                                // delete would also drop any task type that collides with this
-                                // one. Delete just this id from the bucket.
+                                // TaskCache is MultiValue, delete just this id from the bucket.
                                 batch.delete_value(
                                     KeySpace::TaskCache,
                                     WriteBuffer::Borrowed(&task_type_hash[..]),

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -241,10 +241,6 @@ impl TurboBackingStorage {
 
         {
             let span = tracing::trace_span!("update task data");
-            // Each `Delete` item's `TaskMeta`/`TaskData` tombstone is applied inline in the
-            // parallel put phase; its `TaskCache` tombstone is deferred (returned in
-            // `shard_deletes`) to the sequential phase below, which merges these with
-            // the caller-supplied deletes.
             let per_shard =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
                     let _span = span.clone().entered();
@@ -262,14 +258,14 @@ impl TurboBackingStorage {
                                 task_type_hash,
                             } => (task_id, meta, data, task_type_hash),
                             SnapshotItem::Delete(deletion) => {
-                                // `TaskMeta`/`TaskData` are SingleValue: tombstone them inline
-                                // here. The `TaskCache` tombstone
-                                // (a MultiValue read-modify-write) is
-                                // carried out in `deletion` for the sequential phase below.
                                 let key = IntKey::new(*deletion.task_id);
                                 let key = key.as_ref();
+                                // apply these deletions immediately: TaskMeta/TaskData are
+                                // SingleValue, so a key-granular delete is exact
                                 batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
                                 batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
+                                // defer these until after the parallel block: the TaskCache
+                                // tombstone is a MultiValue read-modify-write
                                 shard_deletes.push(deletion);
                                 continue;
                             }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -237,7 +237,7 @@ impl TurboBackingStorage {
 
         {
             let span = tracing::trace_span!("update task data");
-            let per_shard =
+            let mut snapshot_meta =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
                     let _span = span.clone().entered();
                     let mut max_new_task_id = 0;
@@ -245,15 +245,47 @@ impl TurboBackingStorage {
                     let mut meta_items = 0;
                     let mut task_cache_items = 0;
                     for item in shard {
-                        let (task_id, meta, data, task_type_hash) = match item {
+                        match item {
                             SnapshotItem::Put {
                                 task_id,
                                 meta,
                                 data,
                                 task_type_hash,
-                            } => (task_id, meta, data, task_type_hash),
-                            SnapshotItem::Delete(deletion) => {
-                                let key = IntKey::new(*deletion.task_id);
+                            } => {
+                                let key = IntKey::new(*task_id);
+                                let key = key.as_ref();
+                                if let Some(meta) = meta {
+                                    batch.put(
+                                        KeySpace::TaskMeta,
+                                        WriteBuffer::Borrowed(key),
+                                        WriteBuffer::SmallVec(meta),
+                                    )?;
+                                    meta_items += 1;
+                                }
+                                if let Some(data) = data {
+                                    batch.put(
+                                        KeySpace::TaskData,
+                                        WriteBuffer::Borrowed(key),
+                                        WriteBuffer::SmallVec(data),
+                                    )?;
+                                    data_items += 1;
+                                }
+                                // Register the task type only for new tasks.
+                                if let Some(task_type_hash) = task_type_hash {
+                                    batch.put(
+                                        KeySpace::TaskCache,
+                                        WriteBuffer::Borrowed(&task_type_hash),
+                                        WriteBuffer::Borrowed(key),
+                                    )?;
+                                    task_cache_items += 1;
+                                    max_new_task_id = max_new_task_id.max(*task_id);
+                                }
+                            }
+                            SnapshotItem::Delete {
+                                task_id,
+                                task_type_hash,
+                            } => {
+                                let key = IntKey::new(*task_id);
                                 let key = key.as_ref();
                                 // TaskMeta/TaskData are SingleValue, so a key-granular delete is
                                 // exact.
@@ -264,39 +296,10 @@ impl TurboBackingStorage {
                                 // one. Delete just this id from the bucket.
                                 batch.delete_value(
                                     KeySpace::TaskCache,
-                                    WriteBuffer::Borrowed(&deletion.task_type_hash[..]),
+                                    WriteBuffer::Borrowed(&task_type_hash[..]),
                                     WriteBuffer::Borrowed(key),
                                 )?;
-                                continue;
                             }
-                        };
-                        let key = IntKey::new(*task_id);
-                        let key = key.as_ref();
-                        if let Some(meta) = meta {
-                            batch.put(
-                                KeySpace::TaskMeta,
-                                WriteBuffer::Borrowed(key),
-                                WriteBuffer::SmallVec(meta),
-                            )?;
-                            meta_items += 1;
-                        }
-                        if let Some(data) = data {
-                            batch.put(
-                                KeySpace::TaskData,
-                                WriteBuffer::Borrowed(key),
-                                WriteBuffer::SmallVec(data),
-                            )?;
-                            data_items += 1;
-                        }
-                        // Write task cache entry inline if this is a new task
-                        if let Some(task_type_hash) = task_type_hash {
-                            batch.put(
-                                KeySpace::TaskCache,
-                                WriteBuffer::Borrowed(&task_type_hash),
-                                WriteBuffer::Borrowed(key),
-                            )?;
-                            task_cache_items += 1;
-                            max_new_task_id = max_new_task_id.max(*task_id);
                         }
                     }
                     Ok(SnapshotMeta {
@@ -309,8 +312,7 @@ impl TurboBackingStorage {
                         bytes_deleted: 0,
                         max_next_task_id: max_new_task_id,
                     })
-                })?;
-            let mut snapshot_meta = per_shard
+                })?
                 .into_iter()
                 .reduce(|t1, t2| t1.merge(t2))
                 .unwrap_or_default();
@@ -487,10 +489,7 @@ mod tests {
     use turbo_tasks::TaskId;
 
     use super::*;
-    use crate::{
-        backing_storage::TaskDeletion,
-        database::{turbo::TurboKeyValueDatabase, write_batch::WriteBuffer},
-    };
+    use crate::database::{turbo::TurboKeyValueDatabase, write_batch::WriteBuffer};
 
     /// Helper to write to the database using the concurrent batch API.
     fn write_task_cache_entry(
@@ -764,7 +763,7 @@ mod tests {
         Ok(())
     }
 
-    /// End-to-end coverage of collision handling in `save_snapshot`: a `TaskDeletion` must remove
+    /// End-to-end coverage of collision handling in `save_snapshot`: a `Delete` item must remove
     /// only the deleted id from its `TaskCache` bucket, leaving a colliding entry that exists
     /// *only on disk* intact.
     ///
@@ -790,10 +789,10 @@ mod tests {
         // Snapshot with no task data, just the one deletion (carried inline as a delete item).
         storage.save_snapshot(
             Vec::new(),
-            vec![vec![SnapshotItem::Delete(TaskDeletion {
+            vec![vec![SnapshotItem::Delete {
                 task_id: deleted_id,
                 task_type_hash: collision_hash.to_le_bytes(),
-            })]],
+            }]],
         )?;
 
         // The deleted id is gone; the disk-only collision is untouched.

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -503,6 +503,20 @@ mod tests {
         Ok(())
     }
 
+    /// Reads the TaskIds stored under `hash` in `TaskCache`, sorted for stable comparison.
+    fn task_cache_ids(db: &TurboKeyValueDatabase, hash: u64) -> Result<Vec<TaskId>> {
+        let mut ids: Vec<TaskId> = db
+            .get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
+            .iter()
+            .map(|bytes| {
+                let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
+                TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
+            })
+            .collect();
+        ids.sort_by_key(|id| **id);
+        Ok(ids)
+    }
+
     /// Tests that `get_multiple` correctly returns multiple TaskIds when the same hash key
     /// is used (simulating a hash collision scenario).
     ///
@@ -530,25 +544,11 @@ mod tests {
         write_task_cache_entry(&db, collision_hash, task_id_3)?;
 
         // Now query using get_multiple - should return all three TaskIds
-        let results = db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
-
         assert_eq!(
-            results.len(),
-            3,
+            task_cache_ids(&db, collision_hash)?,
+            vec![task_id_1, task_id_2, task_id_3],
             "Should return all 3 task IDs for the colliding hash"
         );
-
-        // Convert results to TaskIds and verify all three are present
-        let mut found_ids: Vec<TaskId> = results
-            .iter()
-            .map(|bytes| {
-                let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
-                TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
-            })
-            .collect();
-        found_ids.sort_by_key(|id| **id);
-
-        assert_eq!(found_ids, vec![task_id_1, task_id_2, task_id_3]);
 
         db.shutdown()?;
         Ok(())
@@ -609,180 +609,53 @@ mod tests {
         Ok(())
     }
 
-    fn task_data_key(task_id: TaskId) -> [u8; 4] {
-        (*task_id).to_le_bytes()
-    }
-
-    /// GC tombstone path: deleting a task must erase its `TaskMeta` and `TaskData`
-    /// (`SingleValue`) entries and its `TaskCache` (`MultiValue`) mapping, and the deletion must
-    /// survive a reopen. Written first so the persistence-layer semantics the sweep relies on are
-    /// pinned down independently of the mark/sweep logic (Stage 0).
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_gc_delete_tombstones_meta_data_and_cache() -> Result<()> {
-        let tempdir = tempfile::tempdir()?;
-        let path = tempdir.path();
-
-        let hash: u64 = 0xABCD_1234;
-        let task_id = TaskId::try_from(42u32).unwrap();
-
-        // Write the task's meta, data, and cache entries in one committed batch.
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            let batch = db.write_batch()?;
-            let key = task_data_key(task_id);
-            batch.put(
-                KeySpace::TaskMeta,
-                WriteBuffer::Borrowed(&key),
-                WriteBuffer::Borrowed(b"meta-bytes"),
-            )?;
-            batch.put(
-                KeySpace::TaskData,
-                WriteBuffer::Borrowed(&key),
-                WriteBuffer::Borrowed(b"data-bytes"),
-            )?;
-            batch.put(
-                KeySpace::TaskCache,
-                WriteBuffer::Borrowed(&hash.to_le_bytes()),
-                WriteBuffer::Borrowed(&key),
-            )?;
-            batch.commit()?;
-            db.shutdown()?;
-        }
-
-        // Sanity: everything is present before deletion.
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            let key = task_data_key(task_id);
-            assert!(db.get(KeySpace::TaskMeta, &key)?.is_some());
-            assert!(db.get(KeySpace::TaskData, &key)?.is_some());
-            assert_eq!(
-                db.get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
-                    .len(),
-                1
-            );
-            db.shutdown()?;
-        }
-
-        // Tombstone the task in a single committed batch (the shape save_snapshot uses for a
-        // delete list with no colliding survivors).
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            let batch = db.write_batch()?;
-            let key = task_data_key(task_id);
-            batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(&key))?;
-            batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(&key))?;
-            batch.delete(
-                KeySpace::TaskCache,
-                WriteBuffer::Borrowed(&hash.to_le_bytes()),
-            )?;
-            batch.commit()?;
-            db.shutdown()?;
-        }
-
-        // Reopen: all three entries must be gone.
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            let key = task_data_key(task_id);
-            assert!(
-                db.get(KeySpace::TaskMeta, &key)?.is_none(),
-                "TaskMeta should be tombstoned"
-            );
-            assert!(
-                db.get(KeySpace::TaskData, &key)?.is_none(),
-                "TaskData should be tombstoned"
-            );
-            assert!(
-                db.get_multiple(KeySpace::TaskCache, &hash.to_le_bytes())?
-                    .is_empty(),
-                "TaskCache mapping should be tombstoned"
-            );
-            db.shutdown()?;
-        }
-
-        Ok(())
-    }
-
-    /// Deleting one id from a shared `TaskCache` hash bucket must leave the colliding id
-    /// readable after a reopen — the tombstone is persisted and applied on read, not just held
-    /// in memory.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_gc_delete_task_cache_keeps_collision() -> Result<()> {
-        let tempdir = tempfile::tempdir()?;
-        let path = tempdir.path();
-
-        let collision_hash: u64 = 0xDEAD_DEAD;
-        let deleted_id = TaskId::try_from(111u32).unwrap();
-        let survivor_id = TaskId::try_from(222u32).unwrap();
-
-        // Two ids share one hash bucket (each write is its own SST so both are stored).
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            write_task_cache_entry(&db, collision_hash, deleted_id)?;
-            write_task_cache_entry(&db, collision_hash, survivor_id)?;
-            let results = db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
-            assert_eq!(results.len(), 2, "both colliding ids should be present");
-            db.shutdown()?;
-        }
-
-        // Delete just `deleted_id` from the bucket.
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            let batch = db.write_batch()?;
-            batch.delete_value(
-                KeySpace::TaskCache,
-                WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
-                WriteBuffer::Vec(task_data_key(deleted_id).to_vec()),
-            )?;
-            batch.commit()?;
-            db.shutdown()?;
-        }
-
-        // Reopen: exactly the colliding id remains under the bucket.
-        {
-            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-            let results = db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
-            let found_ids: Vec<TaskId> = results
-                .iter()
-                .map(|bytes| {
-                    let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
-                    TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
-                })
-                .collect();
-            assert_eq!(
-                found_ids,
-                vec![survivor_id],
-                "only the colliding id should remain after deleting the other"
-            );
-            db.shutdown()?;
-        }
-
-        Ok(())
-    }
-
-    /// End-to-end coverage of collision handling in `save_snapshot`: a `Delete` item must remove
-    /// only the deleted id from its `TaskCache` bucket, leaving a colliding entry that exists
-    /// *only on disk* intact.
+    /// `save_snapshot` delete path: a `Delete` item must erase the task's `TaskMeta` and
+    /// `TaskData` (`SingleValue`) entries and remove *only* that id from its `TaskCache`
+    /// (`MultiValue`) bucket.
     ///
-    /// The survivor is never read or rewritten — the key-value tombstone names the single id it
-    /// deletes, so anything else in the bucket is untouched whether or not this commit knows
-    /// about it.
+    /// The colliding survivor is never read or rewritten — the key-value tombstone names the
+    /// single id it deletes, so anything else in the bucket is untouched whether or not this
+    /// commit knows about it.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_save_snapshot_keeps_disk_only_collision() -> Result<()> {
+    async fn test_save_snapshot_delete_tombstones_task() -> Result<()> {
         let tempdir = tempfile::tempdir()?;
         let path = tempdir.path();
 
         let collision_hash: u64 = 0xC0FFEE;
         let deleted_id = TaskId::try_from(111u32).unwrap();
         let survivor_id = TaskId::try_from(222u32).unwrap();
+        let deleted_key = (*deleted_id).to_le_bytes();
 
         let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-        // Both ids live in the bucket purely on disk; nothing is in an in-memory task cache.
+
+        // Both ids collide in one TaskCache bucket, purely on disk; the deleted task also has
+        // meta and data entries.
         write_task_cache_entry(&db, collision_hash, deleted_id)?;
         write_task_cache_entry(&db, collision_hash, survivor_id)?;
+        let batch = db.write_batch()?;
+        batch.put(
+            KeySpace::TaskMeta,
+            WriteBuffer::Borrowed(&deleted_key),
+            WriteBuffer::Borrowed(b"meta-bytes"),
+        )?;
+        batch.put(
+            KeySpace::TaskData,
+            WriteBuffer::Borrowed(&deleted_key),
+            WriteBuffer::Borrowed(b"data-bytes"),
+        )?;
+        batch.commit()?;
+
+        // Sanity: everything is present before the delete.
+        assert!(db.get(KeySpace::TaskMeta, &deleted_key)?.is_some());
+        assert!(db.get(KeySpace::TaskData, &deleted_key)?.is_some());
+        assert_eq!(
+            task_cache_ids(&db, collision_hash)?,
+            vec![deleted_id, survivor_id],
+        );
 
         let storage = TurboBackingStorage::new_in_memory(db);
 
-        // Snapshot with no task data, just the one deletion (carried inline as a delete item).
+        // Snapshot with no task data, just the one deletion.
         storage.save_snapshot(
             Vec::new(),
             vec![vec![SnapshotItem::Delete {
@@ -791,22 +664,22 @@ mod tests {
             }]],
         )?;
 
-        // The deleted id is gone; the disk-only collision is untouched.
-        let results = storage
-            .inner
-            .database
-            .get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
-        let found_ids: Vec<TaskId> = results
-            .into_iter()
-            .map(|bytes| TaskId::try_from(as_u32(bytes).unwrap()).unwrap())
-            .collect();
+        let db = &storage.inner.database;
+        assert!(
+            db.get(KeySpace::TaskMeta, &deleted_key)?.is_none(),
+            "TaskMeta should be tombstoned"
+        );
+        assert!(
+            db.get(KeySpace::TaskData, &deleted_key)?.is_none(),
+            "TaskData should be tombstoned"
+        );
         assert_eq!(
-            found_ids,
+            task_cache_ids(db, collision_hash)?,
             vec![survivor_id],
             "save_snapshot should delete only the named id from the bucket"
         );
 
-        storage.inner.database.shutdown()?;
+        db.shutdown()?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use turbo_bincode::{new_turbo_bincode_decoder, turbo_bincode_decode, turbo_bincode_encode};
 use turbo_persistence::CommitStats;
@@ -20,10 +19,7 @@ use turbo_tasks::{
 use crate::{
     GitVersionInfo,
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
-    backing_storage::{
-        SnapshotItem, SnapshotMeta, TaskDeletion, TaskTypeHash,
-        compute_task_type_hash_from_components,
-    },
+    backing_storage::{SnapshotItem, SnapshotMeta, compute_task_type_hash_from_components},
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
         db_versioning::handle_db_versioning,
@@ -248,7 +244,6 @@ impl TurboBackingStorage {
                     let mut data_items = 0;
                     let mut meta_items = 0;
                     let mut task_cache_items = 0;
-                    let mut shard_deletes: Vec<TaskDeletion> = Vec::new();
                     for item in shard {
                         let (task_id, meta, data, task_type_hash) = match item {
                             SnapshotItem::Put {
@@ -260,13 +255,18 @@ impl TurboBackingStorage {
                             SnapshotItem::Delete(deletion) => {
                                 let key = IntKey::new(*deletion.task_id);
                                 let key = key.as_ref();
-                                // apply these deletions immediately: TaskMeta/TaskData are
-                                // SingleValue, so a key-granular delete is exact
+                                // TaskMeta/TaskData are SingleValue, so a key-granular delete is
+                                // exact.
                                 batch.delete(KeySpace::TaskMeta, WriteBuffer::Borrowed(key))?;
                                 batch.delete(KeySpace::TaskData, WriteBuffer::Borrowed(key))?;
-                                // defer these until after the parallel block: the TaskCache
-                                // tombstone is a MultiValue read-modify-write
-                                shard_deletes.push(deletion);
+                                // TaskCache is MultiValue and keyed by a hash, so a whole-key
+                                // delete would also drop any task type that collides with this
+                                // one. Delete just this id from the bucket.
+                                batch.delete_value(
+                                    KeySpace::TaskCache,
+                                    WriteBuffer::Borrowed(&deletion.task_type_hash[..]),
+                                    WriteBuffer::Borrowed(key),
+                                )?;
                                 continue;
                             }
                         };
@@ -299,57 +299,28 @@ impl TurboBackingStorage {
                             max_new_task_id = max_new_task_id.max(*task_id);
                         }
                     }
-                    Ok((
-                        SnapshotMeta {
-                            data_items,
-                            meta_items,
-                            task_cache_items,
-                            // The on-disk byte totals aren't known until the batch is committed
-                            // below; they're filled in from `CommitStats` after `batch.commit()`.
-                            bytes_written: 0,
-                            bytes_deleted: 0,
-                            max_next_task_id: max_new_task_id,
-                        },
-                        shard_deletes,
-                    ))
+                    Ok(SnapshotMeta {
+                        data_items,
+                        meta_items,
+                        task_cache_items,
+                        // The on-disk byte totals aren't known until the batch is committed
+                        // below; they're filled in from `CommitStats` after `batch.commit()`.
+                        bytes_written: 0,
+                        bytes_deleted: 0,
+                        max_next_task_id: max_new_task_id,
+                    })
                 })?;
-            // Merge the per-shard snapshot metadata and, in the same pass, group the deleted ids by
-            // their TaskCache hash bucket (their SingleValue TaskMeta/TaskData tombstones were
-            // already applied inline in the parallel phase above). TaskCache is MultiValue and a
-            // tombstone erases the *whole* bucket, so for each distinct hash we must re-insert
-            // every id still living in that bucket (any type that xxh3-collides with a
-            // deleted one). Normally each hash maps to exactly the single id being
-            // deleted, so the survivor set is empty.
-            let mut snapshot_meta = SnapshotMeta::default();
-            let mut deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>> =
-                FxHashMap::default();
-            let mut deleted_count = 0usize;
-            for (meta, shard_deletes) in per_shard {
-                snapshot_meta = snapshot_meta.merge(meta);
-                for deletion in shard_deletes {
-                    deleted_by_hash
-                        .entry(deletion.task_type_hash)
-                        .or_default()
-                        .push(deletion.task_id);
-                    deleted_count += 1;
-                }
-            }
-
-            if !deleted_by_hash.is_empty() {
-                apply_task_cache_deletions(
-                    &self.inner.database,
-                    &batch,
-                    deleted_by_hash,
-                    deleted_count,
-                )?;
-            }
+            let mut snapshot_meta = per_shard
+                .into_iter()
+                .reduce(|t1, t2| t1.merge(t2))
+                .unwrap_or_default();
 
             let span = tracing::trace_span!("flush task data");
             parallel::try_for_each(
                 &[KeySpace::TaskMeta, KeySpace::TaskData, KeySpace::TaskCache],
                 |&key_space| {
                     let _span = span.clone().entered();
-                    // Safety: the two loops above have completed so no concurrent `put` or `delete`
+                    // Safety: `map_collect_owned` has returned, so no concurrent `put` or `delete`
                     // on these key spaces are in-flight.
                     unsafe { batch.flush(key_space) }
                 },
@@ -467,56 +438,6 @@ impl TurboBackingStorage {
     }
 }
 
-/// Applies the `TaskCache` tombstones for GC-collected tasks, grouped by their hash bucket.
-///
-/// `TaskCache` is MultiValue and a tombstone erases the *whole* bucket, so for each distinct hash
-/// we read the authoritative on-disk bucket and re-insert every id NOT being deleted — any type
-/// that xxh3-collides with a deleted one. Normally each hash maps to exactly the single deleted id,
-/// so the survivor set is empty. (A survivor that is a *new* task added in this same commit is
-/// covered by its own put; new tasks aren't on disk yet, so they can't appear here.)
-///
-/// Runs after all puts (each bucket is a read+delete+reinsert), but the buckets are independent
-/// (distinct hash keys, sharing only the `batch`/`database` refs), so they process in parallel:
-/// `batch.delete`/`batch.put` use the same thread-local collectors the put phase does, and
-/// `get_multiple` is a shared-ref read.
-fn apply_task_cache_deletions(
-    database: &TurboKeyValueDatabase,
-    batch: &TurboWriteBatch<'_>,
-    deleted_by_hash: FxHashMap<TaskTypeHash, SmallVec<[TaskId; 4]>>,
-    deleted_count: usize,
-) -> Result<()> {
-    let span = tracing::trace_span!("delete tasks", count = deleted_count);
-    // TODO: this would be a good usecase for a batch_get_multiple, that would optimize reading
-    parallel::try_for_each_owned(
-        deleted_by_hash.into_iter().collect::<Vec<_>>(),
-        |(task_type_hash, deleted_ids)| {
-            let _span = span.clone().entered();
-            let bucket = database
-                .get_multiple(KeySpace::TaskCache, &task_type_hash)
-                .with_context(|| {
-                    format!("Reading TaskCache bucket {task_type_hash:?} for GC re-insert")
-                })?;
-            batch.delete(
-                KeySpace::TaskCache,
-                WriteBuffer::Borrowed(&task_type_hash[..]),
-            )?;
-            for bytes in bucket {
-                let id = TaskId::try_from(as_u32(bytes)?)?;
-                if deleted_ids.contains(&id) {
-                    continue;
-                }
-                let survivor_key = IntKey::new(*id);
-                batch.put(
-                    KeySpace::TaskCache,
-                    WriteBuffer::Borrowed(&task_type_hash[..]),
-                    WriteBuffer::Vec(survivor_key.as_ref().to_vec()),
-                )?;
-            }
-            anyhow::Ok(())
-        },
-    )
-}
-
 fn get_next_free_task_id(batch: &TurboWriteBatch<'_>) -> Result<u32, anyhow::Error> {
     Ok(
         match batch.get(
@@ -566,7 +487,10 @@ mod tests {
     use turbo_tasks::TaskId;
 
     use super::*;
-    use crate::database::{turbo::TurboKeyValueDatabase, write_batch::WriteBuffer};
+    use crate::{
+        backing_storage::TaskDeletion,
+        database::{turbo::TurboKeyValueDatabase, write_batch::WriteBuffer},
+    };
 
     /// Helper to write to the database using the concurrent batch API.
     fn write_task_cache_entry(
@@ -783,104 +707,72 @@ mod tests {
         Ok(())
     }
 
-    /// The load-bearing correctness test for the "whole-key tombstone + re-put survivors" approach
-    /// to deleting one entry from the `MultiValue` `TaskCache`: when two task ids collide in one
-    /// hash bucket and we delete one, tombstoning the whole bucket and re-putting the survivor in
-    /// the *same* committed batch must leave exactly the survivor readable after a reopen.
-    ///
-    /// It also pins down the delete/put ordering question: within one commit the relative order of
-    /// the survivor `put` and the whole-bucket `delete` does **not** matter. `Collector::sorted`
-    /// sorts tombstones last within a key group regardless of insertion order, so the survivor
-    /// (ordered before the tombstone) always survives while older-SST entries for the key are
-    /// erased. We assert both orderings produce the same result.
+    /// Deleting one id from a shared `TaskCache` hash bucket must leave the colliding id
+    /// readable after a reopen — the tombstone is persisted and applied on read, not just held
+    /// in memory.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_gc_delete_task_cache_reput_survivor() -> Result<()> {
-        // `put_before_delete` selects the order the two operations are added to the batch; the
-        // committed outcome must be identical either way.
-        async fn run_case(put_before_delete: bool) -> Result<()> {
-            let tempdir = tempfile::tempdir()?;
-            let path = tempdir.path();
+    async fn test_gc_delete_task_cache_keeps_collision() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
 
-            let collision_hash: u64 = 0xDEAD_DEAD;
-            let deleted_id = TaskId::try_from(111u32).unwrap();
-            let survivor_id = TaskId::try_from(222u32).unwrap();
+        let collision_hash: u64 = 0xDEAD_DEAD;
+        let deleted_id = TaskId::try_from(111u32).unwrap();
+        let survivor_id = TaskId::try_from(222u32).unwrap();
 
-            // Two ids share one hash bucket (each write is its own SST so both are stored).
-            {
-                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-                write_task_cache_entry(&db, collision_hash, deleted_id)?;
-                write_task_cache_entry(&db, collision_hash, survivor_id)?;
-                let results =
-                    db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
-                assert_eq!(results.len(), 2, "both colliding ids should be present");
-                db.shutdown()?;
-            }
-
-            // Delete `deleted_id`: tombstone the whole bucket and re-put the survivor in one batch,
-            // adding the two operations in the order under test.
-            {
-                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-                let batch = db.write_batch()?;
-                let put = |batch: &TurboWriteBatch<'_>| {
-                    batch.put(
-                        KeySpace::TaskCache,
-                        WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
-                        WriteBuffer::Vec(task_data_key(survivor_id).to_vec()),
-                    )
-                };
-                let delete = |batch: &TurboWriteBatch<'_>| {
-                    batch.delete(
-                        KeySpace::TaskCache,
-                        WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
-                    )
-                };
-                if put_before_delete {
-                    put(&batch)?;
-                    delete(&batch)?;
-                } else {
-                    delete(&batch)?;
-                    put(&batch)?;
-                }
-                batch.commit()?;
-                db.shutdown()?;
-            }
-
-            // Reopen: exactly the survivor remains under the bucket.
-            {
-                let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
-                let results =
-                    db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
-                let found_ids: Vec<TaskId> = results
-                    .iter()
-                    .map(|bytes| {
-                        let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
-                        TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
-                    })
-                    .collect();
-                assert_eq!(
-                    found_ids,
-                    vec![survivor_id],
-                    "only the survivor should remain after deleting the colliding id \
-                     (put_before_delete={put_before_delete})"
-                );
-                db.shutdown()?;
-            }
-
-            Ok(())
+        // Two ids share one hash bucket (each write is its own SST so both are stored).
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            write_task_cache_entry(&db, collision_hash, deleted_id)?;
+            write_task_cache_entry(&db, collision_hash, survivor_id)?;
+            let results = db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+            assert_eq!(results.len(), 2, "both colliding ids should be present");
+            db.shutdown()?;
         }
 
-        run_case(true).await?;
-        run_case(false).await?;
+        // Delete just `deleted_id` from the bucket.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let batch = db.write_batch()?;
+            batch.delete_value(
+                KeySpace::TaskCache,
+                WriteBuffer::Borrowed(&collision_hash.to_le_bytes()),
+                WriteBuffer::Vec(task_data_key(deleted_id).to_vec()),
+            )?;
+            batch.commit()?;
+            db.shutdown()?;
+        }
+
+        // Reopen: exactly the colliding id remains under the bucket.
+        {
+            let db = TurboKeyValueDatabase::new(path.to_path_buf(), false, true, false)?;
+            let results = db.get_multiple(KeySpace::TaskCache, &collision_hash.to_le_bytes())?;
+            let found_ids: Vec<TaskId> = results
+                .iter()
+                .map(|bytes| {
+                    let bytes: [u8; 4] = Borrow::<[u8]>::borrow(bytes).try_into().unwrap();
+                    TaskId::try_from(u32::from_le_bytes(bytes)).unwrap()
+                })
+                .collect();
+            assert_eq!(
+                found_ids,
+                vec![survivor_id],
+                "only the colliding id should remain after deleting the other"
+            );
+            db.shutdown()?;
+        }
+
         Ok(())
     }
 
-    /// End-to-end coverage of the survivor path through `save_snapshot`: a `TaskDeletion` must
-    /// tombstone the deleted id's whole `TaskCache` bucket **and** automatically re-insert a
-    /// colliding survivor that exists *only on disk* — i.e. the survivor is resolved by reading the
-    /// on-disk bucket at apply time, not carried on the `TaskDeletion` (the old design) or read
-    /// from the in-memory task cache (which wouldn't know about a disk-only entry).
+    /// End-to-end coverage of collision handling in `save_snapshot`: a `TaskDeletion` must remove
+    /// only the deleted id from its `TaskCache` bucket, leaving a colliding entry that exists
+    /// *only on disk* intact.
+    ///
+    /// The survivor is never read or rewritten — the key-value tombstone names the single id it
+    /// deletes, so anything else in the bucket is untouched whether or not this commit knows
+    /// about it.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_save_snapshot_reinserts_disk_only_survivor() -> Result<()> {
+    async fn test_save_snapshot_keeps_disk_only_collision() -> Result<()> {
         let tempdir = tempfile::tempdir()?;
         let path = tempdir.path();
 
@@ -904,7 +796,7 @@ mod tests {
             })]],
         )?;
 
-        // The deleted id is gone; the disk-only survivor was re-inserted automatically.
+        // The deleted id is gone; the disk-only collision is untouched.
         let results = storage
             .inner
             .database
@@ -916,7 +808,7 @@ mod tests {
         assert_eq!(
             found_ids,
             vec![survivor_id],
-            "save_snapshot should tombstone the deleted id and re-insert the disk-only survivor"
+            "save_snapshot should delete only the named id from the bucket"
         );
 
         storage.inner.database.shutdown()?;


### PR DESCRIPTION
## What

The persistence-layer mechanism to tombstone (delete) tasks from the on-disk cache. A GC-collected task is represented as a `SnapshotItem::Delete` that rides the same streaming iterator `save_snapshot` already consumes for puts, so tombstones are applied in the same commit/batch as the snapshot with no side-channel.

- `SnapshotItem` becomes an enum: `Put { … }` (the existing path) and `Delete(TaskDeletion)`.
- `TurboWriteBatch::delete/value_delete` passthrough to `turbo_persistence`.
- `save_snapshot` applies deletes inline in the parallel put phase


## Note

`SnapshotItem::Delete` is `#[allow(dead_code)]` here: this PR lands the persistence-side *handling* and its tests, but nothing *emits* a `Delete` yet. The GC pass that soft-deletes tasks and serializes them to `Delete` lands in the next PR in the stack. So this PR is a no-op at runtime.

