### PR TITLE
e2e tests for navigation() and <Link prefetch="navigation">

### DIFF
--- a/test/e2e/app-dir/stages-navigation/app/basic/page.tsx
+++ b/test/e2e/app-dir/stages-navigation/app/basic/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+import { unstable_navigation } from 'next/cache'
+
+export default function Page() {
+  return (
+    <main>
+      <div id="above-navigation">Above navigation content</div>
+      <Suspense
+        fallback={<div id="below-fallback">Loading below navigation...</div>}
+      >
+        <BelowNavigation />
+      </Suspense>
+    </main>
+  )
+}
+
+async function BelowNavigation() {
+  // On a fully static page, `await unstable_navigation()` has no effect. It
+  // only defers content during runtime prefetches, which are rendered
+  // per-user, per-link. A static prerender is computed once and shared across
+  // many clients, so there's no per-request cost to save — this content is
+  // included in the static output (and thus in static prefetches).
+  await unstable_navigation()
+  return <div id="below-navigation">Below navigation content</div>
+}

--- a/test/e2e/app-dir/stages-navigation/app/layout.tsx
+++ b/test/e2e/app-dir/stages-navigation/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/stages-navigation/app/page.tsx
+++ b/test/e2e/app-dir/stages-navigation/app/page.tsx
@@ -1,0 +1,62 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Stages navigation home</h1>
+      <ul>
+        <li>
+          {/* Use a full prefetch: the suite asserts that a prefetch of this
+              fully static page includes everything, by navigating without any
+              additional requests. (The app enables `partialPrefetching`, so a
+              default prefetch would be deliberately partial.) */}
+          <LinkAccordion href="/basic" prefetch={true}>
+            Basic
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/workaround">Workaround</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/runtime-prefetch">
+            Runtime prefetch
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* Second accordion to the same href, but at navigation depth.
+              Revealing this link issues a runtime prefetch that renders past
+              `await unstable_navigation()`. */}
+          <LinkAccordion href="/runtime-prefetch" prefetch="navigation">
+            Runtime prefetch (navigation depth)
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* Third accordion to the same href, with a full prefetch. Under
+              Cache Components, `prefetch={true}` uses the same two-phase flow
+              as the default prefetch, but additionally performs the
+              speculative per-link pass, which issues a standalone runtime
+              prefetch for the page (it opts in via
+              `prefetch = 'partial'`). The suite uses this to put
+              runtime-depth entries in the cache before revealing a
+              navigation-depth link to the same route. */}
+          <LinkAccordion href="/runtime-prefetch" prefetch={true}>
+            Runtime prefetch (full)
+          </LinkAccordion>
+        </li>
+        <li>
+          {/* Full prefetch: issues a standalone runtime prefetch for the
+              page (see the comment on the equivalent /runtime-prefetch
+              accordion above). */}
+          <LinkAccordion href="/runtime-ungated" prefetch={true}>
+            Runtime ungated (full)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/runtime-ungated" prefetch="navigation">
+            Runtime ungated (navigation depth)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/stages-navigation/app/runtime-prefetch/page.tsx
+++ b/test/e2e/app-dir/stages-navigation/app/runtime-prefetch/page.tsx
@@ -1,0 +1,55 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { unstable_navigation } from 'next/cache'
+
+// Opt this route into runtime prefetching. When a link to this page becomes
+// visible, the client issues a runtime prefetch — a 'prerender-runtime' work
+// unit on the server — which, unlike a static prefetch, is allowed to read
+// request data like cookies.
+export const prefetch = 'partial'
+
+// Sample cookie values used at build time to validate the runtime prefetch.
+export const instant = {
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense
+        fallback={<div id="cookie-fallback">Loading cookie content...</div>}
+      >
+        <CookieContent />
+      </Suspense>
+    </main>
+  )
+}
+
+// Reads cookies *above* the `await unstable_navigation()` gate. The
+// cookie-derived content is included in a runtime prefetch, which proves the
+// prefetch response contains runtime data — while the gated content below
+// is excluded from it. (It's also absent from static prefetches, since a
+// static prerender suspends at the cookies() read before reaching it.)
+async function CookieContent() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  return (
+    <>
+      <div id="cookie-value">{`Cookie: ${cookieValue}`}</div>
+      <Suspense
+        fallback={<div id="gated-fallback">Loading gated content...</div>}
+      >
+        <Gated />
+      </Suspense>
+    </>
+  )
+}
+
+async function Gated() {
+  // Everything below is deferred to the actual navigation instead of
+  // rendering during a runtime prefetch. Runtime prefetches are rendered
+  // per-user, per-link, so this is exactly the per-request rendering cost
+  // that unstable_navigation() exists to save.
+  await unstable_navigation()
+  return <div id="gated-content">Runtime gated content</div>
+}

