### PR TITLE
[turbopack] Tree-shake CJS exports that use the `Object.defineProperty` syntax

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/cjs_ast.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/cjs_ast.rs
@@ -1,7 +1,11 @@
 use swc_core::{
     common::Mark,
-    ecma::ast::{Expr, Ident, MemberExpr, MemberProp},
+    ecma::{
+        ast::{CallExpr, Callee, Expr, Ident, Lit, MemberExpr, MemberProp, Prop, PropOrSpread},
+        utils::prop_name_eq,
+    },
 };
+use turbo_rcstr::RcStr;
 
 use crate::utils::unparen;
 
@@ -42,6 +46,56 @@ pub(crate) fn is_module_exports_chain(expr: &Expr, unresolved_mark: Mark) -> boo
         }
         _ => false,
     }
+}
+
+/// The exported name of `Object.defineProperty(exports, "<name>", { … })` — the
+/// shape transpilers emit for named exports and the `__esModule` marker.
+pub(crate) fn as_exports_define_property(call: &CallExpr, unresolved_mark: Mark) -> Option<RcStr> {
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(member) = unparen(callee) else {
+        return None;
+    };
+    let Expr::Ident(obj) = unparen(&member.obj) else {
+        return None;
+    };
+    if !is_global(obj, "Object", unresolved_mark) || !prop_is(&member.prop, "defineProperty") {
+        return None;
+    }
+    let [target, name, descriptor] = &call.args[..] else {
+        return None;
+    };
+    if target.spread.is_some() || name.spread.is_some() || descriptor.spread.is_some() {
+        return None;
+    }
+    if !is_exports_object(&target.expr, unresolved_mark) {
+        return None;
+    }
+    let Expr::Lit(Lit::Str(name)) = unparen(&name.expr) else {
+        return None;
+    };
+    if !matches!(unparen(&descriptor.expr), Expr::Object(_)) {
+        return None;
+    }
+    Some(RcStr::from(name.value.to_string_lossy().into_owned()))
+}
+
+/// Whether the `Object.defineProperty` descriptor sets `value: true` (the
+/// `__esModule` interop marker).
+pub(crate) fn define_property_sets_es_module(call: &CallExpr) -> bool {
+    let Some(descriptor) = call.args.get(2) else {
+        return false;
+    };
+    let Expr::Object(descriptor) = unparen(&descriptor.expr) else {
+        return false;
+    };
+    descriptor.props.iter().any(|prop| {
+        matches!(prop, PropOrSpread::Prop(prop)
+            if matches!(&**prop, Prop::KeyValue(kv)
+                if prop_name_eq(&kv.key, "value")
+                    && matches!(unparen(&kv.value), Expr::Lit(Lit::Bool(b)) if b.value)))
+    })
 }
 
 /// Whether `member` writes the module's own CommonJS exports: `exports.<x>`,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -21,7 +21,10 @@ use crate::{
     AnalyzeMode,
     analyzer::{
         Bump, BumpVec, ConstantValue, JsValue, WellKnownFunctionKind,
-        cjs_ast::{is_exports_object, is_global},
+        cjs_ast::{
+            as_exports_define_property, define_property_sets_es_module, is_exports_object,
+            is_global,
+        },
         graph::{ConditionalKind, Effect, EffectArg, EffectsBlock, EvalContext, VarGraph},
         is_unresolved_id,
     },
@@ -1032,6 +1035,21 @@ impl<'a> Analyzer<'a, '_> {
         }
     }
 
