### PR TITLE
useRelativeHref

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -684,6 +684,7 @@ impl ReactServerComponentValidator {
                         "useServerInsertedHTML",
                         "ServerInsertedHTMLContext",
                         "unstable_isUnrecognizedActionError",
+                        "unstable_useRelativeHref",
                     ],
                 ),
                 (atom!("next/link").into(), vec!["useLinkStatus"]),

--- a/packages/next/navigation-types/compat/navigation.d.ts
+++ b/packages/next/navigation-types/compat/navigation.d.ts
@@ -47,4 +47,13 @@ declare module 'next/navigation' {
    * If used from `pages/`, the hook will return `null`.
    */
   export function useSelectedLayoutSegment(): string | null
+
+  /**
+   * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
+   * that computes a relative URL reference from the current page to a target
+   * route pattern.
+   *
+   * If used from `pages/`, the hook will return `null`.
+   */
+  export function unstable_useRelativeHref(target: string): string | null
 }

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -11,6 +11,8 @@ import {
   GlobalLayoutRouterContext,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import type { CacheNode } from '../../shared/lib/app-router-types'
+import { splitPathSegments } from '../../shared/lib/relative-href'
+import { getPrerenderFallbackParams } from './navigation-dynamic-rendering'
 import { ACTION_RESTORE } from './router-reducer/router-reducer-types'
 import type {
   AppHistoryState,
@@ -452,7 +454,14 @@ function Router({
     }
   }, [])
 
-  const { cache, tree, nextUrl, focusAndScrollRef, previousNextUrl } = state
+  const {
+    cache,
+    tree,
+    nextUrl,
+    focusAndScrollRef,
+    previousNextUrl,
+    initialMatchedRoute,
+  } = state
 
   const matchingHead = useMemo(() => {
     return findHeadInCache(cache, tree[1])
@@ -498,13 +507,44 @@ function Router({
   }, [tree, cache, canonicalUrl])
 
   const globalLayoutRouterContext = useMemo(() => {
+    // The current page's URL path parts, for unstable_useRelativeHref:
+    // the server-computed matched route on the initial render (so SSR and
+    // hydration resolve hrefs identically), the URL pathname — the same
+    // source usePathname reads — after the first router state update, or
+    // on the initial render when the route has no statically resolvable
+    // path. Resolved here, once per state, rather than per hook call.
+    let matchedRoute
+    if (initialMatchedRoute !== null) {
+      matchedRoute = initialMatchedRoute
+    } else {
+      // During a prerender with fallback params the pathname is a
+      // placeholder, not a real URL, so it doesn't yield a usable base:
+      // pass null and the hook deopts to dynamic rendering.
+      // `getPrerenderFallbackParams` is server-only (undefined in the
+      // browser) and only returns params during a prerender that has
+      // unknown ones — at request time, and on the client, the pathname
+      // is always real.
+      const fallbackParams = getPrerenderFallbackParams?.()
+      matchedRoute =
+        fallbackParams != null && fallbackParams.size > 0
+          ? null
+          : splitPathSegments(pathname)
+    }
     return {
       tree,
       focusAndScrollRef,
       nextUrl,
       previousNextUrl,
+      matchedRoute,
     }
-  }, [tree, focusAndScrollRef, nextUrl, previousNextUrl])
+  }, [
+    tree,
+    focusAndScrollRef,
+    nextUrl,
+    previousNextUrl,
+    initialMatchedRoute,
+    pathname,
+  ])
 
   let head
   if (matchingHead !== null) {
@@ -603,10 +643,10 @@ function Router({
                 value={globalLayoutRouterContext}
               >
                 {/* TODO: We should be able to remove this context. useRouter
-                    should import from app-router-instance instead. It's only
-                    necessary because useRouter is shared between Pages and
-                    App Router. We should fork that module, then remove this
-                    context provider. */}
+                  should import from app-router-instance instead. It's only
+                  necessary because useRouter is shared between Pages and
+                  App Router. We should fork that module, then remove this
+                  context provider. */}
                 <AppRouterContext.Provider value={publicAppRouterInstance}>
                   <LayoutRouterContext.Provider value={layoutRouterContext}>
                     {content}

--- a/packages/next/src/client/components/navigation-devtools.ts
+++ b/packages/next/src/client/components/navigation-devtools.ts
@@ -120,6 +120,14 @@ export function createRootNavigationPromises(
       readonlySearchParams
     ),
     params: createDevToolsInstrumentedPromise('useParams', pathParams),
+    // One promise for all unstable_useRelativeHref instances (see
+    // NavigationPromises); relative hrefs are position-independent, so
+    // nested layouts share it through the spread in
+    // createNestedLayoutNavigationPromises.
+    relativeHref: createDevToolsInstrumentedPromise(
+      'unstable_useRelativeHref',
+      tree
+    ),
     ...layoutSegmentPromises,
   }
 

--- a/packages/next/src/client/components/navigation-dynamic-rendering.browser.ts
+++ b/packages/next/src/client/components/navigation-dynamic-rendering.browser.ts
@@ -1,5 +1,6 @@
 // Browser variant of `./navigation-dynamic-rendering`. The dynamic-rendering
-// hooks only run on the server; callers use optional calls, so these are
+// helpers only run on the server; callers use optional calls, so these are
 // `undefined` in the browser.
-export const useDynamicRouteParams = undefined
-export const useDynamicSearchParams = undefined
+export const getPrerenderFallbackParams = undefined
+export const trackDynamicRouteParamsAccess = undefined
+export const trackDynamicSearchParamsAccess = undefined

--- a/packages/next/src/client/components/navigation-dynamic-rendering.ts
+++ b/packages/next/src/client/components/navigation-dynamic-rendering.ts
@@ -1,11 +1,13 @@
-// Client-safe access to the server-only dynamic-rendering hooks used by the
-// navigation hooks. On the server these re-export the real implementations; in
-// the browser bundle this module is aliased to
+// Client-safe access to the server-only dynamic-rendering helpers used by
+// the navigation hooks. On the server these re-export the real
+// implementations; in the browser bundle this module is aliased to
 // `./navigation-dynamic-rendering.browser` (see
 // scripts/generate-browser-variant-aliases.mjs), which exports `undefined` so
-// the server module is not bundled into the client. Callers use optional calls
-// (`useDynamicRouteParams?.(...)`), so the browser stub is a no-op.
+// the server module is not bundled into the client. Callers use optional
+// calls (`trackDynamicRouteParamsAccess?.(...)`), so the browser stub is a
+// no-op.
 export {
-  useDynamicRouteParams,
-  useDynamicSearchParams,
+  getPrerenderFallbackParams,
+  trackDynamicRouteParamsAccess,
+  trackDynamicSearchParamsAccess,
 } from '../../server/app-render/dynamic-rendering'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -4,6 +4,7 @@ import React, { useContext, useMemo, use } from 'react'
 import {
   AppRouterContext,
   LayoutRouterContext,
+  GlobalLayoutRouterContext,
   type AppRouterInstance,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import {
@@ -17,10 +18,11 @@ import {
   computeSelectedLayoutSegment,
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
+import { computeRelativeHref } from '../../shared/lib/relative-href'
 
 import {
-  useDynamicRouteParams,
-  useDynamicSearchParams,
+  trackDynamicRouteParamsAccess,
+  trackDynamicSearchParamsAccess,
 } from './navigation-dynamic-rendering'
 
 const {
@@ -30,6 +32,30 @@ const {
 } = process.env.__NEXT_CACHE_COMPONENTS
   ? (require('./instant-samples') as typeof import('./instant-samples'))
   : {}
+
+/**
+ * Marks the calling hook's output as depending on the route params. The
+ * tracker (server-only; undefined in the browser) returns a hanging promise
+ * when a prerender must block on the unknown param values; suspending on it
+ * with `use` is done here, in a hook, where it belongs.
+ */
+function useDynamicRouteParams(expression: string) {
+  const hangingPromise = trackDynamicRouteParamsAccess?.(expression)
+  if (hangingPromise !== undefined) {
+    use(hangingPromise)
+  }
+}
+
+/**
+ * Like `useDynamicRouteParams`, but for search params, which are always
+ * request-time values.
+ */
+function useDynamicSearchParams(expression: string) {
+  const hangingPromise = trackDynamicSearchParamsAccess?.(expression)
+  if (hangingPromise !== undefined) {
+    use(hangingPromise)
+  }
+}
 
 /**
  * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
@@ -53,7 +79,7 @@ const {
  */
 // Client components API
 export function useSearchParams(): ReadonlyURLSearchParams {
-  useDynamicSearchParams?.('useSearchParams()')
+  useDynamicSearchParams('useSearchParams()')
 
   const searchParams = useContext(SearchParamsContext)
 
@@ -110,7 +136,7 @@ export function useSearchParams(): ReadonlyURLSearchParams {
  */
 // Client components API
 export function usePathname(): string {
-  useDynamicRouteParams?.('usePathname()')
+  useDynamicRouteParams('usePathname()')
 
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
@@ -213,7 +239,7 @@ export function useRouter(): AppRouterInstance {
  */
 // Client components API
 export function useParams<T extends Params = Params>(): T {
-  useDynamicRouteParams?.('useParams()')
+  useDynamicRouteParams('useParams()')
 
   const params = useContext(PathParamsContext) as T
 
@@ -267,7 +293,7 @@ export function useParams<T extends Params = Params>(): T {
 export function useSelectedLayoutSegments(
   parallelRouteKey: string = 'children'
 ): string[] {
-  useDynamicRouteParams?.('useSelectedLayoutSegments()')
+  useDynamicRouteParams('useSelectedLayoutSegments()')
 
   const context = useContext(LayoutRouterContext)
   // @ts-expect-error This only happens in `pages`. Type is overwritten in navigation.d.ts
@@ -322,7 +348,7 @@ export function useSelectedLayoutSegments(
 export function useSelectedLayoutSegment(
   parallelRouteKey: string = 'children'
 ): string | null {
-  useDynamicRouteParams?.('useSelectedLayoutSegment()')
+  useDynamicRouteParams('useSelectedLayoutSegment()')
   const navigationPromises = useContext(NavigationPromisesContext)
   const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
 
@@ -349,6 +375,101 @@ export function useSelectedLayoutSegment(
 
   return computeSelectedLayoutSegment(selectedLayoutSegments, parallelRouteKey)
 }
+
+/**
+ * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
+ * that computes a relative URL reference from the current page to a target
+ * route pattern. The result resolves to the target route's URL path; its
+ * path portion always ends in `/`, so child segments can be appended
+ * directly. A query and/or hash in the target is preserved in the result.
+ *
+ * Dynamic segments in the target take their values from the current route
+ * where the target overlaps it, so the target can be a route pattern like
+ * `'/chat/[id]'` — no knowledge of the current param values is required.
+ *
+ * Targets that aren't root-relative paths — absolute URLs (`https://…`,
+ * `mailto:…`), protocol-relative URLs, and hash- or query-only references
+ * (`#faq`, `?tab=1`) — are returned unchanged, so any href that's valid on
+ * a `<Link>` can be passed through the hook without changing its behavior.
+ *
+ * @example
+ * ```ts
+ * 'use client'
+ * import { unstable_useRelativeHref } from 'next/navigation'
+ *
+ * export default function ExampleClientComponent() {
+ *   // On /acme/settings (route /[teamId]/settings), returns './dashboard/'.
+ *   // On /acme/settings/billing, returns '../dashboard/'.
+ *   const dashboardHref = unstable_useRelativeHref('/[teamId]/dashboard')
+ *   // ...
+ * }
+ * ```
+ *
+ * In the Pages Router the returned value is `null`; the compat types added
+ * in `next-env.d.ts` widen the return type to include `null` there.
+ */
+// Client components API
+// Exported publicly as `unstable_useRelativeHref` (see below); named
+// `useRelativeHref` here so React's rules-of-hooks tooling recognizes it as
+// a hook.
+function useRelativeHref(target: string): string {
+  // TODO: Type the target argument against the generated route types
+  // (`Route`), like typed `<Link>` hrefs. For now it's a plain string.
+  //
+  // The current page's URL parts (`matchedRoute`) are resolved once per
+  // router state by AppRouter: the server-computed matched route on the
+  // initial render, the URL pathname (the same source usePathname reads)
+  // after that. In the Pages Router the context has no provider and the
+  // hook returns null.
+  const context = useContext(GlobalLayoutRouterContext)
+
+  const href = useMemo(() => {
+    if (context === null) {
+      return null
+    }
+    return computeRelativeHref(
+      target,
+      context.matchedRoute,
+      Boolean(process.env.__NEXT_TRAILING_SLASH)
+    )
+  }, [context, target])
+
+  // A null href means it would read values that don't exist yet (see
+  // computeRelativeHref), which only happens while prerendering a fallback
+  // shell: deopt to dynamic rendering. Suspending on the tracker's hanging
+  // promise makes this component a dynamic hole, filled in at request time
+  // when the values exist; hrefs that are invariant to the unknown values
+  // come out as strings and stay in the static shell. The tracker isn't a
+  // hook, so it may be called conditionally, and `use` (unlike other
+  // hooks) is allowed in conditional code.
+  if (context !== null && href === null) {
+    const hangingPromise = trackDynamicRouteParamsAccess?.(
+      'unstable_useRelativeHref()'
+    )
+    if (hangingPromise !== undefined) {
+      use(hangingPromise)
+    }
+  }
+
+  // Instrument with Suspense DevTools (dev-only). Every instance of this
+  // hook conceptually blocks on the same thing — the resolved router
+  // state — so they all share a single named promise (see
+  // NavigationPromises). Unlike the sibling hooks, the promise's value is
+  // not the hook's return value, so it isn't returned here.
+  if (process.env.NODE_ENV !== 'production' && 'use' in React) {
+    const navigationPromises = use(NavigationPromisesContext)
+    if (navigationPromises !== null) {
+      use(navigationPromises.relativeHref)
+    }
+  }
+
+  // `href` is null only in the Pages Router (context has no provider),
+  // where the compat types widen the return type to include `null` (see
+  // above).
+  return href as string
+}
+
+export { useRelativeHref as unstable_useRelativeHref }
 
 export { unstable_isUnrecognizedActionError } from './unrecognized-action-error'
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -39,6 +39,7 @@ export function createInitialRouterState({
     c: initialCanonicalUrlParts,
     f: initialFlightData,
     q: initialRenderedSearch,
+    u: initialMatchedRoute,
     i: initialCouldBeIntercepted,
     S: initialSupportsPerSegmentPrefetching,
     s: initialStaleTime,
@@ -269,6 +270,7 @@ export function createInitialRouterState({
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
       null,
     previousNextUrl: null,
+    initialMatchedRoute: initialMatchedRoute ?? null,
     debugInfo: null,
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -212,6 +212,15 @@ export async function fetchServerResponse(
     }
 
     const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
+    // A fetched URL never includes a fragment — not even the redirect
+    // Location's — so on a redirect, carry over the original URL's hash.
+    // This matches browser behavior for redirects whose Location has no
+    // fragment of its own (e.g. the trailing-slash normalization redirect).
+    // When the Location does specify a fragment, we can't see it, so the
+    // original hash wins where a browser would prefer the redirect's.
+    if (url.hash) {
+      responseUrl.hash = url.hash
+    }
     const canonicalUrl = res.redirected ? responseUrl : originalUrl
 
     const contentType = res.headers.get('content-type') || ''
@@ -230,11 +239,8 @@ export async function fetchServerResponse(
     // If fetch returns something different than flight response handle it like a mpa navigation
     // If the fetch was not 200, we also handle it like a mpa navigation
     if (!isFlightResponse || !res.ok || !res.body) {
-      // in case the original URL came with a hash, preserve it before redirecting to the new URL
-      if (url.hash) {
-        responseUrl.hash = url.hash
-      }
-
+      // The original URL's hash was already carried over onto responseUrl
+      // above, so an MPA navigation preserves it too.
       return doMpaNavigation(responseUrl.toString())
     }
 

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -1,5 +1,6 @@
 import type { CacheNode, ScrollRef } from '../../../shared/lib/app-router-types'
 import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import type { BaseUrlPart } from '../../../shared/lib/relative-href'
 import type { NavigationSeed } from '../segment-cache/navigation'
 import type { FetchServerResponseResult } from './fetch-server-response'
 import type { FreshnessPolicy } from './ppr-navigations'
@@ -254,6 +255,18 @@ export type AppRouterState = {
    * The previous next-url that was used previous to a dynamic navigation.
    */
   previousNextUrl: string | null
+
+  /**
+   * The current page's URL path parts as computed by the server for the
+   * initial render (see `InitialRSCPayload.u`). Consumed by
+   * `unstable_useRelativeHref`, so that SSR and hydration render identical
+   * hrefs. Only `createInitialRouterState` populates it — every other place
+   * that creates a router state must set it to null, so that after the
+   * first state transition the hook resolves against the pathname, the
+   * same source `usePathname` reads. Also null on the initial render when
+   * the route has no statically resolvable path.
+   */
+  initialMatchedRoute: BaseUrlPart[] | null
 
   debugInfo: Array<unknown> | null
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -677,6 +677,8 @@ export function completeHardNavigation(
     tree: state.tree,
     nextUrl: state.nextUrl,
     previousNextUrl: state.previousNextUrl,
+    // The server-computed matched route only applies to the initial render.
+    initialMatchedRoute: null,
     debugInfo: null,
   }
   return newState
@@ -815,6 +817,8 @@ export function completeSoftNavigation(
     tree,
     nextUrl: nextUrlForNewRoute,
     previousNextUrl,
+    // The server-computed matched route only applies to the initial render.
+    initialMatchedRoute: null,
     debugInfo: collectedDebugInfo,
   }
   return newState
@@ -847,6 +851,8 @@ export function completeTraverseNavigation(
     // Next-Url that was used to fetch the data. Anywhere we fetch using the
     // canonical URL, there should be a corresponding Next-Url.
     previousNextUrl: null,
+    // The server-computed matched route only applies to the initial render.
+    initialMatchedRoute: null,
     debugInfo: null,
   }
 }

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -9,6 +9,7 @@ import type {
   InitialRSCPayload,
 } from '../shared/lib/app-router-types'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
+import type { BaseUrlPart } from '../shared/lib/relative-href'
 import type { NormalizedSearch } from './components/segment-cache/cache-key'
 import {
   getCacheKeyForDynamicParam,
@@ -126,7 +127,30 @@ export function createInitialRSCPayloadFromFallbackPrerender(
   if (fallbackInitialRSCPayload.b) {
     payload.b = fallbackInitialRSCPayload.b
   }
+  if (fallbackInitialRSCPayload.u) {
+    payload.u = fillInFallbackMatchedRoute(
+      fallbackInitialRSCPayload.u,
+      renderedPathname
+    )
+  }
   return payload
+}
+
+/**
+ * Fills in the parts of the prerendered matched route (see
+ * `InitialRSCPayload.u`) whose values were fallback params of the prerender
+ * (null parts). Each part corresponds positionally to one URL path part, so
+ * the values come straight from the rendered pathname — the same way
+ * `fillInFallbackFlightRouterState` fills the router tree's params.
+ */
+function fillInFallbackMatchedRoute(
+  matchedRoute: BaseUrlPart[],
+  renderedPathname: string
+): BaseUrlPart[] {
+  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
+  return matchedRoute.map((part, i) =>
+    part === null ? (pathnameParts[i] ?? null) : part
+  )
 }
 
 function fillInFallbackFlightRouterState(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -135,6 +135,7 @@ import {
   getMissingPrefetchHintPolicy,
   type MissingPrefetchHintPolicy,
 } from './create-flight-router-state-from-loader-tree'
+import { getMatchedRoute } from './get-matched-route'
 import { handleAction } from './action-handler'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { warn, error } from '../../build/output/log'
@@ -2149,6 +2150,13 @@ async function getRSCPayload(
     getDynamicParamFromSegment,
     query
   )
+  // The current page's URL path parts, derived from the matched route, for
+  // unstable_useRelativeHref. Null when the route has no statically
+  // resolvable path (every path to a page goes through a catch-all). A part
+  // is null when its value is a fallback param of this prerender; those are
+  // filled in from the actual URL before hydration.
+  const matchedRoute = getMatchedRoute(initialTree)
+
   const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
   const hasGlobalNotFound = !!tree[2]['global-not-found']
 
@@ -2238,6 +2246,12 @@ async function getRSCPayload(
     }),
     c: prepareInitialCanonicalUrl(url),
     q: getRenderedSearch(query),
+    // TODO: Consider consolidating this with `c`: both describe the URL the
+    // server rendered, but `c` is the request URL (as parts of a joined
+    // href, including the search) while `u` is derived from the matched
+    // route — it can differ under rewrites and can carry null parts during
+    // a fallback prerender.
+    u: matchedRoute ?? undefined,
     i: !!couldBeIntercepted,
     f: [
       [

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -21,6 +21,7 @@
  */
 
 import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 import type {
   WorkUnitStore,
   PrerenderStoreLegacy,
@@ -644,7 +645,21 @@ export function annotateDynamicAccess(
   }
 }
 
-export function useDynamicRouteParams(expression: string) {
+/**
+ * Called by a client navigation hook whose output depends on the values of
+ * the route params. During a prerender whose params aren't all known (a
+ * fallback shell), makes the calling component dynamic.
+ *
+ * Not a hook — it reads no hook state, only the ambient stores, so callers
+ * may invoke it conditionally (e.g. `unstable_useRelativeHref` only calls it
+ * when its result actually depends on an unknown param value). Instead of
+ * suspending itself, it returns a hanging promise when the render should
+ * block; the calling hook must pass it to `use()`, which is where the
+ * suspension belongs (and where a conditional `use` call is legal).
+ */
+export function trackDynamicRouteParamsAccess(
+  expression: string
+): Promise<never> | undefined {
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workStore && workUnitStore) {
@@ -653,14 +668,13 @@ export function useDynamicRouteParams(expression: string) {
         const fallbackParams = workUnitStore.fallbackRouteParams
 
         if (fallbackParams && fallbackParams.size > 0) {
-          // We are in a prerender with cacheComponents semantics. We are going to
-          // hang here and never resolve. This will cause the currently
-          // rendering component to effectively be a dynamic hole.
-          React.use(
-            makeClientHookHangingPromise(
-              workUnitStore.renderSignal,
-              new ClientHookDynamicError(workStore.route, expression)
-            )
+          // We are in a prerender with cacheComponents semantics. The
+          // returned promise hangs and never resolves, so when the calling
+          // hook passes it to `use()`, the currently rendering component
+          // effectively becomes a dynamic hole.
+          return makeClientHookHangingPromise(
+            workUnitStore.renderSignal,
+            new ClientHookDynamicError(workStore.route, expression)
           )
         }
         break
@@ -708,7 +722,52 @@ export function useDynamicRouteParams(expression: string) {
   }
 }
 
-export function useDynamicSearchParams(expression: string) {
+/**
+ * Reads the fallback route params of the current render, if it's a prerender
+ * that has any: the route params whose values are not known because the
+ * output being generated is shared across all values (e.g. the fallback
+ * shell of a route with dynamic params). Returns null during regular request
+ * rendering, where every param value is known.
+ *
+ * Used by client hooks whose output only sometimes depends on the values of
+ * route params (e.g. `unstable_useRelativeHref`) to detect which values are
+ * unknown, rather than unconditionally deopting.
+ */
+export function getPrerenderFallbackParams(): OpaqueFallbackRouteParams | null {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-client':
+      case 'prerender-ppr':
+      case 'validation-client':
+        return workUnitStore.fallbackRouteParams
+      case 'request':
+      case 'cache':
+      case 'private-cache':
+      case 'unstable-cache':
+      case 'prerender-legacy':
+      case 'prerender-runtime':
+      case 'generate-static-params':
+        return null
+      default:
+        workUnitStore satisfies never
+        return null
+    }
+  }
+  return null
+}
+
+/**
+ * Called by `useSearchParams` in a client page. Search params are always
+ * request time values, so this makes the calling component dynamic in any
+ * prerender. Like `trackDynamicRouteParamsAccess`, not a hook: it returns a
+ * hanging promise when the render should block, and the calling hook passes
+ * it to `use()`.
+ */
+export function trackDynamicSearchParamsAccess(
+  expression: string
+): Promise<never> | undefined {
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
 
@@ -727,13 +786,12 @@ export function useDynamicSearchParams(expression: string) {
       // so this shouldn't hang during SSR.
       return
     case 'prerender-client': {
-      React.use(
-        makeClientHookHangingPromise(
-          workUnitStore.renderSignal,
-          new ClientHookDynamicError(workStore.route, expression)
-        )
+      // The returned promise hangs and never resolves; the calling hook
+      // passes it to `use()`, making the component a dynamic hole.
+      return makeClientHookHangingPromise(
+        workUnitStore.renderSignal,
+        new ClientHookDynamicError(workStore.route, expression)
       )
-      break
     }
     case 'prerender-legacy':
     case 'prerender-ppr': {

--- a/packages/next/src/server/app-render/get-matched-route.ts
+++ b/packages/next/src/server/app-render/get-matched-route.ts
@@ -1,0 +1,109 @@
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
+import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
+import type { BaseUrlPart } from '../../shared/lib/relative-href'
+import {
+  isGroupSegment,
+  isFrameworkInternalRouteSegment,
+  DEFAULT_SEGMENT_KEY,
+  PAGE_SEGMENT_KEY,
+} from '../../shared/lib/segment'
+import { getPrerenderFallbackParams } from './dynamic-rendering'
+
+/**
+ * Reads the current page's URL path from a server-rendered router tree, one
+ * part per entry. Whether a part came from a static segment or a dynamic
+ * param is deliberately not distinguished — a known URL part affects
+ * relative path resolution identically either way.
+ *
+ * A "statically resolvable" path is one reaching a page through only
+ * static, route-group, and plain dynamic ([param]) segments. Every segment
+ * on such a path matches exactly one URL part (or none, for route groups),
+ * so any resolvable path spells out the full URL; when several parallel
+ * routes qualify, the choice is arbitrary.
+ *
+ * The result is shipped to the client on the initial RSC payload (see
+ * `InitialRSCPayload.u`) and consumed by `unstable_useRelativeHref` during
+ * SSR and hydration. It's only ever computed here, on the tree the server
+ * just built — after hydration the client resolves against the actual URL
+ * pathname instead, which always yields the same parts this walk would
+ * have.
+ *
+ * A part is null when its value is not known: the param is a fallback param
+ * of the current prerender (read off the work unit store, like other
+ * navigation hooks do). Null parts are filled in from the actual URL before
+ * hydration (see `createInitialRSCPayloadFromFallbackPrerender`), so they
+ * never reach the browser. Consumers rendering with a null part must deopt
+ * to dynamic rendering if it ends up affecting their output.
+ *
+ * Returns null when the route has no statically resolvable path — every
+ * path to a page goes through a catch-all — in which case relative hrefs
+ * resolve against the actual URL (see `computeRelativeHref`).
+ *
+ * Route groups, the page segment, and the empty root segment contribute no
+ * URL parts and are skipped. Dynamic segments carry their matched URL part,
+ * already URL-encoded (see `getDynamicParam`), so it can be emitted into an
+ * href as-is.
+ */
+export function getMatchedRoute(tree: FlightRouterState): BaseUrlPart[] | null {
+  // The fallback route params of the current prerender, if any. Their
+  // values are placeholders, not real URL parts, so segments matching them
+  // become null parts.
+  const fallbackParams = getPrerenderFallbackParams()
+  return getMatchedRouteImpl(tree, fallbackParams)
+}
+
+function getMatchedRouteImpl(
+  node: FlightRouterState,
+  fallbackParams: OpaqueFallbackRouteParams | null
+): BaseUrlPart[] | null {
+  const segment = node[0]
+  // The URL part this segment contributes, or undefined for segments that
+  // don't appear in URL space (route groups, the empty root segment).
+  let part: BaseUrlPart | undefined
+  if (Array.isArray(segment)) {
+    // A dynamic segment tuple: [paramName, paramCacheKey, type, ...].
+    //
+    // TODO: Interception routes ('di(..)', etc.) can display a URL whose
+    // shape differs from the rendered route tree, so relative hrefs may
+    // not resolve where the tree suggests (see the interception-routes
+    // caveat in the useRelativeHref RFC). For now they're treated like
+    // their non-intercepted counterparts.
+    const dynamicParamType = segment[2]
+    if (dynamicParamType === 'oc' || dynamicParamType[0] === 'c') {
+      // An (optional) catch-all spans an unknown number of URL parts.
+      return null
+    }
+    part =
+      fallbackParams !== null && fallbackParams.has(segment[0])
+        ? null
+        : segment[1]
+  } else if (
+    segment === DEFAULT_SEGMENT_KEY ||
+    isFrameworkInternalRouteSegment(segment)
+  ) {
+    // A default slot renders content that doesn't describe the current URL.
+    // The built-in 404/error routes render at arbitrary URLs, so their
+    // pseudo-segments never appear in URL space.
+    return null
+  } else if (segment.startsWith(PAGE_SEGMENT_KEY)) {
+    // Reached a page (possibly with a query suffix). The path is complete.
+    return []
+  } else if (segment !== '' && !isGroupSegment(segment)) {
+    // A static segment: one URL part.
+    part = segment
+  }
+
+  // Descend into the children; the first resolvable path wins (see above —
+  // the choice is arbitrary).
+  const parallelRoutes = node[1]
+  for (const key in parallelRoutes) {
+    const childPath = getMatchedRouteImpl(parallelRoutes[key], fallbackParams)
+    if (childPath !== null) {
+      if (part !== undefined) {
+        childPath.unshift(part)
+      }
+      return childPath
+    }
+  }
+  return null
+}

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -11,6 +11,7 @@ import type {
   CacheNode,
   LoadingModuleData,
 } from './app-router-types'
+import type { BaseUrlPart } from './relative-href'
 import React from 'react'
 
 export interface NavigateOptions {
@@ -108,6 +109,24 @@ export const GlobalLayoutRouterContext = React.createContext<{
   focusAndScrollRef: FocusAndScrollRef
   nextUrl: string | null
   previousNextUrl: string | null
+  /**
+   * The current page's URL path parts, resolved once per router state by
+   * AppRouter for `unstable_useRelativeHref`. On the initial render this is
+   * the server-computed matched route (see `getMatchedRoute` and
+   * `InitialRSCPayload.u`), so SSR and hydration resolve hrefs
+   * identically. After the first router state update — or on the initial
+   * render when the route has no statically resolvable path — it's the
+   * actual URL pathname split into parts, the same source `usePathname`
+   * reads.
+   *
+   * Null when the current render has no usable base at all: a
+   * fallback-shell prerender of a route with no statically resolvable
+   * path, where the pathname is a placeholder rather than a real URL.
+   * Never null in the browser. An individual part is null when its value
+   * is not known (a fallback param during a static prerender; also never
+   * in the browser).
+   */
+  matchedRoute: readonly BaseUrlPart[] | null
 }>(null as any)
 
 export const TemplateContext = React.createContext<React.ReactNode>(null as any)

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -12,6 +12,7 @@ export type LoadingModuleData =
   | null
 
 import type { VaryParamsIterable } from './segment-cache/vary-params-decoding'
+import type { BaseUrlPart } from './relative-href'
 
 /** viewport metadata node */
 export type HeadData = React.ReactNode
@@ -453,6 +454,18 @@ export type InitialRSCPayload = {
   c: string[]
   /** initialRenderedSearch */
   q: string
+  /**
+   * matchedRoute — the current page's URL path parts, one per entry,
+   * derived from the matched route (see `getMatchedRoute`). Consumed by
+   * `unstable_useRelativeHref` during SSR and hydration; after the first
+   * router state update the client resolves against the actual pathname
+   * instead. Absent when the route has no statically resolvable path
+   * (every path to a page goes through a catch-all). A null part is a
+   * fallback param of the prerender, filled in from the actual URL before
+   * hydration. Like `c`, sent as parts rather than a joined path so
+   * crawlers don't interpret it as a URL to follow.
+   */
+  u?: BaseUrlPart[]
   /** couldBeIntercepted */
   i: boolean
   /** initialFlightData */

--- a/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
@@ -2,6 +2,7 @@
 
 import { createContext } from 'react'
 import type { Params } from '../../server/request/params'
+import type { FlightRouterState } from './app-router-types'
 import { ReadonlyURLSearchParams } from '../../client/components/readonly-url-search-params'
 
 export const SearchParamsContext = createContext<URLSearchParams | null>(null)
@@ -26,6 +27,12 @@ export type NavigationPromises = {
     InstrumentedPromise<string | null>
   >
   selectedLayoutSegmentsPromises?: Map<string, InstrumentedPromise<string[]>>
+  // Shared by every unstable_useRelativeHref instance: conceptually they
+  // all block on the same thing — the resolved router state — so one
+  // promise suffices. Its name attributes the dependency to the hook in
+  // the Suspense DevTools; unlike the other promises here, its value is
+  // not the hook's return value.
+  relativeHref: InstrumentedPromise<FlightRouterState>
 }
 
 export const NavigationPromisesContext =

--- a/packages/next/src/shared/lib/relative-href.ts
+++ b/packages/next/src/shared/lib/relative-href.ts
@@ -1,0 +1,226 @@
+/**
+ * One URL path part of the current page. A string is the concrete part —
+ * whether it came from a static route segment or a dynamic param makes no
+ * difference to relative path resolution. Null means the part's value is not
+ * known: a fallback param during a static prerender. Null never occurs on the
+ * client, where param values are always filled in from the actual URL.
+ */
+export type BaseUrlPart = string | null
+
+/**
+ * Whether a route pattern segment is dynamic ('[id]') rather than static
+ * text. This is the only pattern check the matcher makes: catch-all
+ * ('[...slug]') and optional catch-all ('[[...slug]]') segments aren't
+ * supported as targets — they span an unknown number of URL parts — but
+ * they're not distinguished here; they get the same one-part treatment as
+ * any other dynamic segment, and a development-only warning is emitted
+ * below.
+ */
+function isDynamicPatternSegment(segment: string): boolean {
+  return segment.startsWith('[') && segment.endsWith(']')
+}
+
+/**
+ * Whether a route pattern segment is a catch-all ('[...slug]') or optional
+ * catch-all ('[[...slug]]') pattern. Only used for development warnings —
+ * production treats these like any other dynamic segment.
+ */
+function isCatchAllPatternSegment(segment: string): boolean {
+  return segment.startsWith('[...') || segment.startsWith('[[')
+}
+
+/**
+ * Development-only. A catch-all pattern in the target is a mistake under
+ * every param value — it spans an unknown number of URL parts, so it can't
+ * participate in positional matching — which is why, unlike the
+ * unresolved-segment warning, this one is never suppressed.
+ */
+function warnCatchAllPatternTarget(target: string, segment: string): void {
+  console.error(
+    `unstable_useRelativeHref('${target}') does not support catch-all ` +
+      `segment patterns (${segment}) in the target. Spell out the concrete ` +
+      `path parts instead.`
+  )
+}
+
+/**
+ * Splits a URL path or route pattern into its segments, ignoring leading and
+ * trailing slashes. The root ('/') has zero segments. Segment text is
+ * treated literally — no decoding or validation.
+ */
+export function splitPathSegments(path: string): string[] {
+  let start = 0
+  let end = path.length
+  while (start < end && path[start] === '/') start++
+  while (end > start && path[end - 1] === '/') end--
+  const trimmed = path.slice(start, end)
+  return trimmed === '' ? [] : trimmed.split('/')
+}
+
+/**
+ * Computes a relative URL reference from the current page to a target route
+ * pattern, for `unstable_useRelativeHref`.
+ *
+ * The current page's URL path is given as `baseRoute` — one part per entry,
+ * excluding basePath. The caller derives it either from the route structure
+ * (the statically resolvable matched route, see `getMatchedRoute`) or by
+ * splitting the actual URL pathname, and passes null when neither yields a
+ * usable base: a fallback-shell prerender of a route with no statically
+ * resolvable path, where the pathname is a placeholder rather than a real
+ * URL.
+ *
+ * Returns null when the href would read values that don't exist yet: the
+ * value of an unknown (null) base part, or any base at all when `baseRoute`
+ * is null. This only ever happens while prerendering a fallback shell; the
+ * caller must deopt to dynamic rendering, and the href is recomputed at
+ * request time when the values exist. Hrefs that are invariant to the
+ * unknown values (e.g. the target diverges from the current route before
+ * reaching an unknown part) still come out as strings and can stay in the
+ * static shell.
+ *
+ * The result resolves (against the current page's URL) to the target's URL
+ * path, with dynamic segments filled from the current page where the target
+ * matches it. Its path portion always ends in '/', so appending a child
+ * segment to the result always yields a child of the target. A query and/or
+ * hash in the target is preserved: it's carried over to the result
+ * verbatim, after the trailing slash.
+ *
+ * Target segments are matched against base parts positionally: a dynamic
+ * segment ('[id]') matches any one part — the target is saying it doesn't
+ * care which value it matches — and static text matches an equal concrete
+ * part. Target strings are assumed to be valid paths in the app's route
+ * space (validated via the typed `Route` utility), so no further validation
+ * happens here — including of catch-all patterns, which aren't supported as
+ * targets but are treated like any other dynamic segment.
+ *
+ * A dynamic segment in the target with no value available is left as
+ * literal pattern text in the href; this function never throws. Development
+ * warnings for that case and for catch-all targets are emitted inline, in
+ * the branches that detect them.
+ *
+ * Only a root-relative target ('/...') is treated as a route pattern.
+ * Anything else is returned verbatim — an absolute URL ('https://…',
+ * 'mailto:…'), a protocol-relative URL ('//host/…'), a hash- or query-only
+ * reference ('#faq', '?tab=1'), or an already-relative reference. The hook's
+ * contract is that `<Link href={useRelativeHref(x)}>` behaves identically to
+ * `<Link href={x}>` except for the impact on static prerendering, and those
+ * references already mean the right thing untouched. A verbatim result
+ * never reads the base, so it's returned even when `baseRoute` is null.
+ */
+export function computeRelativeHref(
+  target: string,
+  baseRoute: readonly BaseUrlPart[] | null,
+  trailingSlash: boolean
+): string | null {
+  // Non-root-relative targets pass through verbatim (see above). '//' is a
+  // protocol-relative URL, not a path.
+  if (target[0] !== '/' || target[1] === '/') {
+    return target
+  }
+
+  if (baseRoute === null) {
+    // No usable base this render (see above): every root-relative href
+    // depends on values that only exist at request time.
+    return null
+  }
+
+  // Split off the target's query and hash — everything from the first '?'
+  // or '#' — to be carried over to the result verbatim. Only the path part
+  // participates in matching.
+  let suffixStart = target.indexOf('?')
+  const hashStart = target.indexOf('#')
+  if (hashStart !== -1 && (suffixStart === -1 || hashStart < suffixStart)) {
+    suffixStart = hashStart
+  }
+  const suffix = suffixStart === -1 ? '' : target.slice(suffixStart)
+  const targetPath = suffixStart === -1 ? target : target.slice(0, suffixStart)
+
+  const targetSegments = splitPathSegments(targetPath)
+  const baseParts: readonly BaseUrlPart[] = baseRoute
+
+  // The URL depth of the current page.
+  const pageDepth = baseParts.length
+
+  // Relative URL resolution drops the base URL's final segment, unless the
+  // URL ends in a slash (i.e. `trailingSlash: true`).
+  const baseDepth = trailingSlash ? pageDepth : Math.max(0, pageDepth - 1)
+
+  // Find the shared prefix between the target's pattern segments and the
+  // current page's URL parts.
+  let shared = 0
+  while (shared < targetSegments.length && shared < pageDepth) {
+    const targetSegment = targetSegments[shared]
+    if (isDynamicPatternSegment(targetSegment)) {
+      // '[id]' matches any one URL part, known or unknown.
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        isCatchAllPatternSegment(targetSegment)
+      ) {
+        warnCatchAllPatternTarget(target, targetSegment)
+      }
+    } else if (baseParts[shared] === null) {
+      // A concrete target segment compared against an unknown part: whether
+      // they match can't be known statically, and the two outcomes produce
+      // different hrefs.
+      return null
+    } else if (targetSegment !== baseParts[shared]) {
+      break
+    }
+    shared++
+  }
+
+  // The shared prefix can extend past the resolution base (e.g. the target is
+  // the page's own route); only the portion within the base is expressed as
+  // traversal. The rest must be spelled back out.
+  const effectiveShared = Math.min(shared, baseDepth)
+  const ups = baseDepth - effectiveShared
+
+  // Spell out the concrete URL parts of the current page between the
+  // resolution base and the end of the shared prefix. This covers the
+  // own-route and descendant cases, where the page's final segment(s) must be
+  // spelled back out because relative resolution drops them. An unknown part
+  // here means the href needs a value that doesn't exist yet.
+  const spelled: string[] = []
+  for (let i = effectiveShared; i < shared; i++) {
+    const part = baseParts[i]
+    if (part === null) {
+      return null
+    }
+    spelled.push(part)
+  }
+
+  // Spell out the target's pattern segments past the shared prefix. Static
+  // text is emitted as-is. A dynamic segment here has no value available, so
+  // its literal pattern text is emitted (technically a valid URL segment).
+  // The warning never fires on a render that's about to deopt — resolution
+  // stops (returns null) at the first unknown value, before reaching here —
+  // so it only reports genuine mismatches, on renders whose result is
+  // actually used.
+  for (let i = shared; i < targetSegments.length; i++) {
+    const segment = targetSegments[i]
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      isDynamicPatternSegment(segment)
+    ) {
+      if (isCatchAllPatternSegment(segment)) {
+        warnCatchAllPatternTarget(target, segment)
+      } else {
+        console.error(
+          `unstable_useRelativeHref('${target}') could not resolve the dynamic ` +
+            `segment(s) ${segment} because it doesn't lie on the current ` +
+            `route. The literal segment text was left in the result, which ` +
+            `is almost certainly a mistake.`
+        )
+      }
+    }
+    spelled.push(segment)
+  }
+
+  let href = ups > 0 ? '../'.repeat(ups) : './'
+  for (const segment of spelled) {
+    href += segment + '/'
+  }
+  href += suffix
+
+  return href
+}

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -87,3 +87,23 @@ export function getSelectedLayoutSegmentPath(
 export const PAGE_SEGMENT_KEY = '__PAGE__'
 export const DEFAULT_SEGMENT_KEY = '__DEFAULT__'
 export const NOT_FOUND_SEGMENT_KEY = '/_not-found'
+
+/**
+ * Whether a static segment belongs to a framework-internal route that never
+ * appears in URL space: the built-in 404 route and the app error route.
+ * These routes render at arbitrary URLs, so their segments must not be
+ * treated as URL path parts (see e.g. `unstable_useRelativeHref`, which
+ * resolves against the actual URL on such routes). Depending on how
+ * next-app-loader built the tree, the segments come in slash-prefixed or
+ * bare form (see UNDERSCORE_NOT_FOUND_ROUTE / UNDERSCORE_GLOBAL_ERROR_ROUTE
+ * in entry-constants.ts). User segments can't collide with these names —
+ * underscore-prefixed folders are private and excluded from routing.
+ */
+export function isFrameworkInternalRouteSegment(segment: string): boolean {
+  return (
+    segment === '/_not-found' ||
+    segment === '_not-found' ||
+    segment === '/_global-error' ||
+    segment === '_global-error'
+  )
+}

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -281,6 +281,8 @@
       "test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts",
       "test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts",
       "test/e2e/app-dir/use-params/use-params.test.ts",
+      "test/e2e/app-dir/use-relative-href/use-relative-href.test.ts",
+      "test/e2e/app-dir/use-relative-href-trailing-slash/use-relative-href-trailing-slash.test.ts",
       "test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts",
       "test/e2e/app-dir/use-server-inserted-html/use-server-inserted-html.test.ts",
       "test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts",

--- a/test/e2e/app-dir/use-relative-href-ppr/app/[lang]/profile/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/[lang]/profile/page.tsx
@@ -1,0 +1,3 @@
+export default function ProfilePage() {
+  return <div id="lang-profile-page">Profile</div>
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/[lang]/settings/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/[lang]/settings/page.tsx
@@ -1,0 +1,30 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default function SettingsPage() {
+  // The page itself never reads params, so everything here except the
+  // '/en/profile' link can be prerendered into the fallback shell:
+  // - '/[lang]/profile' diverges from the current route at 'profile', below
+  //   the unknown [lang] part, so the href ('./profile/') is invariant to it.
+  // - '/[lang]/settings' (the own route) respells only the concrete
+  //   'settings' part; the unknown [lang] stays in the retained prefix.
+  // - '/' is pure traversal.
+  // - '/en/profile' compares the concrete 'en' against the unknown [lang]
+  //   value, so the href depends on it → dynamic hole in the shell.
+  // - 'https://example.com/docs' isn't a root-relative path, so it's
+  //   returned verbatim and never depends on route values.
+  return (
+    <>
+      <div id="lang-settings-page">Settings</div>
+      <RelativeHrefs
+        id="lang-settings-hrefs"
+        targets={[
+          '/[lang]/profile',
+          '/[lang]/settings',
+          '/',
+          '/en/profile',
+          'https://example.com/docs',
+        ]}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/blog/[...slug]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/blog/[...slug]/page.tsx
@@ -1,0 +1,19 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default function BlogPage() {
+  // Every path to this page goes through [...slug], so the route has no
+  // statically resolvable path: the number of URL parts the page spans is a
+  // per-request value, and hrefs resolve against the actual URL pathname.
+  // During the fallback-shell prerender the pathname is a placeholder, so
+  // the root-relative targets deopt to dynamic holes; only the non-route
+  // target, which never reads the base, stays in the shell.
+  return (
+    <>
+      <div id="blog-page">Blog</div>
+      <RelativeHrefs
+        id="blog-page-hrefs"
+        targets={['/blog', '/', 'https://example.com/docs']}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/deopt/[id]/edit/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/deopt/[id]/edit/page.tsx
@@ -1,0 +1,3 @@
+export default function DeoptEditPage() {
+  return <div id="deopt-edit-page">Edit</div>
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/deopt/[id]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/deopt/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default function DeoptPage() {
+  // '/deopt' is pure traversal ('./'), invariant to the unknown [id], so it
+  // stays in the fallback shell. The own route '/deopt/[id]' and its
+  // descendant must respell the page's final segment — the [id] value
+  // itself — so both deopt to dynamic holes in the shell.
+  return (
+    <>
+      <div id="deopt-page">Deopt</div>
+      <RelativeHrefs
+        id="deopt-page-hrefs"
+        targets={['/deopt', '/deopt/[id]', '/deopt/[id]/edit']}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/deopt/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/deopt/page.tsx
@@ -1,0 +1,3 @@
+export default function DeoptIndexPage() {
+  return <div id="deopt-index-page">Deopt index</div>
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/layout.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/app/relative-hrefs.tsx
+++ b/test/e2e/app-dir/use-relative-href-ppr/app/relative-hrefs.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { unstable_useRelativeHref } from 'next/navigation'
+
+function RelativeHrefLink({ target }: { target: string }) {
+  const href = unstable_useRelativeHref(target)
+  return (
+    <Link
+      className="relative-href"
+      data-target={target}
+      href={href}
+      prefetch={false}
+    >
+      {href}
+    </Link>
+  )
+}
+
+/**
+ * Each link gets its own Suspense boundary: when the href depends on a
+ * fallback param's value, prerendering the fallback shell deopts just that
+ * link into a dynamic hole (the fallback below is what lands in the shell),
+ * while value-invariant links stay fully static.
+ */
+export function RelativeHrefs({
+  id,
+  targets,
+}: {
+  id: string
+  targets: string[]
+}) {
+  return (
+    <div id={id}>
+      {targets.map((target) => (
+        <div key={target}>
+          <Suspense
+            fallback={
+              <div className="relative-href-fallback" data-target={target}>
+                loading-relative-href
+              </div>
+            }
+          >
+            <RelativeHrefLink target={target} />
+          </Suspense>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-ppr/next.config.js
+++ b/test/e2e/app-dir/use-relative-href-ppr/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-relative-href-ppr/use-relative-href-ppr.test.ts
+++ b/test/e2e/app-dir/use-relative-href-ppr/use-relative-href-ppr.test.ts
@@ -1,0 +1,215 @@
+import { nextTestSetup, type Playwright } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// With cacheComponents, routes with dynamic params get a params-agnostic
+// fallback shell at build time. unstable_useRelativeHref results that are
+// invariant to the unknown param values are prerendered into the shell;
+// results that depend on them deopt to dynamic holes (each link in the
+// fixture has its own Suspense boundary) and are filled in at request time.
+describe('unstable_useRelativeHref - cacheComponents fallback shells', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
+
+  function relativeHrefLink(
+    browser: Playwright,
+    wrapperId: string,
+    target: string
+  ) {
+    return browser.elementByCss(`#${wrapperId} [data-target="${target}"]`)
+  }
+
+  async function getRelativeHref(
+    browser: Playwright,
+    wrapperId: string,
+    target: string
+  ): Promise<string> {
+    return relativeHrefLink(browser, wrapperId, target).text()
+  }
+
+  it('resolves hrefs with the actual param value at request time', async () => {
+    const browser = await next.browser('/en/settings')
+    expect(
+      await getRelativeHref(browser, 'lang-settings-hrefs', '/[lang]/profile')
+    ).toBe('./profile/')
+    expect(
+      await getRelativeHref(browser, 'lang-settings-hrefs', '/[lang]/settings')
+    ).toBe('./settings/')
+    expect(await getRelativeHref(browser, 'lang-settings-hrefs', '/')).toBe(
+      '../'
+    )
+    // The concrete 'en' matches the actual param value, so the shared prefix
+    // includes it and the result is the short form.
+    await retry(async () => {
+      expect(
+        await getRelativeHref(browser, 'lang-settings-hrefs', '/en/profile')
+      ).toBe('./profile/')
+    })
+
+    await relativeHrefLink(
+      browser,
+      'lang-settings-hrefs',
+      '/[lang]/profile'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/en/profile')
+      expect(await browser.elementByCss('#lang-profile-page').text()).toBe(
+        'Profile'
+      )
+    })
+  })
+
+  it('resolves a concrete target that diverges from the actual param value', async () => {
+    const browser = await next.browser('/fr/settings')
+    // 'en' does not match the actual param value 'fr', so the target is
+    // spelled out from the divergence point.
+    await retry(async () => {
+      expect(
+        await getRelativeHref(browser, 'lang-settings-hrefs', '/en/profile')
+      ).toBe('../en/profile/')
+    })
+
+    await relativeHrefLink(
+      browser,
+      'lang-settings-hrefs',
+      '/en/profile'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/en/profile')
+      expect(await browser.elementByCss('#lang-profile-page').text()).toBe(
+        'Profile'
+      )
+    })
+  })
+
+  it('resolves value-dependent hrefs at request time', async () => {
+    const browser = await next.browser('/deopt/123')
+    expect(await getRelativeHref(browser, 'deopt-page-hrefs', '/deopt')).toBe(
+      './'
+    )
+    // Own route and descendant respell the [id] value, which only exists at
+    // request time.
+    await retry(async () => {
+      expect(
+        await getRelativeHref(browser, 'deopt-page-hrefs', '/deopt/[id]')
+      ).toBe('./123/')
+      expect(
+        await getRelativeHref(browser, 'deopt-page-hrefs', '/deopt/[id]/edit')
+      ).toBe('./123/edit/')
+    })
+
+    await relativeHrefLink(
+      browser,
+      'deopt-page-hrefs',
+      '/deopt/[id]/edit'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/deopt/123/edit'
+      )
+      expect(await browser.elementByCss('#deopt-edit-page').text()).toBe('Edit')
+    })
+  })
+
+  it('resolves hrefs from the actual URL at request time on a catch-all route', async () => {
+    // /blog/[...slug] has no statically resolvable path, so root-relative
+    // targets resolve against the actual URL pathname, whose depth is a
+    // per-request value.
+    const browser = await next.browser('/blog/a/b')
+    await retry(async () => {
+      expect(await getRelativeHref(browser, 'blog-page-hrefs', '/blog')).toBe(
+        '../'
+      )
+      expect(await getRelativeHref(browser, 'blog-page-hrefs', '/')).toBe(
+        '../../'
+      )
+    })
+    expect(
+      await getRelativeHref(
+        browser,
+        'blog-page-hrefs',
+        'https://example.com/docs'
+      )
+    ).toBe('https://example.com/docs')
+  })
+
+  it('clicking a shell-resolved ancestor link navigates correctly', async () => {
+    const browser = await next.browser('/deopt/123')
+    await relativeHrefLink(browser, 'deopt-page-hrefs', '/deopt').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/deopt')
+      expect(await browser.elementByCss('#deopt-index-page').text()).toBe(
+        'Deopt index'
+      )
+    })
+  })
+
+  if (isNextStart) {
+    it('bakes value-invariant hrefs into the fallback shell and deopts value-dependent ones', async () => {
+      const cheerio = require('cheerio')
+
+      // The fallback shell of /[lang]/settings: hrefs that don't depend on
+      // the [lang] value are prerendered; the '/en/profile' link (concrete
+      // segment compared against the unknown value) is a dynamic hole,
+      // represented by its Suspense fallback.
+      const settingsShell = cheerio.load(
+        await next.readFile('.next/server/app/[lang]/settings.html')
+      )
+      expect(settingsShell('a[data-target="/[lang]/profile"]').text()).toBe(
+        './profile/'
+      )
+      expect(settingsShell('a[data-target="/[lang]/settings"]').text()).toBe(
+        './settings/'
+      )
+      expect(settingsShell('a[data-target="/"]').text()).toBe('../')
+      // A non-root-relative target is returned verbatim and never depends
+      // on route values, so it's always part of the shell.
+      expect(
+        settingsShell('a[data-target="https://example.com/docs"]').text()
+      ).toBe('https://example.com/docs')
+      expect(settingsShell('a[data-target="/en/profile"]').length).toBe(0)
+      expect(
+        settingsShell('.relative-href-fallback[data-target="/en/profile"]')
+          .length
+      ).toBe(1)
+
+      // The fallback shell of /deopt/[id]: the pure-traversal '/deopt' link
+      // is prerendered; the own-route and descendant links need the [id]
+      // value respelled into the href, so both are dynamic holes.
+      const deoptShell = cheerio.load(
+        await next.readFile('.next/server/app/deopt/[id].html')
+      )
+      expect(deoptShell('a[data-target="/deopt"]').text()).toBe('./')
+      expect(deoptShell('a[data-target="/deopt/[id]"]').length).toBe(0)
+      expect(deoptShell('a[data-target="/deopt/[id]/edit"]').length).toBe(0)
+      expect(
+        deoptShell('.relative-href-fallback[data-target="/deopt/[id]"]').length
+      ).toBe(1)
+      expect(
+        deoptShell('.relative-href-fallback[data-target="/deopt/[id]/edit"]')
+          .length
+      ).toBe(1)
+
+      // The fallback shell of /blog/[...slug]: the route has no statically
+      // resolvable path, so hrefs resolve against the URL pathname — a
+      // placeholder during this prerender. Every root-relative target is a
+      // dynamic hole (even pure-traversal ones: the traversal depth is a
+      // per-request value); only the non-route target, which never reads
+      // the base, is prerendered.
+      const blogShell = cheerio.load(
+        await next.readFile('.next/server/app/blog/[...slug].html')
+      )
+      expect(
+        blogShell('a[data-target="https://example.com/docs"]').text()
+      ).toBe('https://example.com/docs')
+      expect(blogShell('a[data-target="/blog"]').length).toBe(0)
+      expect(blogShell('a[data-target="/"]').length).toBe(0)
+      expect(
+        blogShell('.relative-href-fallback[data-target="/blog"]').length
+      ).toBe(1)
+      expect(blogShell('.relative-href-fallback[data-target="/"]').length).toBe(
+        1
+      )
+    })
+  }
+})

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/app/chat/[id]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/app/chat/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default async function ChatPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return (
+    <>
+      <div id="chat-page-id">{id}</div>
+      <RelativeHrefs
+        id="chat-page-hrefs"
+        targets={['/chat/[id]', '/chat', '/', 'https://example.com/docs']}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/app/chat/[id]/settings/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/app/chat/[id]/settings/page.tsx
@@ -1,0 +1,13 @@
+import { RelativeHrefs } from '../../../relative-hrefs'
+
+export default function SettingsPage() {
+  return (
+    <>
+      <div id="settings-page">Settings</div>
+      <RelativeHrefs
+        id="settings-page-hrefs"
+        targets={['/chat/[id]', '/chat/[id]/settings', '/chat', '/']}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/app/chat/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/app/chat/page.tsx
@@ -1,0 +1,3 @@
+export default function ChatIndexPage() {
+  return <div id="chat-index-page">Chat index</div>
+}

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/app/layout.tsx
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/app/page.tsx
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/app/page.tsx
@@ -1,0 +1,10 @@
+import { RelativeHrefs } from './relative-hrefs'
+
+export default function HomePage() {
+  return (
+    <>
+      <div id="home-page">Home</div>
+      <RelativeHrefs id="home-page-hrefs" targets={['/']} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/app/relative-hrefs.tsx
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/app/relative-hrefs.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { unstable_useRelativeHref } from 'next/navigation'
+
+function RelativeHrefLink({ target }: { target: string }) {
+  const href = unstable_useRelativeHref(target)
+  // The link's text content is the raw hook result, so tests can assert the
+  // exact relative form; clicking the link demonstrates that the href
+  // resolves to the correct route. An intentionally unresolvable result
+  // (literal '[param]' text) is rendered as a plain anchor because <Link>
+  // rejects hrefs containing dynamic pattern text; those results are only
+  // asserted as text, never clicked.
+  if (href.includes('[')) {
+    return (
+      <div>
+        <a className="relative-href" data-target={target} href={href}>
+          {href}
+        </a>
+      </div>
+    )
+  }
+  return (
+    <div>
+      <Link
+        className="relative-href"
+        data-target={target}
+        href={href}
+        prefetch={false}
+      >
+        {href}
+      </Link>
+    </div>
+  )
+}
+
+export function RelativeHrefs({
+  id,
+  targets,
+}: {
+  id: string
+  targets: string[]
+}) {
+  return (
+    <div id={id}>
+      {targets.map((target) => (
+        <RelativeHrefLink key={target} target={target} />
+      ))}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/next.config.js
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  trailingSlash: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-relative-href-trailing-slash/use-relative-href-trailing-slash.test.ts
+++ b/test/e2e/app-dir/use-relative-href-trailing-slash/use-relative-href-trailing-slash.test.ts
@@ -1,0 +1,95 @@
+import { nextTestSetup, type Playwright } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('unstable_useRelativeHref - trailingSlash: true', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  function relativeHrefLink(
+    browser: Playwright,
+    wrapperId: string,
+    target: string
+  ) {
+    return browser.elementByCss(`#${wrapperId} [data-target="${target}"]`)
+  }
+
+  async function getRelativeHref(
+    browser: Playwright,
+    wrapperId: string,
+    target: string
+  ): Promise<string> {
+    return relativeHrefLink(browser, wrapperId, target).text()
+  }
+
+  // With trailingSlash: true, the URL ends in '/', so relative resolution
+  // keeps the final segment: every result shifts one level compared to the
+  // default config.
+
+  it('returns "./" for the root route on the root page', async () => {
+    const browser = await next.browser('/')
+    expect(await getRelativeHref(browser, 'home-page-hrefs', '/')).toBe('./')
+  })
+
+  it('shifts results one level on a page with a dynamic segment', async () => {
+    const browser = await next.browser('/chat/123/')
+    // The own route becomes pure './' traversal (no param value spelled out),
+    // so it stays static even when [id] is request-time-only.
+    expect(
+      await getRelativeHref(browser, 'chat-page-hrefs', '/chat/[id]')
+    ).toBe('./')
+    expect(await getRelativeHref(browser, 'chat-page-hrefs', '/chat')).toBe(
+      '../'
+    )
+    expect(await getRelativeHref(browser, 'chat-page-hrefs', '/')).toBe(
+      '../../'
+    )
+    // A non-root-relative target is returned verbatim — trailing-slash
+    // normalization doesn't apply to it.
+    expect(
+      await getRelativeHref(
+        browser,
+        'chat-page-hrefs',
+        'https://example.com/docs'
+      )
+    ).toBe('https://example.com/docs')
+
+    // Clicking the ancestor link resolves against the trailing-slash URL and
+    // lands on the chat index page.
+    await relativeHrefLink(browser, 'chat-page-hrefs', '/chat').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/chat/')
+      expect(await browser.elementByCss('#chat-index-page').text()).toBe(
+        'Chat index'
+      )
+    })
+  })
+
+  it('shifts results one level on a nested page', async () => {
+    const browser = await next.browser('/chat/123/settings/')
+    expect(
+      await getRelativeHref(browser, 'settings-page-hrefs', '/chat/[id]')
+    ).toBe('../')
+    // Own route: pure traversal, free of the param value.
+    expect(
+      await getRelativeHref(
+        browser,
+        'settings-page-hrefs',
+        '/chat/[id]/settings'
+      )
+    ).toBe('./')
+    expect(await getRelativeHref(browser, 'settings-page-hrefs', '/chat')).toBe(
+      '../../'
+    )
+    expect(await getRelativeHref(browser, 'settings-page-hrefs', '/')).toBe(
+      '../../../'
+    )
+
+    // Clicking the parent-route link navigates to the current chat's page.
+    await relativeHrefLink(browser, 'settings-page-hrefs', '/chat/[id]').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/chat/123/')
+      expect(await browser.elementByCss('#chat-page-id').text()).toBe('123')
+    })
+  })
+})

--- a/test/e2e/app-dir/use-relative-href/app/(group)/about/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/(group)/about/page.tsx
@@ -1,0 +1,10 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default function AboutPage() {
+  return (
+    <>
+      <div id="about-page">About</div>
+      <RelativeHrefs id="about-page-hrefs" targets={['/']} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/chat/[id]/layout.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/chat/[id]/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import { RelativeHrefs } from '../../relative-hrefs'
+import { ChatNavLinks } from './nav-links'
+
+export default function ChatLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <RelativeHrefs
+        id="chat-layout-hrefs"
+        targets={['/chat', '/chat/[id]', '/', '/pricing']}
+      />
+      <ChatNavLinks />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/chat/[id]/nav-links.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/chat/[id]/nav-links.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import Link from 'next/link'
+import { unstable_useRelativeHref } from 'next/navigation'
+
+export function ChatNavLinks() {
+  // '/chat' is an ancestor of every page below this layout, so the result is
+  // pure traversal ('./' on /chat/[id], '../' on /chat/[id]/settings) and the
+  // appended child segment always resolves to /chat/456.
+  const chatHref = unstable_useRelativeHref('/chat')
+  // '/chat/[id]' is the layout's own route; appending a child segment
+  // resolves to a child of the current chat.
+  const chatIdHref = unstable_useRelativeHref('/chat/[id]')
+  return (
+    <div>
+      <Link id="link-to-chat-456" href={`${chatHref}456`}>
+        Go to chat 456
+      </Link>
+      <Link id="link-to-current-chat-settings" href={`${chatIdHref}settings`}>
+        Go to settings of current chat
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/chat/[id]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/chat/[id]/page.tsx
@@ -1,0 +1,27 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default async function ChatPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return (
+    <>
+      <div id="chat-page-id">{id}</div>
+      <RelativeHrefs
+        id="chat-page-hrefs"
+        targets={[
+          '/chat',
+          '/',
+          '/chat/[id]',
+          '/chat/[id]/settings',
+          '/pricing',
+          '/chat/[id]?tab=files',
+          '/pricing#faq',
+          '/chat/[id]/settings?tab=members#invite',
+        ]}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/chat/[id]/settings/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/chat/[id]/settings/page.tsx
@@ -1,0 +1,13 @@
+import { RelativeHrefs } from '../../../relative-hrefs'
+
+export default function SettingsPage() {
+  return (
+    <>
+      <div id="settings-page">Settings</div>
+      <RelativeHrefs
+        id="settings-page-hrefs"
+        targets={['/chat', '/chat/[id]', '/', '/pricing']}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/chat/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/chat/page.tsx
@@ -1,0 +1,3 @@
+export default function ChatIndexPage() {
+  return <div id="chat-index-page">Chat index</div>
+}

--- a/test/e2e/app-dir/use-relative-href/app/docs/[...slug]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/docs/[...slug]/page.tsx
@@ -1,0 +1,15 @@
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default async function DocsPage({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return (
+    <>
+      <div id="docs-page-slug">{slug.join('/')}</div>
+      <RelativeHrefs id="docs-page-hrefs" targets={['/docs', '/']} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/docs/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/docs/page.tsx
@@ -1,0 +1,3 @@
+export default function DocsIndexPage() {
+  return <div id="docs-index-page">Docs index</div>
+}

--- a/test/e2e/app-dir/use-relative-href/app/graft/@side/a/b/c/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/graft/@side/a/b/c/page.tsx
@@ -1,0 +1,3 @@
+export default function GraftSideAbc() {
+  return <p id="graft-side-abc">side abc</p>
+}

--- a/test/e2e/app-dir/use-relative-href/app/graft/@side/default.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/graft/@side/default.tsx
@@ -1,0 +1,3 @@
+export default function GraftSideDefault() {
+  return <p id="graft-side-default">side default</p>
+}

--- a/test/e2e/app-dir/use-relative-href/app/graft/[...slug]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/graft/[...slug]/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default async function GraftPage({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return (
+    <div>
+      <p id="graft-page-slug">Graft page for {slug.join('/')}</p>
+      <RelativeHrefs id="graft-page-hrefs" targets={['/graft', '/']} />
+      <Link id="graft-nav-link" href="/graft/x/y">
+        Go to /graft/x/y
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/graft/layout.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/graft/layout.tsx
@@ -1,0 +1,14 @@
+export default function GraftLayout({
+  children,
+  side,
+}: {
+  children: React.ReactNode
+  side: React.ReactNode
+}) {
+  return (
+    <div>
+      <div id="graft-children">{children}</div>
+      <div id="graft-side">{side}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/graft/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/graft/page.tsx
@@ -1,0 +1,3 @@
+export default function GraftIndexPage() {
+  return <p id="graft-index-page">Graft index</p>
+}

--- a/test/e2e/app-dir/use-relative-href/app/layout.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/not-found.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/not-found.tsx
@@ -1,0 +1,10 @@
+import { RelativeHrefs } from './relative-hrefs'
+
+export default function NotFound() {
+  return (
+    <>
+      <div id="not-found-page">Not found</div>
+      <RelativeHrefs id="not-found-hrefs" targets={['/', '/pricing']} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/page.tsx
@@ -1,0 +1,10 @@
+import { RelativeHrefs } from './relative-hrefs'
+
+export default function HomePage() {
+  return (
+    <>
+      <div id="home-page">Home</div>
+      <RelativeHrefs id="home-page-hrefs" targets={['/']} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/parallel/@slot/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/parallel/@slot/[...catchAll]/page.tsx
@@ -1,0 +1,18 @@
+import { RelativeHrefs } from '../../../relative-hrefs'
+
+export default async function ParallelSlot({
+  params,
+}: {
+  params: Promise<{ catchAll: string[] }>
+}) {
+  const { catchAll } = await params
+  return (
+    <div>
+      <p>Slot for {catchAll.join('/')}</p>
+      <RelativeHrefs
+        id="parallel-slot-hrefs"
+        targets={['/parallel/[id]', '/parallel', '/']}
+      />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/parallel/@slot/default.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/parallel/@slot/default.tsx
@@ -1,0 +1,6 @@
+// Never rendered in practice — the catch-all sibling matches every URL these
+// tests visit — but webpack requires parallel route slots to have a default
+// file.
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/use-relative-href/app/parallel/[id]/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/parallel/[id]/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { RelativeHrefs } from '../../relative-hrefs'
+
+export default async function ParallelPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  return (
+    <div>
+      <p>Parallel page for {id}</p>
+      <RelativeHrefs
+        id="parallel-page-hrefs"
+        targets={['/parallel/[id]', '/parallel', '/']}
+      />
+      <Link id="parallel-nav-link" href="/parallel/456">
+        Go to parallel 456
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/parallel/layout.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/parallel/layout.tsx
@@ -1,0 +1,14 @@
+export default function ParallelLayout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <div>
+      <div id="parallel-children">{children}</div>
+      <div id="parallel-slot">{slot}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/passthrough/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/passthrough/page.tsx
@@ -1,0 +1,21 @@
+import { RelativeHrefs } from '../relative-hrefs'
+
+export default function PassthroughPage() {
+  return (
+    <div>
+      <p id="passthrough-page">Passthrough</p>
+      <RelativeHrefs
+        id="passthrough-page-hrefs"
+        targets={[
+          'https://example.com/docs',
+          'https://example.com/docs?tab=1#top',
+          '//example.com/cdn',
+          'mailto:hi@example.com',
+          '#faq',
+          '?tab=files',
+          'relative/path',
+        ]}
+      />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/pricing/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/pricing/page.tsx
@@ -1,0 +1,10 @@
+import { RelativeHrefs } from '../relative-hrefs'
+
+export default function PricingPage() {
+  return (
+    <>
+      <div id="pricing-page">Pricing</div>
+      <RelativeHrefs id="pricing-page-hrefs" targets={['/chat/[id]']} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/relative-hrefs.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/relative-hrefs.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { unstable_useRelativeHref } from 'next/navigation'
+
+function RelativeHrefLink({ target }: { target: string }) {
+  const href = unstable_useRelativeHref(target)
+  // The link's text content is the raw hook result, so tests can assert the
+  // exact relative form; clicking the link demonstrates that the href
+  // resolves to the correct route. An intentionally unresolvable result
+  // (literal '[param]' text) is rendered as a plain anchor because <Link>
+  // rejects hrefs containing dynamic pattern text; those results are only
+  // asserted as text, never clicked.
+  if (href.includes('[')) {
+    return (
+      <div>
+        <a className="relative-href" data-target={target} href={href}>
+          {href}
+        </a>
+      </div>
+    )
+  }
+  return (
+    <div>
+      <Link
+        className="relative-href"
+        data-target={target}
+        href={href}
+        prefetch={false}
+      >
+        {href}
+      </Link>
+    </div>
+  )
+}
+
+export function RelativeHrefs({
+  id,
+  targets,
+}: {
+  id: string
+  targets: string[]
+}) {
+  return (
+    <div id={id}>
+      {targets.map((target) => (
+        <RelativeHrefLink key={target} target={target} />
+      ))}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/app/warnings/page.tsx
+++ b/test/e2e/app-dir/use-relative-href/app/warnings/page.tsx
@@ -1,0 +1,16 @@
+import { RelativeHrefs } from '../relative-hrefs'
+
+export default function WarningsPage() {
+  // Both targets are misuses that warn in development: '/chat/[id]' can't be
+  // resolved from here (the param doesn't lie on this route), and catch-all
+  // patterns are never supported as targets.
+  return (
+    <>
+      <div id="warnings-page">Warnings</div>
+      <RelativeHrefs
+        id="warnings-page-hrefs"
+        targets={['/chat/[id]', '/docs/[...slug]']}
+      />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-relative-href/next.config.js
+++ b/test/e2e/app-dir/use-relative-href/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-relative-href/use-relative-href.test.ts
+++ b/test/e2e/app-dir/use-relative-href/use-relative-href.test.ts
@@ -1,0 +1,521 @@
+import { nextTestSetup, type Playwright } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('unstable_useRelativeHref', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Each target rendered by the RelativeHrefs fixture component is a <Link>
+  // whose href is the raw hook result and whose text content is the same
+  // string, so tests can assert the exact relative form and then click the
+  // link to demonstrate it resolves to the correct route.
+  function relativeHrefLink(
+    browser: Playwright,
+    wrapperId: string,
+    target: string
+  ) {
+    return browser.elementByCss(`#${wrapperId} [data-target="${target}"]`)
+  }
+
+  async function getRelativeHref(
+    browser: Playwright,
+    wrapperId: string,
+    target: string
+  ): Promise<string> {
+    return relativeHrefLink(browser, wrapperId, target).text()
+  }
+
+  it('returns "./" for the root route on the root page, and clicking it stays on the root', async () => {
+    const browser = await next.browser('/')
+    expect(await getRelativeHref(browser, 'home-page-hrefs', '/')).toBe('./')
+
+    await relativeHrefLink(browser, 'home-page-hrefs', '/').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/')
+      expect(await browser.elementByCss('#home-page').text()).toBe('Home')
+    })
+  })
+
+  it('ignores route groups when computing traversal depth', async () => {
+    // /about is rendered by app/(group)/about/page.tsx; the route group does
+    // not contribute a URL segment, so '/' is the page's parent and clicking
+    // the link lands on the root page.
+    const browser = await next.browser('/about')
+    expect(await getRelativeHref(browser, 'about-page-hrefs', '/')).toBe('./')
+
+    await relativeHrefLink(browser, 'about-page-hrefs', '/').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/')
+      expect(await browser.elementByCss('#home-page').text()).toBe('Home')
+    })
+  })
+
+  it('resolves targets relative to a page with a dynamic segment', async () => {
+    const browser = await next.browser('/chat/123')
+    // Ancestors: pure traversal, no param values.
+    expect(await getRelativeHref(browser, 'chat-page-hrefs', '/chat')).toBe(
+      './'
+    )
+    expect(await getRelativeHref(browser, 'chat-page-hrefs', '/')).toBe('../')
+    // Own route: the final segment is spelled back out.
+    expect(
+      await getRelativeHref(browser, 'chat-page-hrefs', '/chat/[id]')
+    ).toBe('./123/')
+    // Descendant of the current page's route.
+    expect(
+      await getRelativeHref(browser, 'chat-page-hrefs', '/chat/[id]/settings')
+    ).toBe('./123/settings/')
+    // Cousin route: traverse up to the shared ancestor, then spell out the
+    // target's segments below it.
+    expect(await getRelativeHref(browser, 'chat-page-hrefs', '/pricing')).toBe(
+      '../pricing/'
+    )
+
+    // Clicking the descendant link navigates to the settings page of the
+    // current chat.
+    await relativeHrefLink(
+      browser,
+      'chat-page-hrefs',
+      '/chat/[id]/settings'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/chat/123/settings'
+      )
+      expect(await browser.elementByCss('#settings-page').text()).toBe(
+        'Settings'
+      )
+    })
+  })
+
+  it('returns non-root-relative targets as-is', async () => {
+    // The hook only treats root-relative targets ('/...') as route patterns.
+    // Anything else — an absolute URL, a protocol-relative URL, a hash- or
+    // query-only reference, an already-relative reference — is returned
+    // verbatim, so passing an href through the hook never changes how a
+    // <Link> behaves. In particular, no trailing slash is appended.
+    const browser = await next.browser('/passthrough')
+    const targets = [
+      'https://example.com/docs',
+      'https://example.com/docs?tab=1#top',
+      '//example.com/cdn',
+      'mailto:hi@example.com',
+      '#faq',
+      '?tab=files',
+      'relative/path',
+    ]
+    for (const target of targets) {
+      expect(
+        await getRelativeHref(browser, 'passthrough-page-hrefs', target)
+      ).toBe(target)
+    }
+
+    // A query-only reference behaves like it would on a plain <Link>: it
+    // navigates to the current pathname with the query applied.
+    await relativeHrefLink(
+      browser,
+      'passthrough-page-hrefs',
+      '?tab=files'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/passthrough'
+      )
+      expect(await browser.eval('window.location.search')).toBe('?tab=files')
+    })
+  })
+
+  it('preserves a query and hash from the target', async () => {
+    let browser = await next.browser('/chat/123')
+    // The query/hash is carried over verbatim, after the trailing slash of
+    // the path portion. Only the path participates in matching.
+    expect(
+      await getRelativeHref(browser, 'chat-page-hrefs', '/chat/[id]?tab=files')
+    ).toBe('./123/?tab=files')
+    expect(
+      await getRelativeHref(browser, 'chat-page-hrefs', '/pricing#faq')
+    ).toBe('../pricing/#faq')
+    expect(
+      await getRelativeHref(
+        browser,
+        'chat-page-hrefs',
+        '/chat/[id]/settings?tab=members#invite'
+      )
+    ).toBe('./123/settings/?tab=members#invite')
+
+    // Clicking the combined query+hash link lands on the settings page of
+    // the current chat with both preserved.
+    await relativeHrefLink(
+      browser,
+      'chat-page-hrefs',
+      '/chat/[id]/settings?tab=members#invite'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/chat/123/settings'
+      )
+      expect(await browser.eval('window.location.search')).toBe('?tab=members')
+      expect(await browser.eval('window.location.hash')).toBe('#invite')
+      expect(await browser.elementByCss('#settings-page').text()).toBe(
+        'Settings'
+      )
+    })
+
+    // And a query-only link navigates to the current chat page with the
+    // query applied.
+    browser = await next.browser('/chat/123')
+    await relativeHrefLink(
+      browser,
+      'chat-page-hrefs',
+      '/chat/[id]?tab=files'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/chat/123')
+      expect(await browser.eval('window.location.search')).toBe('?tab=files')
+      expect(await browser.elementByCss('#chat-page-id').text()).toBe('123')
+    })
+  })
+
+  it('clicking ancestor and cousin targets navigates to those routes', async () => {
+    let browser = await next.browser('/chat/123')
+    await relativeHrefLink(browser, 'chat-page-hrefs', '/chat').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/chat')
+      expect(await browser.elementByCss('#chat-index-page').text()).toBe(
+        'Chat index'
+      )
+    })
+
+    browser = await next.browser('/chat/123')
+    await relativeHrefLink(browser, 'chat-page-hrefs', '/pricing').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/pricing')
+      expect(await browser.elementByCss('#pricing-page').text()).toBe('Pricing')
+    })
+  })
+
+  it('resolves targets relative to a nested page', async () => {
+    const browser = await next.browser('/chat/123/settings')
+    expect(await getRelativeHref(browser, 'settings-page-hrefs', '/chat')).toBe(
+      '../'
+    )
+    expect(
+      await getRelativeHref(browser, 'settings-page-hrefs', '/chat/[id]')
+    ).toBe('./')
+    expect(await getRelativeHref(browser, 'settings-page-hrefs', '/')).toBe(
+      '../../'
+    )
+    expect(
+      await getRelativeHref(browser, 'settings-page-hrefs', '/pricing')
+    ).toBe('../../pricing/')
+
+    // Clicking the own-route target of the parent layout navigates to the
+    // current chat's page.
+    await relativeHrefLink(browser, 'settings-page-hrefs', '/chat/[id]').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/chat/123')
+      expect(await browser.elementByCss('#chat-page-id').text()).toBe('123')
+    })
+  })
+
+  it('is position-independent: a layout-rendered instance matches a page-rendered instance', async () => {
+    const browser = await next.browser('/chat/123/settings')
+    // The same client component is rendered by app/chat/[id]/layout.tsx
+    // (wrapper #chat-layout-hrefs) and by the settings page
+    // (wrapper #settings-page-hrefs). The result depends only on the current
+    // URL and the target, not on the render position.
+    expect(await getRelativeHref(browser, 'chat-layout-hrefs', '/chat')).toBe(
+      '../'
+    )
+    expect(
+      await getRelativeHref(browser, 'chat-layout-hrefs', '/chat/[id]')
+    ).toBe('./')
+    expect(await getRelativeHref(browser, 'chat-layout-hrefs', '/')).toBe(
+      '../../'
+    )
+    expect(
+      await getRelativeHref(browser, 'chat-layout-hrefs', '/pricing')
+    ).toBe('../../pricing/')
+  })
+
+  it('leaves an unresolvable dynamic segment as literal text', async () => {
+    // /pricing does not lie on the /chat/[id] route, so there's no value
+    // available for [id]; the literal segment text is left in the result.
+    // /pricing has URL depth 1, so the resolution base is the root and no
+    // upward traversal is needed, hence the './' prefix.
+    const browser = await next.browser('/pricing')
+    expect(
+      await getRelativeHref(browser, 'pricing-page-hrefs', '/chat/[id]')
+    ).toBe('./chat/[id]/')
+  })
+
+  if (isNextDev) {
+    it('warns in development about unresolvable params and catch-all targets', async () => {
+      const browser = await next.browser('/warnings')
+      expect(
+        await getRelativeHref(browser, 'warnings-page-hrefs', '/chat/[id]')
+      ).toBe('./chat/[id]/')
+      expect(
+        await getRelativeHref(browser, 'warnings-page-hrefs', '/docs/[...slug]')
+      ).toBe('./docs/[...slug]/')
+
+      await retry(async () => {
+        const logs = await browser.log()
+        expect(logs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.stringContaining(
+                'could not resolve the dynamic segment(s) [id]'
+              ),
+            }),
+            expect.objectContaining({
+              message: expect.stringContaining(
+                'does not support catch-all segment patterns ([...slug])'
+              ),
+            }),
+          ])
+        )
+      })
+    })
+  }
+
+  it('resolves against the most specific parallel route match', async () => {
+    // At /parallel/123, the children slot matches via /parallel/[id] while
+    // @slot matches the same URL part via [...catchAll]. The matched route
+    // is computed on the server from the route tree, so a component
+    // rendered inside the catch-all slot still resolves '[id]' targets.
+    const browser = await next.browser('/parallel/123')
+    expect(
+      await getRelativeHref(browser, 'parallel-slot-hrefs', '/parallel/[id]')
+    ).toBe('./123/')
+    expect(
+      await getRelativeHref(browser, 'parallel-slot-hrefs', '/parallel')
+    ).toBe('./')
+    expect(await getRelativeHref(browser, 'parallel-slot-hrefs', '/')).toBe(
+      '../'
+    )
+    // The page in the children slot agrees.
+    expect(
+      await getRelativeHref(browser, 'parallel-page-hrefs', '/parallel/[id]')
+    ).toBe('./123/')
+
+    // Clicking the root link from inside the catch-all slot lands on the
+    // home page. (There is no /parallel index page — these tests only visit
+    // URLs the slot's catch-all also matches.)
+    await relativeHrefLink(browser, 'parallel-slot-hrefs', '/').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/')
+      expect(await browser.elementByCss('#home-page').text()).toBe('Home')
+    })
+  })
+
+  it('resolves from the actual URL on the 404 page', async () => {
+    // The built-in /_not-found route renders at arbitrary URLs — its
+    // pseudo-segments never appear in URL space — so it provides no
+    // statically resolvable path, and hrefs resolve against the actual URL,
+    // whatever its depth.
+    const browser = await next.browser('/this/page/does/not/exist')
+    expect(await browser.elementByCss('#not-found-page').text()).toBe(
+      'Not found'
+    )
+    expect(await getRelativeHref(browser, 'not-found-hrefs', '/')).toBe(
+      '../../../../'
+    )
+    expect(await getRelativeHref(browser, 'not-found-hrefs', '/pricing')).toBe(
+      '../../../../pricing/'
+    )
+
+    await relativeHrefLink(browser, 'not-found-hrefs', '/pricing').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/pricing')
+      expect(await browser.elementByCss('#pricing-page').text()).toBe('Pricing')
+    })
+  })
+
+  it('computes traversal from the actual URL on a catch-all route', async () => {
+    // The number of segments matched by [...slug] is a per-request value, so
+    // the traversal is computed from the actual URL.
+    const browser = await next.browser('/docs/a/b/c')
+    expect(await getRelativeHref(browser, 'docs-page-hrefs', '/docs')).toBe(
+      '../../'
+    )
+    expect(await getRelativeHref(browser, 'docs-page-hrefs', '/')).toBe(
+      '../../../'
+    )
+
+    await relativeHrefLink(browser, 'docs-page-hrefs', '/docs').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/docs')
+      expect(await browser.elementByCss('#docs-index-page').text()).toBe(
+        'Docs index'
+      )
+    })
+  })
+
+  it('navigates via relative links and updates hook values after client-side navigation', async () => {
+    const browser = await next.browser('/chat/123')
+    expect(
+      await getRelativeHref(browser, 'chat-layout-hrefs', '/chat/[id]')
+    ).toBe('./123/')
+
+    // The chat layout renders a Link whose href is
+    // unstable_useRelativeHref('/chat') + '456', i.e. './456' on /chat/123,
+    // which resolves to /chat/456.
+    await browser.elementByCss('#link-to-chat-456').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/chat/456')
+      expect(await browser.elementByCss('#chat-page-id').text()).toBe('456')
+    })
+
+    // Client-nav reactivity: hook results reflect the new URL.
+    await retry(async () => {
+      expect(
+        await getRelativeHref(browser, 'chat-layout-hrefs', '/chat/[id]')
+      ).toBe('./456/')
+      expect(await getRelativeHref(browser, 'chat-page-hrefs', '/chat')).toBe(
+        './'
+      )
+    })
+
+    // Before clicking, verify the second relative link
+    // (unstable_useRelativeHref('/chat/[id]') + 'settings') now resolves to
+    // the settings page of the *new* chat.
+    await retry(async () => {
+      const resolvedPathname = await browser.eval(
+        `new URL(document.getElementById('link-to-current-chat-settings').getAttribute('href'), window.location.href).pathname`
+      )
+      expect(resolvedPathname).toBe('/chat/456/settings')
+    })
+
+    await browser.elementByCss('#link-to-current-chat-settings').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/chat/456/settings'
+      )
+      expect(await browser.elementByCss('#settings-page').text()).toBe(
+        'Settings'
+      )
+      // The layout's own route is now an ancestor of the current page.
+      expect(
+        await getRelativeHref(browser, 'chat-layout-hrefs', '/chat/[id]')
+      ).toBe('./')
+    })
+  })
+
+  it('recomputes hrefs from the new URL after a client-side navigation between params', async () => {
+    // After the first router update, hrefs resolve against the URL pathname
+    // (the same source usePathname reads), so a navigation between params of
+    // the dynamic segment updates every instance — including those rendered
+    // inside the catch-all slot.
+    //
+    // Note: webpack production builds have a pre-existing router bug
+    // (reproducible on canary): when a dynamic route has a sibling catch-all
+    // parallel slot, this navigation applies only the slot's tree patch and
+    // the children page keeps rendering the old param. The hook doesn't read
+    // the router tree, so the hrefs below are correct regardless.
+    const browser = await next.browser('/parallel/123')
+    expect(
+      await getRelativeHref(browser, 'parallel-slot-hrefs', '/parallel/[id]')
+    ).toBe('./123/')
+    expect(
+      await getRelativeHref(browser, 'parallel-page-hrefs', '/parallel/[id]')
+    ).toBe('./123/')
+
+    await browser.elementByCss('#parallel-nav-link').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/parallel/456'
+      )
+    })
+
+    // Both the catch-all slot and the children page resolve against the new
+    // URL (id = 456).
+    await retry(async () => {
+      expect(
+        await getRelativeHref(browser, 'parallel-slot-hrefs', '/parallel/[id]')
+      ).toBe('./456/')
+      expect(
+        await getRelativeHref(browser, 'parallel-slot-hrefs', '/parallel')
+      ).toBe('./')
+      expect(await getRelativeHref(browser, 'parallel-slot-hrefs', '/')).toBe(
+        '../'
+      )
+      expect(
+        await getRelativeHref(browser, 'parallel-page-hrefs', '/parallel/[id]')
+      ).toBe('./456/')
+    })
+
+    // Clicking the recomputed own-route link navigates (back) to the
+    // current parallel page.
+    await relativeHrefLink(
+      browser,
+      'parallel-page-hrefs',
+      '/parallel/[id]'
+    ).click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe(
+        '/parallel/456'
+      )
+    })
+  })
+
+  it('ignores content grafted into a default slot when resolving hrefs', async () => {
+    // At /graft/a/b/c, @side matches the URL with a fully static path
+    // (graft/a/b/c) while the children slot collapses the same URL parts
+    // into [...slug]. The static path is statically resolvable, so the
+    // matched route the server computes is 4 URL parts deep.
+    const browser = await next.browser('/graft/a/b/c')
+    expect(await browser.elementByCss('#graft-side-abc').text()).toBe(
+      'side abc'
+    )
+    expect(await getRelativeHref(browser, 'graft-page-hrefs', '/')).toBe(
+      '../../../'
+    )
+    expect(await getRelativeHref(browser, 'graft-page-hrefs', '/graft')).toBe(
+      '../../'
+    )
+
+    // Soft-navigate to /graft/x/y. @side has no match there, so the server
+    // sends a default segment for the slot and the client grafts the old
+    // a/b/c content into it instead of rendering @side/default.tsx. The
+    // grafted subtree keeps displaying the old URL's content, but hrefs now
+    // resolve against the current URL, which is only 3 parts deep
+    // (graft/x/y via [...slug]) — the stale content doesn't affect them.
+    await browser.elementByCss('#graft-nav-link').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/graft/x/y')
+      expect(await browser.elementByCss('#graft-page-slug').text()).toBe(
+        'Graft page for x/y'
+      )
+    })
+
+    // The graft actually happened: the old slot content is still displayed
+    // and the default slot content was not rendered.
+    expect(await browser.elementByCss('#graft-side-abc').text()).toBe(
+      'side abc'
+    )
+    expect(await browser.hasElementByCssSelector('#graft-side-default')).toBe(
+      false
+    )
+
+    await retry(async () => {
+      expect(await getRelativeHref(browser, 'graft-page-hrefs', '/')).toBe(
+        '../../'
+      )
+      expect(await getRelativeHref(browser, 'graft-page-hrefs', '/graft')).toBe(
+        '../'
+      )
+    })
+
+    // Clicking the '/graft' link resolves against the *current* URL's depth
+    // and lands on the graft index page.
+    await relativeHrefLink(browser, 'graft-page-hrefs', '/graft').click()
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toBe('/graft')
+      expect(await browser.elementByCss('#graft-index-page').text()).toBe(
+        'Graft index'
+      )
+    })
+  })
+})


### PR DESCRIPTION
Adds a new App Router hook, useRelativeHref(target) (currently prefixed with unstable_), which computes a relative URL reference from the current page to a target URL. For example, if the current page is '/chat/123/settings', then `useRelativeHref('/chat/[id]')` returns './' and `useRelativeHref('/chat/[id]/members')` returns '../members/'. Neither result references the value of [id]. The result can be passed directly to a Link or anchor element's href prop.

The benefit of relative hrefs is that you can link to pages without needing to reference dynamic params in the shared part of the URL. This means that unlike `usePathname`, `useRelativeHref` can often be included during static prerendering (i.e. without being wrapped in a Suspense boundary).

There will still be cases where a relative href cannot be generated statically. If the target is at or below the current page, the result must spell the page's final URL segment back out (relative resolution drops it): on '/chat/123', `useRelativeHref('/chat/[id]/settings')` returns './123/settings/', which includes the value of [id] and therefore deopts when that value is only known at request time. Routes with a catch-all param always resolve at request time, since the amount of traversal depends on how many segments the catch-all matched. However, not all pages that use catch-all params will necessarily trigger a dynamic deopt: as long as there's at least one parallel route that can be fully resolved, we can know the shape of the URL.

Targets that aren't root-relative paths — absolute URLs ('https://…', 'mailto:…'), protocol-relative URLs, and hash- or query-only references ('#faq', '?tab=1') — are returned unchanged, so any href that's valid on a `<Link>` can be passed through the hook without changing its behavior.

The current page's URL parts are computed on the server and sent to the client as part of the initial RSC payload, so the initial render — including hydration — resolves hrefs against the same values on both sides. After the first router state update, the hook resolves against the URL pathname instead, the same source that populates usePathname; on the client these are always equivalent.

## Review notes

Most of the diff is tests. I would start by reviewing the `computeRelativeHref` function, here: https://github.com/vercel/next.js/blob/e0fe5af836a1e222e6823599d8c98fac00ac2cd8/packages/next/src/shared/lib/relative-href.ts#L110-L226

That function contains the core algorithm.



