### PR TITLE
Include additional prerender metadata about build-time routes

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
@@ -136,6 +136,11 @@ ISR-enabled routes and static prerenders:
   pathname: string     // URL pathname
   parentOutputId: string  // ID of the source page/route
   groupId: number        // Revalidation group identifier (prerenders with same groupId revalidate together)
+  route: string           // Source route matcher aligned with the filesystem route, keeping dynamic segments (e.g. /blog/[slug] for the prerendered path /blog/first)
+  routeType?: 'fallback' | 'shell' | 'page'  // Which URLs this prerender serves. fallback: at least one prerenderable param is missing (generateStaticParams/getStaticPaths can still specialize it). shell: all prerenderable params present; remaining params are dynamic, so this is the most specific prerender for its class of URLs. page: the prerender for one specific URL. undefined: unclassified (route handlers)
+  ui?: 'empty' | 'partial' | 'complete'  // Visual completeness of the prerendered HTML — a point-in-time snapshot of the build artifact (revalidation can change it). empty: no initial UI (no shell, or an empty shell). partial: some UI is pending and appears after load (resolved on the server or the client). complete: visually complete on initial load
+  compute?: 'blocking' | 'resuming' | 'static'  // Per-request compute involved in serving this prerender (also a build-time snapshot). blocking: the server must render before any UI is ready. resuming: the prerendered UI is served and the server resumes the postponed parts. static: no per-request compute (pending UI resolves on the client). undefined: does not apply (route handlers, or never-served templates like pages router fallback: false)
+  htmlSize?: number       // Byte size of the prerendered HTML shell for app pages; 0 means an empty shell (everything postponed). Only set on the HTML prerender output; RSC/data/segment, pages router, and route handler outputs leave it undefined
   pprChain?: {
     headers: Record<string, string>  // PPR chain headers (e.g., 'next-resume': '1')
   }

--- a/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
@@ -137,10 +137,10 @@ ISR-enabled routes and static prerenders:
   parentOutputId: string  // ID of the source page/route
   groupId: number        // Revalidation group identifier (prerenders with same groupId revalidate together)
   route: string           // Source route matcher aligned with the filesystem route, keeping dynamic segments (e.g. /blog/[slug] for the prerendered path /blog/first)
-  routeType?: 'fallback' | 'shell' | 'page'  // Which URLs this prerender serves. fallback: at least one prerenderable param is missing (generateStaticParams/getStaticPaths can still specialize it). shell: all prerenderable params present; remaining params are dynamic, so this is the most specific prerender for its class of URLs. page: the prerender for one specific URL. undefined: unclassified (route handlers)
-  ui?: 'empty' | 'partial' | 'complete'  // Visual completeness of the prerendered HTML — a point-in-time snapshot of the build artifact (revalidation can change it). empty: no initial UI (no shell, or an empty shell). partial: some UI is pending and appears after load (resolved on the server or the client). complete: visually complete on initial load
-  compute?: 'blocking' | 'resuming' | 'static'  // Per-request compute involved in serving this prerender (also a build-time snapshot). blocking: the server must render before any UI is ready. resuming: the prerendered UI is served and the server resumes the postponed parts. static: no per-request compute (pending UI resolves on the client). undefined: does not apply (route handlers, or never-served templates like pages router fallback: false)
-  htmlSize?: number       // Byte size of the prerendered HTML shell for app pages; 0 means an empty shell (everything postponed). Only set on the HTML prerender output; RSC/data/segment, pages router, and route handler outputs leave it undefined
+  routeType?: 'route' | 'fallback' | 'shell' | 'page'  // Kind of canonical response
+  response?: 'empty' | 'initial' | 'complete'  // Completeness before request-time work
+  compute?: 'blocking' | 'resuming' | 'static'  // Request-time compute needed for the completed response
+  htmlSize?: number       // Byte size of the prerendered App Router HTML shell
   pprChain?: {
     headers: Record<string, string>  // PPR chain headers (e.g., 'next-resume': '1')
   }
