### PR TITLE
Emit the static paths HMR update after updating the cache

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -866,24 +866,6 @@ export default class DevServer extends Server {
               )
             }
           }
-
-          // Since generateStaticParams run on the background, when accessing the
-          // fallbackParams during the render, it is still set to the previous
-          // result from the cache. Therefore when the result has changed, re-render
-          // the Server Component to sync the fallbackParams with the new result.
-          if (
-            isAppPath &&
-            this.nextConfig.cacheComponents &&
-            // Ensure this is not the first invocation.
-            result &&
-            // Ideally, we would want to compare the whole objects, but that is too expensive.
-            result.prerenderedRoutes?.length !== prerenderedRoutes?.length
-          ) {
-            this.bundlerService.sendHmrMessage({
-              type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-              hash: `generateStaticParams-${Date.now()}`,
-            })
-          }
         }
 
         if (!isAppPath && this.nextConfig.output === 'export') {
@@ -962,6 +944,33 @@ export default class DevServer extends Server {
           }
         }
         this.staticPathsCache.set(pathname, value)
+
+        // Since generateStaticParams runs in the background, the fallbackParams
+        // accessed during a render are derived from the previous result served
+        // by the static paths cache. Now that the cache holds the new result,
+        // trigger an HMR refresh so the next render picks up the new
+        // fallbackParams (e.g. so blocking-route validation reflects params
+        // that just became statically known).
+        //
+        // TODO: Give this its own HMR message instead of reusing
+        // `SERVER_COMPONENT_CHANGES`, which requires a `hash` whose value is
+        // meaningless here (a timestamp) and only serves to trigger a client
+        // refresh.
+        if (
+          isAppPath &&
+          this.nextConfig.cacheComponents &&
+          // Ensure this is not the first invocation.
+          result &&
+          // Comparing lengths rather than the whole objects, which is too
+          // expensive.
+          result.prerenderedRoutes?.length !== prerenderedRoutes?.length
+        ) {
+          this.bundlerService.sendHmrMessage({
+            type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+            hash: `generateStaticParams-${Date.now()}`,
+          })
+        }
+
         return value
       })
       .catch((err) => {

--- a/test/e2e/app-dir/cache-components-errors/use-cache.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/use-cache.util.ts
@@ -1,5 +1,5 @@
 import { isNextDev } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { retry, waitForNoRedbox } from 'next-test-utils'
 import { getDeterministicOutput, getPrerenderOutput } from './utils'
 import type { CacheComponentsErrorsContext } from './shared.util'
 
@@ -1252,6 +1252,50 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
              ],
            }
           `)
+        })
+
+        it('should clear the redbox after adding generateStaticParams via HMR', async () => {
+          // Regression test for NAR-491: after adding `generateStaticParams`
+          // that covers the requested slug, the slug is no longer a fallback
+          // param, so the blocking-route validation must clear. This requires
+          // the render to pick up the fresh `fallbackParams`. Because
+          // `generateStaticParams` is recomputed in the background (the static
+          // paths cache serves the previous result until then), the render
+          // triggered by the edit itself still uses the stale `fallbackParams`;
+          // a follow-up HMR update, sent once the recompute lands, is what
+          // syncs them.
+          const browser = await next.browser('/use-cache-params/foo')
+
+          await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "code": "E1427",
+               "description": "Next.js encountered runtime data during prerendering.",
+               "environmentLabel": "Server",
+               "label": "Blocking Route",
+               "source": null,
+               "stack": [
+                 "Page [Prerender] <anonymous>",
+               ],
+             }
+            `)
+
+          // The recompute is deliberately delayed so it resolves only after the
+          // edit's own HMR refresh has re-rendered with the stale fallback
+          // params. That way the redbox can only clear via the follow-up static
+          // paths sync update, not the edit's refresh itself, which keeps this
+          // an accurate regression test.
+          await next.patchFile(
+            'app/use-cache-params/[slug]/page.tsx',
+            (content) =>
+              `export async function generateStaticParams() {\n` +
+              `  await new Promise((resolve) => setTimeout(resolve, 2000))\n` +
+              `  return [{ slug: 'foo' }]\n` +
+              `}\n\n` +
+              content,
+            async () => {
+              await waitForNoRedbox(browser)
+            }
+          )
         })
       } else {
         it('should error the build', async () => {


### PR DESCRIPTION
In dev, the server sends a `SERVER_COMPONENT_CHANGES` HMR update when `generateStaticParams` produces a different set of static paths, so the render picks up the new `fallbackParams` (added in #85741). It was emitting that update before writing the new result to `staticPathsCache`, so the refresh it triggered could read the previous, stale result and keep rendering with the old `fallbackParams` (there are `await`s for the prerender manifest between the two points, which widens the window). This moves the emit to after `staticPathsCache.set`, so the triggered refresh always observes the updated result.

This also adds the end-to-end regression test that was missing for this behavior. Reusing the existing `use-cache-params/[slug]` fixture, it asserts the blocking-route redbox shown when a route reads a fallback (unknown) param outside a Suspense boundary, then adds a `generateStaticParams` covering the requested slug and asserts the redbox clears. Editing the page produces two refreshes: the one the edit itself triggers, which still renders with the stale `fallbackParams`, and the follow-up update this code emits once the new result is cached, which renders with the fresh ones. To ensure the test only passes because of the latter, `generateStaticParams` is given a deliberate delay so its recompute finishes only after the edit's own refresh has already re-rendered with the stale params.

closes NAR-496

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>