### PR TITLE
Turbopack: Use `swc_core::ecma::utils::prop_name_eq` for a couple of the `next-custom-transforms`

### DIFF
--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -14,7 +14,7 @@ use swc_core::{
             ImportSpecifier, KeyValueProp, Lit, ModuleDecl, ModuleItem, ObjectLit, Pass, Prop,
             PropName, PropOrSpread, Stmt, Str, Tpl, UnaryExpr, UnaryOp, op,
         },
-        utils::{ExprFactory, private_ident, quote_ident},
+        utils::{ExprFactory, private_ident, prop_name_eq, quote_ident},
         visit::{VisitMut, VisitMutWith, visit_mut_pass},
     },
     quote,
@@ -275,10 +275,7 @@ impl VisitMut for NextDynamicPatcher {
                             _ => None,
                         },
                         _ => None,
-                    } && let Some(IdentName { sym, span: _ }) = match key {
-                        PropName::Ident(ident) => Some(ident),
-                        _ => None,
-                    } && sym == "ssr"
+                    } && prop_name_eq(key, "ssr")
                         && let Some(Lit::Bool(Bool {
                             value: false,
                             span: _,

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -31,7 +31,7 @@ use swc_core::{
     },
     ecma::{
         ast::*,
-        utils::{ExprFactory, prepend_stmts, quote_ident, quote_str},
+        utils::{ExprFactory, prepend_stmts, prop_name_eq, quote_ident, quote_str},
         visit::{
             Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type,
             visit_mut_pass,
@@ -1086,13 +1086,7 @@ impl ReactServerComponentValidator {
         let obj = ssr_arg.expr.as_object()?;
 
         for prop in obj.props.iter().filter_map(|v| v.as_prop()?.as_key_value()) {
-            let is_ssr = match &prop.key {
-                PropName::Ident(IdentName { sym, .. }) => sym == "ssr",
-                PropName::Str(s) => s.value == "ssr",
-                _ => false,
-            };
-
-            if is_ssr {
+            if prop_name_eq(&prop.key, "ssr") {
                 let value = prop.value.as_lit()?;
                 if let Lit::Bool(Bool { value: false, .. }) = value {
                     report_error(


### PR DESCRIPTION
Found this helper while looking through one of @sampoder's PRs, noticed that these places could benefit from it.