### PR TITLE
fix(next/font/google): bound Google Fonts fetch timeout on Turbopack

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2711,7 +2711,7 @@ impl NextConfig {
         // TODO: Use a less aggressive timeout for build than dev.
         FetchClientConfig {
             connect_timeout: std::time::Duration::from_secs(5),
-            timeout: std::time::Duration::from_secs(30),
+            timeout: Duration::from_secs(30),
             ..Default::default()
         }
         .cell()

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2705,19 +2705,21 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn fetch_client(&self) -> Vc<FetchClientConfig> {
-        // Used for the Google Fonts fetch.
-        // Use timeouts to prevent indefinite/long hangs.
-        // `next dev` will fall back to system fonts if this fails.
-        // `next build` will fail if this times out.
-        // TODO: Use a less aggressive timeout for build than dev.
-        FetchClientConfig {
-            connect_timeout: Duration::from_secs(10),
-            timeout: Duration::from_secs(30),
-            max_retries: 3,
+    pub async fn fetch_client(&self, next_mode: Vc<NextMode>) -> Result<Vc<FetchClientConfig>> {
+        // Bounds the Google Fonts fetch. Dev fails fast and falls back to a system font;
+        // build tolerates a slower network since a missing font fails the build.
+        let (connect_timeout, timeout) = if matches!(*next_mode.await?, NextMode::Development) {
+            (Duration::from_secs(5), Duration::from_secs(10))
+        } else {
+            (Duration::from_secs(10), Duration::from_secs(30))
+        };
+        Ok(FetchClientConfig {
+            connect_timeout,
+            timeout,
+            max_retries: 1,
             ..Default::default()
         }
-        .cell()
+        .cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use bincode::{Decode, Encode};
@@ -2712,6 +2714,7 @@ impl NextConfig {
         FetchClientConfig {
             connect_timeout: Duration::from_secs(10),
             timeout: Duration::from_secs(30),
+            max_retries: 3,
             ..Default::default()
         }
         .cell()

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2710,7 +2710,7 @@ impl NextConfig {
         // `next build` will fail if this times out.
         // TODO: Use a less aggressive timeout for build than dev.
         FetchClientConfig {
-            connect_timeout: std::time::Duration::from_secs(5),
+            connect_timeout: Duration::from_secs(10),
             timeout: Duration::from_secs(30),
             ..Default::default()
         }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2704,10 +2704,11 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn fetch_client(&self) -> Vc<FetchClientConfig> {
-        // Used for the Google Fonts fetch, which downloads from a fast CDN at compile time. Bound
-        // it tightly: a short connect timeout fails fast when a proxy or captive portal hangs the
-        // connection (so `next build`/`next dev` fall back instead of blocking indefinitely), while
-        // the total timeout stays generous enough for a slow-but-working network during a build.
+        // Used for the Google Fonts fetch.
+        // Use timeouts to prevent indefinite/long hangs.
+        // `next dev` will fall back to system fonts if this fails.
+        // `next build` will fail if this times out.
+        // TODO: Use a less aggressive timeout for build than dev.
         FetchClientConfig {
             connect_timeout: std::time::Duration::from_secs(5),
             timeout: std::time::Duration::from_secs(30),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2704,7 +2704,16 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn fetch_client(&self) -> Vc<FetchClientConfig> {
-        FetchClientConfig::default().cell()
+        // Used for the Google Fonts fetch, which downloads from a fast CDN at compile time. Bound
+        // it tightly: a short connect timeout fails fast when a proxy or captive portal hangs the
+        // connection (so `next build`/`next dev` fall back instead of blocking indefinitely), while
+        // the total timeout stays generous enough for a slow-but-working network during a build.
+        FetchClientConfig {
+            connect_timeout: std::time::Duration::from_secs(5),
+            timeout: std::time::Duration::from_secs(30),
+            ..Default::default()
+        }
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     asset::AssetContent,
     context::AssetContext,
     ident::Layer,
-    issue::{IssueExt, IssueSeverity, StyledString},
+    issue::{IssueExt, IssueSeverity},
     module_graph::{ModuleGraph, SingleModuleGraph},
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
@@ -49,7 +49,7 @@ use crate::{
             stylesheet::build_stylesheet,
             util::{get_font_axes, get_stylesheet_url},
         },
-        issue::NextFontIssue,
+        issue::GoogleFontsFetchIssue,
         util::{
             FontCssProperties, FontFamilyType, can_use_next_font, get_request_hash, get_request_id,
             get_scoped_font_family,
@@ -269,64 +269,15 @@ impl NextFontGoogleCssModuleReplacer {
             ),
             None => {
                 let attempts = self.fetch_client.await?.max_retries + 1;
-                match *self.next_mode.await? {
-                    // If we're in production mode, we want to fail the build to ensure proper font
-                    // rendering.
-                    NextMode::Build => {
-                        NextFontIssue {
-                            path: css_virtual_path.clone(),
-                            title: StyledString::Line(vec![
-                                StyledString::Code(rcstr!("next/font:")),
-                                StyledString::Text(rcstr!(" error:")),
-                            ])
-                            .resolved_cell(),
-                            description: StyledString::Text(
-                                format!(
-                                    "Failed to fetch `{}` from Google Fonts after {} \
-                                     attempts.\nIf you are offline or behind a proxy that blocks \
-                                     `fonts.googleapis.com`, self-host the font with \
-                                     `next/font/local`, or make sure the endpoint is reachable \
-                                     during the build.",
-                                    options.await?.font_family,
-                                    attempts,
-                                )
-                                .into(),
-                            )
-                            .resolved_cell(),
-                            severity: IssueSeverity::Error,
-                        }
-                        .resolved_cell()
-                        .emit();
-                    }
-                    // Inform the user of the failure to retrieve the stylesheet / font, but don't
-                    // propagate this error. We don't want e.g. offline connections to prevent page
-                    // renders during development.
-                    NextMode::Development => {
-                        NextFontIssue {
-                            path: css_virtual_path.clone(),
-                            title: StyledString::Line(vec![
-                                StyledString::Code(rcstr!("next/font:")),
-                                StyledString::Text(rcstr!(" warning:")),
-                            ])
-                            .resolved_cell(),
-                            description: StyledString::Text(
-                                format!(
-                                    "Failed to download `{}` from Google Fonts after {} attempts. \
-                                     Using a fallback font instead.\nIf you are offline or behind \
-                                     a proxy that blocks `fonts.googleapis.com`, self-host the \
-                                     font with `next/font/local`.",
-                                    options.await?.font_family,
-                                    attempts,
-                                )
-                                .into(),
-                            )
-                            .resolved_cell(),
-                            severity: IssueSeverity::Warning,
-                        }
-                        .resolved_cell()
-                        .emit();
-                    }
+                let is_dev = matches!(*self.next_mode.await?, NextMode::Development);
+                GoogleFontsFetchIssue {
+                    path: css_virtual_path.clone(),
+                    font_family: options.await?.font_family.clone(),
+                    attempts,
+                    is_dev,
                 }
+                .resolved_cell()
+                .emit();
 
                 None
             }

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_env::{CommandLineProcessEnv, ProcessEnv};
-use turbo_tasks_fetch::{FetchClientConfig, HttpResponseBody, MAX_FETCH_RETRIES};
+use turbo_tasks_fetch::{FetchClientConfig, HttpResponseBody};
 use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath,
     json::parse_json_with_source_context,
@@ -268,6 +268,7 @@ impl NextFontGoogleCssModuleReplacer {
                 .await?,
             ),
             None => {
+                let attempts = self.fetch_client.await?.max_retries + 1;
                 match *self.next_mode.await? {
                     // If we're in production mode, we want to fail the build to ensure proper font
                     // rendering.
@@ -287,7 +288,7 @@ impl NextFontGoogleCssModuleReplacer {
                                      `next/font/local`, or make sure the endpoint is reachable \
                                      during the build.",
                                     options.await?.font_family,
-                                    MAX_FETCH_RETRIES + 1,
+                                    attempts,
                                 )
                                 .into(),
                             )
@@ -315,7 +316,7 @@ impl NextFontGoogleCssModuleReplacer {
                                      a proxy that blocks `fonts.googleapis.com`, self-host the \
                                      font with `next/font/local`.",
                                     options.await?.font_family,
-                                    MAX_FETCH_RETRIES + 1,
+                                    attempts,
                                 )
                                 .into(),
                             )

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -268,12 +268,10 @@ impl NextFontGoogleCssModuleReplacer {
                 .await?,
             ),
             None => {
-                let attempts = self.fetch_client.await?.max_retries + 1;
                 let is_dev = matches!(*self.next_mode.await?, NextMode::Development);
                 GoogleFontsFetchIssue {
                     path: css_virtual_path.clone(),
                     font_family: options.await?.font_family.clone(),
-                    attempts,
                     is_dev,
                 }
                 .resolved_cell()

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_env::{CommandLineProcessEnv, ProcessEnv};
-use turbo_tasks_fetch::{FetchClientConfig, HttpResponseBody};
+use turbo_tasks_fetch::{FetchClientConfig, HttpResponseBody, MAX_FETCH_RETRIES};
 use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath,
     json::parse_json_with_source_context,
@@ -281,8 +281,13 @@ impl NextFontGoogleCssModuleReplacer {
                             .resolved_cell(),
                             description: StyledString::Text(
                                 format!(
-                                    "Failed to fetch `{}` from Google Fonts.",
-                                    options.await?.font_family
+                                    "Failed to fetch `{}` from Google Fonts after {} \
+                                     attempts.\nIf you are offline or behind a proxy that blocks \
+                                     `fonts.googleapis.com`, self-host the font with \
+                                     `next/font/local`, or make sure the endpoint is reachable \
+                                     during the build.",
+                                    options.await?.font_family,
+                                    MAX_FETCH_RETRIES + 1,
                                 )
                                 .into(),
                             )
@@ -305,9 +310,12 @@ impl NextFontGoogleCssModuleReplacer {
                             .resolved_cell(),
                             description: StyledString::Text(
                                 format!(
-                                    "Failed to download `{}` from Google Fonts. Using fallback \
-                                     font instead.",
-                                    options.await?.font_family
+                                    "Failed to download `{}` from Google Fonts after {} attempts. \
+                                     Using a fallback font instead.\nIf you are offline or behind \
+                                     a proxy that blocks `fonts.googleapis.com`, self-host the \
+                                     font with `next/font/local`.",
+                                    options.await?.font_family,
+                                    MAX_FETCH_RETRIES + 1,
                                 )
                                 .into(),
                             )

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, StyledString};
@@ -33,5 +34,84 @@ impl Issue for NextFontIssue {
 
     async fn description(&self) -> Result<Option<StyledString>> {
         Ok(Some(self.description.owned().await?))
+    }
+}
+
+/// Emitted when the compile-time Google Fonts fetch fails. Error on `next build`, warning in
+/// `next dev` (which renders a fallback font).
+#[turbo_tasks::value(shared)]
+pub(crate) struct GoogleFontsFetchIssue {
+    pub(crate) path: FileSystemPath,
+    pub(crate) font_family: RcStr,
+    pub(crate) attempts: u32,
+    pub(crate) is_dev: bool,
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Issue for GoogleFontsFetchIssue {
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        if self.is_dev {
+            IssueSeverity::Warning
+        } else {
+            IssueSeverity::Error
+        }
+    }
+
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
+    }
+
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Line(vec![
+            StyledString::Code(rcstr!("next/font:")),
+            StyledString::Text(if self.is_dev {
+                rcstr!(" warning:")
+            } else {
+                rcstr!(" error:")
+            }),
+        ]))
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        let summary = if self.is_dev {
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Failed to download ")),
+                StyledString::Code(self.font_family.clone()),
+                StyledString::Text(
+                    format!(
+                        " from Google Fonts after {} attempts. Using a fallback font instead.",
+                        self.attempts
+                    )
+                    .into(),
+                ),
+            ])
+        } else {
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Failed to fetch ")),
+                StyledString::Code(self.font_family.clone()),
+                StyledString::Text(
+                    format!(" from Google Fonts after {} attempts.", self.attempts).into(),
+                ),
+            ])
+        };
+        let guidance = StyledString::Line(vec![
+            StyledString::Text(rcstr!(
+                "If you are offline or behind a proxy, self-host the font with "
+            )),
+            StyledString::Code(rcstr!("next/font/local")),
+            StyledString::Text(rcstr!(", or set ")),
+            StyledString::Code(rcstr!("HTTP_PROXY")),
+            StyledString::Text(rcstr!("/")),
+            StyledString::Code(rcstr!("HTTPS_PROXY")),
+            StyledString::Text(rcstr!(" so Next.js can reach ")),
+            StyledString::Code(rcstr!("fonts.googleapis.com")),
+            StyledString::Text(rcstr!(".")),
+        ]);
+        Ok(Some(StyledString::Stack(vec![summary, guidance])))
     }
 }

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -43,7 +43,6 @@ impl Issue for NextFontIssue {
 pub(crate) struct GoogleFontsFetchIssue {
     pub(crate) path: FileSystemPath,
     pub(crate) font_family: RcStr,
-    pub(crate) attempts: u32,
     pub(crate) is_dev: bool,
 }
 
@@ -82,21 +81,13 @@ impl Issue for GoogleFontsFetchIssue {
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("Failed to download ")),
                 StyledString::Code(self.font_family.clone()),
-                StyledString::Text(
-                    format!(
-                        " from Google Fonts after {} attempts. Using a fallback font instead.",
-                        self.attempts
-                    )
-                    .into(),
-                ),
+                StyledString::Text(rcstr!(" from Google Fonts. Using a fallback font instead.")),
             ])
         } else {
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("Failed to fetch ")),
                 StyledString::Code(self.font_family.clone()),
-                StyledString::Text(
-                    format!(" from Google Fonts after {} attempts.", self.attempts).into(),
-                ),
+                StyledString::Text(rcstr!(" from Google Fonts.")),
             ])
         };
         let guidance = StyledString::Line(vec![

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1106,7 +1106,7 @@ async fn insert_next_shared_aliases(
         next_font_google_replacer_mapping,
     );
 
-    let fetch_client = next_config.fetch_client();
+    let fetch_client = next_config.fetch_client(next_mode);
     import_map.insert_alias(
         AliasPattern::exact(rcstr!(
             "@vercel/turbopack-next/internal/font/google/cssmodule.module.css"

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -52,7 +52,7 @@ describe('next/font/google fetch error', () => {
 
       expect(next.cliOutput.slice(outputIndex)).toInclude(
         isTurbopack
-          ? 'Failed to download Inter from Google Fonts after 4 attempts. Using a fallback font instead.'
+          ? 'Failed to download Inter from Google Fonts. Using a fallback font instead.'
           : 'Failed to download `Inter` from Google Fonts. Using fallback font instead.'
       )
     })
@@ -61,7 +61,7 @@ describe('next/font/google fetch error', () => {
       await expect(next.start()).rejects.toThrow('next build failed')
       expect(next.cliOutput).toInclude(
         isTurbopack
-          ? 'Failed to fetch Inter from Google Fonts after 4 attempts.'
+          ? 'Failed to fetch Inter from Google Fonts.'
           : 'Failed to fetch `Inter` from Google Fonts.'
       )
     })

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -7,6 +7,9 @@ const mockedGoogleFontResponses = require.resolve(
 
 describe('next/font/google fetch error', () => {
   const isDev = (global as any).isNextDev
+  // Turbopack bounds the fetch with retries and an enriched message; the
+  // webpack/JS path still emits the original wording (updated in a follow-up).
+  const isTurbopack = !!process.env.IS_TURBOPACK_TEST
 
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
@@ -50,14 +53,18 @@ describe('next/font/google fetch error', () => {
       expect(sizeAdjust).toMatchInlineSnapshot(`"107.12%"`)
 
       expect(next.cliOutput.slice(outputIndex)).toInclude(
-        'Failed to download `Inter` from Google Fonts. Using fallback font instead.'
+        isTurbopack
+          ? 'Failed to download `Inter` from Google Fonts after 4 attempts. Using a fallback font instead.'
+          : 'Failed to download `Inter` from Google Fonts. Using fallback font instead.'
       )
     })
   } else {
     it('should error when not in dev', async () => {
       await expect(next.start()).rejects.toThrow('next build failed')
       expect(next.cliOutput).toInclude(
-        'Failed to fetch `Inter` from Google Fonts.'
+        isTurbopack
+          ? 'Failed to fetch `Inter` from Google Fonts after 4 attempts.'
+          : 'Failed to fetch `Inter` from Google Fonts.'
       )
     })
   }

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -52,7 +52,7 @@ describe('next/font/google fetch error', () => {
 
       expect(next.cliOutput.slice(outputIndex)).toInclude(
         isTurbopack
-          ? 'Failed to download `Inter` from Google Fonts after 4 attempts. Using a fallback font instead.'
+          ? 'Failed to download Inter from Google Fonts after 4 attempts. Using a fallback font instead.'
           : 'Failed to download `Inter` from Google Fonts. Using fallback font instead.'
       )
     })
@@ -61,7 +61,7 @@ describe('next/font/google fetch error', () => {
       await expect(next.start()).rejects.toThrow('next build failed')
       expect(next.cliOutput).toInclude(
         isTurbopack
-          ? 'Failed to fetch `Inter` from Google Fonts after 4 attempts.'
+          ? 'Failed to fetch Inter from Google Fonts after 4 attempts.'
           : 'Failed to fetch `Inter` from Google Fonts.'
       )
     })

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -7,8 +7,6 @@ const mockedGoogleFontResponses = require.resolve(
 
 describe('next/font/google fetch error', () => {
   const isDev = (global as any).isNextDev
-  // Turbopack bounds the fetch with retries and an enriched message; the
-  // webpack/JS path still emits the original wording (updated in a follow-up).
   const isTurbopack = !!process.env.IS_TURBOPACK_TEST
 
   if ((global as any).isNextDeploy) {

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -34,21 +34,13 @@ pub struct FetchClientConfig {
     /// will be clamped to this value. This prevents pathologically short timeouts from causing an
     /// invalidation bomb. Defaults to 1 hour.
     pub min_cache_control: Duration,
-    /// Maximum time to wait for a connection (DNS + TCP + TLS, including a proxy `CONNECT`
-    /// tunnel) to be established. A short value fails fast when a host hangs rather than refuses
-    /// — an unreachable endpoint, or a captive portal / proxy that drops packets — instead of
-    /// blocking compilation until the OS-level connect timeout fires (~75s). Kept below `timeout`.
-    /// This is generic; callers should override it (e.g. Google Fonts uses a tighter value).
-    /// Defaults to 10 seconds.
+    /// Maximum time to establish a connection (DNS + TCP + TLS). Defaults to 10 seconds.
     pub connect_timeout: Duration,
-    /// Maximum time for the entire request: connection, sending, and reading the full response.
-    /// An overall cap on top of `connect_timeout` (and always larger than it) that bounds a
-    /// connection which establishes but then stalls. Defaults to 60 seconds.
+    /// Maximum time for the entire request. Always larger than `connect_timeout`. Defaults to
+    /// 60 seconds.
     pub timeout: Duration,
-    /// Number of times to retry a transient failure (connection error, timeout, or a 5xx
-    /// response) before surfacing the error to the caller. The total number of attempts made is
-    /// `max_retries + 1`. This is generic, so it defaults to 0 (no retries); callers that fetch
-    /// from a reliable endpoint can opt into retries (e.g. Google Fonts uses a small value).
+    /// Times to retry a transient failure (connection error, timeout, or 5xx) before surfacing
+    /// it. Total attempts is `max_retries + 1`. Defaults to 0.
     pub max_retries: u32,
 }
 
@@ -194,8 +186,6 @@ impl FetchClientConfig {
                 let mut attempt = 0;
                 loop {
                     let request = builder.try_clone().expect("request should be cloneable");
-                    // Each attempt is its own span (not a log event) so retries are visible as
-                    // nested, timed spans in the trace viewer (https://trace.nextjs.org/).
                     let result = {
                         let _span = duration_span!("fetch attempt", url = url_ref, attempt);
                         request.send().await.and_then(|r| r.error_for_status())

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -17,6 +17,10 @@ use turbo_tasks::{
 use crate::{FetchError, FetchResult, HttpResponse, HttpResponseBody};
 
 const MAX_CLIENTS: usize = 16;
+/// Number of times a transient fetch failure (connection error / timeout) is retried before giving
+/// up and surfacing the error to the caller. The total number of attempts made is
+/// `MAX_FETCH_RETRIES + 1`.
+pub const MAX_FETCH_RETRIES: u32 = 3;
 static CLIENT_CACHE: LazyLock<Cache<ReadRef<FetchClientConfig>, reqwest::Client>> =
     LazyLock::new(|| Cache::new(MAX_CLIENTS));
 
@@ -34,12 +38,25 @@ pub struct FetchClientConfig {
     /// will be clamped to this value. This prevents pathologically short timeouts from causing an
     /// invalidation bomb. Defaults to 1 hour.
     pub min_cache_control: Duration,
+    /// Maximum time to wait for a connection (DNS + TCP + TLS, including a proxy `CONNECT`
+    /// tunnel) to be established. A short value fails fast when a host hangs rather than refuses
+    /// — an unreachable endpoint, or a captive portal / proxy that drops packets — instead of
+    /// blocking compilation until the OS-level connect timeout fires (~75s). Kept below `timeout`.
+    /// This is generic; callers should override it (e.g. Google Fonts uses a tighter value).
+    /// Defaults to 10 seconds.
+    pub connect_timeout: Duration,
+    /// Maximum time for the entire request: connection, sending, and reading the full response.
+    /// An overall cap on top of `connect_timeout` (and always larger than it) that bounds a
+    /// connection which establishes but then stalls. Defaults to 60 seconds.
+    pub timeout: Duration,
 }
 
 impl Default for FetchClientConfig {
     fn default() -> Self {
         Self {
             min_cache_control: Duration::from_secs(60 * 60),
+            connect_timeout: Duration::from_secs(10),
+            timeout: Duration::from_secs(60),
         }
     }
 }
@@ -68,7 +85,9 @@ impl FetchClientConfig {
 
     fn try_build_uncached_reqwest_client(&self) -> reqwest::Result<reqwest::Client> {
         #[allow(unused_mut)]
-        let mut builder = reqwest::Client::builder();
+        let mut builder = reqwest::Client::builder()
+            .connect_timeout(self.connect_timeout)
+            .timeout(self.timeout);
         #[cfg(any(target_os = "linux", all(windows, not(target_arch = "aarch64"))))]
         {
             use std::sync::Once;
@@ -169,9 +188,28 @@ impl FetchClientConfig {
 
             let response = {
                 let _span = duration_span!("fetch request", url = url_ref);
-                builder.send().await
-            }
-            .and_then(|r| r.error_for_status())?;
+                let mut attempt = 0;
+                loop {
+                    // A GET request without a body is always cloneable.
+                    let request = builder.try_clone().expect("request should be cloneable");
+                    // Each attempt is its own span (not a log event) so retries are visible as
+                    // nested, timed spans in the trace viewer (https://trace.nextjs.org/).
+                    let result = {
+                        let _span = duration_span!("fetch attempt", url = url_ref, attempt);
+                        request.send().await.and_then(|r| r.error_for_status())
+                    };
+                    match result {
+                        Ok(response) => break response,
+                        Err(err)
+                            if attempt < MAX_FETCH_RETRIES
+                                && (err.is_connect() || err.is_timeout() || err.is_request()) =>
+                        {
+                            attempt += 1;
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            };
 
             let status = response.status().as_u16();
             let max_age = parse_cache_control(response.headers());

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -17,10 +17,6 @@ use turbo_tasks::{
 use crate::{FetchError, FetchResult, HttpResponse, HttpResponseBody};
 
 const MAX_CLIENTS: usize = 16;
-/// Number of times a transient fetch failure (connection error / timeout) is retried before giving
-/// up and surfacing the error to the caller. The total number of attempts made is
-/// `MAX_FETCH_RETRIES + 1`.
-pub const MAX_FETCH_RETRIES: u32 = 3;
 static CLIENT_CACHE: LazyLock<Cache<ReadRef<FetchClientConfig>, reqwest::Client>> =
     LazyLock::new(|| Cache::new(MAX_CLIENTS));
 
@@ -49,6 +45,11 @@ pub struct FetchClientConfig {
     /// An overall cap on top of `connect_timeout` (and always larger than it) that bounds a
     /// connection which establishes but then stalls. Defaults to 60 seconds.
     pub timeout: Duration,
+    /// Number of times to retry a transient failure (connection error, timeout, or a 5xx
+    /// response) before surfacing the error to the caller. The total number of attempts made is
+    /// `max_retries + 1`. This is generic, so it defaults to 0 (no retries); callers that fetch
+    /// from a reliable endpoint can opt into retries (e.g. Google Fonts uses a small value).
+    pub max_retries: u32,
 }
 
 impl Default for FetchClientConfig {
@@ -57,6 +58,7 @@ impl Default for FetchClientConfig {
             min_cache_control: Duration::from_secs(60 * 60),
             connect_timeout: Duration::from_secs(10),
             timeout: Duration::from_secs(60),
+            max_retries: 0,
         }
     }
 }
@@ -178,6 +180,7 @@ impl FetchClientConfig {
         let url_ref = &*url;
         let this = self.await?;
         let min_cache_control_secs = this.min_cache_control;
+        let max_retries = this.max_retries;
         let response_result: reqwest::Result<(HttpResponse, Option<u64>)> = async move {
             let reqwest_client = this.try_get_cached_reqwest_client()?;
 
@@ -200,8 +203,11 @@ impl FetchClientConfig {
                     match result {
                         Ok(response) => break response,
                         Err(err)
-                            if attempt < MAX_FETCH_RETRIES
-                                && (err.is_connect() || err.is_timeout() || err.is_request()) =>
+                            if attempt < max_retries
+                                && (err.is_connect()
+                                    || err.is_timeout()
+                                    || err.is_request()
+                                    || err.status().is_some_and(|s| s.is_server_error())) =>
                         {
                             attempt += 1;
                         }

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -190,7 +190,6 @@ impl FetchClientConfig {
                 let _span = duration_span!("fetch request", url = url_ref);
                 let mut attempt = 0;
                 loop {
-                    // A GET request without a body is always cloneable.
                     let request = builder.try_clone().expect("request should be cloneable");
                     // Each attempt is its own span (not a log event) so retries are visible as
                     // nested, timed spans in the trace viewer (https://trace.nextjs.org/).

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -9,7 +9,7 @@ mod response;
 pub use crate::{
     client::{
         __test_only_reqwest_client_cache_clear, __test_only_reqwest_client_cache_len,
-        FetchClientConfig,
+        FetchClientConfig, MAX_FETCH_RETRIES,
     },
     error::{FetchError, FetchErrorKind, FetchIssue},
     response::{FetchResult, HttpResponse, HttpResponseBody},

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -9,7 +9,7 @@ mod response;
 pub use crate::{
     client::{
         __test_only_reqwest_client_cache_clear, __test_only_reqwest_client_cache_len,
-        FetchClientConfig, MAX_FETCH_RETRIES,
+        FetchClientConfig,
     },
     error::{FetchError, FetchErrorKind, FetchIssue},
     response::{FetchResult, HttpResponse, HttpResponseBody},

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -303,6 +303,7 @@ async fn errors_on_404() {
 async fn fetch_body(url: RcStr) -> Result<Vc<RcStr>> {
     let client_vc = FetchClientConfig {
         min_cache_control: Duration::ZERO,
+        ..Default::default()
     }
     .cell();
     let response = &*client_vc


### PR DESCRIPTION
### What?

Bound the compile-time Google Fonts fetch on the Turbopack path so `next dev` / `next build` can't hang forever on a stuck network.

### Why?

`next/font/google` fetches from Google Fonts at compile time. When the connection *hangs* (captive portal, packet-dropping proxy, broken IPv6), the fetch had no timeout, so compilation blocked until the OS connect timeout (~75s) or indefinitely.

### How?

- `FetchClientConfig` gets a `connect_timeout` (10s) and total `timeout` (60s); Google Fonts overrides them to 5s / 30s.
- Transient failures retry up to 3×, each attempt its own `duration_span!`.
- On failure: `next build` errors (fails the build), `next dev` warns and uses the fallback font. Both messages report the attempt count and suggest `next/font/local`.

### Follow-ups

- [ ] Reduce the dev-mode timeout (build keeps the longer value).
- [ ] Port the fix to the webpack/JS path (`packages/font/src/google`).

 Related: #92301.  #76473.
