### PR TITLE
[test] Unflake more tests

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -111,6 +111,36 @@ async function applyInstallSecuritySettings(installDir, isolationRoot) {
 }
 
 /**
+ * pnpm only honors overrides at the workspace root, so they go into the
+ * `pnpm-workspace.yaml` that governs the install.
+ *
+ * @param {string} installDir
+ * @param {string} isolationRoot
+ * @param {Record<string, string>} overrides
+ * @returns {Promise<void>}
+ */
+async function applyWorkspaceOverrides(installDir, isolationRoot, overrides) {
+  const workspaceFile = await findConfigFile(
+    'pnpm-workspace.yaml',
+    installDir,
+    isolationRoot
+  )
+  if (workspaceFile === null) {
+    return
+  }
+
+  const workspaceConfig =
+    /** @type {Record<string, any>} */ (
+      yaml.load(await fs.readFile(workspaceFile, 'utf8'))
+    ) ?? {}
+  workspaceConfig.overrides = {
+    ...overrides,
+    ...(workspaceConfig.overrides || {}),
+  }
+  await fs.writeFile(workspaceFile, yaml.dump(workspaceConfig))
+}
+
+/**
  *
  * @param {object} param0
  * @param {import('@next/telemetry').Span} param0.parentSpan
@@ -276,13 +306,6 @@ async function createNextInstall({
               ...workspacePkgOverrides,
               ...(packageJson.overrides || {}),
             },
-            pnpm: {
-              ...(packageJson.pnpm || {}),
-              overrides: {
-                ...workspacePkgOverrides,
-                ...(packageJson.pnpm?.overrides || {}),
-              },
-            },
             resolutions: {
               ...workspacePkgOverrides,
               ...(resolutions || {}),
@@ -311,6 +334,10 @@ async function createNextInstall({
         : null
 
       await applyInstallSecuritySettings(installDir, isolationRoot)
+      await applyWorkspaceOverrides(installDir, isolationRoot, {
+        ...workspacePkgOverrides,
+        ...(resolutions || {}),
+      })
 
       if (installString !== null) {
         console.log('running install command', installString)
@@ -324,6 +351,23 @@ async function createNextInstall({
         await rootSpan
           .traceChild('run generic install command', combinedDependencies)
           .traceAsyncFn(() => installDependencies(installDir, tmpDir))
+
+        // `@next/env` is a dependency of `next`, so it only resolves to the
+        // local tarball if the overrides were applied.
+        if (!combinedDependencies['@next/env']) {
+          const envDir = await fs.realpath(
+            path.join(
+              await fs.realpath(path.join(installDir, 'node_modules/next')),
+              '../@next/env'
+            )
+          )
+          if (!envDir.includes('@next+env@file')) {
+            throw new Error(
+              `@next/env resolved from the npm registry instead of the local tarball (${envDir}), ` +
+                'the workspace overrides were not applied to the install'
+            )
+          }
+        }
       }
 
       if (useRspack) {

--- a/test/production/ci-missing-typescript-deps/index.test.ts
+++ b/test/production/ci-missing-typescript-deps/index.test.ts
@@ -92,17 +92,9 @@ describe('ci-missing-typescript-deps', () => {
         '@types/react': 'npm:types-react@beta',
         '@types/react-dom': 'npm:types-react-dom@beta',
       },
-      packageJson: {
-        overrides: {
-          '@types/react': 'npm:types-react@beta',
-          '@types/react-dom': 'npm:types-react-dom@beta',
-        },
-        pnpm: {
-          overrides: {
-            '@types/react': 'npm:types-react@beta',
-            '@types/react-dom': 'npm:types-react-dom@beta',
-          },
-        },
+      resolutions: {
+        '@types/react': 'npm:types-react@beta',
+        '@types/react-dom': 'npm:types-react-dom@beta',
       },
     })
 

--- a/test/unit/image-optimizer/detect-content-type.test.ts
+++ b/test/unit/image-optimizer/detect-content-type.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 
 const getImage = (filepath: string) => readFile(join(__dirname, filepath))
 
-const detectContentType = async (buffer: Buffer, isRetry = false) => {
+const detectContentType = async (buffer: Buffer, attempt = 0) => {
   let maxBlockedMs = 0
   let lastTick = performance.now()
   let running = true
@@ -25,13 +25,14 @@ const detectContentType = async (buffer: Buffer, isRetry = false) => {
   maxBlockedMs = Math.max(maxBlockedMs, performance.now() - lastTick)
 
   if (maxBlockedMs > 1) {
-    if (isRetry) {
+    // The sampled gaps also include JIT warmup and scheduler noise; a real
+    // regression (GHSA-q8wf-6r8g-63ch) fails every attempt.
+    if (attempt >= 4) {
       throw new Error(
         `detectContentType blocked the event loop for ${maxBlockedMs.toFixed(1)}ms`
       )
     } else {
-      // try again because the first run after compile can be slow due to JIT optimizations
-      return await detectContentType(buffer, true)
+      return await detectContentType(buffer, attempt + 1)
     }
   }
   return result


### PR DESCRIPTION
- `detectContentType` test was too aggressive about asserting completion in 1ms, let's give it several tries.
- We weren't correctly setting up pnpm overrides in tests, which breaks things whenever canary comes out.