### PR TITLE
Prevent unhandled rejections when a "use cache" cache handler errors

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -233,6 +233,8 @@ export type SharedCacheResult =
       readonly hangingPromise: Promise<never>
     }
 
+function ignoreReject() {}
+
 /**
  * Manages the deferred promise for a shared cache result, tracks which maps
  * it's registered in, and drives cleanup from resolve/reject.
@@ -265,6 +267,11 @@ class ResolvableSharedCacheResult {
   }
 
   reject(error: unknown): void {
+    // The promise stored in the dedup maps has no consumer unless a concurrent
+    // invocation joined it, so we attach a noop catch handler to prevent the
+    // rejection from being reported as unhandled. The leader rethrows the
+    // error into the render, which is where it's surfaced.
+    this.deferred.promise.catch(ignoreReject)
     this.deferred.reject(error)
     this.cleanup()
   }

--- a/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { hasErrorToast, retry, waitForNoRedbox } from 'next-test-utils'
+import { hasErrorToast, retry, waitFor, waitForNoRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 describe('app-custom-cache-handler-errors - get throws', () => {
@@ -54,14 +54,19 @@ describe('app-custom-cache-handler-errors - get throws', () => {
     }
 
     await retry(async () => {
-      expect(next.cliOutput.slice(outputIndex)).toContain('unhandledRejection:')
+      expect(next.cliOutput.slice(outputIndex)).toContain(
+        '⨯ Error: CustomCacheHandler.get failed'
+      )
     })
+
+    // Give a potential unhandled rejection a chance to be reported before
+    // asserting its absence.
+    await waitFor(1000)
 
     const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
-    if (isNextDev) {
-      const errorBlock =
-        'Error: CustomCacheHandler.get failed' +
+    const errorBlock = isNextDev
+      ? 'Error: CustomCacheHandler.get failed' +
         '\n    at Object.get (throwing-cache-handler.js:24:13)' +
         '\n    at async CachedData (app/page.tsx:19:14)' +
         "\n  17 |   const { input = 'default' } = await searchParams" +
@@ -72,26 +77,22 @@ describe('app-custom-cache-handler-errors - get throws', () => {
         '\n  21 |' +
         '\n  22 | export default function Page({ {' +
         "\n  digest: '"
-
-      expect(cliOutput).toContain('⨯ ' + errorBlock)
-
-      // The same error is additionally reported as two unhandled rejections.
-      expect(cliOutput).toContain('⨯ unhandledRejection: ' + errorBlock)
-      expect(cliOutput).toContain('⨯ unhandledRejection:  ' + errorBlock)
-    } else {
-      // In production, the frames below the cache handler frame are bundled
-      // code, and are therefore not stable across bundlers and builds.
-      const errorBlock =
+      : // In production, the frames below the cache handler frame are bundled
+        // code, and are therefore not stable across bundlers and builds.
         'Error: CustomCacheHandler.get failed' +
         '\n    at Object.get (throwing-cache-handler.js:24:13)' +
         '\n    at '
 
-      expect(cliOutput).toContain('⨯ ' + errorBlock)
-      expect(cliOutput).toContain("  digest: '")
+    expect(cliOutput).toContain('⨯ ' + errorBlock)
 
-      // The same error is additionally reported as an unhandled rejection.
-      expect(cliOutput).toContain('⨯ unhandledRejection:  ' + errorBlock)
+    if (!isNextDev) {
+      expect(cliOutput).toContain("  digest: '")
     }
+
+    // The error must be logged exactly once, as a rendering error, and in
+    // particular not additionally as an unhandled rejection.
+    expect(cliOutput).not.toContain('unhandledRejection')
+    expect(cliOutput.split(errorBlock).length - 1).toBe(1)
   })
 })
 


### PR DESCRIPTION

When a custom `"use cache"` cache handler's `get` method throws, the error was logged up to four times for a single request: once as the intended rendering error (`⨯ Error: ... { digest }`), and up to three more times through the various `unhandledRejection` handlers (the runtime's plain `console.error` in `process-error-handlers.ts`, the router server's `Log.error`, and the dev overlay's log forwarding).

All the redundant logs stemmed from the same root cause: `ResolvableSharedCacheResult` stores its deferred promise in the dedup maps (`pendingCacheInvocations` / `crossRequestPendingCacheInvocations`) so concurrent invocations can join the leader. That promise has no consumer unless another invocation actually joins it, so when the leader's cache access failed, the rejected promise was left behind without a rejection handler, and Node.js reported it as an unhandled rejection that fanned out to every installed handler.