--- a/test/e2e/app-dir/stages-navigation/app/runtime-ungated/page.tsx
+++ b/test/e2e/app-dir/stages-navigation/app/runtime-ungated/page.tsx
@@ -1,0 +1,38 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+// Opt this route into runtime prefetching, like /runtime-prefetch — but this
+// page has no `await unstable_navigation()` gate. A runtime prefetch renders
+// the entire page, so nothing is deferred to the navigation stage. The suite
+// uses this to assert that the client records such an entry as
+// navigation-complete: a later `prefetch="navigation"` link to this route
+// must not issue a second, deeper prefetch.
+export const prefetch = 'partial'
+
+// Sample cookie values used at build time to validate the runtime prefetch.
+export const instant = {
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense
+        fallback={
+          <div id="ungated-cookie-fallback">Loading cookie content...</div>
+        }
+      >
+        <CookieContent />
+      </Suspense>
+    </main>
+  )
+}
+
+// Reads cookies, so the content only renders in a runtime prefetch (or a
+// navigation) — never in a static prefetch. There's no gate below it: once
+// the runtime prefetch completes, the whole page is in the cache.
+async function CookieContent() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  return <div id="ungated-cookie-value">{`Ungated cookie: ${cookieValue}`}</div>
+}

--- a/test/e2e/app-dir/stages-navigation/app/workaround/page.tsx
+++ b/test/e2e/app-dir/stages-navigation/app/workaround/page.tsx
@@ -1,0 +1,74 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { unstable_navigation } from 'next/cache'
+
+// Opt this route into runtime prefetching. unstable_navigation() only has an
+// observable effect during runtime prefetches (it's a no-op during static
+// prerendering), so the route must be runtime-prefetch-enabled for the
+// exclusion to be testable.
+export const prefetch = 'partial'
+
+// Sample cookie values used at build time to validate the runtime prefetch.
+export const instant = {
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+}
+
+// This page demonstrates the canonical pattern for combining
+// unstable_navigation() with "use cache". Awaiting unstable_navigation()
+// inside a cache scope is an error, so keep the unstable_navigation() gate in
+// an uncached wrapper and put the "use cache" directive on inner functions
+// called below the gate. Cached content that isn't behind the gate is still
+// included in runtime prefetches.
+export default function Page() {
+  return (
+    <main>
+      <Suspense
+        fallback={<div id="cookie-fallback">Loading cookie content...</div>}
+      >
+        <CookieSection />
+      </Suspense>
+    </main>
+  )
+}
+
+// Reads cookies above the `await unstable_navigation()` gate, so a runtime
+// prefetch of this page actually renders runtime content. Everything below is
+// nested under the cookie read, so none of it can appear in a static prefetch
+// (a static prerender suspends at cookies() before reaching it) — which lets
+// the test assert unambiguously on the runtime prefetch response.
+async function CookieSection() {
+  const cookieStore = await cookies()
+  const cookieValue = cookieStore.get('testCookie')?.value ?? null
+  return (
+    <>
+      <div id="cookie-value">{`Workaround cookie: ${cookieValue}`}</div>
+      <Suspense
+        fallback={<div id="visible-fallback">Loading cached visible...</div>}
+      >
+        <CachedVisible />
+      </Suspense>
+      <Suspense fallback={<div id="gated-fallback">Loading gated...</div>}>
+        <GatedSection />
+      </Suspense>
+    </>
+  )
+}
+
+// Cached, not gated: included in runtime prefetches.
+async function CachedVisible() {
+  'use cache'
+  return <div id="cached-visible">Cached visible content</div>
+}
+
+// Uncached wrapper: gate first, then read the cached data. Only this subtree
+// is excluded from the runtime prefetch and deferred to the navigation.
+async function GatedSection() {
+  await unstable_navigation()
+  const data = await getWorkaroundData()
+  return <div id="gated-data">{data}</div>
+}
+
+async function getWorkaroundData() {
+  'use cache'
+  return 'Cached workaround data'
+}