@@ -163,6 +163,31 @@ ISR-enabled routes and static prerenders:
   }
 }
 ```
+
+### Prerender classification
+
+`routeType`, `response`, and `compute` are emitted together on the primary response in a prerender group. Related RSC, data, and segment outputs omit these fields. Pages Router templates with `fallback: false` also omit them because those templates are never served for unmatched URLs.
+
+`routeType` identifies the kind of canonical response:
+
+- `route`: a non-UI route, such as a Route Handler
+- `page`: a page whose URL has no missing prerenderable parameters
+- `shell`: the most specific reusable page shell for its class of URLs
+- `fallback`: a reusable page response that can be specialized by filling more prerenderable parameters
+
+`response` describes how complete the response is before request-time work:
+
+- `empty`: no initial page response can be served
+- `initial`: an initial response can be served, but it is not the completed page UI
+- `complete`: the response is complete; this can include a zero-byte response body, such as a `204` Route Handler response
+
+`compute` describes the request-time compute needed to serve the completed response:
+
+- `blocking`: compute must finish before a response can be served
+- `resuming`: an initial response is served while postponed work resumes on the server
+- `static`: no server compute is required per request
+
+`htmlSize` is only included on the primary App Router HTML output. A value of `0` means that the HTML shell is empty. Pages Router prerenders, Route Handlers, and related RSC, data, and segment outputs omit it.
 
 ## Static Files (`outputs.staticFiles`)
 

--- a/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
@@ -178,12 +178,12 @@ ISR-enabled routes and static prerenders:
 `response` describes how complete the response is before request-time work:
 
 - `empty`: no initial page response can be served
-- `initial`: an initial response can be served, but it is not the completed page UI
+- `initial`: an initial response can be served, but it is not the completed page UI. In practice, this only applies to UI routes that are partially prerenderable
 - `complete`: the response is complete; this can include a zero-byte response body, such as a `204` Route Handler response
 
 `compute` describes the request-time compute needed to serve the completed response:
 
-- `blocking`: compute must finish before a response can be served
+- `blocking`: no initial response can be sent before request-time compute starts; once started, the response can stream while compute continues
 - `resuming`: an initial response is served while postponed work resumes on the server
 - `static`: no server compute is required per request
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1453,5 +1453,8 @@
   "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1455": "Page \"%s\" returned incomplete params from \"generateStaticParams()\". With \"output: export\", every params object must include all dynamic route parameters. Missing: %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1455": "Page \"%s\" returned incomplete params from \"generateStaticParams()\". With \"output: export\", every params object must include all dynamic route parameters. Missing: %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1456": "Expected an HTML size for prerendered app route \"%s\"",
+  "1457": "Expected prerender classification data for PPR route \"%s\"",
+  "1458": "Expected complete prerender classification for route \"%s\""
 }

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import crypto from 'crypto'
 import fs from 'fs/promises'
-import { statSync } from 'fs'
 import { pathToFileURL } from 'url'
 import * as Log from '../output/log'
 import { isMiddlewareFilename } from '../utils'
@@ -29,6 +28,7 @@ import type {
 import type {
   RoutesManifest,
   PrerenderManifest,
+  PrerenderManifestRoute,
   ManifestRewriteRoute,
   FunctionsConfigManifest,
   DynamicPrerenderManifestRoute,
@@ -56,6 +56,7 @@ import { generateRoutesManifest } from '../generate-routes-manifest'
 import { Bundler } from '../../lib/bundler'
 import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
 import { isAPIRoute } from '../../lib/is-api-route'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 interface SharedRouteFields {
   /**
@@ -143,6 +144,57 @@ interface SharedRouteFields {
   }
 }
 
+/**
+ * Classification metadata for the primary response in a prerender group.
+ * Related RSC, data, and segment outputs do not expose these fields.
+ */
+type PrerenderClassification =
+  | {
+      /**
+       * Which kind of canonical response this output represents.
+       *
+       * - `route`: a non-UI route, such as a Route Handler.
+       * - `page`: a page whose URL has no missing prerenderable params.
+       * - `shell`: the most specific reusable page shell for its URL class.
+       * - `fallback`: a reusable page response that can be specialized by
+       *   filling more prerenderable params.
+       */
+      routeType: 'route' | 'fallback' | 'shell' | 'page'
+
+      /**
+       * How complete the response is before any request-time work.
+       *
+       * - `empty`: no initial page response can be served.
+       * - `initial`: an initial response can be served, but it is not the
+       *   completed page UI.
+       * - `complete`: the response is complete. This can still describe a
+       *   zero-byte response body, such as a 204 Route Handler response.
+       */
+      response: 'empty' | 'initial' | 'complete'
+
+      /**
+       * The request-time compute needed to serve the completed response.
+       *
+       * - `blocking`: compute must finish before a response can be served.
+       * - `resuming`: an initial response is served while postponed work
+       *   resumes on the server.
+       * - `static`: no server compute is required per request.
+       */
+      compute: 'blocking' | 'resuming' | 'static'
+
+      /**
+       * The byte size of the prerendered HTML shell. Only the HTML output
+       * exposes this; sibling RSC/data/segment outputs omit it.
+       */
+      htmlSize?: number
+    }
+  | {
+      routeType?: never
+      response?: never
+      compute?: never
+      htmlSize?: never
+    }
+
 export interface AdapterOutput {
   /**
    * `PAGES` represents all the React pages that are under `pages/`.
@@ -200,65 +252,6 @@ export interface AdapterOutput {
      * `/blog/[slug]` for the prerendered path `/blog/first`).
      */
     route: string
-
-    /**
-     * routeType classifies which URLs this prerender serves. Like `ui` and
-     * `compute`, it is a point-in-time snapshot of what this build
-     * produced — revalidation can specialize or generalize it.
-     *
-     * - `fallback`: at least one prerenderable param (fillable by
-     *   `generateStaticParams` / `getStaticPaths`) is missing, so this is
-     *   the generic UI for a class of URLs that can still be prerendered
-     *   into something more specific.
-     * - `shell`: all prerenderable params are present; the remaining
-     *   params are dynamic and resolve per request, so this is the most
-     *   specific prerender possible for its class of URLs.
-     * - `page`: no params are missing — the prerender for one specific
-     *   URL.
-     *
-     * `undefined` means unclassified (route handlers, or entries with no
-     * served shell such as `notFound: true` pages).
-     *
-     * routeType/ui/compute describe the route's HTML prerender and are
-     * mirrored onto its sibling RSC/data/segment outputs.
-     */
-    routeType?: 'fallback' | 'shell' | 'page'
-
-    /**
-     * ui describes the visual completeness of this build's prerendered
-     * HTML. It is a point-in-time snapshot of the build artifact, not an
-     * intrinsic property of the route — revalidation can change it.
-     *
-     * - `empty`: no initial UI at all (no shell, or an empty shell).
-     * - `partial`: some UI is pending and appears after the page loads,
-     *   resolved on the server or the client.
-     * - `complete`: visually complete on initial load.
-     */
-    ui?: 'empty' | 'partial' | 'complete'
-
-    /**
-     * compute describes the per-request compute involved in serving this
-     * prerender. Like `ui`, it is a snapshot of the build artifact.
-     *
-     * - `blocking`: the server must render before any UI is ready.
-     * - `resuming`: the prerendered UI is served immediately and the
-     *   server resumes the postponed parts.
-     * - `static`: no per-request compute — any pending UI resolves on
-     *   the client.
-     *
-     * `undefined` means the signal does not apply (route handlers, or
-     * templates that are never served because unmatched paths 404, e.g.
-     * `fallback: false` / `dynamicParams = false`).
-     */
-    compute?: 'blocking' | 'resuming' | 'static'
-
-    /**
-     * htmlSize is the byte size of the prerendered HTML shell for app
-     * pages. `0` means an empty shell (everything postponed). It is only
-     * set on the HTML prerender output; RSC/data/segment outputs leave it
-     * `undefined`, as do pages router and route handler outputs.
-     */
-    htmlSize?: number
 
     pprChain?: {
       headers: Record<string, string>
@@ -342,7 +335,7 @@ export interface AdapterOutput {
        */
       bypassToken?: string
     }
-  }
+  } & PrerenderClassification
 
   /**
    * `STATIC_FILE` represents a static file (ie /_next/static) or a purely
@@ -392,14 +385,6 @@ export interface AdapterOutput {
   }
 }
 
-/**
- * The routeType/ui/compute classification dimensions of a PRERENDER output.
- */
-type PrerenderClassification = Pick<
-  AdapterOutput['PRERENDER'],
-  'routeType' | 'ui' | 'compute'
->
-
 export interface AdapterOutputs {
   pages: Array<AdapterOutput['PAGES']>
   middleware?: AdapterOutput['MIDDLEWARE']
@@ -408,6 +393,40 @@ export interface AdapterOutputs {
   appRoutes: Array<AdapterOutput['APP_ROUTE']>
   prerenders: Array<AdapterOutput['PRERENDER']>
   staticFiles: Array<AdapterOutput['STATIC_FILE']>
+}
+
+function getPrerenderClassification(
+  route: string,
+  routeType: PrerenderManifestRoute['routeType'],
+  response: PrerenderManifestRoute['response'],
+  compute: PrerenderManifestRoute['compute'],
+  htmlSize: PrerenderManifestRoute['htmlSize']
+): PrerenderClassification {
+  if (
+    routeType === undefined &&
+    response === undefined &&
+    compute === undefined &&
+    htmlSize === undefined
+  ) {
+    return {}
+  }
+
+  if (
+    routeType === undefined ||
+    response === undefined ||
+    compute === undefined
+  ) {
+    throw new InvariantError(
+      `Expected complete prerender classification for route "${route}"`
+    )
+  }
+
+  return {
+    routeType,
+    response,
+    compute,
+    ...(typeof htmlSize === 'number' && { htmlSize }),
+  }
 }
 
 type RewriteItem = {
@@ -1260,11 +1279,6 @@ export async function handleBuildComplete({
               groupId: initialOutput.groupId,
 
               route: initialOutput.route,
-              routeType: initialOutput.routeType,
-              ui: initialOutput.ui,
-              compute: initialOutput.compute,
-              // htmlSize is intentionally omitted: segment outputs are RSC
-              // payloads, not HTML shells
 
               config: {
                 ...initialOutput.config,
@@ -1298,7 +1312,6 @@ export async function handleBuildComplete({
         postponed?: string
         headers?: Record<string, string>
         status?: number
-        hasPendingUi?: boolean
       }
 
       const getAppRouteMeta = async (
@@ -1351,38 +1364,6 @@ export async function handleBuildComplete({
         return newCheck
       }
 
-      // A missing file yields `undefined` ("no signal"), never 0 — an empty
-      // shell that exists on disk is a meaningful 0.
-      const statHtmlSize = (filePath: string): number | undefined => {
-        try {
-          return statSync(filePath).size
-        } catch {
-          return undefined
-        }
-      }
-
-      // Derives the ui/compute dimensions for an app page prerender from
-      // its shell size and route metadata.
-      const classifyAppShell = (
-        htmlSize: number | undefined,
-        meta: AppRouteMeta
-      ): Pick<PrerenderClassification, 'ui' | 'compute'> => {
-        const isEmptyShell = htmlSize === 0
-        return {
-          ui: isEmptyShell
-            ? 'empty'
-            : meta.hasPendingUi || meta.postponed
-              ? 'partial'
-              : 'complete',
-          compute: meta.postponed
-            ? isEmptyShell
-              ? // an empty shell has no UI ready until the server renders
-                'blocking'
-              : 'resuming'
-            : 'static',
-        }
-      }
-
       for (const route in prerenderManifest.routes) {
         const {
           initialExpireSeconds: initialExpiration,
@@ -1392,6 +1373,10 @@ export async function handleBuildComplete({
           dataRoute,
           prefetchDataRoute,
           renderingMode,
+          routeType,
+          response,
+          compute,
+          htmlSize,
           allowHeader,
           experimentalBypassFor,
         } = prerenderManifest.routes[route]
@@ -1509,26 +1494,13 @@ export async function handleBuildComplete({
             'private, no-store, no-cache, max-age=0, must-revalidate'
         }
 
-        // only app pages (not route handlers, which have no dataRoute and
-        // write a `.body` file) have an HTML shell to measure; the
-        // isNotFoundTrue condition mirrors the `fallback` field below
-        const htmlSize =
-          isAppPage && dataRoute && (!isNotFoundTrue || hasStatic404)
-            ? statHtmlSize(filePath)
-            : undefined
-
-        // concrete prerenders have no params missing, so they serve
-        // exactly one URL
-        const classification: PrerenderClassification = isAppPage
-          ? dataRoute
-            ? { routeType: 'page', ...classifyAppShell(htmlSize, meta) }
-            : // route handlers are classified separately in the future
-              {}
-          : isNotFoundTrue && !hasStatic404
-            ? // no HTML shell is served for this entry
-              {}
-            : // pages router prerenders are always complete static HTML
-              { routeType: 'page', ui: 'complete', compute: 'static' }
+        const classification = getPrerenderClassification(
+          route,
+          routeType,
+          response,
+          compute,
+          htmlSize
+        )
 
         const initialOutput: AdapterOutput['PRERENDER'] = {
           id: route,
@@ -1541,7 +1513,6 @@ export async function handleBuildComplete({
           groupId: prerenderGroupId,
 
           route: srcRoute,
-          ...classification,
 
           pprChain:
             isAppPage && renderingMode === RenderingMode.PARTIALLY_STATIC
@@ -1587,12 +1558,11 @@ export async function handleBuildComplete({
             bypassToken: prerenderManifest.preview.previewModeId,
           },
         }
-        // htmlSize describes the HTML shell only, so it's attached here
-        // rather than on initialOutput, which is spread into the RSC/data
-        // outputs below. The shallow spread shares `fallback` by reference,
-        // so handleAppMeta's postponedState mutation still reaches this
-        // pushed output.
-        outputs.prerenders.push({ ...initialOutput, htmlSize })
+        // Classification describes the primary HTML or Route Handler body,
+        // not the related RSC/data/segment outputs that spread initialOutput.
+        // The shallow spread shares `fallback` by reference, so
+        // handleAppMeta's postponedState mutation still reaches this output.
+        outputs.prerenders.push({ ...initialOutput, ...classification })
 
         if (!isAppPage && appPageKeys && appPageKeys.length > 0) {
           const rscPage = `${route === '/' ? '/index' : route}.rsc`
@@ -1702,6 +1672,10 @@ export async function handleBuildComplete({
           allowHeader,
           dataRoute,
           renderingMode,
+          routeType,
+          response,
+          compute,
+          htmlSize,
           experimentalBypassFor,
         } = prerenderManifest.dynamicRoutes[dynamicRoute]
 
@@ -1805,44 +1779,13 @@ export async function handleBuildComplete({
             ? path.join(isAppPage ? appDistDir : pagesDistDir, fallbackHtmlFile)
             : undefined
 
-        const htmlSize =
-          isAppPage && fallbackHtmlPath !== undefined
-            ? statHtmlSize(fallbackHtmlPath)
-            : undefined
-
-        const classification: PrerenderClassification = !isAppPage
-          ? typeof fallback === 'string'
-            ? // fallback: true — serving the loading shell itself is
-              // static; the client then fetches the data, and generation
-              // happens on that data-route request
-              { routeType: 'fallback', ui: 'partial', compute: 'static' }
-            : fallback === null
-              ? // fallback: 'blocking' — rendered on request
-                { routeType: 'fallback', ui: 'empty', compute: 'blocking' }
-              : // fallback: false — the template is never served
-                // (unmatched paths 404; parentFallbackMode is false)
-                { routeType: 'fallback', ui: 'empty', compute: undefined }
-          : typeof fallback !== 'string'
-            ? // app template without a prerendered shell. Its missing
-              // params are fillable (via generateStaticParams or on
-              // request), which is why concrete siblings exist, so it's a
-              // `fallback`; `remainingPrerenderableParams` only describes
-              // prerendered shells and can't refine this.
-              fallback === null
-              ? { routeType: 'fallback', ui: 'empty', compute: 'blocking' }
-              : // fallback: false / dynamicParams = false — never served
-                { routeType: 'fallback', ui: 'empty', compute: undefined }
-            : {
-                // params that generateStaticParams can still fill make the
-                // template upgradable (`fallback`); otherwise the
-                // remaining params are dynamic and this is the most
-                // specific prerender for its class of URLs (`shell`)
-                routeType:
-                  (remainingPrerenderableParams?.length ?? 0) > 0
-                    ? 'fallback'
-                    : 'shell',
-                ...classifyAppShell(htmlSize, meta),
-              }
+        const classification = getPrerenderClassification(
+          dynamicRoute,
+          routeType,
+          response,
+          compute,
+          htmlSize
+        )
 
         const initialOutput: AdapterOutput['PRERENDER'] = {
           id: dynamicRoute,
@@ -1852,7 +1795,6 @@ export async function handleBuildComplete({
           groupId: prerenderGroupId,
 
           route: srcRoute,
-          ...classification,
 
           pprChain:
             isAppPage && renderingMode === RenderingMode.PARTIALLY_STATIC
@@ -1890,12 +1832,11 @@ export async function handleBuildComplete({
         }
 
         if (!config.i18n || isAppPage) {
-          // htmlSize describes the HTML shell only, so it's attached here
-          // rather than on initialOutput, which is spread into the RSC/data
-          // outputs below. The shallow spread shares `fallback` by reference,
-          // so handleAppMeta's postponedState mutation still reaches this
-          // pushed output.
-          outputs.prerenders.push({ ...initialOutput, htmlSize })
+          // Classification describes only the primary HTML response, not the
+          // related RSC/data/segment outputs that spread initialOutput. The
+          // shallow spread shares `fallback` by reference, so handleAppMeta's
+          // postponedState mutation still reaches this output.
+          outputs.prerenders.push({ ...initialOutput, ...classification })
 
           if (
             !isAppPage &&

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import crypto from 'crypto'
 import fs from 'fs/promises'
+import { statSync } from 'fs'
 import { pathToFileURL } from 'url'
 import * as Log from '../output/log'
 import { isMiddlewareFilename } from '../utils'
@@ -193,6 +194,72 @@ export interface AdapterOutput {
      */
     groupId: number
 
+    /**
+     * route is the source route matcher this prerender belongs to, aligned
+     * with the route on the filesystem — it keeps dynamic segments (e.g.
+     * `/blog/[slug]` for the prerendered path `/blog/first`).
+     */
+    route: string
+
+    /**
+     * routeType classifies which URLs this prerender serves. Like `ui` and
+     * `compute`, it is a point-in-time snapshot of what this build
+     * produced — revalidation can specialize or generalize it.
+     *
+     * - `fallback`: at least one prerenderable param (fillable by
+     *   `generateStaticParams` / `getStaticPaths`) is missing, so this is
+     *   the generic UI for a class of URLs that can still be prerendered
+     *   into something more specific.
+     * - `shell`: all prerenderable params are present; the remaining
+     *   params are dynamic and resolve per request, so this is the most
+     *   specific prerender possible for its class of URLs.
+     * - `page`: no params are missing — the prerender for one specific
+     *   URL.
+     *
+     * `undefined` means unclassified (route handlers, or entries with no
+     * served shell such as `notFound: true` pages).
+     *
+     * routeType/ui/compute describe the route's HTML prerender and are
+     * mirrored onto its sibling RSC/data/segment outputs.
+     */
+    routeType?: 'fallback' | 'shell' | 'page'
+
+    /**
+     * ui describes the visual completeness of this build's prerendered
+     * HTML. It is a point-in-time snapshot of the build artifact, not an
+     * intrinsic property of the route — revalidation can change it.
+     *
+     * - `empty`: no initial UI at all (no shell, or an empty shell).
+     * - `partial`: some UI is pending and appears after the page loads,
+     *   resolved on the server or the client.
+     * - `complete`: visually complete on initial load.
+     */
+    ui?: 'empty' | 'partial' | 'complete'
+
+    /**
+     * compute describes the per-request compute involved in serving this
+     * prerender. Like `ui`, it is a snapshot of the build artifact.
+     *
+     * - `blocking`: the server must render before any UI is ready.
+     * - `resuming`: the prerendered UI is served immediately and the
+     *   server resumes the postponed parts.
+     * - `static`: no per-request compute — any pending UI resolves on
+     *   the client.
+     *
+     * `undefined` means the signal does not apply (route handlers, or
+     * templates that are never served because unmatched paths 404, e.g.
+     * `fallback: false` / `dynamicParams = false`).
+     */
+    compute?: 'blocking' | 'resuming' | 'static'
+
+    /**
+     * htmlSize is the byte size of the prerendered HTML shell for app
+     * pages. `0` means an empty shell (everything postponed). It is only
+     * set on the HTML prerender output; RSC/data/segment outputs leave it
+     * `undefined`, as do pages router and route handler outputs.
+     */
+    htmlSize?: number
+
     pprChain?: {
       headers: Record<string, string>
     }
@@ -324,6 +391,14 @@ export interface AdapterOutput {
     }
   }
 }
+
+/**
+ * The routeType/ui/compute classification dimensions of a PRERENDER output.
+ */
+type PrerenderClassification = Pick<
+  AdapterOutput['PRERENDER'],
+  'routeType' | 'ui' | 'compute'
+>
 
 export interface AdapterOutputs {
   pages: Array<AdapterOutput['PAGES']>
@@ -1184,6 +1259,13 @@ export async function handleBuildComplete({
               parentOutputId: initialOutput.parentOutputId,
               groupId: initialOutput.groupId,
 
+              route: initialOutput.route,
+              routeType: initialOutput.routeType,
+              ui: initialOutput.ui,
+              compute: initialOutput.compute,
+              // htmlSize is intentionally omitted: segment outputs are RSC
+              // payloads, not HTML shells
+
               config: {
                 ...initialOutput.config,
                 bypassFor: undefined,
@@ -1216,6 +1298,7 @@ export async function handleBuildComplete({
         postponed?: string
         headers?: Record<string, string>
         status?: number
+        hasPendingUi?: boolean
       }
 
       const getAppRouteMeta = async (
@@ -1266,6 +1349,38 @@ export async function handleBuildComplete({
         filePathCache.set(filePath, newCheck)
 
         return newCheck
+      }
+
+      // A missing file yields `undefined` ("no signal"), never 0 — an empty
+      // shell that exists on disk is a meaningful 0.
+      const statHtmlSize = (filePath: string): number | undefined => {
+        try {
+          return statSync(filePath).size
+        } catch {
+          return undefined
+        }
+      }
+
+      // Derives the ui/compute dimensions for an app page prerender from
+      // its shell size and route metadata.
+      const classifyAppShell = (
+        htmlSize: number | undefined,
+        meta: AppRouteMeta
+      ): Pick<PrerenderClassification, 'ui' | 'compute'> => {
+        const isEmptyShell = htmlSize === 0
+        return {
+          ui: isEmptyShell
+            ? 'empty'
+            : meta.hasPendingUi || meta.postponed
+              ? 'partial'
+              : 'complete',
+          compute: meta.postponed
+            ? isEmptyShell
+              ? // an empty shell has no UI ready until the server renders
+                'blocking'
+              : 'resuming'
+            : 'static',
+        }
       }
 
       for (const route in prerenderManifest.routes) {
@@ -1394,6 +1509,27 @@ export async function handleBuildComplete({
             'private, no-store, no-cache, max-age=0, must-revalidate'
         }
 
+        // only app pages (not route handlers, which have no dataRoute and
+        // write a `.body` file) have an HTML shell to measure; the
+        // isNotFoundTrue condition mirrors the `fallback` field below
+        const htmlSize =
+          isAppPage && dataRoute && (!isNotFoundTrue || hasStatic404)
+            ? statHtmlSize(filePath)
+            : undefined
+
+        // concrete prerenders have no params missing, so they serve
+        // exactly one URL
+        const classification: PrerenderClassification = isAppPage
+          ? dataRoute
+            ? { routeType: 'page', ...classifyAppShell(htmlSize, meta) }
+            : // route handlers are classified separately in the future
+              {}
+          : isNotFoundTrue && !hasStatic404
+            ? // no HTML shell is served for this entry
+              {}
+            : // pages router prerenders are always complete static HTML
+              { routeType: 'page', ui: 'complete', compute: 'static' }
+
         const initialOutput: AdapterOutput['PRERENDER'] = {
           id: route,
           type: AdapterOutputType.PRERENDER,
@@ -1403,6 +1539,9 @@ export async function handleBuildComplete({
               ? srcRoute
               : getParentOutput(srcRoute, route).id,
           groupId: prerenderGroupId,
+
+          route: srcRoute,
+          ...classification,
 
           pprChain:
             isAppPage && renderingMode === RenderingMode.PARTIALLY_STATIC
@@ -1448,7 +1587,12 @@ export async function handleBuildComplete({
             bypassToken: prerenderManifest.preview.previewModeId,
           },
         }
-        outputs.prerenders.push(initialOutput)
+        // htmlSize describes the HTML shell only, so it's attached here
+        // rather than on initialOutput, which is spread into the RSC/data
+        // outputs below. The shallow spread shares `fallback` by reference,
+        // so handleAppMeta's postponedState mutation still reaches this
+        // pushed output.
+        outputs.prerenders.push({ ...initialOutput, htmlSize })
 
         if (!isAppPage && appPageKeys && appPageKeys.length > 0) {
           const rscPage = `${route === '/' ? '/index' : route}.rsc`
@@ -1647,12 +1791,68 @@ export async function handleBuildComplete({
           didFilterBlockingAllowQuery = true
         }
 
+        // app router dynamic route fallbacks don't have the extension so
+        // ensure it's added here
+        const fallbackHtmlFile =
+          typeof fallback === 'string'
+            ? fallback.endsWith('.html')
+              ? fallback
+              : `${fallback}.html`
+            : undefined
+
+        const fallbackHtmlPath =
+          fallbackHtmlFile !== undefined
+            ? path.join(isAppPage ? appDistDir : pagesDistDir, fallbackHtmlFile)
+            : undefined
+
+        const htmlSize =
+          isAppPage && fallbackHtmlPath !== undefined
+            ? statHtmlSize(fallbackHtmlPath)
+            : undefined
+
+        const classification: PrerenderClassification = !isAppPage
+          ? typeof fallback === 'string'
+            ? // fallback: true — serving the loading shell itself is
+              // static; the client then fetches the data, and generation
+              // happens on that data-route request
+              { routeType: 'fallback', ui: 'partial', compute: 'static' }
+            : fallback === null
+              ? // fallback: 'blocking' — rendered on request
+                { routeType: 'fallback', ui: 'empty', compute: 'blocking' }
+              : // fallback: false — the template is never served
+                // (unmatched paths 404; parentFallbackMode is false)
+                { routeType: 'fallback', ui: 'empty', compute: undefined }
+          : typeof fallback !== 'string'
+            ? // app template without a prerendered shell. Its missing
+              // params are fillable (via generateStaticParams or on
+              // request), which is why concrete siblings exist, so it's a
+              // `fallback`; `remainingPrerenderableParams` only describes
+              // prerendered shells and can't refine this.
+              fallback === null
+              ? { routeType: 'fallback', ui: 'empty', compute: 'blocking' }
+              : // fallback: false / dynamicParams = false — never served
+                { routeType: 'fallback', ui: 'empty', compute: undefined }
+            : {
+                // params that generateStaticParams can still fill make the
+                // template upgradable (`fallback`); otherwise the
+                // remaining params are dynamic and this is the most
+                // specific prerender for its class of URLs (`shell`)
+                routeType:
+                  (remainingPrerenderableParams?.length ?? 0) > 0
+                    ? 'fallback'
+                    : 'shell',
+                ...classifyAppShell(htmlSize, meta),
+              }
+
         const initialOutput: AdapterOutput['PRERENDER'] = {
           id: dynamicRoute,
           type: AdapterOutputType.PRERENDER,
           pathname: dynamicRoute,
           parentOutputId: parentOutput.id,
           groupId: prerenderGroupId,
+
+          route: srcRoute,
+          ...classification,
 
           pprChain:
             isAppPage && renderingMode === RenderingMode.PARTIALLY_STATIC
@@ -1664,14 +1864,9 @@ export async function handleBuildComplete({
               : undefined,
 
           fallback:
-            typeof fallback === 'string'
+            fallbackHtmlPath !== undefined
               ? {
-                  filePath: path.join(
-                    isAppPage ? appDistDir : pagesDistDir,
-                    // app router dynamic route fallbacks don't have the
-                    // extension so ensure it's added here
-                    fallback.endsWith('.html') ? fallback : `${fallback}.html`
-                  ),
+                  filePath: fallbackHtmlPath,
                   postponedState: undefined,
                   initialStatus: fallbackStatus ?? meta.status,
                   initialHeaders: {
@@ -1695,7 +1890,12 @@ export async function handleBuildComplete({
         }
 
         if (!config.i18n || isAppPage) {
-          outputs.prerenders.push(initialOutput)
+          // htmlSize describes the HTML shell only, so it's attached here
+          // rather than on initialOutput, which is spread into the RSC/data
+          // outputs below. The shallow spread shares `fallback` by reference,
+          // so handleAppMeta's postponedState mutation still reaches this
+          // pushed output.
+          outputs.prerenders.push({ ...initialOutput, htmlSize })
 
           if (
             !isAppPage &&
@@ -1796,7 +1996,7 @@ export async function handleBuildComplete({
               pathname: path.posix.join(`/${locale}`, initialOutput.pathname),
               id: path.posix.join(`/${locale}`, initialOutput.id),
               fallback:
-                typeof fallback === 'string'
+                fallbackHtmlFile !== undefined
                   ? {
                       ...initialOutput.fallback,
                       initialStatus: undefined,
@@ -1804,11 +2004,7 @@ export async function handleBuildComplete({
                       filePath: path.join(
                         pagesDistDir,
                         locale,
-                        // app router dynamic route fallbacks don't have the
-                        // extension so ensure it's added here
-                        fallback.endsWith('.html')
-                          ? fallback
-                          : `${fallback}.html`
+                        fallbackHtmlFile
                       ),
                     }
                   : undefined,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -237,7 +237,29 @@ import { validateAppPaths } from './validate-app-paths'
 
 type Fallback = null | boolean | string
 
-export interface PrerenderManifestRoute {
+export type PrerenderRouteType = 'route' | 'fallback' | 'shell' | 'page'
+export type PrerenderResponse = 'empty' | 'initial' | 'complete'
+export type PrerenderCompute = 'blocking' | 'resuming' | 'static'
+
+/**
+ * Classification for the primary response in a prerender group.
+ */
+interface PrerenderManifestClassification {
+  /** Which URLs this prerender can serve. */
+  routeType?: PrerenderRouteType
+
+  /** The completeness of the prerendered response. */
+  response?: PrerenderResponse
+
+  /** The per-request compute needed to serve this prerender. */
+  compute?: PrerenderCompute
+
+  /** The byte size of this route's prerendered HTML. */
+  htmlSize?: number
+}
+
+export interface PrerenderManifestRoute
+  extends PrerenderManifestClassification {
   dataRoute: string | null
   experimentalBypassFor?: RouteHas[]
 
@@ -296,7 +318,8 @@ export interface PrerenderManifestRoute {
   allowHeader: string[]
 }
 
-export interface DynamicPrerenderManifestRoute {
+export interface DynamicPrerenderManifestRoute
+  extends PrerenderManifestClassification {
   dataRoute: string | null
   dataRouteRegex: string | null
   experimentalBypassFor?: RouteHas[]
@@ -388,6 +411,95 @@ export type PrerenderManifest = {
   dynamicRoutes: { [route: string]: DynamicPrerenderManifestRoute }
   notFoundRoutes: string[]
   preview: __ApiPreviewProps
+}
+
+function getPprAppPageClassification(
+  route: string,
+  result:
+    | {
+        hasEmptyStaticShell?: boolean
+        hasPostponed?: boolean
+        hasPendingUi?: boolean
+        htmlSize?: number
+      }
+    | undefined
+): Required<
+  Pick<PrerenderManifestClassification, 'response' | 'compute' | 'htmlSize'>
+> {
+  if (typeof result?.htmlSize !== 'number') {
+    throw new InvariantError(
+      `Expected an HTML size for prerendered app route "${route}"`
+    )
+  }
+
+  if (
+    typeof result.hasEmptyStaticShell !== 'boolean' ||
+    typeof result.hasPostponed !== 'boolean' ||
+    typeof result.hasPendingUi !== 'boolean'
+  ) {
+    throw new InvariantError(
+      `Expected prerender classification data for PPR route "${route}"`
+    )
+  }
+
+  return {
+    response: result.hasEmptyStaticShell
+      ? 'empty'
+      : result.hasPendingUi || result.hasPostponed
+        ? 'initial'
+        : 'complete',
+    compute: result.hasPostponed
+      ? result.hasEmptyStaticShell
+        ? 'blocking'
+        : 'resuming'
+      : 'static',
+    htmlSize: result.htmlSize,
+  }
+}
+
+function getStaticAppPageClassification(
+  route: string,
+  result: { htmlSize?: number } | undefined
+): Required<
+  Pick<
+    PrerenderManifestClassification,
+    'routeType' | 'response' | 'compute' | 'htmlSize'
+  >
+> {
+  if (typeof result?.htmlSize !== 'number') {
+    throw new InvariantError(
+      `Expected an HTML size for prerendered app route "${route}"`
+    )
+  }
+
+  return {
+    routeType: 'page',
+    response: 'complete',
+    compute: 'static',
+    htmlSize: result.htmlSize,
+  }
+}
+
+function getPagesFallbackClassification(
+  fallback: Fallback
+): PrerenderManifestClassification {
+  if (fallback === null) {
+    return {
+      routeType: 'page',
+      response: 'empty',
+      compute: 'blocking',
+    }
+  }
+
+  if (typeof fallback === 'string' || fallback === true) {
+    return {
+      routeType: 'fallback',
+      response: 'initial',
+      compute: 'static',
+    }
+  }
+
+  return {}
 }
 
 export type SubresourceIntegrityManifest = Record<string, string>
@@ -3309,12 +3421,13 @@ export default async function build(
               if (isDynamicRoute(page) && route.pathname === page) continue
 
               const pageInfo = pageInfos.get(page) as PageInfo
+              const routeResult = exportResult.byPath.get(route.pathname)
               const {
                 metadata = {},
                 hasEmptyStaticShell,
                 hasPostponed,
                 hasStaticRsc,
-              } = exportResult.byPath.get(route.pathname) ?? {}
+              } = routeResult ?? {}
 
               const cacheControl = getCacheControl(
                 route.pathname,
@@ -3370,6 +3483,31 @@ export default async function build(
                   route.pathname === UNDERSCORE_NOT_FOUND_ROUTE
                     ? 404
                     : meta.status
+                const isNotFoundTrue =
+                  prerenderManifest.notFoundRoutes.includes(route.pathname)
+                let classification: PrerenderManifestClassification = {}
+                if (!isNotFoundTrue) {
+                  if (isAppRouteHandler) {
+                    classification = {
+                      routeType: 'route',
+                      response: 'complete',
+                      compute: 'static',
+                    }
+                  } else if (isRoutePPREnabled) {
+                    classification = {
+                      routeType: 'page',
+                      ...getPprAppPageClassification(
+                        route.pathname,
+                        routeResult
+                      ),
+                    }
+                  } else {
+                    classification = getStaticAppPageClassification(
+                      route.pathname,
+                      routeResult
+                    )
+                  }
+                }
 
                 prerenderManifest.routes[route.pathname] = {
                   initialStatus: status,
@@ -3379,6 +3517,7 @@ export default async function build(
                       ? RenderingMode.PARTIALLY_STATIC
                       : RenderingMode.STATIC
                     : undefined,
+                  ...classification,
                   experimentalPPR: isRoutePPREnabled,
                   experimentalBypassFor: bypassFor,
                   initialRevalidateSeconds: cacheControl.revalidate,
@@ -3457,9 +3596,8 @@ export default async function build(
                 const normalizedRoute = normalizePagePath(route.pathname)
                 const parentPageInfo = pageInfos.get(page) as PageInfo
 
-                const metadata = exportResult.byPath.get(
-                  route.pathname
-                )?.metadata
+                const routeResult = exportResult.byPath.get(route.pathname)
+                const metadata = routeResult?.metadata
 
                 const cacheControl = getCacheControl(route.pathname)
 
@@ -3602,6 +3740,27 @@ export default async function build(
                   fallbackMode === FallbackMode.PRERENDER
                     ? collectMeta(metadata)
                     : {}
+                let classification: PrerenderManifestClassification = {}
+                if (!isAppRouteHandler) {
+                  if (typeof fallback === 'string' && isRoutePPREnabled) {
+                    classification = {
+                      routeType:
+                        (route.remainingPrerenderableParams?.length ?? 0) > 0
+                          ? 'fallback'
+                          : 'shell',
+                      ...getPprAppPageClassification(
+                        route.pathname,
+                        routeResult
+                      ),
+                    }
+                  } else if (fallback === null) {
+                    classification = {
+                      routeType: 'page',
+                      response: 'empty',
+                      compute: 'blocking',
+                    }
+                  }
+                }
 
                 prerenderManifest.dynamicRoutes[route.pathname] = {
                   experimentalPPR: isRoutePPREnabled,
@@ -3612,6 +3771,7 @@ export default async function build(
                       ? RenderingMode.PARTIALLY_STATIC
                       : RenderingMode.STATIC
                     : undefined,
+                  ...classification,
                   experimentalBypassFor: bypassFor,
                   routeRegex: normalizeRouteRegex(
                     getNamedRouteRegex(route.pathname, {
@@ -3862,8 +4022,10 @@ export default async function build(
                   // TODO: do we want to show all locale variants in build output
                   for (const locale of i18n.locales) {
                     const localePage = `/${locale}${page === '/' ? '' : page}`
+                    const isNotFoundTrue =
+                      prerenderManifest.notFoundRoutes.includes(localePage)
 
-                    if (prerenderManifest.notFoundRoutes.includes(localePage)) {
+                    if (isNotFoundTrue) {
                       await deleteNotFoundPageFiles(
                         normalizePagePath(localePage)
                       )
@@ -3872,6 +4034,11 @@ export default async function build(
                     const cacheControl = getCacheControl(localePage)
 
                     prerenderManifest.routes[localePage] = {
+                      ...(!isNotFoundTrue && {
+                        routeType: 'page' as const,
+                        response: 'complete' as const,
+                        compute: 'static' as const,
+                      }),
                       initialRevalidateSeconds: cacheControl.revalidate,
                       initialExpireSeconds: cacheControl.expire,
                       experimentalPPR: undefined,
@@ -3887,13 +4054,20 @@ export default async function build(
                     }
                   }
                 } else {
-                  if (prerenderManifest.notFoundRoutes.includes(page)) {
+                  const isNotFoundTrue =
+                    prerenderManifest.notFoundRoutes.includes(page)
+                  if (isNotFoundTrue) {
                     await deleteNotFoundPageFiles(file)
                   }
 
                   const cacheControl = getCacheControl(page)
 
                   prerenderManifest.routes[page] = {
+                    ...(!isNotFoundTrue && {
+                      routeType: 'page' as const,
+                      response: 'complete' as const,
+                      compute: 'static' as const,
+                    }),
                     initialRevalidateSeconds: cacheControl.revalidate,
                     initialExpireSeconds: cacheControl.expire,
                     experimentalPPR: undefined,
@@ -3917,9 +4091,9 @@ export default async function build(
                 // the HTML/JSON files directly to their final location.
                 // We only need to update the prerender manifest.
                 for (const route of additionalPaths.get(page) ?? []) {
-                  if (
+                  const isNotFoundTrue =
                     prerenderManifest.notFoundRoutes.includes(route.pathname)
-                  ) {
+                  if (isNotFoundTrue) {
                     await deleteNotFoundPageFiles(
                       normalizePagePath(route.pathname)
                     )
@@ -3928,6 +4102,11 @@ export default async function build(
                   const cacheControl = getCacheControl(route.pathname)
 
                   prerenderManifest.routes[route.pathname] = {
+                    ...(!isNotFoundTrue && {
+                      routeType: 'page' as const,
+                      response: 'complete' as const,
+                      compute: 'static' as const,
+                    }),
                     initialRevalidateSeconds: cacheControl.revalidate,
                     initialExpireSeconds: cacheControl.expire,
                     experimentalPPR: undefined,
@@ -4051,6 +4230,12 @@ export default async function build(
             buildId,
             `${normalizedRoute}.json`
           )
+          let fallback: Fallback = false
+          if (ssgBlockingFallbackPages.has(tbdRoute)) {
+            fallback = null
+          } else if (ssgStaticFallbackPages.has(tbdRoute)) {
+            fallback = `${normalizedRoute}.html`
+          }
 
           prerenderManifest.dynamicRoutes[tbdRoute] = {
             routeRegex: normalizeRouteRegex(
@@ -4061,11 +4246,8 @@ export default async function build(
             experimentalPPR: undefined,
             renderingMode: undefined,
             dataRoute,
-            fallback: ssgBlockingFallbackPages.has(tbdRoute)
-              ? null
-              : ssgStaticFallbackPages.has(tbdRoute)
-                ? `${normalizedRoute}.html`
-                : false,
+            fallback,
+            ...getPagesFallbackClassification(fallback),
             fallbackRevalidate: undefined,
             fallbackExpire: undefined,
             fallbackSourceRoute: undefined,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -856,6 +856,14 @@ async function exportAppImpl(
         info.hasPostponed = result.hasPostponed
       }
 
+      if (typeof result.hasPendingUi !== 'undefined') {
+        info.hasPendingUi = result.hasPendingUi
+      }
+
+      if (typeof result.htmlSize !== 'undefined') {
+        info.htmlSize = result.htmlSize
+      }
+
       if (typeof result.hasStaticRsc !== 'undefined') {
         info.hasStaticRsc = result.hasStaticRsc
       }

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -102,6 +102,7 @@ export async function exportAppPage(
       segmentData,
       prefetchHints,
       renderResumeDataCache,
+      hasPendingUi,
     } = metadata
 
     // Ensure we don't postpone without having PPR enabled.
@@ -220,12 +221,6 @@ export async function exportAppPage(
       postponed,
       segmentPaths,
       prefetchHints,
-      // React marks a Suspense boundary whose content hasn't flushed with a
-      // `<!--$?-->` comment, and one that will client-render with
-      // `<!--$!-->`. User text can't produce these sequences (React escapes
-      // `<`), so their presence means the HTML contains pending UI —
-      // fallbacks that resolve on resume (postponed) or on the client.
-      hasPendingUi: html.includes('<!--$?-->') || html.includes('<!--$!-->'),
     }
 
     fileWriter.append(
@@ -243,6 +238,8 @@ export async function exportAppPage(
           },
       hasEmptyStaticShell: Boolean(postponed) && html === '',
       hasPostponed: Boolean(postponed),
+      hasPendingUi: hasPendingUi ?? false,
+      htmlSize: Buffer.byteLength(html),
       hasStaticRsc,
       cacheControl,
       fetchMetrics,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -220,6 +220,12 @@ export async function exportAppPage(
       postponed,
       segmentPaths,
       prefetchHints,
+      // React marks a Suspense boundary whose content hasn't flushed with a
+      // `<!--$?-->` comment, and one that will client-render with
+      // `<!--$!-->`. User text can't produce these sequences (React escapes
+      // `<`), so their presence means the HTML contains pending UI —
+      // fallbacks that resolve on resume (postponed) or on the client.
+      hasPendingUi: html.includes('<!--$?-->') || html.includes('<!--$!-->'),
     }
 
     fileWriter.append(

--- a/packages/next/src/export/routes/types.ts
+++ b/packages/next/src/export/routes/types.ts
@@ -7,4 +7,11 @@ export type RouteMetadata = {
   postponed: string | undefined
   segmentPaths: Array<string> | undefined
   prefetchHints: PrefetchHints | undefined
+  /**
+   * Whether the prerendered HTML contains pending UI: Suspense fallbacks
+   * that resolve later, either by resuming on the server (postponed) or on
+   * the client (e.g. a boundary reading search params). Complete HTML has
+   * no pending UI.
+   */
+  hasPendingUi: boolean | undefined
 }

--- a/packages/next/src/export/routes/types.ts
+++ b/packages/next/src/export/routes/types.ts
@@ -7,11 +7,4 @@ export type RouteMetadata = {
   postponed: string | undefined
   segmentPaths: Array<string> | undefined
   prefetchHints: PrefetchHints | undefined
-  /**
-   * Whether the prerendered HTML contains pending UI: Suspense fallbacks
-   * that resolve later, either by resuming on the server (postponed) or on
-   * the client (e.g. a boundary reading search params). Complete HTML has
-   * no pending UI.
-   */
-  hasPendingUi: boolean | undefined
 }

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -72,6 +72,8 @@ export type ExportRouteResult =
       ssgNotFound?: boolean
       hasEmptyStaticShell?: boolean
       hasPostponed?: boolean
+      hasPendingUi?: boolean
+      htmlSize?: number
       hasStaticRsc?: boolean
       fetchMetrics?: FetchMetrics
       renderResumeDataCache?: string
@@ -150,6 +152,14 @@ export type ExportAppResult = {
        * If the page has postponed when using PPR.
        */
       hasPostponed?: boolean
+      /**
+       * If the prerender has UI that will resolve after the initial HTML.
+       */
+      hasPendingUi?: boolean
+      /**
+       * The byte size of the HTML returned by the prerender.
+       */
+      htmlSize?: number
       /**
        * If the page emitted a static RSC payload.
        */

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2623,6 +2623,7 @@ async function renderToHTMLOrFlightImpl(
 
   const metadata: AppPageRenderResultMetadata = {
     statusCode: isNotFoundPath ? 404 : undefined,
+    hasPendingUi: false,
   }
 
   const appUsingSizeAdjustment = !!nextFontManifest?.appUsingSizeAdjust
@@ -8771,6 +8772,8 @@ async function prerenderToStream(
           }
         )
 
+      metadata.hasPendingUi = postponed != null
+
       const { prelude, preludeIsEmpty } =
         await processPreludeOp(unprocessedPrelude)
 
@@ -8970,6 +8973,8 @@ async function prerenderToStream(
             bootstrapScripts: [bootstrapScript],
           }
         )
+
+      metadata.hasPendingUi = postponed != null
       const getServerInsertedHTML = makeGetServerInsertedHTML({
         polyfills,
         renderServerInsertedHTML,
@@ -9538,6 +9543,8 @@ async function prerenderToStream(
             )
           }
         )
+
+        metadata.hasPendingUi = errorPostponed != null
 
         const { prelude, preludeIsEmpty } = await processPreludeOp(
           unprocessedErrorHtmlStream

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -380,6 +380,7 @@ export default class FileSystemCache implements CacheHandler {
         postponed: undefined,
         segmentPaths: undefined,
         prefetchHints: undefined,
+        hasPendingUi: undefined,
       }
 
       writer.append(
@@ -434,6 +435,9 @@ export default class FileSystemCache implements CacheHandler {
           postponed: data.postponed,
           segmentPaths,
           prefetchHints: undefined,
+          // Not computed on runtime revalidation writes: nothing consumes
+          // the pending-UI signal from runtime meta.
+          hasPendingUi: undefined,
         }
 
         writer.append(

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -380,7 +380,6 @@ export default class FileSystemCache implements CacheHandler {
         postponed: undefined,
         segmentPaths: undefined,
         prefetchHints: undefined,
-        hasPendingUi: undefined,
       }
 
       writer.append(
@@ -435,9 +434,6 @@ export default class FileSystemCache implements CacheHandler {
           postponed: data.postponed,
           segmentPaths,
           prefetchHints: undefined,
-          // Not computed on runtime revalidation writes: nothing consumes
-          // the pending-UI signal from runtime meta.
-          hasPendingUi: undefined,
         }
 
         writer.append(

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -44,6 +44,13 @@ export type AppPageRenderResultMetadata = {
   postponed?: string
 
   /**
+   * Whether the prerender left any UI pending in a Suspense boundary. This is
+   * reported directly by React's prerender result before Next.js resumes
+   * client-only boundaries.
+   */
+  hasPendingUi?: boolean
+
+  /**
    * The headers to set on the response that were added by the render.
    */
   headers?: OutgoingHttpHeaders

--- a/test/e2e/404-page-ssg/404-page-ssg.test.ts
+++ b/test/e2e/404-page-ssg/404-page-ssg.test.ts
@@ -55,6 +55,9 @@ describe('404 Page Support SSG', () => {
     it('should have 404 page in prerender-manifest', async () => {
       const data = await next.readJSON('.next/prerender-manifest.json')
       expect(data.routes['/404']).toEqual({
+        routeType: 'page',
+        response: 'complete',
+        compute: 'static',
         allowHeader: [
           'host',
           'x-matched-path',

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1353,15 +1353,20 @@ describe('app-dir static/dynamic handling', () => {
       }
 
       for (const key of Object.keys(curManifest.routes)) {
+        const item = curManifest.routes[key]
+        if (item.htmlSize !== undefined) {
+          expect(item.htmlSize).toBeGreaterThan(0)
+          delete item.htmlSize
+        }
+
         const newKey = key.replace(
           /partial-gen-params-no-additional-([\w]{1,})\/([\w]{1,})\/([\d]{1,})/,
           'partial-gen-params-no-additional-$1/$2/RAND'
         )
         if (newKey !== key) {
-          const route = curManifest.routes[key]
           delete curManifest.routes[key]
           curManifest.routes[newKey] = {
-            ...route,
+            ...item,
             dataRoute: `${newKey}.rsc`,
           }
         }
@@ -1379,6 +1384,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/index.rsc",
            "experimentalBypassFor": [
              {
@@ -1392,6 +1398,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/",
          },
          "/_not-found": {
@@ -1403,6 +1411,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/_not-found.rsc",
            "experimentalBypassFor": [
              {
@@ -1417,6 +1426,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialRevalidateSeconds": false,
            "initialStatus": 404,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/_not-found",
          },
          "/api/large-data": {
@@ -1428,6 +1439,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": null,
            "experimentalBypassFor": [
              {
@@ -1445,6 +1457,8 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-cache-tags": "_N_T_/layout,_N_T_/api/layout,_N_T_/api/large-data/layout,_N_T_/api/large-data/route,_N_T_/api/large-data",
            },
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "route",
            "srcRoute": "/api/large-data",
          },
          "/articles/works": {
@@ -1456,6 +1470,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/articles/works.rsc",
            "experimentalBypassFor": [
              {
@@ -1470,6 +1485,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 1,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/articles/[slug]",
          },
          "/blog/seb": {
@@ -1481,6 +1498,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/seb.rsc",
            "experimentalBypassFor": [
              {
@@ -1495,6 +1513,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]",
          },
          "/blog/seb/second-post": {
@@ -1506,6 +1526,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/seb/second-post.rsc",
            "experimentalBypassFor": [
              {
@@ -1519,6 +1540,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]/[slug]",
          },
          "/blog/styfle": {
@@ -1530,6 +1553,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/styfle.rsc",
            "experimentalBypassFor": [
              {
@@ -1544,6 +1568,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]",
          },
          "/blog/styfle/first-post": {
@@ -1555,6 +1581,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/styfle/first-post.rsc",
            "experimentalBypassFor": [
              {
@@ -1568,6 +1595,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]/[slug]",
          },
          "/blog/styfle/second-post": {
@@ -1579,6 +1608,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/styfle/second-post.rsc",
            "experimentalBypassFor": [
              {
@@ -1592,6 +1622,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]/[slug]",
          },
          "/blog/tim": {
@@ -1603,6 +1635,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/tim.rsc",
            "experimentalBypassFor": [
              {
@@ -1617,6 +1650,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]",
          },
          "/blog/tim/first-post": {
@@ -1628,6 +1663,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/blog/tim/first-post.rsc",
            "experimentalBypassFor": [
              {
@@ -1641,6 +1677,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/blog/[author]/[slug]",
          },
          "/default-config-fetch": {
@@ -1652,6 +1690,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/default-config-fetch.rsc",
            "experimentalBypassFor": [
              {
@@ -1665,6 +1704,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/default-config-fetch",
          },
          "/force-cache": {
@@ -1676,6 +1717,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/force-cache.rsc",
            "experimentalBypassFor": [
              {
@@ -1690,6 +1732,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/force-cache",
          },
          "/force-static-fetch-no-store": {
@@ -1701,6 +1745,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/force-static-fetch-no-store.rsc",
            "experimentalBypassFor": [
              {
@@ -1714,6 +1759,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/force-static-fetch-no-store",
          },
          "/force-static/first": {
@@ -1725,6 +1772,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/force-static/first.rsc",
            "experimentalBypassFor": [
              {
@@ -1738,6 +1786,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/force-static/[slug]",
          },
          "/force-static/second": {
@@ -1749,6 +1799,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/force-static/second.rsc",
            "experimentalBypassFor": [
              {
@@ -1762,6 +1813,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/force-static/[slug]",
          },
          "/gen-params-catch-all-unique/foo/bar": {
@@ -1773,6 +1826,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/gen-params-catch-all-unique/foo/bar.rsc",
            "experimentalBypassFor": [
              {
@@ -1786,6 +1840,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/gen-params-catch-all-unique/[...slug]",
          },
          "/gen-params-catch-all-unique/foo/foo": {
@@ -1797,6 +1853,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/gen-params-catch-all-unique/foo/foo.rsc",
            "experimentalBypassFor": [
              {
@@ -1810,6 +1867,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/gen-params-catch-all-unique/[...slug]",
          },
          "/gen-params-dynamic-revalidate/one": {
@@ -1821,6 +1880,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/gen-params-dynamic-revalidate/one.rsc",
            "experimentalBypassFor": [
              {
@@ -1835,6 +1895,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/gen-params-dynamic-revalidate/[slug]",
          },
          "/hooks/use-pathname/slug": {
@@ -1846,6 +1908,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/hooks/use-pathname/slug.rsc",
            "experimentalBypassFor": [
              {
@@ -1859,6 +1922,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/hooks/use-pathname/[slug]",
          },
          "/hooks/use-search-params/force-static": {
@@ -1870,6 +1935,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/hooks/use-search-params/force-static.rsc",
            "experimentalBypassFor": [
              {
@@ -1883,6 +1949,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/hooks/use-search-params/force-static",
          },
          "/hooks/use-search-params/with-suspense": {
@@ -1894,6 +1962,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/hooks/use-search-params/with-suspense.rsc",
            "experimentalBypassFor": [
              {
@@ -1907,6 +1976,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/hooks/use-search-params/with-suspense",
          },
          "/isr-error-handling": {
@@ -1918,6 +1989,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/isr-error-handling.rsc",
            "experimentalBypassFor": [
              {
@@ -1932,6 +2004,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/isr-error-handling",
          },
          "/no-config-fetch": {
@@ -1943,6 +2017,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/no-config-fetch.rsc",
            "experimentalBypassFor": [
              {
@@ -1956,6 +2031,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/no-config-fetch",
          },
          "/no-store/static": {
@@ -1967,6 +2044,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/no-store/static.rsc",
            "experimentalBypassFor": [
              {
@@ -1980,6 +2058,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/no-store/static",
          },
          "/partial-gen-params-no-additional-lang/en/RAND": {
@@ -1991,6 +2071,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-lang/en/RAND.rsc",
            "experimentalBypassFor": [
              {
@@ -2004,6 +2085,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-lang/en/first": {
@@ -2015,6 +2098,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-lang/en/first.rsc",
            "experimentalBypassFor": [
              {
@@ -2028,6 +2112,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-lang/en/second": {
@@ -2039,6 +2125,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-lang/en/second.rsc",
            "experimentalBypassFor": [
              {
@@ -2052,6 +2139,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-lang/fr/RAND": {
@@ -2063,6 +2152,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-lang/fr/RAND.rsc",
            "experimentalBypassFor": [
              {
@@ -2076,6 +2166,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-lang/fr/first": {
@@ -2087,6 +2179,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-lang/fr/first.rsc",
            "experimentalBypassFor": [
              {
@@ -2100,6 +2193,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-lang/fr/second": {
@@ -2111,6 +2206,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-lang/fr/second.rsc",
            "experimentalBypassFor": [
              {
@@ -2124,6 +2220,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-slug/en/RAND": {
@@ -2135,6 +2233,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-slug/en/RAND.rsc",
            "experimentalBypassFor": [
              {
@@ -2148,6 +2247,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-slug/en/first": {
@@ -2159,6 +2260,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-slug/en/first.rsc",
            "experimentalBypassFor": [
              {
@@ -2172,6 +2274,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-slug/en/second": {
@@ -2183,6 +2287,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-slug/en/second.rsc",
            "experimentalBypassFor": [
              {
@@ -2196,6 +2301,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-slug/fr/RAND": {
@@ -2207,6 +2314,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-slug/fr/RAND.rsc",
            "experimentalBypassFor": [
              {
@@ -2220,6 +2328,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-slug/fr/first": {
@@ -2231,6 +2341,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-slug/fr/first.rsc",
            "experimentalBypassFor": [
              {
@@ -2244,6 +2355,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
          "/partial-gen-params-no-additional-slug/fr/second": {
@@ -2255,6 +2368,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-gen-params-no-additional-slug/fr/second.rsc",
            "experimentalBypassFor": [
              {
@@ -2268,6 +2382,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
          "/partial-params-false/en/static": {
@@ -2279,6 +2395,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-params-false/en/static.rsc",
            "experimentalBypassFor": [
              {
@@ -2292,6 +2409,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-params-false/[locale]/static",
          },
          "/partial-params-false/fr/static": {
@@ -2303,6 +2422,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/partial-params-false/fr/static.rsc",
            "experimentalBypassFor": [
              {
@@ -2316,6 +2436,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/partial-params-false/[locale]/static",
          },
          "/prerendered-not-found/first": {
@@ -2327,6 +2449,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/prerendered-not-found/first.rsc",
            "experimentalBypassFor": [
              {
@@ -2340,6 +2463,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/prerendered-not-found/[slug]",
          },
          "/prerendered-not-found/second": {
@@ -2351,6 +2476,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/prerendered-not-found/second.rsc",
            "experimentalBypassFor": [
              {
@@ -2364,6 +2490,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/prerendered-not-found/[slug]",
          },
          "/prerendered-not-found/segment-revalidate": {
@@ -2375,6 +2503,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/prerendered-not-found/segment-revalidate.rsc",
            "experimentalBypassFor": [
              {
@@ -2389,6 +2518,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/prerendered-not-found/segment-revalidate",
          },
          "/route-handler/no-store-force-static": {
@@ -2400,6 +2531,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": null,
            "experimentalBypassFor": [
              {
@@ -2418,6 +2550,8 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-cache-tags": "_N_T_/layout,_N_T_/route-handler/layout,_N_T_/route-handler/no-store-force-static/layout,_N_T_/route-handler/no-store-force-static/route,_N_T_/route-handler/no-store-force-static",
            },
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "route",
            "srcRoute": "/route-handler/no-store-force-static",
          },
          "/route-handler/revalidate-360-isr": {
@@ -2429,6 +2563,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": null,
            "experimentalBypassFor": [
              {
@@ -2447,6 +2582,8 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-cache-tags": "_N_T_/layout,_N_T_/route-handler/layout,_N_T_/route-handler/revalidate-360-isr/layout,_N_T_/route-handler/revalidate-360-isr/route,_N_T_/route-handler/revalidate-360-isr,thankyounext",
            },
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "route",
            "srcRoute": "/route-handler/revalidate-360-isr",
          },
          "/route-handler/static-cookies": {
@@ -2458,6 +2595,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": null,
            "experimentalBypassFor": [
              {
@@ -2475,6 +2613,8 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-cache-tags": "_N_T_/layout,_N_T_/route-handler/layout,_N_T_/route-handler/static-cookies/layout,_N_T_/route-handler/static-cookies/route,_N_T_/route-handler/static-cookies",
            },
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "route",
            "srcRoute": "/route-handler/static-cookies",
          },
          "/ssg-draft-mode": {
@@ -2486,6 +2626,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/ssg-draft-mode.rsc",
            "experimentalBypassFor": [
              {
@@ -2499,6 +2640,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/ssg-draft-mode/[[...route]]",
          },
          "/ssg-draft-mode/test": {
@@ -2510,6 +2653,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/ssg-draft-mode/test.rsc",
            "experimentalBypassFor": [
              {
@@ -2523,6 +2667,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/ssg-draft-mode/[[...route]]",
          },
          "/ssg-draft-mode/test-2": {
@@ -2534,6 +2680,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/ssg-draft-mode/test-2.rsc",
            "experimentalBypassFor": [
              {
@@ -2547,6 +2694,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/ssg-draft-mode/[[...route]]",
          },
          "/strip-w3c-trace-context-headers": {
@@ -2558,6 +2707,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/strip-w3c-trace-context-headers.rsc",
            "experimentalBypassFor": [
              {
@@ -2572,6 +2722,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 50,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/strip-w3c-trace-context-headers",
          },
          "/unstable-cache/fetch/no-cache": {
@@ -2583,6 +2735,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/unstable-cache/fetch/no-cache.rsc",
            "experimentalBypassFor": [
              {
@@ -2596,6 +2749,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/unstable-cache/fetch/no-cache",
          },
          "/unstable-cache/fetch/no-store": {
@@ -2607,6 +2762,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/unstable-cache/fetch/no-store.rsc",
            "experimentalBypassFor": [
              {
@@ -2620,6 +2776,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/unstable-cache/fetch/no-store",
          },
          "/update-tag-test": {
@@ -2631,6 +2789,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/update-tag-test.rsc",
            "experimentalBypassFor": [
              {
@@ -2644,6 +2803,8 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/update-tag-test",
          },
          "/variable-config-revalidate/revalidate-3": {
@@ -2655,6 +2816,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-config-revalidate/revalidate-3.rsc",
            "experimentalBypassFor": [
              {
@@ -2669,6 +2831,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-config-revalidate/revalidate-3",
          },
          "/variable-revalidate-stable/revalidate-3": {
@@ -2680,6 +2844,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate-stable/revalidate-3.rsc",
            "experimentalBypassFor": [
              {
@@ -2694,6 +2859,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate-stable/revalidate-3",
          },
          "/variable-revalidate/authorization": {
@@ -2705,6 +2872,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate/authorization.rsc",
            "experimentalBypassFor": [
              {
@@ -2719,6 +2887,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate/authorization",
          },
          "/variable-revalidate/cookie": {
@@ -2730,6 +2900,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate/cookie.rsc",
            "experimentalBypassFor": [
              {
@@ -2744,6 +2915,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate/cookie",
          },
          "/variable-revalidate/encoding": {
@@ -2755,6 +2928,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate/encoding.rsc",
            "experimentalBypassFor": [
              {
@@ -2769,6 +2943,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate/encoding",
          },
          "/variable-revalidate/headers-instance": {
@@ -2780,6 +2956,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate/headers-instance.rsc",
            "experimentalBypassFor": [
              {
@@ -2794,6 +2971,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate/headers-instance",
          },
          "/variable-revalidate/revalidate-3": {
@@ -2805,6 +2984,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate/revalidate-3.rsc",
            "experimentalBypassFor": [
              {
@@ -2819,6 +2999,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 3,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate/revalidate-3",
          },
          "/variable-revalidate/revalidate-360-isr": {
@@ -2830,6 +3012,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "static",
            "dataRoute": "/variable-revalidate/revalidate-360-isr.rsc",
            "experimentalBypassFor": [
              {
@@ -2844,6 +3027,8 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 10,
+           "response": "complete",
+           "routeType": "page",
            "srcRoute": "/variable-revalidate/revalidate-360-isr",
          },
        }
@@ -2859,6 +3044,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/articles/[slug].rsc",
            "dataRouteRegex": "^\\/articles\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -2876,7 +3062,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/articles\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/blog/[author]": {
            "allowHeader": [
@@ -2915,6 +3103,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/blog/[author]/[slug].rsc",
            "dataRouteRegex": "^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -2932,7 +3121,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/dynamic-error/[id]": {
            "allowHeader": [
@@ -2943,6 +3134,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/dynamic-error/[id].rsc",
            "dataRouteRegex": "^\\/dynamic\\-error\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -2960,7 +3152,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/dynamic\\-error\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/force-static/[slug]": {
            "allowHeader": [
@@ -2971,6 +3165,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/force-static/[slug].rsc",
            "dataRouteRegex": "^\\/force\\-static\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -2988,7 +3183,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/force\\-static\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/gen-params-catch-all-unique/[...slug]": {
            "allowHeader": [
@@ -3027,6 +3224,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/gen-params-dynamic-revalidate/[slug].rsc",
            "dataRouteRegex": "^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -3044,7 +3242,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/hooks/use-pathname/[slug]": {
            "allowHeader": [
@@ -3055,6 +3255,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/hooks/use-pathname/[slug].rsc",
            "dataRouteRegex": "^\\/hooks\\/use\\-pathname\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -3072,7 +3273,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/hooks\\/use\\-pathname\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/partial-gen-params-no-additional-lang/[lang]/[slug]": {
            "allowHeader": [
@@ -3167,6 +3370,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/prerendered-not-found/[slug].rsc",
            "dataRouteRegex": "^\\/prerendered\\-not\\-found\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -3184,7 +3388,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/prerendered\\-not\\-found\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
          "/ssg-draft-mode/[[...route]]": {
            "allowHeader": [
@@ -3195,6 +3401,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/ssg-draft-mode/[[...route]].rsc",
            "dataRouteRegex": "^\\/ssg\\-draft\\-mode(?:\\/(.+?))?\\.rsc$",
            "experimentalBypassFor": [
@@ -3212,7 +3419,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/ssg\\-draft\\-mode(?:\\/(.+?))?(?:\\/)?$",
+           "routeType": "page",
          },
          "/static-to-dynamic-error-forced/[id]": {
            "allowHeader": [
@@ -3223,6 +3432,7 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidated-tags",
              "x-next-revalidate-tag-token",
            ],
+           "compute": "blocking",
            "dataRoute": "/static-to-dynamic-error-forced/[id].rsc",
            "dataRouteRegex": "^\\/static\\-to\\-dynamic\\-error\\-forced\\/([^\\/]+?)\\.rsc$",
            "experimentalBypassFor": [
@@ -3240,7 +3450,9 @@ describe('app-dir static/dynamic handling', () => {
            "fallbackRootParams": [],
            "fallbackRouteParams": [],
            "prefetchDataRoute": null,
+           "response": "empty",
            "routeRegex": "^\\/static\\-to\\-dynamic\\-error\\-forced\\/([^\\/]+?)(?:\\/)?$",
+           "routeType": "page",
          },
        }
       `)

