### PR TITLE
fix: recognize Meta's 2024 crawler UAs as HTML-limited bots

### DIFF
--- a/packages/next/src/shared/lib/router/utils/html-bots.ts
+++ b/packages/next/src/shared/lib/router/utils/html-bots.ts
@@ -2,5 +2,9 @@
 // due to how they parse the DOM. For example, they might explicitly check for metadata in the `head` tag, so we can't stream metadata tags after the `head` was sent.
 // Note: The pattern [\w-]+-Google captures all Google crawlers with "-Google" suffix (e.g., Mediapartners-Google, AdsBot-Google, Storebot-Google)
 // as well as crawlers starting with "Google-" (e.g., Google-PageRenderer, Google-InspectionTool)
+// Note: meta-externalagent and meta-externalfetcher are the crawler UAs Meta
+// introduced in 2024 alongside the legacy facebookexternalhit; none of them
+// execute JavaScript, so they only see metadata that is in the initial <head>.
+// x-ref: https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
 export const HTML_LIMITED_BOT_UA_RE =
-  /[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i
+  /[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|meta-externalagent|meta-externalfetcher|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -197,5 +197,29 @@ describe('app-dir - metadata-streaming', () => {
       expect($('title').length).toBe(1)
       expect($('head title').text()).toBe('partial static page')
     })
+
+    it("should still render blocking metadata for Meta's 2024 crawlers", async () => {
+      // Meta's current crawlers alongside the legacy facebookexternalhit.
+      // None of them execute JavaScript, so streamed metadata (tags after
+      // </head>) is invisible to them and link previews render blank.
+      // x-ref: https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
+      const userAgents = [
+        'meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+        'meta-externalfetcher/1.1',
+      ]
+      for (const userAgent of userAgents) {
+        const $ = await next.render$(
+          '/static/partial',
+          {},
+          {
+            headers: {
+              'user-agent': userAgent,
+            },
+          }
+        )
+        expect($('title').length).toBe(1)
+        expect($('head title').text()).toBe('partial static page')
+      }
+    })
   })
 })


### PR DESCRIPTION
Link previews on WhatsApp/Instagram/Facebook can render blank for Next.js sites even when the page's metadata is correct.

Cause: Meta introduced new crawler UAs in 2024, `meta-externalagent` and `meta-externalfetcher` ([Meta's crawler docs](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)). `HTML_LIMITED_BOT_UA_RE` only carries the legacy `facebookexternalhit`, so the new UAs get streaming metadata. Meta's crawlers don't execute JS, which means every `og:*`/`title` tag lands after `</head>` and they never see it.

I hit this in production this week. Easy to check on any deployed app with dynamic metadata:

```
$ curl -s -A "meta-externalagent/1.1" https://<site> | grep -bo 'og:title\|</head>'

# og:title byte offset AFTER </head>'s  → streamed, crawler never sees it, blank card
# og:title byte offset BEFORE </head>'s → blocking, card renders
```

The fix adds the two UAs to the regex so they get blocking metadata like `facebookexternalhit` already does, plus an e2e case in `metadata-streaming.test.ts` mirroring the existing Chrome-Lighthouse special case.

For reference, Cloudflare's vinext (which mirrors this list) shipped the same two UAs earlier today: cloudflare/vinext#2666.

🧠 Thought by a Human ([@MrIago](https://github.com/MrIago)) · 🤖 Generated with [Claude Code](https://claude.com/claude-code)
