### PR TITLE
docs: fix unstable_cache syntax error

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/unstable_cache.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unstable_cache.mdx
@@ -72,20 +72,20 @@ export default async function Page({
 ```
 
 ```jsx filename="app/page.jsx" switcher
-import { unstable_cache } from 'next/cache';
+import { unstable_cache } from 'next/cache'
 
-export default async function Page({ params } }) {
+export default async function Page({ params }) {
   const { userId } = await params
   const getCachedUser = unstable_cache(
     async () => {
-      return { id: userId };
+      return { id: userId }
     },
     [userId], // add the user ID to the cache key
     {
-      tags: ["users"],
+      tags: ['users'],
       revalidate: 60,
     }
-  );
+  )
 
   //...
 }


### PR DESCRIPTION
The function signature was wrong:

```tsx
function Page({ params } }){
```

Which also prevented prettier from running in the code block. This PR fixes the signature and formats the code block.