+    /// Visits a call/new argument, guarding it as a CJS export target when `guard`
+    /// is set so a bare `exports` / `module` reference there doesn't taint.
+    fn visit_arg_maybe_cjs_export_target<'ast: 'r, 'r>(
+        &mut self,
+        guard: bool,
+        arg: &'ast ExprOrSpread,
+        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+    ) {
+        if guard {
+            self.with_cjs_export_target(|this| arg.visit_with_ast_path(this, ast_path));
+        } else {
+            arg.visit_with_ast_path(self, ast_path);
+        }
+    }
+
     fn check_call_expr_for_effects<'ast: 'r, 'n, 'r>(
         &mut self,
         callee: &'n Callee,
@@ -1039,11 +1057,15 @@ impl<'a> Analyzer<'a, '_> {
         span: Span,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
         n: CallOrNewExpr<'ast>,
+        // Index of the `exports` export-target arg to guard from tainting; other
+        // args (incl. descriptor getter/value bodies) taint normally.
+        cjs_export_target_arg: Option<usize>,
     ) {
         let new = n.as_new().is_some();
         let args = BumpVec::from_iter_in(
             self.arena,
             args.enumerate().map(|(i, arg)| {
+                let guard_cjs_export_target = cjs_export_target_arg == Some(i);
                 let mut ast_path = ast_path.with_guard(match n {
                     CallOrNewExpr::Call(n) => AstParentNodeRef::CallExpr(n, CallExprField::Args(i)),
                     CallOrNewExpr::New(n) => AstParentNodeRef::NewExpr(n, NewExprField::Args(i)),
@@ -1088,7 +1110,11 @@ impl<'a> Analyzer<'a, '_> {
                     };
                     if let Some(path) = block_path {
                         let old_effects = take(&mut self.effects);
-                        arg.visit_with_ast_path(self, &mut ast_path);
+                        self.visit_arg_maybe_cjs_export_target(
+                            guard_cjs_export_target,
+                            arg,
+                            &mut ast_path,
+                        );
                         let effects = replace(&mut self.effects, old_effects);
                         EffectArg::Closure(
                             value,
@@ -1101,11 +1127,19 @@ impl<'a> Analyzer<'a, '_> {
                             ),
                         )
                     } else {
-                        arg.visit_with_ast_path(self, &mut ast_path);
+                        self.visit_arg_maybe_cjs_export_target(
+                            guard_cjs_export_target,
+                            arg,
+                            &mut ast_path,
+                        );
                         EffectArg::Value(value)
                     }
                 } else {
-                    arg.visit_with_ast_path(self, &mut ast_path);
+                    self.visit_arg_maybe_cjs_export_target(
+                        guard_cjs_export_target,
+                        arg,
+                        &mut ast_path,
+                    );
                     EffectArg::Spread
                 }
             }),
@@ -1237,6 +1271,28 @@ impl<'a> Analyzer<'a, '_> {
             as_parent_path(ast_path).into(),
         );
     }
+
+    /// Records a top-level `Object.defineProperty(exports, "NAME", …)` export so
+    /// an unused one can be dropped; the `__esModule` marker sets the interop flag.
+    fn recognize_cjs_define_property(
+        &mut self,
+        name: &str,
+        n: &CallExpr,
+        ast_path: &AstNodePath<AstParentNodeRef<'_>>,
+    ) {
+        // Only top-level defines can be dropped.
+        if self.is_in_fn() || self.is_in_nested_block_scope() {
+            self.taint_cjs_exports();
+            return;
+        }
+        if name == "__esModule" {
+            if define_property_sets_es_module(n) {
+                self.set_cjs_has_es_module();
+            }
+            return;
+        }
+        self.record_cjs_export(RcStr::from(name), as_parent_path(ast_path).into());
+    }
 }
 
 impl VisitAstPath for Analyzer<'_, '_> {
@@ -1336,6 +1392,17 @@ impl VisitAstPath for Analyzer<'_, '_> {
         n: &'ast CallExpr,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
+        // `Object.defineProperty(exports, …)` is a CommonJS export write; recognize
+        // it so unused entries drop (its `exports` argument is guarded below).
+        let is_cjs_define_property = if self.cjs_exports_enabled()
+            && let Some(name) = as_exports_define_property(n, self.eval_context.unresolved_mark)
+        {
+            self.recognize_cjs_define_property(&name, n, ast_path);
+            true
+        } else {
+            false
+        };
+
         // We handle `define(function (require) {})` here.
         if let Callee::Expr(callee) = &n.callee
             && n.args.len() == 1
@@ -1366,12 +1433,19 @@ impl VisitAstPath for Analyzer<'_, '_> {
             n.callee.visit_with_ast_path(self, &mut ast_path);
         }
 
+        // Guard only the `exports` target arg; the descriptor is visited normally.
+        let cjs_export_target_arg = if is_cjs_define_property {
+            Some(0)
+        } else {
+            None
+        };
         self.check_call_expr_for_effects(
             &n.callee,
             n.args.iter(),
             n.span(),
             ast_path,
             CallOrNewExpr::Call(n),
+            cjs_export_target_arg,
         );
     }
 
@@ -1392,6 +1466,7 @@ impl VisitAstPath for Analyzer<'_, '_> {
             n.span(),
             ast_path,
             CallOrNewExpr::New(n),
+            None,
         );
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use bincode::{Decode, Encode};
 use swc_core::{
     common::util::take::Take,
-    ecma::ast::{CallExpr, Expr, ExprOrSpread, Lit},
+    ecma::{
+        ast::{CallExpr, Expr, ExprOrSpread, Lit, Prop, PropOrSpread},
+        utils::prop_name_eq,
+    },
     quote,
 };
 use turbo_rcstr::{RcStr, rcstr};
@@ -408,9 +411,10 @@ impl From<CjsRequireCacheAccess> for CodeGen {
     }
 }
 
