### PR TITLE
Fix Request Insights production tracing

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -340,8 +340,9 @@ describe('request insights tracing', () => {
     expect(startActiveSpan).toHaveBeenCalledWith(
       AppRenderSpan.fetch,
       expect.any(Object),
-      expect.any(Function)
+      expect.anything()
     )
+    expect(typeof startActiveSpan.mock.calls[0].at(-1)).toBe('function')
     expect(getRequestInsightsSnapshot().requests[0].operations).toEqual([])
   })
 

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -1,6 +1,7 @@
 import type { FetchEventResult } from '../../web/types'
 import type { TextMapSetter } from '@opentelemetry/api'
 import type { SpanTypes } from './constants'
+import type { RequestInsightsRuntime } from './request-insights'
 import { LogSpanAllowList, NextVanillaSpanAllowlist } from './constants'
 
 import type {
@@ -14,15 +15,21 @@ import type {
 import { isThenable } from '../../../shared/lib/is-thenable'
 
 const NEXT_OTEL_PERFORMANCE_PREFIX = process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+const REQUEST_INSIGHTS_RUNTIME_KEY = Symbol.for(
+  '@next/request-insights-runtime'
+)
+
+type GlobalWithRequestInsightsRuntime = typeof globalThis & {
+  [REQUEST_INSIGHTS_RUNTIME_KEY]?: RequestInsightsRuntime
+}
 
 let api: typeof import('next/dist/compiled/@opentelemetry/api')
-let requestInsightsFacade: typeof import('./request-insights') | undefined
 
-function getRequestInsightsFacade() {
+function getRequestInsightsRuntime() {
   if (process.env.__NEXT_DEV_SERVER) {
-    requestInsightsFacade ??=
-      require('./request-insights') as typeof import('./request-insights')
-    return requestInsightsFacade
+    return (globalThis as GlobalWithRequestInsightsRuntime)[
+      REQUEST_INSIGHTS_RUNTIME_KEY
+    ]
   } else {
     return undefined
   }
@@ -277,7 +284,7 @@ class NextTracerImpl implements NextTracer {
    * edge middleware which runs in a detached sandbox.
    */
   public runWithDetachedContext<T>(fn: () => T): T {
-    const requestInsights = getRequestInsightsFacade()
+    const requestInsights = getRequestInsightsRuntime()
     const run = () => {
       if (!NEXT_OTEL_PERFORMANCE_PREFIX && !this.isOpenTelemetryEnabled()) {
         return fn()
@@ -285,8 +292,8 @@ class NextTracerImpl implements NextTracer {
       return context.with(ROOT_CONTEXT, fn)
     }
 
-    return requestInsights
-      ? requestInsights.runWithDetachedRequestInsightContext(run)
+    return requestInsights?.isActive()
+      ? requestInsights.runDetached(run)
       : run()
   }
 
@@ -350,10 +357,9 @@ class NextTracerImpl implements NextTracer {
   ): T
   public trace<T>(...args: Array<any>) {
     const [type, fnOrOptions, fnOrEmpty] = args
-    const requestInsights = getRequestInsightsFacade()
+    const requestInsights = getRequestInsightsRuntime()
     const openTelemetryEnabled = this.isOpenTelemetryEnabled()
-    const requestInsightsActive =
-      requestInsights?.isRequestInsightsActive() ?? false
+    const requestInsightsActive = requestInsights?.isActive() ?? false
 
     if (
       !NEXT_OTEL_PERFORMANCE_PREFIX &&
@@ -392,7 +398,7 @@ class NextTracerImpl implements NextTracer {
     }
 
     const operation = requestInsightsActive
-      ? requestInsights?.beginRequestInsightOperation({
+      ? requestInsights?.beginOperation({
           type,
           name: spanName,
           category: 'nextjs',
@@ -437,7 +443,7 @@ class NextTracerImpl implements NextTracer {
             }
           }
         } finally {
-          requestInsights?.endRequestInsightOperation(
+          requestInsights?.endOperation(
             operation,
             failed ? { status: 'error', error } : { status: 'ok' }
           )
@@ -516,7 +522,7 @@ class NextTracerImpl implements NextTracer {
       }
 
       return requestInsights
-        ? requestInsights.runWithRequestInsightOperation(operation, invoke)
+        ? requestInsights.runWithOperation(operation, invoke)
         : invoke()
     }
 


### PR DESCRIPTION
## Summary

I changed how the shared tracer accesses Request Insights from loading the facade with a literal `require()` to reading the runtime already registered globally by the development server. This prevents `request-insights.js` and `request-insights-runtime.js` from appearing in production NFT output, while keeping Request Insights behavior in development unchanged.

I also changed the `expect.any(Function)` matcher to an existence matcher plus an explicit `typeof` assertion so the repository's banned-function-call checker passes without weakening the test.

This PR is stacked on #95897.

## Before: Tracer Owns Loading

- Production-used tracer
- Literal `require()`
- Request-insights facade
- Request-insights runtime
- NFT includes development modules

## After: Dev Server Owns Loading

- `next-dev-server` registers the runtime
- Global `Symbol` slot
- Tracer performs an optional lookup
- No runtime module import
- NFT excludes development modules

```js
// The production-used tracer now performs a lookup, not a load.
if (process.env.__NEXT_DEV_SERVER) {
  return globalThis[
    Symbol.for('@next/request-insights-runtime')
  ]
}
```

  ## Verification

  - `pnpm exec jest packages/next/src/server/lib/trace/tracer.test.ts packages/next/src/server/lib/trace/request-insights.test.ts
  --runInBand`
  - `pnpm --filter=next typescript`
  - `pnpm --filter=next types`
  - `HEADLESS=true IS_TURBOPACK_TEST=1 TURBOPACK_BUILD=1 NEXT_TEST_MODE=start pnpm test-start-turbo test/production/next-server-nft/
  next-server-nft.test.ts`
  - `HEADLESS=true pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts`
  - `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/app/standalone.test.ts`
  - `pnpm --filter=next build`

  <!-- NEXT_JS_LLM -->