### PR TITLE
Rewrite edge server source map sources in Rust, drop JS fallback

### DIFF
--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -7,7 +7,8 @@ use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
     chunk::{
         AssetSuffix, ChunkingConfig, ChunkingContext, CrossOrigin, MangleType, MinifyType,
-        SourceMapsType, UnusedReferences, UrlBehavior, chunk_id_strategy::ModuleIdStrategy,
+        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        chunk_id_strategy::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
     environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
@@ -264,6 +265,15 @@ pub async fn get_edge_chunking_context_with_client_assets(
         MinifyType::NoMinify
     })
     .source_maps(*turbo_source_maps.await?)
+    // The edge server runtime is browser-like, so it uses a `BrowserChunkingContext` whose default
+    // source map source type is `TurbopackUri` (sources left as `turbopack:///[project]/...`).
+    // Match the Node.js server context instead so server stack traces get real file paths:
+    // absolute `file://` URIs in dev, relative paths in production.
+    .source_map_source_type(if next_mode.is_development() {
+        SourceMapSourceType::AbsoluteFileUri
+    } else {
+        SourceMapSourceType::RelativeUri
+    })
     .cross_origin(cross_origin_loading)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)
@@ -368,6 +378,15 @@ pub async fn get_edge_chunking_context(
         MinifyType::NoMinify
     })
     .source_maps(*turbo_source_maps.await?)
+    // The edge server runtime is browser-like, so it uses a `BrowserChunkingContext` whose default
+    // source map source type is `TurbopackUri` (sources left as `turbopack:///[project]/...`).
+    // Match the Node.js server context instead so server stack traces get real file paths:
+    // absolute `file://` URIs in dev, relative paths in production.
+    .source_map_source_type(if next_mode.is_development() {
+        SourceMapSourceType::AbsoluteFileUri
+    } else {
+        SourceMapSourceType::RelativeUri
+    })
     .cross_origin(cross_origin)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -2,7 +2,6 @@ import type { Socket } from 'net'
 import { mkdir, writeFile } from 'fs/promises'
 import * as inspector from 'inspector'
 import { join, extname, relative } from 'path'
-import { pathToFileURL } from 'url'
 
 import ws from 'next/dist/compiled/ws'
 
@@ -263,32 +262,8 @@ function setupServerHmr(
   return serverHmrSubscriptions
 }
 
-/**
- * Replaces turbopack:///[project] with the specified project in the `source` field.
- */
-function rewriteTurbopackSources(
-  projectRoot: string,
-  sourceMap: ModernSourceMapPayload
-): void {
-  if ('sections' in sourceMap) {
-    for (const section of sourceMap.sections) {
-      rewriteTurbopackSources(projectRoot, section.map)
-    }
-  } else {
-    for (let i = 0; i < sourceMap.sources.length; i++) {
-      sourceMap.sources[i] = pathToFileURL(
-        join(
-          projectRoot,
-          sourceMap.sources[i].replace(/turbopack:\/\/\/\[project\]/, '')
-        )
-      ).toString()
-    }
-  }
-}
-
 function getSourceMapFromTurbopack(
   project: Project,
-  projectRoot: string,
   sourceURL: string
 ): ModernSourceMapPayload | undefined {
   let sourceMapJson: string | null = null
@@ -300,11 +275,11 @@ function getSourceMapFromTurbopack(
   if (sourceMapJson === null) {
     return undefined
   } else {
-    const payload: ModernSourceMapPayload = JSON.parse(sourceMapJson)
-    // The sourcemap from Turbopack is not yet written to disk so its `sources`
-    // are not absolute paths yet. We need to rewrite them to be absolute paths.
-    rewriteTurbopackSources(projectRoot, payload)
-    return payload
+    // Turbopack rewrites source map `sources` in Rust before serialization, based on the chunking
+    // context's source_map_source_type. In dev, all Next.js server contexts (Node.js and edge) use
+    // AbsoluteFileUri, which converts `turbopack:///[project]/...` into absolute `file://` URIs, so
+    // the payload's sources are already absolute by the time `getSourceMapSync` returns.
+    return JSON.parse(sourceMapJson)
   }
 }
 
@@ -436,7 +411,7 @@ export async function createHotReloaderTurbopack(
     parentSpan: hotReloaderSpan,
   })
   setBundlerFindSourceMapImplementation(
-    getSourceMapFromTurbopack.bind(null, project, projectPath)
+    getSourceMapFromTurbopack.bind(null, project)
   )
 
   // Set up code frame renderer using native bindings

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -275,10 +275,6 @@ function getSourceMapFromTurbopack(
   if (sourceMapJson === null) {
     return undefined
   } else {
-    // Turbopack rewrites source map `sources` in Rust before serialization, based on the chunking
-    // context's source_map_source_type. In dev, all Next.js server contexts (Node.js and edge) use
-    // AbsoluteFileUri, which converts `turbopack:///[project]/...` into absolute `file://` URIs, so
-    // the payload's sources are already absolute by the time `getSourceMapSync` returns.
     return JSON.parse(sourceMapJson)
   }
 }


### PR DESCRIPTION
The `rewriteTurbopackSources` function has been mostly dead since #85146 this closes the remaining gap with the edge runtime in dev (an accidental omission) and drops the js side munging