### PR TITLE
Gate `partialFallback` behavior behind `partialPrefetching` flag

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1572,6 +1572,9 @@ export async function handleBuildComplete({
           )?.routeKeys || {}
         const allowQuery = Object.values(routeKeys)
         const partialFallback =
+          // Partial fallback shells are only emitted when Partial Prefetching
+          // is enabled in the app's Next.js config.
+          Boolean(config.partialPrefetching) &&
           isAppPage &&
           remainingPrerenderableParams !== undefined &&
           remainingPrerenderableParams.length > 0 &&

--- a/test/production/app-dir/adapter-partial-fallback-disabled/adapter-partial-fallback-disabled.test.ts
+++ b/test/production/app-dir/adapter-partial-fallback-disabled/adapter-partial-fallback-disabled.test.ts
@@ -1,0 +1,41 @@
+import { nextTestSetup } from 'e2e-utils'
+import type { NextAdapter } from 'next'
+
+describe('adapter-partial-fallback-disabled', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not emit partial fallback metadata when partialPrefetching is disabled', async () => {
+    const { outputs }: Parameters<NextAdapter['onBuildComplete']>[0] =
+      await next.readJSON('build-complete.json')
+
+    const withGspPrerender = outputs.prerenders.find(
+      (output) => output.pathname === '/with-gsp/[slug]'
+    )
+    const withGspRouteTreePrerender = outputs.prerenders.find(
+      (output) =>
+        output.pathname === '/with-gsp/[slug].segments/_tree.segment.rsc'
+    )
+    const withGspOtherSegmentPrerenders = outputs.prerenders.filter(
+      (output) =>
+        output.pathname.startsWith('/with-gsp/[slug].segments/') &&
+        output.pathname !== '/with-gsp/[slug].segments/_tree.segment.rsc'
+    )
+
+    expect(withGspPrerender).toBeDefined()
+    expect(withGspRouteTreePrerender).toBeDefined()
+    expect(withGspOtherSegmentPrerenders.length).toBeGreaterThan(0)
+
+    // Without `partialPrefetching` enabled, the route that would otherwise
+    // qualify for a partial fallback shell must not emit the partialFallback
+    // config, and its fallback shell collapses to the shared shell (empty
+    // allowQuery).
+    expect(withGspPrerender.config.partialFallback).toBeUndefined()
+    expect(withGspPrerender.config.allowQuery).toEqual([])
+    expect(withGspRouteTreePrerender.config.partialFallback).toBeUndefined()
+    for (const output of withGspOtherSegmentPrerenders) {
+      expect(output.config.partialFallback).toBeUndefined()
+    }
+  })
+})

--- a/test/production/app-dir/adapter-partial-fallback-disabled/app/layout.tsx
+++ b/test/production/app-dir/adapter-partial-fallback-disabled/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-partial-fallback-disabled/app/with-gsp/[slug]/loading.tsx
+++ b/test/production/app-dir/adapter-partial-fallback-disabled/app/with-gsp/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>loading...</div>
+}

--- a/test/production/app-dir/adapter-partial-fallback-disabled/app/with-gsp/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-partial-fallback-disabled/app/with-gsp/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+
+async function Dynamic() {
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  return <div>Custom Data</div>
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'one' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return (
+    <div>
+      <div>{slug}</div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/production/app-dir/adapter-partial-fallback-disabled/my-adapter.mjs
+++ b/test/production/app-dir/adapter-partial-fallback-disabled/my-adapter.mjs
@@ -1,0 +1,9 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter } */
+export default {
+  name: 'adapter-partial-fallback-disabled',
+  async onBuildComplete(ctx) {
+    await fs.writeFile('build-complete.json', JSON.stringify(ctx, null, 2))
+  },
+}

--- a/test/production/app-dir/adapter-partial-fallback-disabled/next.config.js
+++ b/test/production/app-dir/adapter-partial-fallback-disabled/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  partialPrefetching: true,
   adapterPath: require.resolve('./my-adapter.mjs'),
 }
 


### PR DESCRIPTION
`partialFallback` is an internal flag in the build output that controls the behavior of ISR. When it's enabled, in a Cache Components app, pages that are not generated at build time are upgraded to a full ISR entry upon the first request.

This is a useful feature but there's a risk it could lead to an explosion in ISR costs, because even a prefetch request is sufficient to trigger an upgrade.

The desired behavior is that we only trigger an upgrade for an actual navigation request, or if a link opts into prefetching with the `prefetch` prop.

Currently there's no way for ISR to differentiate between a shell prefetch request (no prefetch prop on the link) and an actual prefetch (`prefetch={true}`). The plan is to introduce additional configuration to the build output that specifies which headers should trigger which operations.

So by default, this PR turns the `partialFallback` flag back off until the new mechanism is available to us.

However, for apps that opt into Partial Prefetching, we will continue to set `partialFallback` to true. That's because in a Partial Prefetching app, per-link prefetch requests are always opt-in. So even without additional support at the ISR behavior, we avoid an unexpected surge in ISR costs by not sending the prefetching request in the first place. There will still be a single request per distinct route (_not_ per distinct URL!), which we will optimize later.