--- a/test/e2e/i18n-support/shared.ts
+++ b/test/e2e/i18n-support/shared.ts
@@ -773,6 +773,9 @@ export function runTests(ctx) {
       ).toMatchInlineSnapshot(`
        "{
          "/do": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do.json",
@@ -786,6 +789,9 @@ export function runTests(ctx) {
            ]
          },
          "/do-BE": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do-BE.json",
@@ -799,6 +805,9 @@ export function runTests(ctx) {
            ]
          },
          "/do-BE/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do-BE/404.json",
@@ -812,6 +821,9 @@ export function runTests(ctx) {
            ]
          },
          "/do-BE/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do-BE/frank.json",
@@ -825,6 +837,9 @@ export function runTests(ctx) {
            ]
          },
          "/do-BE/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do-BE/gsp.json",
@@ -838,6 +853,9 @@ export function runTests(ctx) {
            ]
          },
          "/do-BE/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/do-BE/gsp/fallback/always.json",
@@ -851,6 +869,9 @@ export function runTests(ctx) {
            ]
          },
          "/do-BE/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do-BE/not-found.json",
@@ -864,6 +885,9 @@ export function runTests(ctx) {
            ]
          },
          "/do/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do/404.json",
@@ -877,6 +901,9 @@ export function runTests(ctx) {
            ]
          },
          "/do/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do/frank.json",
@@ -890,6 +917,9 @@ export function runTests(ctx) {
            ]
          },
          "/do/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do/gsp.json",
@@ -903,6 +933,9 @@ export function runTests(ctx) {
            ]
          },
          "/do/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/do/gsp/fallback/always.json",
@@ -916,6 +949,9 @@ export function runTests(ctx) {
            ]
          },
          "/do/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/do/not-found.json",
@@ -929,6 +965,9 @@ export function runTests(ctx) {
            ]
          },
          "/en": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en.json",
@@ -942,6 +981,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en-US.json",
@@ -955,6 +997,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en-US/404.json",
@@ -968,6 +1013,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en-US/frank.json",
@@ -981,6 +1029,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp.json",
@@ -994,6 +1045,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/always.json",
@@ -1007,6 +1061,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/gsp/fallback/first": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/first.json",
@@ -1020,6 +1077,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/gsp/fallback/second": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/second.json",
@@ -1033,6 +1093,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/gsp/no-fallback/first": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/no-fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/first.json",
@@ -1046,6 +1109,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/gsp/no-fallback/second": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/no-fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/second.json",
@@ -1059,6 +1125,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found.json",
@@ -1072,6 +1141,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/not-found/blocking-fallback/first": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/not-found/blocking-fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/first.json",
@@ -1085,6 +1157,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/not-found/blocking-fallback/second": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/not-found/blocking-fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/second.json",
@@ -1098,6 +1173,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/not-found/fallback/first": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/not-found/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/first.json",
@@ -1111,6 +1189,9 @@ export function runTests(ctx) {
            ]
          },
          "/en-US/not-found/fallback/second": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/not-found/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/second.json",
@@ -1124,6 +1205,9 @@ export function runTests(ctx) {
            ]
          },
          "/en/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en/404.json",
@@ -1137,6 +1221,9 @@ export function runTests(ctx) {
            ]
          },
          "/en/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en/frank.json",
@@ -1150,6 +1237,9 @@ export function runTests(ctx) {
            ]
          },
          "/en/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/en/gsp.json",
@@ -1163,6 +1253,9 @@ export function runTests(ctx) {
            ]
          },
          "/en/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/en/gsp/fallback/always.json",
@@ -1189,6 +1282,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr.json",
@@ -1202,6 +1298,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr-BE": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr-BE.json",
@@ -1215,6 +1314,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr-BE/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr-BE/404.json",
@@ -1228,6 +1330,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr-BE/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr-BE/frank.json",
@@ -1241,6 +1346,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr-BE/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr-BE/gsp.json",
@@ -1254,6 +1362,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr-BE/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/fr-BE/gsp/fallback/always.json",
@@ -1267,6 +1378,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr-BE/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr-BE/not-found.json",
@@ -1280,6 +1394,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr/404.json",
@@ -1293,6 +1410,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr/frank.json",
@@ -1306,6 +1426,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr/gsp.json",
@@ -1319,6 +1442,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/fr/gsp/fallback/always.json",
@@ -1332,6 +1458,9 @@ export function runTests(ctx) {
            ]
          },
          "/fr/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/fr/not-found.json",
@@ -1345,6 +1474,9 @@ export function runTests(ctx) {
            ]
          },
          "/go": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go.json",
@@ -1358,6 +1490,9 @@ export function runTests(ctx) {
            ]
          },
          "/go-BE": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go-BE.json",
@@ -1371,6 +1506,9 @@ export function runTests(ctx) {
            ]
          },
          "/go-BE/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go-BE/404.json",
@@ -1384,6 +1522,9 @@ export function runTests(ctx) {
            ]
          },
          "/go-BE/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go-BE/frank.json",
@@ -1397,6 +1538,9 @@ export function runTests(ctx) {
            ]
          },
          "/go-BE/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go-BE/gsp.json",
@@ -1410,6 +1554,9 @@ export function runTests(ctx) {
            ]
          },
          "/go-BE/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/go-BE/gsp/fallback/always.json",
@@ -1423,6 +1570,9 @@ export function runTests(ctx) {
            ]
          },
          "/go-BE/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go-BE/not-found.json",
@@ -1436,6 +1586,9 @@ export function runTests(ctx) {
            ]
          },
          "/go/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go/404.json",
@@ -1449,6 +1602,9 @@ export function runTests(ctx) {
            ]
          },
          "/go/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go/frank.json",
@@ -1462,6 +1618,9 @@ export function runTests(ctx) {
            ]
          },
          "/go/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go/gsp.json",
@@ -1475,6 +1634,9 @@ export function runTests(ctx) {
            ]
          },
          "/go/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/go/gsp/fallback/always.json",
@@ -1488,6 +1650,9 @@ export function runTests(ctx) {
            ]
          },
          "/go/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/go/not-found.json",
@@ -1501,6 +1666,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl.json",
@@ -1514,6 +1682,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-BE": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-BE.json",
@@ -1527,6 +1698,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-BE/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-BE/404.json",
@@ -1540,6 +1714,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-BE/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-BE/frank.json",
@@ -1553,6 +1730,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-BE/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-BE/gsp.json",
@@ -1566,6 +1746,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-BE/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/nl-BE/gsp/fallback/always.json",
@@ -1579,6 +1762,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-BE/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-BE/not-found.json",
@@ -1592,6 +1778,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-NL.json",
@@ -1605,6 +1794,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-NL/404.json",
@@ -1618,6 +1810,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-NL/frank.json",
@@ -1631,6 +1826,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp.json",
@@ -1644,6 +1842,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/fallback/always.json",
@@ -1657,6 +1858,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL/gsp/no-fallback/second": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/no-fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/no-fallback/second.json",
@@ -1670,6 +1874,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl-NL/not-found": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl-NL/not-found.json",
@@ -1683,6 +1890,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl/404": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl/404.json",
@@ -1696,6 +1906,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl/frank": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl/frank.json",
@@ -1709,6 +1922,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl/gsp": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": null,
            "dataRoute": "/_next/data/BUILD_ID/nl/gsp.json",
@@ -1722,6 +1938,9 @@ export function runTests(ctx) {
            ]
          },
          "/nl/gsp/fallback/always": {
+           "routeType": "page",
+           "response": "complete",
+           "compute": "static",
            "initialRevalidateSeconds": false,
            "srcRoute": "/gsp/fallback/[slug]",
            "dataRoute": "/_next/data/BUILD_ID/nl/gsp/fallback/always.json",
@@ -1759,64 +1978,73 @@ export function runTests(ctx) {
             'BUILD_ID'
           )
       ).toMatchInlineSnapshot(`
-        "{
-          "/gsp/fallback/[slug]": {
-            "routeRegex": "^\\/gsp\\/fallback\\/([^\\/]+?)(?:\\/)?$",
-            "dataRoute": "/_next/data/BUILD_ID/gsp/fallback/[slug].json",
-            "fallback": "/gsp/fallback/[slug].html",
-            "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/fallback\\/([^\\/]+?)\\.json$",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/gsp/no-fallback/[slug]": {
-            "routeRegex": "^\\/gsp\\/no\\-fallback\\/([^\\/]+?)(?:\\/)?$",
-            "dataRoute": "/_next/data/BUILD_ID/gsp/no-fallback/[slug].json",
-            "fallback": false,
-            "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/no\\-fallback\\/([^\\/]+?)\\.json$",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/not-found/blocking-fallback/[slug]": {
-            "routeRegex": "^\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)(?:\\/)?$",
-            "dataRoute": "/_next/data/BUILD_ID/not-found/blocking-fallback/[slug].json",
-            "fallback": null,
-            "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)\\.json$",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/not-found/fallback/[slug]": {
-            "routeRegex": "^\\/not\\-found\\/fallback\\/([^\\/]+?)(?:\\/)?$",
-            "dataRoute": "/_next/data/BUILD_ID/not-found/fallback/[slug].json",
-            "fallback": "/not-found/fallback/[slug].html",
-            "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/fallback\\/([^\\/]+?)\\.json$",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          }
-        }"
+       "{
+         "/gsp/fallback/[slug]": {
+           "routeRegex": "^\\/gsp\\/fallback\\/([^\\/]+?)(?:\\/)?$",
+           "dataRoute": "/_next/data/BUILD_ID/gsp/fallback/[slug].json",
+           "fallback": "/gsp/fallback/[slug].html",
+           "routeType": "fallback",
+           "response": "initial",
+           "compute": "static",
+           "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/fallback\\/([^\\/]+?)\\.json$",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/gsp/no-fallback/[slug]": {
+           "routeRegex": "^\\/gsp\\/no\\-fallback\\/([^\\/]+?)(?:\\/)?$",
+           "dataRoute": "/_next/data/BUILD_ID/gsp/no-fallback/[slug].json",
+           "fallback": false,
+           "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/no\\-fallback\\/([^\\/]+?)\\.json$",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/not-found/blocking-fallback/[slug]": {
+           "routeRegex": "^\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)(?:\\/)?$",
+           "dataRoute": "/_next/data/BUILD_ID/not-found/blocking-fallback/[slug].json",
+           "fallback": null,
+           "routeType": "page",
+           "response": "empty",
+           "compute": "blocking",
+           "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)\\.json$",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/not-found/fallback/[slug]": {
+           "routeRegex": "^\\/not\\-found\\/fallback\\/([^\\/]+?)(?:\\/)?$",
+           "dataRoute": "/_next/data/BUILD_ID/not-found/fallback/[slug].json",
+           "fallback": "/not-found/fallback/[slug].html",
+           "routeType": "fallback",
+           "response": "initial",
+           "compute": "static",
+           "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/fallback\\/([^\\/]+?)\\.json$",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         }
+       }"
       `)
     })
   }

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -94,6 +94,22 @@ describe('Prerender', () => {
     'x-next-revalidate-tag-token',
   ]
 
+  const completeStaticPageClassification = {
+    routeType: 'page',
+    response: 'complete',
+    compute: 'static',
+  }
+  const initialStaticFallbackClassification = {
+    routeType: 'fallback',
+    response: 'initial',
+    compute: 'static',
+  }
+  const emptyBlockingPageClassification = {
+    routeType: 'page',
+    response: 'empty',
+    compute: 'blocking',
+  }
+
   const expectedManifestRoutes = () => ({
     '/': {
       allowHeader,
@@ -1721,9 +1737,22 @@ describe('Prerender', () => {
           })
 
           expect(manifest.version).toBe(4)
-          expect(manifest.routes).toEqual(expectedManifestRoutes())
+          expect(manifest.routes).toEqual(
+            Object.fromEntries(
+              Object.entries(expectedManifestRoutes()).map(
+                ([pathname, route]) => [
+                  pathname,
+                  {
+                    ...route,
+                    ...completeStaticPageClassification,
+                  },
+                ]
+              )
+            )
+          )
           expect(manifest.dynamicRoutes).toEqual({
             '/api-docs/[...slug]': {
+              ...initialStaticFallbackClassification,
               dataRoute: `/_next/data/${next.buildId}/api-docs/[...slug].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/api\\-docs\\/(.+?)\\.json$`
@@ -1733,6 +1762,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/blocking-fallback-once/[slug]': {
+              ...emptyBlockingPageClassification,
               dataRoute: `/_next/data/${next.buildId}/blocking-fallback-once/[slug].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\-once\\/([^\\/]+?)\\.json$`
@@ -1744,6 +1774,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/blocking-fallback-some/[slug]': {
+              ...emptyBlockingPageClassification,
               dataRoute: `/_next/data/${next.buildId}/blocking-fallback-some/[slug].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\-some\\/([^\\/]+?)\\.json$`
@@ -1755,6 +1786,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/blocking-fallback/[slug]': {
+              ...emptyBlockingPageClassification,
               dataRoute: `/_next/data/${next.buildId}/blocking-fallback/[slug].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\/([^\\/]+?)\\.json$`
@@ -1766,6 +1798,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/blog/[post]': {
+              ...initialStaticFallbackClassification,
               fallback: '/blog/[post].html',
               dataRoute: `/_next/data/${next.buildId}/blog/[post].json`,
               dataRouteRegex: normalizeRegEx(
@@ -1775,6 +1808,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/blog/[post]/[comment]': {
+              ...initialStaticFallbackClassification,
               fallback: '/blog/[post]/[comment].html',
               dataRoute: `/_next/data/${next.buildId}/blog/[post]/[comment].json`,
               dataRouteRegex: normalizeRegEx(
@@ -1795,6 +1829,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/fallback-only/[slug]': {
+              ...initialStaticFallbackClassification,
               dataRoute: `/_next/data/${next.buildId}/fallback-only/[slug].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/fallback\\-only\\/([^\\/]+?)\\.json$`
@@ -1806,6 +1841,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/fallback-true/[slug]': {
+              ...initialStaticFallbackClassification,
               allowHeader,
               dataRoute: `/_next/data/${next.buildId}/fallback-true/[slug].json`,
               dataRouteRegex: normalizeRegEx(
@@ -1828,6 +1864,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/non-json-blocking/[p]': {
+              ...emptyBlockingPageClassification,
               dataRoute: `/_next/data/${next.buildId}/non-json-blocking/[p].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/non\\-json\\-blocking\\/([^\\/]+?)\\.json$`
@@ -1839,6 +1876,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/non-json/[p]': {
+              ...initialStaticFallbackClassification,
               dataRoute: `/_next/data/${next.buildId}/non-json/[p].json`,
               dataRouteRegex: normalizeRegEx(
                 `^\\/_next\\/data\\/${escapedBuildId}\\/non\\-json\\/([^\\/]+?)\\.json$`
@@ -1850,6 +1888,7 @@ describe('Prerender', () => {
               allowHeader,
             },
             '/user/[user]/profile': {
+              ...initialStaticFallbackClassification,
               fallback: '/user/[user]/profile.html',
               dataRoute: `/_next/data/${next.buildId}/user/[user]/profile.json`,
               dataRouteRegex: normalizeRegEx(
@@ -1862,6 +1901,7 @@ describe('Prerender', () => {
             },
 
             '/catchall/[...slug]': {
+              ...initialStaticFallbackClassification,
               fallback: '/catchall/[...slug].html',
               routeRegex: normalizeRegEx('^\\/catchall\\/(.+?)(?:\\/)?$'),
               dataRoute: `/_next/data/${next.buildId}/catchall/[...slug].json`,

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/adapter-prerender-metadata-non-cc.test.ts
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/adapter-prerender-metadata-non-cc.test.ts
@@ -1,0 +1,151 @@
+import { nextTestSetup } from 'e2e-utils'
+import type { NextAdapter } from 'next'
+
+type AdapterBuildContext = Parameters<NextAdapter['onBuildComplete']>[0]
+
+type Classification = {
+  routeType: 'route' | 'page' | 'fallback'
+  response: 'complete' | 'initial' | 'empty'
+  compute: 'static' | 'blocking'
+}
+
+const classificationKey = ({ routeType, response, compute }: Classification) =>
+  `${routeType}/${response}/${compute}`
+
+// Cache Components CI enables the feature for every fixture through this
+// environment variable, which would change the expected non-CC taxonomy.
+// Skip the whole suite so nextTestSetup does not start a build in that job.
+;(process.env.__NEXT_CACHE_COMPONENTS === 'true' ? describe.skip : describe)(
+  'adapter-prerender-metadata-non-cc',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+    })
+
+    async function getPrerenders() {
+      const { outputs }: AdapterBuildContext = await next.readJSON(
+        'build-complete.json'
+      )
+      return outputs.prerenders
+    }
+
+    it('exercises every valid non-Cache-Components combination', async () => {
+      const cases: Array<
+        Classification & {
+          pathname: string
+          manifestSection: 'routes' | 'dynamicRoutes'
+        }
+      > = [
+        {
+          pathname: '/static-route',
+          manifestSection: 'routes',
+          routeType: 'route',
+          response: 'complete',
+          compute: 'static',
+        },
+        {
+          pathname: '/',
+          manifestSection: 'routes',
+          routeType: 'page',
+          response: 'complete',
+          compute: 'static',
+        },
+        {
+          pathname: '/gsp',
+          manifestSection: 'routes',
+          routeType: 'page',
+          response: 'complete',
+          compute: 'static',
+        },
+        {
+          pathname: '/products/[slug]',
+          manifestSection: 'dynamicRoutes',
+          routeType: 'page',
+          response: 'empty',
+          compute: 'blocking',
+        },
+        {
+          pathname: '/blocking/[id]',
+          manifestSection: 'dynamicRoutes',
+          routeType: 'page',
+          response: 'empty',
+          compute: 'blocking',
+        },
+        {
+          pathname: '/static-fallback/[id]',
+          manifestSection: 'dynamicRoutes',
+          routeType: 'fallback',
+          response: 'initial',
+          compute: 'static',
+        },
+      ]
+
+      const expectedKeys = [
+        'route/complete/static',
+        'page/complete/static',
+        'page/empty/blocking',
+        'fallback/initial/static',
+      ]
+      expect(Array.from(new Set(cases.map(classificationKey))).sort()).toEqual(
+        expectedKeys.sort()
+      )
+
+      const prerenders = await getPrerenders()
+      const manifest = await next.readJSON('.next/prerender-manifest.json')
+      for (const { pathname, manifestSection, ...classification } of cases) {
+        const output = prerenders.find(
+          (prerender) => prerender.pathname === pathname
+        )
+        expect(output).toMatchObject(classification)
+        expect(manifest[manifestSection][pathname]).toMatchObject(
+          classification
+        )
+      }
+
+      const omittedFallback = prerenders.find(
+        (prerender) => prerender.pathname === '/omitted/[id]'
+      )
+      expect(omittedFallback).toBeDefined()
+      expect(omittedFallback).not.toHaveProperty('routeType')
+      expect(omittedFallback).not.toHaveProperty('response')
+      expect(omittedFallback).not.toHaveProperty('compute')
+    })
+
+    it('exposes classification only on canonical responses', async () => {
+      const prerenders = await getPrerenders()
+      const completePage = prerenders.find((output) => output.pathname === '/')
+      const blockingPage = prerenders.find(
+        (output) => output.pathname === '/products/[slug]'
+      )
+      const route = prerenders.find(
+        (output) => output.pathname === '/static-route'
+      )
+      const rsc = prerenders.find((output) => output.pathname === '/index.rsc')
+
+      expect(completePage).toMatchObject({
+        routeType: 'page',
+        response: 'complete',
+        compute: 'static',
+        htmlSize: expect.any(Number),
+      })
+      expect(blockingPage).toMatchObject({
+        routeType: 'page',
+        response: 'empty',
+        compute: 'blocking',
+      })
+      expect(blockingPage).not.toHaveProperty('htmlSize')
+      expect(route).toMatchObject({
+        routeType: 'route',
+        response: 'complete',
+        compute: 'static',
+      })
+      expect(route).not.toHaveProperty('htmlSize')
+
+      expect(rsc).toBeDefined()
+      expect(rsc).not.toHaveProperty('routeType')
+      expect(rsc).not.toHaveProperty('response')
+      expect(rsc).not.toHaveProperty('compute')
+      expect(rsc).not.toHaveProperty('htmlSize')
+    })
+  }
+)

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/app/layout.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/app/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>static page</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/app/products/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/app/products/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>product {slug}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/app/static-route/route.ts
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/app/static-route/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-static'
+
+export function GET() {
+  return Response.json({ static: true })
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/my-adapter.mjs
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/my-adapter.mjs
@@ -1,0 +1,9 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter } */
+export default {
+  name: 'adapter-prerender-metadata-non-cc',
+  async onBuildComplete(ctx) {
+    await fs.writeFile('build-complete.json', JSON.stringify(ctx, null, 2))
+  },
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/next.config.js
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/blocking/[id].tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/blocking/[id].tsx
@@ -1,0 +1,14 @@
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { id: 'known' } }],
+    fallback: 'blocking',
+  }
+}
+
+export function getStaticProps({ params }: { params: { id: string } }) {
+  return { props: { id: params.id } }
+}
+
+export default function Page({ id }: { id: string }) {
+  return <p>blocking {id}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/gsp.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/gsp.tsx
@@ -1,0 +1,7 @@
+export function getStaticProps() {
+  return { props: { message: 'pages static props' } }
+}
+
+export default function Page({ message }: { message: string }) {
+  return <p>{message}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/omitted/[id].tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/omitted/[id].tsx
@@ -1,0 +1,14 @@
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { id: 'known' } }],
+    fallback: false,
+  }
+}
+
+export function getStaticProps({ params }: { params: { id: string } }) {
+  return { props: { id: params.id } }
+}
+
+export default function Page({ id }: { id: string }) {
+  return <p>omitted {id}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/static-fallback/[id].tsx
+++ b/test/production/app-dir/adapter-prerender-metadata-non-cc/pages/static-fallback/[id].tsx
@@ -1,0 +1,11 @@
+export function getStaticPaths() {
+  return { paths: [], fallback: true }
+}
+
+export function getStaticProps({ params }: { params: { id: string } }) {
+  return { props: { id: params.id } }
+}
+
+export default function Page({ id }: { id: string }) {
+  return <p>static fallback {id}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts
+++ b/test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts
@@ -3,6 +3,30 @@ import type { NextAdapter } from 'next'
 
 type AdapterBuildContext = Parameters<NextAdapter['onBuildComplete']>[0]
 
+type Classification = {
+  routeType: 'route' | 'page' | 'shell' | 'fallback'
+  response: 'complete' | 'initial' | 'empty'
+  compute: 'static' | 'resuming' | 'blocking'
+}
+
+const validClassifications: Classification[] = [
+  { routeType: 'route', response: 'complete', compute: 'static' },
+  { routeType: 'page', response: 'complete', compute: 'static' },
+  { routeType: 'page', response: 'initial', compute: 'static' },
+  { routeType: 'page', response: 'initial', compute: 'resuming' },
+  { routeType: 'page', response: 'empty', compute: 'blocking' },
+  { routeType: 'shell', response: 'complete', compute: 'static' },
+  { routeType: 'shell', response: 'initial', compute: 'static' },
+  { routeType: 'shell', response: 'initial', compute: 'resuming' },
+  { routeType: 'shell', response: 'empty', compute: 'blocking' },
+  { routeType: 'fallback', response: 'complete', compute: 'static' },
+  { routeType: 'fallback', response: 'initial', compute: 'static' },
+  { routeType: 'fallback', response: 'initial', compute: 'resuming' },
+]
+
+const classificationKey = ({ routeType, response, compute }: Classification) =>
+  `${routeType}/${response}/${compute}`
+
 describe('adapter-prerender-metadata', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -14,6 +38,175 @@ describe('adapter-prerender-metadata', () => {
     )
     return outputs.prerenders
   }
+
+  async function getPrerenderManifest() {
+    return next.readJSON('.next/prerender-manifest.json')
+  }
+
+  it('exercises every valid classification combination', async () => {
+    const cases: Array<
+      Classification & {
+        pathname: string
+        manifestSection: 'routes' | 'dynamicRoutes'
+      }
+    > = [
+      {
+        pathname: '/static-route',
+        manifestSection: 'routes',
+        routeType: 'route',
+        response: 'complete',
+        compute: 'static',
+      },
+      {
+        pathname: '/static',
+        manifestSection: 'routes',
+        routeType: 'page',
+        response: 'complete',
+        compute: 'static',
+      },
+      {
+        pathname: '/client-hole',
+        manifestSection: 'routes',
+        routeType: 'page',
+        response: 'initial',
+        compute: 'static',
+      },
+      {
+        pathname: '/ppr-shell',
+        manifestSection: 'routes',
+        routeType: 'page',
+        response: 'initial',
+        compute: 'resuming',
+      },
+      {
+        pathname: '/empty-shell',
+        manifestSection: 'routes',
+        routeType: 'page',
+        response: 'empty',
+        compute: 'blocking',
+      },
+      {
+        pathname: '/combinations/fallback-complete-static/known/[rest]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'shell',
+        response: 'complete',
+        compute: 'static',
+      },
+      {
+        pathname: '/combinations/shell-initial-static/[slug]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'shell',
+        response: 'initial',
+        compute: 'static',
+      },
+      {
+        pathname: '/prefix/b/[two]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'shell',
+        response: 'initial',
+        compute: 'resuming',
+      },
+      {
+        pathname: '/combinations/shell-empty-blocking/[slug]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'shell',
+        response: 'empty',
+        compute: 'blocking',
+      },
+      {
+        pathname: '/combinations/fallback-complete-static/[slug]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'fallback',
+        response: 'complete',
+        compute: 'static',
+      },
+      {
+        pathname: '/combinations/fallback-initial-static/[slug]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'fallback',
+        response: 'initial',
+        compute: 'static',
+      },
+      {
+        pathname: '/blog/[slug]',
+        manifestSection: 'dynamicRoutes',
+        routeType: 'fallback',
+        response: 'initial',
+        compute: 'resuming',
+      },
+    ]
+
+    const exercisedKeys = cases.map(classificationKey)
+    const expectedKeys = validClassifications.map(classificationKey)
+    expect(Array.from(new Set(exercisedKeys)).sort()).toEqual(
+      expectedKeys.sort()
+    )
+
+    const prerenders = await getPrerenders()
+    const manifest = await getPrerenderManifest()
+    for (const { pathname, manifestSection, ...classification } of cases) {
+      const output = prerenders.find(
+        (prerender) => prerender.pathname === pathname
+      )
+      expect(output).toMatchObject(classification)
+      expect(manifest[manifestSection][pathname]).toMatchObject(classification)
+    }
+  })
+
+  it('persists canonical classifications in the prerender manifest', async () => {
+    const manifest = await getPrerenderManifest()
+
+    expect(manifest.routes['/static']).toMatchObject({
+      renderingMode: 'PARTIALLY_STATIC',
+      routeType: 'page',
+      response: 'complete',
+      compute: 'static',
+      htmlSize: expect.any(Number),
+    })
+    expect(manifest.routes['/client-hole']).toMatchObject({
+      routeType: 'page',
+      response: 'initial',
+      compute: 'static',
+      htmlSize: expect.any(Number),
+    })
+    expect(manifest.routes['/empty-shell']).toMatchObject({
+      routeType: 'page',
+      response: 'empty',
+      compute: 'blocking',
+      htmlSize: 0,
+    })
+    expect(manifest.dynamicRoutes['/blog/[slug]']).toMatchObject({
+      routeType: 'fallback',
+      response: 'initial',
+      compute: 'resuming',
+      htmlSize: expect.any(Number),
+    })
+    expect(manifest.dynamicRoutes['/blocking/[id]']).toMatchObject({
+      routeType: 'page',
+      response: 'empty',
+      compute: 'blocking',
+    })
+    expect(manifest.dynamicRoutes['/static-fallback/[id]']).toMatchObject({
+      routeType: 'fallback',
+      response: 'initial',
+      compute: 'static',
+    })
+    expect(manifest.routes['/static-route']).toMatchObject({
+      routeType: 'route',
+      response: 'complete',
+      compute: 'static',
+    })
+    expect(manifest.routes['/empty-route']).toMatchObject({
+      routeType: 'route',
+      response: 'complete',
+      compute: 'static',
+    })
+
+    const omittedFallback = manifest.dynamicRoutes['/omitted/[id]']
+    expect(omittedFallback).not.toHaveProperty('routeType')
+    expect(omittedFallback).not.toHaveProperty('response')
+    expect(omittedFallback).not.toHaveProperty('compute')
+  })
 
   it('classifies a complete static app page', async () => {
     const prerenders = await getPrerenders()
@@ -28,7 +221,7 @@ describe('adapter-prerender-metadata', () => {
     // no dynamic params: the prerender serves exactly one URL
     expect(staticPage.routeType).toBe('page')
     // visually complete on initial load
-    expect(staticPage.ui).toBe('complete')
+    expect(staticPage.response).toBe('complete')
     // no per-request compute
     expect(staticPage.compute).toBe('static')
     // full static shell on disk
@@ -47,7 +240,7 @@ describe('adapter-prerender-metadata', () => {
     // prerender
     expect(template.routeType).toBe('fallback')
     // the shell contains pending UI for the params/dynamic content
-    expect(template.ui).toBe('partial')
+    expect(template.response).toBe('initial')
     // the prerender postponed, so serving it resumes on the server
     expect(template.compute).toBe('resuming')
     expect(template.htmlSize).toBeGreaterThan(0)
@@ -66,7 +259,7 @@ describe('adapter-prerender-metadata', () => {
     expect(generic).toBeDefined()
     expect(generic.route).toBe('/prefix/[one]/[two]')
     expect(generic.routeType).toBe('fallback')
-    expect(generic.ui).toBe('partial')
+    expect(generic.response).toBe('initial')
     expect(generic.compute).toBe('resuming')
 
     // partial fallback: all prerenderable params are present; [two] is a
@@ -74,11 +267,57 @@ describe('adapter-prerender-metadata', () => {
     expect(partial).toBeDefined()
     expect(partial.route).toBe('/prefix/[one]/[two]')
     expect(partial.routeType).toBe('shell')
-    expect(partial.ui).toBe('partial')
+    expect(partial.response).toBe('initial')
     expect(partial.compute).toBe('resuming')
   })
 
-  it('classifies client-resolving pending UI as partial without compute', async () => {
+  it('upgrades a complete static fallback to a shell after filling one param', async () => {
+    const prerenders = await getPrerenders()
+    const concrete = prerenders.find(
+      (output) =>
+        output.pathname === '/combinations/fallback-complete-static/known'
+    )
+    const generic = prerenders.find(
+      (output) =>
+        output.pathname ===
+        '/combinations/fallback-complete-static/[slug]/[rest]'
+    )
+    const partial = prerenders.find(
+      (output) =>
+        output.pathname ===
+        '/combinations/fallback-complete-static/known/[rest]'
+    )
+
+    // The fully resolved route is a page serving exactly one URL.
+    expect(concrete).toBeDefined()
+    expect(concrete.route).toBe('/combinations/fallback-complete-static/[slug]')
+    expect(concrete.routeType).toBe('page')
+    expect(concrete.response).toBe('complete')
+    expect(concrete.compute).toBe('static')
+
+    // [slug] can still be filled by generateStaticParams, so this is an
+    // upgradable fallback for the source route.
+    expect(generic).toBeDefined()
+    expect(generic.route).toBe(
+      '/combinations/fallback-complete-static/[slug]/[rest]'
+    )
+    expect(generic.routeType).toBe('fallback')
+    expect(generic.response).toBe('complete')
+    expect(generic.compute).toBe('static')
+
+    // generateStaticParams filled [slug], but [rest] remains unresolved and
+    // is not prerenderable. The response therefore serves a class of URLs,
+    // but it can no longer be specialized by another generated param.
+    expect(partial).toBeDefined()
+    expect(partial.route).toBe(
+      '/combinations/fallback-complete-static/[slug]/[rest]'
+    )
+    expect(partial.routeType).toBe('shell')
+    expect(partial.response).toBe('complete')
+    expect(partial.compute).toBe('static')
+  })
+
+  it('classifies client-resolving pending UI as initial without compute', async () => {
     const prerenders = await getPrerenders()
     const clientHole = prerenders.find(
       (output) => output.pathname === '/client-hole'
@@ -89,10 +328,37 @@ describe('adapter-prerender-metadata', () => {
     expect(clientHole.routeType).toBe('page')
     // the HTML contains a Suspense fallback that resolves on the client
     // (useSearchParams)...
-    expect(clientHole.ui).toBe('partial')
+    expect(clientHole.response).toBe('initial')
     // ...but serving it needs no per-request compute
     expect(clientHole.compute).toBe('static')
     expect(clientHole.htmlSize).toBeGreaterThan(0)
+  })
+
+  it('classifies an empty Cache Components shell as blocking', async () => {
+    const prerenders = await getPrerenders()
+    const emptyShell = prerenders.find(
+      (output) => output.pathname === '/empty-shell'
+    )
+
+    expect(emptyShell).toBeDefined()
+    expect(emptyShell.routeType).toBe('page')
+    expect(emptyShell.response).toBe('empty')
+    expect(emptyShell.compute).toBe('blocking')
+    expect(emptyShell.htmlSize).toBe(0)
+  })
+
+  it('classifies static Route Handler bodies as complete routes', async () => {
+    const prerenders = await getPrerenders()
+
+    for (const pathname of ['/static-route', '/empty-route']) {
+      const route = prerenders.find((output) => output.pathname === pathname)
+      expect(route).toBeDefined()
+      expect(route.routeType).toBe('route')
+      expect(route.response).toBe('complete')
+      expect(route.compute).toBe('static')
+      expect(route).not.toHaveProperty('htmlSize')
+      expect(route.fallback.filePath.endsWith(`${pathname}.body`)).toBe(true)
+    }
   })
 
   it('classifies concrete prerenders that postponed as resuming', async () => {
@@ -113,101 +379,104 @@ describe('adapter-prerender-metadata', () => {
     expect(concrete.route).toBe('/blog/[slug]')
     expect(concrete.pathname).not.toBe(concrete.route)
     expect(concrete.routeType).toBe('page')
-    expect(concrete.ui).toBe('partial')
+    expect(concrete.response).toBe('initial')
     expect(concrete.compute).toBe('resuming')
 
     expect(pprShell).toBeDefined()
     expect(pprShell.routeType).toBe('page')
-    expect(pprShell.ui).toBe('partial')
+    expect(pprShell.response).toBe('initial')
     expect(pprShell.compute).toBe('resuming')
     expect(pprShell.htmlSize).toBeGreaterThan(0)
 
     // even when the whole page postpones (loading.tsx boundary), the shell
     // still contains the root layout HTML under cacheComponents, so
-    // htmlSize is > 0 and the UI is partial rather than empty
+    // htmlSize is > 0 and the response is initial rather than empty
     expect(pagePostponed).toBeDefined()
     expect(pagePostponed.routeType).toBe('page')
-    expect(pagePostponed.ui).toBe('partial')
+    expect(pagePostponed.response).toBe('initial')
     expect(pagePostponed.compute).toBe('resuming')
     expect(pagePostponed.htmlSize).toBeGreaterThan(0)
   })
 
-  it('classifies pages router prerenders', async () => {
+  it('classifies Pages Router prerenders', async () => {
     const prerenders = await getPrerenders()
     const gsp = prerenders.find((output) => output.pathname === '/gsp')
     const blockingTemplate = prerenders.find(
       (output) => output.pathname === '/blocking/[id]'
     )
+    const staticFallback = prerenders.find(
+      (output) => output.pathname === '/static-fallback/[id]'
+    )
     const omittedTemplate = prerenders.find(
       (output) => output.pathname === '/omitted/[id]'
     )
 
-    // concrete pages-router prerender: complete static HTML
     expect(gsp).toBeDefined()
     expect(gsp.route).toBe('/gsp')
+    expect(gsp.config.renderingMode).toBeUndefined()
     expect(gsp.routeType).toBe('page')
-    expect(gsp.ui).toBe('complete')
+    expect(gsp.response).toBe('complete')
     expect(gsp.compute).toBe('static')
-    expect(gsp.htmlSize).toBeUndefined()
+    expect(gsp).not.toHaveProperty('htmlSize')
 
-    // fallback: 'blocking' template — [id] is prerenderable via
-    // getStaticPaths, but no shell was produced: the server renders
-    // before any UI is ready
     expect(blockingTemplate).toBeDefined()
     expect(blockingTemplate.route).toBe('/blocking/[id]')
-    expect(blockingTemplate.routeType).toBe('fallback')
-    expect(blockingTemplate.ui).toBe('empty')
+    expect(blockingTemplate.config.renderingMode).toBeUndefined()
+    expect(blockingTemplate.routeType).toBe('page')
+    expect(blockingTemplate.response).toBe('empty')
     expect(blockingTemplate.compute).toBe('blocking')
-    expect(blockingTemplate.htmlSize).toBeUndefined()
+    expect(blockingTemplate).not.toHaveProperty('htmlSize')
 
-    // fallback: false (omitted) template — no shell, and unmatched paths
-    // 404 instead of rendering, so compute does not apply
-    // (parentFallbackMode `false` marks the entry as not served)
+    expect(staticFallback).toBeDefined()
+    expect(staticFallback.route).toBe('/static-fallback/[id]')
+    expect(staticFallback.config.renderingMode).toBeUndefined()
+    expect(staticFallback.routeType).toBe('fallback')
+    expect(staticFallback.response).toBe('initial')
+    expect(staticFallback.compute).toBe('static')
+    expect(staticFallback).not.toHaveProperty('htmlSize')
+
+    // fallback: false templates exist in the adapter graph, but are never
+    // served for an unmatched URL and therefore have no classification.
     expect(omittedTemplate).toBeDefined()
     expect(omittedTemplate.route).toBe('/omitted/[id]')
-    expect(omittedTemplate.routeType).toBe('fallback')
-    expect(omittedTemplate.ui).toBe('empty')
-    expect(omittedTemplate.compute).toBeUndefined()
-    expect(omittedTemplate.htmlSize).toBeUndefined()
+    expect(omittedTemplate.config.renderingMode).toBeUndefined()
+    expect(omittedTemplate).not.toHaveProperty('routeType')
+    expect(omittedTemplate).not.toHaveProperty('response')
+    expect(omittedTemplate).not.toHaveProperty('compute')
+    expect(omittedTemplate).not.toHaveProperty('htmlSize')
   })
 
-  it('mirrors route-level fields on secondary outputs and keeps htmlSize HTML-only', async () => {
+  it('keeps classification on canonical outputs only', async () => {
     const prerenders = await getPrerenders()
 
-    // RSC data output of a concrete app page (spread from initialOutput)
+    const expectUnclassified = (output: any) => {
+      expect(output).not.toHaveProperty('routeType')
+      expect(output).not.toHaveProperty('response')
+      expect(output).not.toHaveProperty('compute')
+      expect(output).not.toHaveProperty('htmlSize')
+    }
+
     const staticRsc = prerenders.find(
       (output) => output.pathname === '/static.rsc'
     )
     expect(staticRsc).toBeDefined()
     expect(staticRsc.route).toBe('/static')
-    expect(staticRsc.routeType).toBe('page')
-    expect(staticRsc.ui).toBe('complete')
-    expect(staticRsc.compute).toBe('static')
-    expect(staticRsc.htmlSize).toBeUndefined()
+    expectUnclassified(staticRsc)
 
-    // RSC output of a fallback template (spread from initialOutput)
     const templateRsc = prerenders.find(
       (output) => output.pathname === '/blog/[slug].rsc'
     )
     expect(templateRsc).toBeDefined()
     expect(templateRsc.route).toBe('/blog/[slug]')
-    expect(templateRsc.routeType).toBe('fallback')
-    expect(templateRsc.ui).toBe('partial')
-    expect(templateRsc.compute).toBe('resuming')
-    expect(templateRsc.htmlSize).toBeUndefined()
+    expectUnclassified(templateRsc)
 
-    // segment prerenders (built as fresh literals in handleAppMeta) must
-    // carry the same route-level fields as their HTML output
     const segments = prerenders.filter((output) =>
       output.pathname.startsWith('/blog/[slug].segments/')
     )
     expect(segments.length).toBeGreaterThan(0)
     for (const segment of segments) {
       expect(segment.route).toBe('/blog/[slug]')
-      expect(segment.routeType).toBe('fallback')
-      expect(segment.ui).toBe('partial')
-      expect(segment.compute).toBe('resuming')
-      expect(segment.htmlSize).toBeUndefined()
+      expectUnclassified(segment)
     }
   })
 })

--- a/test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts
+++ b/test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts
@@ -1,0 +1,213 @@
+import { nextTestSetup } from 'e2e-utils'
+import type { NextAdapter } from 'next'
+
+type AdapterBuildContext = Parameters<NextAdapter['onBuildComplete']>[0]
+
+describe('adapter-prerender-metadata', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  async function getPrerenders() {
+    const { outputs }: AdapterBuildContext = await next.readJSON(
+      'build-complete.json'
+    )
+    return outputs.prerenders
+  }
+
+  it('classifies a complete static app page', async () => {
+    const prerenders = await getPrerenders()
+    const staticPage = prerenders.find(
+      (output) => output.pathname === '/static'
+    )
+
+    expect(staticPage).toBeDefined()
+    // route is the source route matcher; for a non-dynamic page it equals
+    // the pathname
+    expect(staticPage.route).toBe('/static')
+    // no dynamic params: the prerender serves exactly one URL
+    expect(staticPage.routeType).toBe('page')
+    // visually complete on initial load
+    expect(staticPage.ui).toBe('complete')
+    // no per-request compute
+    expect(staticPage.compute).toBe('static')
+    // full static shell on disk
+    expect(staticPage.htmlSize).toBeGreaterThan(0)
+  })
+
+  it('classifies an upgradable app template as fallback', async () => {
+    const prerenders = await getPrerenders()
+    const template = prerenders.find(
+      (output) => output.pathname === '/blog/[slug]'
+    )
+
+    expect(template).toBeDefined()
+    expect(template.route).toBe('/blog/[slug]')
+    // [slug] is prerenderable (generateStaticParams) and missing from this
+    // prerender
+    expect(template.routeType).toBe('fallback')
+    // the shell contains pending UI for the params/dynamic content
+    expect(template.ui).toBe('partial')
+    // the prerender postponed, so serving it resumes on the server
+    expect(template.compute).toBe('resuming')
+    expect(template.htmlSize).toBeGreaterThan(0)
+  })
+
+  it('classifies a terminal partial fallback as shell', async () => {
+    const prerenders = await getPrerenders()
+    const generic = prerenders.find(
+      (output) => output.pathname === '/prefix/[one]/[two]'
+    )
+    const partial = prerenders.find(
+      (output) => output.pathname === '/prefix/b/[two]'
+    )
+
+    // generic template: [one] can still be filled by generateStaticParams
+    expect(generic).toBeDefined()
+    expect(generic.route).toBe('/prefix/[one]/[two]')
+    expect(generic.routeType).toBe('fallback')
+    expect(generic.ui).toBe('partial')
+    expect(generic.compute).toBe('resuming')
+
+    // partial fallback: all prerenderable params are present; [two] is a
+    // dynamic param, so this is the generic UI for a class of URLs
+    expect(partial).toBeDefined()
+    expect(partial.route).toBe('/prefix/[one]/[two]')
+    expect(partial.routeType).toBe('shell')
+    expect(partial.ui).toBe('partial')
+    expect(partial.compute).toBe('resuming')
+  })
+
+  it('classifies client-resolving pending UI as partial without compute', async () => {
+    const prerenders = await getPrerenders()
+    const clientHole = prerenders.find(
+      (output) => output.pathname === '/client-hole'
+    )
+
+    expect(clientHole).toBeDefined()
+    // one URL, no dynamic params
+    expect(clientHole.routeType).toBe('page')
+    // the HTML contains a Suspense fallback that resolves on the client
+    // (useSearchParams)...
+    expect(clientHole.ui).toBe('partial')
+    // ...but serving it needs no per-request compute
+    expect(clientHole.compute).toBe('static')
+    expect(clientHole.htmlSize).toBeGreaterThan(0)
+  })
+
+  it('classifies concrete prerenders that postponed as resuming', async () => {
+    const prerenders = await getPrerenders()
+    const concrete = prerenders.find(
+      (output) => output.pathname === '/blog/first'
+    )
+    const pprShell = prerenders.find(
+      (output) => output.pathname === '/ppr-shell'
+    )
+    const pagePostponed = prerenders.find(
+      (output) => output.pathname === '/page-postponed'
+    )
+
+    // concrete prerendered path: no dynamic params remain, and the
+    // pathname differs from the route matcher
+    expect(concrete).toBeDefined()
+    expect(concrete.route).toBe('/blog/[slug]')
+    expect(concrete.pathname).not.toBe(concrete.route)
+    expect(concrete.routeType).toBe('page')
+    expect(concrete.ui).toBe('partial')
+    expect(concrete.compute).toBe('resuming')
+
+    expect(pprShell).toBeDefined()
+    expect(pprShell.routeType).toBe('page')
+    expect(pprShell.ui).toBe('partial')
+    expect(pprShell.compute).toBe('resuming')
+    expect(pprShell.htmlSize).toBeGreaterThan(0)
+
+    // even when the whole page postpones (loading.tsx boundary), the shell
+    // still contains the root layout HTML under cacheComponents, so
+    // htmlSize is > 0 and the UI is partial rather than empty
+    expect(pagePostponed).toBeDefined()
+    expect(pagePostponed.routeType).toBe('page')
+    expect(pagePostponed.ui).toBe('partial')
+    expect(pagePostponed.compute).toBe('resuming')
+    expect(pagePostponed.htmlSize).toBeGreaterThan(0)
+  })
+
+  it('classifies pages router prerenders', async () => {
+    const prerenders = await getPrerenders()
+    const gsp = prerenders.find((output) => output.pathname === '/gsp')
+    const blockingTemplate = prerenders.find(
+      (output) => output.pathname === '/blocking/[id]'
+    )
+    const omittedTemplate = prerenders.find(
+      (output) => output.pathname === '/omitted/[id]'
+    )
+
+    // concrete pages-router prerender: complete static HTML
+    expect(gsp).toBeDefined()
+    expect(gsp.route).toBe('/gsp')
+    expect(gsp.routeType).toBe('page')
+    expect(gsp.ui).toBe('complete')
+    expect(gsp.compute).toBe('static')
+    expect(gsp.htmlSize).toBeUndefined()
+
+    // fallback: 'blocking' template — [id] is prerenderable via
+    // getStaticPaths, but no shell was produced: the server renders
+    // before any UI is ready
+    expect(blockingTemplate).toBeDefined()
+    expect(blockingTemplate.route).toBe('/blocking/[id]')
+    expect(blockingTemplate.routeType).toBe('fallback')
+    expect(blockingTemplate.ui).toBe('empty')
+    expect(blockingTemplate.compute).toBe('blocking')
+    expect(blockingTemplate.htmlSize).toBeUndefined()
+
+    // fallback: false (omitted) template — no shell, and unmatched paths
+    // 404 instead of rendering, so compute does not apply
+    // (parentFallbackMode `false` marks the entry as not served)
+    expect(omittedTemplate).toBeDefined()
+    expect(omittedTemplate.route).toBe('/omitted/[id]')
+    expect(omittedTemplate.routeType).toBe('fallback')
+    expect(omittedTemplate.ui).toBe('empty')
+    expect(omittedTemplate.compute).toBeUndefined()
+    expect(omittedTemplate.htmlSize).toBeUndefined()
+  })
+
+  it('mirrors route-level fields on secondary outputs and keeps htmlSize HTML-only', async () => {
+    const prerenders = await getPrerenders()
+
+    // RSC data output of a concrete app page (spread from initialOutput)
+    const staticRsc = prerenders.find(
+      (output) => output.pathname === '/static.rsc'
+    )
+    expect(staticRsc).toBeDefined()
+    expect(staticRsc.route).toBe('/static')
+    expect(staticRsc.routeType).toBe('page')
+    expect(staticRsc.ui).toBe('complete')
+    expect(staticRsc.compute).toBe('static')
+    expect(staticRsc.htmlSize).toBeUndefined()
+
+    // RSC output of a fallback template (spread from initialOutput)
+    const templateRsc = prerenders.find(
+      (output) => output.pathname === '/blog/[slug].rsc'
+    )
+    expect(templateRsc).toBeDefined()
+    expect(templateRsc.route).toBe('/blog/[slug]')
+    expect(templateRsc.routeType).toBe('fallback')
+    expect(templateRsc.ui).toBe('partial')
+    expect(templateRsc.compute).toBe('resuming')
+    expect(templateRsc.htmlSize).toBeUndefined()
+
+    // segment prerenders (built as fresh literals in handleAppMeta) must
+    // carry the same route-level fields as their HTML output
+    const segments = prerenders.filter((output) =>
+      output.pathname.startsWith('/blog/[slug].segments/')
+    )
+    expect(segments.length).toBeGreaterThan(0)
+    for (const segment of segments) {
+      expect(segment.route).toBe('/blog/[slug]')
+      expect(segment.routeType).toBe('fallback')
+      expect(segment.ui).toBe('partial')
+      expect(segment.compute).toBe('resuming')
+      expect(segment.htmlSize).toBeUndefined()
+    }
+  })
+})

--- a/test/production/app-dir/adapter-prerender-metadata/app/blog/[slug]/loading.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/blog/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>loading...</div>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/blog/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/blog/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+
+async function Dynamic() {
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return <div>Custom Data</div>
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return (
+    <div>
+      <div>{slug}</div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/client-hole/client.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/client-hole/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+
+export function ClientHole() {
+  const searchParams = useSearchParams()
+  return <p>q: {searchParams?.get('q')}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/client-hole/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/client-hole/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import { ClientHole } from './client'
+
+export default function Page() {
+  return (
+    <div>
+      <p>static part</p>
+      <Suspense fallback={<p>loading...</p>}>
+        <ClientHole />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/client-hole.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/client-hole.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+export function ClientHole() {
+  return <p>query: {useSearchParams()?.get('query')}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-complete-static/[slug]/[rest]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-complete-static/[slug]/[rest]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>complete static partial fallback</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-complete-static/[slug]/layout.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-complete-static/[slug]/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-complete-static/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-complete-static/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>complete static fallback</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-initial-static/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/fallback-initial-static/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+import { ClientHole } from '../../client-hole'
+
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>loading query</p>}>
+      <ClientHole />
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/shell-complete-static/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/shell-complete-static/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>complete static shell</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/shell-empty-blocking/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/shell-empty-blocking/[slug]/page.tsx
@@ -1,0 +1,8 @@
+import { cookies } from 'next/headers'
+
+export const instant = false
+
+export default async function Page() {
+  await cookies()
+  return <p>empty blocking shell</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/combinations/shell-initial-static/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/combinations/shell-initial-static/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import { ClientHole } from '../../client-hole'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>loading query</p>}>
+      <ClientHole />
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/empty-route/route.ts
+++ b/test/production/app-dir/adapter-prerender-metadata/app/empty-route/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return new Response(null)
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/empty-shell/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/empty-shell/page.tsx
@@ -1,0 +1,8 @@
+import { cookies } from 'next/headers'
+
+export const instant = false
+
+export default async function Page() {
+  await cookies()
+  return <p>empty shell</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/layout.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/page-postponed/loading.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/page-postponed/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>loading...</div>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/page-postponed/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/page-postponed/page.tsx
@@ -1,0 +1,6 @@
+import { headers } from 'next/headers'
+
+export default async function Page() {
+  const requestHeaders = await headers()
+  return <div>{requestHeaders.get('user-agent')}</div>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/ppr-shell/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/ppr-shell/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+
+async function Dynamic() {
+  const requestHeaders = await headers()
+  return <div>{requestHeaders.get('user-agent')}</div>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <p>static shell content</p>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/prefix/[one]/[two]/loading.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/prefix/[one]/[two]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>loading...</div>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/prefix/[one]/[two]/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/prefix/[one]/[two]/page.tsx
@@ -1,0 +1,13 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ one: string; two: string }>
+}) {
+  const { one, two } = await params
+
+  return (
+    <div>
+      {one}:{two}
+    </div>
+  )
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/prefix/[one]/layout.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/prefix/[one]/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export function generateStaticParams() {
+  return [{ one: 'b' }]
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/static-route/route.ts
+++ b/test/production/app-dir/adapter-prerender-metadata/app/static-route/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ static: true })
+}

--- a/test/production/app-dir/adapter-prerender-metadata/app/static/page.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/app/static/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>fully static shell</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/my-adapter.mjs
+++ b/test/production/app-dir/adapter-prerender-metadata/my-adapter.mjs
@@ -1,0 +1,9 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter } */
+export default {
+  name: 'adapter-prerender-metadata',
+  async onBuildComplete(ctx) {
+    await fs.writeFile('build-complete.json', JSON.stringify(ctx, null, 2))
+  },
+}

--- a/test/production/app-dir/adapter-prerender-metadata/next.config.js
+++ b/test/production/app-dir/adapter-prerender-metadata/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/adapter-prerender-metadata/pages/blocking/[id].tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/pages/blocking/[id].tsx
@@ -1,0 +1,14 @@
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { id: 'a' } }],
+    fallback: 'blocking',
+  }
+}
+
+export function getStaticProps({ params }: { params: { id: string } }) {
+  return { props: { id: params.id } }
+}
+
+export default function Page({ id }: { id: string }) {
+  return <p>blocking {id}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/pages/gsp.tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/pages/gsp.tsx
@@ -1,0 +1,7 @@
+export function getStaticProps() {
+  return { props: { message: 'pages static props' } }
+}
+
+export default function Page({ message }: { message: string }) {
+  return <p>{message}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/pages/omitted/[id].tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/pages/omitted/[id].tsx
@@ -1,0 +1,14 @@
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { id: 'a' } }],
+    fallback: false,
+  }
+}
+
+export function getStaticProps({ params }: { params: { id: string } }) {
+  return { props: { id: params.id } }
+}
+
+export default function Page({ id }: { id: string }) {
+  return <p>omitted {id}</p>
+}

--- a/test/production/app-dir/adapter-prerender-metadata/pages/static-fallback/[id].tsx
+++ b/test/production/app-dir/adapter-prerender-metadata/pages/static-fallback/[id].tsx
@@ -1,0 +1,11 @@
+export function getStaticPaths() {
+  return { paths: [], fallback: true }
+}
+
+export function getStaticProps({ params }) {
+  return { props: { id: params.id } }
+}
+
+export default function Page({ id }) {
+  return <p>static fallback {id}</p>
+}


### PR DESCRIPTION
Building on top of @agadzik work (see first commit)

Adds prerender route metadata to help downstream consumers understand the nature of build-time prerenders

We break down prerender taxonomy as follows

routeType describes what the prerender serves:
* `route`: a non-UI endpoint, such as a Route Handler.
* `page`: a page whose route parameters are fully known.
* `shell`: a reusable PPR shell for a parameterized page.
* `fallback`: a fallback that may serve or specialize additional parameter values.

response describes how complete the static response is:
* `complete`: the prerender contains the completed response.
* `initial`: an initial response is available, but the page UI is incomplete; in practice this applies to partially prerenderable UI routes.
* `empty`: there is no initial static response to send.

compute describes the request-time work required:
* `static`: no request-time server compute is needed.
* `resuming`: request-time compute resumes from the static response.
* `blocking`: the initial response is blocked until request-time compute starts, but it may stream while that compute continues.

`htmlSize` reports the byte size of prerendered HTML when the output has HTML.

The taxonomy is included only on a prerender group’s canonical primary output—the HTML output for pages or the response output for Route Handlers—and is omitted from secondary RSC and segment-data outputs.