### PR TITLE
[turbopack] Fix deployment skew protection for component chunks

### DIFF
--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -555,7 +555,10 @@ async fn build_manifest(
                             for (const key in globalThis.__RSC_MANIFEST[{entry_name}].clientModules) {{
                                 const val = {{ ...globalThis.__RSC_MANIFEST[{entry_name}].clientModules[key] }}
                                 globalThis.__RSC_MANIFEST[{entry_name}].clientModules[key] = val
-                                val.chunks = val.chunks.map((c) => `${{c}}?dpl=${{process.env.NEXT_DEPLOYMENT_ID}}`)
+                                val.chunks = val.chunks.map((c) =>
+                                    typeof c === 'string'
+                                        ? `${{c}}?dpl=${{process.env.NEXT_DEPLOYMENT_ID}}`
+                                        : [`${{c[0]}}?dpl=${{process.env.NEXT_DEPLOYMENT_ID}}`, c[1], c[2]])
                             }}
                             "#,
                             entry_name = StringifyJs(&normalized_manifest_entry),


### PR DESCRIPTION
Noticed this bug where we were assuming chunks were plain strings, which may not always be the case given #95261. When putting together https://github.com/react/react/pull/37095, I noticed this was also a spot we were missing so this fixes that. 

Almost all of this diff is a regression test.