--- a/test/e2e/app-dir/stages-navigation/components/link-accordion.tsx
+++ b/test/e2e/app-dir/stages-navigation/components/link-accordion.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+// Controls when a <Link> enters the DOM. A Next.js <Link> triggers a prefetch
+// when it enters the viewport (via IntersectionObserver). By hiding the Link
+// behind a checkbox toggle, tests control exactly when prefetches happen —
+// only when the accordion is explicitly toggled inside an `act` scope.
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+        data-prefetch={getPrefetchKind(prefetch)}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}
+
+// A stable label for the `prefetch` prop, exposed as a `data-prefetch`
+// attribute so tests can distinguish multiple accordions that point to the
+// same href but use different prefetch modes.
+function getPrefetchKind(prefetch: LinkProps['prefetch']): string {
+  switch (prefetch) {
+    case false:
+      return 'disabled'
+    case undefined:
+    case null:
+    case 'auto':
+      return 'auto'
+    case true:
+      return 'true'
+    case 'prefetch':
+      return 'prefetch'
+    case 'navigation':
+      return 'navigation'
+    default:
+      prefetch satisfies never
+      return 'unknown'
+  }
+}

--- a/test/e2e/app-dir/stages-navigation/next.config.js
+++ b/test/e2e/app-dir/stages-navigation/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/stages-navigation/stages-navigation.test.ts
+++ b/test/e2e/app-dir/stages-navigation/stages-navigation.test.ts
@@ -1,0 +1,372 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('unstable_navigation() (stages)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Prefetching (and thus unstable_navigation()'s observable behavior) is
+    // not meaningful in dev, so this suite only runs against a production
+    // build.
+    it('is not relevant in dev', () => {})
+    return
+  }
+
+  async function startBrowser(url: string) {
+    let page!: Playwright.Page
+    const browser = await next.browser(url, {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    // Include App Shell requests in assertions: for pages without params, the
+    // static shell content arrives in the App Shell prefetch, and `block:
+    // 'reject'` assertions must cover *every* prefetch response, including
+    // the App Shell.
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+    return { browser, act }
+  }
+
+  it('has no effect on fully static pages: content below `await unstable_navigation()` is included in the prefetch', async () => {
+    const { browser, act } = await startBrowser('/')
+
+    // Reveal the link to trigger a full prefetch (the link uses
+    // `prefetch={true}`). The page is fully static and the route does not opt
+    // into runtime prefetching, so no runtime prefetch happens — and
+    // unstable_navigation() is a no-op during static prerendering. Both the
+    // above- and below-gate content are part of the static output and arrive
+    // in the prefetch responses. (We don't assert on the prefetch bodies
+    // directly because the static content can appear in more than one
+    // prefetch response; instead, the 'no-requests' navigation below proves
+    // everything was already prefetched.)
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/basic"]'
+      )
+      await toggle.click()
+    })
+
+    // Navigate. The entire page — including the content below
+    // `await unstable_navigation()` — is served from the prefetch cache
+    // without any additional requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/basic"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementById('above-navigation').text()).toBe(
+      'Above navigation content'
+    )
+    expect(await browser.elementById('below-navigation').text()).toBe(
+      'Below navigation content'
+    )
+  })
+
+  it('renders content below `await unstable_navigation()` on initial load', async () => {
+    // On a hard navigation (initial load), the content below the gate renders
+    // like any other content. (On a fully static page it's part of the static
+    // output to begin with.)
+    const browser = await next.browser('/basic')
+    expect(await browser.elementById('above-navigation').text()).toBe(
+      'Above navigation content'
+    )
+    expect(await browser.elementById('below-navigation').text()).toBe(
+      'Below navigation content'
+    )
+  })
+
+  it('excludes content below `await unstable_navigation()` from runtime prefetches', async () => {
+    const { browser, act } = await startBrowser('/')
+    // Clear cookies after the test. This currently doesn't happen
+    // automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+    // Reveal the link to trigger a prefetch. The route opts into runtime
+    // prefetching (`prefetch = 'partial'`), so in addition to the static
+    // prefetch, a runtime prefetch is issued, which is allowed to read request
+    // data like cookies. The cookie-derived content proves the runtime
+    // prefetch happened; the gated content must not appear in any prefetch
+    // response — unstable_navigation() excludes it from the runtime prefetch,
+    // and it's nested below the cookies() read, so a static prefetch never
+    // reaches it.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/runtime-prefetch"]'
+      )
+      await toggle.click()
+    }, [
+      // The cookie-derived content above `await unstable_navigation()` is
+      // included in the runtime prefetch. (It cannot appear in a static
+      // prefetch, which is not allowed to read cookies.)
+      { includes: 'Cookie: initialValue' },
+      // The content below `await unstable_navigation()` must not appear in
+      // any prefetch response, including the runtime prefetch.
+      { includes: 'Runtime gated content', block: 'reject' },
+    ])
+
+    // Navigate. The navigation response fills in the gated content.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/runtime-prefetch"]').click()
+      },
+      { includes: 'Runtime gated content' }
+    )
+
+    expect(await browser.elementById('cookie-value').text()).toBe(
+      'Cookie: initialValue'
+    )
+    expect(await browser.elementById('gated-content').text()).toBe(
+      'Runtime gated content'
+    )
+  })
+
+  it("supports cached content below unstable_navigation() when the 'use cache' directive is on an inner function", async () => {
+    const { browser, act } = await startBrowser('/')
+    // Clear cookies after the test. This currently doesn't happen
+    // automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+    // Reveal the link to trigger a prefetch. The route opts into runtime
+    // prefetching, and the page reads cookies, so a runtime prefetch fires
+    // and renders runtime content. The cached-but-not-gated content IS
+    // included in the runtime prefetch; only the subtree behind
+    // `await unstable_navigation()` is excluded. This is the canonical
+    // pattern for combining unstable_navigation() with "use cache": the
+    // uncached wrapper awaits unstable_navigation(), then calls a "use cache"
+    // function (awaiting unstable_navigation() *inside* a cache scope is an
+    // error).
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/workaround"]'
+      )
+      await toggle.click()
+    }, [
+      // The runtime prefetch contains the cookie-derived content...
+      { includes: 'Workaround cookie: initialValue' },
+      // ...and the cached content that isn't behind the gate...
+      { includes: 'Cached visible content' },
+      // ...but not the gated cached data.
+      { includes: 'Cached workaround data', block: 'reject' },
+    ])
+
+    // Navigate. The gated cached data renders as part of the navigation.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/workaround"]').click()
+      },
+      { includes: 'Cached workaround data' }
+    )
+
+    expect(await browser.elementById('cookie-value').text()).toBe(
+      'Workaround cookie: initialValue'
+    )
+    expect(await browser.elementById('cached-visible').text()).toBe(
+      'Cached visible content'
+    )
+    expect(await browser.elementById('gated-data').text()).toBe(
+      'Cached workaround data'
+    )
+  })
+
+  it('shows the Suspense fallback for gated content while the navigation response is pending', async () => {
+    const { browser, act } = await startBrowser('/')
+    // Clear cookies after the test. This currently doesn't happen
+    // automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+    // Reveal the link. The runtime prefetch includes the cookie-derived
+    // content but excludes the content below `await unstable_navigation()`.
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/runtime-prefetch"]'
+        )
+        await toggle.click()
+      },
+      { includes: 'Cookie: initialValue' }
+    )
+
+    // Navigate, but block the navigation response that contains the gated
+    // content. While it's pending, the prefetched content should already be
+    // visible: the cookie-derived content from the runtime prefetch, and the
+    // Suspense fallback in place of the gated content.
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/runtime-prefetch"]').click()
+        },
+        {
+          // Temporarily block the navigation response. It's fulfilled when
+          // the outer `act` scope completes.
+          includes: 'Runtime gated content',
+          block: true,
+        }
+      )
+      expect(await browser.elementById('cookie-value').text()).toBe(
+        'Cookie: initialValue'
+      )
+      expect(await browser.elementById('gated-fallback').text()).toBe(
+        'Loading gated content...'
+      )
+    })
+
+    // Once the navigation response is released, the gated content replaces
+    // the fallback.
+    expect(await browser.elementById('gated-content').text()).toBe(
+      'Runtime gated content'
+    )
+  })
+
+  it('includes content below `await unstable_navigation()` in a `prefetch="navigation"` prefetch', async () => {
+    const { browser, act } = await startBrowser('/')
+    // Clear cookies after the test. This currently doesn't happen
+    // automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+    // Reveal the navigation-depth link. `prefetch="navigation"` issues a
+    // runtime prefetch that renders past `await unstable_navigation()`, so
+    // unlike a default runtime prefetch, the gated content is included in the
+    // prefetch response, alongside the cookie-derived content above the gate.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/runtime-prefetch"][data-prefetch="navigation"]'
+      )
+      await toggle.click()
+    }, [
+      { includes: 'Cookie: initialValue' },
+      { includes: 'Runtime gated content' },
+    ])
+
+    // Navigate. The entire page — including the gated content — is served
+    // from the prefetch cache without any additional requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/runtime-prefetch"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementById('cookie-value').text()).toBe(
+      'Cookie: initialValue'
+    )
+    expect(await browser.elementById('gated-content').text()).toBe(
+      'Runtime gated content'
+    )
+  })
+
+  it('does not prefetch again when a `prefetch="navigation"` link targets a route whose runtime prefetch deferred nothing', async () => {
+    const { browser, act } = await startBrowser('/')
+    // Clear cookies after the test. This currently doesn't happen
+    // automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+    // Reveal a full-prefetch (`prefetch={true}`) link to /runtime-ungated.
+    // The route opts into runtime prefetching, so in addition to the App
+    // Shell prefetch this issues a standalone runtime prefetch for the page.
+    // The page has no `await unstable_navigation()` gate, so the runtime
+    // prefetch renders the entire page — nothing is deferred at the
+    // navigation stage. The response records this, and the client marks the
+    // cached entries as navigation-complete.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/runtime-ungated"][data-prefetch="true"]'
+      )
+      await toggle.click()
+    }, [
+      // The cookie-derived content appears once in the App Shell prefetch
+      // response and once in the runtime prefetch response.
+      { includes: 'Ungated cookie: initialValue' },
+      { includes: 'Ungated cookie: initialValue' },
+    ])
+
+    // Reveal the navigation-depth link to the same route. Because the earlier
+    // runtime prefetch deferred nothing, its entries were recorded as
+    // navigation-complete, so a deeper prefetch would yield nothing new — no
+    // request is issued.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/runtime-ungated"][data-prefetch="navigation"]'
+      )
+      await toggle.click()
+    }, 'no-requests')
+
+    // Navigate. The page is fully served from the prefetch cache.
+    await act(async () => {
+      await browser.elementByCss('a[href="/runtime-ungated"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementById('ungated-cookie-value').text()).toBe(
+      'Ungated cookie: initialValue'
+    )
+  })
+
+  it('prefetches deeper when a `prefetch="navigation"` link targets a route whose runtime prefetch deferred gated content', async () => {
+    const { browser, act } = await startBrowser('/')
+    // Clear cookies after the test. This currently doesn't happen
+    // automatically.
+    await using _ = defer(() => browser.deleteCookies())
+
+    await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
+
+    // Reveal a full-prefetch (`prefetch={true}`) link to /runtime-prefetch.
+    // In addition to the App Shell prefetch, this issues a standalone runtime
+    // prefetch, which includes the cookie-derived content but defers the
+    // content below `await unstable_navigation()`. Because content was
+    // deferred, the response records it and the cached entries are not
+    // navigation-complete.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/runtime-prefetch"][data-prefetch="true"]'
+      )
+      await toggle.click()
+    }, [
+      // The cookie-derived content appears once in the App Shell prefetch
+      // response and once in the runtime prefetch response.
+      { includes: 'Cookie: initialValue' },
+      { includes: 'Cookie: initialValue' },
+      // The gated content must not appear in any prefetch response.
+      { includes: 'Runtime gated content', block: 'reject' },
+    ])
+
+    // Reveal the navigation-depth link to the same route. The existing
+    // entries are not navigation-complete, so a deeper prefetch can provide
+    // more content: a new, navigation-depth prefetch fires and includes the
+    // gated content.
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/runtime-prefetch"][data-prefetch="navigation"]'
+        )
+        await toggle.click()
+      },
+      { includes: 'Runtime gated content' }
+    )
+
+    // Navigate. Everything is now served from the prefetch cache.
+    await act(async () => {
+      await browser.elementByCss('a[href="/runtime-prefetch"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementById('cookie-value').text()).toBe(
+      'Cookie: initialValue'
+    )
+    expect(await browser.elementById('gated-content').text()).toBe(
+      'Runtime gated content'
+    )
+  })
+})
+
+function defer(callback: () => Promise<void>) {
+  return {
+    [Symbol.asyncDispose]: callback,
+  }
+}


### PR DESCRIPTION
Test suite for `await navigation()` and `<Link prefetch="navigation">`. I've split these into a separate PR for ease of review.