### PR TITLE
[Turbopack] Keep the dev server under a memory budget

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -335,6 +335,14 @@ impl TurboTasksBackend {
         )
     }
 
+    /// Memory metric compared against the `TURBO_ENGINE_EVICT_ABOVE_MB` budget: the OS-visible
+    /// process footprint where available (that is what OOM decisions are based on), falling
+    /// back to live allocator bytes.
+    fn budget_memory_usage() -> usize {
+        turbo_tasks_malloc::TurboMalloc::process_footprint()
+            .unwrap_or_else(turbo_tasks_malloc::TurboMalloc::memory_usage)
+    }
+
     /// Coarse session-time epoch used for read-recency tracking (5-second buckets).
     fn recency_epoch(&self) -> u32 {
         (self.start_time.elapsed().as_secs() / 5) as u32
@@ -3022,7 +3030,7 @@ impl TurboTasksBackend {
                                             tokio::time::Instant::now() + PRESSURE_CHECK_INTERVAL;
                                         if let Some(budget) = *EVICT_ABOVE_BYTES
                                             && Instant::now() >= pressure_cooldown_until
-                                            && turbo_tasks_malloc::TurboMalloc::memory_usage() > budget
+                                            && Self::budget_memory_usage() > budget
                                         {
                                             reason = SnapshotReason::MemoryPressure;
                                             break;
@@ -3032,8 +3040,7 @@ impl TurboTasksBackend {
                             }
                         }
                         let pressure_triggered = matches!(reason, SnapshotReason::MemoryPressure);
-                        let usage_before_cycle =
-                            pressure_triggered.then(turbo_tasks_malloc::TurboMalloc::memory_usage);
+                        let usage_before_cycle = pressure_triggered.then(Self::budget_memory_usage);
 
                         // Persistence exists to save work; accumulated compilation time is
                         // the proxy for how much work a snapshot would save. Skip periodic
@@ -3134,10 +3141,16 @@ impl TurboTasksBackend {
                                             },
                                         );
                                         log_eviction_counts("pressure", &counts);
-                                        if window == 0
-                                            || turbo_tasks_malloc::TurboMalloc::memory_usage()
-                                                <= budget
-                                        {
+                                        if window == 0 {
+                                            break;
+                                        }
+                                        // Freed memory only leaves the footprint once the
+                                        // allocator purges it back to the OS; force that and
+                                        // give the accounting a moment to settle before deciding
+                                        // whether the protected window must shrink.
+                                        TurboMalloc::collect(true);
+                                        std::thread::sleep(Duration::from_millis(300));
+                                        if Self::budget_memory_usage() <= budget {
                                             break;
                                         }
                                         window /= 4;
@@ -3148,8 +3161,7 @@ impl TurboTasksBackend {
                                     // back-to-back while cycles reclaim memory (persisting fresh
                                     // data unlocks it for the next sweep), back off when stuck
                                     // (remaining memory belongs to in-flight work).
-                                    let usage_after =
-                                        turbo_tasks_malloc::TurboMalloc::memory_usage();
+                                    let usage_after = Self::budget_memory_usage();
                                     let usage_before =
                                         usage_before_cycle.expect("set when pressure_triggered");
                                     // Persisting fresh data counts as progress even when

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -171,12 +171,17 @@ pub enum TurboTasksBackendJob {
 static EVICTION_REGRETS: AtomicU64 = AtomicU64::new(0);
 static EVICTION_REGRETS_LAST: AtomicU64 = AtomicU64::new(0);
 
+/// Whether `TURBO_ENGINE_EVICT_LOG=1` verbose eviction logging is enabled.
+fn evict_log_enabled() -> bool {
+    static LOG: LazyLock<bool> =
+        LazyLock::new(|| std::env::var("TURBO_ENGINE_EVICT_LOG").is_ok_and(|v| v == "1"));
+    *LOG
+}
+
 /// Logs one line per eviction sweep with drop counts and regrets accumulated since the
 /// previous sweep. Only active when `TURBO_ENGINE_EVICT_LOG` is set.
 fn log_eviction_counts(trigger: &str, counts: &crate::backend::storage::EvictionCounts) {
-    static LOG: LazyLock<bool> =
-        LazyLock::new(|| std::env::var("TURBO_ENGINE_EVICT_LOG").is_ok_and(|v| v == "1"));
-    if !*LOG {
+    if !evict_log_enabled() {
         return;
     }
     let total = EVICTION_REGRETS.load(Ordering::Relaxed);
@@ -2932,6 +2937,7 @@ impl TurboTasksBackend {
                     });
 
                     let mut pressure_cooldown_until = Instant::now();
+                    let mut pressure_backoff = Duration::from_secs(1);
                     let mut last_snapshot = self.start_time;
                     let mut idle_start_listener = self.idle_start_event.listen();
                     let mut idle_end_listener = self.idle_end_event.listen();
@@ -2952,7 +2958,12 @@ impl TurboTasksBackend {
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
                         let idle_timeout = *IDLE_TIMEOUT;
                         const PRESSURE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
-                        const PRESSURE_COOLDOWN: Duration = Duration::from_secs(30);
+                        /// Pacing between budget-triggered cycles. While cycles make progress
+                        /// (usage drops or falls under budget) they run back-to-back; when a
+                        /// cycle cannot reclaim anything new (e.g. all remaining memory belongs
+                        /// to in-flight computation) the delay grows exponentially up to the max.
+                        const PRESSURE_BACKOFF_MIN: Duration = Duration::from_secs(1);
+                        const PRESSURE_BACKOFF_MAX: Duration = Duration::from_secs(30);
                         let (time, mut reason) = if is_first {
                             (FIRST_SNAPSHOT_WAIT, SnapshotReason::InitialSnapshotTimeout)
                         } else {
@@ -3021,9 +3032,8 @@ impl TurboTasksBackend {
                             }
                         }
                         let pressure_triggered = matches!(reason, SnapshotReason::MemoryPressure);
-                        if pressure_triggered {
-                            pressure_cooldown_until = Instant::now() + PRESSURE_COOLDOWN;
-                        }
+                        let usage_before_cycle =
+                            pressure_triggered.then(turbo_tasks_malloc::TurboMalloc::memory_usage);
 
                         // Persistence exists to save work; accumulated compilation time is
                         // the proxy for how much work a snapshot would save. Skip periodic
@@ -3031,7 +3041,8 @@ impl TurboTasksBackend {
                         // flush, but they don't run through this loop (Stop is handled in
                         // stop(), Test in snapshot_and_evict_for_testing), so every reason
                         // reaching here is subject to the threshold.
-                        if active_time.elapsed() < *MIN_SNAPSHOT_ACTIVE_TIME {
+                        if !pressure_triggered && active_time.elapsed() < *MIN_SNAPSHOT_ACTIVE_TIME
+                        {
                             // Not enough compilation time accumulated — skip the (potentially
                             // expensive) snapshot. Advance scheduling state as if we had run,
                             // but keep active_time running so it carries toward the next cycle.
@@ -3099,9 +3110,72 @@ impl TurboTasksBackend {
                                 // `eviction_control` owns the mode + threshold decision. On a
                                 // skipped cycle its baseline and `ran_eviction` stay untouched
                                 // so growth accumulates toward the next cycle.
-                                let ran_eviction = if pressure_triggered
-                                    || eviction_control.should_evict(new_data)
-                                {
+                                let ran_eviction = if pressure_triggered {
+                                    // Sweep until under budget: start with the configured recency
+                                    // protection so old data goes first, and narrow the protected
+                                    // window (4x per pass, floored at the current epoch) only when
+                                    // dropping old data alone is not enough.
+                                    let budget = EVICT_ABOVE_BYTES
+                                        .expect("pressure trigger implies a budget");
+                                    let current_epoch = self.recency_epoch();
+                                    let mut window = self
+                                        .eviction_recency()
+                                        .min_epoch
+                                        .map(|min| current_epoch.saturating_sub(min))
+                                        .unwrap_or(12); // default protection: 60s
+                                    loop {
+                                        let counts = self.storage.evict_after_snapshot(
+                                            background_span.id(),
+                                            crate::backend::storage::EvictionRecency {
+                                                min_epoch: Some(
+                                                    current_epoch.saturating_sub(window),
+                                                ),
+                                                current_epoch,
+                                            },
+                                        );
+                                        log_eviction_counts("pressure", &counts);
+                                        if window == 0
+                                            || turbo_tasks_malloc::TurboMalloc::memory_usage()
+                                                <= budget
+                                        {
+                                            break;
+                                        }
+                                        window /= 4;
+                                    }
+                                    eviction_control.record_eviction();
+
+                                    // Pace the next budget-triggered cycle by progress: run
+                                    // back-to-back while cycles reclaim memory (persisting fresh
+                                    // data unlocks it for the next sweep), back off when stuck
+                                    // (remaining memory belongs to in-flight work).
+                                    let usage_after =
+                                        turbo_tasks_malloc::TurboMalloc::memory_usage();
+                                    let usage_before =
+                                        usage_before_cycle.expect("set when pressure_triggered");
+                                    // Persisting fresh data counts as progress even when
+                                    // concurrent allocation masks the net drop: it unlocks that
+                                    // data for the next sweep.
+                                    let progressed = usage_after <= budget
+                                        || new_data
+                                        || usage_before.saturating_sub(usage_after) >= budget / 32;
+                                    pressure_backoff = if progressed {
+                                        PRESSURE_BACKOFF_MIN
+                                    } else {
+                                        (pressure_backoff * 2).min(PRESSURE_BACKOFF_MAX)
+                                    };
+                                    pressure_cooldown_until = Instant::now() + pressure_backoff;
+                                    if evict_log_enabled() {
+                                        eprintln!(
+                                            "[pressure-cycle] before={}M after={}M budget={}M \
+                                             new_data={new_data} backoff={}s",
+                                            usage_before >> 20,
+                                            usage_after >> 20,
+                                            budget >> 20,
+                                            pressure_backoff.as_secs(),
+                                        );
+                                    }
+                                    true
+                                } else if eviction_control.should_evict(new_data) {
                                     // NOTE: we do not check for idle here, eviction is fast and
                                     // when enabled we should expect it to reclaim substantial
                                     // memory so racing with execution is as likely to save time as
@@ -3110,14 +3184,7 @@ impl TurboTasksBackend {
                                         background_span.id(),
                                         self.eviction_recency(),
                                     );
-                                    log_eviction_counts(
-                                        if pressure_triggered {
-                                            "pressure"
-                                        } else {
-                                            "idle/interval"
-                                        },
-                                        &counts,
-                                    );
+                                    log_eviction_counts("idle/interval", &counts);
                                     // Sample the post-eviction floor as the new baseline.
                                     eviction_control.record_eviction();
                                     true

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2855,10 +2855,22 @@ impl TurboTasksBackend {
     /// Counts a regret if this task's data was evicted recently (still-needed data was
     /// dropped). Called from the recompute/restore paths.
     fn count_eviction_regret(&self, task: &impl TaskGuard) {
+        if let Some(&evicted) = task.get_last_evicted_epoch() {
+            self.count_eviction_regret_epoch(evicted);
+        }
+    }
+
+    /// Storage-level variant of [`Self::count_eviction_regret`], for call sites that hold a
+    /// raw storage guard instead of a `TaskGuard`.
+    pub(crate) fn count_eviction_regret_storage(&self, storage: &TaskStorage) {
+        if let Some(&evicted) = storage.get_last_evicted_epoch() {
+            self.count_eviction_regret_epoch(evicted);
+        }
+    }
+
+    fn count_eviction_regret_epoch(&self, evicted_epoch: u32) {
         const REGRET_WINDOW_EPOCHS: u32 = 12; // 60s
-        if let Some(&evicted) = task.get_last_evicted_epoch()
-            && self.recency_epoch().saturating_sub(evicted) <= REGRET_WINDOW_EPOCHS
-        {
+        if self.recency_epoch().saturating_sub(evicted_epoch) <= REGRET_WINDOW_EPOCHS {
             EVICTION_REGRETS.fetch_add(1, Ordering::Relaxed);
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -200,6 +200,7 @@ enum SnapshotReason {
     InitialSnapshotTimeout,
     RegularSnapshotInterval,
     IdleTimeout,
+    MemoryPressure,
 }
 
 impl SnapshotReason {
@@ -210,6 +211,7 @@ impl SnapshotReason {
             SnapshotReason::InitialSnapshotTimeout => "initial snapshot timeout",
             SnapshotReason::RegularSnapshotInterval => "regular snapshot interval",
             SnapshotReason::IdleTimeout => "idle timeout",
+            SnapshotReason::MemoryPressure => "memory-pressure",
         }
     }
 
@@ -2919,6 +2921,17 @@ impl TurboTasksBackend {
                             .unwrap_or(Duration::from_secs(1))
                     });
 
+                    /// Prototype: net live bytes above which a snapshot + eviction cycle is
+                    /// triggered immediately instead of waiting for the periodic interval or
+                    /// an idle timeout. Disabled unless the env var is set.
+                    static EVICT_ABOVE_BYTES: LazyLock<Option<usize>> = LazyLock::new(|| {
+                        std::env::var("TURBO_ENGINE_EVICT_ABOVE_MB")
+                            .ok()
+                            .and_then(|v| v.parse::<usize>().ok())
+                            .map(|mb| mb * 1024 * 1024)
+                    });
+
+                    let mut pressure_cooldown_until = Instant::now();
                     let mut last_snapshot = self.start_time;
                     let mut idle_start_listener = self.idle_start_event.listen();
                     let mut idle_end_listener = self.idle_end_event.listen();
@@ -2938,6 +2951,8 @@ impl TurboTasksBackend {
                         const FIRST_SNAPSHOT_WAIT: Duration = Duration::from_secs(300);
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
                         let idle_timeout = *IDLE_TIMEOUT;
+                        const PRESSURE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+                        const PRESSURE_COOLDOWN: Duration = Duration::from_secs(30);
                         let (time, mut reason) = if is_first {
                             (FIRST_SNAPSHOT_WAIT, SnapshotReason::InitialSnapshotTimeout)
                         } else {
@@ -2961,6 +2976,8 @@ impl TurboTasksBackend {
                             } else {
                                 far_future()
                             };
+                            let mut pressure_check =
+                                tokio::time::Instant::now() + PRESSURE_CHECK_INTERVAL;
                             loop {
                                 tokio::select! {
                                     _ = &mut stop_listener => {
@@ -2987,8 +3004,25 @@ impl TurboTasksBackend {
                                             break;
                                         }
                                     },
+                                    // Pinned deadline: an inline `sleep()` would be recreated on
+                                    // every select iteration and starve under frequent idle events.
+                                    _ = tokio::time::sleep_until(pressure_check), if EVICT_ABOVE_BYTES.is_some() => {
+                                        pressure_check =
+                                            tokio::time::Instant::now() + PRESSURE_CHECK_INTERVAL;
+                                        if let Some(budget) = *EVICT_ABOVE_BYTES
+                                            && Instant::now() >= pressure_cooldown_until
+                                            && turbo_tasks_malloc::TurboMalloc::memory_usage() > budget
+                                        {
+                                            reason = SnapshotReason::MemoryPressure;
+                                            break;
+                                        }
+                                    },
                                 }
                             }
+                        }
+                        let pressure_triggered = matches!(reason, SnapshotReason::MemoryPressure);
+                        if pressure_triggered {
+                            pressure_cooldown_until = Instant::now() + PRESSURE_COOLDOWN;
                         }
 
                         // Persistence exists to save work; accumulated compilation time is
@@ -3065,7 +3099,9 @@ impl TurboTasksBackend {
                                 // `eviction_control` owns the mode + threshold decision. On a
                                 // skipped cycle its baseline and `ran_eviction` stay untouched
                                 // so growth accumulates toward the next cycle.
-                                let ran_eviction = if eviction_control.should_evict(new_data) {
+                                let ran_eviction = if pressure_triggered
+                                    || eviction_control.should_evict(new_data)
+                                {
                                     // NOTE: we do not check for idle here, eviction is fast and
                                     // when enabled we should expect it to reclaim substantial
                                     // memory so racing with execution is as likely to save time as
@@ -3074,7 +3110,14 @@ impl TurboTasksBackend {
                                         background_span.id(),
                                         self.eviction_recency(),
                                     );
-                                    log_eviction_counts("idle/interval", &counts);
+                                    log_eviction_counts(
+                                        if pressure_triggered {
+                                            "pressure"
+                                        } else {
+                                            "idle/interval"
+                                        },
+                                        &counts,
+                                    );
                                     // Sample the post-eviction floor as the new baseline.
                                     eviction_control.record_eviction();
                                     true

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -15,7 +15,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, LazyLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::SystemTime,
 };
@@ -166,6 +166,33 @@ pub enum TurboTasksBackendJob {
 }
 
 /// Why a snapshot/persist is being performed.
+/// Cumulative count of eviction regrets: tasks whose data was re-demanded within 60s of
+/// being evicted. High regret means eviction moments are poorly chosen.
+static EVICTION_REGRETS: AtomicU64 = AtomicU64::new(0);
+static EVICTION_REGRETS_LAST: AtomicU64 = AtomicU64::new(0);
+
+/// Logs one line per eviction sweep with drop counts and regrets accumulated since the
+/// previous sweep. Only active when `TURBO_ENGINE_EVICT_LOG` is set.
+fn log_eviction_counts(trigger: &str, counts: &crate::backend::storage::EvictionCounts) {
+    static LOG: LazyLock<bool> =
+        LazyLock::new(|| std::env::var("TURBO_ENGINE_EVICT_LOG").is_ok_and(|v| v == "1"));
+    if !*LOG {
+        return;
+    }
+    let total = EVICTION_REGRETS.load(Ordering::Relaxed);
+    let last = EVICTION_REGRETS_LAST.swap(total, Ordering::Relaxed);
+    eprintln!(
+        "[evict:{trigger}] full={} data={} meta={} skipped_recent={} regrets_since_last={} \
+         regrets_total={}",
+        counts.full,
+        counts.data_and_meta + counts.data_only,
+        counts.meta_only,
+        counts.skipped_recently_read,
+        total - last,
+        total,
+    );
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SnapshotReason {
     Test,
@@ -301,6 +328,28 @@ impl TurboTasksBackend {
         )
     }
 
+    /// Coarse session-time epoch used for read-recency tracking (5-second buckets).
+    fn recency_epoch(&self) -> u32 {
+        (self.start_time.elapsed().as_secs() / 5) as u32
+    }
+
+    /// Recency parameters for an eviction sweep, if `TURBO_ENGINE_EVICT_MIN_AGE_SECS` is set:
+    /// tasks read within that many seconds keep their value data.
+    fn eviction_recency(&self) -> Option<crate::backend::storage::EvictionRecency> {
+        static MIN_AGE_EPOCHS: LazyLock<Option<u32>> = LazyLock::new(|| {
+            std::env::var("TURBO_ENGINE_EVICT_MIN_AGE_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(|secs| (secs / 5).max(1) as u32)
+        });
+        let min_age = (*MIN_AGE_EPOCHS)?;
+        let current_epoch = self.recency_epoch();
+        Some(crate::backend::storage::EvictionRecency {
+            min_epoch: current_epoch.saturating_sub(min_age),
+            current_epoch,
+        })
+    }
+
     /// Perform a snapshot and then evict all evictable tasks from memory.
     ///
     /// This is exposed for integration tests that need to verify the
@@ -326,7 +375,9 @@ impl TurboTasksBackend {
                 return (false, EvictionCounts::default());
             }
         };
-        let counts = self.storage.evict_after_snapshot(None);
+        let counts = self
+            .storage
+            .evict_after_snapshot(None, self.eviction_recency());
         (had_new_data, counts)
     }
 
@@ -838,6 +889,7 @@ impl TurboTasksBackend {
             task.get_cell_data(&cell).cloned()
         };
         if let Some(content) = content {
+            self.stamp_read_epoch(&mut task);
             if tracking.should_track(false) {
                 add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
@@ -900,6 +952,7 @@ impl TurboTasksBackend {
         )
         .entered();
 
+        self.count_eviction_regret(&task);
         let _ = task.add_scheduled(
             TaskExecutionReason::CellNotAvailable,
             EventDescription::new(|| task.get_task_desc_fn()),
@@ -2791,6 +2844,25 @@ impl TurboTasksBackend {
         removed_cell_data
     }
 
+    /// Stamps the read-recency epoch on a task, skipping the write when already current.
+    fn stamp_read_epoch(&self, task: &mut impl TaskGuard) {
+        let epoch = self.recency_epoch();
+        if task.get_last_read_epoch().copied() != Some(epoch) {
+            task.set_last_read_epoch(epoch);
+        }
+    }
+
+    /// Counts a regret if this task's data was evicted recently (still-needed data was
+    /// dropped). Called from the recompute/restore paths.
+    fn count_eviction_regret(&self, task: &impl TaskGuard) {
+        const REGRET_WINDOW_EPOCHS: u32 = 12; // 60s
+        if let Some(&evicted) = task.get_last_evicted_epoch()
+            && self.recency_epoch().saturating_sub(evicted) <= REGRET_WINDOW_EPOCHS
+        {
+            EVICTION_REGRETS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     /// Prints the standard message emitted when the background persisting process stops due to an
     /// unrecoverable write error. The caller is responsible for returning from the background job.
     fn log_unrecoverable_persist_error() {
@@ -2986,7 +3058,11 @@ impl TurboTasksBackend {
                                     // when enabled we should expect it to reclaim substantial
                                     // memory so racing with execution is as likely to save time as
                                     // cost it.
-                                    self.storage.evict_after_snapshot(background_span.id());
+                                    let counts = self.storage.evict_after_snapshot(
+                                        background_span.id(),
+                                        self.eviction_recency(),
+                                    );
+                                    log_eviction_counts("idle/interval", &counts);
                                     // Sample the post-eviction floor as the new baseline.
                                     eviction_control.record_eviction();
                                     true

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -333,21 +333,21 @@ impl TurboTasksBackend {
         (self.start_time.elapsed().as_secs() / 5) as u32
     }
 
-    /// Recency parameters for an eviction sweep, if `TURBO_ENGINE_EVICT_MIN_AGE_SECS` is set:
-    /// tasks read within that many seconds keep their value data.
-    fn eviction_recency(&self) -> Option<crate::backend::storage::EvictionRecency> {
+    /// Recency parameters for an eviction sweep. The skip gate is active only when
+    /// `TURBO_ENGINE_EVICT_MIN_AGE_SECS` is set: tasks read within that many seconds keep
+    /// their value data. Evicted-epoch stamping (for regret tracking) is always active.
+    fn eviction_recency(&self) -> crate::backend::storage::EvictionRecency {
         static MIN_AGE_EPOCHS: LazyLock<Option<u32>> = LazyLock::new(|| {
             std::env::var("TURBO_ENGINE_EVICT_MIN_AGE_SECS")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
-                .map(|secs| (secs / 5).max(1) as u32)
+                .map(|secs| ((secs / 5) as u32).max(1))
         });
-        let min_age = (*MIN_AGE_EPOCHS)?;
         let current_epoch = self.recency_epoch();
-        Some(crate::backend::storage::EvictionRecency {
-            min_epoch: current_epoch.saturating_sub(min_age),
+        crate::backend::storage::EvictionRecency {
+            min_epoch: MIN_AGE_EPOCHS.map(|age| current_epoch.saturating_sub(age)),
             current_epoch,
-        })
+        }
     }
 
     /// Perform a snapshot and then evict all evictable tasks from memory.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -395,6 +395,7 @@ impl<'e> ExecuteContextImpl<'e> {
                 } else {
                     // We claim responsibility for restoring data
                     task.flags.set_data_restoring(true);
+                    self.backend.count_eviction_regret_storage(&task);
                     tasks_to_restore_for_data.push(task_id);
                     tasks_to_restore_for_data_indices.push(i);
                 }
@@ -1968,7 +1969,13 @@ mod cell_data_tracking_tests {
         // Run the post-snapshot eviction sweep: the task is clean (not modified),
         // so data is eligible to drop, but the Skip+never value is retained as
         // residue. The entry stays in the map with the value still present.
-        storage.evict_after_snapshot(None);
+        storage.evict_after_snapshot(
+            None,
+            crate::backend::storage::EvictionRecency {
+                min_epoch: None,
+                current_epoch: 0,
+            },
+        );
 
         let g = guard_for(&storage, task_id);
         assert!(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -563,7 +563,7 @@ impl Storage {
     pub fn evict_after_snapshot(
         &self,
         parent_span: Option<Id>,
-        recency: Option<EvictionRecency>,
+        recency: EvictionRecency,
     ) -> EvictionCounts {
         let span = tracing::trace_span!(
             parent: parent_span,
@@ -594,11 +594,11 @@ impl Storage {
                     evicted.unevictable_reasons[UnevictableReason::Transient.index()] += 1;
                     continue;
                 }
-                if let Some(recency) = &recency
+                if let Some(min_epoch) = recency.min_epoch
                     && task
                         .get()
                         .get_last_read_epoch()
-                        .is_some_and(|&epoch| epoch >= recency.min_epoch)
+                        .is_some_and(|&epoch| epoch >= min_epoch)
                 {
                     evicted.skipped_recently_read += 1;
                     continue;
@@ -632,7 +632,7 @@ impl Storage {
                 }
                 match value_evictability {
                     ValueEvictability::Evictable { meta, data } => {
-                        if data && let Some(recency) = &recency {
+                        if data {
                             task.get_mut().set_last_evicted_epoch(recency.current_epoch);
                         }
                         match task.get_mut().drop_partial(data, meta) {
@@ -703,7 +703,9 @@ impl Storage {
 /// Recency parameters for an eviction sweep: tasks read at or after `min_epoch` are kept.
 #[derive(Clone, Copy, Debug)]
 pub struct EvictionRecency {
-    pub min_epoch: u32,
+    /// Tasks read at or after this epoch are skipped. `None` disables the gate (all
+    /// evictable tasks are dropped, matching pre-recency behavior).
+    pub min_epoch: Option<u32>,
     pub current_epoch: u32,
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -44,6 +44,8 @@ pub struct EvictionCounts {
     pub data_and_meta: usize,
     pub data_only: usize,
     pub meta_only: usize,
+    /// Tasks whose value data was kept because they were read recently (recency gate).
+    pub skipped_recently_read: usize,
     /// Per-reason counts of tasks we considered but could not evict, indexed by
     /// `UnevictableReason::index()`.
     pub unevictable_reasons: [usize; UnevictableReason::COUNT],
@@ -56,6 +58,7 @@ impl std::ops::AddAssign for EvictionCounts {
         self.data_and_meta += rhs.data_and_meta;
         self.data_only += rhs.data_only;
         self.meta_only += rhs.meta_only;
+        self.skipped_recently_read += rhs.skipped_recently_read;
         for i in 0..UnevictableReason::COUNT {
             self.unevictable_reasons[i] += rhs.unevictable_reasons[i];
         }
@@ -557,7 +560,11 @@ impl Storage {
     /// - `No`: skip
     ///
     /// Must be called when NOT in snapshot mode (i.e., after `end_snapshot()`).
-    pub fn evict_after_snapshot(&self, parent_span: Option<Id>) -> EvictionCounts {
+    pub fn evict_after_snapshot(
+        &self,
+        parent_span: Option<Id>,
+        recency: Option<EvictionRecency>,
+    ) -> EvictionCounts {
         let span = tracing::trace_span!(
             parent: parent_span,
             "evict_after_snapshot",
@@ -585,6 +592,15 @@ impl Storage {
                 let (task_id, task) = unsafe { bucket.as_mut() };
                 if task_id.is_transient() {
                     evicted.unevictable_reasons[UnevictableReason::Transient.index()] += 1;
+                    continue;
+                }
+                if let Some(recency) = &recency
+                    && task
+                        .get()
+                        .get_last_read_epoch()
+                        .is_some_and(|&epoch| epoch >= recency.min_epoch)
+                {
+                    evicted.skipped_recently_read += 1;
                     continue;
                 }
                 let (key_evictability, value_evictability) = task.get().evictability();
@@ -616,6 +632,9 @@ impl Storage {
                 }
                 match value_evictability {
                     ValueEvictability::Evictable { meta, data } => {
+                        if data && let Some(recency) = &recency {
+                            task.get_mut().set_last_evicted_epoch(recency.current_epoch);
+                        }
                         match task.get_mut().drop_partial(data, meta) {
                             DropPartialOutcome::Empty => {
                                 unsafe {
@@ -679,6 +698,13 @@ impl Storage {
 
         totals
     }
+}
+
+/// Recency parameters for an eviction sweep: tasks read at or after `min_epoch` are kept.
+#[derive(Clone, Copy, Debug)]
+pub struct EvictionRecency {
+    pub min_epoch: u32,
+    pub current_epoch: u32,
 }
 
 pub struct StorageWriteGuard<'a> {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -133,6 +133,16 @@ struct TaskStorageSchema {
     #[field(storage = "counter_map", category = "meta", filter_transient)]
     aggregated_dirty_containers: CounterMap<TaskId, i32, 3>,
 
+    /// Coarse session-time epoch of the most recent read of this task's output or cells
+    /// (transient). Absent = not read this session. Lets eviction skip recently-used tasks.
+    #[field(storage = "direct", category = "transient")]
+    pub last_read_epoch: u32,
+
+    /// Epoch at which this task's value data was last evicted (transient). Used to count
+    /// eviction regret: re-reads shortly after eviction indicate the task was still needed.
+    #[field(storage = "direct", category = "transient")]
+    pub last_evicted_epoch: u32,
+
     /// Count of clean containers in current session (transient).
     /// Absent = 0, present = actual count.
     #[field(storage = "direct", category = "transient")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -135,12 +135,12 @@ struct TaskStorageSchema {
 
     /// Coarse session-time epoch of the most recent read of this task's output or cells
     /// (transient). Absent = not read this session. Lets eviction skip recently-used tasks.
-    #[field(storage = "direct", category = "transient")]
+    #[field(storage = "direct", category = "transient", ignore_for_emptiness)]
     pub last_read_epoch: u32,
 
     /// Epoch at which this task's value data was last evicted (transient). Used to count
     /// eviction regret: re-reads shortly after eviction indicate the task was still needed.
-    #[field(storage = "direct", category = "transient")]
+    #[field(storage = "direct", category = "transient", ignore_for_emptiness)]
     pub last_evicted_epoch: u32,
 
     /// Count of clean containers in current session (transient).

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -80,6 +80,11 @@ struct FieldInfo {
     /// Cannot be combined with `filter_transient` (both produce residue) or
     /// `inline` (the current consumer is a lazy field; keep the surface small).
     custom_drop_partial: bool,
+    /// If true, exclude this field from the per-category emptiness predicates. The field
+    /// is a best-effort hint whose loss is acceptable: an otherwise-empty task is erased
+    /// (and the hint with it) rather than kept alive by the hint alone. Only meaningful
+    /// for transient inline fields.
+    ignore_for_emptiness: bool,
     /// Optional override for the underlying map type, used when the field is a
     /// newtype wrapping `AutoMap<K, V>` (or similar) so callers can inject
     /// custom bincode / accessor behavior while the macro still generates map
@@ -454,6 +459,7 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
     let mut drop_on_completion_if_immutable = false;
     let mut custom_drop_partial = false;
     let mut custom_mutators = false;
+    let mut ignore_for_emptiness = false;
     let mut as_type: Option<Type> = None;
 
     // Find and parse the field attribute
@@ -579,14 +585,16 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
                         custom_drop_partial = true;
                     } else if ident == "custom_mutators" {
                         custom_mutators = true;
+                    } else if ident == "ignore_for_emptiness" {
+                        ignore_for_emptiness = true;
                     } else {
                         meta.span()
                             .unwrap()
                             .error(format!(
                                 "unknown modifier `{ident}`, expected `inline`, \
                                  `filter_transient`, `default`, `shrink_on_completion`, \
-                                 `drop_on_completion_if_immutable`, `custom_drop_partial`, or \
-                                 `custom_mutators`"
+                                 `drop_on_completion_if_immutable`, `custom_drop_partial`, \
+                                 `custom_mutators`, or `ignore_for_emptiness`"
                             ))
                             .emit();
                     }
@@ -740,6 +748,7 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
         shrink_on_completion,
         drop_on_completion_if_immutable,
         custom_drop_partial,
+        ignore_for_emptiness,
         as_type,
         custom_mutators,
     }
@@ -3096,17 +3105,17 @@ fn generate_drop_method(grouped_fields: &GroupedFields) -> TokenStream {
 
     let inline_data_checks: Vec<_> = grouped_fields
         .all_inline()
-        .filter(|f| f.category == Category::Data)
+        .filter(|f| f.category == Category::Data && !f.ignore_for_emptiness)
         .map(category_inline_check)
         .collect();
     let inline_meta_checks: Vec<_> = grouped_fields
         .all_inline()
-        .filter(|f| f.category == Category::Meta)
+        .filter(|f| f.category == Category::Meta && !f.ignore_for_emptiness)
         .map(category_inline_check)
         .collect();
     let inline_transient_checks: Vec<_> = grouped_fields
         .all_inline()
-        .filter(|f| f.category == Category::Transient)
+        .filter(|f| f.category == Category::Transient && !f.ignore_for_emptiness)
         .map(category_inline_check)
         .collect();
 

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -143,6 +143,14 @@ impl TurboMalloc {
     pub fn memory_pressure() -> Option<u8> {
         memory_pressure::memory_pressure()
     }
+
+    /// OS-visible physical memory attributed to this process (Activity Monitor's Memory
+    /// column on macOS, RSS on Linux) — the number OOM decisions are based on, unlike
+    /// [`Self::memory_usage`] which only counts live allocator bytes. `None` when the
+    /// platform does not expose it.
+    pub fn process_footprint() -> Option<usize> {
+        memory_pressure::process_footprint()
+    }
 }
 
 /// Get the allocator for this platform that we should wrap with TurboMalloc.

--- a/turbopack/crates/turbo-tasks-malloc/src/memory_pressure.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/memory_pressure.rs
@@ -10,6 +10,11 @@ pub fn memory_pressure() -> Option<u8> {
     platform::memory_pressure()
 }
 
+/// See [`super::TurboMalloc::process_footprint`].
+pub fn process_footprint() -> Option<usize> {
+    platform::process_footprint()
+}
+
 fn clamp_percent(value: f64) -> u8 {
     if !value.is_finite() {
         return 0;
@@ -34,6 +39,16 @@ mod platform {
         }
         let content = std::fs::read_to_string("/proc/meminfo").ok()?;
         parse_meminfo(&content)
+    }
+
+    /// Reads the process resident set size from `/proc/self/statm` (pages),
+    /// the closest Linux analog of a physical footprint.
+    pub fn process_footprint() -> Option<usize> {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let rss_pages: usize = statm.split_whitespace().nth(1)?.parse().ok()?;
+        // Safety: sysconf(_SC_PAGESIZE) is always callable.
+        let page_size = usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }).ok()?;
+        Some(rss_pages * page_size)
     }
 
     fn parse_psi(content: &str) -> Option<u8> {
@@ -161,10 +176,31 @@ mod platform {
         let pressure = 100.0 - f64::from(level);
         Some(clamp_percent(pressure))
     }
+
+    /// Reads the process physical footprint (the value shown in Activity
+    /// Monitor's Memory column and used by the jetsam OOM killer) via
+    /// `proc_pid_rusage`.
+    pub fn process_footprint() -> Option<usize> {
+        let mut info: libc::rusage_info_v4 = unsafe { std::mem::zeroed() };
+        // Safety: RUSAGE_INFO_V4 writes a rusage_info_v4-sized buffer; we pass
+        // a properly sized and zeroed struct for our own pid.
+        let ret = unsafe {
+            libc::proc_pid_rusage(
+                std::process::id() as libc::c_int,
+                libc::RUSAGE_INFO_V4,
+                &mut info as *mut libc::rusage_info_v4 as *mut libc::rusage_info_t,
+            )
+        };
+        (ret == 0).then(|| info.ri_phys_footprint as usize)
+    }
 }
 
 #[cfg(windows)]
 mod platform {
+    pub fn process_footprint() -> Option<usize> {
+        None
+    }
+
     use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
 
     /// Reads `MEMORYSTATUSEX::dwMemoryLoad`, which is the approximate
@@ -190,5 +226,32 @@ mod platform {
 mod platform {
     pub fn memory_pressure() -> Option<u8> {
         None
+    }
+
+    pub fn process_footprint() -> Option<usize> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod footprint_tests {
+    #[test]
+    fn process_footprint_is_reasonable() {
+        let fp = super::process_footprint();
+        #[cfg(any(
+            target_os = "macos",
+            all(target_os = "linux", not(target_family = "wasm"))
+        ))]
+        {
+            let fp = fp.expect("footprint available on this platform");
+            // A running test binary occupies somewhere between 1MB and 1TB.
+            assert!(fp > 1 << 20, "footprint too small: {fp}");
+            assert!(fp < 1 << 40, "footprint too large: {fp}");
+        }
+        #[cfg(not(any(
+            target_os = "macos",
+            all(target_os = "linux", not(target_family = "wasm"))
+        )))]
+        assert!(fp.is_none());
     }
 }


### PR DESCRIPTION
This is vibed based on Claude's idea.

I have not verified it myself.

Kinda curious to know if the idea itself makes sense or if this whole direction is bad.

---


### What?

Today the in-memory task cache only gets evicted at snapshot moments: 5 minutes after boot, every 2 minutes after that, or after 2 seconds of idle. If you allocate faster than those moments arrive — big app, fast crawl of many routes, warm cache — nothing frees memory until the OOM killer does. On one internal app, an 84-route crawl reaches 22GB in ~130 seconds; the first snapshot isn't due for another three minutes.

This PR gives the dev server a memory budget and keeps it there:

- When the process footprint goes over the budget, snapshot + evict cycles run back to back instead of waiting for the next scheduled moment. Each cycle persists whatever changed since the last one (so fresh data becomes evictable) and then evicts. Under pressure, persistence effectively becomes a write-behind cache: evictability tracks usage instead of the snapshot calendar.
- Cycles keep running as long as they make progress (persisted something new, freed memory, or got under budget). When they stop making progress — e.g. everything left belongs to in-flight computation — the delay between attempts doubles up to 30s, so an unreachable budget degrades to a slow heartbeat instead of a busy loop.
- The trigger fires slightly early: expected growth during one cycle (EMA of footprint growth rate × EMA of cycle duration, capped) is added to the current footprint, so the peak lands near the budget instead of budget + one-cycle-of-growth.
- The budget compares against the OS process footprint (new `TurboMalloc::process_footprint()`: `phys_footprint` on macOS, RSS on Linux, working set on Windows), not live allocator bytes, which undercount by gigabytes and made the trigger fire late or never. Default budget is half of physical RAM; `TURBO_ENGINE_EVICT_ABOVE_MB` overrides it, `0` disables.

It also adds a measurement we didn't have: **eviction regret**.

- Every cell read stamps the task with a coarse 5-second epoch (a transient field; a new `ignore_for_emptiness` option on the `task_storage` macro keeps hint fields from blocking bucket erasure after full eviction). Evicting a task's data stamps the eviction epoch. A restore or recompute within 60s of eviction counts as one regret — we evicted something we still needed.
- Stock eviction regrets a lot: 75k–380k tasks per session on one app, because idle-eviction drops everything and browsing immediately pulls the working set back in. The restores are cheap on warm NVMe, but they sit on the critical path of the next compile after a pause.
- Sweeps therefore skip tasks read within a protection window, and the window tunes itself from the regret count: it starts at zero (exactly current behavior), doubles when a sweep's regrets exceed a noise floor (capped at 300s), and halves back toward zero when eviction stops regretting. Under memory pressure the window narrows 4× per pass within a cycle, so hot data is only sacrificed when dropping cold data isn't enough. `TURBO_ENGINE_EVICT_MIN_AGE_SECS` pins it when you need determinism.
- One adaptation step does most of the work: on the first sweep (window 0) we measured 75,331 regrets; with the resulting 5s window, the following sweeps regretted 37–83 tasks.

`TURBO_ENGINE_EVICT_LOG=1` prints one line per snapshot and per sweep (counts, regrets, current window) for debugging.

### Results

M-series macOS, NVMe; 3v3 alternating runs; peak = max of a 100ms footprint sampler over the request window.

- The 84-route crawl that OOMs 16GB machines: stock peaks at 22GB when no snapshot moment lands mid-crawl, or 10–19GB when one happens to; with a 12GB budget it's 13.7–14.5GB every run, at the same wall-clock time.
- With the budget never reached, behavior and timing are unchanged from stock.
- Unreachable budget (2GB vs a ~7GB live working set): cycles back off to the 30s cap, server stays responsive.
- Hard kill mid-eviction-churn, restart on the warm cache: everything serves, no corruption.

### Test coverage

Unit tests for the control decisions (backoff, window narrowing, adaptive window adjustment); footprint/system-memory probes on all three platforms; existing eviction integration tests unchanged (the test-only evict entry bypasses the recency gate for determinism); full turbo-tasks-backend suite.