### PR TITLE
navigation(): Omit content from runtime prefetches

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -718,6 +718,7 @@ impl ReactServerComponentValidator {
                         "unstable_cacheLife",
                         "cacheTag",
                         "unstable_cacheTag",
+                        "unstable_navigation",
                         // "unstable_noStore" // no-op in client, but allowed for legacy reasons
                     ],
                 ),

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/input.js
@@ -1,0 +1,6 @@
+import { unstable_navigation } from 'next/cache'
+
+export async function test() {
+  await unstable_navigation()
+  return null
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.js
@@ -1,0 +1,5 @@
+import { unstable_navigation } from 'next/cache';
+export async function test() {
+    await unstable_navigation();
+    return null;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.stderr
@@ -1,0 +1,9 @@
+  x You're importing a module that depends on "unstable_navigation" into a React Client Component module. This API is only available in Server Components but one of its parents is marked with "use
+  | client", so this module is also a Client Component.
+  | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+  | 
+  | 
+   ,-[input.js:1:1]
+ 1 | import { unstable_navigation } from 'next/cache'
+   :          ^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/input.js
@@ -1,0 +1,6 @@
+import { unstable_navigation } from 'next/cache'
+
+export async function test() {
+  await unstable_navigation()
+  return null
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.js
@@ -1,0 +1,5 @@
+import { unstable_navigation } from 'next/cache';
+export async function test() {
+    await unstable_navigation();
+    return null;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.stderr
@@ -1,0 +1,8 @@
+  x You're importing a module that depends on "unstable_navigation". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
+  | Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+  | 
+  | 
+   ,-[input.js:1:1]
+ 1 | import { unstable_navigation } from 'next/cache'
+   :          ^^^^^^^^^^^^^^^^^^^
+   `----

--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -154,3 +154,5 @@ export function cacheLife(profile: {
 
 export const unstable_cacheLife: typeof cacheLife
 export const unstable_cacheTag: typeof cacheTag
+
+export { unstable_navigation } from 'next/dist/server/request/stages'

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -25,6 +25,7 @@ if (process.env.NEXT_RUNTIME === '') {
     refresh: notAvailableInClient('refresh'),
     cacheLife: notAvailableInClient('cacheLife'),
     cacheTag: notAvailableInClient('cacheTag'),
+    unstable_navigation: notAvailableInClient('unstable_navigation'),
   }
 } else {
   // Keep server requires in this branch so browser builds can DCE them.
@@ -49,6 +50,8 @@ if (process.env.NEXT_RUNTIME === '') {
     io: require('next/dist/server/request/io').io,
     cacheLife: require('next/dist/server/use-cache/cache-life').cacheLife,
     cacheTag: require('next/dist/server/use-cache/cache-tag').cacheTag,
+    unstable_navigation: require('next/dist/server/request/stages')
+      .unstable_navigation,
   }
 }
 
@@ -95,3 +98,4 @@ exports.cacheTag = cacheExports.cacheTag
 exports.unstable_cacheTag = cacheExports.unstable_cacheTag
 exports.refresh = cacheExports.refresh
 exports.io = cacheExports.io
+exports.unstable_navigation = cacheExports.unstable_navigation

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1460,5 +1460,12 @@
   "1459": "[Server HMR] unreachable: unknown HMR instruction type %s",
   "1460": "[Server HMR] unreachable: unexpected update instruction type %s",
   "1461": "Expected segment cache to have data for stage '%s'",
-  "1462": "Unexpected chunk emitted in Before stage"
+  "1462": "Unexpected chunk emitted in Before stage",
+  "1463": "`unstable_navigation` must not be used within a Client Component. Next.js should be preventing `unstable_navigation` from being included in Client Components statically, but did not in this case.",
+  "1464": "Route %s used \\`unstable_navigation()\\` inside a function cached with \\`unstable_cache()\\`. The \\`unstable_navigation()\\` function is used to indicate the subsequent code must only run during an actual navigation, but \\`unstable_cache()\\` caches must be able to be produced before a navigation, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
+  "1465": "Route %s used \\`unstable_navigation()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without a navigation. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
+  "1466": "Route %s used \\`unstable_navigation()\\`, which requires Cache Components to be enabled. Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents",
+  "1467": "Route %s used \\`unstable_navigation()\\` inside \\`after()\\` while rendering. The \\`unstable_navigation()\\` function is used to indicate the subsequent code must only run during an actual navigation, but \\`after()\\` executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
+  "1468": "Route %s used \\`unstable_navigation()\\` inside \"use cache: private\". This is not currently supported. Instead, move the \"use cache\" directive to a function that's called below \\`await unstable_navigation()\\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+  "1469": "Route %s used \\`unstable_navigation()\\` inside \"use cache\". This is not currently supported. Instead, move the \"use cache\" directive to a function that's called below \\`await unstable_navigation()\\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache"
 }

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
@@ -30,6 +30,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/stages'
 
        
          /**
@@ -188,6 +189,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/stages'
 
        
          /**
@@ -266,6 +268,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/stages'
 
        
          /**
@@ -343,6 +346,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/stages'
 
        
          /**
@@ -421,6 +425,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/stages'
 
        
          /**
@@ -503,6 +508,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/stages'
 
        
          /**

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
@@ -178,6 +178,7 @@ declare module 'next/cache' {
   } from 'next/dist/server/web/spec-extension/revalidate'
   export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
   export { io } from 'next/dist/server/request/io'
+  export { unstable_navigation } from 'next/dist/server/request/stages'
 
   ${overloads}
 

--- a/packages/next/src/server/request/stages.ts
+++ b/packages/next/src/server/request/stages.ts
@@ -1,0 +1,135 @@
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import {
+  throwForMissingRequestStore,
+  workUnitAsyncStorage,
+} from '../app-render/work-unit-async-storage.external'
+import {
+  applyOwnerStack,
+  makeStageHangingPromise,
+} from '../dynamic-rendering-utils'
+import { isRequestApiAllowedInCurrentPhase } from './utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
+
+/**
+ * This function allows you to indicate that the subsequent code should be
+ * deferred to the actual navigation instead of rendering during a runtime
+ * prefetch. Runtime prefetches are rendered per-user, per-link, so deferring
+ * content below `await unstable_navigation()` saves that per-request
+ * rendering cost.
+ *
+ * It has no effect during static prerendering — static output is computed
+ * once and shared across many clients, so there's no per-request cost to
+ * save — and no effect on the initial load of a page.
+ *
+ * Unlike `connection()`, it does not mark the subtree as request-dependent —
+ * content below `await unstable_navigation()` remains fully cacheable.
+ */
+export function unstable_navigation(): Promise<void> {
+  const callingExpression = 'unstable_navigation'
+  const workStore = workAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (workStore) {
+    if (workUnitStore && !isRequestApiAllowedInCurrentPhase(workUnitStore)) {
+      throw new Error(
+        `Route ${workStore.route} used \`unstable_navigation()\` inside \`after()\` while rendering. The \`unstable_navigation()\` function is used to indicate the subsequent code must only run during an actual navigation, but \`after()\` executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after`
+      )
+    }
+
+    if (workStore.forceStatic) {
+      // When using forceStatic, we override all other logic and always just
+      // return a resolving promise without tracking. This matches the behavior
+      // of connection().
+      return Promise.resolve(undefined)
+    }
+
+    // Note: unlike connection(), we deliberately do NOT throw for
+    // `dynamic = "error"`. unstable_navigation() does not make anything
+    // dynamic; a page that uses it can still be fully static — the content
+    // below it is merely excluded from runtime prefetches.
+
+    if (workUnitStore) {
+      switch (workUnitStore.type) {
+        case 'cache': {
+          const error = new Error(
+            `Route ${workStore.route} used \`unstable_navigation()\` inside "use cache". This is not currently supported. Instead, move the "use cache" directive to a function that's called below \`await unstable_navigation()\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+          )
+          Error.captureStackTrace(error, unstable_navigation)
+          applyOwnerStack(error)
+          workStore.invalidDynamicUsageError ??= error
+          throw error
+        }
+        case 'private-cache': {
+          const error = new Error(
+            `Route ${workStore.route} used \`unstable_navigation()\` inside "use cache: private". This is not currently supported. Instead, move the "use cache" directive to a function that's called below \`await unstable_navigation()\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+          )
+          Error.captureStackTrace(error, unstable_navigation)
+          applyOwnerStack(error)
+          workStore.invalidDynamicUsageError ??= error
+          throw error
+        }
+        case 'unstable-cache':
+          throw new Error(
+            `Route ${workStore.route} used \`unstable_navigation()\` inside a function cached with \`unstable_cache()\`. The \`unstable_navigation()\` function is used to indicate the subsequent code must only run during an actual navigation, but \`unstable_cache()\` caches must be able to be produced before a navigation, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+          )
+        case 'generate-static-params':
+          throw new Error(
+            `Route ${workStore.route} used \`unstable_navigation()\` inside \`generateStaticParams\`. This is not supported because \`generateStaticParams\` runs at build time without a navigation. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
+          )
+        case 'prerender':
+        case 'prerender-client':
+          // unstable_navigation() is a no-op during static prerendering.
+          // Static prerenders are computed once and shared across many
+          // clients, so there's no per-request prefetch cost to save by
+          // deferring the content — it's deliberately included in the static
+          // output (and thus in static prefetches).
+          return Promise.resolve(undefined)
+        case 'prerender-runtime':
+          // Runtime prefetches are rendered per-user, per-link, so this is
+          // exactly the cost unstable_navigation() exists to save: we return
+          // a promise that never resolves so the runtime prefetch stalls at
+          // this point, and the content below is deferred to the actual
+          // navigation. Note that this does not mark the subtree as dynamic —
+          // the content below is still cacheable and is filled in during the
+          // navigation.
+          return makeStageHangingPromise(
+            workUnitStore.renderSignal,
+            workStore.route,
+            '`unstable_navigation()`',
+            workUnitStore
+          )
+        case 'validation-client': {
+          // TODO(NAR-789): make this consistent with the actual browser behavior when we change it.
+          // Until then, erroring is fine.
+          const exportName = '`unstable_navigation`'
+          throw new InvariantError(
+            `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
+          )
+        }
+        case 'prerender-ppr':
+        case 'prerender-legacy':
+          // unstable_navigation() relies on the staged rendering model, which
+          // only exists with Cache Components.
+          throw new Error(
+            `Route ${workStore.route} used \`unstable_navigation()\`, which requires Cache Components to be enabled. Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents`
+          )
+        case 'request':
+          // Invariant: an actual navigation or initial load never defers
+          // content — in dev or prod. unstable_navigation() only defers
+          // content out of runtime prefetches.
+          // TODO: Track this access in dev so that instant validation can
+          // model the content below `unstable_navigation()` being deferred
+          // out of runtime prefetches.
+          return Promise.resolve(undefined)
+        default:
+          workUnitStore satisfies never
+      }
+    }
+  }
+
+  // If we end up here, there was no work store or work unit store present.
+  // Importing `unstable_navigation` from `next/cache` in client components is
+  // a compile-time error, so this is only reachable from code that skips that
+  // check (e.g. node_modules), where we error about a missing work unit store.
+  throwForMissingRequestStore(callingExpression)
+}


### PR DESCRIPTION
Adds a new server API, `await navigation()`. (Currently prefixed as `unstable_navigation`). Its purpose is to save on prefetching costs by preventing content from being rendered at runtime, except during an actual navigation (or during build/ISR). Unlike `await connection()`, it does not prevent the content from being cacheable.

For example, when prefetching a product page, you might want to include only the above-the-fold content.

```ts
function ProductPage() {
  return (
    <>
      <ItemHeader />
      <Suspense fallback={<Loading />}>
        <FullItemContent />
      </Suspense>
    </>
  )
}

async function FullItemContent() {
  await navigation()
  ...
}
```

In this example, `<ItemHeader>` will be prefetched, but not `<FullItemContent>`.

Calling `navigation()` inside "use cache" or "use cache: private" is an error for now. The supported pattern is to await `navigation()` in an uncached wrapper and put the "use cache" directive on an inner function below the gate. Direct support inside cache scopes — omitting the entire cache entry from runtime prefetches — will be added in a subsequent PR.