-/// Removes each named `exports.NAME = …` write the module graph proved unused.
-/// Built by the analyzer for statically-analyzable CommonJS modules; recognition
-/// happens inline during the walk (see `analyzer::graph::visitor`).
+/// Removes each named `exports.NAME = …` write (or `Object.defineProperty`
+/// export) the module graph proved unused. Built by the analyzer for
+/// statically-analyzable CommonJS modules; recognition happens inline during the
+/// walk (see `analyzer::graph::visitor`).
 #[derive(
     PartialEq, Eq, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug, Encode, Decode,
 )]
@@ -421,13 +425,14 @@ pub struct CjsExportsDropCodeGen {
     has_es_module: bool,
 }
 
-/// A single named `exports.NAME = …` write.
+/// A single named CommonJS export write.
 #[derive(
     PartialEq, Eq, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug, Encode, Decode,
 )]
 pub struct DroppableCjsExportAssignment {
     pub name: RcStr,
-    /// Path to the `exports.NAME = …` assignment expression.
+    /// Path to the write: an `exports.NAME = …` assignment expression or an
+    /// `Object.defineProperty(exports, "NAME", …)` call.
     pub path: AstPath,
 }
 
@@ -469,9 +474,21 @@ impl CjsExportsDropCodeGen {
                 drop.path,
                 visit_mut_expr,
                 |expr: &mut Expr| {
-                    if let Expr::Assign(assign) = expr {
-                        let value = assign.right.take();
-                        *expr = *value;
+                    match expr {
+                        // `exports.NAME = <value>` → `<value>` (keep side effects).
+                        Expr::Assign(assign) => {
+                            let value = assign.right.take();
+                            *expr = *value;
+                        }
+                        // `Object.defineProperty(exports, …)`: keep an eager
+                        // `value`'s side effects; a getter is lazy, drop the call.
+                        Expr::Call(call) => {
+                            *expr = match take_define_property_value(call) {
+                                Some(value) => *value,
+                                None => quote!("0" as Expr),
+                            };
+                        }
+                        _ => {}
                     }
                 }
             ));
@@ -479,6 +496,24 @@ impl CjsExportsDropCodeGen {
 
         Ok(CodeGeneration::visitors(visitors))
     }
