### PR TITLE
[Not for merge] Fixture for sourcemaps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -96,3 +96,4 @@ test/production/app-dir/symbolic-file-links/src/app/page.tsx
 turbopack/crates/turbopack-tracing/tests/node-file-trace/integration/pnpm/node_modules/*
 turbopack/crates/turbopack-tracing/tests/node-file-trace/integration/symlink-to-file/linked.js
 turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/component
+test/unit/fake-stack-frames/react-flight-semantics.js

--- a/test/unit/fake-stack-frames.test.ts
+++ b/test/unit/fake-stack-frames.test.ts
@@ -1,0 +1,7265 @@
+/**
+ * Exercises the semantics of React's fake stack frames for revived errors
+ * against the real Next.js modules that participate in them, without a
+ * bundler or a dev server. See fake-stack-frames/scenario.js for the moving
+ * pieces.
+ *
+ * Each scenario's observations are pinned as an inline snapshot of the whole
+ * result — stack text, terminal rendering, debugger symbolication, fake
+ * scripts, owner task chains — normalized only where output is
+ * machine-specific (paths) or volatile (line numbers of the harness and of
+ * Node.js internals, `data:` source map payloads, padding runs). The
+ * snapshots encode the current behavior, including its defects, so that any
+ * change to the machinery shows up as a diff here.
+ */
+/* eslint jest/no-standalone-expect: ["error", { "additionalTestBlockFunctions": ["itObservesTaskChains"] }] */
+
+import { execFileSync } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as url from 'url'
+
+const scenarioPath = require.resolve('./fake-stack-frames/scenario.js')
+const repoRoot = path.resolve(__dirname, '../..')
+const nextDist = path.join(
+  path.dirname(require.resolve('next/package.json')),
+  'dist'
+)
+
+interface SymbolicatedFrame {
+  frame: {
+    methodName: string
+    url: string
+    line1: number
+    column1: number
+  } | null
+  script?: { hasSourceMap: boolean } | null
+  original?: { source: string; line1: number } | null
+}
+
+interface OwnerTask {
+  description: string
+  top: SymbolicatedFrame | null
+}
+
+interface OverlayFrame {
+  status: 'fulfilled' | 'rejected'
+  reason?: string
+  value?: {
+    originalStackFrame: {
+      file: string
+      methodName: string
+      line1: number | null
+      column1: number | null
+      ignored: boolean
+    }
+    originalCodeFrame: string | null
+  }
+}
+
+interface Hop {
+  environmentName: string
+  stack: string
+  symbolicated: SymbolicatedFrame
+  symbolicatedCaller?: SymbolicatedFrame
+  symbolicatedThrow?: SymbolicatedFrame
+  symbolicatedModuleFrame?: SymbolicatedFrame
+  stackWithoutMessage?: string
+  ownerTasks?: OwnerTask[]
+  overlayFrames?: OverlayFrame[]
+  cause?: Hop
+  errors?: Hop[]
+  revivedConstructor?: string
+  terminal: string
+}
+
+interface ScenarioResult {
+  hops: Hop[]
+  fakeScripts: {
+    url: string
+    sourceMapURL: string
+    source?: string
+    resolvedSourceMap?: { version: number } | null
+  }[]
+  digests?: string[]
+  htmlHandler?: Record<string, boolean>
+  browserLogs?: {
+    kind: string
+    frames: { frameText: string; hasCodeFrame: boolean }[] | null
+    consoleLocation: string | null
+    decorated: string[]
+  }
+  endpoint?: Record<string, { status: number | string; hasMap: boolean }>
+  dir: string
+}
+
+/**
+ * Known invariant violations, declared by the test that owns the scenario.
+ * Entries name the place within the run (e.g. `hop 0 top`, `hop 1 cause`).
+ */
+interface KnownDefects {
+  // Fake `about://React/` frames whose position does not resolve through
+  // their script's own source map (the debugger falls back to the fake
+  // script's generated position).
+  unresolvedFakeFrames?: string[]
+  // Terminal output showing a raw `about://React/` URL: when the frame's
+  // position falls into a mapping hole, `frameToString` prints the fake
+  // sourceURL without devirtualizing it.
+  rawTerminalURLs?: string[]
+  // Fake scripts (matched by URL substring) whose `http:` source map URL the
+  // dev server answers with no content, leaving the debugger unable to map
+  // the script at all.
+  unmappedFakeScripts?: string[]
+}
+
+// `Runtime.getExceptionDetails` only reports the `console.createTask` chain
+// on Node.js 24+, so tests observing owner task chains cannot run on the
+// older versions CI uses.
+const itObservesTaskChains =
+  Number(process.versions.node.split('.')[0]) >= 24 ? it : it.skip
+
+function runScenario(
+  name: string,
+  extraEnv: Record<string, string> = {},
+  moduleFormat: 'cjs' | 'esm' = 'cjs',
+  knownDefects: KnownDefects = {}
+): ScenarioResult {
+  const stdout = execFileSync(
+    process.execPath,
+    ['--enable-source-maps', scenarioPath, name, moduleFormat],
+    {
+      encoding: 'utf8',
+      // Terminal output renders paths relative to the working directory.
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        NEXT_DIST: nextDist,
+        ...extraEnv,
+      },
+    }
+  )
+  const result: ScenarioResult = JSON.parse(stdout)
+  fs.rmSync(result.dir, { recursive: true, force: true })
+  verifyInvariants(result, knownDefects)
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Universal invariants
+// ---------------------------------------------------------------------------
+// Checked on every scenario run, in both directions: a violation the test
+// did not declare fails, and a declared defect that stops reproducing
+// fails too, so fixing one forces its declaration to be deleted.
+
+function verifyInvariants(
+  result: ScenarioResult,
+  knownDefects: KnownDefects
+): void {
+  // Every fake stack frame script must carry an inline, parseable source
+  // map — `createFakeFunction` only mints `about://React/` URLs when
+  // `findSourceMapURL` returned one.
+  const unmappedFakeScripts = new Set(knownDefects.unmappedFakeScripts)
+  for (const script of result.fakeScripts) {
+    if (!script.url.startsWith('about://React/')) continue
+    // The browser consumer's `findSourceMapURL` returns dev server endpoint
+    // URLs instead of inline data URLs; the scenario resolves those through
+    // the real middleware so the map can still be verified.
+    const payload = script.sourceMapURL.startsWith('http:')
+      ? script.resolvedSourceMap
+      : (expect(script.sourceMapURL).toMatch(/^data:application\/json;base64,/),
+        JSON.parse(
+          Buffer.from(
+            script.sourceMapURL.slice('data:application/json;base64,'.length),
+            'base64'
+          ).toString('utf8')
+        ))
+    const declared = [...unmappedFakeScripts].find((substring) =>
+      script.url.includes(substring)
+    )
+    if (declared !== undefined) {
+      // A declared unmapped script must keep coming back empty until the
+      // defect is fixed.
+      expect({ url: script.url, map: payload ?? null }).toEqual({
+        url: script.url,
+        map: null,
+      })
+      continue
+    }
+    expect({ url: script.url, version: payload?.version }).toEqual({
+      url: script.url,
+      version: 3,
+    })
+  }
+  // Every declared unmapped script must have matched a fake script.
+  for (const substring of unmappedFakeScripts) {
+    expect(
+      result.fakeScripts.some((script) => script.url.includes(substring))
+    ).toBe(true)
+  }
+
+  const unresolvedFakeFrames = new Set(knownDefects.unresolvedFakeFrames)
+  const rawTerminalURLs = new Set(knownDefects.rawTerminalURLs)
+
+  const checkFrame = (
+    symbolicated: SymbolicatedFrame | null | undefined,
+    at: string
+  ) => {
+    const frame = symbolicated?.frame
+    if (!frame || !frame.url.startsWith('about://React/')) return
+    const resolved =
+      symbolicated!.original !== null && symbolicated!.original !== undefined
+    const expected = !unresolvedFakeFrames.has(at)
+    expect({ at, resolved }).toEqual({ at, resolved: expected })
+  }
+
+  const visitHop = (hop: Hop, place: string) => {
+    checkFrame(hop.symbolicated, `${place} top`)
+    checkFrame(hop.symbolicatedCaller, `${place} caller`)
+    checkFrame(hop.symbolicatedThrow, `${place} throw`)
+    checkFrame(hop.symbolicatedModuleFrame, `${place} module`)
+    hop.ownerTasks?.forEach((task) =>
+      checkFrame(task.top, `${place} owner ${task.description}`)
+    )
+    const showsAboutURL = hop.terminal.includes('about://React/')
+    const expected = rawTerminalURLs.has(place)
+    expect({ at: place, showsAboutURL }).toEqual({
+      at: place,
+      showsAboutURL: expected,
+    })
+    if (hop.cause) visitHop(hop.cause, `${place} cause`)
+    hop.errors?.forEach((inner, index) =>
+      visitHop(inner, `${place} errors[${index}]`)
+    )
+  }
+  result.hops.forEach((hop, index) => visitHop(hop, `hop ${index}`))
+}
+
+/**
+ * Replaces machine-specific and volatile output with stable placeholders:
+ * the scenario's temp directory (in file URL, absolute, and
+ * relative-to-either-root spellings) becomes `<tmp>`, the repository root
+ * `<repo>`, positions inside the harness and Node.js internals `<pos>`
+ * (they shift with every edit or Node.js upgrade), and base64 source map
+ * payloads `<map>`.
+ */
+function createNormalizer(dir: string): (text: string) => string {
+  const substitutions: [string, string][] = [
+    [url.pathToFileURL(dir).href, 'file://<tmp>'],
+    // The endpoint query string carries the percent-encoded filename.
+    [encodeURIComponent(dir), '<tmp>'],
+    [encodeURIComponent(repoRoot), '<repo>'],
+    [path.relative(repoRoot, dir), '<tmp>'],
+    [path.relative(dir, repoRoot), '<repo>'],
+    [dir, '<tmp>'],
+    [url.pathToFileURL(repoRoot).href, 'file://<repo>'],
+    [repoRoot, '<repo>'],
+  ]
+  return (text) => {
+    for (const [from, to] of substitutions) {
+      text = text.split(from).join(to)
+    }
+    return (
+      text
+        .replace(
+          /(scenario\.js|react-flight-semantics\.js|flight-client\/index\.js|node:internal\/[\w/]+)(\?\d+)?:\d+:\d+/g,
+          '$1$2:<pos>'
+        )
+        // Fake scripts minted for the harness's own frames pad to the
+        // harness's geometry, which shifts with every scenario edit.
+        .replace(
+          /(scenario\.js\?\d+\n {2}map: [^\n]+\n {2}\| \(\{"[^"]*":_=>)[^\n]*(_\(\)\}\))/g,
+          '$1<padding>$2'
+        )
+        .replace(/data:application\/json;base64,[A-Za-z0-9+/=]+/g, '<map>')
+        // The overlay endpoint renders code frames with colors.
+        // eslint-disable-next-line no-control-regex
+        .replace(/\x1b\[[0-9;]*m/g, '')
+        // Hashed digests embed the stack text, so their values are
+        // machine-specific.
+        .replace(/digest: '\d+(@E\d+)?'/g, "digest: '<hash>$1'")
+        // Long `../` runs escape the repo root, so their length depends on
+        // where the repo sits on the machine.
+        .replace(/(?:\.\.\/){3,}/g, '<up>/')
+        .replace(/\n{3,}/g, (run) => `<${run.length} newlines>`)
+        .replace(/ {8,}/g, (run) => `<${run.length} spaces>`)
+        // Node.js 24 collapses duplicate stack lines in `util.inspect`;
+        // older versions print every line. Fold both renderings to the
+        // same text.
+        .replace(
+          /\.\.\. collapsed (\d+) duplicate lines matching above \d+ lines \d+ times\.\.\./g,
+          '... repeated $1 more times ...'
+        )
+        .split('\n')
+        .reduce<string[]>((lines, line) => {
+          const previous = lines[lines.length - 1]
+          if (line.trim() !== '' && line === previous) {
+            lines.push(line)
+            return lines
+          }
+          let count = 0
+          while (
+            lines.length >= 2 &&
+            lines[lines.length - 1] === lines[lines.length - 2]
+          ) {
+            lines.pop()
+            count++
+          }
+          if (count > 1) {
+            const indent = previous.match(/^\s*/)![0]
+            lines.push(`${indent}... repeated ${count} more times ...`)
+          } else {
+            for (let i = 0; i < count; i++) lines.push(previous)
+          }
+          lines.push(line)
+          return lines
+        }, [])
+        .join('\n')
+    )
+  }
+}
+
+/**
+ * Renders a scenario result as one snapshot-friendly document. Everything
+ * observable is included: per hop the revived stack text, the terminal
+ * (`util.inspect`) rendering, and the debugger's view of each observed
+ * frame; then owner task chains, overlay resolutions, nested cause/errors
+ * hops, and the fake scripts the consumer evaled.
+ */
+function renderScenario(result: ScenarioResult): string {
+  const normalize = createNormalizer(result.dir)
+  const lines: string[] = []
+  const indent = (text: string, prefix = '  ') =>
+    text
+      .split('\n')
+      .map((line) => (prefix + line).trimEnd())
+      .join('\n')
+
+  const renderFrame = (symbolicated: SymbolicatedFrame): string => {
+    if (symbolicated.frame === null) {
+      return 'no frame'
+    }
+    const { methodName, url: frameURL, line1, column1 } = symbolicated.frame
+    let out = `${methodName || '<no name>'} at ${frameURL}:${line1}:${column1}`
+    if (symbolicated.script === null) {
+      out += '\n  script: not loaded'
+    } else if (!symbolicated.script!.hasSourceMap) {
+      out += '\n  script: no source map'
+    } else if (
+      symbolicated.original === null ||
+      symbolicated.original === undefined
+    ) {
+      out += '\n  script: has source map, position unmapped'
+    } else {
+      out += `\n  original: ${symbolicated.original.source}:${symbolicated.original.line1}`
+    }
+    return out
+  }
+
+  const renderHop = (hop: Hop, label: string) => {
+    lines.push(`== ${label} (${hop.environmentName}) ==`)
+    lines.push('error.stack (the raw string):')
+    lines.push(indent(hop.stack))
+    lines.push('terminal (the dev server prints through the patched inspect):')
+    lines.push(indent(hop.terminal))
+    lines.push(
+      'top frame (as an attached debugger resolves it): ' +
+        indent(renderFrame(hop.symbolicated)).trim()
+    )
+    const extraFrames: [string, SymbolicatedFrame | undefined][] = [
+      ['caller frame', hop.symbolicatedCaller],
+      ['throw frame', hop.symbolicatedThrow],
+      ['module frame', hop.symbolicatedModuleFrame],
+    ]
+    for (const [frameLabel, symbolicated] of extraFrames) {
+      if (symbolicated !== undefined) {
+        lines.push(`${frameLabel}: ` + indent(renderFrame(symbolicated)).trim())
+      }
+    }
+    if (hop.revivedConstructor !== undefined) {
+      lines.push(`constructor: ${hop.revivedConstructor}`)
+    }
+    if (hop.stackWithoutMessage !== undefined) {
+      lines.push('getStackWithoutErrorMessage:')
+      lines.push(indent(hop.stackWithoutMessage))
+    }
+    if (hop.ownerTasks !== undefined) {
+      lines.push('owner tasks:')
+      for (const task of hop.ownerTasks) {
+        lines.push(`  ${task.description}`)
+        if (task.top !== null) {
+          lines.push(indent(renderFrame(task.top), '    '))
+        }
+      }
+    }
+    if (hop.overlayFrames !== undefined) {
+      lines.push('overlay frames:')
+      for (const frame of hop.overlayFrames) {
+        if (frame.status === 'rejected') {
+          lines.push(indent(`rejected: ${frame.reason}`))
+          continue
+        }
+        const { originalStackFrame, originalCodeFrame } = frame.value!
+        lines.push(
+          `  ${originalStackFrame.methodName} at ` +
+            `${originalStackFrame.file}:${originalStackFrame.line1}:${originalStackFrame.column1}` +
+            (originalStackFrame.ignored ? ' (ignored)' : '')
+        )
+        if (originalCodeFrame !== null) {
+          lines.push(indent(originalCodeFrame, '    | '))
+        }
+      }
+    }
+    if (hop.cause !== undefined) {
+      renderHop(hop.cause, `${label} cause`)
+    }
+    hop.errors?.forEach((inner, index) => {
+      renderHop(inner, `${label} errors[${index}]`)
+    })
+  }
+
+  result.hops.forEach((hop, index) => renderHop(hop, `hop ${index}`))
+
+  if (result.browserLogs !== undefined) {
+    const { kind, frames, consoleLocation, decorated } = result.browserLogs
+    lines.push('== browser log mapping ==')
+    lines.push(`  kind: ${kind}`)
+    for (const mappedFrame of frames ?? []) {
+      lines.push(
+        `  ${mappedFrame.frameText.trim()}${mappedFrame.hasCodeFrame ? ' [code frame]' : ''}`
+      )
+    }
+    lines.push(`  console location: ${consoleLocation}`)
+    lines.push(`  decorated: ${JSON.stringify(decorated)}`)
+  }
+
+  if (result.endpoint !== undefined) {
+    lines.push('== /__nextjs_source-map ==')
+    for (const [label, response] of Object.entries(result.endpoint)) {
+      lines.push(
+        `  ${label}: ${response.status}${response.hasMap ? ' with map' : ''}`
+      )
+    }
+  }
+
+  lines.push('== fake scripts ==')
+  for (const script of result.fakeScripts) {
+    lines.push(script.url)
+    lines.push(
+      `  map: ${script.sourceMapURL === '' ? '-' : script.sourceMapURL}`
+    )
+    if (script.source !== undefined) {
+      // Padding runs fold before indentation turns them into empty lines.
+      const folded = script.source
+        // Long `../` runs escape the repo root, so their length depends on
+        // where the repo sits on the machine.
+        .replace(/(?:\.\.\/){3,}/g, '<up>/')
+        .replace(/\n{3,}/g, (run) => `<${run.length} newlines>`)
+        .replace(/ {8,}/g, (run) => `<${run.length} spaces>`)
+      lines.push(indent(folded, '  | '))
+    }
+  }
+
+  return normalize(lines.join('\n'))
+}
+
+/**
+ * Chunk-loading scenarios run in both module formats in one snapshot:
+ * frames of CJS chunks carry file paths, frames of ES modules carry
+ * (percent-encoded) `file://` URLs, and Node.js keys their source maps
+ * through different loader caches — so path-encoding defects and symlink
+ * behavior differ between the two.
+ */
+function renderBothModes(name: string): string {
+  return [
+    '======== cjs ========',
+    renderScenario(runScenario(name)),
+    '======== esm ========',
+    renderScenario(runScenario(name, {}, 'esm')),
+  ].join('\n')
+}
+
+describe('react-flight-semantics.js', () => {
+  // Token-level comparison, insensitive to formatting: comments, whitespace,
+  // quote style, semicolons, and trailing commas.
+  function normalize(code: string): string {
+    return code
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '')
+      .replace(/\s+/g, '')
+      .replace(/'/g, '"')
+      .replace(/;/g, '')
+      .replace(/,\]/g, ']')
+      .replace(/,\)/g, ')')
+      .replace(/,\}/g, '}')
+  }
+
+  function extract(source: string, start: string, end: string): string {
+    const from = source.indexOf(start)
+    expect(from).not.toBe(-1)
+    const to = source.indexOf(end, from)
+    expect(to).not.toBe(-1)
+    return source.slice(from, to)
+  }
+
+  it('matches the vendored React implementation', () => {
+    const compiledDir = path.join(
+      path.dirname(require.resolve('next/package.json')),
+      'src/compiled/react-server-dom-webpack/cjs'
+    )
+    const server = fs.readFileSync(
+      path.join(
+        compiledDir,
+        'react-server-dom-webpack-server.node.development.js'
+      ),
+      'utf8'
+    )
+    const client = fs.readFileSync(
+      path.join(
+        compiledDir,
+        'react-server-dom-webpack-client.node.development.js'
+      ),
+      'utf8'
+    )
+    const copies = fs.readFileSync(
+      path.join(__dirname, 'fake-stack-frames/react-flight-semantics.js'),
+      'utf8'
+    )
+
+    const pieces: [string, string, string, string][] = [
+      [
+        'collectStackTracePrivate',
+        server,
+        'function collectStackTracePrivate(',
+        'function collectStackTrace(',
+      ],
+      [
+        'collectStackTrace',
+        server,
+        'function collectStackTrace(',
+        'function parseStackTracePrivate(',
+      ],
+      [
+        'parseStackTrace',
+        server,
+        'function parseStackTrace(error, skipFrames) {\n      var existing',
+        'function createTemporaryReference(',
+      ],
+      [
+        'devirtualizeURL',
+        server,
+        'function devirtualizeURL(',
+        'function isPromiseCreationInternal(',
+      ],
+      [
+        'filterStackTrace',
+        server,
+        'function filterStackTrace(',
+        'function hasUnfilteredFrame(',
+      ],
+      [
+        'objectName',
+        server,
+        'function objectName(',
+        'function describeKeyForErrorMessage(',
+      ],
+      [
+        'describeKeyForErrorMessage',
+        server,
+        'function describeKeyForErrorMessage(',
+        'function describeValueForErrorMessage(',
+      ],
+      [
+        'describeValueForErrorMessage',
+        server,
+        'function describeValueForErrorMessage(',
+        'function describeElementType(',
+      ],
+      [
+        'describeElementType',
+        server,
+        'function describeElementType(',
+        'function describeObjectForErrorMessage(',
+      ],
+      [
+        'describeObjectForErrorMessage',
+        server,
+        'function describeObjectForErrorMessage(',
+        'function defaultFilterStackFrame(',
+      ],
+      [
+        'serializeByValueID',
+        server,
+        'function serializeByValueID(',
+        'function serializeLazyID(',
+      ],
+      [
+        'serializeErrorValue',
+        server,
+        'function serializeErrorValue(',
+        'function emitErrorChunk(',
+      ],
+      [
+        'emitErrorChunk',
+        server,
+        'function emitErrorChunk(',
+        'function emitImportChunk(',
+      ],
+      [
+        'outlineComponentInfo',
+        server,
+        'function outlineComponentInfo(',
+        'function emitIOInfoChunk(',
+      ],
+      [
+        'createFakeFunction',
+        client,
+        'function createFakeFunction(',
+        'function buildFakeCallStack(',
+      ],
+      [
+        'buildFakeCallStack',
+        client,
+        'function buildFakeCallStack(',
+        'function getRootTask(',
+      ],
+      [
+        'getRootTask',
+        client,
+        'function getRootTask(',
+        'function initializeFakeTask(',
+      ],
+      [
+        'resolveErrorDev',
+        client,
+        'function resolveErrorDev(',
+        'function createFakeFunction(',
+      ],
+      [
+        'initializeFakeTask',
+        client,
+        'function initializeFakeTask(',
+        'function fakeJSXCallSite',
+      ],
+      [
+        'createModel',
+        client,
+        'function createModel(',
+        'function getInferredFunctionApproximate(',
+      ],
+      [
+        'parseModelString',
+        client,
+        'function parseModelString(',
+        'function missingCall(',
+      ],
+      ['reviveModel', client, 'function reviveModel(', 'function close('],
+      [
+        'ReactPromise',
+        client,
+        'function ReactPromise(',
+        'function hasGCedResponse(',
+      ],
+      [
+        'createPendingChunk',
+        client,
+        'function createPendingChunk(',
+        'function releasePendingChunk(',
+      ],
+      [
+        'createResolvedModelChunk',
+        client,
+        'function createResolvedModelChunk(',
+        'function createResolvedIteratorResultChunk(',
+      ],
+      ['getChunk', client, 'function getChunk(', 'function fulfillReference('],
+      ['parseModel', client, 'function parseModel(', 'function reviveModel('],
+      [
+        'initializeDebugChunk',
+        client,
+        'function initializeDebugChunk(',
+        'function initializeModelChunk(',
+      ],
+      [
+        'initializeModelChunk',
+        client,
+        'function initializeModelChunk(',
+        'function initializeModuleChunk(',
+      ],
+      [
+        'resolveLazy',
+        client,
+        'function resolveLazy(',
+        'function transferReferencedDebugInfo(',
+      ],
+      [
+        'filterDebugInfo',
+        client,
+        'function filterDebugInfo(',
+        'function moveDebugInfoFromChunkToInnerValue(',
+      ],
+      [
+        'moveDebugInfoFromChunkToInnerValue',
+        client,
+        'function moveDebugInfoFromChunkToInnerValue(',
+        'function wakeChunk(',
+      ],
+      [
+        'transferReferencedDebugInfo',
+        client,
+        'function transferReferencedDebugInfo(',
+        'function getOutlinedModel(',
+      ],
+      [
+        'getOutlinedModel',
+        client,
+        'function getOutlinedModel(',
+        'function createMap(',
+      ],
+    ]
+
+    for (const [name, vendoredSource, start, end] of pieces) {
+      const vendored = normalize(extract(vendoredSource, start, end))
+      const copyStart = copies.indexOf(`function ${name}(`)
+      expect(copyStart).not.toBe(-1)
+      const rest = copies.slice(copyStart)
+      const boundary =
+        /\n(?:function |var |const |\/\/ -|module\.exports)/.exec(
+          rest.slice(10)
+        )
+      const copy = normalize(
+        boundary === null ? rest : rest.slice(0, boundary.index + 10)
+      )
+      expect({ name, identical: copy === vendored }).toEqual({
+        name,
+        identical: true,
+      })
+    }
+
+    expect(
+      normalize(extract(copies, 'frameRegExp =', 'stackTraceCache ='))
+    ).toBe(normalize(extract(server, 'frameRegExp =', 'stackTraceCache =')))
+
+    for (const declaration of [
+      'supportsCreateTask = !!console.createTask',
+      'REACT_ELEMENT_TYPE = Symbol.for("react.transitional.element")',
+      'mightHaveStaticConstructor = /\\bclass\\b.*\\bstatic\\b/',
+      'isArrayImpl = Array.isArray',
+      'ASYNC_ITERATOR = Symbol.asyncIterator',
+      'isInitializingDebugInfo = !1',
+    ]) {
+      expect(client).toContain(declaration)
+      expect(copies).toContain(declaration)
+    }
+    for (const declaration of [
+      'stringify = JSON.stringify',
+      'jsxChildrenParents = new WeakMap()',
+      'jsxPropsParents = new WeakMap()',
+      'CLIENT_REFERENCE_TAG = Symbol.for("react.client.reference")',
+      'REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref")',
+      'REACT_VIEW_TRANSITION_TYPE = Symbol.for("react.view_transition")',
+    ]) {
+      expect(server).toContain(declaration)
+      expect(copies).toContain(declaration)
+    }
+  })
+})
+
+describe('fake stack frames', () => {
+  // The baseline mechanism: the producer serializes a thrown error's filtered
+  // stack, the consumer revives it by constructing the error inside a chain of
+  // eval'd fake functions, one per frame, each carrying a `sourceURL` and the
+  // source map served by `findSourceMapURLDEV`.
+  describe('reviving one error', () => {
+    it('revives an error with a source mapped fake stack frame', () => {
+      // TODO: the terminal code frame glues the printed properties' opening
+      // brace on as a phantom source line (the \`5 | {\` below, and in every
+      // code frame that reaches the end of the source).
+      expect(renderBothModes('one-hop')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at one-hop (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at one-hop (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Server/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at one-hop (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at one-hop (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Server/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('reproduces the fake script layout byte-for-byte across revivals', () => {
+      const result = runScenario('three-hops')
+      const reactScripts = result.fakeScripts.filter((script) =>
+        script.url.startsWith('about://React/')
+      )
+      expect(reactScripts).toHaveLength(3)
+      // Later revivals parse frames of the previous fake function, whose
+      // enclosing `_=>` position reproduces the same padding, so every hop
+      // evals a byte-identical script body.
+      expect(reactScripts[1].source).toBe(reactScripts[0].source)
+      expect(reactScripts[2].source).toBe(reactScripts[0].source)
+      // The `_()` call sits at the frame's own position, padded out with
+      // newlines and spaces.
+      const frame = result.hops[0].symbolicated.frame
+      expect(reactScripts[0].source).toBe(
+        '({"Object.throwsInChunk":_=>' +
+          '\n'.repeat(frame.line1 - 1) +
+          ' '.repeat(frame.column1 - 1) +
+          '_()})' +
+          '\n/* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */'
+      )
+      // The `?N` counter is per consumer, and each hop's consumer creates its
+      // first fake function here. A consumer that revived other frames before
+      // would count on.
+      for (const script of reactScripts) {
+        expect(script.url).toMatch(/\?0$/)
+      }
+    })
+
+    it('reuses fake stack frame scripts for identical frames', () => {
+      expect(renderScenario(runScenario('fake-function-cache')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fake-function-cache (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fake-function-cache (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fake-function-cache (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fake-function-cache (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('creates one fake script per consumer under colliding URLs', () => {
+      // Each consumer numbers its fake scripts with its own counter, so both
+      // evals produce the same `?0` URL.
+      expect(renderScenario(runScenario('fan-out-consumers')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fan-out-consumers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fan-out-consumers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fan-out-consumers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at fan-out-consumers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // `filterStackFrameDEV` decides which frames reach the wire.
+  describe('which frames serialize', () => {
+    it('serializes no frames for code in node_modules', () => {
+      expect(renderScenario(runScenario('node-modules-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at node-modules-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at node-modules-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/node_modules/some-pkg/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('serializes no frames for chunks in directories named like node_modules', () => {
+      // The stack frame filter matches `node_modules` as a substring.
+      // TODO: match whole path segments so project paths containing the
+      // substring keep their frames.
+      expect(renderBothModes('node-modules-substring-in-project-path'))
+        .toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at node-modules-substring-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at node-modules-substring-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/my_node_modules_backup/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at node-modules-substring-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at node-modules-substring-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/my_node_modules_backup/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('serializes no frames for chunks whose source map ignore-lists everything', () => {
+      expect(renderScenario(runScenario('ignore-listed-chunk')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at ignore-listed-chunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at ignore-listed-chunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('keeps frames of chunks whose source map ignore-lists only other sources', () => {
+      expect(renderScenario(runScenario('partial-ignore-list')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:partial
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at partial-ignore-list (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:partial
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at partial-ignore-list (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('drops `new Promise` frames', () => {
+      expect(renderScenario(runScenario('new-promise-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at new-promise-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at new-promise-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // How different callsites serialize and revive.
+  describe('frame shapes', () => {
+    it('keeps a leading space on the method name of async frames', () => {
+      // React strips the `async ` marker with `name.slice(5)`, which leaves
+      // the space, and the fake function's name keeps it.
+      // TODO: strip the marker without leaving a leading space in the name.
+      expect(renderScenario(runScenario('async-function-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:async
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:49)
+             at  Object.outer (about://React/Server/file://<tmp>/chunk.js?1:102:26)
+             at  async-function-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:async
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at  Object.outer (<tmp>/original.js:2:1)
+             at  async-function-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:49
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><100 newlines><48 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | ({" Object.outer":_=><101 newlines><25 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('preserves constructor frame names', () => {
+      expect(renderScenario(runScenario('constructor-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:constructor
+             at new Boom (about://React/Server/file://<tmp>/chunk.js?0:114:15)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at constructor-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:constructor
+             at new Boom (<tmp>/original.js:4:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at constructor-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           2 | export class Boom {
+           3 |   constructor() {
+         > 4 |     throw new Error('boom:constructor')
+             |<11 spaces>^
+           5 |   }
+           6 | }
+           7 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): new Boom at about://React/Server/file://<tmp>/chunk.js?0:114:15
+           original: file://<tmp>/original.js:4
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"new Boom":_=><113 newlines><14 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('revives native frames under <anonymous> at the fake script position', () => {
+      // Native frames serialize without a filename or position, so the fake
+      // frame's position is the `_()` call inside the one-line fake script.
+      expect(renderScenario(runScenario('native-and-builtin-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at Array.map (<anonymous>:1:18)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at native-and-builtin-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Array.map (<anonymous>:1:18)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at native-and-builtin-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('preserves the frame count of deep stacks', () => {
+      // The dev server raises `Error.stackTraceLimit` to 50; each recursive
+      // frame is revived through the same cached fake function.
+      expect(renderScenario(runScenario('deep-stack'))).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:deep
+             at recurses (file://<tmp>/chunk.js:101:45)
+             at recurses (file://<tmp>/chunk.js:101:78)
+             ... repeated 28 more times ...
+             at Object.recurses (file://<tmp>/chunk.js:101:78)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at deep-stack (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:deep
+             at recurses (<tmp>/chunk.js:101:45)
+             at recurses (<tmp>/chunk.js:101:78)
+             ... repeated 28 more times ...
+             at Object.recurses (<tmp>/chunk.js:101:78)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at deep-stack (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): recurses at file://<tmp>/chunk.js:101:45
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -"
+      `)
+    })
+
+    it("splits the eval origin of frames of eval'd scripts without a sourceURL", () => {
+      // React's stack frame regex matches the method name greedily, so the
+      // `eval at <fn> (` prefix of the eval origin ends up in the method name
+      // and the filename is only the origin's tail.
+      // TODO: parse the eval origin into the filename, not the method name.
+      expect(renderScenario(runScenario('anonymous-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:anonymous
+             at Object.throwsInChunk (eval at anonymous-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>),%20%3Canonymous%3E:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at anonymous-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:anonymous
+             at Object.throwsInChunk (file://file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at anonymous-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk (eval at anonymous-frames at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>),%20%3Canonymous%3E:101:34
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('revives module-evaluation frames', () => {
+      // The fixture's map has a single mapping, and lookups resolve to the
+      // nearest preceding entry.
+      expect(renderBothModes('module-evaluation-throw')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:evaluation
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at Object.<anonymous> (about://React/Server/file://<tmp>/chunk.js?1:115:1)
+             at loadChunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at module-evaluation-throw (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:evaluation
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Object.<anonymous> (<tmp>/original.js:5:1)
+             at loadChunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at module-evaluation-throw (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:evaluation')
+             |<9 spaces>^
+           4 | }
+           5 | throwsInChunk()
+           6 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       module frame: Object.<anonymous> at about://React/Server/file://<tmp>/chunk.js?1:115:1
+           original: file://<tmp>/original.js:5
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | ({"Object.<anonymous>":_=><114 newlines>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:evaluation
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (about://React/Server/file://<tmp>/chunk.mjs?1:105:1)
+             at  loadChunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  module-evaluation-throw (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:evaluation
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (<tmp>/original.js:5:1)
+             at  loadChunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  module-evaluation-throw (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:evaluation')
+             |<9 spaces>^
+           4 | }
+           5 | throwsInChunk()
+           6 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       module frame: <anonymous> at about://React/Server/file://<tmp>/chunk.mjs?1:105:1
+           original: file://<tmp>/original.js:5
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.mjs?1
+         map: <map>
+         | ({"<anonymous>":_=><104 newlines>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves every frame of stacks that span multiple chunks', () => {
+      expect(renderScenario(runScenario('multiple-chunks')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk-b.js
+             at throwsInChunk (about://React/Cache/file://<tmp>/chunk-b.js?0:113:11)
+             at Object.callsThrough (about://React/Cache/file://<tmp>/chunk-a.js?1:114:38)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multiple-chunks (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk-b.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Object.callsThrough (<tmp>/original.js:4:23)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multiple-chunks (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk-b.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Cache/file://<tmp>/chunk-b.js?0:113:11
+           original: file://<tmp>/original.js:3
+       caller frame: Object.callsThrough at about://React/Cache/file://<tmp>/chunk-a.js?1:114:38
+           original: file://<tmp>/original.js:4
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk-b.js
+             at throwsInChunk (about://React/Cache/file://<tmp>/chunk-b.js?0:113:11)
+             at Object.callsThrough (about://React/Cache/file://<tmp>/chunk-a.js?1:114:38)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multiple-chunks (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk-b.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Object.callsThrough (<tmp>/original.js:4:23)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multiple-chunks (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk-b.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Cache/file://<tmp>/chunk-b.js?0:113:11
+           original: file://<tmp>/original.js:3
+       caller frame: Object.callsThrough at about://React/Cache/file://<tmp>/chunk-a.js?1:114:38
+           original: file://<tmp>/original.js:4
+       == fake scripts ==
+       file://<tmp>/chunk-a.js
+         map: chunk-a.js.map
+       file://<tmp>/chunk-b.js
+         map: chunk-b.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk-b.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Cache/file://<tmp>/chunk-a.js?1
+         map: <map>
+         | ({"Object.callsThrough":_=><113 newlines><37 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk-b.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Cache/file://<tmp>/chunk-a.js?1
+         map: <map>
+         | ({"Object.callsThrough":_=><113 newlines><37 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('revives message lines that look like stack frames as frames', () => {
+      // The message survives intact, including its frame-shaped last line, but
+      // React's frame regex also matches that line, so the revived error
+      // additionally gets a fake `phantom` frame. Its position is the `_()`
+      // call inside the fake script: the phantom's 1:1 position takes the
+      // `line < 1` layout, which cannot represent the original position. The
+      // terminal formatter then re-parses the message's line as a frame too,
+      // so it prints three phantoms: the message text, its rewrite (as a
+      // root-escaping relative path), and the revived fake frame.
+      // TODO: frame-shaped message lines should not revive or print as
+      // extra frames.
+      expect(renderScenario(runScenario('multi-line-message')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: first line
+         second line
+             at phantom (file:///not-a-frame.js:1:1)
+             at phantom (file:///not-a-frame.js:1:16)
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multi-line-message (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: first line
+         second line
+             at phantom (file:///not-a-frame.js:1:1)
+             at phantom (<up>/not-a-frame.js:1:1)
+             at phantom (<up>/not-a-frame.js:1:16)
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multi-line-message (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): phantom at file:///not-a-frame.js:1:1
+           script: no source map
+       throw frame: throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       getStackWithoutErrorMessage:
+         second line
+             at phantom (file:///not-a-frame.js:1:1)
+             at phantom (file:///not-a-frame.js:1:16)
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multi-line-message (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // What the error object itself carries across the boundary.
+  describe('error shapes', () => {
+    it('applies a custom error name to the revived stack', () => {
+      // `resolveErrorDev` assigns the name after constructing the error, and
+      // V8 formats the stack with the current name on first access.
+      expect(renderScenario(runScenario('custom-error-name')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         CustomError: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at custom-error-name (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error [CustomError]: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at custom-error-name (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('replaces empty messages with the fallback message', () => {
+      expect(renderScenario(runScenario('empty-message')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: An error occurred in the Server Components render but no message was provided
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at empty-message (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: An error occurred in the Server Components render but no message was provided
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at empty-message (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('revives thrown non-Error values with a machinery-only stack', () => {
+      // `emitErrorChunk` serializes non-Error values with an empty stack, so
+      // the revived error's stack has only the revival machinery below it,
+      // and the terminal formatter collapses it entirely.
+      expect(renderScenario(runScenario('thrown-string')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:string
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:string
+             at ignore-listed frames {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.resolveErrorDev at <tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>
+           script: not loaded
+       == fake scripts ==
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('describes thrown non-Error objects in the message', () => {
+      expect(renderScenario(runScenario('thrown-object')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: {reason: "boom", code: 7}
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: {reason: "boom", code: 7}
+             at ignore-listed frames {
+           environmentName: 'Server',
+           digest: '<hash>@E394'
+         }
+       top frame (as an attached debugger resolves it): Object.resolveErrorDev at <tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>
+           script: not loaded
+       == fake scripts ==
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('revives the cause with its own fake stack', () => {
+      // Errors crossing as values (`serializeErrorValue`) carry no digest.
+      expect(renderScenario(runScenario('error-with-cause')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:outer
+             at Object.throwsOuter (about://React/Server/file://<tmp>/chunk.js?2:127:15)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-with-cause (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:outer
+             at Object.throwsOuter (<tmp>/original.js:9:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-with-cause (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+            7 |     throwsCause()
+            8 |   } catch (cause) {
+         >  9 |     throw new Error('boom:outer', { cause })
+              |<11 spaces>^
+           10 |   }
+           11 | }
+           12 | {
+           environmentName: 'Server',
+           digest: '<hash>',
+           [cause]: Error: boom:cause
+       <8 spaces>at throwsCause (<tmp>/original.js:3:9)
+       <8 spaces>at Object.throwsOuter (<tmp>/original.js:7:5)
+       <8 spaces>at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at error-with-cause (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsCause() {
+           > 3 |   throw new Error('boom:cause')
+       <8 spaces>|<9 spaces>^
+             4 | }
+             5 | export function throwsOuter() {
+             6 |   try { {
+             environmentName: 'Server'
+           }
+         }
+       top frame (as an attached debugger resolves it): Object.throwsOuter at about://React/Server/file://<tmp>/chunk.js?2:127:15
+           original: file://<tmp>/original.js:9
+       == hop 0 cause (Server) ==
+       error.stack (the raw string):
+         Error: boom:cause
+             at throwsCause (about://React/Server/file://<tmp>/chunk.js?0:121:11)
+             at Object.throwsOuter (about://React/Server/file://<tmp>/chunk.js?1:125:9)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-with-cause (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:cause
+             at throwsCause (<tmp>/original.js:3:9)
+             at Object.throwsOuter (<tmp>/original.js:7:5)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-with-cause (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsCause() {
+         > 3 |   throw new Error('boom:cause')
+             |<9 spaces>^
+           4 | }
+           5 | export function throwsOuter() {
+           6 |   try { {
+           environmentName: 'Server'
+         }
+       top frame (as an attached debugger resolves it): throwsCause at about://React/Server/file://<tmp>/chunk.js?0:121:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<118 newlines>({"throwsCause":
+         | _=>
+         | <10 spaces>_()})
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<121 newlines>({"Object.throwsOuter":
+         | _=>
+         |
+         | <8 spaces>_()})
+       about://React/Server/file://<tmp>/chunk.js?2
+         map: <map>
+         | ({"Object.throwsOuter":_=><126 newlines><14 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('round-trips the model value encodings through a cause', () => {
+      // `$`-prefixed strings escape, and negative zero, infinities, and NaN
+      // use the renderer's encodings — the same rules that protect function
+      // names and native-frame positions inside serialized stacks.
+      expect(renderScenario(runScenario('cause-value-encodings')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:outer
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-value-encodings (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:outer
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-value-encodings (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>',
+           [cause]: Error: boom:chunk.js
+       <8 spaces>at Object.throwsInChunk (<tmp>/original.js:3:9)
+       <8 spaces>at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at cause-value-encodings (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+       <8 spaces>|<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Server',
+             [cause]: {
+       <8 spaces>reference: '$100',
+       <8 spaces>negativeZero: -0,
+       <8 spaces>infinite: Infinity,
+       <8 spaces>notANumber: NaN
+             }
+           }
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == hop 0 cause (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-value-encodings (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-value-encodings (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           [cause]: {
+             reference: '$100',
+             negativeZero: -0,
+             infinite: Infinity,
+             notANumber: NaN
+           }
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<110 newlines>({"Object.throwsInChunk":
+         | _=>
+         | <10 spaces>_()})"
+      `)
+    })
+
+    it('revives nested cause chains down to primitive causes', () => {
+      expect(renderScenario(runScenario('nested-cause-chain')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:outer
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at nested-cause-chain (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:outer
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at nested-cause-chain (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>',
+           [cause]: Error: boom:chunk.js
+       <8 spaces>at Object.throwsInChunk (<tmp>/original.js:3:9)
+       <8 spaces>at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at nested-cause-chain (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+       <8 spaces>|<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Server',
+             [cause]: 'root cause'
+           }
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == hop 0 cause (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at nested-cause-chain (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at nested-cause-chain (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           [cause]: 'root cause'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<110 newlines>({"Object.throwsInChunk":
+         | _=>
+         | <10 spaces>_()})"
+      `)
+    })
+
+    it('revives causes under the environment they carry', () => {
+      expect(renderScenario(runScenario('cause-across-environments')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:outer
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-across-environments (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:outer
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-across-environments (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>',
+           [cause]: Error: boom:chunk.js
+       <8 spaces>at Object.throwsInChunk (<tmp>/original.js:3:9)
+       <8 spaces>at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at cause-across-environments (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+       <8 spaces>|<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache'
+           }
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       == hop 0 cause (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-across-environments (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModel (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at cause-across-environments (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('revives AggregateError errors with their own fake stacks', () => {
+      expect(renderScenario(runScenario('aggregate-error')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         AggregateError: boom:aggregate
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at aggregate-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         AggregateError: boom:aggregate
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at aggregate-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>',
+           [errors]: [
+             Error: boom:chunk.js
+       <10 spaces>at throwsInChunk (<tmp>/original.js:3:9)
+       <10 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at aggregate-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>1 | // original source
+       <8 spaces>2 | export function throwsInChunk() {
+             > 3 |   throw new Error("boom:chunk.js")
+       <10 spaces>|<9 spaces>^
+       <8 spaces>4 | }
+       <8 spaces>5 | {
+       <8 spaces>environmentName: 'Server'
+             },
+             Error: boom:chunk.js
+       <10 spaces>at throwsInChunk (<tmp>/original.js:3:9)
+       <10 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at aggregate-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <10 spaces>at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+       <8 spaces>1 | // original source
+       <8 spaces>2 | export function throwsInChunk() {
+             > 3 |   throw new Error("boom:chunk.js")
+       <10 spaces>|<9 spaces>^
+       <8 spaces>4 | }
+       <8 spaces>5 | {
+       <8 spaces>environmentName: 'Server'
+             }
+           ]
+         }
+       top frame (as an attached debugger resolves it): <anonymous> at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+           script: no source map
+       constructor: AggregateError
+       == hop 0 errors[0] (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at aggregate-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at aggregate-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 0 errors[1] (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at aggregate-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at aggregate-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<110 newlines>({"throwsInChunk":
+         | _=>
+         | <10 spaces>_()})"
+      `)
+    })
+  })
+
+  // `createReactServerErrorHandler` runs before every serialization and
+  // `createHTMLErrorHandler` on the SSR side; digests decide dedup identity and
+  // whether the stack materializes before React parses it.
+  describe('digests and the Next.js error handlers', () => {
+    it('parses the structured stack trace for errors logged before thrown', () => {
+      // Serializing an error as a debug value (e.g. a console argument)
+      // caches a structured stack parse that the error serialization reuses,
+      // flipping even the first hop off the materialized-string path.
+      expect(renderScenario(runScenario('error-logged-before-thrown')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-logged-before-thrown (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-logged-before-thrown (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<110 newlines>({"Object.throwsInChunk":
+         | _=>
+         | <10 spaces>_()})"
+      `)
+    })
+
+    it('parses the structured stack trace for errors that carry a digest', () => {
+      // Framework errors skip the digest hash, so the stack is never
+      // materialized and the first serialization parses V8's structured stack
+      // trace. Its real enclosing function positions produce the other fake
+      // script layout, with the banner comment first.
+      expect(renderScenario(runScenario('predigested-error')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at predigested-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at predigested-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: 'NEXT_REDIRECT;push;/target;307;'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<110 newlines>({"Object.throwsInChunk":
+         | _=>
+         | <10 spaces>_()})"
+      `)
+    })
+
+    it('serializes the digest before formatServerError rewrites the message', () => {
+      // The wire carries the rewritten multi-line message, but the digest
+      // hashed the original message and stack.
+      expect(renderScenario(runScenario('formatted-server-error')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: Class extends value undefined is not a constructor or null
+
+         This might be caused by a React Class Component being rendered in a Server Component, React Class Components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at formatted-server-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: Class extends value undefined is not a constructor or null
+
+         This might be caused by a React Class Component being rendered in a Server Component, React Class Components only works in Client Components. Read more: https://nextjs.org/docs/messages/class-component-in-server-component
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at formatted-server-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("Class extends value undefined is not a constructor or null")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('rewrites createContext errors after the digest', () => {
+      expect(renderScenario(runScenario('formatted-context-error')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at formatted-context-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at formatted-context-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("createContext is not a function")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('rewrites client hook errors after the digest', () => {
+      expect(renderScenario(runScenario('formatted-hook-error')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at formatted-hook-error (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at formatted-hook-error (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("useState is not a function")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('recovers RSC errors by digest in the HTML error handler', () => {
+      const result = runScenario('html-error-handler')
+      expect(result.htmlHandler).toEqual({
+        recoveredDigestForwarded: true,
+        freshDigestHashed: true,
+        freshDigestDiffers: true,
+        capturedBoth: true,
+        revivedIsUserLandError: true,
+        redirectDigestForwarded: true,
+        largeShellSilenced: true,
+      })
+    })
+  })
+
+  // `findSourceMapURLDEV` (for the debugger) and the terminal formatter both
+  // resolve through Node.js' source map cache; the map's shape decides what
+  // survives.
+  describe('resolving source maps', () => {
+    it('splits the consumers on sparse mappings', () => {
+      // A map covering only the throw itself: the debugger resolves the
+      // caller frame to the nearest preceding mapping, the terminal falls
+      // back to the raw URL.
+      // TODO: the terminal should fall back to the frame's original URL,
+      // not print the fake sourceURL.
+      expect(
+        renderScenario(
+          runScenario('sparse-mappings', {}, 'cjs', {
+            rawTerminalURLs: ['hop 0'],
+          })
+        )
+      ).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:sparse
+             at throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:121:11)
+             at Object.callsThrough (about://React/Server/file://<tmp>/chunk.js?1:124:12)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at sparse-mappings (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:sparse
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Object.callsThrough (about://React/Server/file://<tmp>/chunk.js?1:124:12)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at sparse-mappings (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:sparse')
+             |<9 spaces>^
+           4 | }
+           5 | export function callsThrough() {
+           6 |   return throwsInChunk() {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:121:11
+           original: file://<tmp>/original.js:3
+       caller frame: Object.callsThrough at about://React/Server/file://<tmp>/chunk.js?1:124:12
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"throwsInChunk":_=><120 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | ({"Object.callsThrough":_=><123 newlines><11 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves index source maps shaped like Turbopack emits them', () => {
+      expect(renderBothModes('index-source-map')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves frames mapped by a later section of an index source map', () => {
+      expect(renderScenario(runScenario('multi-section-index-map')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:sections
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multi-section-index-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:sections
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at multi-section-index-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves frames mapped by the first section of an index source map', () => {
+      expect(renderScenario(runScenario('index-map-first-section')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:sections
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-map-first-section (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:sections
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-map-first-section (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('keeps frames positioned before every index map section', () => {
+      // TODO: unmapped positions should fall back to the frame's original
+      // URL in both the debugger and the terminal.
+      expect(
+        renderScenario(
+          runScenario('index-map-position-before-sections', {}, 'cjs', {
+            unresolvedFakeFrames: ['hop 0 top'],
+            rawTerminalURLs: ['hop 0'],
+          })
+        )
+      ).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:sections
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-map-position-before-sections (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:sections
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-map-position-before-sections (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           script: has source map, position unmapped
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('keeps frames of chunks whose index source map has no sections', () => {
+      // TODO: unmapped positions should fall back to the frame's original
+      // URL in both the debugger and the terminal.
+      expect(
+        renderScenario(
+          runScenario('index-map-empty-sections', {}, 'cjs', {
+            unresolvedFakeFrames: ['hop 0 top'],
+            rawTerminalURLs: ['hop 0'],
+          })
+        )
+      ).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:sections
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-map-empty-sections (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:sections
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-map-empty-sections (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           script: has source map, position unmapped
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('serves relative section sources that a debugger cannot resolve', () => {
+      // Node.js resolves top-level `sources` against the source map's location
+      // but leaves section sources untouched, and the fake script's `data:`
+      // source map provides no location to resolve them against.
+      // TODO: serve section sources a debugger can resolve.
+      expect(renderBothModes('index-source-map-relative-sources'))
+        .toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map-relative-sources (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map-relative-sources (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Server/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map-relative-sources (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at index-source-map-relative-sources (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Server/file://<tmp>/chunk.mjs?0:103:11
+           original: original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('does not resolve spec-conformant index source maps', () => {
+      // Node.js fails to cache index source maps without a top-level `sources`
+      // array, which the source map spec requires index maps to omit.
+      // TODO: spec-conformant index maps should resolve (upstream Node.js).
+      expect(renderBothModes('spec-index-source-map')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (file://<tmp>/chunk.js:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at spec-index-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/chunk.js:113:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at spec-index-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/chunk.js:113:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (file://<tmp>/chunk.mjs:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at spec-index-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/chunk.mjs:103:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at spec-index-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at file://<tmp>/chunk.mjs:103:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.mjs
+         map: -"
+      `)
+    })
+
+    it('does not resolve frames of scripts with an invalid source map', () => {
+      expect(renderBothModes('invalid-source-map')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (file://<tmp>/chunk.js:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at invalid-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/chunk.js:113:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at invalid-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/chunk.js:113:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (file://<tmp>/chunk.mjs:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at invalid-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/chunk.mjs:103:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at invalid-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at file://<tmp>/chunk.mjs:103:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.mjs
+         map: -"
+      `)
+    })
+
+    it('falls back to the plain file URL for scripts without a source map', () => {
+      expect(renderBothModes('missing-source-map')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (file://<tmp>/chunk.js:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at missing-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/chunk.js:113:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at missing-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/chunk.js:113:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (file://<tmp>/chunk.mjs:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at missing-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/chunk.mjs:103:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at missing-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at file://<tmp>/chunk.mjs:103:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.mjs
+         map: -"
+      `)
+    })
+
+    it("resolves frames of eval'd scripts with inline source maps", () => {
+      expect(renderScenario(runScenario('eval-with-inline-source-map')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:eval
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?module-id?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at eval-with-inline-source-map (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:eval
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at eval-with-inline-source-map (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?module-id?0:101:34
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js?module-id
+         map: data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2h1bmsuanMiLCJzb3VyY2VzIjpbIm9yaWdpbmFsLmpzIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIG9yaWdpbmFsIHNvdXJjZVxuZXhwb3J0IGZ1bmN0aW9uIHRocm93c0luQ2h1bmsoKSB7XG4gIHRocm93IG5ldyBFcnJvcignYm9vbScpXG59XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztpQ0FFUSJ9
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?module-id?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves chunks whose files were deleted after loading', () => {
+      // Node.js caches source maps in memory when the chunk is loaded.
+      expect(renderBothModes('chunk-deleted-after-require'))
+        .toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-deleted-after-require (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-deleted-after-require (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Server/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-deleted-after-require (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-deleted-after-require (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Server/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves errors from an edited chunk file with the stale source map', () => {
+      // Like webpack HMR replacing a file: Node.js re-reads the map after
+      // the module cache is busted, but `findSourceMapURLDEV` still serves
+      // the first map for the unchanged URL.
+      // TODO: `findSourceMapURLDEV` should refresh its cache when the file
+      // changes.
+      expect(renderScenario(runScenario('chunk-file-edited')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:edited
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-file-edited (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:edited
+             at Object.throwsInChunk (<tmp>/original.js:2:1)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-file-edited (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+         > 2 | export function throwsInChunk() {
+             | ^
+           3 |   throw new Error('boom')
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           original: file://<tmp>/original.js:2
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:edited
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-file-edited (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:edited
+             at Object.throwsInChunk (<tmp>/original.js:2:1)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at chunk-file-edited (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+         > 2 | export function throwsInChunk() {
+             | ^
+           3 |   throw new Error('boom')
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:101:34
+           original: file://<tmp>/original.js:2
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves query-busted ES module reloads with their own maps', () => {
+      // The `?v=2` URL is a distinct cache key end to end, so unlike
+      // same-URL updates, every version resolves through its own map.
+      expect(renderScenario(runScenario('esm-query-busted-reload')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:reloaded
+             at Module.throwsInChunk (about://React/Server/file://<tmp>/chunk.mjs?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at esm-query-busted-reload (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:reloaded
+             at Module.throwsInChunk (<tmp>/original.js:2:1)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at esm-query-busted-reload (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+         > 2 | export function throwsInChunk() {
+             | ^
+           3 |   throw new Error('boom')
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Server/file://<tmp>/chunk.mjs?0:101:34
+           original: file://<tmp>/original.js:2
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:reloaded
+             at Module.throwsInChunk (about://React/Server/file://<tmp>/chunk.mjs?v=2?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at esm-query-busted-reload (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:reloaded
+             at Module.throwsInChunk (<tmp>/original.js:3:1)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at esm-query-busted-reload (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             | ^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Server/file://<tmp>/chunk.mjs?v=2?0:101:34
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/chunk.mjs?v=2
+         map: chunk.mjs.map
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.mjs?v=2?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves errors from a replaced eval with the stale source map', () => {
+      // The first update's map points to line 2, the second update's to
+      // line 3. Node.js replaces its cached map on the second eval, but
+      // reviving the first error cached the first map in `findSourceMapURLDEV`
+      // under the shared sourceURL, so the second error resolves through the
+      // stale map.
+      // TODO: `findSourceMapURLDEV` should serve the latest map for reused
+      // sourceURLs.
+      expect(renderScenario(runScenario('repeated-hmr-updates')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:update
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?module-id?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at repeated-hmr-updates (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:update
+             at Object.throwsInChunk (<tmp>/original.js:2:1)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at repeated-hmr-updates (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+         > 2 | export function throwsInChunk() {
+             | ^
+           3 |   throw new Error('boom')
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?module-id?0:101:34
+           original: file://<tmp>/original.js:2
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:update
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?module-id?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at repeated-hmr-updates (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:update
+             at Object.throwsInChunk (<tmp>/original.js:2:1)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at repeated-hmr-updates (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+         > 2 | export function throwsInChunk() {
+             | ^
+           3 |   throw new Error('boom')
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?module-id?0:101:34
+           original: file://<tmp>/original.js:2
+       == fake scripts ==
+       file://<tmp>/chunk.js?module-id
+         map: data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2h1bmsuanMiLCJzb3VyY2VzIjpbIm9yaWdpbmFsLmpzIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIG9yaWdpbmFsIHNvdXJjZVxuZXhwb3J0IGZ1bmN0aW9uIHRocm93c0luQ2h1bmsoKSB7XG4gIHRocm93IG5ldyBFcnJvcignYm9vbScpXG59XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztpQ0FDQSJ9
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?module-id?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/chunk.js?module-id
+         map: data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2h1bmsuanMiLCJzb3VyY2VzIjpbIm9yaWdpbmFsLmpzIl0sInNvdXJjZXNDb250ZW50IjpbIi8vIG9yaWdpbmFsIHNvdXJjZVxuZXhwb3J0IGZ1bmN0aW9uIHRocm93c0luQ2h1bmsoKSB7XG4gIHRocm93IG5ldyBFcnJvcignYm9vbScpXG59XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztpQ0FFQSJ9
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?module-id?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves terminal frames through the bundler source map fallback', () => {
+      // Turbopack dev injects a bundler lookup into the terminal formatter;
+      // the debugger-facing `findSourceMapURLDEV` only consults Node.js, so
+      // the fake script gets no source map while the terminal resolves.
+      // TODO: `findSourceMapURLDEV` should consult the bundler fallback too,
+      // so debuggers resolve these frames.
+      expect(renderScenario(runScenario('bundler-source-map-fallback')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (file://<tmp>/chunk.js:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at bundler-source-map-fallback (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/chunk.js:113:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at bundler-source-map-fallback (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/chunk.js:113:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/chunk.js
+         map: -"
+      `)
+    })
+
+    it('ignore-lists frames whose original source is in node_modules', () => {
+      expect(renderScenario(runScenario('map-source-in-node-modules')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:vendored
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at map-source-in-node-modules (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:vendored
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at map-source-in-node-modules (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/node_modules/lib/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // Frame URLs round-trip through `encodeURI` (into the fake script's
+  // sourceURL) and `decodeURI` (devirtualization on the next hop); CJS frames
+  // carry raw paths and ES module frames carry percent-encoded URLs, so the two
+  // diverge on special characters.
+  describe('paths and encodings', () => {
+    it('resolves every revival for chunk paths that percent-encoding does not change', () => {
+      // Revived errors carry the environment they were first serialized in.
+      // Every hop crosses into a different consumer, and each consumer evals
+      // its own fake stack frame script.
+      expect(renderBothModes('three-hops')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 2 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-2/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-2/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == hop 2 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-2/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at three-hops (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/chunk.mjs?0:103:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-2/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    // For CJS chunks, the revived stack serializes with a percent-decoded
+    // URL, whose spelling misses the source map lookup. React then evals the
+    // second revival's fake stack frame script without a source map, under
+    // the chunk's own URL instead of an `about://React/` URL, and a debugger
+    // cannot resolve its frames. The terminal resolves both revivals: the
+    // fake script's URL spelling matches how Node.js keys the chunk's own
+    // source map. ES module frames carry percent-encoded URLs instead of
+    // paths, so `encodeURI` double-encodes them and `devirtualizeURL`'s
+    // decode lands back on the loader's own spelling: every revival resolves.
+    // TODO: the second CJS revival should resolve; the fake script URL
+    // spelling must round-trip to the map lookup's key.
+    describe('does not resolve the second CJS revival for chunk paths that percent-encoding changes', () => {
+      it('brackets', () => {
+        expect(renderBothModes('two-hops-bracket-chunk'))
+          .toMatchInlineSnapshot(`
+         "======== cjs ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Object.throwsInChunk (about://React/Cache/file://<tmp>/%5Broot-of-the-server%5D__sim._.js?0:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Object.throwsInChunk (<tmp>/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:[root-of-the-server]__sim._.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/%5Broot-of-the-server%5D__sim._.js?0:113:11
+             original: file://<tmp>/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Object.throwsInChunk (file://<tmp>/%5Broot-of-the-server%5D__sim._.js:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Object.throwsInChunk (<tmp>/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:[root-of-the-server]__sim._.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/%5Broot-of-the-server%5D__sim._.js:113:11
+             script: no source map
+         == fake scripts ==
+         file://<tmp>/[root-of-the-server]__sim._.js
+           map: [root-of-the-server]__sim._.js.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/%5Broot-of-the-server%5D__sim._.js?0
+           map: <map>
+           | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         file://<tmp>/%5Broot-of-the-server%5D__sim._.js
+           map: -
+         ======== esm ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/%255Broot-of-the-server%255D__sim._.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Module.throwsInChunk (<tmp>/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:[root-of-the-server]__sim._.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/%255Broot-of-the-server%255D__sim._.mjs?0:103:11
+             original: file://<tmp>/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/%255Broot-of-the-server%255D__sim._.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:[root-of-the-server]__sim._.js
+               at Module.throwsInChunk (<tmp>/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at two-hops-bracket-chunk (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:[root-of-the-server]__sim._.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/%255Broot-of-the-server%255D__sim._.mjs?0:103:11
+             original: file://<tmp>/original.js:3
+         == fake scripts ==
+         file://<tmp>/%5Broot-of-the-server%5D__sim._.mjs
+           map: [root-of-the-server]__sim._.mjs.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/%255Broot-of-the-server%255D__sim._.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/%255Broot-of-the-server%255D__sim._.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+        `)
+      })
+
+      it('space', () => {
+        expect(renderBothModes('space-in-project-path')).toMatchInlineSnapshot(`
+         "======== cjs ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (about://React/Cache/file://<tmp>/my%20project/chunk.js?0:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (<tmp>/my project/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/my%20project/chunk.js?0:113:11
+             original: file://<tmp>/my%20project/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (file://<tmp>/my%20project/chunk.js:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (<tmp>/my project/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/my%20project/chunk.js:113:11
+             script: no source map
+         == fake scripts ==
+         file://<tmp>/my%20project/chunk.js
+           map: chunk.js.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/my%20project/chunk.js?0
+           map: <map>
+           | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         file://<tmp>/my%20project/chunk.js
+           map: -
+         ======== esm ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/my%2520project/chunk.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (<tmp>/my project/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/my%2520project/chunk.mjs?0:103:11
+             original: file://<tmp>/my%20project/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/my%2520project/chunk.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (<tmp>/my project/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at space-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/my%2520project/chunk.mjs?0:103:11
+             original: file://<tmp>/my%20project/original.js:3
+         == fake scripts ==
+         file://<tmp>/my%20project/chunk.mjs
+           map: chunk.mjs.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/my%2520project/chunk.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/my%2520project/chunk.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+        `)
+      })
+
+      it('unicode', () => {
+        expect(renderBothModes('unicode-in-project-path'))
+          .toMatchInlineSnapshot(`
+         "======== cjs ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (about://React/Cache/file://<tmp>/caf%C3%A9/chunk.js?0:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (<tmp>/café/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/caf%C3%A9/chunk.js?0:113:11
+             original: file://<tmp>/caf%C3%A9/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (file://<tmp>/caf%C3%A9/chunk.js:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (<tmp>/café/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/caf%C3%A9/chunk.js:113:11
+             script: no source map
+         == fake scripts ==
+         file://<tmp>/caf%C3%A9/chunk.js
+           map: chunk.js.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/caf%C3%A9/chunk.js?0
+           map: <map>
+           | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         file://<tmp>/caf%C3%A9/chunk.js
+           map: -
+         ======== esm ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/caf%25C3%25A9/chunk.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (<tmp>/café/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/caf%25C3%25A9/chunk.mjs?0:103:11
+             original: file://<tmp>/caf%C3%A9/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/caf%25C3%25A9/chunk.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (<tmp>/café/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at unicode-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/caf%25C3%25A9/chunk.mjs?0:103:11
+             original: file://<tmp>/caf%C3%A9/original.js:3
+         == fake scripts ==
+         file://<tmp>/caf%C3%A9/chunk.mjs
+           map: chunk.mjs.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/caf%25C3%25A9/chunk.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/caf%25C3%25A9/chunk.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+        `)
+      })
+
+      it('percent', () => {
+        expect(renderBothModes('percent-in-project-path'))
+          .toMatchInlineSnapshot(`
+         "======== cjs ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (about://React/Cache/file://<tmp>/per%25cent/chunk.js?0:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (<tmp>/per%cent/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/per%25cent/chunk.js?0:113:11
+             original: file://<tmp>/per%25cent/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (file://<tmp>/per%25cent/chunk.js:113:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Object.throwsInChunk (<tmp>/per%cent/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/per%25cent/chunk.js:113:11
+             script: no source map
+         == fake scripts ==
+         file://<tmp>/per%25cent/chunk.js
+           map: chunk.js.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/per%25cent/chunk.js?0
+           map: <map>
+           | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         file://<tmp>/per%25cent/chunk.js
+           map: -
+         ======== esm ========
+         == hop 0 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/per%2525cent/chunk.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (<tmp>/per%cent/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/per%2525cent/chunk.mjs?0:103:11
+             original: file://<tmp>/per%25cent/original.js:3
+         == hop 1 (Cache) ==
+         error.stack (the raw string):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (about://React/Cache/file://<tmp>/per%2525cent/chunk.mjs?0:103:11)
+               at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+               at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+               at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+               at process.processImmediate (node:internal/timers:<pos>)
+               at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+         terminal (the dev server prints through the patched inspect):
+           Error: boom:chunk.js
+               at Module.throwsInChunk (<tmp>/per%cent/original.js:3:9)
+               at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at percent-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+               at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+             1 | // original source
+             2 | export function throwsInChunk() {
+           > 3 |   throw new Error("boom:chunk.js")
+               |<9 spaces>^
+             4 | }
+             5 | {
+             environmentName: 'Cache',
+             digest: '<hash>'
+           }
+         top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/per%2525cent/chunk.mjs?0:103:11
+             original: file://<tmp>/per%25cent/original.js:3
+         == fake scripts ==
+         file://<tmp>/per%25cent/chunk.mjs
+           map: chunk.mjs.map
+         file://<tmp>/consumer-0/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/per%2525cent/chunk.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+         file://<tmp>/consumer-1/node_modules/flight-client/index.js
+           map: -
+         file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+           map: -
+         about://React/Cache/file://<tmp>/per%2525cent/chunk.mjs?0
+           map: <map>
+           | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+           | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+        `)
+      })
+    })
+
+    it('does not resolve the second revival for chunk paths with a hash', () => {
+      // `encodeURI` leaves `#` intact, so the first revival's `sourceURL`
+      // comment carries it raw and still resolves (Node.js keys the map under
+      // the percent-encoded file URL). The second revival's fake script gets
+      // the raw `file:` URL, and the source map lookup parses it as a URL
+      // whose fragment starts at the `#`.
+      // TODO: the second revival should resolve; `#` needs encoding before
+      // the lookup parses the URL.
+      expect(renderBothModes('hash-in-project-path')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/my#app/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/my#app/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/my#app/chunk.js?0:113:11
+           original: file://<tmp>/my%23app/original.js:3
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (file://<tmp>/my#app/chunk.js:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/my:113:11)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at file://<tmp>/my#app/chunk.js:113:11
+           script: no source map
+       == fake scripts ==
+       file://<tmp>/my%23app/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/my#app/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       file://<tmp>/my#app/chunk.js
+         map: -
+       ======== esm ========
+       == hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/my%2523app/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/my#app/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/my%2523app/chunk.mjs?0:103:11
+           original: file://<tmp>/my%23app/original.js:3
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Cache/file://<tmp>/my%2523app/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/my#app/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at hash-in-project-path (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Cache/file://<tmp>/my%2523app/chunk.mjs?0:103:11
+           original: file://<tmp>/my%23app/original.js:3
+       == fake scripts ==
+       file://<tmp>/my%23app/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/my%2523app/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/my%2523app/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves chunks required through a symlink', () => {
+      // CJS resolution realpaths the module, so the frame already carries the
+      // real path.
+      expect(renderBothModes('symlinked-project-dir')).toMatchInlineSnapshot(`
+       "======== cjs ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/real/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at symlinked-project-dir (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/real/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at symlinked-project-dir (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/real/chunk.js?0:113:11
+           original: file://<tmp>/real/original.js:3
+       == fake scripts ==
+       file://<tmp>/real/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/real/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       ======== esm ========
+       == hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (about://React/Server/file://<tmp>/real/chunk.mjs?0:103:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at symlinked-project-dir (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Module.throwsInChunk (<tmp>/real/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at symlinked-project-dir (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Module.throwsInChunk at about://React/Server/file://<tmp>/real/chunk.mjs?0:103:11
+           original: file://<tmp>/real/original.js:3
+       == fake scripts ==
+       file://<tmp>/real/chunk.mjs
+         map: chunk.mjs.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/real/chunk.mjs?0
+         map: <map>
+         | ({"Module.throwsInChunk":_=><102 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves every revival of webpack-internal frames', () => {
+      // Node.js resolves the `webpack://` source as a URL, dropping `/./`.
+      expect(renderScenario(runScenario('webpack-internal-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:webpack
+             at Object.throwsInChunk (about://React/Server/webpack-internal:///(rsc)/./app/page.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at webpack-internal-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:webpack
+             at Object.throwsInChunk (webpack://_N_E/app/page.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at webpack-internal-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/webpack-internal:///(rsc)/./app/page.js?0:101:34
+           original: webpack://_N_E/app/page.js:3
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:webpack
+             at Object.throwsInChunk (about://React/Server/webpack-internal:///(rsc)/./app/page.js?0:101:34)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at webpack-internal-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:webpack
+             at Object.throwsInChunk (webpack://_N_E/app/page.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at webpack-internal-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom')
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/webpack-internal:///(rsc)/./app/page.js?0:101:34
+           original: webpack://_N_E/app/page.js:3
+       == fake scripts ==
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/webpack-internal:///(rsc)/./app/page.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/webpack-internal:///(rsc)/./app/page.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><100 newlines><33 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // Errors carry the environment of their first serialization across every
+  // later boundary; consumers root their responses in their own environment.
+  describe('environments and layers', () => {
+    itObservesTaskChains(
+      'revives use cache errors across the RSC and SSR layers',
+      () => {
+        // The first revival happens in the use-cache consumer's 'Cache'-rooted
+        // response, so the root task itself is `"use cache"` and the owner chain
+        // sits directly on it. The second revival happens in the SSR layer's
+        // 'Server'-rooted response, where the error's carried environment no
+        // longer matches the root, so `getRootTask` nests a `"use cache"`
+        // boundary task instead (and the re-serialization carried no owner).
+        expect(renderScenario(runScenario('use-cache-layers')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  use-cache-layers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  use-cache-layers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Cache/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         <Layout>
+           Object.renderLayout at about://React/Cache/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use cache"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  use-cache-layers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  use-cache-layers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use cache"
+           getRootTask at file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>
+             script: no source map
+         "use server"
+           <no name> at file://<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Cache/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Cache/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'revives nested use cache errors across three layers',
+      () => {
+        // Two Cache-rooted consumers in a row: at both, the error's environment
+        // matches the response root, so the owner chain (first hop) and the
+        // plain root task (second hop) sit on `"use cache"` directly. Only the
+        // SSR hop nests a boundary task.
+        expect(renderScenario(runScenario('nested-cache-layers')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  nested-cache-layers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  nested-cache-layers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Cache/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         <Layout>
+           Object.renderLayout at about://React/Cache/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use cache"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == hop 1 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  nested-cache-layers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  nested-cache-layers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use cache"
+           <no name> at file://<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == hop 2 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  nested-cache-layers (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-2/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  nested-cache-layers (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use cache"
+           getRootTask at file://<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>
+             script: no source map
+         "use server"
+           <no name> at file://<tmp>/consumer-2/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Cache/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Cache/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-2/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'wraps prefetch-stage errors in a "use prefetch" task',
+      () => {
+        expect(renderScenario(runScenario('prefetch-environment')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Prefetch) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Prefetch/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at prefetch-environment (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at prefetch-environment (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Prefetch',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Prefetch/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use prefetch"
+           getRootTask at file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>
+             script: no source map
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Prefetch/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'revives instant validation errors into the dev overlay payload',
+      () => {
+        const result = runScenario('instant-validation-stacks')
+        // The per-segment re-encode forwards the digest verbatim; the value
+        // crossing into the overlay's `{ errors }` payload drops it, and any
+        // later serialization mints a fresh one — dedup identity does not
+        // survive the value hop.
+        // TODO: dedup identity should survive the value crossing into the
+        // overlay payload.
+        const [minted, forwarded, reminted] = result.digests
+        expect(forwarded).toBe(minted)
+        expect(reminted).not.toBe(minted)
+        expect(renderScenario(result)).toMatchInlineSnapshot(`
+       "== hop 0 (Prerender) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Prerender/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  instant-validation-stacks (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  instant-validation-stacks (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Prerender',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Prerender/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Prerender/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         "use prerender"
+           Object.renderLayout at about://React/Server/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == hop 1 (Prerender) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Prerender/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  instant-validation-stacks (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  instant-validation-stacks (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Prerender',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Prerender/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       == hop 2 (Prerender) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Prerender/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  instant-validation-stacks (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at resolveErrorDev (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             ... repeated 2 more times ...
+             at parseModel (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at initializeModelChunk (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at getOutlinedModel (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at parseModelString (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at reviveModel (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Object.reviveRootModel (<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-2/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  instant-validation-stacks (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Prerender'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Prerender/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use prerender"
+           getRootTask at file://<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js:<pos>
+             script: no source map
+         "use server"
+           <no name> at file://<tmp>/consumer-2/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Prerender/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Prerender/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Prerender/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-2/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-2/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Prerender/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+  })
+
+  describe('owner task chains', () => {
+    // The async part of the revived error's stack, as an attached debugger
+    // shows it: one task per owner, rooted in the response's task, each
+    // task's top frame being the `createTask` call inside the owner's fake
+    // stack frames. The chain continues into the dispatch context below the
+    // root.
+    itObservesTaskChains(
+      'revives the owner chain as tasks over fake owner frames',
+      () => {
+        expect(renderScenario(runScenario('owner-stack')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-stack (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-stack (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Server/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         <Layout>
+           Object.renderLayout at about://React/Server/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Server/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'labels owners from another environment with the environment',
+      () => {
+        // The owner's fake frames eval under the parent's environment name.
+        expect(renderScenario(runScenario('owner-stack-cross-environment')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-stack-cross-environment (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-stack-cross-environment (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use cache"
+           Object.renderPage at about://React/Server/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         <Layout>
+           Object.renderLayout at about://React/Server/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Server/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'wraps ownerless prerender-stage errors in a "use prerender" task',
+      () => {
+        // `getRootTask` creates the boundary task with no fake frames around
+        // it, so its top frame is `getRootTask` itself, not user source.
+        // TODO: the boundary task's top frame should not be the revival
+        // machinery.
+        expect(renderScenario(runScenario('prerender-environment')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Prerender) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Prerender/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at prerender-environment (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at prerender-environment (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Prerender',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Prerender/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use prerender"
+           getRootTask at file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>
+             script: no source map
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Prerender/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'replaces the boundary owner name with the prerender label',
+      () => {
+        // The boundary task keeps the owner's callsite frames even though its
+        // name is the environment label.
+        expect(renderScenario(runScenario('prerender-owner-stack')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Prerender) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Prerender/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  prerender-owner-stack (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  prerender-owner-stack (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Prerender',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Prerender/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Prerender/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         "use prerender"
+           Object.renderLayout at about://React/Server/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Prerender/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Prerender/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})"
+      `)
+      }
+    )
+
+    itObservesTaskChains('attaches each serialization its own owner', () => {
+      // Owners are not carried across hops: the first serialization here has
+      // none, the second attaches the serializing task's owner chain.
+      expect(renderScenario(runScenario('owner-at-second-hop')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-at-second-hop (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-at-second-hop (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-at-second-hop (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-at-second-hop (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Server/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         <Layout>
+           Object.renderLayout at about://React/Server/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use server"
+           <no name> at file://<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Server/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})"
+      `)
+    })
+
+    itObservesTaskChains(
+      'labels a server owner under a cache root with "use server"',
+      () => {
+        expect(renderScenario(runScenario('owner-stack-inverse-environment')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Cache) ==
+       error.stack (the raw string):
+         Error: boom:owner
+             at Object.throwsInChunk (about://React/Cache/file://<tmp>/chunk.js?0:124:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-stack-inverse-environment (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at writeOwnerFixture (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  owner-stack-inverse-environment (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner')
+             |<9 spaces>^
+           4 | }
+           5 | function jsx() {
+           6 |   return new Error('react-stack-top-frame') {
+           environmentName: 'Cache',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Cache/file://<tmp>/chunk.js?0:124:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           Object.renderPage at about://React/Server/file://<tmp>/chunk.js?2:130:12
+             original: file://<tmp>/original.js:9
+         "use server"
+           Object.renderLayout at about://React/Cache/file://<tmp>/chunk.js?1:133:12
+             original: file://<tmp>/original.js:12
+         "use cache"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Cache/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><123 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Cache/file://<tmp>/chunk.js?1
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<130 newlines>({"Object.renderLayout":
+         | _=>
+         | <11 spaces>_()})
+       about://React/Server/file://<tmp>/chunk.js?2
+         map: <map>
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */<127 newlines>({"Object.renderPage":
+         | _=>
+         | <11 spaces>_()})"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'falls back to the root task for owners without a stack',
+      () => {
+        expect(renderScenario(runScenario('owner-without-stack')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at owner-without-stack (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at owner-without-stack (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+
+    itObservesTaskChains(
+      'creates the owner task without frames when its stack filters away',
+      () => {
+        // An empty (fully filtered) owner stack still creates the component
+        // task, but with no fake frames around the `createTask` call, so its
+        // top frame is the revival machinery.
+        // TODO: the owner task's top frame should not be the revival
+        // machinery.
+        expect(renderScenario(runScenario('owner-with-filtered-stack')))
+          .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at owner-with-filtered-stack (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at owner-with-filtered-stack (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       owner tasks:
+         <Page>
+           initializeFakeTask at file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>
+             script: no source map
+         "use server"
+           <no name> at file://<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>
+             script: no source map
+         Immediate
+           init at node:internal/inspector_async_hook:<pos>
+             script: no source map
+         await
+           main at file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             script: no source map
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/node_modules/owner-lib/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+      }
+    )
+
+    it('revives owner-stack rewritten errors with owner callsite frames', () => {
+      // `applyOwnerStack` kept the error's own frames up to React's bottom
+      // frame and appended the owner stack, so the frames below the throw are
+      // the owner callsites, revived as fake frames like any other.
+      expect(renderScenario(runScenario('owner-stack-rewrite')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:owner-rewrite
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:121:11)
+             at Page (about://React/Server/file://<tmp>/chunk.js?1:124:12)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:owner-rewrite
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at Page (<tmp>/original.js:6:10)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:owner-rewrite')
+             |<9 spaces>^
+           4 | }
+           5 | export function Page() {
+           6 |   return throwsInChunk() {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:121:11
+           original: file://<tmp>/original.js:3
+       caller frame: Page at about://React/Server/file://<tmp>/chunk.js?1:124:12
+           original: file://<tmp>/original.js:6
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><120 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<tmp>/chunk.js?1
+         map: <map>
+         | ({"Page":_=><123 newlines><11 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // `patchErrorInspectNodeJS` formats every printed error: source-mapped
+  // frames, code frames, ignore-list collapsing, and the react bottom frame
+  // cut.
+  describe('terminal output', () => {
+    it('cuts terminal output at the react bottom frame', () => {
+      // Errors that never cross a Flight boundary still print through the
+      // patched inspect, which cuts everything below React's bottom frame.
+      expect(renderScenario(runScenario('unserialized-error-terminal')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (unserialized) ==
+       error.stack (the raw string):
+         Error: boom:unserialized
+             at throwsInChunk (<tmp>/chunk.js:121:11)
+             at Object.react_stack_bottom_frame (<tmp>/chunk.js:124:12)
+             at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             at throwAndCatch (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at unserialized-error-terminal (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:unserialized
+             at throwsInChunk (<tmp>/original.js:3:9)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error('boom:unserialized')
+             |<9 spaces>^
+           4 | }
+           5 | export function react_stack_bottom_frame() {
+           6 |   return throwsInChunk()
+       top frame (as an attached debugger resolves it): throwsInChunk at <tmp>/chunk.js:121:11
+           script: not loaded
+       == hop 1 (unserialized) ==
+       error.stack (the raw string):
+         Error: boom:plain.js
+             at throwsInChunk (<tmp>/plain.js:113:11)
+             at Array.map (<anonymous>)
+             at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             at throwAndCatch (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at unserialized-error-terminal (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:plain.js
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Array.map (<anonymous>)
+             at <unknown> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at unserialized-error-terminal (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:plain.js")
+             |<9 spaces>^
+           4 | }
+           5 |
+       top frame (as an attached debugger resolves it): throwsInChunk at <tmp>/plain.js:113:11
+           script: not loaded
+       == hop 2 (unserialized) ==
+       error.stack (the raw string):
+         Error: boom:react-stack-bottom-frame.js
+             at Object.throwsInChunk (<tmp>/marker/react-stack-bottom-frame.js:113:11)
+             at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             at throwAndCatch (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at unserialized-error-terminal (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:react-stack-bottom-frame.js
+             at Object.throwsInChunk (<tmp>/marker/original.js:3:9)
+             at <unknown> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at unserialized-error-terminal (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:react-stack-bottom-frame.js")
+             |<9 spaces>^
+           4 | }
+           5 |
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at <tmp>/marker/react-stack-bottom-frame.js:113:11
+           script: not loaded
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/plain.js
+         map: plain.js.map
+       file://<tmp>/marker/react-stack-bottom-frame.js
+         map: react-stack-bottom-frame.js.map"
+      `)
+    })
+
+    it('ignore-lists native frames sandwiched between ignored frames', () => {
+      expect(renderScenario(runScenario('sandwiched-native-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (unserialized) ==
+       error.stack (the raw string):
+         Error: boom:sandwich
+             at inner (<tmp>/node_modules/lib/index.js:3:11)
+             at Array.map (<anonymous>)
+             at outer (<tmp>/node_modules/lib/index.js:2:14)
+             at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             at throwAndCatch (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at sandwiched-native-frames (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:sandwich
+             at <unknown> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at sandwiched-native-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at main (test/unit/fake-stack-frames/scenario.js:<pos>)
+       top frame (as an attached debugger resolves it): inner at <tmp>/node_modules/lib/index.js:3:11
+           script: not loaded
+       == fake scripts ==
+       file://<tmp>/node_modules/lib/index.js
+         map: -"
+      `)
+    })
+
+    it('caches terminal source map lookups per file within one error', () => {
+      // The second frame from each file reuses the cached consumer (good
+      // chunk, both frames resolve) or the cached failure (bad bundler map,
+      // the invalid-map warning prints once, both frames stay generated).
+      expect(renderScenario(runScenario('terminal-cache-paths')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (unserialized) ==
+       error.stack (the raw string):
+         Error: boom:cached-consumer
+             at throwsInChunk (<tmp>/good.js:121:11)
+             at Object.callsThrough (<tmp>/good.js:124:12)
+             at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             at throwAndCatch (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at terminal-cache-paths (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:cached-consumer
+             at throwsInChunk (<tmp>/original.js:3:9)
+             at Object.callsThrough (<tmp>/original.js:6:10)
+             at <unknown> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at terminal-cache-paths (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:cached-consumer")
+             |<9 spaces>^
+           4 | }
+           5 | export function callsThrough() {
+           6 |   return throwsInChunk()
+       top frame (as an attached debugger resolves it): throwsInChunk at <tmp>/good.js:121:11
+           script: not loaded
+       == hop 1 (unserialized) ==
+       error.stack (the raw string):
+         Error: boom:cached-failure
+             at throwsInChunk (<tmp>/bad/bad.js:121:11)
+             at Object.callsThrough (<tmp>/bad/bad.js:124:12)
+             at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+             at throwAndCatch (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at terminal-cache-paths (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:cached-failure
+             at throwsInChunk (<tmp>/bad/bad.js:121:11)
+             at Object.callsThrough (<tmp>/bad/bad.js:124:12)
+             at <unknown> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at terminal-cache-paths (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at async main (test/unit/fake-stack-frames/scenario.js:<pos>)
+       top frame (as an attached debugger resolves it): throwsInChunk at <tmp>/bad/bad.js:121:11
+           script: not loaded
+       == fake scripts ==
+       file://<tmp>/good.js
+         map: good.js.map
+       file://<tmp>/bad/bad.js
+         map: -"
+      `)
+    })
+
+    it('keeps ignore-listed frames in terminal output when asked to', () => {
+      expect(
+        renderScenario(
+          runScenario('thrown-string', { __NEXT_SHOW_IGNORE_LISTED: 'true' })
+        )
+      ).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:string
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:string
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.resolveErrorDev at <tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>
+           script: not loaded
+       == fake scripts ==
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -"
+      `)
+    })
+
+    it('prints terminal output without code frames when none is installed', () => {
+      // `next start` never installs the code frame renderer.
+      expect(
+        renderScenario(
+          runScenario('one-hop', { SCENARIO_SKIP_CODE_FRAMES: 'true' })
+        )
+      ).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at one-hop (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at one-hop (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('rewrites webpack export helper names in terminal frames', () => {
+      expect(renderScenario(runScenario('webpack-export-frame-names')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:export
+             at Object.__WEBPACK_DEFAULT_EXPORT__ (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at webpack-export-frame-names (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:export
+             at Object.default (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at webpack-export-frame-names (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | function __WEBPACK_DEFAULT_EXPORT__() {
+         > 3 |   throw new Error('boom:export')
+             |<9 spaces>^
+           4 | }
+           5 | export { __WEBPACK_DEFAULT_EXPORT__ as throwsInChunk }
+           6 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.__WEBPACK_DEFAULT_EXPORT__ at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.__WEBPACK_DEFAULT_EXPORT__":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  // The redbox: the overlay client posts parsed frames to
+  // `/__nextjs_original-stack-frames`, resolved server-side by
+  // `getOriginalStackFrames` with the endpoint's code frame options. Only
+  // the browser-side fetch wrapper and rendering are not modeled.
+  describe('digests', () => {
+    it('suffixes digests with the error code and forwards them', () => {
+      expect(renderScenario(runScenario('error-code-digest')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-code-digest (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-code-digest (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>@E118'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == hop 1 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-code-digest (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-1/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at error-code-digest (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>@E118'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       file://<tmp>/consumer-1/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-1/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('collides digests of identical throws onto the first error', () => {
+      // TODO: distinct error objects with identical stacks should not
+      // collapse onto the first thrown error during digest recovery.
+      const result = runScenario('digest-collision')
+      expect(result.htmlHandler).toEqual({
+        digestsCollide: true,
+        mapKeepsFirstError: true,
+      })
+      expect(renderScenario(result)).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at digest-collision (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at digest-collision (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+  })
+
+  describe('the dev overlay', () => {
+    it('resolves revived frames through the dev overlay machinery', () => {
+      expect(renderScenario(runScenario('dev-overlay-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at dev-overlay-frames (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (file://<repo>/test/unit/fake-stack-frames/scenario.js:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (<tmp>/original.js:3:9)
+             at <anonymous> (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at throwAndCatch (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at dev-overlay-frames (test/unit/fake-stack-frames/scenario.js:<pos>)
+             at  main (test/unit/fake-stack-frames/scenario.js:<pos>)
+           1 | // original source
+           2 | export function throwsInChunk() {
+         > 3 |   throw new Error("boom:chunk.js")
+             |<9 spaces>^
+           4 | }
+           5 | {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       overlay frames:
+         Object.throwsInChunk at original.js:3:9
+           |   1 | // original source
+           |   2 | export function throwsInChunk() {
+           | > 3 |   throw new Error("boom:chunk.js")
+           |     |<9 spaces>^
+           |   4 | }
+           |   5 |
+         <anonymous> at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+         throwAndCatch at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+         dev-overlay-frames at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+          main at <repo>/test/unit/fake-stack-frames/scenario.js:<pos>
+         Object.resolveErrorDev at <tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos> (ignored)
+         Immediate.<anonymous> at <tmp>/consumer-0/node_modules/flight-client/index.js:<pos> (ignored)
+         process.processImmediate at node:internal/timers:<pos> (ignored)
+         process.callbackTrampoline at node:internal/async_hooks:<pos> (ignored)
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: <map>
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('resolves fake frame maps through the endpoint like a browser', () => {
+      // The real browser `findSourceMapURL` mints `/__nextjs_source-map`
+      // URLs for the fake scripts, and a debugger fetches them through the
+      // dev server.
+      expect(
+        renderScenario(
+          runScenario('browser-flight-source-maps', {}, 'cjs', {
+            // The browser client mints endpoint URLs for every filename;
+            // the dev server has no map for the harness's own files, so
+            // the debugger's fetch for those comes back empty.
+            // TODO: only mint fake script map URLs the server can answer.
+            unmappedFakeScripts: ['/fake-stack-frames/scenario.js'],
+            // A harness artifact, not a real crossing: the harness prints
+            // every revived error through the patched Node inspect, which
+            // cannot fetch `http:` map URLs. A browser-revived error only
+            // reaches the real terminal as forwarded log text, which
+            // devirtualizes fake frames (covered below).
+            rawTerminalURLs: ['hop 0'],
+          })
+        )
+      ).toMatchInlineSnapshot(`
+       "== hop 0 (Server) ==
+       error.stack (the raw string):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?1:<pos>)
+             at throwAndCatch (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?2:<pos>)
+             at browser-flight-source-maps (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?3:<pos>)
+             at  main (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?4:<pos>)
+             at Object.resolveErrorDev (<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js:<pos>)
+             at Immediate.<anonymous> (<tmp>/consumer-0/node_modules/flight-client/index.js:<pos>)
+             at process.processImmediate (node:internal/timers:<pos>)
+             at process.callbackTrampoline (node:internal/async_hooks:<pos>)
+       terminal (the dev server prints through the patched inspect):
+         Error: boom:chunk.js
+             at Object.throwsInChunk (about://React/Server/file://<tmp>/chunk.js?0:113:11)
+             at <anonymous> (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?1:<pos>)
+             at throwAndCatch (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?2:<pos>)
+             at browser-flight-source-maps (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?3:<pos>)
+             at  main (about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?4:<pos>) {
+           environmentName: 'Server',
+           digest: '<hash>'
+         }
+       top frame (as an attached debugger resolves it): Object.throwsInChunk at about://React/Server/file://<tmp>/chunk.js?0:113:11
+           original: file://<tmp>/original.js:3
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/consumer-0/node_modules/flight-client/index.js
+         map: -
+       file://<tmp>/consumer-0/node_modules/flight-client/react-flight-semantics.js
+         map: -
+       about://React/Server/file://<tmp>/chunk.js?0
+         map: http://localhost:3000/__nextjs_source-map?filename=<tmp>%2Fchunk.js
+         | ({"Object.throwsInChunk":_=><112 newlines><10 spaces>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?1
+         map: http://localhost:3000/__nextjs_source-map?filename=<repo>%2Ftest%2Funit%2Ffake-stack-frames%2Fscenario.js
+         | ({"<anonymous>":_=><padding>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?2
+         map: http://localhost:3000/__nextjs_source-map?filename=<repo>%2Ftest%2Funit%2Ffake-stack-frames%2Fscenario.js
+         | ({"throwAndCatch":_=><padding>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?3
+         map: http://localhost:3000/__nextjs_source-map?filename=<repo>%2Ftest%2Funit%2Ffake-stack-frames%2Fscenario.js
+         | ({"browser-flight-source-maps":_=><padding>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */
+       about://React/Server/file://<repo>/test/unit/fake-stack-frames/scenario.js?4
+         map: http://localhost:3000/__nextjs_source-map?filename=<repo>%2Ftest%2Funit%2Ffake-stack-frames%2Fscenario.js
+         | ({" main":_=><padding>_()})
+         | /* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */"
+      `)
+    })
+
+    it('maps browser console log frames for the terminal', () => {
+      // Extension frames are dropped, unmapped chunks stay generated,
+      // fake frames of revived errors logged in the browser devirtualize
+      // to their server path, and `withLocation` appends the mapped
+      // top-frame location to the args.
+      expect(renderScenario(runScenario('browser-log-source-mapping')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (browser) ==
+       error.stack (the raw string):
+         Error: client log
+             at throwsInChunk (http://localhost:3000/_next/static/chunks/app.js:113:11)
+             at injected (chrome-extension://abcdef/content.js:1:1)
+             at unknown (http://localhost:3000/_next/static/chunks/other.js:1:1)
+             at Page (about://React/Server/file://<tmp>/server-page.js?0:113:11)
+       terminal (the dev server prints through the patched inspect):
+         (not printed)
+       top frame (as an attached debugger resolves it): no frame
+       == browser log mapping ==
+         kind: with-frame-code
+         at throwsInChunk (static/chunks/original.js:3:9) [code frame]
+         at unknown (static/chunks/other.js:1:1)
+         at Page (server-page.js:113:11)
+         console location: static/chunks/original.js:3:9
+         decorated: ["hello from the browser","(static/chunks/original.js:3:9)"]
+       == fake scripts ==
+       file://<tmp>/static/chunks/app.js
+         map: app.js.map"
+      `)
+    })
+
+    it('serves source maps to the browser through the endpoint', () => {
+      // The decoded `file://` spelling with a raw space misses both the
+      // native lookup and the decode fallback — the endpoint-side twin of
+      // the percent-encoding defects.
+      // TODO: the endpoint should resolve decoded `file://` spellings like
+      // the encoded ones.
+      expect(renderScenario(runScenario('source-map-endpoint')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (browser) ==
+       error.stack (the raw string):
+         (not observed)
+       terminal (the dev server prints through the patched inspect):
+         (not printed)
+       top frame (as an attached debugger resolves it): no frame
+       == /__nextjs_source-map ==
+         chunk path: 200 with map
+         chunk file URL: 200 with map
+         path with a space: 200 with map
+         encoded file URL with a space: 200 with map
+         decoded file URL with a space: 204
+         unknown file: 204
+       == fake scripts ==
+       file://<tmp>/chunk.js
+         map: chunk.js.map
+       file://<tmp>/my%20project/chunk.js
+         map: chunk.js.map"
+      `)
+    })
+
+    it('cleans up browser-reported frames for the overlay', () => {
+      expect(renderScenario(runScenario('overlay-browser-frames')))
+        .toMatchInlineSnapshot(`
+       "== hop 0 (browser) ==
+       error.stack (the raw string):
+         Error: boom
+             at evil (eval at run (<tmp>/host.js:1:1), <anonymous>:5:9)
+             at page (http://localhost:3000/_next/static/chunks/app/page.js:10:5)
+       terminal (the dev server prints through the patched inspect):
+         (not printed)
+       top frame (as an attached debugger resolves it): no frame
+       overlay frames:
+         evil at host.js:1:1
+         page at static/chunks/app/page.js:10:5
+       == fake scripts =="
+      `)
+    })
+  })
+})

--- a/test/unit/fake-stack-frames/README.md
+++ b/test/unit/fake-stack-frames/README.md
@@ -1,0 +1,175 @@
+# Fake stack frame semantics
+
+In development, React's Flight client evals a small script per revived stack
+frame so that debuggers can bind the frames of revived errors to something
+resolvable. This directory exercises that machinery end-to-end without a
+bundler or a dev server, so its behavior can be covered exhaustively and
+iterated on in milliseconds.
+
+## Pieces
+
+- `react-flight-semantics.js` — verbatim copies of the participating React
+  Flight pieces (producer: stack capture, filtering, devirtualization, error
+  serialization; consumer: fake function creation, error revival including
+  `cause` and `AggregateError`, owner task chains).
+  `fake-stack-frames.test.ts` verifies token-identity of the copies against
+  the vendored React builds, so a React sync that changes them fails the
+  suite until the copies are updated.
+- `scenario.js` — one scenario per process, run with `--enable-source-maps`
+  like `next dev` runs the server. Every participating Next.js piece is the
+  real `next/dist` module: `findSourceMapURLDEV`, `filterStackFrameDEV`,
+  `patchErrorInspectNodeJS` with the real SWC code frame renderer installed
+  (`installCodeFrameSupport` after `loadBindings`, like dev initialization),
+  `createReactServerErrorHandler` as the producer's `onError` (real
+  `stringHash` digests, well-known-error short-circuits, cross-boundary
+  dedup, `formatServerError`), `applyOwnerStack`, and the dev overlay's
+  `getOriginalStackFrames`/`parseStack`. Chunk fixtures are real compiled
+  output: authored original sources go through SWC (like `next dev`
+  compiles modules) and the compiled module is offset inside the chunk by
+  line-shifting its map, the way bundlers concatenate — so mappings have
+  real density and shape (their generated positions in snapshots move when
+  the vendored SWC changes, which is a diff worth seeing). Only the
+  fixtures whose subject is the map or cache shape itself (evals, HMR
+  updates, index map sections, sparse mappings) stay synthetic. Chunks load
+  through real `require()`/`import()`, and an in-process `node:inspector`
+  session provides the debugger's view (`Debugger.scriptParsed`, and
+  `Runtime.getExceptionDetails` for the `console.createTask` chain a
+  debugger shows as the async part of a revived error's stack). A Flight
+  boundary is elided to the calls React makes around it: `emitErrorChunk`
+  on the producer, `resolveErrorDev` on the consumer. Because digests are
+  computed from the stack on the first serialization and carried by revived
+  errors, the first hop parses the materialized stack string while later
+  hops parse V8's structured stack trace; and each hop revives in a
+  separate copy of the Flight client module (the RSC and SSR layers bundle
+  their own), placed under a `node_modules` directory and dispatched from
+  an empty task so that the revival machinery below the fake frames is
+  filtered on the next serialization, like the real Flight client's.
+
+## Coverage dimensions
+
+Scenarios vary one dimension at a time from the `one-hop` baseline (a named
+function in a CJS chunk with a plain sibling source map, revived once):
+
+- **Frame shape** — named function, method, constructor, native
+  (`Array.map (<anonymous>)`), module evaluation (`Object.<anonymous>`),
+  async (leading-space name), deep recursion, eval origin without a
+  sourceURL, `new Promise` (filtered), message lines that parse as frames.
+- **Chunk shape** — CJS file, eval with a sourceURL and inline source map,
+  repeated evals under one sourceURL, a stack spanning two chunks, files
+  deleted after loading, code under `node_modules`. Every chunk-loading
+  scenario runs as both CJS and ES module (frames carry paths vs
+  percent-encoded `file://` URLs, so e.g. the percent-encoding defects are
+  CJS-only), snapshotted side by side.
+- **HMR shapes** — repeated evals under one sourceURL, an edited chunk file
+  behind a busted module cache (both resolve revivals through the stale
+  first map), and query-busted ES module reloads (each version resolves
+  through its own map).
+- **Source map shape** — real compiled (dense), sparse (splitting the
+  terminal and debugger consumers), index map with an empty top-level `sources`
+  (Turbopack), index map with relative section sources, spec-conformant
+  index map, multi-section index map, invalid, missing, fully and partially
+  ignore-listed.
+- **Path shape** — plain, brackets, space, unicode, percent, hash, symlink,
+  a directory name containing `node_modules`, `webpack-internal:` URLs.
+- **Hops** — one, two, three, one serialization revived by two consumers,
+  the "use cache" layer topology (a `Cache`-rooted consumer for the first
+  revival, a `Server`-rooted one for the second), nested "use cache" (two
+  `Cache`-rooted consumers in a row), and the instant validation chain (a
+  segment re-encode whose `onError` forwards digests, then the dev
+  overlay's `{ errors }` payload where the error crosses as a value and
+  loses its digest).
+- **Error shape** — `Error`, custom `name`, multi-line message, empty
+  message (fallback message on revival), thrown non-Error string and
+  object, a `cause` chain (including a non-object innermost cause and a
+  cause carrying its own environment), `AggregateError`, a pre-digested
+  framework error (structured first-hop parse, banner-first fake scripts),
+  a message rewritten by `formatServerError` after the digest.
+- **Terminal formatting** — resolved frames, ignore-listed collapsing and
+  the `__NEXT_SHOW_IGNORE_LISTED` escape hatch, webpack export helper
+  renames.
+- **Downstream and upstream Next machinery** (real `next/dist` modules) —
+  the dev overlay's `/__nextjs_original-stack-frames` resolution
+  (`getOriginalStackFrames` with the native source map path and SWC code
+  frames), the browser-facing `/__nextjs_source-map` endpoint
+  (`getSourceMapMiddleware`) both queried directly and closed into a loop
+  with the real browser-side `findSourceMapURL` (fake scripts carry `http:`
+  map URLs that resolve through the middleware, and the harness's own
+  frames pin the empty answers the endpoint gives for unmapped files),
+  browser console logs mapped server-side for the terminal
+  (`getSourceMappedStackFrames`, `getConsoleLocation`, `withLocation` over
+  a browser-shaped stack with an extension frame, an unmapped chunk, and a
+  fake frame of a revived error, which devirtualizes to its server path),
+  and `applyOwnerStack` rewriting an error's stack with owner frames before
+  serialization.
+- **Digest identity** — hashed, `@Exxx` error-code-suffixed, forwarded
+  across hops and segment re-encodes, dropped on value crossings, colliding
+  for identical throws (the shared map keeps the first error).
+- **Owner chain** — none, a two-level component chain, an owner from a
+  different environment in both directions (task labels), an owner attached
+  only at re-serialization, an owner without a stack, an owner whose stack
+  filters away, and `Prerender`/`Prefetch`-stage chains under a
+  `Server`-rooted consumer (the `"use ..."` boundary tasks).
+
+## What is deliberately not modeled
+
+- Console replay (`initializeFakeStack` and the `initializeFakeTask`
+  consumers other than error revival: await/IO debug info, and with it the
+  `useEnclosingLine` variants of `createFakeFunction`). Its one effect on
+  the error path — serializing an error as a debug value first caches a
+  structured stack parse that the error serialization reuses, flipping the
+  first hop off the materialized-string path — is covered.
+- The Flight stream: outlined rows are serialized to row text eagerly
+  (instead of by the streaming renderer's task queue) and seeded into the
+  real chunk cache as resolved model chunks (instead of arriving through
+  `processFullStringRow`). The error row itself round-trips as row text, and
+  the harness parses it like the client's `E`-row handler.
+- The browser's actual HTTP transport: the client `findSourceMapURL` and
+  the endpoint middleware are real and wired together, but the fetch
+  between them is the harness, not a network stack, and the client-chunk
+  shortcut branch (returning `filename + '.map'` for `/_next/static` URLs)
+  never fires because fake frames carry server paths.
+- Abort and halt wire semantics: render-type aborts emit one shared error
+  chunk for the abort reason (owner-less, digest from `onError`), prerender
+  aborts halt rows without emitting stacks at all.
+- Next machinery around the boundary that swaps or rewrites stacks outside
+  serialization: `createHTMLErrorHandler` recovering the original error by
+  digest during SSR, and `addErrorContext` (not exported; its
+  component-stack rewrite has the same shape as the covered
+  `applyOwnerStack`).
+- The webpack overlay middleware (needs a webpack compilation) and the
+  Turbopack bundler fallbacks (`project.traceSource` in the middleware and
+  in the browser-log mapping): only the native source map paths are
+  covered.
+- The overlay payload's `errorCodes` Map (keyed by error object identity,
+  relying on the chunk cache preserving it) and `deobfuscateText` rewriting
+  Turbopack magic identifiers in logged messages
+  (`setup-dev-bundler.ts`).
+
+## Coverage of the Next.js pieces
+
+Running the suite with `NODE_V8_COVERAGE` over the scenario processes shows
+every logic branch of `source-maps.ts`, `patch-error-inspect.ts`,
+`create-error-handler.ts`, `format-server-error.ts`, and `parse-stack.ts`
+executing, except: the edge runtime variants (`noSourceMap`,
+`patchErrorInspectEdgeLite`), production-only branches (`NODE_ENV` gates,
+the error-swap in the digest recovery), tracing spans (need an active
+tracer), the invalid-source-map `catch` blocks around `module.findSourceMap`
+(it does not throw on current Node.js; the terminal's consumer-side catch
+is covered through a bundler-provided invalid map), and runs of multiple
+consecutive anonymous native frames in the sandwich ignore-listing.
+
+## Universal invariants
+
+Beyond the per-scenario snapshots, every run is checked against invariants
+in both directions: every `about://React/` fake script must carry a
+parseable inline source map, every fake frame must resolve through it, and
+no terminal output may show a raw `about://React/` URL — except for known
+defects a test declares inline at its `runScenario` call, which must keep
+reproducing until fixed (fixing one fails the suite until the declaration
+is removed).
+
+The assertions in `fake-stack-frames.test.ts` encode the current behavior,
+including its defects (for example: the second revival of a stack whose chunk
+path contains characters that `encodeURI` escapes produces a fake script
+without a source map, under the chunk's own URL). Changes to the machinery
+are expected to show up as assertion changes there.

--- a/test/unit/fake-stack-frames/react-flight-semantics.js
+++ b/test/unit/fake-stack-frames/react-flight-semantics.js
@@ -1,0 +1,1545 @@
+/**
+ * Verbatim copies of the React Flight pieces involved in creating fake stack
+ * frames, so that their semantics can be exercised end-to-end without a
+ * Flight wire, a renderer, or a bundler in between.
+ *
+ * Producer pieces are copied from
+ * `packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js`,
+ * consumer pieces from
+ * `packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.node.development.js`.
+ *
+ * Copies must not be "improved". The only permitted deviations are marked
+ * with DEVIATION comments and are limited to module plumbing (e.g. the
+ * `response` object is reduced to the properties the copied code reads).
+ */
+
+/* eslint-disable */
+
+'use strict'
+
+// ---------------------------------------------------------------------------
+// Producer: stack capture and serialization
+// ---------------------------------------------------------------------------
+
+var identifierRegExp = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/,
+  frameRegExp =
+    /^ {3} at (?:(.+) \((?:(.+):(\d+):(\d+)|<anonymous>)\)|(?:async )?(.+):(\d+):(\d+)|<anonymous>)$/,
+  stackTraceCache = new WeakMap()
+
+var collectedStackTrace = null
+var framesToSkip = 0
+
+function collectStackTracePrivate(error, structuredStackTrace) {
+  error = []
+  for (var i = framesToSkip; i < structuredStackTrace.length; i++) {
+    var callSite = structuredStackTrace[i],
+      name = callSite.getFunctionName() || '<anonymous>'
+    if (name.includes('react_stack_bottom_frame')) break
+    else if (callSite.isNative())
+      (callSite = callSite.isAsync()),
+        error.push([name, '', 0, 0, 0, 0, callSite])
+    else {
+      if (callSite.isConstructor()) name = 'new ' + name
+      else if (!callSite.isToplevel()) {
+        var callSite$jscomp$0 = callSite
+        name = callSite$jscomp$0.getTypeName()
+        var methodName = callSite$jscomp$0.getMethodName()
+        callSite$jscomp$0 = callSite$jscomp$0.getFunctionName()
+        var result = ''
+        callSite$jscomp$0
+          ? (name &&
+              identifierRegExp.test(callSite$jscomp$0) &&
+              callSite$jscomp$0 !== name &&
+              (result += name + '.'),
+            (result += callSite$jscomp$0),
+            !methodName ||
+              callSite$jscomp$0 === methodName ||
+              callSite$jscomp$0.endsWith('.' + methodName) ||
+              callSite$jscomp$0.endsWith(' ' + methodName) ||
+              (result += ' [as ' + methodName + ']'))
+          : (name && (result += name + '.'),
+            (result = methodName
+              ? result + methodName
+              : result + '<anonymous>'))
+        name = result
+      }
+      '<anonymous>' === name && (name = '')
+      methodName = callSite.getScriptNameOrSourceURL() || '<anonymous>'
+      '<anonymous>' === methodName &&
+        ((methodName = ''),
+        callSite.isEval() &&
+          (callSite$jscomp$0 = callSite.getEvalOrigin()) &&
+          (methodName = callSite$jscomp$0.toString() + ', <anonymous>'))
+      callSite$jscomp$0 = callSite.getLineNumber() || 0
+      result = callSite.getColumnNumber() || 0
+      var enclosingLine =
+          'function' === typeof callSite.getEnclosingLineNumber
+            ? callSite.getEnclosingLineNumber() || 0
+            : 0,
+        enclosingCol =
+          'function' === typeof callSite.getEnclosingColumnNumber
+            ? callSite.getEnclosingColumnNumber() || 0
+            : 0
+      callSite = callSite.isAsync()
+      error.push([
+        name,
+        methodName,
+        callSite$jscomp$0,
+        result,
+        enclosingLine,
+        enclosingCol,
+        callSite,
+      ])
+    }
+  }
+  collectedStackTrace = error
+  return ''
+}
+
+function collectStackTrace(error, structuredStackTrace) {
+  collectStackTracePrivate(error, structuredStackTrace)
+  error = (error.name || 'Error') + ': ' + (error.message || '')
+  for (var i = 0; i < structuredStackTrace.length; i++)
+    error += '\n    at ' + structuredStackTrace[i].toString()
+  return error
+}
+
+function parseStackTrace(error, skipFrames) {
+  var existing = stackTraceCache.get(error)
+  if (void 0 !== existing) return existing
+  collectedStackTrace = null
+  framesToSkip = skipFrames
+  existing = Error.prepareStackTrace
+  Error.prepareStackTrace = collectStackTrace
+  try {
+    var stack = String(error.stack)
+  } finally {
+    Error.prepareStackTrace = existing
+  }
+  if (null !== collectedStackTrace)
+    return (
+      (stack = collectedStackTrace),
+      (collectedStackTrace = null),
+      stackTraceCache.set(error, stack),
+      stack
+    )
+  stack.startsWith('Error: react-stack-top-frame\n') &&
+    (stack = stack.slice(29))
+  existing = stack.indexOf('react_stack_bottom_frame')
+  ;-1 !== existing && (existing = stack.lastIndexOf('\n', existing))
+  ;-1 !== existing && (stack = stack.slice(0, existing))
+  stack = stack.split('\n')
+  for (existing = []; skipFrames < stack.length; skipFrames++) {
+    var parsed = frameRegExp.exec(stack[skipFrames])
+    if (parsed) {
+      var name = parsed[1] || '',
+        isAsync = 'async ' === parsed[8]
+      '<anonymous>' === name
+        ? (name = '')
+        : name.startsWith('async ') && ((name = name.slice(5)), (isAsync = !0))
+      var filename = parsed[2] || parsed[5] || ''
+      '<anonymous>' === filename && (filename = '')
+      existing.push([
+        name,
+        filename,
+        +(parsed[3] || parsed[6]),
+        +(parsed[4] || parsed[7]),
+        0,
+        0,
+        isAsync,
+      ])
+    }
+  }
+  stackTraceCache.set(error, existing)
+  return existing
+}
+
+function devirtualizeURL(url) {
+  if (url.startsWith('about://React/')) {
+    var envIdx = url.indexOf('/', 14),
+      suffixIdx = url.lastIndexOf('?')
+    if (-1 < envIdx && -1 < suffixIdx)
+      return decodeURI(url.slice(envIdx + 1, suffixIdx))
+  }
+  return url
+}
+
+function filterStackTrace(request, stack) {
+  request = request.filterStackFrame
+  for (var filteredStack = [], i = 0; i < stack.length; i++) {
+    var callsite = stack[i],
+      functionName = callsite[0],
+      url = devirtualizeURL(callsite[1])
+    request(url, functionName, callsite[2], callsite[3]) &&
+      ((callsite = callsite.slice(0)),
+      (callsite[1] = url),
+      filteredStack.push(callsite))
+  }
+  return filteredStack
+}
+
+// ---------------------------------------------------------------------------
+// Producer: error serialization
+// ---------------------------------------------------------------------------
+
+var REACT_FORWARD_REF_TYPE = Symbol.for("react.forward_ref"),
+  REACT_LAZY_TYPE = Symbol.for("react.lazy"),
+  REACT_MEMO_TYPE = Symbol.for("react.memo"),
+  REACT_SUSPENSE_TYPE = Symbol.for("react.suspense"),
+  REACT_SUSPENSE_LIST_TYPE = Symbol.for("react.suspense_list"),
+  REACT_VIEW_TRANSITION_TYPE = Symbol.for("react.view_transition"),
+  CLIENT_REFERENCE_TAG = Symbol.for("react.client.reference"),
+  stringify = JSON.stringify,
+  jsxChildrenParents = new WeakMap(),
+  jsxPropsParents = new WeakMap()
+
+function objectName(object) {
+  object = Object.prototype.toString.call(object);
+  return object.slice(8, object.length - 1);
+}
+function describeKeyForErrorMessage(key) {
+  var encodedKey = JSON.stringify(key);
+  return '"' + key + '"' === encodedKey ? key : encodedKey;
+}
+function describeValueForErrorMessage(value) {
+  switch (typeof value) {
+    case "string":
+      return JSON.stringify(
+        10 >= value.length ? value : value.slice(0, 10) + "..."
+      );
+    case "object":
+      if (isArrayImpl(value)) return "[...]";
+      if (null !== value && value.$$typeof === CLIENT_REFERENCE_TAG)
+        return "client";
+      value = objectName(value);
+      return "Object" === value ? "{...}" : value;
+    case "function":
+      return value.$$typeof === CLIENT_REFERENCE_TAG
+        ? "client"
+        : (value = value.displayName || value.name)
+          ? "function " + value
+          : "function";
+    default:
+      return String(value);
+  }
+}
+function describeElementType(type) {
+  if ("string" === typeof type) return type;
+  switch (type) {
+    case REACT_SUSPENSE_TYPE:
+      return "Suspense";
+    case REACT_SUSPENSE_LIST_TYPE:
+      return "SuspenseList";
+    case REACT_VIEW_TRANSITION_TYPE:
+      return "ViewTransition";
+  }
+  if ("object" === typeof type)
+    switch (type.$$typeof) {
+      case REACT_FORWARD_REF_TYPE:
+        return describeElementType(type.render);
+      case REACT_MEMO_TYPE:
+        return describeElementType(type.type);
+      case REACT_LAZY_TYPE:
+        var payload = type._payload;
+        type = type._init;
+        try {
+          return describeElementType(type(payload));
+        } catch (x) {}
+    }
+  return "";
+}
+function describeObjectForErrorMessage(objectOrArray, expandedName) {
+  var objKind = objectName(objectOrArray);
+  if ("Object" !== objKind && "Array" !== objKind) return objKind;
+  var start = -1,
+    length = 0;
+  if (isArrayImpl(objectOrArray))
+    if (jsxChildrenParents.has(objectOrArray)) {
+      var type = jsxChildrenParents.get(objectOrArray);
+      objKind = "<" + describeElementType(type) + ">";
+      for (var i = 0; i < objectOrArray.length; i++) {
+        var value = objectOrArray[i];
+        value =
+          "string" === typeof value
+            ? value
+            : "object" === typeof value && null !== value
+              ? "{" + describeObjectForErrorMessage(value) + "}"
+              : "{" + describeValueForErrorMessage(value) + "}";
+        "" + i === expandedName
+          ? ((start = objKind.length),
+            (length = value.length),
+            (objKind += value))
+          : (objKind =
+              15 > value.length && 40 > objKind.length + value.length
+                ? objKind + value
+                : objKind + "{...}");
+      }
+      objKind += "</" + describeElementType(type) + ">";
+    } else {
+      objKind = "[";
+      for (type = 0; type < objectOrArray.length; type++)
+        0 < type && (objKind += ", "),
+          (i = objectOrArray[type]),
+          (i =
+            "object" === typeof i && null !== i
+              ? describeObjectForErrorMessage(i)
+              : describeValueForErrorMessage(i)),
+          "" + type === expandedName
+            ? ((start = objKind.length),
+              (length = i.length),
+              (objKind += i))
+            : (objKind =
+                10 > i.length && 40 > objKind.length + i.length
+                  ? objKind + i
+                  : objKind + "...");
+      objKind += "]";
+    }
+  else if (objectOrArray.$$typeof === REACT_ELEMENT_TYPE)
+    objKind = "<" + describeElementType(objectOrArray.type) + "/>";
+  else {
+    if (objectOrArray.$$typeof === CLIENT_REFERENCE_TAG) return "client";
+    if (jsxPropsParents.has(objectOrArray)) {
+      objKind = jsxPropsParents.get(objectOrArray);
+      objKind = "<" + (describeElementType(objKind) || "...");
+      type = Object.keys(objectOrArray);
+      for (i = 0; i < type.length; i++) {
+        objKind += " ";
+        value = type[i];
+        objKind += describeKeyForErrorMessage(value) + "=";
+        var _value2 = objectOrArray[value];
+        var _substr2 =
+          value === expandedName &&
+          "object" === typeof _value2 &&
+          null !== _value2
+            ? describeObjectForErrorMessage(_value2)
+            : describeValueForErrorMessage(_value2);
+        "string" !== typeof _value2 && (_substr2 = "{" + _substr2 + "}");
+        value === expandedName
+          ? ((start = objKind.length),
+            (length = _substr2.length),
+            (objKind += _substr2))
+          : (objKind =
+              10 > _substr2.length && 40 > objKind.length + _substr2.length
+                ? objKind + _substr2
+                : objKind + "...");
+      }
+      objKind += ">";
+    } else {
+      objKind = "{";
+      type = Object.keys(objectOrArray);
+      for (i = 0; i < type.length; i++)
+        0 < i && (objKind += ", "),
+          (value = type[i]),
+          (objKind += describeKeyForErrorMessage(value) + ": "),
+          (_value2 = objectOrArray[value]),
+          (_value2 =
+            "object" === typeof _value2 && null !== _value2
+              ? describeObjectForErrorMessage(_value2)
+              : describeValueForErrorMessage(_value2)),
+          value === expandedName
+            ? ((start = objKind.length),
+              (length = _value2.length),
+              (objKind += _value2))
+            : (objKind =
+                10 > _value2.length && 40 > objKind.length + _value2.length
+                  ? objKind + _value2
+                  : objKind + "...");
+      objKind += "}";
+    }
+  }
+  return void 0 === expandedName
+    ? objKind
+    : -1 < start && 0 < length
+      ? ((objectOrArray = " ".repeat(start) + "^".repeat(length)),
+        "\n  " + objKind + "\n  " + objectOrArray)
+      : "\n  " + objKind;
+}
+
+function serializeByValueID(id) {
+  return "$" + id.toString(16);
+}
+
+function serializeErrorValue(request, error) {
+  var name = "Error",
+    env = (0, request.environmentName)();
+  try {
+    name = error.name;
+    var message = String(error.message);
+    var stack = filterStackTrace(request, parseStackTrace(error, 0));
+    var errorEnv = error.environmentName;
+    "string" === typeof errorEnv && (env = errorEnv);
+  } catch (x) {
+    (message =
+      "An error occurred but serializing the error message failed."),
+      (stack = []);
+  }
+  name = { name: name, message: message, stack: stack, env: env };
+  "cause" in error &&
+    ((message = outlineModel(request, error.cause)),
+    (name.cause = serializeByValueID(message)));
+  "undefined" !== typeof AggregateError &&
+    error instanceof AggregateError &&
+    ((error = outlineModel(request, error.errors)),
+    (name.errors = serializeByValueID(error)));
+  return "$Z" + outlineModel(request, name).toString(16);
+}
+
+function emitErrorChunk(request, id, digest, error, debug, owner) {
+  var name = "Error",
+    env = (0, request.environmentName)(),
+    causeReference = null,
+    errorsReference = null;
+  try {
+    if (error instanceof Error) {
+      name = error.name;
+      var message = String(error.message);
+      var stack = filterStackTrace(request, parseStackTrace(error, 0));
+      var errorEnv = error.environmentName;
+      "string" === typeof errorEnv && (env = errorEnv);
+      if ("cause" in error) {
+        var cause = error.cause,
+          causeId = debug
+            ? outlineDebugModel(request, { objectLimit: 5 }, cause)
+            : outlineModel(request, cause);
+        causeReference = serializeByValueID(causeId);
+      }
+      if (
+        "undefined" !== typeof AggregateError &&
+        error instanceof AggregateError
+      ) {
+        var errors = error.errors,
+          errorsId = debug
+            ? outlineDebugModel(request, { objectLimit: 5 }, errors)
+            : outlineModel(request, errors);
+        errorsReference = serializeByValueID(errorsId);
+      }
+    } else
+      (message =
+        "object" === typeof error && null !== error
+          ? describeObjectForErrorMessage(error)
+          : String(error)),
+        (stack = []);
+  } catch (x) {
+    (message =
+      "An error occurred but serializing the error message failed."),
+      (stack = []);
+  }
+  error = null == owner ? null : outlineComponentInfo(request, owner);
+  digest = {
+    digest: digest,
+    name: name,
+    message: message,
+    stack: stack,
+    env: env,
+    owner: error
+  };
+  null !== causeReference && (digest.cause = causeReference);
+  null !== errorsReference && (digest.errors = errorsReference);
+  id = id.toString(16) + ":E" + stringify(digest) + "\n";
+  debug
+    ? request.completedDebugChunks.push(id)
+    : request.completedErrorChunks.push(id);
+}
+
+function outlineComponentInfo(request, componentInfo) {
+  var existingRef = request.writtenDebugObjects.get(componentInfo);
+  if (void 0 !== existingRef) return existingRef;
+  null != componentInfo.owner &&
+    outlineComponentInfo(request, componentInfo.owner);
+  existingRef = 10;
+  null != componentInfo.stack &&
+    (existingRef += componentInfo.stack.length);
+  existingRef = { objectLimit: existingRef };
+  var componentDebugInfo = {
+    name: componentInfo.name,
+    key: componentInfo.key
+  };
+  null != componentInfo.env && (componentDebugInfo.env = componentInfo.env);
+  null != componentInfo.owner &&
+    (componentDebugInfo.owner = componentInfo.owner);
+  null == componentInfo.stack && null != componentInfo.debugStack
+    ? (componentDebugInfo.stack = filterStackTrace(
+        request,
+        parseStackTrace(componentInfo.debugStack, 1)
+      ))
+    : null != componentInfo.stack &&
+      (componentDebugInfo.stack = componentInfo.stack);
+  componentDebugInfo.props = componentInfo.props;
+  existingRef = outlineDebugModel(request, existingRef, componentDebugInfo);
+  existingRef = serializeByValueID(existingRef);
+  request.writtenDebugObjects.set(componentInfo, existingRef);
+  request.writtenObjects.set(componentInfo, existingRef);
+  return existingRef;
+}
+
+// DEVIATION: Outlining enqueues a wire task that the streaming renderer
+// serializes later; reduced to immediate serialization of the row text,
+// covering the value shapes that reach the wire from the error path: error
+// info objects, owner rows, and their stack arrays. Strings escape `$` and
+// numbers use the renderer's encodings because both appear inside
+// serialized stack frames. The rest of the renderer's value domain (dates,
+// bigints, undefined, shared references, outlined text rows, class
+// instances) is not modeled and throws. Objects already outlined are
+// replaced with their reference, like the debug serializer's
+// `writtenDebugObjects` check.
+function serializeModelToRow(request, value) {
+  if (typeof value === 'string') {
+    return value[0] === '$' ? '$' + value : value
+  }
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) {
+      return value === 0 && 1 / value === -Infinity ? '$-0' : value
+    }
+    if (value === Infinity) return '$Infinity'
+    if (value === -Infinity) return '$-Infinity'
+    return '$NaN'
+  }
+  if (value instanceof Error) {
+    return serializeErrorValue(request, value)
+  }
+  if (isArrayImpl(value)) {
+    var array = []
+    for (var i = 0; i < value.length; i++) {
+      array.push(serializeModelToRow(request, value[i]))
+    }
+    return array
+  }
+  if ('object' === typeof value && null !== value) {
+    var written = request.writtenDebugObjects.get(value)
+    if (written !== undefined) {
+      return written
+    }
+    var proto = Object.getPrototypeOf(value)
+    if (proto !== Object.prototype && proto !== null) {
+      throw new Error('non-plain object values in models are not modeled')
+    }
+    var object = {}
+    for (var key of Object.keys(value)) {
+      object[key] = serializeModelToRow(request, value[key])
+    }
+    return object
+  }
+  if (typeof value === 'boolean' || value === null) {
+    return value
+  }
+  throw new Error(`\`${typeof value}\` values in models are not modeled`)
+}
+
+function outlineModel(request, value) {
+  var id = request.nextChunkId++
+  request._outlinedRows[id.toString(16)] = stringify(
+    serializeModelToRow(request, value)
+  )
+  return id
+}
+
+function outlineDebugModel(request, counter, model) {
+  var id = request.nextChunkId++
+  request._outlinedRows[id.toString(16)] = stringify(
+    serializeModelToRow(request, model)
+  )
+  return id
+}
+
+// ---------------------------------------------------------------------------
+// Consumer: fake stack frame creation
+// ---------------------------------------------------------------------------
+
+var fakeFunctionCache = new Map()
+var fakeFunctionIdx = 0
+
+function createFakeFunction(
+  name,
+  filename,
+  sourceMap,
+  line,
+  col,
+  enclosingLine,
+  enclosingCol,
+  environmentName
+) {
+  name || (name = '<anonymous>')
+  var encodedName = JSON.stringify(name)
+  1 > enclosingLine ? (enclosingLine = 0) : enclosingLine--
+  1 > enclosingCol ? (enclosingCol = 0) : enclosingCol--
+  1 > line ? (line = 0) : line--
+  1 > col ? (col = 0) : col--
+  if (line < enclosingLine || (line === enclosingLine && col < enclosingCol))
+    enclosingCol = enclosingLine = 0
+  1 > line
+    ? ((line = encodedName.length + 3),
+      (enclosingCol -= line),
+      0 > enclosingCol && (enclosingCol = 0),
+      (col = col - enclosingCol - line - 3),
+      0 > col && (col = 0),
+      (encodedName =
+        '({' +
+        encodedName +
+        ':' +
+        ' '.repeat(enclosingCol) +
+        '_=>' +
+        ' '.repeat(col) +
+        '_()})'))
+    : 1 > enclosingLine
+      ? ((enclosingCol -= encodedName.length + 3),
+        0 > enclosingCol && (enclosingCol = 0),
+        (encodedName =
+          '({' +
+          encodedName +
+          ':' +
+          ' '.repeat(enclosingCol) +
+          '_=>' +
+          '\n'.repeat(line - enclosingLine) +
+          ' '.repeat(col) +
+          '_()})'))
+      : enclosingLine === line
+        ? ((col = col - enclosingCol - 3),
+          0 > col && (col = 0),
+          (encodedName =
+            '\n'.repeat(enclosingLine - 1) +
+            '({' +
+            encodedName +
+            ':\n' +
+            ' '.repeat(enclosingCol) +
+            '_=>' +
+            ' '.repeat(col) +
+            '_()})'))
+        : (encodedName =
+            '\n'.repeat(enclosingLine - 1) +
+            '({' +
+            encodedName +
+            ':\n' +
+            ' '.repeat(enclosingCol) +
+            '_=>' +
+            '\n'.repeat(line - enclosingLine) +
+            ' '.repeat(col) +
+            '_()})')
+  encodedName =
+    1 > enclosingLine
+      ? encodedName +
+        '\n/* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */'
+      : '/* This module was rendered by a Server Component. Turn on Source Maps to see the server source. */' +
+        encodedName
+  filename.startsWith('/') && (filename = 'file://' + filename)
+  sourceMap
+    ? ((encodedName +=
+        '\n//# sourceURL=about://React/' +
+        encodeURIComponent(environmentName) +
+        '/' +
+        encodeURI(filename) +
+        '?' +
+        fakeFunctionIdx++),
+      (encodedName += '\n//# sourceMappingURL=' + sourceMap))
+    : (encodedName = filename
+        ? encodedName + ('\n//# sourceURL=' + encodeURI(filename))
+        : encodedName + '\n//# sourceURL=<anonymous>')
+  try {
+    var fn = (0, eval)(encodedName)[name]
+  } catch (x) {
+    ;(fn = function (_) {
+      return _()
+    }),
+      Object.defineProperty(fn, 'name', { value: name })
+  }
+  return fn
+}
+
+function buildFakeCallStack(
+  response,
+  stack,
+  environmentName,
+  useEnclosingLine,
+  innerCall
+) {
+  for (var i = 0; i < stack.length; i++) {
+    var frame = stack[i],
+      frameKey =
+        frame.join('-') +
+        '-' +
+        environmentName +
+        (useEnclosingLine ? '-e' : '-n'),
+      fn = fakeFunctionCache.get(frameKey)
+    if (void 0 === fn) {
+      fn = frame[0]
+      var filename = frame[1],
+        line = frame[2],
+        col = frame[3],
+        enclosingLine = frame[4]
+      frame = frame[5]
+      var findSourceMapURL = response._debugFindSourceMapURL
+      findSourceMapURL = findSourceMapURL
+        ? findSourceMapURL(filename, environmentName)
+        : null
+      fn = createFakeFunction(
+        fn,
+        filename,
+        findSourceMapURL,
+        line,
+        col,
+        useEnclosingLine ? line : enclosingLine,
+        useEnclosingLine ? col : frame,
+        environmentName
+      )
+      fakeFunctionCache.set(frameKey, fn)
+    }
+    innerCall = fn.bind(null, innerCall)
+  }
+  return innerCall
+}
+
+function getRootTask(response, childEnvironmentName) {
+  var rootTask = response._debugRootTask
+  return rootTask
+    ? response._rootEnvironmentName !== childEnvironmentName
+      ? ((response = console.createTask.bind(
+          console,
+          '"use ' + childEnvironmentName.toLowerCase() + '"'
+        )),
+        rootTask.run(response))
+      : rootTask
+    : null
+}
+
+var REACT_ELEMENT_TYPE = Symbol.for("react.transitional.element"),
+  ASYNC_ITERATOR = Symbol.asyncIterator,
+  isArrayImpl = Array.isArray,
+  mightHaveStaticConstructor = /\bclass\b.*\bstatic\b/,
+  supportsCreateTask = !!console.createTask,
+  initializingHandler = null,
+  initializingChunk = null,
+  isInitializingDebugInfo = !1
+
+function nullRefGetter() {
+  return null
+}
+
+// DEVIATION: These are reachable only through wire features the scenarios
+// never serialize (chunk streaming, lazy and server references, typed
+// collections, function values, the debug channel, elements). They throw if
+// a scenario starts exercising one without modeling it.
+function createLazyChunkWrapper() {
+  throw new Error('lazy references are not modeled')
+}
+function defineLazyGetter() {
+  throw new Error('the debug channel is not modeled')
+}
+function getInferredFunctionApproximate() {
+  throw new Error('function values are not modeled')
+}
+function loadServerReference() {
+  throw new Error('server references are not modeled')
+}
+function createMap() {
+  throw new Error('Map values are not modeled')
+}
+function createSet() {
+  throw new Error('Set values are not modeled')
+}
+function createBlob() {
+  throw new Error('Blob values are not modeled')
+}
+function createFormData() {
+  throw new Error('FormData values are not modeled')
+}
+function extractIterator() {
+  throw new Error('iterator values are not modeled')
+}
+function applyConstructor() {
+  throw new Error('class instance values are not modeled')
+}
+function initializeElement() {
+  throw new Error('elements are not modeled')
+}
+function getComponentNameFromType() {
+  throw new Error('elements are not modeled')
+}
+function initializeModuleChunk() {
+  throw new Error('module references are not modeled')
+}
+function waitForReference() {
+  throw new Error('pending wire chunks are not modeled')
+}
+function fulfillReference() {
+  throw new Error('pending wire chunks are not modeled')
+}
+function triggerErrorOnChunk() {
+  throw new Error('pending wire chunks are not modeled')
+}
+function initializeDebugInfo() {
+  throw new Error('debug info rows are not modeled')
+}
+
+function ReactPromise(status, value, reason) {
+  this.status = status;
+  this.value = value;
+  this.reason = reason;
+  this._children = [];
+  this._debugChunk = null;
+  this._debugInfo = [];
+}
+
+function createPendingChunk(response) {
+  0 === response._pendingChunks++ &&
+    ((response._weakResponse.response = response),
+    null !== response._pendingInitialRender &&
+      (clearTimeout(response._pendingInitialRender),
+      (response._pendingInitialRender = null)));
+  return new ReactPromise("pending", null, null);
+}
+
+function createResolvedModelChunk(response, value) {
+  return new ReactPromise("resolved_model", value, response);
+}
+
+function getChunk(response, id) {
+  var chunks = response._chunks,
+    chunk = chunks.get(id);
+  chunk ||
+    (response._closed
+      ? response._allowPartialStream
+        ? ((response = chunk = createPendingChunk(response)),
+          (response.status = "halted"),
+          (response.value = null),
+          (response.reason = null))
+        : (chunk = new ReactPromise(
+            "rejected",
+            null,
+            response._closedReason
+          ))
+      : (chunk = createPendingChunk(response)),
+    chunks.set(id, chunk));
+  return chunk;
+}
+
+function parseModel(response, json) {
+  json = JSON.parse(json);
+  return reviveModel(response, json, { "": json }, "");
+}
+
+function initializeDebugChunk(response, chunk) {
+  var debugChunk = chunk._debugChunk;
+  if (null !== debugChunk) {
+    var debugInfo = chunk._debugInfo,
+      prevIsInitializingDebugInfo = isInitializingDebugInfo;
+    isInitializingDebugInfo = !0;
+    try {
+      if ("resolved_model" === debugChunk.status) {
+        for (
+          var idx = debugInfo.length, c = debugChunk._debugChunk;
+          null !== c;
+
+        )
+          "fulfilled" !== c.status && idx++, (c = c._debugChunk);
+        initializeModelChunk(debugChunk);
+        switch (debugChunk.status) {
+          case "fulfilled":
+            debugInfo[idx] = initializeDebugInfo(
+              response,
+              debugChunk.value
+            );
+            break;
+          case "blocked":
+          case "pending":
+            waitForReference(
+              debugChunk,
+              debugInfo,
+              "" + idx,
+              response,
+              initializeDebugInfo,
+              [""],
+              !0
+            );
+            break;
+          default:
+            throw debugChunk.reason;
+        }
+      } else
+        switch (debugChunk.status) {
+          case "fulfilled":
+            break;
+          case "blocked":
+          case "pending":
+            waitForReference(
+              debugChunk,
+              {},
+              "debug",
+              response,
+              initializeDebugInfo,
+              [""],
+              !0
+            );
+            break;
+          default:
+            throw debugChunk.reason;
+        }
+    } catch (error) {
+      triggerErrorOnChunk(response, chunk, error);
+    } finally {
+      isInitializingDebugInfo = prevIsInitializingDebugInfo;
+    }
+  }
+}
+
+function initializeModelChunk(chunk) {
+  var prevHandler = initializingHandler,
+    prevChunk = initializingChunk;
+  initializingHandler = null;
+  var resolvedModel = chunk.value,
+    response = chunk.reason;
+  chunk.status = "blocked";
+  chunk.value = null;
+  chunk.reason = null;
+  initializingChunk = chunk;
+  initializeDebugChunk(response, chunk);
+  try {
+    var value = parseModel(response, resolvedModel),
+      resolveListeners = chunk.value;
+    if (null !== resolveListeners)
+      for (
+        chunk.value = null, chunk.reason = null, resolvedModel = 0;
+        resolvedModel < resolveListeners.length;
+        resolvedModel++
+      ) {
+        var listener = resolveListeners[resolvedModel];
+        "function" === typeof listener
+          ? listener(value)
+          : fulfillReference(response, listener, value, chunk);
+      }
+    if (null !== initializingHandler) {
+      if (initializingHandler.errored) throw initializingHandler.reason;
+      if (0 < initializingHandler.deps) {
+        initializingHandler.value = value;
+        initializingHandler.chunk = chunk;
+        return;
+      }
+    }
+    chunk.status = "fulfilled";
+    chunk.value = value;
+    chunk.reason = null;
+    filterDebugInfo(response, chunk);
+    moveDebugInfoFromChunkToInnerValue(chunk, value);
+  } catch (error) {
+    (chunk.status = "rejected"), (chunk.reason = error);
+  } finally {
+    (initializingHandler = prevHandler), (initializingChunk = prevChunk);
+  }
+}
+
+function resolveLazy(value) {
+  for (
+    ;
+    "object" === typeof value &&
+    null !== value &&
+    value.$$typeof === REACT_LAZY_TYPE;
+
+  ) {
+    var payload = value._payload;
+    if ("fulfilled" === payload.status) value = payload.value;
+    else break;
+  }
+  return value;
+}
+
+function filterDebugInfo(response, value) {
+  if (null !== response._debugEndTime) {
+    response = response._debugEndTime - performance.timeOrigin;
+    for (var debugInfo = [], i = 0; i < value._debugInfo.length; i++) {
+      var info = value._debugInfo[i];
+      if ("number" === typeof info.time && info.time > response) break;
+      debugInfo.push(info);
+    }
+    value._debugInfo = debugInfo;
+  }
+}
+
+function moveDebugInfoFromChunkToInnerValue(chunk, value) {
+  value = resolveLazy(value);
+  "object" !== typeof value ||
+    null === value ||
+    (!isArrayImpl(value) &&
+      "function" !== typeof value[ASYNC_ITERATOR] &&
+      value.$$typeof !== REACT_ELEMENT_TYPE &&
+      value.$$typeof !== REACT_LAZY_TYPE) ||
+    ((chunk = chunk._debugInfo.splice(0)),
+    isArrayImpl(value._debugInfo)
+      ? value._debugInfo.unshift.apply(value._debugInfo, chunk)
+      : Object.isFrozen(value) ||
+        Object.defineProperty(value, "_debugInfo", {
+          configurable: !1,
+          enumerable: !1,
+          writable: !0,
+          value: chunk
+        }));
+}
+
+function transferReferencedDebugInfo(parentChunk, referencedChunk) {
+  if (null !== parentChunk) {
+    referencedChunk = referencedChunk._debugInfo;
+    parentChunk = parentChunk._debugInfo;
+    for (var i = 0; i < referencedChunk.length; ++i) {
+      var debugInfoEntry = referencedChunk[i];
+      null == debugInfoEntry.name && parentChunk.push(debugInfoEntry);
+    }
+  }
+}
+
+function getOutlinedModel(response, reference, parentObject, key, map) {
+  var path = reference.split(":");
+  reference = parseInt(path[0], 16);
+  reference = getChunk(response, reference);
+  null !== initializingChunk &&
+    isArrayImpl(initializingChunk._children) &&
+    initializingChunk._children.push(reference);
+  switch (reference.status) {
+    case "resolved_model":
+      initializeModelChunk(reference);
+      break;
+    case "resolved_module":
+      initializeModuleChunk(reference);
+  }
+  switch (reference.status) {
+    case "fulfilled":
+      for (var value = reference.value, i = 1; i < path.length; i++) {
+        for (
+          ;
+          "object" === typeof value &&
+          null !== value &&
+          value.$$typeof === REACT_LAZY_TYPE;
+
+        ) {
+          value = value._payload;
+          switch (value.status) {
+            case "resolved_model":
+              initializeModelChunk(value);
+              break;
+            case "resolved_module":
+              initializeModuleChunk(value);
+          }
+          switch (value.status) {
+            case "fulfilled":
+              value = value.value;
+              break;
+            case "blocked":
+            case "pending":
+              return waitForReference(
+                value,
+                parentObject,
+                key,
+                response,
+                map,
+                path.slice(i - 1),
+                isInitializingDebugInfo
+              );
+            case "halted":
+              return (
+                initializingHandler
+                  ? ((parentObject = initializingHandler),
+                    parentObject.deps++)
+                  : (initializingHandler = {
+                      parent: null,
+                      chunk: null,
+                      value: null,
+                      reason: null,
+                      deps: 1,
+                      errored: !1
+                    }),
+                null
+              );
+            default:
+              return (
+                initializingHandler
+                  ? ((initializingHandler.errored = !0),
+                    (initializingHandler.value = null),
+                    (initializingHandler.reason = value.reason))
+                  : (initializingHandler = {
+                      parent: null,
+                      chunk: null,
+                      value: null,
+                      reason: value.reason,
+                      deps: 0,
+                      errored: !0
+                    }),
+                null
+              );
+          }
+        }
+        value = value[path[i]];
+      }
+      for (
+        ;
+        "object" === typeof value &&
+        null !== value &&
+        value.$$typeof === REACT_LAZY_TYPE;
+
+      ) {
+        path = value._payload;
+        switch (path.status) {
+          case "resolved_model":
+            initializeModelChunk(path);
+            break;
+          case "resolved_module":
+            initializeModuleChunk(path);
+        }
+        switch (path.status) {
+          case "fulfilled":
+            value = path.value;
+            continue;
+        }
+        break;
+      }
+      response = map(response, value, parentObject, key);
+      if (
+        parentObject[0] !== REACT_ELEMENT_TYPE ||
+        ("4" !== key && "5" !== key)
+      )
+        isInitializingDebugInfo ||
+          transferReferencedDebugInfo(initializingChunk, reference);
+      return response;
+    case "pending":
+    case "blocked":
+      return waitForReference(
+        reference,
+        parentObject,
+        key,
+        response,
+        map,
+        path,
+        isInitializingDebugInfo
+      );
+    case "halted":
+      return (
+        initializingHandler
+          ? ((parentObject = initializingHandler), parentObject.deps++)
+          : (initializingHandler = {
+              parent: null,
+              chunk: null,
+              value: null,
+              reason: null,
+              deps: 1,
+              errored: !1
+            }),
+        null
+      );
+    default:
+      return (
+        initializingHandler
+          ? ((initializingHandler.errored = !0),
+            (initializingHandler.value = null),
+            (initializingHandler.reason = reference.reason))
+          : (initializingHandler = {
+              parent: null,
+              chunk: null,
+              value: null,
+              reason: reference.reason,
+              deps: 0,
+              errored: !0
+            }),
+        null
+      );
+  }
+}
+
+function createModel(response, model) {
+  return model;
+}
+
+function parseModelString(response, parentObject, key, value) {
+  if ("$" === value[0]) {
+    if ("$" === value)
+      return (
+        null !== initializingHandler &&
+          "0" === key &&
+          (initializingHandler = {
+            parent: initializingHandler,
+            chunk: null,
+            value: null,
+            reason: null,
+            deps: 0,
+            errored: !1
+          }),
+        REACT_ELEMENT_TYPE
+      );
+    switch (value[1]) {
+      case "$":
+        return value.slice(1);
+      case "L":
+        return (
+          (parentObject = parseInt(value.slice(2), 16)),
+          (response = getChunk(response, parentObject)),
+          null !== initializingChunk &&
+            isArrayImpl(initializingChunk._children) &&
+            initializingChunk._children.push(response),
+          createLazyChunkWrapper(response, 0)
+        );
+      case "@":
+        return (
+          (parentObject = parseInt(value.slice(2), 16)),
+          (response = getChunk(response, parentObject)),
+          null !== initializingChunk &&
+            isArrayImpl(initializingChunk._children) &&
+            initializingChunk._children.push(response),
+          response
+        );
+      case "S":
+        return Symbol.for(value.slice(2));
+      case "h":
+        var ref = value.slice(2);
+        return getOutlinedModel(
+          response,
+          ref,
+          parentObject,
+          key,
+          loadServerReference
+        );
+      case "T":
+        parentObject = "$" + value.slice(2);
+        response = response._tempRefs;
+        if (null == response)
+          throw Error(
+            "Missing a temporary reference set but the RSC response returned a temporary reference. Pass a temporaryReference option with the set that was used with the reply."
+          );
+        return response.get(parentObject);
+      case "Q":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(response, ref, parentObject, key, createMap)
+        );
+      case "W":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(response, ref, parentObject, key, createSet)
+        );
+      case "B":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(response, ref, parentObject, key, createBlob)
+        );
+      case "K":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(response, ref, parentObject, key, createFormData)
+        );
+      case "Z":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(
+            response,
+            ref,
+            parentObject,
+            key,
+            resolveErrorDev
+          )
+        );
+      case "i":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(
+            response,
+            ref,
+            parentObject,
+            key,
+            extractIterator
+          )
+        );
+      case "I":
+        return Infinity;
+      case "-":
+        return "$-0" === value ? -0 : -Infinity;
+      case "N":
+        return NaN;
+      case "u":
+        return;
+      case "D":
+        return new Date(Date.parse(value.slice(2)));
+      case "n":
+        return BigInt(value.slice(2));
+      case "P":
+        return (
+          (ref = value.slice(2)),
+          getOutlinedModel(
+            response,
+            ref,
+            parentObject,
+            key,
+            applyConstructor
+          )
+        );
+      case "E":
+        response = value.slice(2);
+        try {
+          if (!mightHaveStaticConstructor.test(response))
+            return (0, eval)(response);
+        } catch (x) {}
+        try {
+          if (
+            ((ref = getInferredFunctionApproximate(response)),
+            response.startsWith("Object.defineProperty("))
+          ) {
+            var idx = response.lastIndexOf(',"name",{value:"');
+            if (-1 !== idx) {
+              var name = JSON.parse(
+                response.slice(idx + 16 - 1, response.length - 2)
+              );
+              Object.defineProperty(ref, "name", { value: name });
+            }
+          }
+        } catch (_) {
+          ref = function () {};
+        }
+        return ref;
+      case "Y":
+        if (
+          2 < value.length &&
+          (ref = response._debugChannel && response._debugChannel.callback)
+        ) {
+          if ("@" === value[2])
+            return (
+              (parentObject = value.slice(3)),
+              (key = parseInt(parentObject, 16)),
+              response._chunks.has(key) || ref("P:" + parentObject),
+              getChunk(response, key)
+            );
+          value = value.slice(2);
+          idx = parseInt(value, 16);
+          response._chunks.has(idx) || ref("Q:" + value);
+          ref = getChunk(response, idx);
+          return "fulfilled" === ref.status
+            ? ref.value
+            : defineLazyGetter(response, ref, parentObject, key);
+        }
+        "__proto__" !== key &&
+          Object.defineProperty(parentObject, key, {
+            get: function () {
+              return "This object has been omitted by React in the console log to avoid sending too much data from the server. Try logging smaller or more specific objects.";
+            },
+            set: function () {},
+            enumerable: !0,
+            configurable: !1
+          });
+        return null;
+      default:
+        return (
+          (ref = value.slice(1)),
+          getOutlinedModel(response, ref, parentObject, key, createModel)
+        );
+    }
+  }
+  return value;
+}
+
+function reviveModel(response, value, parentObject, key) {
+  if ("string" === typeof value)
+    return "$" === value[0]
+      ? parseModelString(response, parentObject, key, value)
+      : value;
+  if ("object" !== typeof value || null === value) return value;
+  if (isArrayImpl(value)) {
+    for (var i = 0; i < value.length; i++)
+      value[i] = reviveModel(response, value[i], value, "" + i);
+    if (value[0] === REACT_ELEMENT_TYPE) {
+      if (value[0] === REACT_ELEMENT_TYPE)
+        b: {
+          key = value[4];
+          parentObject = value[5];
+          i = value[6];
+          value = {
+            $$typeof: REACT_ELEMENT_TYPE,
+            type: value[1],
+            key: value[2],
+            props: value[3],
+            _owner: void 0 === key ? null : key
+          };
+          Object.defineProperty(value, "ref", {
+            enumerable: !1,
+            get: nullRefGetter
+          });
+          value._store = {};
+          Object.defineProperty(value._store, "validated", {
+            configurable: !1,
+            enumerable: !1,
+            writable: !0,
+            value: i
+          });
+          Object.defineProperty(value, "_debugInfo", {
+            configurable: !1,
+            enumerable: !1,
+            writable: !0,
+            value: null
+          });
+          Object.defineProperty(value, "_debugStack", {
+            configurable: !1,
+            enumerable: !1,
+            writable: !0,
+            value: void 0 === parentObject ? null : parentObject
+          });
+          Object.defineProperty(value, "_debugTask", {
+            configurable: !1,
+            enumerable: !1,
+            writable: !0,
+            value: null
+          });
+          if (null !== initializingHandler) {
+            key = initializingHandler;
+            initializingHandler = key.parent;
+            if (key.errored) {
+              parentObject = new ReactPromise("rejected", null, key.reason);
+              initializeElement(response, value, null);
+              response = {
+                name: getComponentNameFromType(value.type) || "",
+                owner: value._owner
+              };
+              response.debugStack = value._debugStack;
+              supportsCreateTask && (response.debugTask = value._debugTask);
+              parentObject._debugInfo = [response];
+              response = createLazyChunkWrapper(parentObject, i);
+              break b;
+            }
+            if (0 < key.deps) {
+              parentObject = new ReactPromise("blocked", null, null);
+              key.value = value;
+              key.chunk = parentObject;
+              i = createLazyChunkWrapper(parentObject, i);
+              response = initializeElement.bind(null, response, value, i);
+              parentObject.then(response, response);
+              response = i;
+              break b;
+            }
+          }
+          initializeElement(response, value, null);
+          response = value;
+        }
+      else response = value;
+      return response;
+    }
+    return value;
+  }
+  for (i in value)
+    "__proto__" === i
+      ? delete value[i]
+      : ((parentObject = reviveModel(response, value[i], value, i)),
+        void 0 !== parentObject
+          ? (value[i] = parentObject)
+          : delete value[i]);
+  return value;
+}
+
+function initializeFakeTask(response, debugInfo) {
+  if (!supportsCreateTask || null == debugInfo.stack) return null;
+  var cachedEntry = debugInfo.debugTask;
+  if (void 0 !== cachedEntry) return cachedEntry;
+  var useEnclosingLine = void 0 === debugInfo.key,
+    stack = debugInfo.stack,
+    env =
+      null == debugInfo.env ? response._rootEnvironmentName : debugInfo.env;
+  cachedEntry =
+    null == debugInfo.owner || null == debugInfo.owner.env
+      ? response._rootEnvironmentName
+      : debugInfo.owner.env;
+  var ownerTask =
+    null == debugInfo.owner
+      ? null
+      : initializeFakeTask(response, debugInfo.owner);
+  env =
+    env !== cachedEntry
+      ? '"use ' + env.toLowerCase() + '"'
+      : void 0 !== debugInfo.key
+        ? "<" + (debugInfo.name || "...") + ">"
+        : void 0 !== debugInfo.name
+          ? debugInfo.name || "unknown"
+          : "await " + (debugInfo.awaited.name || "unknown");
+  env = console.createTask.bind(console, env);
+  useEnclosingLine = buildFakeCallStack(
+    response,
+    stack,
+    cachedEntry,
+    useEnclosingLine,
+    env
+  );
+  null === ownerTask
+    ? ((response = getRootTask(response, cachedEntry)),
+      (response =
+        null != response
+          ? response.run(useEnclosingLine)
+          : useEnclosingLine()))
+    : (response = ownerTask.run(useEnclosingLine));
+  return (debugInfo.debugTask = response);
+}
+
+function resolveErrorDev(response, errorInfo) {
+  var name = errorInfo.name,
+    message = errorInfo.message,
+    stack = errorInfo.stack,
+    env = errorInfo.env,
+    errorOptions =
+      'cause' in errorInfo
+        ? {
+            cause: reviveModel(response, errorInfo.cause, errorInfo, 'cause'),
+          }
+        : void 0,
+    isAggregateError =
+      'undefined' !== typeof AggregateError && 'errors' in errorInfo,
+    revivedErrors = isAggregateError
+      ? reviveModel(response, errorInfo.errors, errorInfo, 'errors')
+      : null
+  message = buildFakeCallStack(
+    response,
+    stack,
+    env,
+    !1,
+    isAggregateError
+      ? AggregateError.bind(
+          null,
+          revivedErrors,
+          message ||
+            'An error occurred in the Server Components render but no message was provided',
+          errorOptions
+        )
+      : Error.bind(
+          null,
+          message ||
+            'An error occurred in the Server Components render but no message was provided',
+          errorOptions
+        )
+  )
+  stack = null
+  null != errorInfo.owner &&
+    ((errorInfo = errorInfo.owner.slice(1)),
+    (errorInfo = getOutlinedModel(response, errorInfo, {}, '', createModel)),
+    null !== errorInfo && (stack = initializeFakeTask(response, errorInfo)))
+  null === stack
+    ? ((response = getRootTask(response, env)),
+      (response = null != response ? response.run(message) : message()))
+    : (response = stack.run(message))
+  response.name = name
+  response.environmentName = env
+  return response
+}
+
+// DEVIATION: The root of a value payload initializes like a model chunk:
+// the initializing state is saved and restored around the parse, like
+// `initializeModelChunk` does.
+function reviveRootModel(response, reference) {
+  var prevHandler = initializingHandler
+  var prevChunk = initializingChunk
+  initializingHandler = null
+  initializingChunk = null
+  try {
+    return reviveModel(response, reference, { '': reference }, '')
+  } finally {
+    initializingHandler = prevHandler
+    initializingChunk = prevChunk
+  }
+}
+
+module.exports = {
+  parseStackTrace,
+  filterStackTrace,
+  devirtualizeURL,
+  emitErrorChunk,
+  outlineModel,
+  buildFakeCallStack,
+  createFakeFunction,
+  createResolvedModelChunk,
+  reviveRootModel,
+  resolveErrorDev,
+}

--- a/test/unit/fake-stack-frames/scenario.js
+++ b/test/unit/fake-stack-frames/scenario.js
@@ -1,0 +1,2668 @@
+/**
+ * Runs one fake-stack-frame scenario in a bare Node.js process and prints the
+ * observations as JSON. Must run with `--enable-source-maps`, like `next dev`
+ * runs the server.
+ *
+ * Everything between the copied React pieces (react-flight-semantics.js) and
+ * the real Next.js modules is elided: a "hop" across a Flight boundary is the
+ * producer's `emitErrorChunk` followed by the consumer's `resolveErrorDev`,
+ * exactly the calls React makes, minus the wire.
+ */
+
+/* global AggregateError */
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const url = require('url')
+const util = require('util')
+const inspector = require('node:inspector')
+const { SourceMap } = require('module')
+
+const R = require('./react-flight-semantics')
+
+// The Next.js server bootstrap exposes this global before any server code
+// runs (see packages/next/src/server/node-environment.ts).
+globalThis.AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+
+const nextDist =
+  process.env.NEXT_DIST ?? path.join(__dirname, '../../../packages/next/dist')
+const sourceMaps = require(path.join(nextDist, 'server/lib/source-maps'))
+const {
+  createReactServerErrorHandler,
+  createHTMLErrorHandler,
+  getDigestForWellKnownError,
+  isUserLandError,
+} = require(path.join(nextDist, 'server/app-render/create-error-handler'))
+const patchErrorInspect = require(
+  path.join(nextDist, 'server/patch-error-inspect')
+)
+
+// Next.js installs this for the server process; it replaces
+// `Error.prepareStackTrace` and the `util.inspect` handling of errors.
+patchErrorInspect.patchErrorInspectNodeJS(Error)
+
+// The dev server raises the stack trace limit (see next-dev-server.ts).
+Error.stackTraceLimit = 50
+
+// ---------------------------------------------------------------------------
+// Fixture: a synthetic chunk with a real source map
+// ---------------------------------------------------------------------------
+
+const BASE64_VLQ =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+function encodeVLQ(value) {
+  let vlq = value < 0 ? (-value << 1) + 1 : value << 1
+  let encoded = ''
+  do {
+    let digit = vlq & 0b11111
+    vlq >>>= 5
+    if (vlq > 0) digit |= 0b100000
+    encoded += BASE64_VLQ[digit]
+  } while (vlq > 0)
+  return encoded
+}
+
+/** @param mappings - `{ genLine, genCol, srcLine, srcCol }[]`, 0-based, sorted */
+function encodeMappings(mappings) {
+  let out = ''
+  let previousGenLine = 0
+  let previousGenCol = 0
+  let previousSrcLine = 0
+  let previousSrcCol = 0
+  for (const mapping of mappings) {
+    if (previousGenLine < mapping.genLine) {
+      while (previousGenLine < mapping.genLine) {
+        out += ';'
+        previousGenLine++
+      }
+      previousGenCol = 0
+    } else if (out !== '' && !out.endsWith(';')) {
+      out += ','
+    }
+    out +=
+      encodeVLQ(mapping.genCol - previousGenCol) +
+      encodeVLQ(0) +
+      encodeVLQ(mapping.srcLine - previousSrcLine) +
+      encodeVLQ(mapping.srcCol - previousSrcCol)
+    previousGenCol = mapping.genCol
+    previousSrcLine = mapping.srcLine
+    previousSrcCol = mapping.srcCol
+  }
+  return out
+}
+
+const ORIGINAL_SOURCE = [
+  '// original source',
+  'export function throwsInChunk() {',
+  "  throw new Error('boom')",
+  '}',
+  '',
+].join('\n')
+// 1-based position of `new Error` in the original source above.
+const ORIGINAL_LINE = 3
+const ORIGINAL_COLUMN = 9
+
+/**
+ * Compiles an original source for real (SWC, like `next dev` compiles
+ * modules) and assembles the chunk the way bundlers do: the compiled module
+ * sits below `offsetLines` of runtime code, and the module's own source map
+ * is shifted by prepending empty generated lines to `mappings`.
+ */
+async function compileChunk(
+  originalSource,
+  { moduleFormat = 'cjs', offsetLines = 100 } = {}
+) {
+  const swc = require(path.join(nextDist, 'build/swc'))
+  const output = await swc.transform(originalSource, {
+    filename: 'original.js',
+    sourceMaps: true,
+    module: { type: moduleFormat === 'esm' ? 'es6' : 'commonjs' },
+    jsc: { target: 'es2022' },
+  })
+  const map = JSON.parse(output.map)
+  map.mappings = ';'.repeat(offsetLines) + map.mappings
+  const padding = new Array(offsetLines).fill('/* runtime */')
+  return { code: padding.join('\n') + '\n' + output.code, map }
+}
+
+/** The generated 1-based position mapping to the given original position. */
+async function findGeneratedPosition(map, srcLine1, srcCol1) {
+  const { SourceMapConsumer } = require(
+    path.join(nextDist, 'compiled/source-map08')
+  )
+  const consumer = await new SourceMapConsumer(map)
+  const position = consumer.generatedPositionFor({
+    source: map.sources[0],
+    line: srcLine1,
+    column: srcCol1 - 1,
+  })
+  consumer.destroy()
+  return { line1: position.line, column1: position.column + 1 }
+}
+
+/**
+ * Generates chunk code whose `throw new Error(...)` sits at `throwLine1`,
+ * mirroring how a function ends up deep inside a bundled chunk.
+ */
+// Synthetic chunk generator for the fixtures whose subject is the map or
+// cache shape itself (evals, HMR updates, index map sections, sparse
+// mappings); everything else compiles real chunks via `compileChunk`.
+function generateChunkCode(throwLine1, message, { moduleFormat = 'cjs' } = {}) {
+  const throwingLine = `function throwsInChunk() { throw new Error(${JSON.stringify(message)}); }`
+  const lines = ['"use strict";']
+  while (lines.length < throwLine1 - 1) {
+    lines.push('/* padding */')
+  }
+  lines.push(throwingLine)
+  lines.push(
+    moduleFormat === 'cjs'
+      ? 'module.exports = { throwsInChunk: throwsInChunk };'
+      : moduleFormat === 'esm'
+        ? 'export { throwsInChunk };'
+        : // The completion value of the eval'd code.
+          '({ throwsInChunk: throwsInChunk });'
+  )
+  return {
+    code: lines.join('\n'),
+    // 1-based position of `new Error` in the generated code.
+    line1: throwLine1,
+    column1: throwingLine.indexOf('new Error') + 1,
+  }
+}
+
+function generateSourceMap(chunk, sourceMapFileName) {
+  return {
+    version: 3,
+    file: path.basename(sourceMapFileName, '.map'),
+    sources: ['original.js'],
+    sourcesContent: [ORIGINAL_SOURCE],
+    names: [],
+    mappings: encodeMappings([
+      {
+        genLine: chunk.line1 - 1,
+        genCol: chunk.column1 - 1,
+        srcLine: ORIGINAL_LINE - 1,
+        srcCol: ORIGINAL_COLUMN - 1,
+      },
+    ]),
+  }
+}
+
+async function writeChunkFixture(
+  dir,
+  chunkFileName,
+  {
+    sourceMap = true,
+    mapShape = 'basic',
+    ignoreList = false,
+    message = `boom:${chunkFileName}`,
+    moduleFormat = 'cjs',
+    source = [
+      '// original source',
+      'export function throwsInChunk() {',
+      `  throw new Error(${JSON.stringify(message)})`,
+      '}',
+      '',
+    ].join('\n'),
+  } = {}
+) {
+  if (moduleFormat === 'esm') {
+    chunkFileName = chunkFileName.replace(/\.js$/, '.mjs')
+  }
+  const { code, map: compiledMap } = await compileChunk(source, {
+    moduleFormat,
+  })
+  // Turbopack dev server chunks reference their sources by absolute
+  // percent-encoded `file://` URI.
+  compiledMap.sources = compiledMap.sources.map(
+    (sourceName) => url.pathToFileURL(path.join(dir, sourceName)).href
+  )
+  const chunkPath = path.join(dir, chunkFileName)
+  let chunkCode = code
+  if (sourceMap) {
+    const mapFileName = `${chunkFileName}.map`
+    let map = compiledMap
+    if (mapShape === 'sparse') {
+      // A map with only the throw's own mapping. Real maps are dense;
+      // sparse ones split the consumers (see the `sparse-mappings`
+      // scenario).
+      const generated = await findGeneratedPosition(
+        compiledMap,
+        ORIGINAL_LINE,
+        ORIGINAL_COLUMN
+      )
+      map = {
+        version: 3,
+        file: chunkFileName,
+        sources: compiledMap.sources,
+        sourcesContent: compiledMap.sourcesContent,
+        names: [],
+        mappings: encodeMappings([
+          {
+            genLine: generated.line1 - 1,
+            genCol: generated.column1 - 1,
+            srcLine: ORIGINAL_LINE - 1,
+            srcCol: ORIGINAL_COLUMN - 1,
+          },
+        ]),
+      }
+    }
+    if (ignoreList) {
+      map.ignoreList = [0]
+    }
+    if (mapShape !== 'basic' && mapShape !== 'sparse') {
+      if (mapShape === 'index-relative-sources') {
+        map.sources = ['original.js']
+      }
+      map = {
+        version: 3,
+        sections: [{ offset: { line: 0, column: 0 }, map }],
+      }
+      if (mapShape !== 'index') {
+        // Turbopack emits index maps with an empty top-level `sources` array,
+        // which the source map spec does not allow for index maps.
+        map.sources = []
+      }
+    }
+    fs.writeFileSync(
+      path.join(dir, mapFileName),
+      mapShape === 'invalid' ? 'not a source map' : JSON.stringify(map)
+    )
+    chunkCode += `\n//# sourceMappingURL=${mapFileName}`
+  }
+  fs.writeFileSync(chunkPath, chunkCode)
+  fs.writeFileSync(path.join(dir, 'original.js'), source)
+  return chunkPath
+}
+
+// ---------------------------------------------------------------------------
+// The elided Flight boundary
+// ---------------------------------------------------------------------------
+
+function createFlightRequest(producerEnvironmentName) {
+  // The request reduced to the fields the copied producer code reads. The
+  // environment name is a function like the staged dev render's, evaluated
+  // at each serialization.
+  return {
+    environmentName: () => producerEnvironmentName,
+    filterStackFrame: sourceMaps.filterStackFrameDEV,
+    writtenObjects: new Map(),
+    writtenDebugObjects: new Map(),
+    nextChunkId: 1,
+    pendingDebugChunks: 0,
+    completedErrorChunks: [],
+    completedDebugChunks: [],
+    _outlinedRows: {},
+  }
+}
+
+/**
+ * Serializes a thrown value like the Flight server's `emitErrorChunk`, into
+ * the error info row and the outlined rows it references.
+ */
+function serializeThrown(thrown, producerEnvironmentName, digest, owner) {
+  const request = createFlightRequest(producerEnvironmentName)
+  R.emitErrorChunk(request, 0, digest, thrown, false, owner)
+  const row = request.completedErrorChunks[0]
+  return {
+    errorInfo: JSON.parse(row.slice(row.indexOf(':E') + 2)),
+    outlinedModels: request._outlinedRows,
+  }
+}
+
+/**
+ * The dev RSC render's `onError`: digests are hashed from the error's stack
+ * (materializing it before React's `parseStackTrace` runs) unless the error
+ * carries one, errors are recorded for cross-boundary dedup in a map that
+ * lives on the request's work store (one per scenario process), and known
+ * confusing messages are rewritten after the digest. Logging is elided.
+ */
+const reactServerErrorsByDigest = new Map()
+const handleError = createReactServerErrorHandler(
+  true,
+  false,
+  reactServerErrorsByDigest,
+  () => {}
+)
+
+/**
+ * Serializes a value model like `logMessagesAndSendErrorsToBrowser` renders
+ * the `{ errors }` payload for the dev overlay, or like instant validation
+ * re-encodes revived segment trees: errors inside the value go through
+ * `serializeErrorValue` and lose their digest.
+ */
+function serializeValue(value, producerEnvironmentName) {
+  const request = createFlightRequest(producerEnvironmentName)
+  const id = R.outlineModel(request, value)
+  return {
+    rootReference: '$' + id.toString(16),
+    outlinedModels: request._outlinedRows,
+  }
+}
+
+function serializeError(error, producerEnvironmentName, owner = null) {
+  // Like `logRecoverableError`.
+  const digest = handleError(error) || ''
+  return serializeThrown(error, producerEnvironmentName, digest, owner)
+}
+
+/** Like `serializeError` for a thrown value that is not an `Error`. */
+function serializeThrownValue(value, producerEnvironmentName) {
+  return serializeThrown(
+    value,
+    producerEnvironmentName,
+    handleError(value) || '',
+    null
+  )
+}
+
+/**
+ * What the Flight client does when it revives a serialized error. Each hop
+ * crosses into a different consumer (e.g. the page render and then the SSR
+ * render), and each consumer is a separate copy of the Flight client module
+ * with its own fake function cache. Like the real Flight client, the copy
+ * lives in a `node_modules` directory and revives from a task with no other
+ * user code on the stack, so that everything below the fake stack frames is
+ * dropped when the revived error's stack is serialized again.
+ */
+let flightClientInstances = 0
+function createFlightClientInstance(
+  dir,
+  { environmentName, findSourceMapURL = sourceMaps.findSourceMapURLDEV } = {}
+) {
+  const packageDir = path.join(
+    dir,
+    `consumer-${flightClientInstances++}`,
+    'node_modules',
+    'flight-client'
+  )
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.copyFileSync(
+    require.resolve('./react-flight-semantics'),
+    path.join(packageDir, 'react-flight-semantics.js')
+  )
+  fs.writeFileSync(
+    path.join(packageDir, 'index.js'),
+    [
+      "const R = require('./react-flight-semantics.js')",
+      'exports.reviveError = (errorInfo, outlinedModels, findSourceMapURL, environmentName) => {',
+      "  environmentName = environmentName === undefined ? 'Server' : environmentName",
+      '  return new Promise((resolve) => {',
+      '    setImmediate(() => {',
+      '      // The response reduced to the fields the copied consumer code',
+      '      // reads, like `createResponse` with the environmentName option',
+      "      // (the use-cache consumer passes 'Cache').",
+      '      const response = {',
+      '        _debugFindSourceMapURL: findSourceMapURL,',
+      '        _debugRootTask: console.createTask(',
+      "          '\"use ' + environmentName.toLowerCase() + '\"'",
+      '        ),',
+      '        _rootEnvironmentName: environmentName,',
+      '        _chunks: new Map(),',
+      '        _closed: false,',
+      '        _closedReason: null,',
+      '        _allowPartialStream: false,',
+      '        _pendingChunks: 0,',
+      '        _weakResponse: { response: null },',
+      '        _pendingInitialRender: null,',
+      '        _debugEndTime: null,',
+      '      }',
+      '      // Each outlined row resolves like the stream would resolve it.',
+      '      for (const id in outlinedModels) {',
+      '        response._chunks.set(',
+      '          parseInt(id, 16),',
+      '          R.createResolvedModelChunk(response, outlinedModels[id])',
+      '        )',
+      '      }',
+      '      resolve(R.resolveErrorDev(response, errorInfo))',
+      '    })',
+      '  })',
+      '}',
+      'exports.reviveValue = (reference, outlinedModels, findSourceMapURL, environmentName) => {',
+      "  environmentName = environmentName === undefined ? 'Server' : environmentName",
+      '  return new Promise((resolve) => {',
+      '    setImmediate(() => {',
+      '      const response = {',
+      '        _debugFindSourceMapURL: findSourceMapURL,',
+      '        _debugRootTask: console.createTask(',
+      "          '\"use ' + environmentName.toLowerCase() + '\"'",
+      '        ),',
+      '        _rootEnvironmentName: environmentName,',
+      '        _chunks: new Map(),',
+      '        _closed: false,',
+      '        _closedReason: null,',
+      '        _allowPartialStream: false,',
+      '        _pendingChunks: 0,',
+      '        _weakResponse: { response: null },',
+      '        _pendingInitialRender: null,',
+      '        _debugEndTime: null,',
+      '      }',
+      '      for (const id in outlinedModels) {',
+      '        response._chunks.set(',
+      '          parseInt(id, 16),',
+      '          R.createResolvedModelChunk(response, outlinedModels[id])',
+      '        )',
+      '      }',
+      '      resolve(R.reviveRootModel(response, reference))',
+      '    })',
+      '  })',
+      '}',
+    ].join('\n')
+  )
+  const instance = require(path.join(packageDir, 'index.js'))
+  return {
+    // Revives a value model, like the `{ errors }` payload the dev overlay
+    // receives. No digest is assigned: only error chunks carry one.
+    reviveValue({ rootReference, outlinedModels }) {
+      return instance.reviveValue(
+        rootReference,
+        outlinedModels,
+        findSourceMapURL,
+        environmentName
+      )
+    },
+    async reviveError({ errorInfo, outlinedModels }) {
+      const error = await instance.reviveError(
+        errorInfo,
+        outlinedModels,
+        findSourceMapURL,
+        environmentName
+      )
+      // The real caller of `resolveErrorDev` assigns the serialized digest to
+      // the revived error.
+      error.digest = errorInfo.digest
+      return error
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Debugger-faithful observations
+// ---------------------------------------------------------------------------
+
+const parsedScripts = []
+const session = new inspector.Session()
+session.connect()
+session.on('Debugger.scriptParsed', ({ params }) => {
+  parsedScripts.push({
+    scriptId: params.scriptId,
+    url: params.url,
+    sourceMapURL: params.sourceMapURL ?? '',
+  })
+})
+
+function post(method, params) {
+  return new Promise((resolve, reject) => {
+    session.post(method, params, (err, result) =>
+      err ? reject(err) : resolve(result)
+    )
+  })
+}
+
+// The method name is matched greedily, like in React's `frameRegExp`, so
+// frames whose name embeds an eval origin split at the same position.
+const FRAME_RE = /^ {4}at (.+) \((.+):(\d+):(\d+)\)$/m
+
+/** Like `symbolicateTopFrameLikeADebugger`, for a frame further down. */
+function symbolicateFrameLikeADebugger(stackText, methodName) {
+  const line = stackText
+    .split('\n')
+    .find((frameLine) => frameLine.includes(` at ${methodName} (`))
+  return symbolicateTopFrameLikeADebugger(line ?? '')
+}
+
+/**
+ * Resolves the top frame of an error's stack text the way a debugger
+ * frontend would: bind the frame's URL to the script loaded under that URL,
+ * then map the position through that script's own source map.
+ */
+function symbolicateTopFrameLikeADebugger(stackText) {
+  const match = FRAME_RE.exec(stackText)
+  if (match === null) {
+    return { frame: null }
+  }
+  const [, methodName, frameURL, line1, column1] = match
+  return symbolicatePosition({
+    methodName,
+    url: frameURL,
+    line1: +line1,
+    column1: +column1,
+  })
+}
+
+// Set by scenarios whose fake scripts carry `http:` source map URLs (the
+// browser consumer): resolves the URL like a debugger fetching through the
+// dev server.
+let resolveHttpSourceMap = null
+
+function symbolicatePosition(frame) {
+  const frameURL = frame.url
+  const script = parsedScripts.findLast((parsed) => parsed.url === frameURL)
+  if (script === undefined) {
+    return { frame, script: null }
+  }
+  if (script.sourceMapURL === '') {
+    return { frame, script: { hasSourceMap: false }, original: null }
+  }
+
+  const dataPrefix = 'data:application/json;base64,'
+  const payload = script.sourceMapURL.startsWith(dataPrefix)
+    ? JSON.parse(
+        Buffer.from(
+          script.sourceMapURL.slice(dataPrefix.length),
+          'base64'
+        ).toString('utf8')
+      )
+    : script.sourceMapURL.startsWith('http:')
+      ? (resolveHttpSourceMap(script.sourceMapURL) ?? undefined)
+      : JSON.parse(
+          fs.readFileSync(
+            url.fileURLToPath(new URL(script.sourceMapURL, frameURL)),
+            'utf8'
+          )
+        )
+  if (payload === undefined) {
+    return { frame, script: { hasSourceMap: true }, original: null }
+  }
+  const entry = new SourceMap(payload).findEntry(
+    frame.line1 - 1,
+    frame.column1 - 1
+  )
+  return {
+    frame,
+    script: { hasSourceMap: true },
+    original:
+      entry.originalSource === undefined
+        ? null
+        : { source: entry.originalSource, line1: entry.originalLine + 1 },
+  }
+}
+
+/**
+ * Reads the async part of an error's stack the way an attached debugger
+ * frontend shows it: the `console.createTask` chain recorded when the error
+ * was constructed. Each task's top frame is the `createTask` call inside
+ * the owner's fake stack frames.
+ */
+async function observeOwnerTaskChain(error) {
+  globalThis.__observedError = error
+  const { result } = await post('Runtime.evaluate', {
+    expression: '__observedError',
+  })
+  const { exceptionDetails } = await post('Runtime.getExceptionDetails', {
+    errorObjectId: result.objectId,
+  })
+  const chain = []
+  for (
+    let stackTrace = exceptionDetails.stackTrace?.parent;
+    stackTrace !== undefined;
+    stackTrace = stackTrace.parent
+  ) {
+    const top = stackTrace.callFrames[0]
+    chain.push({
+      description: stackTrace.description ?? '',
+      top:
+        top === undefined
+          ? null
+          : symbolicatePosition({
+              methodName: top.functionName,
+              url: top.url,
+              line1: top.lineNumber + 1,
+              column1: top.columnNumber + 1,
+            }),
+    })
+  }
+  return chain
+}
+
+function observeError(environmentName, error) {
+  const stackText = String(error.stack)
+  return {
+    environmentName,
+    stack: stackText,
+    symbolicated: symbolicateTopFrameLikeADebugger(stackText),
+    terminal: util.inspect(error, { colors: false }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+function throwAndCatch(fn) {
+  try {
+    fn()
+  } catch (error) {
+    return error
+  }
+  throw new Error('expected the fixture to throw')
+}
+
+/**
+ * Revives an error across the given chain of producer environments, like an
+ * error thrown in "use cache" that is revived by the page render and then
+ * revived again by the SSR render of the page. Revived errors carry the
+ * environment they were first serialized in, which takes precedence on every
+ * further serialization.
+ */
+async function reviveAcrossEnvironments(
+  dir,
+  originalError,
+  producerEnvironments
+) {
+  const revived = []
+  let error = originalError
+  for (const producerEnvironmentName of producerEnvironments) {
+    const wire = serializeError(error, producerEnvironmentName)
+    error = await createFlightClientInstance(dir).reviveError(wire)
+    revived.push({ environmentName: wire.errorInfo.env, error })
+  }
+  // Stacks are only observed after the whole chain: in the real system, a
+  // revived error's stack is first read during the next serialization (by
+  // `parseStackTrace`), or not at all.
+  return revived.map(({ environmentName, error }) =>
+    observeError(environmentName, error)
+  )
+}
+
+/**
+ * A module standing in for compiled JSX: `jsx` captures the
+ * `react-stack-top-frame` error like `jsxDEV` does, so each render function
+ * yields a debug stack whose top frame (after skipping the factory frame)
+ * is its own callsite in the original source.
+ */
+async function writeOwnerFixture(
+  dir,
+  { pageEnvironmentName, layoutEnvironmentName = 'Server' }
+) {
+  const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+    source: [
+      '// original source',
+      'export function throwsInChunk() {',
+      "  throw new Error('boom:owner')",
+      '}',
+      'function jsx() {',
+      "  return new Error('react-stack-top-frame')",
+      '}',
+      'export function renderPage() {',
+      '  return jsx()',
+      '}',
+      'export function renderLayout() {',
+      '  return jsx()',
+      '}',
+      '',
+    ].join('\n'),
+  })
+  const mod = require(chunkPath)
+  const layoutInfo = {
+    name: 'Layout',
+    env: layoutEnvironmentName,
+    key: null,
+    owner: null,
+    props: {},
+    debugStack: mod.renderLayout(),
+  }
+  const pageInfo = {
+    name: 'Page',
+    env: pageEnvironmentName,
+    key: null,
+    owner: layoutInfo,
+    props: {},
+    debugStack: mod.renderPage(),
+  }
+  const error = throwAndCatch(() => mod.throwsInChunk())
+  return { pageInfo, error }
+}
+
+// Chunk-loading scenarios run in both module formats: frames of CJS chunks
+// carry file paths, frames of ES modules carry (percent-encoded) `file://`
+// URLs, and Node.js keys their source maps through different loader caches.
+const chunkModuleFormat = process.argv[3] === 'esm' ? 'esm' : 'cjs'
+
+function chunkFixtureOptions(options = {}) {
+  return { ...options, moduleFormat: chunkModuleFormat }
+}
+
+async function loadChunk(chunkPath) {
+  return chunkModuleFormat === 'esm'
+    ? await import(url.pathToFileURL(chunkPath).href)
+    : require(chunkPath)
+}
+
+const scenarios = {
+  async 'one-hop'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'two-hops-bracket-chunk'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      '[root-of-the-server]__sim._.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Cache', 'Server']),
+    }
+  },
+
+  async 'missing-source-map'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions({ sourceMap: false })
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'three-hops'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, [
+        'Cache',
+        'Server',
+        'Prerender',
+      ]),
+    }
+  },
+
+  // Chunk basenames stay plain even in exotic setups; special characters
+  // arrive through the project path (`next dev "my project"`), so they are
+  // modeled as directory names.
+  async 'space-in-project-path'(dir) {
+    const projectDir = path.join(dir, 'my project')
+    fs.mkdirSync(projectDir)
+    const chunkPath = await writeChunkFixture(
+      projectDir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Cache', 'Server']),
+    }
+  },
+
+  async 'unicode-in-project-path'(dir) {
+    const projectDir = path.join(dir, 'café')
+    fs.mkdirSync(projectDir)
+    const chunkPath = await writeChunkFixture(
+      projectDir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Cache', 'Server']),
+    }
+  },
+
+  async 'percent-in-project-path'(dir) {
+    const projectDir = path.join(dir, 'per%cent')
+    fs.mkdirSync(projectDir)
+    const chunkPath = await writeChunkFixture(
+      projectDir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Cache', 'Server']),
+    }
+  },
+
+  // Real bundler maps are dense. With a map covering only the throw itself,
+  // the consumers split: the debugger's whole-map lookup resolves other
+  // frames to the nearest preceding mapping, while the terminal consumer
+  // only matches mappings on the frame's own line and falls back to the
+  // raw URL.
+  async 'sparse-mappings'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      mapShape: 'sparse',
+      source: [
+        '// original source',
+        'export function throwsInChunk() {',
+        "  throw new Error('boom:sparse')",
+        '}',
+        'export function callsThrough() {',
+        '  return throwsInChunk()',
+        '}',
+        '',
+      ].join('\n'),
+    })
+    const error = throwAndCatch(() => require(chunkPath).callsThrough())
+    const hops = await reviveAcrossEnvironments(dir, error, ['Server'])
+    for (const hop of hops) {
+      hop.symbolicatedCaller = symbolicateFrameLikeADebugger(
+        hop.stack,
+        'Object.callsThrough'
+      )
+    }
+    return { hops }
+  },
+
+  async 'index-source-map'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions({ mapShape: 'index-with-empty-sources' })
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Cache', 'Server']),
+    }
+  },
+
+  async 'index-source-map-relative-sources'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions({ mapShape: 'index-relative-sources' })
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'spec-index-source-map'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions({ mapShape: 'index' })
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'invalid-source-map'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions({ mapShape: 'invalid' })
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'node-modules-frames'(dir) {
+    const packageDir = path.join(dir, 'node_modules', 'some-pkg')
+    fs.mkdirSync(packageDir, { recursive: true })
+    const chunkPath = await writeChunkFixture(packageDir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'anonymous-frames'(dir) {
+    const chunk = generateChunkCode(101, 'boom:anonymous', {
+      moduleFormat: 'eval',
+    })
+    // eslint-disable-next-line no-eval
+    const moduleExports = (0, eval)(chunk.code)
+    const error = throwAndCatch(() => moduleExports.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'fake-function-cache'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const first = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const second = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    // One consumer reviving two errors with identical frames.
+    const consumer = createFlightClientInstance(dir)
+    const revived = []
+    for (const error of [first, second]) {
+      const wire = serializeError(error, 'Server')
+      revived.push({
+        environmentName: wire.errorInfo.env,
+        error: await consumer.reviveError(wire),
+      })
+    }
+    return {
+      hops: revived.map(({ environmentName, error }) =>
+        observeError(environmentName, error)
+      ),
+    }
+  },
+
+  async 'multiple-chunks'(dir) {
+    await writeChunkFixture(dir, 'chunk-b.js', { message: 'boom:chunk-b.js' })
+    const chunkAPath = await writeChunkFixture(dir, 'chunk-a.js', {
+      source: [
+        '// original source',
+        "import { throwsInChunk } from './chunk-b.js'",
+        'export function callsThrough() {',
+        '  return throwsInChunk()',
+        '}',
+        '',
+      ].join('\n'),
+    })
+    const error = throwAndCatch(() => require(chunkAPath).callsThrough())
+    const hops = await reviveAcrossEnvironments(dir, error, ['Cache', 'Server'])
+    for (const hop of hops) {
+      hop.symbolicatedCaller = symbolicateFrameLikeADebugger(
+        hop.stack,
+        'Object.callsThrough'
+      )
+    }
+    return { hops }
+  },
+
+  async 'multi-line-message'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const { throwsInChunk } = require(chunkPath)
+    const error = throwAndCatch(() => {
+      try {
+        throwsInChunk()
+      } catch (cause) {
+        cause.message =
+          'first line\nsecond line\n    at phantom (file:///not-a-frame.js:1:1)'
+        throw cause
+      }
+    })
+    const hops = await reviveAcrossEnvironments(dir, error, ['Server'])
+    const { getStackWithoutErrorMessage } = require(
+      path.join(nextDist, 'lib/format-server-error')
+    )
+    for (const hop of hops) {
+      hop.symbolicatedThrow = symbolicateFrameLikeADebugger(
+        hop.stack,
+        'throwsInChunk'
+      )
+      // `app-render` strips the message off `error.stack` for the overlay
+      // payload; only the first line goes, so multi-line messages leak.
+      hop.stackWithoutMessage = getStackWithoutErrorMessage({
+        stack: hop.stack,
+      })
+    }
+    return { hops }
+  },
+
+  async 'module-evaluation-throw'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      moduleFormat: chunkModuleFormat,
+      source: [
+        '// original source',
+        'export function throwsInChunk() {',
+        "  throw new Error('boom:evaluation')",
+        '}',
+        'throwsInChunk()',
+        '',
+      ].join('\n'),
+    })
+    let error
+    try {
+      await loadChunk(chunkPath)
+      throw new Error('expected the fixture to throw')
+    } catch (thrown) {
+      error = thrown
+    }
+    const hops = await reviveAcrossEnvironments(dir, error, ['Server'])
+    for (const hop of hops) {
+      // The ESM module-evaluation frame is nameless and revives under the
+      // fake function's fallback name.
+      hop.symbolicatedModuleFrame = symbolicateFrameLikeADebugger(
+        hop.stack,
+        chunkModuleFormat === 'esm' ? '<anonymous>' : 'Object.<anonymous>'
+      )
+    }
+    return { hops }
+  },
+
+  async 'thrown-string'(dir) {
+    const revived = await createFlightClientInstance(dir).reviveError(
+      serializeThrownValue('boom:string', 'Server')
+    )
+    return { hops: [observeError('Server', revived)] }
+  },
+
+  async 'custom-error-name'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => {
+      try {
+        require(chunkPath).throwsInChunk()
+      } catch (cause) {
+        cause.name = 'CustomError'
+        throw cause
+      }
+    })
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'chunk-deleted-after-require'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    fs.rmSync(chunkPath)
+    fs.rmSync(`${chunkPath}.map`)
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'repeated-hmr-updates'(dir) {
+    // Two updates of the same module: both are eval'd under the same
+    // `//# sourceURL`, each with its own inline source map.
+    const sourceURL = `${url.pathToFileURL(path.join(dir, 'chunk.js')).href}?module-id`
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+    const evalUpdate = (throwLine1, srcLine1) => {
+      const chunk = generateChunkCode(throwLine1, 'boom:update', {
+        moduleFormat: 'eval',
+      })
+      const map = {
+        version: 3,
+        file: 'chunk.js',
+        sources: ['original.js'],
+        sourcesContent: [ORIGINAL_SOURCE],
+        names: [],
+        mappings: encodeMappings([
+          {
+            genLine: chunk.line1 - 1,
+            genCol: chunk.column1 - 1,
+            srcLine: srcLine1 - 1,
+            srcCol: 0,
+          },
+        ]),
+      }
+      const code =
+        chunk.code +
+        '\n\n//# sourceURL=' +
+        sourceURL +
+        '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+        Buffer.from(JSON.stringify(map)).toString('base64')
+      // eslint-disable-next-line no-eval
+      return (0, eval)(code)
+    }
+    const first = evalUpdate(101, 2)
+    const firstError = throwAndCatch(() => first.throwsInChunk())
+    const firstHops = await reviveAcrossEnvironments(dir, firstError, [
+      'Server',
+    ])
+    const second = evalUpdate(101, 3)
+    const secondError = throwAndCatch(() => second.throwsInChunk())
+    const secondHops = await reviveAcrossEnvironments(dir, secondError, [
+      'Server',
+    ])
+    return { hops: [...firstHops, ...secondHops] }
+  },
+
+  // A file-based chunk replaced on disk, like webpack HMR writes updates:
+  // the module cache is busted, Node.js re-reads the source map, but
+  // `findSourceMapURLDEV`'s cache still serves the first map to revivals.
+  async 'chunk-file-edited'(dir) {
+    const writeVersion = (srcLine1) => {
+      const chunk = generateChunkCode(101, 'boom:edited')
+      const map = generateSourceMap(chunk, 'chunk.js.map')
+      map.mappings = encodeMappings([
+        {
+          genLine: chunk.line1 - 1,
+          genCol: chunk.column1 - 1,
+          srcLine: srcLine1 - 1,
+          srcCol: 0,
+        },
+      ])
+      fs.writeFileSync(path.join(dir, 'chunk.js.map'), JSON.stringify(map))
+      fs.writeFileSync(
+        path.join(dir, 'chunk.js'),
+        chunk.code + '\n//# sourceMappingURL=chunk.js.map'
+      )
+    }
+    const chunkPath = path.join(dir, 'chunk.js')
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+
+    writeVersion(2)
+    const firstError = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const firstHops = await reviveAcrossEnvironments(dir, firstError, [
+      'Server',
+    ])
+
+    writeVersion(3)
+    delete require.cache[chunkPath]
+    const secondError = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const secondHops = await reviveAcrossEnvironments(dir, secondError, [
+      'Server',
+    ])
+    return { hops: [...firstHops, ...secondHops] }
+  },
+
+  // ES module updates cannot replace a cached URL, so dev servers bust the
+  // import with a query.
+  async 'esm-query-busted-reload'(dir) {
+    const writeVersion = (srcLine1) => {
+      const chunk = generateChunkCode(101, 'boom:reloaded', {
+        moduleFormat: 'esm',
+      })
+      const map = generateSourceMap(chunk, 'chunk.mjs.map')
+      map.mappings = encodeMappings([
+        {
+          genLine: chunk.line1 - 1,
+          genCol: chunk.column1 - 1,
+          srcLine: srcLine1 - 1,
+          srcCol: 0,
+        },
+      ])
+      fs.writeFileSync(path.join(dir, 'chunk.mjs.map'), JSON.stringify(map))
+      fs.writeFileSync(
+        path.join(dir, 'chunk.mjs'),
+        chunk.code + '\n//# sourceMappingURL=chunk.mjs.map'
+      )
+    }
+    const chunkURL = url.pathToFileURL(path.join(dir, 'chunk.mjs')).href
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+
+    writeVersion(2)
+    const first = await import(chunkURL)
+    const firstError = throwAndCatch(() => first.throwsInChunk())
+    const firstHops = await reviveAcrossEnvironments(dir, firstError, [
+      'Server',
+    ])
+
+    writeVersion(3)
+    const second = await import(`${chunkURL}?v=2`)
+    const secondError = throwAndCatch(() => second.throwsInChunk())
+    const secondHops = await reviveAcrossEnvironments(dir, secondError, [
+      'Server',
+    ])
+    return { hops: [...firstHops, ...secondHops] }
+  },
+
+  async 'multi-section-index-map'(dir) {
+    const chunk = generateChunkCode(101, 'boom:sections')
+    const emptySection = {
+      version: 3,
+      file: 'chunk.js',
+      sources: [url.pathToFileURL(path.join(dir, 'unrelated.js')).href],
+      sourcesContent: ['// unrelated'],
+      names: [],
+      mappings: 'AAAA',
+    }
+    const throwingSection = {
+      version: 3,
+      file: 'chunk.js',
+      sources: [url.pathToFileURL(path.join(dir, 'original.js')).href],
+      sourcesContent: [ORIGINAL_SOURCE],
+      names: [],
+      mappings: encodeMappings([
+        {
+          // Section-relative: the section starts at generated line 50.
+          genLine: chunk.line1 - 1 - 50,
+          genCol: chunk.column1 - 1,
+          srcLine: ORIGINAL_LINE - 1,
+          srcCol: ORIGINAL_COLUMN - 1,
+        },
+      ]),
+    }
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js.map'),
+      JSON.stringify({
+        version: 3,
+        sources: [],
+        sections: [
+          { offset: { line: 0, column: 0 }, map: emptySection },
+          { offset: { line: 50, column: 0 }, map: throwingSection },
+        ],
+      })
+    )
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js'),
+      chunk.code + '\n//# sourceMappingURL=chunk.js.map'
+    )
+    const error = throwAndCatch(() =>
+      require(path.join(dir, 'chunk.js')).throwsInChunk()
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'partial-ignore-list'(dir) {
+    const chunk = generateChunkCode(101, 'boom:partial')
+    const map = generateSourceMap(chunk, 'chunk.js.map')
+    map.sources.push('vendor.js')
+    map.sourcesContent.push('// vendor')
+    map.ignoreList = [1]
+    fs.writeFileSync(path.join(dir, 'chunk.js.map'), JSON.stringify(map))
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js'),
+      chunk.code + '\n//# sourceMappingURL=chunk.js.map'
+    )
+    const error = throwAndCatch(() =>
+      require(path.join(dir, 'chunk.js')).throwsInChunk()
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'fan-out-consumers'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const wire = serializeError(error, 'Server')
+    const hops = []
+    for (const consumer of [
+      createFlightClientInstance(dir),
+      createFlightClientInstance(dir),
+    ]) {
+      hops.push(
+        observeError(wire.errorInfo.env, await consumer.reviveError(wire))
+      )
+    }
+    return { hops }
+  },
+
+  async 'symlinked-project-dir'(dir) {
+    const realDir = path.join(dir, 'real')
+    fs.mkdirSync(realDir)
+    const chunkPath = await writeChunkFixture(
+      realDir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    fs.symlinkSync(realDir, path.join(dir, 'linked'))
+    // Both loaders realpath the module, so the frames carry the real path.
+    const mod = await loadChunk(
+      path.join(dir, 'linked', path.basename(chunkPath))
+    )
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'hash-in-project-path'(dir) {
+    const projectDir = path.join(dir, 'my#app')
+    fs.mkdirSync(projectDir)
+    const chunkPath = await writeChunkFixture(
+      projectDir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Cache', 'Server']),
+    }
+  },
+
+  async 'node-modules-substring-in-project-path'(dir) {
+    const projectDir = path.join(dir, 'my_node_modules_backup')
+    fs.mkdirSync(projectDir)
+    const chunkPath = await writeChunkFixture(
+      projectDir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'native-and-builtin-frames'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const { throwsInChunk } = require(chunkPath)
+    const error = throwAndCatch(() => [1].map(throwsInChunk))
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'new-promise-frames'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const { throwsInChunk } = require(chunkPath)
+    // A throw inside an executor rejects the promise with a stack that has a
+    // `new Promise (<anonymous>)` frame.
+    const error = await new Promise(() => throwsInChunk()).then(
+      () => {
+        throw new Error('expected the fixture to throw')
+      },
+      (thrown) => thrown
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'constructor-frames'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      source: [
+        '// original source',
+        'export class Boom {',
+        '  constructor() {',
+        "    throw new Error('boom:constructor')",
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
+    })
+    const { Boom } = require(chunkPath)
+    const error = throwAndCatch(() => new Boom())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'dev-overlay-frames'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const hops = await reviveAcrossEnvironments(dir, error, ['Server'])
+    // The dev overlay resolves the revived error's frames server-side: the
+    // client parses the stack text and posts the frames to
+    // `/__nextjs_original-stack-frames`.
+    const { getOriginalStackFrames } = require(
+      path.join(nextDist, 'server/dev/middleware-turbopack')
+    )
+    const { parseStack } = require(
+      path.join(nextDist, 'server/lib/parse-stack')
+    )
+    const project = {
+      async traceSource() {
+        return null
+      },
+      async getSourceMap() {
+        return null
+      },
+    }
+    const { DEVTOOLS_CODE_FRAME_MAX_WIDTH } = require(
+      path.join(nextDist, 'next-devtools/server/shared')
+    )
+    hops[0].overlayFrames = (
+      await getOriginalStackFrames({
+        project,
+        projectPath: dir,
+        frames: parseStack(hops[0].stack, dir),
+        isServer: true,
+        isEdgeServer: false,
+        isAppDirectory: true,
+        // Like the `/__nextjs_original-stack-frames` endpoint the redbox
+        // posts to.
+        codeFrameOptions: {
+          colors: true,
+          maxWidth: DEVTOOLS_CODE_FRAME_MAX_WIDTH,
+        },
+      })
+    ).map((entry) =>
+      entry.status === 'rejected'
+        ? { status: entry.status, reason: String(entry.reason) }
+        : entry
+    )
+    return { hops }
+  },
+
+  async 'owner-stack-rewrite'(dir) {
+    const { workUnitAsyncStorage } = require(
+      path.join(nextDist, 'server/app-render/work-unit-async-storage.external')
+    )
+    const { applyOwnerStack } = require(
+      path.join(nextDist, 'server/dynamic-rendering-utils')
+    )
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      source: [
+        '// original source',
+        'export function throwsInChunk() {',
+        "  throw new Error('boom:owner-rewrite')",
+        '}',
+        'export function Page() {',
+        '  return throwsInChunk()',
+        '}',
+        '',
+      ].join('\n'),
+    })
+    const mod = require(chunkPath)
+    // Sync-IO validation errors get their stack rewritten before they are
+    // serialized: the error's own frames are kept up to React's bottom
+    // frame, then the owner stack is appended.
+    const react_stack_bottom_frame = () => mod.throwsInChunk()
+    const error = throwAndCatch(() => react_stack_bottom_frame())
+    // Owner stacks point at real callsites: `Page`'s call at original 6:10.
+    const generated = await findGeneratedPosition(
+      JSON.parse(fs.readFileSync(`${chunkPath}.map`, 'utf8')),
+      6,
+      10
+    )
+    const ownerStack = `\n    at Page (${url.pathToFileURL(chunkPath).href}:${generated.line1}:${generated.column1})`
+    const rewritten = workUnitAsyncStorage.run(
+      { type: 'cache', outerOwnerStack: ownerStack },
+      () => applyOwnerStack(error)
+    )
+    const hops = await reviveAcrossEnvironments(dir, rewritten, ['Server'])
+    for (const hop of hops) {
+      hop.symbolicatedCaller = symbolicateFrameLikeADebugger(hop.stack, 'Page')
+    }
+    return { hops }
+  },
+
+  async 'predigested-error'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    // Framework errors like redirects carry their digest, so the handler
+    // never materializes the stack and the first serialization parses V8's
+    // structured stack trace, with real enclosing function positions.
+    error.digest = 'NEXT_REDIRECT;push;/target;307;'
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'formatted-server-error'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      message: 'Class extends value undefined is not a constructor or null',
+    })
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'webpack-export-frame-names'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      source: [
+        '// original source',
+        'function __WEBPACK_DEFAULT_EXPORT__() {',
+        "  throw new Error('boom:export')",
+        '}',
+        'export { __WEBPACK_DEFAULT_EXPORT__ as throwsInChunk }',
+        '',
+      ].join('\n'),
+    })
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'error-with-cause'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      source: [
+        '// original source',
+        'export function throwsCause() {',
+        "  throw new Error('boom:cause')",
+        '}',
+        'export function throwsOuter() {',
+        '  try {',
+        '    throwsCause()',
+        '  } catch (cause) {',
+        "    throw new Error('boom:outer', { cause })",
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
+    })
+    const error = throwAndCatch(() => require(chunkPath).throwsOuter())
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.cause = observeError(revived.cause.environmentName, revived.cause)
+    return { hops: [hop] }
+  },
+
+  async 'aggregate-error'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const { throwsInChunk } = require(chunkPath)
+    const error = throwAndCatch(() => {
+      throw new AggregateError(
+        [throwAndCatch(throwsInChunk), throwAndCatch(throwsInChunk)],
+        'boom:aggregate'
+      )
+    })
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.revivedConstructor = revived.constructor.name
+    hop.errors = revived.errors.map((inner) =>
+      observeError(inner.environmentName, inner)
+    )
+    return { hops: [hop] }
+  },
+
+  // The full topology of an error thrown inside "use cache": the cache
+  // render serializes it (env 'Cache', with the owning component), the RSC
+  // layer revives it from a response created with `environmentName: 'Cache'`
+  // like the use-cache consumer's, the staged RSC render re-serializes it
+  // (the error's own environment wins over the request's), and the SSR
+  // layer revives it from a default 'Server'-rooted response.
+  async 'use-cache-layers'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Cache',
+      layoutEnvironmentName: 'Cache',
+    })
+    const cacheWire = serializeError(error, 'Cache', pageInfo)
+    const cacheConsumer = createFlightClientInstance(dir, {
+      environmentName: 'Cache',
+    })
+    const revivedInRSC = await cacheConsumer.reviveError(cacheWire)
+    const rscHop = observeError(cacheWire.errorInfo.env, revivedInRSC)
+    rscHop.ownerTasks = await observeOwnerTaskChain(revivedInRSC)
+
+    const serverWire = serializeError(revivedInRSC, 'Server')
+    const ssrConsumer = createFlightClientInstance(dir)
+    const revivedInSSR = await ssrConsumer.reviveError(serverWire)
+    const ssrHop = observeError(serverWire.errorInfo.env, revivedInSSR)
+    ssrHop.ownerTasks = await observeOwnerTaskChain(revivedInSSR)
+
+    return { hops: [rscHop, ssrHop] }
+  },
+
+  // Nested "use cache": the inner cache's error crosses an extra Cache-rooted
+  // consumer before reaching the RSC and SSR layers.
+  async 'nested-cache-layers'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Cache',
+      layoutEnvironmentName: 'Cache',
+    })
+    const layers = [
+      {
+        producerEnvironmentName: 'Cache',
+        owner: pageInfo,
+        consumerEnvironmentName: 'Cache',
+      },
+      {
+        producerEnvironmentName: 'Cache',
+        owner: null,
+        consumerEnvironmentName: 'Cache',
+      },
+      {
+        producerEnvironmentName: 'Server',
+        owner: null,
+        consumerEnvironmentName: 'Server',
+      },
+    ]
+    const hops = []
+    let current = error
+    for (const layer of layers) {
+      const wire = serializeError(
+        current,
+        layer.producerEnvironmentName,
+        layer.owner
+      )
+      current = await createFlightClientInstance(dir, {
+        environmentName: layer.consumerEnvironmentName,
+      }).reviveError(wire)
+      const hop = observeError(wire.errorInfo.env, current)
+      hop.ownerTasks = await observeOwnerTaskChain(current)
+      hops.push(hop)
+    }
+    return { hops }
+  },
+
+  async 'prefetch-environment'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const wire = serializeError(error, 'Prefetch')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  // Owners are not carried across hops: each serialization attaches the
+  // serializing task's own owner.
+  async 'owner-at-second-hop'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Server',
+    })
+    const first = serializeError(error, 'Server')
+    const revivedOnce = await createFlightClientInstance(dir).reviveError(first)
+    const firstHop = observeError(first.errorInfo.env, revivedOnce)
+    firstHop.ownerTasks = await observeOwnerTaskChain(revivedOnce)
+
+    const second = serializeError(revivedOnce, 'Server', pageInfo)
+    const revivedTwice =
+      await createFlightClientInstance(dir).reviveError(second)
+    const secondHop = observeError(second.errorInfo.env, revivedTwice)
+    secondHop.ownerTasks = await observeOwnerTaskChain(revivedTwice)
+    return { hops: [firstHop, secondHop] }
+  },
+
+  async 'owner-stack-inverse-environment'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Server',
+    })
+    const wire = serializeError(error, 'Cache', pageInfo)
+    const revived = await createFlightClientInstance(dir, {
+      environmentName: 'Cache',
+    }).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  async 'owner-without-stack'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    // An owner that carries no debug stack serializes without one, and the
+    // consumer falls back to the root task.
+    const pageInfo = {
+      name: 'Page',
+      env: 'Server',
+      key: null,
+      owner: null,
+      props: {},
+    }
+    const wire = serializeError(error, 'Server', pageInfo)
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  async 'owner-with-filtered-stack'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    // An owner whose debug stack has only library and runtime frames
+    // serializes with an empty stack (unlike no stack at all).
+    const pkgDir = path.join(dir, 'node_modules', 'owner-lib')
+    fs.mkdirSync(pkgDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(pkgDir, 'index.js'),
+      [
+        "function jsx() { return new Error('react-stack-top-frame'); }",
+        'exports.captureAsync = () =>',
+        '  new Promise((resolve) => {',
+        '    setImmediate(() => resolve(jsx()))',
+        '  })',
+      ].join('\n')
+    )
+    const debugStack = await require(
+      path.join(pkgDir, 'index.js')
+    ).captureAsync()
+    const pageInfo = {
+      name: 'Page',
+      env: 'Server',
+      key: null,
+      owner: null,
+      props: {},
+      debugStack,
+    }
+    const wire = serializeError(error, 'Server', pageInfo)
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  async 'empty-message'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', { message: '' })
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'thrown-object'(dir) {
+    const revived = await createFlightClientInstance(dir).reviveError(
+      serializeThrownValue({ reason: 'boom', code: 7 }, 'Server')
+    )
+    return { hops: [observeError('Server', revived)] }
+  },
+
+  // The `$` escape and number encodings that also protect serialized stack
+  // frames (function names and file paths are strings, native frames carry
+  // `NaN` positions), round-tripped through a cause object.
+  async 'cause-value-encodings'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => {
+      try {
+        require(chunkPath).throwsInChunk()
+      } catch (cause) {
+        cause.cause = {
+          reference: '$100',
+          negativeZero: -0,
+          infinite: Infinity,
+          notANumber: NaN,
+        }
+        throw new Error('boom:outer', { cause })
+      }
+    })
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.cause = observeError(revived.cause.environmentName, revived.cause)
+    return { hops: [hop] }
+  },
+
+  async 'nested-cause-chain'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => {
+      try {
+        require(chunkPath).throwsInChunk()
+      } catch (middle) {
+        middle.cause = 'root cause'
+        throw new Error('boom:outer', { cause: middle })
+      }
+    })
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.cause = observeError(revived.cause.environmentName, revived.cause)
+    return { hops: [hop] }
+  },
+
+  // A revived cache error used as the cause of a fresh error: the cause
+  // value carries its own environment through `serializeErrorValue`.
+  async 'cause-across-environments'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const cacheError = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const revivedCause = await createFlightClientInstance(dir, {
+      environmentName: 'Cache',
+    }).reviveError(serializeError(cacheError, 'Cache'))
+    const error = throwAndCatch(() => {
+      throw new Error('boom:outer', { cause: revivedCause })
+    })
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.cause = observeError(revived.cause.environmentName, revived.cause)
+    return { hops: [hop] }
+  },
+
+  // The instant validation chain: a staged render's error chunks are
+  // accumulated and revived, the revived tree is re-encoded per segment
+  // with an `onError` that only forwards digests, and the resulting error
+  // reaches the dev overlay as a value inside the `{ errors }` payload.
+  async 'instant-validation-stacks'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Prerender',
+      layoutEnvironmentName: 'Prerender',
+    })
+    const digests = []
+
+    // The staged render serializes the error during the static stage.
+    const staged = serializeError(error, 'Prerender', pageInfo)
+    digests.push(staged.errorInfo.digest)
+    const revivedByValidation =
+      await createFlightClientInstance(dir).reviveError(staged)
+    const validationHop = observeError(
+      staged.errorInfo.env,
+      revivedByValidation
+    )
+    validationHop.ownerTasks = await observeOwnerTaskChain(revivedByValidation)
+
+    // The per-segment re-encode replays the static stage. Its `onError`
+    // forwards digests and never mints one (instant-validation.tsx).
+    const validationDigest =
+      getDigestForWellKnownError(revivedByValidation) ??
+      (typeof revivedByValidation.digest === 'string'
+        ? revivedByValidation.digest
+        : undefined)
+    const reencoded = serializeThrown(
+      revivedByValidation,
+      'Prerender',
+      validationDigest || '',
+      null
+    )
+    digests.push(reencoded.errorInfo.digest)
+    const revivedFromSegment =
+      await createFlightClientInstance(dir).reviveError(reencoded)
+    const segmentHop = observeError(reencoded.errorInfo.env, revivedFromSegment)
+
+    // The overlay payload carries the error as a value, dropping the digest.
+    const payloadWire = serializeValue(
+      { errors: [revivedFromSegment] },
+      'Server'
+    )
+    const payload =
+      await createFlightClientInstance(dir).reviveValue(payloadWire)
+    const overlayError = payload.errors[0]
+    const overlayHop = observeError(overlayError.environmentName, overlayError)
+    overlayHop.ownerTasks = await observeOwnerTaskChain(overlayError)
+
+    // A further serialization of the now digest-less error mints a fresh
+    // digest, so overlay dedup identity does not survive the value crossing.
+    digests.push(serializeError(overlayError, 'Server').errorInfo.digest)
+
+    return {
+      hops: [validationHop, segmentHop, overlayHop],
+      digests,
+    }
+  },
+
+  // Errors that never cross a Flight boundary are still printed by the dev
+  // server through the same patched inspect.
+  async 'unserialized-error-terminal'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      source: [
+        '// original source',
+        'export function throwsInChunk() {',
+        "  throw new Error('boom:unserialized')",
+        '}',
+        'export function react_stack_bottom_frame() {',
+        '  return throwsInChunk()',
+        '}',
+        '',
+      ].join('\n'),
+    })
+    const mod = require(chunkPath)
+    const error = throwAndCatch(() => mod.react_stack_bottom_frame())
+
+    // Native frames print with an `<anonymous>` file the formatter keeps
+    // as-is.
+    const plainChunk = await writeChunkFixture(dir, 'plain.js')
+    const nativeError = throwAndCatch(() =>
+      [1].map(require(plainChunk).throwsInChunk)
+    )
+
+    // The cut looks for the marker as a substring, so a chunk *file* named
+    // like React's bottom frame also truncates the printed stack.
+    const markerDir = path.join(dir, 'marker')
+    fs.mkdirSync(markerDir)
+    const markerChunk = await writeChunkFixture(
+      markerDir,
+      'react-stack-bottom-frame.js'
+    )
+    const markerError = throwAndCatch(() =>
+      require(markerChunk).throwsInChunk()
+    )
+
+    return {
+      hops: [
+        observeError('unserialized', error),
+        observeError('unserialized', nativeError),
+        observeError('unserialized', markerError),
+      ],
+    }
+  },
+
+  // One printed stack symbolicates each file once: later frames from the
+  // same file reuse the cached consumer — or the cached failure, when the
+  // bundler hands back a source map the consumer rejects. (Files without
+  // any map are not cached; every frame re-queries.)
+  async 'terminal-cache-paths'(dir) {
+    const source = (message) =>
+      [
+        '// original source',
+        'export function throwsInChunk() {',
+        `  throw new Error(${JSON.stringify(message)})`,
+        '}',
+        'export function callsThrough() {',
+        '  return throwsInChunk()',
+        '}',
+        '',
+      ].join('\n')
+
+    const goodChunk = await writeChunkFixture(dir, 'good.js', {
+      source: source('boom:cached-consumer'),
+    })
+    const good = require(goodChunk)
+    const goodError = throwAndCatch(() => good.callsThrough())
+
+    const badDir = path.join(dir, 'bad')
+    fs.mkdirSync(badDir)
+    const badChunk = await writeChunkFixture(badDir, 'bad.js', {
+      source: source('boom:cached-failure'),
+      sourceMap: false,
+    })
+    const section = (line) => ({
+      offset: { line, column: 0 },
+      map: {
+        version: 3,
+        sources: ['a.js'],
+        sourcesContent: ['x'],
+        names: [],
+        mappings: 'AAAA',
+      },
+    })
+    const badChunkURL = url.pathToFileURL(badChunk).href
+    require(
+      path.join(nextDist, 'server/patch-error-inspect')
+    ).setBundlerFindSourceMapImplementation((sourceURL) =>
+      sourceURL === badChunkURL
+        ? // Unordered sections: the sync consumer rejects what the bundler
+          // handed back.
+          { version: 3, sources: [], sections: [section(100), section(0)] }
+        : undefined
+    )
+    const bad = require(badChunk)
+    const badError = throwAndCatch(() => bad.callsThrough())
+
+    return {
+      hops: [
+        observeError('unserialized', goodError),
+        observeError('unserialized', badError),
+      ],
+    }
+  },
+
+  async 'map-source-in-node-modules'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      message: 'boom:vendored',
+    })
+    // A library chunk maps back to sources under `node_modules`.
+    const mapPath = `${chunkPath}.map`
+    const map = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
+    map.sources = ['node_modules/lib/original.js']
+    fs.writeFileSync(mapPath, JSON.stringify(map))
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'sandwiched-native-frames'(dir) {
+    const pkgDir = path.join(dir, 'node_modules', 'lib')
+    fs.mkdirSync(pkgDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(pkgDir, 'index.js'),
+      [
+        'exports.outer = function outer() {',
+        '  return [1].map(function inner() {',
+        "    throw new Error('boom:sandwich');",
+        '  });',
+        '};',
+      ].join('\n')
+    )
+    const { outer } = require(path.join(pkgDir, 'index.js'))
+    const error = throwAndCatch(() => outer())
+    return { hops: [observeError('unserialized', error)] }
+  },
+
+  async 'index-map-first-section'(dir) {
+    const chunk = generateChunkCode(101, 'boom:sections')
+    const throwingSection = {
+      version: 3,
+      file: 'chunk.js',
+      sources: [url.pathToFileURL(path.join(dir, 'original.js')).href],
+      sourcesContent: [ORIGINAL_SOURCE],
+      names: [],
+      mappings: encodeMappings([
+        {
+          genLine: chunk.line1 - 1,
+          genCol: chunk.column1 - 1,
+          srcLine: ORIGINAL_LINE - 1,
+          srcCol: ORIGINAL_COLUMN - 1,
+        },
+      ]),
+    }
+    const emptySection = {
+      version: 3,
+      file: 'chunk.js',
+      sources: [url.pathToFileURL(path.join(dir, 'unrelated.js')).href],
+      sourcesContent: ['// unrelated'],
+      names: [],
+      mappings: 'AAAA',
+    }
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js.map'),
+      JSON.stringify({
+        version: 3,
+        sources: [],
+        sections: [
+          { offset: { line: 0, column: 0 }, map: throwingSection },
+          { offset: { line: 200, column: 0 }, map: emptySection },
+        ],
+      })
+    )
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js'),
+      chunk.code + '\n//# sourceMappingURL=chunk.js.map'
+    )
+    const error = throwAndCatch(() =>
+      require(path.join(dir, 'chunk.js')).throwsInChunk()
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'index-map-position-before-sections'(dir) {
+    const chunk = generateChunkCode(101, 'boom:sections')
+    const laterSection = {
+      version: 3,
+      file: 'chunk.js',
+      sources: [url.pathToFileURL(path.join(dir, 'unrelated.js')).href],
+      sourcesContent: ['// unrelated'],
+      names: [],
+      mappings: 'AAAA',
+    }
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js.map'),
+      JSON.stringify({
+        version: 3,
+        sources: [],
+        sections: [{ offset: { line: 200, column: 0 }, map: laterSection }],
+      })
+    )
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js'),
+      chunk.code + '\n//# sourceMappingURL=chunk.js.map'
+    )
+    const error = throwAndCatch(() =>
+      require(path.join(dir, 'chunk.js')).throwsInChunk()
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'index-map-empty-sections'(dir) {
+    const chunk = generateChunkCode(101, 'boom:sections')
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js.map'),
+      JSON.stringify({ version: 3, sources: [], sections: [] })
+    )
+    fs.writeFileSync(
+      path.join(dir, 'chunk.js'),
+      chunk.code + '\n//# sourceMappingURL=chunk.js.map'
+    )
+    const error = throwAndCatch(() =>
+      require(path.join(dir, 'chunk.js')).throwsInChunk()
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  // Turbopack dev injects a bundler-side source map lookup into the terminal
+  // formatter (`setBundlerFindSourceMapImplementation`); the debugger-facing
+  // `findSourceMapURLDEV` only consults Node.js.
+  async 'bundler-source-map-fallback'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      sourceMap: false,
+    })
+    const chunk = generateChunkCode(101, 'boom:chunk.js')
+    const payload = generateSourceMap(chunk, 'chunk.js.map')
+    const chunkURL = url.pathToFileURL(chunkPath).href
+    require(
+      path.join(nextDist, 'server/patch-error-inspect')
+    ).setBundlerFindSourceMapImplementation((sourceURL) =>
+      sourceURL === chunkURL ? payload : undefined
+    )
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  // The SSR render's `onError` recovers RSC errors by digest and hashes
+  // fresh SSR errors with the component stack.
+  async 'html-error-handler'(dir) {
+    const chunkPath = await writeChunkFixture(
+      dir,
+      'chunk.js',
+      chunkFixtureOptions()
+    )
+    const mod = await loadChunk(chunkPath)
+    const error = throwAndCatch(() => mod.throwsInChunk())
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+
+    const allCapturedErrors = []
+    const handleHTMLError = createHTMLErrorHandler(
+      true,
+      false,
+      reactServerErrorsByDigest,
+      allCapturedErrors,
+      () => {}
+    )
+    const recoveredDigest = handleHTMLError(revived, {
+      componentStack: '\n    at Page (<anonymous>)',
+    })
+    const freshError = throwAndCatch(() => mod.throwsInChunk())
+    const freshDigest = handleHTMLError(freshError, {
+      componentStack: '\n    at Layout (<anonymous>)',
+    })
+    const redirect = new Error('NEXT_REDIRECT')
+    redirect.digest = 'NEXT_REDIRECT;push;/target;307;'
+    const redirectDigest = handleHTMLError(redirect)
+    const largeShell = new Error(
+      'This rendered a large document (>128kB) without any Suspense boundaries.'
+    )
+    const largeShellDigest = handleHTMLError(largeShell)
+    const largeShellRSCDigest = handleError(largeShell)
+    return {
+      hops: [observeError(wire.errorInfo.env, revived)],
+      htmlHandler: {
+        recoveredDigestForwarded: recoveredDigest === wire.errorInfo.digest,
+        freshDigestHashed: /^\d+$/.test(freshDigest.split('@')[0]),
+        freshDigestDiffers: freshDigest !== recoveredDigest,
+        capturedBoth: allCapturedErrors.length === 3,
+        revivedIsUserLandError: isUserLandError(revived),
+        redirectDigestForwarded: redirectDigest === redirect.digest,
+        largeShellSilenced:
+          largeShellDigest === undefined && largeShellRSCDigest === undefined,
+      },
+    }
+  },
+
+  async 'formatted-context-error'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      message: 'createContext is not a function',
+    })
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'formatted-hook-error'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      message: 'useState is not a function',
+    })
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  // Frames as browsers report them to the overlay endpoint: eval origins
+  // and `_next/static` URLs, cleaned up and rewritten by `parseStack`.
+  async 'overlay-browser-frames'(dir) {
+    const { getOriginalStackFrames } = require(
+      path.join(nextDist, 'server/dev/middleware-turbopack')
+    )
+    const { parseStack } = require(
+      path.join(nextDist, 'server/lib/parse-stack')
+    )
+    const stackText = [
+      'Error: boom',
+      `    at evil (eval at run (${path.join(dir, 'host.js')}:1:1), <anonymous>:5:9)`,
+      '    at page (http://localhost:3000/_next/static/chunks/app/page.js:10:5)',
+    ].join('\n')
+    const project = {
+      async traceSource() {
+        return null
+      },
+      async getSourceMap() {
+        return null
+      },
+    }
+    const hop = {
+      environmentName: 'browser',
+      stack: stackText,
+      symbolicated: { frame: null },
+      terminal: '(not printed)',
+    }
+    hop.overlayFrames = (
+      await getOriginalStackFrames({
+        project,
+        projectPath: dir,
+        frames: parseStack(stackText, dir),
+        isServer: false,
+        isEdgeServer: false,
+        isAppDirectory: true,
+      })
+    ).map((entry) =>
+      entry.status === 'rejected'
+        ? { status: entry.status, reason: String(entry.reason) }
+        : entry
+    )
+    return { hops: [hop] }
+  },
+
+  // The browser's Flight client resolves fake frame source maps through
+  // `/__nextjs_source-map?filename=...` instead of `findSourceMapURLDEV`;
+  // this is that endpoint's server half.
+  async 'source-map-endpoint'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    require(chunkPath)
+    const spacedDir = path.join(dir, 'my project')
+    fs.mkdirSync(spacedDir)
+    const spacedChunk = await writeChunkFixture(spacedDir, 'chunk.js')
+    require(spacedChunk)
+
+    const { getSourceMapMiddleware } = require(
+      path.join(nextDist, 'server/dev/middleware-turbopack')
+    )
+    const middleware = getSourceMapMiddleware({
+      async getSourceMap() {
+        return null
+      },
+    })
+    const resolve = (filename) =>
+      new Promise((done) => {
+        const res = {
+          statusCode: 200,
+          setHeader() {
+            return res
+          },
+          end(body) {
+            done({
+              status: res.statusCode,
+              hasMap:
+                body !== undefined &&
+                String(body).includes('"version":3') &&
+                String(body).includes('"mappings"'),
+            })
+          },
+        }
+        middleware(
+          {
+            url: `/__nextjs_source-map?filename=${encodeURIComponent(filename)}`,
+            method: 'GET',
+          },
+          res,
+          () => done({ status: 'next' })
+        )
+      })
+
+    const queries = {
+      'chunk path': chunkPath,
+      'chunk file URL': url.pathToFileURL(chunkPath).href,
+      'path with a space': spacedChunk,
+      'encoded file URL with a space': url.pathToFileURL(spacedChunk).href,
+      'decoded file URL with a space': `file://${spacedChunk}`,
+      'unknown file': path.join(dir, 'unknown.js'),
+    }
+    const endpoint = {}
+    for (const [label, filename] of Object.entries(queries)) {
+      endpoint[label] = await resolve(filename)
+    }
+    return {
+      hops: [
+        {
+          environmentName: 'browser',
+          stack: '(not observed)',
+          symbolicated: { frame: null },
+          terminal: '(not printed)',
+        },
+      ],
+      endpoint,
+    }
+  },
+
+  // The SWC error-code transform stamps framework errors with
+  // `__NEXT_ERROR_CODE`, which suffixes the digest.
+  async 'error-code-digest'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    Object.defineProperty(error, '__NEXT_ERROR_CODE', {
+      value: 'E118',
+      enumerable: false,
+      configurable: true,
+    })
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Server', 'Server']),
+    }
+  },
+
+  // Two identical throws hash to the same digest; the shared map keeps the
+  // first error object, so recovery hands it back for both.
+  async 'digest-collision'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const mod = require(chunkPath)
+    const errors = []
+    for (let i = 0; i < 2; i++) {
+      errors.push(throwAndCatch(() => mod.throwsInChunk()))
+    }
+    const first = serializeError(errors[0], 'Server')
+    const second = serializeError(errors[1], 'Server')
+    const digests = [first.errorInfo.digest, second.errorInfo.digest]
+    return {
+      hops: [
+        observeError(
+          first.errorInfo.env,
+          await createFlightClientInstance(dir).reviveError(first)
+        ),
+      ],
+      digests,
+      htmlHandler: {
+        digestsCollide: digests[0] === digests[1],
+        mapKeepsFirstError:
+          reactServerErrorsByDigest.get(digests[0]) === errors[0],
+      },
+    }
+  },
+
+  // The browser's Flight client passes a `findSourceMapURL` that returns
+  // `/__nextjs_source-map?...` URLs, so fake scripts carry an `http:` source
+  // map URL that a debugger fetches through the dev server.
+  async 'browser-flight-source-maps'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+
+    process.env.__NEXT_DEV_SERVER = 'true'
+    globalThis.document = {
+      location: { origin: 'http://localhost:3000' },
+    }
+    const { findSourceMapURL } = require(
+      path.join(nextDist, 'client/app-find-source-map-url')
+    )
+    const { getSourceMapMiddleware } = require(
+      path.join(nextDist, 'server/dev/middleware-turbopack')
+    )
+    const middleware = getSourceMapMiddleware({
+      async getSourceMap() {
+        return null
+      },
+    })
+    resolveHttpSourceMap = (sourceMapURL) => {
+      let payload
+      const { pathname, search } = new URL(sourceMapURL)
+      middleware(
+        { url: pathname + search, method: 'GET' },
+        {
+          statusCode: 200,
+          setHeader() {
+            return this
+          },
+          end(body) {
+            try {
+              payload = JSON.parse(String(body))
+            } catch {
+              payload = null
+            }
+          },
+        },
+        () => {}
+      )
+      return payload
+    }
+
+    const wire = serializeError(error, 'Server')
+    const revived = await createFlightClientInstance(dir, {
+      findSourceMapURL,
+    }).reviveError(wire)
+    return { hops: [observeError(wire.errorInfo.env, revived)] }
+  },
+
+  // Serializing an error as a debug value first (e.g. a console argument)
+  // caches a structured stack parse that the error serialization then
+  // reuses, so even the first hop takes the structured path.
+  async 'error-logged-before-thrown'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    serializeValue({ args: [error] }, 'Server')
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  // Browser console logs forwarded to the dev server terminal have their
+  // frames mapped server-side.
+  async 'browser-log-source-mapping'(dir) {
+    const staticDir = path.join(dir, 'static', 'chunks')
+    fs.mkdirSync(staticDir, { recursive: true })
+    const chunkPath = await writeChunkFixture(staticDir, 'app.js', {
+      message: 'boom:browser-log',
+    })
+    require(chunkPath)
+    const generated = await findGeneratedPosition(
+      JSON.parse(fs.readFileSync(`${chunkPath}.map`, 'utf8')),
+      ORIGINAL_LINE,
+      ORIGINAL_COLUMN
+    )
+    const fakeFrameURL = `about://React/Server/${encodeURI(
+      url.pathToFileURL(path.join(dir, 'server-page.js')).href
+    )}?0`
+    const stackTrace = [
+      'Error: client log',
+      `    at throwsInChunk (http://localhost:3000/_next/static/chunks/app.js:${generated.line1}:${generated.column1})`,
+      '    at injected (chrome-extension://abcdef/content.js:1:1)',
+      '    at unknown (http://localhost:3000/_next/static/chunks/other.js:1:1)',
+      // A revived server error logged in the browser carries fake frames;
+      // forwarding the log sends their sourceURLs as text.
+      `    at Page (${fakeFrameURL}:113:11)`,
+    ].join('\n')
+
+    const {
+      getSourceMappedStackFrames,
+      getConsoleLocation,
+      withLocation,
+    } = require(path.join(nextDist, 'server/dev/browser-logs/source-map'))
+    const ctx = {
+      bundler: 'turbopack',
+      isServer: false,
+      isEdgeServer: false,
+      isAppDirectory: true,
+      project: {
+        async traceSource() {
+          return null
+        },
+        async getSourceMap() {
+          return null
+        },
+      },
+      projectPath: dir,
+    }
+    const mapped = await getSourceMappedStackFrames(stackTrace, ctx, dir)
+    const decorated = await withLocation(
+      { original: ['hello from the browser'], stack: stackTrace },
+      ctx,
+      dir,
+      true
+    )
+    return {
+      hops: [
+        {
+          environmentName: 'browser',
+          stack: stackTrace,
+          symbolicated: { frame: null },
+          terminal: '(not printed)',
+        },
+      ],
+      browserLogs: {
+        kind: mapped.kind,
+        frames:
+          mapped.frames?.map((frame) => ({
+            frameText: frame.frameText,
+            hasCodeFrame: frame.codeFrame != null,
+          })) ?? null,
+        consoleLocation: getConsoleLocation(mapped),
+        decorated,
+      },
+    }
+  },
+
+  async 'owner-stack'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Server',
+    })
+    const wire = serializeError(error, 'Server', pageInfo)
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  async 'owner-stack-cross-environment'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Cache',
+    })
+    const wire = serializeError(error, 'Cache', pageInfo)
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  // With cache components, the dev render's `environmentName` is a function
+  // of the current render stage and returns 'Prerender' while the static
+  // stages run, so everything serialized there carries that environment.
+  async 'prerender-environment'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js')
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    const wire = serializeError(error, 'Prerender')
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  async 'prerender-owner-stack'(dir) {
+    const { pageInfo, error } = await writeOwnerFixture(dir, {
+      pageEnvironmentName: 'Prerender',
+      layoutEnvironmentName: 'Prerender',
+    })
+    const wire = serializeError(error, 'Prerender', pageInfo)
+    const revived = await createFlightClientInstance(dir).reviveError(wire)
+    const hop = observeError(wire.errorInfo.env, revived)
+    hop.ownerTasks = await observeOwnerTaskChain(revived)
+    return { hops: [hop] }
+  },
+
+  async 'ignore-listed-chunk'(dir) {
+    const chunkPath = await writeChunkFixture(dir, 'chunk.js', {
+      ignoreList: true,
+    })
+    const error = throwAndCatch(() => require(chunkPath).throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'async-function-frames'(dir) {
+    const chunkFileName = 'chunk.js'
+    const lines = ['"use strict";']
+    while (lines.length < 100) {
+      lines.push('/* padding */')
+    }
+    const throwingLine =
+      "async function throwsInChunk() { await 0; throw new Error('boom:async'); }"
+    lines.push(throwingLine)
+    lines.push('async function outer() { await throwsInChunk(); }')
+    lines.push('module.exports = { outer: outer };')
+    fs.writeFileSync(
+      path.join(dir, `${chunkFileName}.map`),
+      JSON.stringify({
+        version: 3,
+        file: chunkFileName,
+        sources: ['original.js'],
+        sourcesContent: [ORIGINAL_SOURCE],
+        names: [],
+        mappings: encodeMappings([
+          {
+            genLine: 100,
+            genCol: throwingLine.indexOf('new Error'),
+            srcLine: ORIGINAL_LINE - 1,
+            srcCol: ORIGINAL_COLUMN - 1,
+          },
+          { genLine: 101, genCol: 25, srcLine: 1, srcCol: 0 },
+        ]),
+      })
+    )
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+    fs.writeFileSync(
+      path.join(dir, chunkFileName),
+      lines.join('\n') + `\n//# sourceMappingURL=${chunkFileName}.map`
+    )
+    let error
+    try {
+      await require(path.join(dir, chunkFileName)).outer()
+      throw new Error('expected the fixture to throw')
+    } catch (thrown) {
+      error = thrown
+    }
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'deep-stack'(dir) {
+    const chunkFileName = 'chunk.js'
+    const lines = ['"use strict";']
+    while (lines.length < 100) {
+      lines.push('/* padding */')
+    }
+    lines.push(
+      "function recurses(n) { if (n === 0) { throw new Error('boom:deep'); } return recurses(n - 1); }"
+    )
+    lines.push('module.exports = { recurses: recurses };')
+    fs.writeFileSync(path.join(dir, chunkFileName), lines.join('\n'))
+    const error = throwAndCatch(() =>
+      require(path.join(dir, chunkFileName)).recurses(30)
+    )
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+
+  async 'webpack-internal-frames'(dir) {
+    // Mirrors Webpack's development `eval-source-map` output: each module is
+    // eval'd with a `webpack-internal:` sourceURL and an inline source map
+    // whose sources use the `webpack://` scheme.
+    const chunk = generateChunkCode(101, 'boom:webpack', {
+      moduleFormat: 'eval',
+    })
+    const map = {
+      version: 3,
+      file: 'page.js',
+      sources: ['webpack://_N_E/./app/page.js'],
+      sourcesContent: [ORIGINAL_SOURCE],
+      names: [],
+      mappings: encodeMappings([
+        {
+          genLine: chunk.line1 - 1,
+          genCol: chunk.column1 - 1,
+          srcLine: ORIGINAL_LINE - 1,
+          srcCol: ORIGINAL_COLUMN - 1,
+        },
+      ]),
+    }
+    const code =
+      chunk.code +
+      '\n//# sourceURL=webpack-internal:///(rsc)/./app/page.js' +
+      '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+      Buffer.from(JSON.stringify(map)).toString('base64')
+    // eslint-disable-next-line no-eval
+    const moduleExports = (0, eval)(code)
+    const error = throwAndCatch(() => moduleExports.throwsInChunk())
+    return {
+      hops: await reviveAcrossEnvironments(dir, error, ['Server', 'Server']),
+    }
+  },
+
+  async 'eval-with-inline-source-map'(dir) {
+    // Mirrors how the Turbopack Node.js HMR client evals updated modules:
+    // an explicit `//# sourceURL` with the module id as a query, and the
+    // source map inlined as a `data:` URL.
+    const chunk = generateChunkCode(101, 'boom:eval', { moduleFormat: 'eval' })
+    const chunkPath = path.join(dir, 'chunk.js')
+    fs.writeFileSync(chunkPath, chunk.code)
+    fs.writeFileSync(path.join(dir, 'original.js'), ORIGINAL_SOURCE)
+    const sourceURL = `${url.pathToFileURL(chunkPath).href}?module-id`
+    const map = generateSourceMap(chunk, 'chunk.js.map')
+    const code =
+      chunk.code +
+      '\n\n//# sourceURL=' +
+      sourceURL +
+      '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,' +
+      Buffer.from(JSON.stringify(map)).toString('base64')
+    // eslint-disable-next-line no-eval
+    const moduleExports = (0, eval)(code)
+    const error = throwAndCatch(() => moduleExports.throwsInChunk())
+    return { hops: await reviveAcrossEnvironments(dir, error, ['Server']) }
+  },
+}
+
+async function main() {
+  const scenarioName = process.argv[2]
+  const scenario = scenarios[scenarioName]
+  if (scenario === undefined) {
+    throw new Error(`unknown scenario: ${scenarioName}`)
+  }
+
+  await post('Debugger.enable', { maxScriptsCacheSize: 10_000_000 })
+
+  // Like the dev server's initialization: native bindings load first, then
+  // code frame rendering is injected into the error formatter. Without the
+  // injection (`next start` has none), the formatter omits code frames.
+  await require(path.join(nextDist, 'build/swc')).loadBindings()
+  if (!process.env.SCENARIO_SKIP_CODE_FRAMES) {
+    require(
+      path.join(nextDist, 'server/lib/install-code-frame')
+    ).installCodeFrameSupport()
+  }
+  await post('Runtime.enable')
+  // An attached debugger frontend enables async stack tracking, which is
+  // what records the `console.createTask` chain at error construction.
+  await post('Debugger.setAsyncCallStackDepth', { maxDepth: 64 })
+
+  const dir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'fsf-'))
+  const result = await scenario(dir)
+
+  // Let trailing `Debugger.scriptParsed` events drain.
+  await new Promise((resolve) => setImmediate(resolve))
+
+  result.fakeScripts = parsedScripts.filter(
+    (script) =>
+      script.url.startsWith('about://React/') ||
+      script.url.startsWith(url.pathToFileURL(dir).href)
+  )
+  for (const script of result.fakeScripts) {
+    if (!script.url.startsWith('about://React/')) continue
+    const { scriptSource } = await post('Debugger.getScriptSource', {
+      scriptId: script.scriptId,
+    })
+    // The sourceURL and source map URL comments are dropped: they are
+    // asserted on separately, and the `?N` counter suffix depends on how
+    // many fake functions the consumer created before.
+    script.source = scriptSource.replace(/\n\/\/# source.*$/s, '')
+    // For the browser consumer the map URL points at the dev server
+    // endpoint; resolve it here so the harness can still verify the map.
+    if (script.sourceMapURL.startsWith('http:')) {
+      script.resolvedSourceMap = resolveHttpSourceMap(script.sourceMapURL)
+    }
+  }
+  result.dir = dir
+
+  process.stdout.write(JSON.stringify(result))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
**Not for merge.**

I asked Claude to make this fixture to help me understand the impact of changes to sourcemapping logic in Next.js. It hardcodes checked-in faithful (hopefully) copies of the relevant React logic without actual Flight stuff, rendering, etc.

So we can capture dozens of inline snapshots that show how different pieces of Next.js see the stack. I've nudged Claude towards as much Next.js coverage as reasonable.  If you scroll through this test, you'll see what I mean.

This reflects the current behavior so there might be some weird tests.

---

Since this would require updating whenever React updates upstream, even though (I believe) any divergence is caught by tests, this is still too annoying. So I don't actually aim to merge it but can use every once in a while as an aid.