### PR TITLE
Add failing test for allow-runtime routes under the Instant Navigation lock

### DIFF
--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/full-prefetch-runtime-target/loading.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/full-prefetch-runtime-target/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div data-testid="full-prefetch-runtime-loading">
+      Loading full prefetch runtime target...
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/full-prefetch-runtime-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/full-prefetch-runtime-target/page.tsx
@@ -1,0 +1,20 @@
+import { connection } from 'next/server'
+
+// Identical to full-prefetch-target except for the added runtime-prefetch
+// opt-in. A full link prefetch (prefetch={true}) should still resolve the
+// dynamic content ahead of navigation, exactly as it does for the sibling
+// page without this export.
+export const prefetch = 'allow-runtime'
+
+export default async function FullPrefetchRuntimeTargetPage() {
+  await connection()
+
+  return (
+    <div>
+      <h1>Full Prefetch Runtime Target</h1>
+      <div data-testid="full-prefetch-runtime-content">
+        Full prefetch runtime content loaded
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
@@ -29,6 +29,15 @@ export default function HomePage() {
           </Link>
         </li>
         <li>
+          <Link
+            href="/full-prefetch-runtime-target"
+            prefetch={true}
+            id="link-to-full-prefetch-runtime"
+          >
+            Go to full prefetch runtime target
+          </Link>
+        </li>
+        <li>
           <Link href="/cookies-page" id="link-to-cookies-page">
             Go to cookies page
           </Link>

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -243,6 +243,34 @@ describe('instant-navigation-testing-api', () => {
     })
   })
 
+  it('renders full prefetch content instantly when the target also allows runtime prefetching', async () => {
+    // Same scenario as the previous test, but the target page additionally
+    // opts into runtime prefetching (`export const prefetch = 'allow-runtime'`,
+    // the only difference between the two fixture pages). The opt-in must not
+    // reduce what a full link prefetch delivers.
+    //
+    // Regressed by the appShells unification (#95415): the locked navigation
+    // stops committing anything at all. The previous page stays on screen, the
+    // prefetched content and even loading.tsx never appear, and the router
+    // re-issues the prefetch requests it already made before waiting on the
+    // dynamic request that the lock withholds.
+    const page = await openPage(next, '/')
+
+    await instant(page, async () => {
+      await page.click('#link-to-full-prefetch-runtime')
+
+      // With prefetch={true}, the dynamic content is included in the prefetch
+      // response, so it appears immediately without a loading state
+      const content = page.locator(
+        '[data-testid="full-prefetch-runtime-content"]'
+      )
+      await content.waitFor({ state: 'visible' })
+      expect(await content.textContent()).toContain(
+        'Full prefetch runtime content loaded'
+      )
+    })
+  })
+
   it('throws when attempting to nest instant scopes', async () => {
     const page = await openPage(next, '/')
 


### PR DESCRIPTION
Adds a failing test demonstrating a regression from #95415: a route that opts into runtime prefetching (`export const prefetch = 'allow-runtime'`) can no longer commit a navigation from a full link prefetch while the Instant Navigation lock is held.

The new fixture page is a copy of `full-prefetch-target` plus that single export, and the new test is a copy of the sibling full-prefetch test pointed at it. The sibling passes and the new test times out; under the lock the navigation commits nothing at all: not the prefetched content, not `loading.tsx`, and the source page stays on screen.

```
✓ renders full prefetch content instantly when prefetch={true} (122 ms)
✕ renders full prefetch content instantly when the target also allows runtime prefetching (20093 ms)
```

Reproduces in both dev and start modes. Bisected against published packages in an external repro: passes through `16.3.0-canary.87`, fails from `16.3.0-canary.88` (the release containing #95415), under webpack as well as Turbopack. Request logs there show the router re-issuing prefetch requests it had already completed (identical `_rsc` cache-bust hashes) and then waiting on the dynamic request the lock withholds. v0 hit this on its canary bump and skipped the affected app test until this is fixed (vercel/v0#27128).
