### PR TITLE
[turbopack] Track re-exports in `import_usage` inside of `compute_import_usage`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use auto_hash_map::AutoSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
@@ -284,6 +285,8 @@ pub(crate) struct ProgramDeclUsage {
     pub(crate) decl_usages: FxHashMap<Id, DeclUsage>,
     // import -> immediate usage (top level decl)
     pub(crate) import_usages: FxHashMap<usize, DeclUsage>,
+    // import reference -> names it is directly re-exported as (`export { x } from '...'`)
+    pub(crate) named_reexports: FxHashMap<usize, AutoSet<RcStr>>,
     // export name -> top level decl
     pub(crate) exports: FxHashMap<RcStr, Id>,
 }
@@ -331,6 +334,24 @@ impl ProgramDeclUsage {
                     },
                 );
             }
+        }
+        // Fold re-exports (`export { x } from "foo"`) into `import_usage` for tree-shaking.
+        for (reference, names) in &self.named_reexports {
+            let usage = match import_usage.get(reference) {
+                Some(ImportUsage::TopLevel) => continue,
+                // Used locally and re-exported, e.g.
+                // `import {foo} from 'm'; export function w(){foo()} export {foo} from 'm'`
+                // → union: Exports({"w"}) ∪ {"foo"}.
+                Some(ImportUsage::Exports(existing)) => ImportUsage::Exports(
+                    existing
+                        .iter()
+                        .cloned()
+                        .chain(names.iter().cloned())
+                        .collect(),
+                ),
+                None => ImportUsage::Exports(names.iter().cloned().collect()),
+            };
+            import_usage.insert(*reference, usage);
         }
         import_usage
     }
@@ -934,26 +955,37 @@ impl Visit for Analyzer<'_> {
                     annotations.clone(),
                 );
 