+}
+
+/// Takes the `value: <expr>` out of an `Object.defineProperty` descriptor, if it
+/// has one. A descriptor without `value` is a getter, so there's nothing to keep.
+fn take_define_property_value(call: &mut CallExpr) -> Option<Box<Expr>> {
+    let descriptor = call.args.get_mut(2)?;
+    let Expr::Object(descriptor) = &mut *descriptor.expr else {
+        return None;
+    };
+    descriptor.props.iter_mut().find_map(|prop| {
+        let PropOrSpread::Prop(prop) = prop else {
+            return None;
+        };
+        let Prop::KeyValue(kv) = &mut **prop else {
+            return None;
+        };
+        prop_name_eq(&kv.key, "value").then(|| kv.value.take())
+    })
 }
 
 impl From<CjsExportsDropCodeGen> for CodeGen {

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/index.js
@@ -1,0 +1,3 @@
+import { b } from './lib.js'
+
+console.log(b)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/lib.js
@@ -1,0 +1,15 @@
+// `b`'s getter reads `exports.a`, so `a` is reachable through `b`. That read must
+// taint the module (nothing dropped), even though only `b` is imported.
+Object.defineProperty(exports, '__esModule', { value: true })
+Object.defineProperty(exports, 'a', {
+  enumerable: true,
+  get: function () {
+    return 'a-value'
+  },
+})
+Object.defineProperty(exports, 'b', {
+  enumerable: true,
+  get: function () {
+    return exports.a
+  },
+})

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/options.json
@@ -1,0 +1,6 @@
+{
+  "removeUnusedImports": false,
+  "removeUnusedExports": true,
+  "cjsTreeShaking": true,
+  "treeShakingMode": "reexports-only"
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js
@@ -1,0 +1,32 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$cjs$2d$remove$2d$unused$2d$exports$2f$define$2d$property$2d$getter$2d$reads$2d$export$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/lib.js [test] (ecmascript)");
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$cjs$2d$remove$2d$unused$2d$exports$2f$define$2d$property$2d$getter$2d$reads$2d$export$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__["b"]);
+__turbopack_context__.s([]);
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/lib.js [test] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+// `b`'s getter reads `exports.a`, so `a` is reachable through `b`. That read must
+// taint the module (nothing dropped), even though only `b` is imported.
+Object.defineProperty(exports, '__esModule', {
+    value: true
+});
+Object.defineProperty(exports, 'a', {
+    enumerable: true,
+    get: function() {
+        return 'a-value';
+    }
+});
+Object.defineProperty(exports, 'b', {
+    enumerable: true,
+    get: function() {
+        return exports.a;
+    }
+});
+}),
+]);
+
+//# sourceMappingURL=154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/index.js"],"sourcesContent":["import { b } from './lib.js'\n\nconsole.log(b)\n"],"names":["console","log"],"mappings":"AAAA;;AAEAA,QAAQC,GAAG,CAAC,sQAAC"}},
+    {"offset": {"line": 11, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/lib.js"],"sourcesContent":["// `b`'s getter reads `exports.a`, so `a` is reachable through `b`. That read must\n// taint the module (nothing dropped), even though only `b` is imported.\nObject.defineProperty(exports, '__esModule', { value: true })\nObject.defineProperty(exports, 'a', {\n  enumerable: true,\n  get: function () {\n    return 'a-value'\n  },\n})\nObject.defineProperty(exports, 'b', {\n  enumerable: true,\n  get: function () {\n    return exports.a\n  },\n})\n"],"names":["Object","defineProperty","exports","value","enumerable","get","a"],"mappings":"AAAA,kFAAkF;AAClF,wEAAwE;AACxEA,OAAOC,cAAc,CAACC,SAAS,cAAc;IAAEC,OAAO;AAAK;AAC3DH,OAAOC,cAAc,CAACC,SAAS,KAAK;IAClCE,YAAY;IACZC,KAAK;QACH,OAAO;IACT;AACF;AACAL,OAAOC,cAAc,CAACC,SAAS,KAAK;IAClCE,YAAY;IACZC,KAAK;QACH,OAAOH,QAAQI,CAAC;IAClB;AACF"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/1ngs_js-remove-unused-exports_define-property-getter-reads-export_input_index_20zrr4b.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/1ngs_js-remove-unused-exports_define-property-getter-reads-export_input_index_20zrr4b.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/1oio_js-remove-unused-exports_define-property-getter-reads-export_input_index_20zrr4b.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/output/1oio_js-remove-unused-exports_define-property-getter-reads-export_input_index_20zrr4b.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1oio_js-remove-unused-exports_define-property-getter-reads-export_input_index_20zrr4b.js",
+    {"otherChunks":["output/154e_cjs-remove-unused-exports_define-property-getter-reads-export_input_0v-648l._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property-getter-reads-export/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/index.js
@@ -1,0 +1,3 @@
+import { used } from './lib.js'
+
+console.log(used)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/lib.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/lib.js
@@ -1,0 +1,15 @@
+// Transpiled-ESM output shape (Babel/TSC/esbuild): the `__esModule` marker and
+// named exports are declared via `Object.defineProperty(exports, …)`.
+Object.defineProperty(exports, '__esModule', { value: true })
+Object.defineProperty(exports, 'used', {
+  enumerable: true,
+  get: function () {
+    return 'used-value'
+  },
+})
+Object.defineProperty(exports, 'unused', {
+  enumerable: true,
+  get: function () {
+    return 'unused-value'
+  },
+})

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/options.json
@@ -1,0 +1,6 @@
+{
+  "removeUnusedImports": false,
+  "removeUnusedExports": true,
+  "cjsTreeShaking": true,
+  "treeShakingMode": "reexports-only"
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1ece_tests_snapshot_cjs-remove-unused-exports_define-property_input_index_1ht3b94.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1ece_tests_snapshot_cjs-remove-unused-exports_define-property_input_index_1ht3b94.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/1ece_tests_snapshot_cjs-remove-unused-exports_define-property_input_index_1ht3b94.js",
+    {"otherChunks":["output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js
@@ -1,0 +1,27 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$cjs$2d$remove$2d$unused$2d$exports$2f$define$2d$property$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/lib.js [test] (ecmascript)");
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$cjs$2d$remove$2d$unused$2d$exports$2f$define$2d$property$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__["used"]);
+__turbopack_context__.s([]);
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/lib.js [test] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+// Transpiled-ESM output shape (Babel/TSC/esbuild): the `__esModule` marker and
+// named exports are declared via `Object.defineProperty(exports, …)`.
+Object.defineProperty(exports, '__esModule', {
+    value: true
+});
+Object.defineProperty(exports, 'used', {
+    enumerable: true,
+    get: function() {
+        return 'used-value';
+    }
+});
+0;
+}),
+]);
+
+//# sourceMappingURL=1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_1o3aj7m._.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/index.js"],"sourcesContent":["import { used } from './lib.js'\n\nconsole.log(used)\n"],"names":["console","log"],"mappings":"AAAA;;AAEAA,QAAQC,GAAG,CAAC,4OAAI"}},
+    {"offset": {"line": 11, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/input/lib.js"],"sourcesContent":["// Transpiled-ESM output shape (Babel/TSC/esbuild): the `__esModule` marker and\n// named exports are declared via `Object.defineProperty(exports, …)`.\nObject.defineProperty(exports, '__esModule', { value: true })\nObject.defineProperty(exports, 'used', {\n  enumerable: true,\n  get: function () {\n    return 'used-value'\n  },\n})\nObject.defineProperty(exports, 'unused', {\n  enumerable: true,\n  get: function () {\n    return 'unused-value'\n  },\n})\n"],"names":["Object","defineProperty","exports","value","enumerable","get"],"mappings":"AAAA,+EAA+E;AAC/E,sEAAsE;AACtEA,OAAOC,cAAc,CAACC,SAAS,cAAc;IAAEC,OAAO;AAAK;AAC3DH,OAAOC,cAAc,CAACC,SAAS,QAAQ;IACrCE,YAAY;IACZC,KAAK;QACH,OAAO;IACT;AACF"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_index_1ht3b94.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/cjs-remove-unused-exports/define-property/output/1jsg_tests_snapshot_cjs-remove-unused-exports_define-property_input_index_1ht3b94.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}


### PR DESCRIPTION
This is a common format for transpilers to produce CJS code from ESM, eg. this output:

```javascript
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
var x = { color: 'red' };
```

from https://www.typescript-training.com/course/intermediate-v2/05-modules/. 

This PR extends the work done in https://github.com/vercel/next.js/pull/95716 to support this syntax.