### PR TITLE
Fix stale dev `'use cache'` for cookieless requests and route handlers

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1445,5 +1445,6 @@
   "1444": "Invalid target hostname \"%s\" for proxy request, expected \"%s\"",
   "1445": "Invariant: Missing `__NEXT_PRIVATE_ORIGIN` environment variable.",
   "1446": "Missing initURL",
-  "1447": "Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server."
+  "1447": "Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.",
+  "1448": "Error in the \"%s\" app-route HMR subscription"
 }

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -253,6 +253,7 @@ export async function handler(
       validationLevel: nextConfig.experimental.instantInsights.validationLevel,
       supportsDynamicResponse,
       incrementalCache,
+      hmrRefreshHash: getRequestMeta(req, 'hmrRefreshHash'),
       cacheLifeProfiles: nextConfig.cacheLife,
       staticPageGenerationTimeout: nextConfig.staticPageGenerationTimeout,
       waitUntil: ctx.waitUntil,

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -12,7 +12,6 @@ export const NEXT_ROUTER_PREFETCH_HEADER = 'next-router-prefetch' as const
 export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER =
   'next-router-segment-prefetch' as const
 export const NEXT_HMR_REFRESH_HEADER = 'next-hmr-refresh' as const
-export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
 export const NEXT_URL = 'next-url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -31,7 +31,6 @@ import type { McpPageMetadataResponse } from '../../../../shared/lib/mcp-page-me
 import { useUntrackedPathname } from '../../../components/navigation-untracked'
 import reportHmrLatency from '../../report-hmr-latency'
 import { TurbopackHmr } from '../turbopack-hot-reloader-common'
-import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../../components/app-router-headers'
 import {
   publicAppRouterInstance,
   type GlobalErrorState,
@@ -412,13 +411,8 @@ export function processMessage(
         JSON.stringify({
           event: 'server-component-reload-page',
           clientId: __nextDevClientId,
-          hash: message.hash,
         })
       )
-
-      // Store the latest hash in a session cookie so that it's sent back to the
-      // server with any subsequent requests.
-      document.cookie = `${NEXT_HMR_REFRESH_HASH_COOKIE}=${message.hash};path=/`
 
       if (
         RuntimeErrorHandler.hadRuntimeError ||

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2856,6 +2856,7 @@ async function renderToHTMLOrFlightImpl(
 
     const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
     const fallbackParams = getRequestMeta(req, 'fallbackParams') || null
+    const hmrRefreshHash = getRequestMeta(req, 'hmrRefreshHash')
 
     const createRequestStore = createRequestStoreForRender.bind(
       null,
@@ -2869,7 +2870,8 @@ async function renderToHTMLOrFlightImpl(
       isHmrRefresh,
       serverComponentsHmrCache,
       renderResumeDataCache,
-      fallbackParams
+      fallbackParams,
+      hmrRefreshHash
     )
     const requestStore = createRequestStore()
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -18,7 +18,6 @@ import type {
 import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
-import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../client/components/app-router-headers'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import type { StagedRenderingController } from './staged-rendering'
 import type { ValidationBoundaryTracking } from './instant-validation/boundary-tracking'
@@ -61,6 +60,7 @@ export interface RequestStore extends CommonWorkUnitStore {
   readonly draftMode: DraftModeProvider
   readonly isHmrRefresh?: boolean
   readonly serverComponentsHmrCache?: ServerComponentsHmrCache
+  readonly hmrRefreshHash?: string
 
   readonly rootParams: Params
 
@@ -438,9 +438,8 @@ export function getHmrRefreshHash(
       case 'private-cache':
       case 'prerender':
       case 'prerender-runtime':
-        return workUnitStore.hmrRefreshHash
       case 'request':
-        return workUnitStore.cookies.get(NEXT_HMR_REFRESH_HASH_COOKIE)?.value
+        return workUnitStore.hmrRefreshHash
       case 'prerender-client':
       case 'validation-client':
       case 'prerender-ppr':

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -126,6 +126,12 @@ export type RequestStoreInputs = {
   previewProps: WrapperRenderOpts['previewProps']
   isHmrRefresh: boolean | undefined
   serverComponentsHmrCache: ServerComponentsHmrCache | undefined
+  /**
+   * The hash of the most recent server component change (dev only). Included in
+   * `"use cache"` cache keys so that cached entries are revalidated after an
+   * edit, for every client, regardless of whether it runs the HMR client.
+   */
+  hmrRefreshHash: string | undefined
   fallbackParams: OpaqueFallbackRouteParams | null | undefined
 }
 
@@ -173,7 +179,8 @@ export function createRequestStoreForRender(
   isHmrRefresh: RequestContext['isHmrRefresh'],
   serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
   resumeDataCache: ResumeDataCache | null,
-  fallbackParams: OpaqueFallbackRouteParams | null
+  fallbackParams: OpaqueFallbackRouteParams | null,
+  hmrRefreshHash: string | undefined
 ): RequestStore {
   return createRequestStore({
     // Pages start in render phase by default
@@ -193,6 +200,7 @@ export function createRequestStoreForRender(
     previewProps,
     isHmrRefresh,
     serverComponentsHmrCache,
+    hmrRefreshHash,
     fallbackParams,
   })
 }
@@ -202,7 +210,8 @@ export function createRequestStoreForAPI(
   url: RequestContext['url'],
   implicitTags: RequestContext['implicitTags'],
   onUpdateCookies: RenderOpts['onUpdateCookies'],
-  previewProps: WrapperRenderOpts['previewProps']
+  previewProps: WrapperRenderOpts['previewProps'],
+  hmrRefreshHash: string | undefined
 ): RequestStore {
   return createRequestStore({
     // API routes start in action phase by default
@@ -216,6 +225,7 @@ export function createRequestStoreForAPI(
     previewProps,
     isHmrRefresh: false,
     serverComponentsHmrCache: undefined,
+    hmrRefreshHash,
     fallbackParams: null,
   })
 }
@@ -239,6 +249,7 @@ export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
     previewProps,
     isHmrRefresh,
     serverComponentsHmrCache,
+    hmrRefreshHash,
     fallbackParams,
   } = inputs
 
@@ -321,6 +332,7 @@ export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
     serverComponentsHmrCache:
       serverComponentsHmrCache ||
       (globalThis as any).__serverComponentsHmrCache,
+    hmrRefreshHash,
     fallbackParams,
   }
 }

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -28,6 +28,12 @@ export type WorkStoreContext = {
     cacheLifeProfiles: ResolvedCacheLifeProfiles
     staticPageGenerationTimeout: number
     incrementalCache?: IncrementalCache
+    /**
+     * The hash of the most recent server component change (dev only). Included
+     * in `"use cache"` cache keys so that cached entries are revalidated after
+     * an edit, for every client, regardless of whether it runs the HMR client.
+     */
+    hmrRefreshHash?: string
     isOnDemandRevalidate?: boolean
     cacheComponents: boolean
     validationLevel: ValidationLevel

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -425,6 +425,15 @@ export default abstract class Server<
       : undefined
   }
 
+  /**
+   * The hash of the most recent server component change (dev only), used to
+   * revalidate `"use cache"` entries after an edit. Overridden by the dev
+   * server; returns `undefined` otherwise.
+   */
+  protected getServerComponentsHmrRefreshHash(): string | undefined {
+    return undefined
+  }
+
   protected abstract loadEnvConfig(params: {
     dev: boolean
     forceReload: boolean
@@ -1547,6 +1556,20 @@ export default abstract class Server<
           req,
           'serverComponentsHmrCache',
           this.getServerComponentsHmrCache()
+        )
+      }
+
+      // Attach the server components HMR refresh hash here, alongside the HMR
+      // cache, so it reaches every render that passes through this request
+      // handling, including internal renders (e.g. dev validation/warmup) that
+      // don't re-enter the top-level request handler. It's included in `"use
+      // cache"` keys so cached entries revalidate after an edit, for every
+      // client.
+      if (!getRequestMeta(req, 'hmrRefreshHash')) {
+        addRequestMeta(
+          req,
+          'hmrRefreshHash',
+          this.getServerComponentsHmrRefreshHash()
         )
       }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -696,6 +696,14 @@ export async function createHotReloaderTurbopack(
   let serverHmrSubscriptions: ServerHmrSubscriptions | undefined
 
   let hmrEventHappened = false
+  // A counter identifying the current version of the compiled output, included
+  // by `"use cache"` in dev cache keys so that cached entries revalidate after
+  // an edit. It advances once per HMR change event (for App Router pages that
+  // is an RSC change, which is what a cached render depends on), independent of
+  // how many clients are connected. It deliberately does not advance on `BUILT`
+  // messages: those are sent per connected client on every compilation, so
+  // advancing there would both churn the hash without an edit and fail to
+  // advance it at all when no client is connected.
   let hmrHash = 0
 
   const clientsWithoutHtmlRequestId = new Set<ws>()
@@ -1495,6 +1503,16 @@ export async function createHotReloaderTurbopack(
       }
     },
 
+    getServerComponentsHmrRefreshHash() {
+      // The current server-components generation. Only the change subscription
+      // (an actual recompile) advances `hmrHash`; reloads and config
+      // invalidations don't, so the value stays stable across requests until a
+      // real edit. Returned unconditionally (`"0"` before the first edit) so
+      // `"use cache"` keys are present and consistent for every request,
+      // mirroring webpack's always-present `stats.hash`.
+      return String(hmrHash)
+    },
+
     sendToLegacyClients(action) {
       const payload = JSON.stringify(action)
 
@@ -1641,7 +1659,6 @@ export async function createHotReloaderTurbopack(
         await clearAllModuleContexts()
         this.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-          hash: String(++hmrHash),
         })
       }
     },
@@ -1924,7 +1941,10 @@ export async function createHotReloaderTurbopack(
 
             sendToClient(client, {
               type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
-              hash: String(++hmrHash),
+              // Report the current version without advancing it: a completed
+              // compilation is not itself an edit, and this hash is not
+              // consumed by the Turbopack client.
+              hash: String(hmrHash),
               errors: [...clientErrors.values()],
               warnings: [],
             })
@@ -1983,7 +2003,6 @@ export async function createHotReloaderTurbopack(
         // Tell browsers to refetch RSC (soft refresh, not full page reload)
         hotReloader.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-          hash: String(++hmrHash),
         })
       },
     })

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -117,7 +117,6 @@ export interface ReloadPageMessage {
 
 export interface ServerComponentChangesMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
-  hash: string
 }
 
 /**
@@ -259,6 +258,13 @@ export interface NextJsHotReloaderInterface {
    * and App Router clients that don't have Cache Components enabled.
    */
   sendToLegacyClients(action: HmrMessageSentToBrowser): void
+  /**
+   * The hash of the most recent server component change, or `undefined` if no
+   * server component change has occurred yet. In dev, this is included in `"use
+   * cache"` cache keys so that cached entries are revalidated after an edit,
+   * for every client, regardless of whether it runs the HMR client.
+   */
+  getServerComponentsHmrRefreshHash(): string | undefined
   setCacheStatus(status: ServerCacheStatus, htmlRequestId: string): void
   setReactDebugChannel(
     debugChannel: ReactDebugChannelForBrowser,

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -241,6 +241,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private serverError: Error | null = null
   private hmrServerError: Error | null = null
   private serverPrevDocumentHash: string | null
+  private serverComponentsHmrRefreshHash: string | undefined
   private serverChunkNames?: Set<string>
   private prevChunkNames?: Set<any>
   private onDemandEntries?: ReturnType<typeof onDemandEntryHandler>
@@ -431,12 +432,16 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   }
 
   protected async refreshServerComponents(hash: string): Promise<void> {
+    this.serverComponentsHmrRefreshHash = hash
     this.send({
       type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-      hash,
       // TODO: granular reloading of changes
       // entrypoints: serverComponentChanges,
     })
+  }
+
+  public getServerComponentsHmrRefreshHash(): string | undefined {
+    return this.serverComponentsHmrRefreshHash
   }
 
   public onHMR(

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -231,6 +231,10 @@ export default class DevServer extends Server {
     return this.serverComponentsHmrCache
   }
 
+  protected override getServerComponentsHmrRefreshHash(): string | undefined {
+    return this.bundlerService.getServerComponentsHmrRefreshHash()
+  }
+
   protected getRouteMatchers(): RouteMatcherManager {
     const { pagesDir, appDir } = findPagesDir(this.dir)
 

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -413,6 +413,34 @@ export async function handleRouteType({
       const writtenEndpoint = await route.endpoint.writeToDisk()
       hooks?.handleWrittenEndpoint(key, writtenEndpoint, false)
 
+      if (dev) {
+        // Advance the hot-reloader's HMR refresh hash whenever this route
+        // handler is recompiled, so its `"use cache"` entries are invalidated
+        // after an edit. Subscribing runs `subscribeToClientChanges`, which
+        // bumps the `hmrHash` counter on each change; that counter is returned
+        // by `getServerComponentsHmrRefreshHash` and folded into cache keys by
+        // `getHmrRefreshHash`. Unlike app pages there is no RSC for a connected
+        // browser to refetch, so `createMessage` returns nothing; the
+        // subscription exists only to advance the hash.
+        hooks?.subscribeToChanges(
+          key,
+          /** includeIssues= */ true,
+          route.endpoint,
+          () => undefined,
+          (error) => {
+            // This subscription only advances the refresh hash, so there is
+            // nothing to send the browser when it fails. `subscribeToChanges`
+            // drops the subscription on error and re-creates it the next time
+            // this route is ensured, so just log it.
+            console.error(
+              new Error(`Error in the "${page}" app-route HMR subscription`, {
+                cause: error,
+              })
+            )
+          }
+        )
+      }
+
       const type = writtenEndpoint.type
 
       manifestLoader.loadAppPathsManifest(page)

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -167,6 +167,7 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
       previewProps: undefined,
       isHmrRefresh: msg.request.isHmrRefresh,
       serverComponentsHmrCache: undefined,
+      hmrRefreshHash: msg.request.hmrRefreshHash,
       fallbackParams: null,
     })
 

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -64,6 +64,10 @@ export class DevBundlerService {
     return await this.bundler.hotReloader.ensurePage(definition)
   }
 
+  public getServerComponentsHmrRefreshHash(): string | undefined {
+    return this.bundler.hotReloader.getServerComponentsHmrRefreshHash()
+  }
+
   public logErrorWithOriginalStack =
     this.bundler.logErrorWithOriginalStack.bind(this.bundler)
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -115,6 +115,14 @@ export interface RequestMeta {
   serverComponentsHmrCache?: ServerComponentsHmrCache
 
   /**
+   * The hash of the most recent server component change (dev only), set by the
+   * router-server from the hot-reloader. Included in `"use cache"` cache keys
+   * so that cached entries are revalidated after an edit, for every client,
+   * regardless of whether it runs the HMR client.
+   */
+  hmrRefreshHash?: string
+
+  /**
    * Equals the segment path that was used for the prefetch RSC request.
    */
   segmentPrefetchRSCRequest?: string

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -805,7 +805,8 @@ export class AppRouteRouteModule extends RouteModule<
       req.nextUrl,
       implicitTags,
       undefined,
-      context.previewProps
+      context.previewProps,
+      context.renderOpts.hmrRefreshHash
     )
 
     const workStore = createWorkStore(staticGenerationContext)

--- a/packages/next/src/server/use-cache/use-cache-probe-globals.ts
+++ b/packages/next/src/server/use-cache/use-cache-probe-globals.ts
@@ -24,6 +24,7 @@ export type UseCacheProbeRequestSnapshot = {
   rootParams: Params
   isDraftMode: boolean
   isHmrRefresh: boolean
+  hmrRefreshHash: string | undefined
 }
 
 /**

--- a/packages/next/src/server/use-cache/use-cache-probe-scheduler.ts
+++ b/packages/next/src/server/use-cache/use-cache-probe-scheduler.ts
@@ -115,6 +115,7 @@ export function setupProbeScheduler(
         rootParams: outerRequestStore.rootParams ?? {},
         isDraftMode: workStore.isDraftMode ?? false,
         isHmrRefresh: outerRequestStore.isHmrRefresh ?? false,
+        hmrRefreshHash: outerRequestStore.hmrRefreshHash,
       },
       timeoutMs: probeInternalTimeoutMs,
     }).then(

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -74,10 +74,7 @@ import {
 } from './handlers'
 import type { CacheReadWriteHandler } from './tiered-cache-handler'
 import { cloneCacheEntry } from './clone-cache-entry'
-import {
-  NEXT_HMR_REFRESH_HASH_COOKIE,
-  NEXT_INSTANT_TEST_COOKIE,
-} from '../../client/components/app-router-headers'
+import { NEXT_INSTANT_TEST_COOKIE } from '../../client/components/app-router-headers'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
 import type { ReadonlyHeaders } from '../web/spec-extension/adapters/headers'
 import {
@@ -366,10 +363,8 @@ function computeRootParamsCacheKeySuffix(
 // Next-internal cookies that must not vary the private cache key, since they're
 // not part of the application's own cookie state. The instant-navigation cookie
 // toggles while a navigation lock is held, so including it would force spurious
-// misses. The HMR refresh hash is already part of the cache key (see
-// `cacheKeyParts`), so including its cookie too would just be redundant.
+// misses.
 const COOKIES_EXCLUDED_FROM_PRIVATE_CACHE_KEY = new Set<string>([
-  NEXT_HMR_REFRESH_HASH_COOKIE,
   NEXT_INSTANT_TEST_COOKIE,
 ])
 

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -313,7 +313,10 @@ export async function adapter(
               request.nextUrl,
               implicitTags,
               onUpdateCookies,
-              previewProps
+              previewProps,
+              // Edge route handlers can't use `"use cache"`, so there's no HMR
+              // refresh hash to thread through here.
+              undefined
             )
 
             const workStore = createWorkStore({

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -27,12 +27,15 @@ describe('use-cache-custom-handler', () => {
 
     expect(cliOutput).toContain('ModernCustomCacheHandler::refreshTags')
 
+    // In development the cache key carries a trailing HMR refresh hash element
+    // (absent in production), so the args array may be followed by an optional
+    // quoted hash.
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\]\] \[ '_N_T_\/layout', '_N_T_\/page', '_N_T_\/', '_N_T_\/index' \]/
+      /ModernCustomCacheHandler::get \["(development|[A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\](,"[^"]+")?\] \[ '_N_T_\/layout', '_N_T_\/page', '_N_T_\/', '_N_T_\/index' \]/
     )
 
     expect(next.cliOutput.slice(outputIndex)).toMatch(
-      /ModernCustomCacheHandler::set \["(development|[A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\]\]/
+      /ModernCustomCacheHandler::set \["(development|[A-Za-z0-9_-]+)","([0-9a-f]{2})+",\[\](,"[^"]+")?\]/
     )
 
     // Since no existing cache entry was retrieved, we don't need to call

--- a/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
+++ b/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
@@ -50,15 +50,16 @@ describe('use-cache-default-handler-expire-zero', () => {
 
       // In development the default handler keeps `expire: 0` entries (its
       // minimum retention serves them warm across reloads), so it stores rather
-      // than skips.
+      // than skips. The dev cache key always carries a trailing HMR refresh
+      // hash element after the args array.
       await retry(async () => {
         expect(next.cliOutput).toMatch(
-          /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}]\] done/
+          /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}],"[^"]+"\] done/
         )
       })
 
       expect(next.cliOutput).not.toMatch(
-        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}]\] skipped/
+        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","([0-9a-f]{2})+",\[{"id":"expire-zero"}],"[^"]+"\] skipped/
       )
     })
   }

--- a/test/e2e/app-dir/use-cache-dev/use-cache-dev.test.ts
+++ b/test/e2e/app-dir/use-cache-dev/use-cache-dev.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('use-cache-dev', () => {
-  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+  const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
@@ -11,333 +11,276 @@ describe('use-cache-dev', () => {
     return
   }
 
-  if (isNextDev) {
-    it('should update cached data after editing a file', async () => {
-      const browser = await next.browser('/')
+  if (isNextStart) {
+    // Every test below is dev-only now that the HMR refresh hash is sourced on
+    // the server instead of a client cookie (the removed "next start" cookie
+    // test was the only non-dev case). This placeholder keeps the suite from
+    // being empty in non-dev modes. TODO: Move this whole suite to
+    // `test/development/app-dir/use-cache-dev` (a dev-only location) in a
+    // separate PR, and delete this placeholder. It's kept separate to keep this
+    // PR's diff readable.
+    return it('has no production-mode assertions', () => {})
+  }
 
-      const [initialFetchedRandom, initialText, initialMathRandom] =
-        await Promise.all([
-          browser.elementById('fetchedRandom').text(),
-          browser.elementById('text').text(),
-          browser.elementById('mathRandom').text(),
-        ])
+  it('should update cached data after editing a file', async () => {
+    const browser = await next.browser('/')
 
-      expect(initialFetchedRandom).toMatch(/[0,1]\.\d+/)
-      expect(initialText).toBe('foo')
-      expect(initialMathRandom).toMatch(/[0,1]\.\d+/)
-
-      // Edit something inside of "use cache" in the page.tsx file.
-      await next.patchFile('app/page.tsx', (content) =>
-        content.replace('foo', 'bar')
-      )
-
-      let newFetchedRandom: string
-      let newText: string
-      let newMathRandom: string
-
-      await retry(async () => {
-        ;[newFetchedRandom, newText, newMathRandom] = await Promise.all([
-          browser.elementById('fetchedRandom').text(),
-          browser.elementById('text').text(),
-          browser.elementById('mathRandom').text(),
-        ])
-
-        // Cached via server components HMR cache:
-        expect(newFetchedRandom).toBe(initialFetchedRandom)
-
-        // Edited value:
-        expect(newText).toBe('bar')
-
-        // Newly computed value due to cache miss.
-        expect(newMathRandom).not.toBe(initialMathRandom)
-        expect(newMathRandom).toMatch(/[0,1]\.\d+/)
-      })
-
-      // Now revert the edit.
-      await next.patchFile('app/page.tsx', (content) =>
-        content.replace('bar', 'foo')
-      )
-
-      await retry(async () => {
-        const [fetchedRandom, text, mathRandom] = await Promise.all([
-          browser.elementById('fetchedRandom').text(),
-          browser.elementById('text').text(),
-          browser.elementById('mathRandom').text(),
-        ])
-
-        // Cached via server components HMR cache:
-        expect(fetchedRandom).toBe(initialFetchedRandom)
-
-        // Edited value:
-        expect(text).toBe(initialText)
-
-        // Newly computed value due to cache miss, because the initial request did
-        // not use an HMR hash for the cache key.
-        // TODO: Can we get a cache hit here? It's a micro optimization though.
-        expect(mathRandom).not.toBe(initialFetchedRandom)
-        expect(mathRandom).not.toBe(newMathRandom)
-        expect(mathRandom).toMatch(/[0,1]\.\d+/)
-      })
-
-      // Apply the initial edit again.
-      await next.patchFile(
-        'app/page.tsx',
-        (content) => content.replace('foo', 'bar'),
-        async () =>
-          retry(async () => {
-            const [fetchedRandom, text, mathRandom] = await Promise.all([
-              browser.elementById('fetchedRandom').text(),
-              browser.elementById('text').text(),
-              browser.elementById('mathRandom').text(),
-            ])
-
-            // This should be a full cache hit now:
-            expect(fetchedRandom).toBe(newFetchedRandom)
-            expect(text).toBe(newText)
-
-            if (isTurbopack) {
-              // TODO: Turbopack does not provide content hashes during HMR, so we
-              // actually get a cache miss. However, fetchedRandom is still cached
-              // because of the server components HMR cache.
-              expect(mathRandom).not.toBe(newMathRandom)
-              expect(mathRandom).toMatch(/[0,1]\.\d+/)
-            } else {
-              expect(mathRandom).toBe(newMathRandom)
-            }
-          })
-      )
-    })
-
-    // These two currently fail in both Turbopack and Webpack. Dev "use cache"
-    // invalidation relies on the __next_hmr_refresh_hash__ cookie that the
-    // browser HMR client sets after an edit; a client that fetches directly
-    // (curl, a plain fetch, a second device) never sends that cookie, so the
-    // "use cache" key does not change across the edit and the stale entry is
-    // reused. Change these to `it` once editing a file invalidates cached data
-    // for requests that do not carry the cookie, covering both route handlers
-    // and pages.
-    it.failing(
-      'should update cached data used by a route handler after editing a file',
-      async () => {
-        const initialData = await next
-          .fetch('/api/cached')
-          .then((res) => res.json())
-
-        expect(initialData.text).toBe('foo')
-        expect(initialData.uncachedText).toBe('foo')
-        expect(initialData.mathRandom).toEqual(expect.any(Number))
-
-        // A subsequent fetch returns the same cached value.
-        const cachedData = await next
-          .fetch('/api/cached')
-          .then((res) => res.json())
-
-        expect(cachedData.text).toBe('foo')
-        expect(cachedData.mathRandom).toBe(initialData.mathRandom)
-
-        // Edit the source literals inside and outside of "use cache".
-        await next.patchFile('app/api/cached/route.ts', (content) =>
-          content.replaceAll('foo', 'bar')
-        )
-
-        // Wait until the route handler module has recompiled. The uncached
-        // value is read outside of "use cache", so it reflects the edited
-        // source. This ensures we then assert the cached value against the
-        // post-edit module, not a request that raced the recompilation.
-        await retry(async () => {
-          const recompiledData = await next
-            .fetch('/api/cached')
-            .then((res) => res.json())
-
-          expect(recompiledData.uncachedText).toBe('bar')
-        })
-
-        const newData = await next
-          .fetch('/api/cached')
-          .then((res) => res.json())
-
-        // The cached function should return the edited value and recompute its
-        // random value due to a cache miss.
-        expect(newData.text).toBe('bar')
-        expect(newData.mathRandom).not.toBe(initialData.mathRandom)
-      }
-    )
-
-    it.failing(
-      'should update cached data used by a page fetched without a cookie after editing a file',
-      async () => {
-        // `next.render$` fetches directly, without the browser HMR client, so
-        // the request does not carry the __next_hmr_refresh_hash__ cookie.
-        let $ = await next.render$('/cached-page')
-        const initialText = $('#text').text()
-        const initialMathRandom = $('#mathRandom').text()
-
-        expect(initialText).toBe('foo')
-        expect($('#uncachedText').text()).toBe('foo')
-
-        // A subsequent fetch returns the same cached value.
-        $ = await next.render$('/cached-page')
-
-        expect($('#text').text()).toBe('foo')
-        expect($('#mathRandom').text()).toBe(initialMathRandom)
-
-        // Edit the source literals inside and outside of "use cache".
-        await next.patchFile('app/cached-page/page.tsx', (content) =>
-          content.replaceAll('foo', 'bar')
-        )
-
-        // Wait until the page module has recompiled. The uncached value is read
-        // outside of "use cache", so it reflects the edited source. This
-        // ensures we then assert the cached value against the post-edit module,
-        // not a request that raced the recompilation.
-        await retry(async () => {
-          const $$ = await next.render$('/cached-page')
-
-          expect($$('#uncachedText').text()).toBe('bar')
-        })
-
-        $ = await next.render$('/cached-page')
-
-        // The cached function should return the edited value and recompute its
-        // random value due to a cache miss.
-        expect($('#text').text()).toBe('bar')
-        expect($('#mathRandom').text()).not.toBe(initialMathRandom)
-      }
-    )
-
-    it('should return cached data after reload', async () => {
-      let $ = await next.render$('/')
-      const initialContent = $('#container').text()
-      $ = await next.render$('/')
-      const content = $('#container').text()
-
-      expect(content).toEqual(initialContent)
-    })
-
-    it('should return fresh data after hard reload', async () => {
-      let $ = await next.render$('/')
-      const initialContent = $('#container').text()
-
-      $ = await next.render$(
-        '/',
-        {},
-        { headers: { 'cache-control': 'no-cache' } }
-      )
-
-      const hardReloadContent = $('#container').text()
-
-      expect(hardReloadContent).not.toEqual(initialContent)
-
-      // After a subsequent soft reload, cached data from the hard reload should
-      // be returned.
-
-      const softReloadContent = $('#container').text()
-
-      expect(softReloadContent).toEqual(hardReloadContent)
-    })
-
-    it('should successfully finish compilation when "use cache" directive is added/removed', async () => {
-      await next.browser('/')
-      let cliOutputLength = next.cliOutput.length
-
-      // Disable "use cache" directive
-      await next.patchFile('app/page.tsx', (content) =>
-        content.replace(`'use cache'`, `// 'use cache'`)
-      )
-
-      await retry(async () => {
-        expect(next.cliOutput.slice(cliOutputLength)).toInclude('GET / 200')
-      }, 10_000)
-
-      cliOutputLength = next.cliOutput.length
-
-      // Re-enable "use cache" directive
-      await next.patchFile('app/page.tsx', (content) =>
-        content.replace(`// 'use cache'`, `'use cache'`)
-      )
-
-      await retry(async () => {
-        expect(next.cliOutput.slice(cliOutputLength)).toInclude('GET / 200')
-      }, 10_000)
-    })
-
-    it('should handle edits on nested pages', async () => {
-      // This is a regression test that ensures that setting the HMR refresh
-      // hash cookie is not done per path, leading to a stale cookie being used
-      // for nested pages.
-      const browser = await next.browser('/')
-
-      // Edit something in the root page.tsx file.
-      await next.patchFile('app/page.tsx', (content) =>
-        content.replace('foo', 'bar')
-      )
-
-      // Navigate to the nested page. This an explicit hard navigation. A soft
-      // navigation plus refresh would also reproduce the issue.
-      await browser.loadPage(new URL('/some/path', next.url).href)
-
-      expect(await browser.elementById('greeting').text()).toBe('Hi')
-
-      // Edit something in the nested page.tsx file.
-      await next.patchFile('app/some/path/page.tsx', (content) =>
-        content.replace('Hi', 'Hello')
-      )
-
-      await retry(async () => {
-        expect(await browser.elementById('greeting').text()).toBe('Hello')
-      })
-    })
-  } else {
-    it('should ignore an existing HMR refresh hash cookie with "next start"', async () => {
-      const browser = await next.browser('/')
-
-      const [initialFetchedRandom, initialMathRandom] = await Promise.all([
+    const [initialFetchedRandom, initialText, initialMathRandom] =
+      await Promise.all([
         browser.elementById('fetchedRandom').text(),
+        browser.elementById('text').text(),
         browser.elementById('mathRandom').text(),
       ])
 
-      await browser.addCookie({
-        name: '__next_hmr_refresh_hash__',
-        value: 'test',
-      })
+    expect(initialFetchedRandom).toMatch(/[0,1]\.\d+/)
+    expect(initialText).toBe('foo')
+    expect(initialMathRandom).toMatch(/[0,1]\.\d+/)
 
-      // First, revalidate the prerendered page with a server action. This uses
-      // a request work unit store, so the HMR refresh cookie is available.
+    // Edit something inside of "use cache" in the page.tsx file.
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace('foo', 'bar')
+    )
 
-      await browser.elementById('revalidate').click()
+    let newFetchedRandom: string
+    let newText: string
+    let newMathRandom: string
 
-      let revalidatedFetchedRandom: string
-      let revalidatedMathRandom: string
+    await retry(async () => {
+      ;[newFetchedRandom, newText, newMathRandom] = await Promise.all([
+        browser.elementById('fetchedRandom').text(),
+        browser.elementById('text').text(),
+        browser.elementById('mathRandom').text(),
+      ])
 
-      await retry(async () => {
-        ;[revalidatedFetchedRandom, revalidatedMathRandom] = await Promise.all([
-          browser.elementById('fetchedRandom').text(),
-          browser.elementById('mathRandom').text(),
-        ])
+      // Cached via server components HMR cache:
+      expect(newFetchedRandom).toBe(initialFetchedRandom)
 
-        expect(revalidatedFetchedRandom).not.toBe(initialFetchedRandom)
-        expect(revalidatedMathRandom).not.toBe(initialMathRandom)
-      })
+      // Edited value:
+      expect(newText).toBe('bar')
 
-      let initialUncached = await browser.elementById('uncached').text()
-
-      // Now refresh the page. Due to the prior revalidation it will be a cache
-      // miss, and the page will be prerendered. This uses a prerender work unit
-      // store, so the HMR refresh cookie is not available.
-
-      await browser.refresh()
-
-      await retry(async () => {
-        const [fetchedRandom, mathRandom, uncached] = await Promise.all([
-          browser.elementById('fetchedRandom').text(),
-          browser.elementById('mathRandom').text(),
-          browser.elementById('uncached').text(),
-        ])
-
-        expect(uncached).not.toBe(initialUncached)
-        expect(fetchedRandom).toBe(revalidatedFetchedRandom)
-        expect(mathRandom).toBe(revalidatedMathRandom)
-      })
+      // Newly computed value due to cache miss.
+      expect(newMathRandom).not.toBe(initialMathRandom)
+      expect(newMathRandom).toMatch(/[0,1]\.\d+/)
     })
-  }
+
+    // Now revert the edit.
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace('bar', 'foo')
+    )
+
+    await retry(async () => {
+      const [fetchedRandom, text, mathRandom] = await Promise.all([
+        browser.elementById('fetchedRandom').text(),
+        browser.elementById('text').text(),
+        browser.elementById('mathRandom').text(),
+      ])
+
+      // Cached via server components HMR cache:
+      expect(fetchedRandom).toBe(initialFetchedRandom)
+
+      // Edited value:
+      expect(text).toBe(initialText)
+
+      // Newly computed value due to cache miss, because the initial request did
+      // not use an HMR hash for the cache key.
+      // TODO: Can we get a cache hit here? It's a micro optimization though.
+      expect(mathRandom).not.toBe(initialFetchedRandom)
+      expect(mathRandom).not.toBe(newMathRandom)
+      expect(mathRandom).toMatch(/[0,1]\.\d+/)
+    })
+
+    // Apply the initial edit again.
+    await next.patchFile(
+      'app/page.tsx',
+      (content) => content.replace('foo', 'bar'),
+      async () =>
+        retry(async () => {
+          const [fetchedRandom, text, mathRandom] = await Promise.all([
+            browser.elementById('fetchedRandom').text(),
+            browser.elementById('text').text(),
+            browser.elementById('mathRandom').text(),
+          ])
+
+          // This should be a full cache hit now:
+          expect(fetchedRandom).toBe(newFetchedRandom)
+          expect(text).toBe(newText)
+
+          if (isTurbopack) {
+            // TODO: Turbopack does not provide content hashes during HMR, so we
+            // actually get a cache miss. However, fetchedRandom is still cached
+            // because of the server components HMR cache.
+            expect(mathRandom).not.toBe(newMathRandom)
+            expect(mathRandom).toMatch(/[0,1]\.\d+/)
+          } else {
+            expect(mathRandom).toBe(newMathRandom)
+          }
+        })
+    )
+  })
+
+  it('should update cached data used by a route handler after editing a file', async () => {
+    const initialData = await next
+      .fetch('/api/cached')
+      .then((res) => res.json())
+
+    expect(initialData.text).toBe('foo')
+    expect(initialData.uncachedText).toBe('foo')
+    expect(initialData.mathRandom).toEqual(expect.any(Number))
+
+    // A subsequent fetch returns the same cached value.
+    const cachedData = await next.fetch('/api/cached').then((res) => res.json())
+
+    expect(cachedData.text).toBe('foo')
+    expect(cachedData.mathRandom).toBe(initialData.mathRandom)
+
+    // Edit the source literals inside and outside of "use cache".
+    await next.patchFile('app/api/cached/route.ts', (content) =>
+      content.replaceAll('foo', 'bar')
+    )
+
+    // Wait until the route handler module has recompiled. The uncached value
+    // is read outside of "use cache", so it reflects the edited source. This
+    // ensures we then assert the cached value against the post-edit module,
+    // not a request that raced the recompilation.
+    await retry(async () => {
+      const recompiledData = await next
+        .fetch('/api/cached')
+        .then((res) => res.json())
+
+      expect(recompiledData.uncachedText).toBe('bar')
+    })
+
+    const newData = await next.fetch('/api/cached').then((res) => res.json())
+
+    // The cached function should return the edited value and recompute its
+    // random value due to a cache miss.
+    expect(newData.text).toBe('bar')
+    expect(newData.mathRandom).not.toBe(initialData.mathRandom)
+  })
+
+  it('should update cached data used by a page fetched without a cookie after editing a file', async () => {
+    // `next.render$` fetches directly, without the browser HMR client. The
+    // edit is still reflected because the HMR refresh hash is sourced on the
+    // server, not from a client-set cookie.
+    let $ = await next.render$('/cached-page')
+    const initialText = $('#text').text()
+    const initialMathRandom = $('#mathRandom').text()
+
+    expect(initialText).toBe('foo')
+    expect($('#uncachedText').text()).toBe('foo')
+
+    // A subsequent fetch returns the same cached value.
+    $ = await next.render$('/cached-page')
+
+    expect($('#text').text()).toBe('foo')
+    expect($('#mathRandom').text()).toBe(initialMathRandom)
+
+    // Edit the source literals inside and outside of "use cache".
+    await next.patchFile('app/cached-page/page.tsx', (content) =>
+      content.replaceAll('foo', 'bar')
+    )
+
+    // Wait until the page module has recompiled. The uncached value is read
+    // outside of "use cache", so it reflects the edited source. This ensures
+    // we then assert the cached value against the post-edit module, not a
+    // request that raced the recompilation.
+    await retry(async () => {
+      const $$ = await next.render$('/cached-page')
+
+      expect($$('#uncachedText').text()).toBe('bar')
+    })
+
+    $ = await next.render$('/cached-page')
+
+    // The cached function should return the edited value and recompute its
+    // random value due to a cache miss.
+    expect($('#text').text()).toBe('bar')
+    expect($('#mathRandom').text()).not.toBe(initialMathRandom)
+  })
+
+  it('should return cached data after reload', async () => {
+    let $ = await next.render$('/')
+    const initialContent = $('#container').text()
+    $ = await next.render$('/')
+    const content = $('#container').text()
+
+    expect(content).toEqual(initialContent)
+  })
+
+  it('should return fresh data after hard reload', async () => {
+    let $ = await next.render$('/')
+    const initialContent = $('#container').text()
+
+    $ = await next.render$(
+      '/',
+      {},
+      { headers: { 'cache-control': 'no-cache' } }
+    )
+
+    const hardReloadContent = $('#container').text()
+
+    expect(hardReloadContent).not.toEqual(initialContent)
+
+    // After a subsequent soft reload, cached data from the hard reload should
+    // be returned.
+
+    const softReloadContent = $('#container').text()
+
+    expect(softReloadContent).toEqual(hardReloadContent)
+  })
+
+  it('should successfully finish compilation when "use cache" directive is added/removed', async () => {
+    await next.browser('/')
+    let cliOutputLength = next.cliOutput.length
+
+    // Disable "use cache" directive
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace(`'use cache'`, `// 'use cache'`)
+    )
+
+    await retry(async () => {
+      expect(next.cliOutput.slice(cliOutputLength)).toInclude('GET / 200')
+    }, 10_000)
+
+    cliOutputLength = next.cliOutput.length
+
+    // Re-enable "use cache" directive
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace(`// 'use cache'`, `'use cache'`)
+    )
+
+    await retry(async () => {
+      expect(next.cliOutput.slice(cliOutputLength)).toInclude('GET / 200')
+    }, 10_000)
+  })
+
+  it('should handle edits on nested pages', async () => {
+    // Regression test: the HMR refresh hash was previously transported in a
+    // cookie that was scoped per path, so the hash set while on one route
+    // wasn't sent for a different (nested) route, and an edit there was
+    // masked by a stale hash. The hash is now sourced server-side and is
+    // path-independent, so this can't recur; the test still guards that an
+    // edit to a nested page is reflected after navigating to it.
+    const browser = await next.browser('/')
+
+    // Edit something in the root page.tsx file.
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace('foo', 'bar')
+    )
+
+    // Navigate to the nested page. This an explicit hard navigation. A soft
+    // navigation plus refresh would also reproduce the issue.
+    await browser.loadPage(new URL('/some/path', next.url).href)
+
+    expect(await browser.elementById('greeting').text()).toBe('Hi')
+
+    // Edit something in the nested page.tsx file.
+    await next.patchFile('app/some/path/page.tsx', (content) =>
+      content.replace('Hi', 'Hello')
+    )
+
+    await retry(async () => {
+      expect(await browser.elementById('greeting').text()).toBe('Hello')
+    })
+  })
 })

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -458,7 +458,6 @@ async function readNormalizedNFT(next, name) {
         expect(trace).toMatchInlineSnapshot(`
          [
            "/node_modules/client-only/index.js",
-           "/node_modules/next/dist/client/components/app-router-headers.js",
            "/node_modules/next/dist/compiled/@opentelemetry/api/index.js",
            "/node_modules/next/dist/compiled/next-server/server.runtime.prod.js",
            "/node_modules/next/dist/compiled/source-map/source-map.js",
@@ -628,7 +627,6 @@ async function readNormalizedNFT(next, name) {
            "./.next/server/server-reference-manifest.json",
            "/node_modules/@swc/helpers/cjs/_interop_require_default.cjs",
            "/node_modules/next/dist/build/adapter/setup-node-env.external.js",
-           "/node_modules/next/dist/client/components/app-router-headers.js",
            "/node_modules/next/dist/client/components/hooks-server-context.js",
            "/node_modules/next/dist/client/components/static-generation-bailout.js",
            "/node_modules/next/dist/client/lib/console.js",


### PR DESCRIPTION
In development, editing a file does not evict existing `'use cache'` entries; an entry is invalidated only by re-keying, and the key includes an HMR refresh hash. That hash was delivered through the `__next_hmr_refresh_hash__` cookie, which the browser HMR client set from each server-components change and sent back on later requests. Two cases were therefore broken. First, any request that does not carry the cookie (a `curl`, a plain `fetch`, a fresh browser profile, a second device) served stale cached content after an edit, for both pages and route handlers. Second, on Turbopack a route handler served stale content even when fetched from a page whose HMR client had the cookie, because a route-handler edit never advanced the hash there and so never updated the cookie; on webpack that case happens to work, leaving only cookieless route handlers broken.

The hash is server-authored to begin with (webpack's `stats.hash`, Turbopack's `hmrHash` counter), so this change sources it directly on the server and removes the cookie entirely. The hot-reloader exposes it, and `base-server` attaches it to each request with `addRequestMeta`, next to `serverComponentsHmrCache`, so it reaches every render, including the internal Cache Components validation and warmup renders. It is threaded onto the request store the same way `serverComponentsHmrCache` is, so `'use cache'` is invalidated for every client regardless of whether it ran the HMR client. Route handlers, whose `NextRequest` does not carry request meta, receive it through the app-route template's `renderOpts`.

Editing a route handler also has to advance the hash in the first place. On webpack it already did, but on Turbopack the `app-route` entry wired no change subscription, so a route edit recompiled the module without advancing `hmrHash`; it now subscribes to the route endpoint so an edit advances the hash without broadcasting a page refresh. That subscription is also made the only thing that advances `hmrHash`: the config-invalidation and server Fast Refresh reset paths previously bumped it even without a content change, for example on a route's first load, and with the hash now read synchronously instead of bounced back through a cookie, such a bump would land between a route's cold write and warm read and evict a still-valid entry. The getter returns the counter unconditionally so the key is present and stable for every request, matching webpack's always-present `stats.hash`.

With the cookie gone, the `hash` field on the `SERVER_COMPONENT_CHANGES` HMR message has no remaining consumer, so it is dropped from the message type and both bundlers.

This is a short-term stopgap until the granular implementation hash (`codeHash` plus `runtimeEnvVars` plus the Next.js version) is used in `next dev`, which invalidates server-authoritatively by construction and will let this mechanism be removed.

> [!TIP]
> Best reviewed with hidden whitespace changes. 

closes NAR-894

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>