### PR TITLE
[test] Add failing tests for stale route handler and page cached data

### DIFF
--- a/test/e2e/app-dir/use-cache-dev/app/api/cached/route.ts
+++ b/test/e2e/app-dir/use-cache-dev/app/api/cached/route.ts
@@ -1,0 +1,16 @@
+async function getCachedData() {
+  'use cache'
+
+  return { text: 'foo', mathRandom: Math.random() }
+}
+
+export async function GET() {
+  const { text, mathRandom } = await getCachedData()
+
+  // Read outside of "use cache" so it reflects the recompiled module on every
+  // request. This lets the test distinguish a stale cache hit (where `text`
+  // keeps its old value) from the module never having recompiled at all.
+  const uncachedText = 'foo'
+
+  return Response.json({ text, mathRandom, uncachedText })
+}

--- a/test/e2e/app-dir/use-cache-dev/app/cached-page/page.tsx
+++ b/test/e2e/app-dir/use-cache-dev/app/cached-page/page.tsx
@@ -1,0 +1,22 @@
+async function getCachedData() {
+  'use cache'
+
+  return { text: 'foo', mathRandom: Math.random() }
+}
+
+export default async function Page() {
+  const { text, mathRandom } = await getCachedData()
+
+  // Read outside of "use cache" so it reflects the recompiled module on every
+  // request. This lets the test distinguish a stale cache hit (where `text`
+  // keeps its old value) from the module never having recompiled at all.
+  const uncachedText = 'foo'
+
+  return (
+    <div id="container">
+      <span id="text">{text}</span>
+      <span id="mathRandom">{mathRandom}</span>
+      <span id="uncachedText">{uncachedText}</span>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-cache-dev/use-cache-dev.test.ts
+++ b/test/e2e/app-dir/use-cache-dev/use-cache-dev.test.ts
@@ -108,6 +108,103 @@ describe('use-cache-dev', () => {
       )
     })
 
+    // These two currently fail in both Turbopack and Webpack. Dev "use cache"
+    // invalidation relies on the __next_hmr_refresh_hash__ cookie that the
+    // browser HMR client sets after an edit; a client that fetches directly
+    // (curl, a plain fetch, a second device) never sends that cookie, so the
+    // "use cache" key does not change across the edit and the stale entry is
+    // reused. Change these to `it` once editing a file invalidates cached data
+    // for requests that do not carry the cookie, covering both route handlers
+    // and pages.
+    it.failing(
+      'should update cached data used by a route handler after editing a file',
+      async () => {
+        const initialData = await next
+          .fetch('/api/cached')
+          .then((res) => res.json())
+
+        expect(initialData.text).toBe('foo')
+        expect(initialData.uncachedText).toBe('foo')
+        expect(initialData.mathRandom).toEqual(expect.any(Number))
+
+        // A subsequent fetch returns the same cached value.
+        const cachedData = await next
+          .fetch('/api/cached')
+          .then((res) => res.json())
+
+        expect(cachedData.text).toBe('foo')
+        expect(cachedData.mathRandom).toBe(initialData.mathRandom)
+
+        // Edit the source literals inside and outside of "use cache".
+        await next.patchFile('app/api/cached/route.ts', (content) =>
+          content.replaceAll('foo', 'bar')
+        )
+
+        // Wait until the route handler module has recompiled. The uncached
+        // value is read outside of "use cache", so it reflects the edited
+        // source. This ensures we then assert the cached value against the
+        // post-edit module, not a request that raced the recompilation.
+        await retry(async () => {
+          const recompiledData = await next
+            .fetch('/api/cached')
+            .then((res) => res.json())
+
+          expect(recompiledData.uncachedText).toBe('bar')
+        })
+
+        const newData = await next
+          .fetch('/api/cached')
+          .then((res) => res.json())
+
+        // The cached function should return the edited value and recompute its
+        // random value due to a cache miss.
+        expect(newData.text).toBe('bar')
+        expect(newData.mathRandom).not.toBe(initialData.mathRandom)
+      }
+    )
+
+    it.failing(
+      'should update cached data used by a page fetched without a cookie after editing a file',
+      async () => {
+        // `next.render$` fetches directly, without the browser HMR client, so
+        // the request does not carry the __next_hmr_refresh_hash__ cookie.
+        let $ = await next.render$('/cached-page')
+        const initialText = $('#text').text()
+        const initialMathRandom = $('#mathRandom').text()
+
+        expect(initialText).toBe('foo')
+        expect($('#uncachedText').text()).toBe('foo')
+
+        // A subsequent fetch returns the same cached value.
+        $ = await next.render$('/cached-page')
+
+        expect($('#text').text()).toBe('foo')
+        expect($('#mathRandom').text()).toBe(initialMathRandom)
+
+        // Edit the source literals inside and outside of "use cache".
+        await next.patchFile('app/cached-page/page.tsx', (content) =>
+          content.replaceAll('foo', 'bar')
+        )
+
+        // Wait until the page module has recompiled. The uncached value is read
+        // outside of "use cache", so it reflects the edited source. This
+        // ensures we then assert the cached value against the post-edit module,
+        // not a request that raced the recompilation.
+        await retry(async () => {
+          const $$ = await next.render$('/cached-page')
+
+          expect($$('#uncachedText').text()).toBe('bar')
+        })
+
+        $ = await next.render$('/cached-page')
+
+        // The cached function should return the edited value and recompute its
+        // random value due to a cache miss.
+        expect($('#text').text()).toBe('bar')
+        expect($('#mathRandom').text()).not.toBe(initialMathRandom)
+      }
+    )
+
     it('should return cached data after reload', async () => {
       let $ = await next.render$('/')
       const initialContent = $('#container').text()


### PR DESCRIPTION
In dev, editing a file does not evict existing `use cache` entries; an entry is invalidated only by re-keying, which today is driven by the `__next_hmr_refresh_hash__` cookie that the browser HMR client sets after each server-component change. A client that fetches directly (curl, a plain fetch, a second device) never sends that cookie, so its `use cache` key does not change across an edit and the stale entry keeps being served even after the module recompiles. This affects both route handlers and pages.

This adds two e2e tests, each with its own fixture: a route handler at `app/api/cached` fetched through `next.fetch`, and a page at `app/cached-page` rendered through `next.render$`. Both paths bypass the browser HMR client, so neither request carries the cookie. Each test edits its source, waits for the module to recompile (observed through a literal read outside `use cache`), then asserts the cached value reflects the edit. Both are marked `it.failing` because the gap is not yet fixed. They run in dev only and fail in both Turbopack and webpack.

A follow-up change sources the HMR refresh hash on the server rather than via the client cookie, so the cache is invalidated for every client regardless of how it fetches. Because route handlers and pages build their request stores through different paths, covering both here guards each one; that change will flip these tests to regular `it`.

closes #95931

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>