### PR TITLE
fix(export): disable i18n locale stripping for App Router paths during static export

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -141,7 +141,7 @@ async function exportPageImpl(
   let updatedPath = exportPath._ssgPath || path
   let locale = exportPath._locale || commonRenderOpts.locale
 
-  if (commonRenderOpts.locale) {
+  if (!isAppDir && commonRenderOpts.locale) {
     const localePathResult = normalizeLocalePath(path, commonRenderOpts.locales)
 
     if (localePathResult.detectedLocale) {
@@ -155,10 +155,10 @@ async function exportPageImpl(
   const hasOrigQueryValues = Object.keys(originalQuery).length > 0
 
   // Check if the page is a specified dynamic route
-  const { pathname: nonLocalizedPath } = normalizeLocalePath(
-    path,
-    commonRenderOpts.locales
-  )
+  const { pathname: nonLocalizedPath } =
+    !isAppDir && commonRenderOpts.locales
+      ? normalizeLocalePath(path, commonRenderOpts.locales)
+      : { pathname: path }
 
   let params: Params | undefined
 

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,9 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  P extends { pageProps: any }
+    ? Omit<P, 'pageProps'> & AppPropsType<NextRouter, P['pageProps']>
+    : P & AppPropsType<NextRouter>
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
Fixes #55331. When i18n is defined in 
ext.config.js, the static export worker was incorrectly stripping the locale from App Router paths. This resulted in an export path mismatch error when generateStaticParams returned a path containing a locale. This PR ensures that i18n locale stripping is disabled for App Router paths (isAppDir).