### PR TITLE
turbo-tasks-backend: anchor GC roots, gate on Data residency, wire up the app

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
+    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbo_tasks, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -173,7 +173,32 @@ impl VersionedContentMap {
             client_output_path,
         );
         this.map_op_to_compute_entry.update_conditionally(|map| {
-            map.insert(assets_operation, compute_entry) != Some(compute_entry)
+            let previous = map.insert(assets_operation, compute_entry);
+            if previous == Some(compute_entry) {
+                // Nothing changed: the same value was already stored under this key, so the
+                // `insert` replaced `compute_entry` with an identical `compute_entry`. The key op's
+                // pin (taken when it was first inserted) and the value op's pin are both still
+                // correct; no pin bookkeeping needed.
+                return false;
+            }
+            // Pin the operations so GC keeps their tasks alive while they're held in this map (the
+            // map stores them outside the task graph, so nothing else anchors them). This runs in a
+            // task function body — the unguarded region — so acquiring the pin guard is safe.
+            let tt = turbo_tasks();
+            match previous {
+                None => {
+                    // New key: pin both the key op and the value op.
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+                Some(old_compute_entry) => {
+                    // Key already present (its pin stays); the value op changed — unpin the old,
+                    // pin the new.
+                    tt.unpin_task_for_gc(old_compute_entry.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+            }
+            true
         });
         Ok(())
     }
@@ -197,30 +222,42 @@ impl VersionedContentMap {
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
+            // The map stores `assets_operation` outside the task graph, so pin its task for the
+            // duration of each (path -> op) membership: pin on a genuine insert, unpin on a genuine
+            // removal. This runs in a task function body (the unguarded region), so acquiring the
+            // pin guard is safe. Balance is one pin per distinct path bucket the op lives in.
+            let tt = turbo_tasks();
+
             // get current map's keys, subtract keys that don't exist in operation
             let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                let res = map
+                let inserted = map
                     .0
                     .entry(k.clone())
                     .or_default()
                     .0
                     .insert(assets_operation);
+                if inserted {
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                }
                 stale_assets.remove(k);
-                changed = changed || res;
+                changed = changed || inserted;
             }
 
             // Make more efficient with reverse map
             for k in &stale_assets {
-                let res = map
+                let removed = map
                     .0
                     .get_mut(k)
                     // guaranteed
                     .unwrap()
                     .0
                     .swap_remove(&assets_operation);
-                changed = changed || res
+                if removed {
+                    tt.unpin_task_for_gc(assets_operation.task_id());
+                }
+                changed = changed || removed
             }
             changed
         });

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -43,8 +43,9 @@ use crate::next_api::turbopack_ctx::NextTurbopackContext;
 /// [`turbo_tasks::OperationValue`] and should be dereferenced to an [`OperationVc`] before being
 /// passed to a [`turbo_tasks::function`].
 //
-// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
-#[derive(Clone)]
+/// A `DetachedVc` holds its operation's task alive against garbage collection for as long as the
+/// handle exists: it is a reference that escapes the tracked task graph, so no
+/// persistent parent lists the task as a child and GC would otherwise collect it.
 pub struct DetachedVc<T> {
     turbopack_ctx: NextTurbopackContext,
     /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
@@ -53,11 +54,30 @@ pub struct DetachedVc<T> {
 
 impl<T> DetachedVc<T> {
     pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
+        // Pin the operation's task so GC treats this out-of-graph handle as a root.
+        turbopack_ctx.turbo_tasks().pin_task_for_gc(vc.task_id());
+
         Self { turbopack_ctx, vc }
     }
 
     pub fn turbopack_ctx(&self) -> &NextTurbopackContext {
         &self.turbopack_ctx
+    }
+}
+
+// Manual clone and Drop routines are required for proper reference counting to prevent GC
+
+impl<T> Clone for DetachedVc<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.turbopack_ctx.clone(), self.vc)
+    }
+}
+
+impl<T> Drop for DetachedVc<T> {
+    fn drop(&mut self) {
+        self.turbopack_ctx
+            .turbo_tasks()
+            .unpin_task_for_gc(self.task_id());
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -48,6 +48,8 @@ enum GcJob {
 /// several percent of collect time in profiles.
 #[derive(Default)]
 pub(crate) struct GcStats {
+    /// Total number of gc roots
+    pub gc_roots: usize,
     /// Tasks collected (marked soft-deleted).
     pub collected: usize,
     /// Edges torn down across all collected tasks (children + forward-dependency reverse edges).
@@ -60,6 +62,7 @@ impl GcStats {
     fn merge(mut self, other: Self) -> Self {
         self.collected += other.collected;
         self.edges_deleted += other.edges_deleted;
+        self.gc_roots += other.gc_roots;
         self
     }
 }
@@ -136,11 +139,10 @@ impl TurboTasksBackend {
             |spawner, job, stats| {
                 let task_id = match job {
                     GcJob::ScanShard(index) => {
-                        // Enqueue under the shard read lock — `spawn` is just an accounting bump
-                        // plus a queue push, which is what `gc_scan_shard` requires of its
-                        // callback.
-                        self.storage
+                        let roots = self
+                            .storage
                             .gc_scan_shard(index, |task_id| spawner.spawn(GcJob::Collect(task_id)));
+                        stats.gc_roots += roots;
                         return ControlFlow::Continue(());
                     }
                     GcJob::Collect(task_id) => task_id,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1059,12 +1059,14 @@ impl TurboTasksBackend {
             let gc_span = tracing::info_span!(
                 parent: parent_span.clone(),
                 "gc",
+                gc_roots = tracing::field::Empty,
                 collected = tracing::field::Empty,
                 edges_deleted = tracing::field::Empty,
             )
             .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
             let stats = self.gc_collect(turbo_tasks);
+            gc_span.record("gc_roots", stats.gc_roots);
             gc_span.record("collected", stats.collected);
             gc_span.record("edges_deleted", stats.edges_deleted);
             gc_phase.into_snapshot()
@@ -1704,8 +1706,15 @@ impl TurboTasksBackend {
                     // Initialize storage BEFORE making task_id visible in the cache.
                     // This ensures any thread that reads task_id from the cache sees
                     // the storage entry already initialized (restored flags set).
-                    self.storage
-                        .initialize_new_task(task_id, Some(task_type.clone()));
+                    // A task created with no parent is spawned from outside the tracked graph (a
+                    // top-level `run`/NAPI call, `run_once`, or `OperationVc::connect` outside a
+                    // task) — mark it a GC root so it is never collected (it has no persistent
+                    // parent to anchor it).
+                    self.storage.initialize_new_task(
+                        task_id,
+                        Some(task_type.clone()),
+                        parent_task.is_none(),
+                    );
                     // insert() consumes e, releasing the shard write lock.
                     e.insert(task_type, task_id);
                     self.track_cache_miss_by_fn(native_fn);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -273,10 +273,16 @@ impl Storage {
     /// Mark a newly allocated task as restored (skip DB queries) and new (include in persistence
     /// snapshots). Optionally sets the `persistent_task_type` eagerly so it's available for
     /// persistence snapshots without needing to propagate it through `connect_child`.
-    pub fn initialize_new_task(&self, task_id: TaskId, task_type: Option<CachedTaskTypeArc>) {
+    pub fn initialize_new_task(
+        &self,
+        task_id: TaskId,
+        task_type: Option<CachedTaskTypeArc>,
+        is_gc_root: bool,
+    ) {
         let mut task = self.access_mut(task_id);
         task.flags.set_restored(TaskDataCategory::All);
         task.flags.set_new_task(true);
+        task.flags.set_gc_root(is_gc_root);
         if let Some(task_type) = task_type {
             task.set_persistent_task_type(task_type);
             if !task_id.is_transient() {
@@ -575,16 +581,22 @@ impl Storage {
     /// # Panics
     ///
     /// If `index >= self.shard_count()`.
-    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) {
+    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) -> usize {
         let shard = self.map.shards()[index].read();
+        let mut roots_found = 0usize;
         // SAFETY: we hold the shard read lock for the duration of iteration.
         for bucket in unsafe { shard.iter() } {
             // SAFETY: the read lock guard outlives the bucket reference.
             let (task_id, shared_value) = unsafe { bucket.as_ref() };
-            if !task_id.is_transient() && shared_value.get().gc_maybe_collectible() {
-                on_candidate(*task_id);
+            if !task_id.is_transient() {
+                if shared_value.get().gc_maybe_collectible() {
+                    on_candidate(*task_id);
+                } else if shared_value.get().flags.gc_root() {
+                    roots_found += 1;
+                }
             }
         }
+        roots_found
     }
 
     pub fn access_pair_mut(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -250,6 +250,10 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     deleted: bool,
 
+    /// Marks the task as a GC root meaning it can never be collected via reference counting.
+    #[field(storage = "flag", category = "meta")]
+    gc_root: bool,
+
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -898,15 +902,28 @@ impl TaskStorage {
     /// The aggregation-edges check is conservative: a disconnected task is typically removed from
     /// the aggregation graph, but that can lag and race GC, so we back off rather than collect.
     pub fn gc_maybe_collectible(&self) -> bool {
+        // Note: this intentionally does NOT gate on `Data` being resident. Data holds
+        // `persistent_task_type` (needed to tombstone the `TaskCache` entry), but the collect path
+        // opens the task with `All`, restoring Data before it reads the type. Gating here would
+        // instead strand a truly-unreferenced Data-evicted task forever (it would never be
+        // selected, so its Data would never be restored) — a disk-space leak. Accepting the
+        // extra Data restore for a task about to be deleted is the better trade.
         self.flags.is_restored(TaskDataCategory::Meta)
             // Already collected this session (soft-deleted, awaiting tombstone + hard-delete):
             // don't re-select it, or a second pass would collect it again while it is still
             // resident.
             && !self.flags.deleted()
+            // A GC root (a task spawned with no parent, see the `gc_root` flag) is held from
+            // outside the tracked graph and has no persistent parent — never collect it.
+            && !self.flags.gc_root()
+            // Refcounts must be 0
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
+            // Must not be in progress or being connected
             && self.get_activeness().is_none()
             && self.get_in_progress().is_none()
+            // Must not be participating in the aggregation graph.  Getting disconnected from parents
+            // should clear these but that process isn't atomic.
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
     }
@@ -1155,23 +1172,25 @@ mod tests {
         storage.flags.set_current_session_clean(true);
         assert!(storage.flags.current_session_clean());
 
-        // Test persisted_bits only includes non-transient flags
-        // optimization_pending=bit 0 (meta, persisted)
-        // invalidator=bit 1, immutable=bit 2 (data, persisted)
-        // current_session_clean=bit 3 (transient)
+        // Test persisted_bits only includes non-transient flags.
+        // Persisted flags are laid out meta-first then data (each in declaration order):
+        //   optimization_pending=bit 0, gc_root=bit 1 (meta, persisted)
+        //   invalidator=bit 2, immutable=bit 3 (data, persisted)
+        //   current_session_clean and later (transient)
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b110); // invalidator + immutable
+        assert_eq!(persisted, 0b1100); // invalidator (bit 2) + immutable (bit 3)
 
         // Test TaskFlags constants
-        assert_eq!(TaskFlags::PERSISTED_MASK, 0b111); // 3 persisted flags
+        assert_eq!(TaskFlags::PERSISTED_MASK, 0b1111); // 4 persisted flags
 
         // Test set_persisted_bits preserves transient flags
         let mut storage2 = TaskStorage::new();
         storage2.flags.set_current_session_clean(true); // Set transient flag
-        storage2.flags.set_persisted_bits(0b100); // Set immutable only
+        storage2.flags.set_persisted_bits(0b1000); // Set immutable only (bit 3)
         assert!(storage2.flags.immutable());
         assert!(!storage2.flags.invalidator());
         assert!(!storage2.flags.optimization_pending());
+        assert!(!storage2.flags.gc_root());
         assert!(storage2.flags.current_session_clean()); // Transient flag preserved
     }
 
@@ -1212,14 +1231,14 @@ mod tests {
         assert!(storage.flags.prefetched());
 
         // Verify these are all transient (not in persisted_bits)
-        // Only invalidator, immutable should be persisted
+        // Only optimization_pending/gc_root (meta) and invalidator/immutable (data) are persisted.
         let persisted = storage.flags.persisted_bits();
         assert_eq!(persisted, 0b00); // No persisted flags set
 
         // Set a persisted flag and verify internal state flags are still transient
         storage.flags.set_immutable(true);
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b100); // Only immutable (bit 2)
+        assert_eq!(persisted, 0b1000); // Only immutable (bit 3)
     }
 
     // Helper to create encoder

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
@@ -75,11 +75,18 @@ async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
-/// A cleanly-disconnected subtree must be collected, cascading from the disconnected root to its
-/// children: flipping the selector drops `branch_a` to `parent_count 0`, and collecting it zeroes
-/// `leaf(10)` so that it is collected in the same pass. The live branch (branch_b + leaf(20)) is
-/// untouched and the graph still computes; flipping back recomputes branch_a fresh, proving no
-/// dangling references.
+/// A plain leaf used to test the "spawned with no parent → GC root" rule. When called at the top
+/// level of a `run` (where the current task is `None`), its task is created with `parent == None`
+/// and marked a GC root, so it must never be collected even once disconnected.
+#[turbo_tasks::function]
+async fn gc_root_leaf() -> Result<Vc<u32>> {
+    Ok(Vc::cell(77))
+}
+
+/// A GC pass collects a disconnected subtree via the parent_count cascade: disconnecting branch_a
+/// drops its count to 0 (branch_a is collected), which decrements its child leaf(10) to 0 (leaf(10)
+/// is then collected too). The live branch (branch_b + leaf(20)) is untouched and the graph still
+/// computes; flipping back recomputes branch_a fresh, proving no dangling references.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gc_collects_disconnected_subtree() {
     let (tt, _persistence_dir) = create_tt("gc_collects_disconnected_subtree");
@@ -182,6 +189,60 @@ async fn gc_does_not_collect_pinned_task() {
         tt2.backend().gc_for_testing(&tt2),
         0,
         "pinned task must survive eviction and not be collected"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// A task spawned with **no parent** — called at the top level of a `run`, where the current task
+/// is `None` — is marked a GC root at creation and must never be collected, even with
+/// `parent_count == 0`. This is what keeps externally-spawned root operations (project container,
+/// endpoints, per-request source-map ops) alive: their handles live outside the tracked graph, so
+/// nothing else anchors them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_does_not_collect_parentless_root_task() {
+    let (tt, _persistence_dir) = create_tt("gc_does_not_collect_parentless_root_task");
+    let tt2 = tt.clone();
+    let tt3 = tt.clone();
+
+    let root_id = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        // Called directly in the `run` future: the current task is `None`, so gc_root_leaf's task
+        // is created with `parent == None` and marked a GC root. It has NO persistent parent edge.
+        assert_eq!(*gc_root_leaf().await?, 77);
+
+        let root_id = task_id_of(gc_root_leaf().resolve().await?);
+        // No parent connected it, so its parent_count is 0 from the start — yet it is a GC root.
+        assert_eq!(
+            tt3.backend().parent_count_for_testing(root_id),
+            0,
+            "a parentless root has no persistent parent edge"
+        );
+
+        anyhow::Ok(root_id)
+    })
+    .await
+    .unwrap();
+
+    // parent_count is 0 and it is disconnected, but the gc_root flag must keep it uncollectible.
+    assert_eq!(
+        tt2.backend().parent_count_for_testing(root_id),
+        0,
+        "still parent_count 0 after the run"
+    );
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 0,
+        "a parentless (gc_root) task must not be collected even with parent_count 0"
+    );
+
+    // Survives snapshot + eviction too (the gc_root flag is persisted meta).
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "gc_root task must survive eviction and not be collected"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1025,20 +1025,18 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
     let data_count = grouped_fields.persisted_data_flags_count();
     let persisted_count = meta_count + data_count;
 
-    // Ensure counts fit within u16 bitfield (and u8 for individual categories)
+    // Ensure counts fit within u32 bitfield (and u8 for individual categories)
     assert!(
-        meta_count <= 8,
-        "Too many persisted meta flags ({meta_count}), maximum is 8 (though this could be \
-         expanded)"
+        meta_count <= 16,
+        "Too many persisted meta flags ({meta_count}), maximum is 16"
     );
     assert!(
-        data_count <= 8,
-        "Too many persisted data flags ({data_count}), maximum is 8 (though this could be \
-         expanded)"
+        data_count <= 16,
+        "Too many persisted data flags ({data_count}), maximum is 16"
     );
     assert!(
-        all_flags.len() <= 16,
-        "Too many total flags ({}), maximum is 16 (though this could be expanded)",
+        all_flags.len() <= 32,
+        "Too many total flags ({}), maximum is 32",
         all_flags.len()
     );
 
@@ -1063,17 +1061,17 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
     // Data flags are in bits meta_count..meta_count+data_count
     // Combined persisted mask covers both
     let meta_mask = if meta_count > 0 {
-        (1u16 << meta_count) - 1
+        (1u32 << meta_count) - 1
     } else {
         0
     };
     let data_mask = if data_count > 0 {
-        ((1u16 << data_count) - 1) << meta_count
+        ((1u32 << data_count) - 1) << meta_count
     } else {
         0
     };
     let persisted_mask = if persisted_count > 0 {
-        (1u16 << persisted_count) - 1
+        (1u32 << persisted_count) - 1
     } else {
         0
     };
@@ -1085,7 +1083,7 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
             #[doc = "Bit layout: [meta flags: 0..M] [data flags: M..M+D] [transient: M+D..]"]
             #[doc = "This ordering allows separate masks for per-category serialization."]
             #[derive(Clone, Default, PartialEq, Eq)]
-            pub struct TaskFlags(u16);
+            pub struct TaskFlags(u32);
             impl Debug;
 
             #(#bitfield_accessors;)*
@@ -1094,54 +1092,54 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
         #[automatically_derived]
         impl TaskFlags {
             #[doc = "Mask for persisted meta flags"]
-            pub const META_MASK: u16 = #meta_mask;
+            pub const META_MASK: u32 = #meta_mask;
 
             #[doc = "Mask for persisted data flags"]
-            pub const DATA_MASK: u16 = #data_mask;
+            pub const DATA_MASK: u32 = #data_mask;
 
             #[doc = "Mask for all persisted flags (meta + data)"]
-            pub const PERSISTED_MASK: u16 = #persisted_mask;
+            pub const PERSISTED_MASK: u32 = #persisted_mask;
 
             #[doc = "Get the raw bits value"]
-            pub fn bits(&self) -> u16 {
+            pub fn bits(&self) -> u32 {
                 self.0
             }
 
             #[doc = "Get only the persisted meta bits (for meta serialization)"]
-            pub fn persisted_meta_bits(&self) -> u8 {
+            pub fn persisted_meta_bits(&self) -> u16 {
                 // Meta bits are in the lowest positions (bits 0..meta_count),
-                // and we assert meta_count <= 8, so this fits in a u8
-                (self.0 & Self::META_MASK) as u8
+                // and we assert meta_count <= 16, so this fits in a u16
+                (self.0 & Self::META_MASK) as u16
             }
 
             #[doc = "Get only the persisted data bits (for data serialization)"]
-            pub fn persisted_data_bits(&self) -> u8 {
+            pub fn persisted_data_bits(&self) -> u16 {
                 // Data bits are in positions meta_count..meta_count+data_count,
                 // so we shift right to get them into the low bits.
-                // We assert data_count <= 8, so this fits in a u8
-                ((self.0 & Self::DATA_MASK) >> #meta_count) as u8
+                // We assert data_count <= 16, so this fits in a u16
+                ((self.0 & Self::DATA_MASK) >> #meta_count) as u16
             }
 
             #[doc = "Get all persisted bits (for serialization)"]
-            pub fn persisted_bits(&self) -> u16 {
+            pub fn persisted_bits(&self) -> u32 {
                 self.0 & Self::PERSISTED_MASK
             }
 
             #[doc = "Set meta bits from a raw value, preserving other flags"]
-            pub fn set_persisted_meta_bits(&mut self, bits: u8) {
+            pub fn set_persisted_meta_bits(&mut self, bits: u16) {
                 // Meta bits go in the lowest positions (bits 0..meta_count)
-                self.0 = (self.0 & !Self::META_MASK) | (bits as u16 & Self::META_MASK);
+                self.0 = (self.0 & !Self::META_MASK) | (bits as u32 & Self::META_MASK);
             }
 
             #[doc = "Set data bits from a raw value, preserving other flags"]
-            pub fn set_persisted_data_bits(&mut self, bits: u8) {
+            pub fn set_persisted_data_bits(&mut self, bits: u16) {
                 // Data bits go in positions meta_count..meta_count+data_count,
                 // so we shift left to place them correctly
-                self.0 = (self.0 & !Self::DATA_MASK) | (((bits as u16) << #meta_count) & Self::DATA_MASK);
+                self.0 = (self.0 & !Self::DATA_MASK) | (((bits as u32) << #meta_count) & Self::DATA_MASK);
             }
 
             #[doc = "Set all persisted bits from a raw value, preserving transient flags"]
-            pub fn set_persisted_bits(&mut self, bits: u16) {
+            pub fn set_persisted_bits(&mut self, bits: u32) {
                 self.0 = (self.0 & !Self::PERSISTED_MASK) | (bits & Self::PERSISTED_MASK);
             }
 
@@ -1162,7 +1160,7 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
             }
 
             #[doc = "Create from raw bits (for deserialization)"]
-            pub fn from_bits(bits: u16) -> Self {
+            pub fn from_bits(bits: u32) -> Self {
                 Self(bits)
             }
         }


### PR DESCRIPTION
## What

Makes GC correct and safe on a real application: anchors GC roots, refuses to collect tasks whose data isn't resident, and wires the anchoring into the app.

- **`gc_root`**: a task created with **no parent** (`parent == None`) — spawned from outside the tracked graph (a `turbo_tasks.run`/NAPI entry, `run_once`, or `OperationVc::connect` outside a task) — is marked a GC root and is never collected. Without this, root operations reach `parent_count == 0` once their transient creator finishes and GC collects them, cascading into their whole subgraph. 
- **Data-resident gate**: `gc_maybe_collectible` also requires Data restored, so GC never selects a task whose type-bearing Data was evicted (which crashed at snapshot). Interim stop-gap with a `TODO` — the real fix is restore-Data-in-GC or moving the task-type-hash into Meta.
- **`DetachedVc`** pins its `OperationVc` across the NAPI boundary; pinned tasks are partially evicted rather than forced fully resident.
- **`VersionedContentMap`**: `serialization = "skip"` + `evict = "never"` + pin/unpin of the `OperationVc`s it stores, so the ops held in its `State` are anchored (they live outside the task graph and would otherwise be collected).
- **`keys_in_path` / `raw_get` are `session_dependent`**: these are the two tasks that read the map's non-persisted `State`. Because the map is `serialization = "skip"`, its `State` (and the read-subscription invalidators recorded inside it) is not persisted — but the reader tasks *are* persisted, so on a cross-session restore their cached output would be served against a fresh, empty map with no edge to invalidate it. `session_dependent` forces both to re-execute on restore instead of reusing cache, so they recompute against the empty map (`keys_in_path → []`, `raw_get → None`). Without this, a route deleted between sessions was still keyed by the stale restored `keys_in_path` output, causing the next session to re-subscribe and re-drive the deleted route's endpoint (`AppEndpoint::output` against a tree with no such route → `AppPageLoaderTree` cell miss → a burst of non-fatal "Failed to write app endpoint" errors at startup). This is a no-op without dependency tracking (non-persistent runs), so it's inert exactly where it's irrelevant.

## Why

The collection pass (PR below) is correct for graph-reachable tasks but over-collects anything held *outside* the tracked graph — the project container, per-request operations, and ops stashed in long-lived `State`. This PR anchors those.

## Known tradeoff (interim)

`gc_root` is a permanent pin, so request-scoped roots (e.g. a fresh source-map/trace operation per navigation) accumulate uncollected within a session. This is the conservative correctness-over-reclamation choice; a real root lifecycle is a follow-up.

## Verification

Backend GC suites (incl. `gc_does_not_collect_parentless_root_task` and the flag-layout tests), and a dev-app run with `TURBO_ENGINE_GC` enabled through navigation/HMR cycles — no crashes, dead leaves collected.