-                match spec {
+                let name = match spec {
                     ExportSpecifier::Namespace(n) => {
-                        self.data.exports.insert(
-                            RcStr::from(n.name.atom().as_str()),
-                            Export::ImportedNamespace(i),
-                        );
+                        let name = RcStr::from(n.name.atom().as_str());
+                        self.data
+                            .exports
+                            .insert(name.clone(), Export::ImportedNamespace(i));
+                        name
                     }
                     ExportSpecifier::Default(d) => {
+                        let name = RcStr::from(d.exported.sym.as_str());
                         self.data.exports.insert(
-                            RcStr::from(d.exported.sym.as_str()),
+                            name.clone(),
                             Export::ImportedBinding(i, rcstr!("default"), false),
                         );
+                        name
                     }
                     ExportSpecifier::Named(n) => {
+                        let name =
+                            RcStr::from(n.exported.as_ref().unwrap_or(&n.orig).atom().as_str());
                         self.data.exports.insert(
-                            RcStr::from(n.exported.as_ref().unwrap_or(&n.orig).atom().as_str()),
+                            name.clone(),
                             Export::ImportedBinding(i, RcStr::from(n.orig.atom().as_str()), false),
                         );
+                        name
                     }
-                }
+                };
+                self.program_decl_usage
+                    .named_reexports
+                    .entry(i)
+                    .or_default()
+                    .insert(name);
             }
         } else {
             for spec in export.specifiers.iter() {

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/index.js
@@ -1,0 +1,6 @@
+async function load() {
+  const { used } = await import('./lib.js')
+  console.log(used)
+}
+
+load()

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js
@@ -1,0 +1,2 @@
+export const used = 'USED'
+export { unused } from './unused.js'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/unused.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/unused.js
@@ -1,0 +1,1 @@
+export const unused = 'UNUSED_MARKER'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/options.json
@@ -1,0 +1,6 @@
+{
+  "removeUnusedImports": true,
+  "removeUnusedExports": true,
+  "treeShakingMode": "reexports-only",
+  "scopeHoisting": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_0riermg.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_0riermg.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js
@@ -1,0 +1,12 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/index.js [test] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+async function load() {
+    const { used } = await __turbopack_context__.A("[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js [test] (ecmascript, async loader)");
+    console.log(used);
+}
+load();
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 3, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/index.js"],"sourcesContent":["async function load() {\n  const { used } = await import('./lib.js')\n  console.log(used)\n}\n\nload()\n"],"names":["load","used","console","log"],"mappings":"AAAA,eAAeA;IACb,MAAM,EAAEC,IAAI,EAAE,GAAG;IACjBC,QAAQC,GAAG,CAACF;AACd;AAEAD"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js
@@ -1,0 +1,15 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const used = 'USED';
+;
+__turbopack_context__.s([
+    "used",
+    0,
+    used
+]);
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js"],"sourcesContent":["export const used = 'USED'\nexport { unused } from './unused.js'\n"],"names":["used"],"mappings":"AAAO,MAAMA,OAAO"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_0u9f373.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_0u9f373.js
@@ -1,0 +1,12 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_0u9f373.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js [test] (ecmascript, async loader)", ((__turbopack_context__) => {
+
+__turbopack_context__.v((parentImport) => {
+    return Promise.all([
+  "output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_02nzs5r.js"
+].map((chunk) => __turbopack_context__.l(chunk))).then(() => {
+        return parentImport("[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/lib.js [test] (ecmascript)");
+    });
+});
+}),
+]);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_0u9f373.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_0u9f373.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_0riermg.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_0riermg.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_0riermg.js",
+    {"otherChunks":["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_lib_0u9f373.js","output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_basic_input_index_14t7f_0.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/basic/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/index.js
@@ -1,0 +1,6 @@
+async function load() {
+  const { used } = await import('./lib.js')
+  console.log(used)
+}
+
+load()

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js
@@ -1,0 +1,2 @@
+export const used = 'USED'
+export { unused } from './unused.js'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/unused.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/unused.js
@@ -1,0 +1,1 @@
+export const unused = 'UNUSED_MARKER'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/options.json
@@ -1,0 +1,6 @@
+{
+  "removeUnusedImports": true,
+  "removeUnusedExports": true,
+  "treeShakingMode": null,
+  "scopeHoisting": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js
@@ -1,0 +1,12 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/index.js [test] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+async function load() {
+    const { used } = await __turbopack_context__.A("[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js [test] (ecmascript, async loader)");
+    console.log(used);
+}
+load();
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 3, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/index.js"],"sourcesContent":["async function load() {\n  const { used } = await import('./lib.js')\n  console.log(used)\n}\n\nload()\n"],"names":["load","used","console","log"],"mappings":"AAAA,eAAeA;IACb,MAAM,EAAEC,IAAI,EAAE,GAAG;IACjBC,QAAQC,GAAG,CAACF;AACd;AAEAD"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_1dawwqa.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_1dawwqa.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_062uldb.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_062uldb.js
@@ -1,0 +1,12 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_062uldb.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js [test] (ecmascript, async loader)", ((__turbopack_context__) => {
+
+__turbopack_context__.v((parentImport) => {
+    return Promise.all([
+  "output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js"
+].map((chunk) => __turbopack_context__.l(chunk))).then(() => {
+        return parentImport("[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js [test] (ecmascript)");
+    });
+});
+}),
+]);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_062uldb.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_062uldb.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js
@@ -1,0 +1,15 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+const used = 'USED';
+;
+__turbopack_context__.s([
+    "used",
+    0,
+    used
+]);
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_1_1s1zh.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/lib.js"],"sourcesContent":["export const used = 'USED'\nexport { unused } from './unused.js'\n"],"names":["used"],"mappings":"AAAO,MAAMA,OAAO"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_1dawwqa.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_1dawwqa.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_1dawwqa.js",
+    {"otherChunks":["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_lib_062uldb.js","output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_dynamic_input_index_138bkae.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/dynamic/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js
@@ -1,0 +1,3 @@
+import { y } from './lib.js'
+
+console.log(y)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/lib.js
@@ -1,0 +1,2 @@
+export { x as y } from './origin.js'
+export { z } from './unused.js'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/origin.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/origin.js
@@ -1,0 +1,1 @@
+export const x = 'X_USED_MARKER'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/unused.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/unused.js
@@ -1,0 +1,1 @@
+export const z = 'Z_UNUSED_MARKER'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/options.json
@@ -1,0 +1,5 @@
+{
+  "removeUnusedImports": true,
+  "removeUnusedExports": true,
+  "scopeHoisting": true
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_03l_5yx.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_03l_5yx.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js
@@ -1,0 +1,20 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js [test] (ecmascript)
+;
+// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/lib.js [test] (ecmascript)
+;
+// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/origin.js [test] (ecmascript)
+;
+const x = 'X_USED_MARKER';
+;
+;
+;
+console.log(x);
+__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js [test] (ecmascript)");
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/origin.js","turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js"],"sourcesContent":["export const x = 'X_USED_MARKER'\n","import { y } from './lib.js'\n\nconsole.log(y)\n"],"names":["x"],"mappings":";;;;;;AAAO,MAAMA,IAAI;;;;ACEjB,QAAQ,GAAG,CAAC"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_03l_5yx.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_03l_5yx.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_03l_5yx.js",
+    {"otherChunks":["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_renamed_input_index_19qb5ne.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/renamed/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js
@@ -1,0 +1,3 @@
+import { used } from './lib.js'
+
+console.log(used)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/lib.js
@@ -1,0 +1,2 @@
+export const used = 'USED'
+export { unused } from './unused.js'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/unused.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/unused.js
@@ -1,0 +1,1 @@
+export const unused = 'UNUSED_MARKER'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/options.json
@@ -1,0 +1,1 @@
+{ "removeUnusedImports": true, "removeUnusedExports": true, "scopeHoisting": true }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js
@@ -1,0 +1,17 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js [test] (ecmascript)
+;
+// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/lib.js [test] (ecmascript)
+;
+const used = 'USED';
+;
+;
+console.log(used);
+__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js [test] (ecmascript)");
+}),
+]);
+
+//# sourceMappingURL=1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/lib.js","turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js"],"sourcesContent":["export const used = 'USED'\nexport { unused } from './unused.js'\n","import { used } from './lib.js'\n\nconsole.log(used)\n"],"names":["used"],"mappings":";;;;AAAO,MAAMA,OAAO;;;ACEpB,QAAQ,GAAG,CAAC"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_1noyz-u.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_1noyz-u.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_1noyz-u.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_1noyz-u.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1i9t_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_1noyz-u.js",
+    {"otherChunks":["output/1do3_crates_turbopack-tests_tests_snapshot_reexport-drop_static_input_index_01ttfgs.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/reexport-drop/static/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
Previously, code such as:

```
export { foo } from "bar"
```

Would contribute to a module's exports (we export foo).

However, it would not contribute to our tracking of imports from "bar".  Therefore we would fall back to the default import usage:

https://github.com/vercel/next.js/blob/c0a7b91becb33490bf412d02bbf09ebaa7216083/turbopack/crates/turbopack-ecmascript/src/references/exports.rs#L140

```rust
pub enum ImportUsage {
    #[default]
    TopLevel,
    Exports(FrozenSet<RcStr>),
}
```

We would therefore not tree-shake. This is rarely a problem with normal imports / exports because they support following reexports and this is enabled by default in Turbopack. However, async imports do not support following reexports.

In https://github.com/vercel/next.js/issues/95698, the import of the Viem chain definitions is an async-imported module:

<img width="796" height="81" alt="Screenshot 2026-07-20 at 5 47 43 pm" src="https://github.com/user-attachments/assets/2fc46711-469f-4f28-8369-9c1ea01b808d" />

Closes https://github.com/vercel/next.js/issues/95698

I looked at the reproduction from the original issue, and this was the result:


```
Client graph contains 11/712 viem chain definition files.
Not reproduced; missing 701 definitions.
```

Yay!