### PR TITLE
Ensure unique resolved `headers()` value between render passes

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -132,6 +132,7 @@ import { handleAction } from './action-handler'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { warn, error } from '../../build/output/log'
 import { appendMutableCookies } from '../web/spec-extension/adapters/request-cookies'
+import { HeadersAdapter } from '../web/spec-extension/adapters/headers'
 import { createServerInsertedHTML } from './server-inserted-html'
 import { getRequiredScripts } from './required-scripts'
 import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
@@ -1175,9 +1176,7 @@ async function spawnRuntimePrefetchWithFilledCaches(
       }),
       prerenderResumeDataCache,
       rootParams,
-      // Copy the request store's headers so that this render pass resolves
-      // `headers()` to its own object identity.
-      new Headers(requestStore.headers),
+      requestStore.headers,
       requestStore.cookies,
       requestStore.draftMode,
       onError,
@@ -1543,9 +1542,7 @@ async function generateRuntimePrefetchResult(
     generateDynamicRSCPayload.bind(null, ctx),
     prerenderResumeDataCache,
     rootParams,
-    // Copy the request store's headers so that this render pass resolves
-    // `headers()` to its own object identity.
-    new Headers(requestStore.headers),
+    requestStore.headers,
     requestStore.cookies,
     requestStore.draftMode
   )
@@ -1581,9 +1578,7 @@ async function generateRuntimePrefetchResult(
     }),
     prerenderResumeDataCache,
     rootParams,
-    // Copy the request store's headers so that this render pass resolves
-    // `headers()` to its own object identity.
-    new Headers(requestStore.headers),
+    requestStore.headers,
     requestStore.cookies,
     requestStore.draftMode,
     onError,
@@ -1652,9 +1647,10 @@ async function prospectiveRuntimeServerPrerender(
     stagedRendering: null,
     isSessionShell: isShellPrefetch,
     // These are not present in regular prerenders, but allowed in a runtime
-    // prerender. Callers pass a copy of the request store's headers so that
-    // each render pass resolves `headers()` to its own object identity.
-    headers,
+    // prerender.
+    // Any cache keyed on headers() needs to be invalidated.
+    // Otherwise some Next.js API semantics leak across render passes.
+    headers: HeadersAdapter.fresh(headers),
     cookies,
     draftMode,
   }
@@ -1830,9 +1826,8 @@ async function finalRuntimeServerPrerender(
     stagedRendering: finalStageController,
     isSessionShell: mode.type === 'session-shell-only',
     // These are not present in regular prerenders, but allowed in a runtime
-    // prerender. Callers pass a copy of the request store's headers so that
-    // each render pass resolves `headers()` to its own object identity.
-    headers,
+    // prerender.
+    headers: HeadersAdapter.fresh(headers),
     cookies,
     draftMode,
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -131,7 +131,10 @@ import { createFlightRouterStateFromLoaderTree } from './create-flight-router-st
 import { handleAction } from './action-handler'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { warn, error } from '../../build/output/log'
-import { appendMutableCookies } from '../web/spec-extension/adapters/request-cookies'
+import {
+  appendMutableCookies,
+  RequestCookiesAdapter,
+} from '../web/spec-extension/adapters/request-cookies'
 import { HeadersAdapter } from '../web/spec-extension/adapters/headers'
 import { createServerInsertedHTML } from './server-inserted-html'
 import { getRequiredScripts } from './required-scripts'
@@ -1648,10 +1651,10 @@ async function prospectiveRuntimeServerPrerender(
     isSessionShell: isShellPrefetch,
     // These are not present in regular prerenders, but allowed in a runtime
     // prerender.
-    // Any cache keyed on headers() needs to be invalidated.
+    // Any cache keyed on headers() or cookies() needs to be invalidated.
     // Otherwise some Next.js API semantics leak across render passes.
     headers: HeadersAdapter.fresh(headers),
-    cookies,
+    cookies: RequestCookiesAdapter.fresh(cookies),
     draftMode,
   }
 
@@ -1828,7 +1831,7 @@ async function finalRuntimeServerPrerender(
     // These are not present in regular prerenders, but allowed in a runtime
     // prerender.
     headers: HeadersAdapter.fresh(headers),
-    cookies,
+    cookies: RequestCookiesAdapter.fresh(cookies),
     draftMode,
   }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1175,7 +1175,9 @@ async function spawnRuntimePrefetchWithFilledCaches(
       }),
       prerenderResumeDataCache,
       rootParams,
-      requestStore.headers,
+      // Copy the request store's headers so that this render pass resolves
+      // `headers()` to its own object identity.
+      new Headers(requestStore.headers),
       requestStore.cookies,
       requestStore.draftMode,
       onError,
@@ -1541,7 +1543,9 @@ async function generateRuntimePrefetchResult(
     generateDynamicRSCPayload.bind(null, ctx),
     prerenderResumeDataCache,
     rootParams,
-    requestStore.headers,
+    // Copy the request store's headers so that this render pass resolves
+    // `headers()` to its own object identity.
+    new Headers(requestStore.headers),
     requestStore.cookies,
     requestStore.draftMode
   )
@@ -1577,7 +1581,9 @@ async function generateRuntimePrefetchResult(
     }),
     prerenderResumeDataCache,
     rootParams,
-    requestStore.headers,
+    // Copy the request store's headers so that this render pass resolves
+    // `headers()` to its own object identity.
+    new Headers(requestStore.headers),
     requestStore.cookies,
     requestStore.draftMode,
     onError,
@@ -1645,7 +1651,9 @@ async function prospectiveRuntimeServerPrerender(
     // No stage sequencing needed for prospective renders.
     stagedRendering: null,
     isSessionShell: isShellPrefetch,
-    // These are not present in regular prerenders, but allowed in a runtime prerender.
+    // These are not present in regular prerenders, but allowed in a runtime
+    // prerender. Callers pass a copy of the request store's headers so that
+    // each render pass resolves `headers()` to its own object identity.
     headers,
     cookies,
     draftMode,
@@ -1821,7 +1829,9 @@ async function finalRuntimeServerPrerender(
     varyParamsAccumulator,
     stagedRendering: finalStageController,
     isSessionShell: mode.type === 'session-shell-only',
-    // These are not present in regular prerenders, but allowed in a runtime prerender.
+    // These are not present in regular prerenders, but allowed in a runtime
+    // prerender. Callers pass a copy of the request store's headers so that
+    // each render pass resolves `headers()` to its own object identity.
     headers,
     cookies,
     draftMode,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -77,7 +77,10 @@ import {
 import type { CacheReadWriteHandler } from './tiered-cache-handler'
 import { cloneCacheEntry } from './clone-cache-entry'
 import { NEXT_INSTANT_TEST_COOKIE } from '../../client/components/app-router-headers'
-import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
+import {
+  RequestCookiesAdapter,
+  type ReadonlyRequestCookies,
+} from '../web/spec-extension/adapters/request-cookies'
 import {
   HeadersAdapter,
   type ReadonlyHeaders,
@@ -685,10 +688,10 @@ function createUseCacheStore(
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: process.env.__NEXT_DEV_SERVER ? new Set() : undefined,
       // Every private cache scope is its own work unit. Any cache keyed on
-      // headers() needs to be invalidated. Otherwise some Next.js API
-      // semantics leak across render passes.
+      // headers() or cookies() needs to be invalidated. Otherwise some
+      // Next.js API semantics leak across render passes.
       headers: HeadersAdapter.fresh(outerWorkUnitStore.headers),
-      cookies: outerWorkUnitStore.cookies,
+      cookies: RequestCookiesAdapter.fresh(outerWorkUnitStore.cookies),
       outerOwnerStack: cacheContext.outerOwnerStack,
     }
   } else {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -78,7 +78,10 @@ import type { CacheReadWriteHandler } from './tiered-cache-handler'
 import { cloneCacheEntry } from './clone-cache-entry'
 import { NEXT_INSTANT_TEST_COOKIE } from '../../client/components/app-router-headers'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
-import type { ReadonlyHeaders } from '../web/spec-extension/adapters/headers'
+import {
+  HeadersAdapter,
+  type ReadonlyHeaders,
+} from '../web/spec-extension/adapters/headers'
 import {
   NestedDynamicUseCacheError,
   UseCacheDeadlockError,
@@ -681,7 +684,10 @@ function createUseCacheStore(
       ),
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: process.env.__NEXT_DEV_SERVER ? new Set() : undefined,
-      headers: outerWorkUnitStore.headers,
+      // Every private cache scope is its own work unit. Any cache keyed on
+      // headers() needs to be invalidated. Otherwise some Next.js API
+      // semantics leak across render passes.
+      headers: HeadersAdapter.fresh(outerWorkUnitStore.headers),
       cookies: outerWorkUnitStore.cookies,
       outerOwnerStack: cacheContext.outerOwnerStack,
     }

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -134,6 +134,18 @@ export class HeadersAdapter extends Headers {
   }
 
   /**
+   * @param headers
+   * @returns A fresh object identity backed by the original value
+   */
+  public static fresh(headers: ReadonlyHeaders): ReadonlyHeaders {
+    return new Proxy<ReadonlyHeaders>(headers, {
+      get(target, prop, receiver) {
+        return ReflectAdapter.get(target, prop, receiver)
+      },
+    })
+  }
+
+  /**
    * Merges a header value into a string. This stores multiple values as an
    * array, so we need to merge them into a string.
    *

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -48,6 +48,18 @@ export class RequestCookiesAdapter {
       },
     })
   }
+
+  /**
+   * @param cookies
+   * @returns A fresh object identity backed by the original value
+   */
+  public static fresh(cookies: ReadonlyRequestCookies): ReadonlyRequestCookies {
+    return new Proxy(cookies, {
+      get(target, prop, receiver) {
+        return ReflectAdapter.get(target, prop, receiver)
+      },
+    })
+  }
 }
 
 const SYMBOL_MODIFY_COOKIE_VALUES = Symbol.for('next.mutated.cookies')

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/dynamic/error.tsx
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/dynamic/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function DynamicError() {
+  return <div id="dynamic-error">Failed to render dynamic content</div>
+}

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/dynamic/page.tsx
@@ -1,0 +1,66 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+import { connection } from 'next/server'
+
+export const instant = {
+  unstable_samples: [{ headers: [['host', 'test-host']] }],
+}
+export const prefetch = 'partial'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="intro">This page gates its dynamic content on connection().</p>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 1...</div>}>
+        <RuntimePrefetchable />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RuntimePrefetchable() {
+  const headersStore = await headers()
+  const headerValue = headersStore.get('host') === null ? 'missing' : 'present'
+  return (
+    <div>
+      <div id="header-value">{`Header: ${headerValue}`}</div>
+      <Suspense fallback={<div style={{ color: 'grey' }}>Loading 2...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}
+
+// A module-level cache keyed on the identity of the headers object (like
+// `dedupe()` from the Flags SDK, or any per-request memoization that treats
+// the headers object as "the request"), gating its data on `connection()` so
+// it only produces data during actual navigations, never during (runtime)
+// prefetches.
+//
+// A request can be rendered by multiple passes with different semantics for
+// `connection()`: the prospective and final prerenders of a runtime prefetch,
+// or a navigation's dynamic render and the runtime prerender that is spawned
+// from it to refresh the client's prefetch cache. In prerenders the
+// connection() promise hangs and is rejected when the pass is aborted; during
+// navigations it resolves. Each render pass resolves `await headers()` to a
+// distinct object, which scopes identity-keyed memoization like this cache to
+// a single pass: a promise created under one pass's semantics is never
+// consumed by another pass.
+const requestDataCache = new WeakMap<object, Promise<string>>()
+async function getRequestData(): Promise<string> {
+  const headersStore = await headers()
+  let dataPromise = requestDataCache.get(headersStore)
+  if (dataPromise === undefined) {
+    dataPromise = (async () => {
+      await connection()
+      return 'request data'
+    })()
+    requestDataCache.set(headersStore, dataPromise)
+  }
+  return dataPromise
+}
+
+async function Dynamic() {
+  const data = await getRequestData()
+  return <div id="dynamic-content">Dynamic content: {data}</div>
+}

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body style={{ fontFamily: 'monospace' }}>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/app/page.tsx
@@ -1,0 +1,14 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Index</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/dynamic">Dynamic page</LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/components/link-accordion.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+}: {
+  href: string
+  children: React.ReactNode
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/headers-keyed-caches.test.ts
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/headers-keyed-caches.test.ts
@@ -14,7 +14,7 @@ describe('module-level caches keyed on the headers object', () => {
     return
   }
 
-  it('breaks the dynamic content of a navigation when the spawned runtime prerender populated the cache first', async () => {
+  it('renders dynamic content on navigation even when the spawned runtime prerender populated the cache first', async () => {
     const cliOutputStart = next.cliOutput.length
 
     let page: Playwright.Page
@@ -36,32 +36,25 @@ describe('module-level caches keyed on the headers object', () => {
       { includes: 'Header:' }
     )
 
-    // Navigate. connection() resolves during navigations, so the page should
-    // render its dynamic content. But the navigation request also spawns a
-    // runtime prerender to refresh the client's prefetch cache, which shares
-    // the request's headers object and reaches the module-level cache before
-    // the stage-gated dynamic render of the navigation does. The prerender
-    // memoizes a hanging connection() promise, which rejects when the
-    // prerender is aborted. The navigation's dynamic render awaits the same
-    // promise and fails: the user gets the error boundary instead of the
-    // dynamic content.
+    // Navigate. The navigation request also spawns a runtime prerender to
+    // refresh the client's prefetch cache, which reaches the module-level
+    // cache before the stage-gated dynamic render of the navigation does.
+    // Because each render pass resolves `headers()` to a distinct object, the
+    // hanging connection() promise it memoizes is keyed to the prerender pass
+    // only: the navigation's dynamic render misses the cache, creates its own
+    // promise, and connection() resolves, so the dynamic content renders.
     await browser.elementByCss('a[href="/dynamic"]').click()
 
     await retry(async () => {
-      expect(await browser.elementById('dynamic-error').text()).toBe(
-        'Failed to render dynamic content'
+      expect(await browser.elementById('dynamic-content').text()).toBe(
+        'Dynamic content: request data'
       )
     })
-    expect(await browser.hasElementByCssSelector('#dynamic-content')).toBe(
-      false
-    )
+    expect(await browser.hasElementByCssSelector('#dynamic-error')).toBe(false)
 
-    // The navigation request reports the render error as well.
-    await retry(async () => {
-      const cliOutput = next.cliOutput.slice(cliOutputStart)
-      expect(cliOutput).toContain(
-        '[instrumentation] onRequestError:During prerendering, `connection()` rejects when the prerender is complete'
-      )
-    }, 5000)
+    // The rejection of the prerender pass's hanging promise stays within the
+    // pass that created it, so nothing is reported to onRequestError either.
+    const cliOutput = next.cliOutput.slice(cliOutputStart)
+    expect(cliOutput).not.toContain('[instrumentation] onRequestError:')
   })
 })

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/headers-keyed-caches.test.ts
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/headers-keyed-caches.test.ts
@@ -1,0 +1,67 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('module-level caches keyed on the headers object', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Runtime prefetching only happens in production builds.
+    it('is skipped in dev', () => {})
+    return
+  }
+
+  it('breaks the dynamic content of a navigation when the spawned runtime prerender populated the cache first', async () => {
+    const cliOutputStart = next.cliOutput.length
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link, triggering the runtime prefetch.
+    await act(
+      async () => {
+        const linkToggle = await browser.elementByCss(
+          'input[data-link-accordion="/dynamic"]'
+        )
+        await linkToggle.click()
+      },
+      { includes: 'Header:' }
+    )
+
+    // Navigate. connection() resolves during navigations, so the page should
+    // render its dynamic content. But the navigation request also spawns a
+    // runtime prerender to refresh the client's prefetch cache, which shares
+    // the request's headers object and reaches the module-level cache before
+    // the stage-gated dynamic render of the navigation does. The prerender
+    // memoizes a hanging connection() promise, which rejects when the
+    // prerender is aborted. The navigation's dynamic render awaits the same
+    // promise and fails: the user gets the error boundary instead of the
+    // dynamic content.
+    await browser.elementByCss('a[href="/dynamic"]').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('dynamic-error').text()).toBe(
+        'Failed to render dynamic content'
+      )
+    })
+    expect(await browser.hasElementByCssSelector('#dynamic-content')).toBe(
+      false
+    )
+
+    // The navigation request reports the render error as well.
+    await retry(async () => {
+      const cliOutput = next.cliOutput.slice(cliOutputStart)
+      expect(cliOutput).toContain(
+        '[instrumentation] onRequestError:During prerendering, `connection()` rejects when the prerender is complete'
+      )
+    }, 5000)
+  })
+})

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/instrumentation.ts
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/instrumentation.ts
@@ -1,0 +1,5 @@
+import { type Instrumentation } from 'next'
+
+export const onRequestError: Instrumentation.onRequestError = (err) => {
+  console.log(`[instrumentation] onRequestError:${(err as Error).message}`)
+}

--- a/test/e2e/app-dir/segment-cache/headers-keyed-caches/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/headers-keyed-caches/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    cachedNavigations: true,
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
A HTTP request can render the same React tree in multiple passes with different semantics for `connection()`: the prospective and final prerenders of a runtime prefetch, or a navigation's dynamic render and the runtime prerender that is spawned from it to refresh the client's prefetch cache. All of these passes previously resolved `headers()` to the single sealed headers object created lazily by the request store, so userland caches keyed on the identity of `await headers()` (any per-request memoization that treats the headers object as "the request") leaked promises across passes.

With this change, every render pass resolves `headers()` to a distinct object over the same underlying data, making "the headers object identifies the request within one render pass" a real contract.

## test plan

- Added test that shows the previous, incorrect behavior 