### PR TITLE
Attempt static prefetch before resorting to runtime

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -545,14 +545,30 @@ export async function decodeStageUntilBoundary<T>(
   byteLength: number,
   headers: RequestHeaders | undefined
 ): Promise<T> {
-  // Buffer the truncated stream into a single chunk before passing it to
-  // Flight. This ensures all model data is available synchronously, which is
-  // required for readVaryParams to synchronously read the thenable status.
-  const { stream } = await createNonTaskyPrefetchResponseStream(
+  const { buffer } = await createNonTaskyPrefetchResponseStream(
     responseBodyClone,
     byteLength
   )
+  return decodeBufferedStage<T>(buffer, headers)
+}
 
+/**
+ * Decodes already-buffered Flight response bytes as a stage payload. The
+ * bytes are delivered to Flight as a single chunk so all rows are processed
+ * synchronously in one call — required for the thenable-status reads that
+ * scope a response's late-resolving metadata (vary params, isPartial, ...)
+ * to this decode.
+ */
+export function decodeBufferedStage<T>(
+  buffer: Uint8Array,
+  headers: RequestHeaders | undefined
+): Promise<T> {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(buffer)
+      controller.close()
+    },
+  })
   return createFromNextReadableStream<T>(stream, headers, {
     allowPartialStream: true,
   })

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -27,6 +27,7 @@ import {
 import {
   createFetch,
   createFromNextReadableStream,
+  decodeBufferedStage,
   resolveShellStageData,
   type RSCResponse,
   type RequestHeaders,
@@ -244,6 +245,24 @@ export type RouteCacheEntry =
   | RejectedRouteCacheEntry
 
 type SegmentCacheEntryShared = {
+  /**
+   * The fetch strategy this entry's content EFFECTIVELY corresponds to,
+   * which may be deeper than the strategy that requested it: an entry is
+   * recorded at the tier of the payload that fully satisfied it (e.g. a
+   * shell-spawned entry fulfilled by a response whose shell IS the full
+   * response is recorded at the full tier, while still keyed at the shell
+   * vary path — valid precisely because the variants coincide). Compared
+   * via `canNewFetchStrategyProvideMoreContent` to decide whether a new
+   * request could yield more content than what's already cached.
+   *
+   * "Effectively" spans both of the tier axes, static-vs-runtime included: a
+   * static response that accessed no runtime data is as complete as a runtime
+   * response of the same variant, so it records the RUNTIME tier (see
+   * `recordedFetchStrategy` in writeSegmentBundleResponse). That is what lets
+   * "would a runtime request return more?" be answered by comparing tiers,
+   * with no separate per-entry signal — the question the scheduler asks in
+   * `wouldRuntimeRequestProvideMore`.
+   */
   fetchStrategy: FetchStrategy
 
   /**
@@ -316,8 +335,10 @@ export type NonEmptySegmentCacheEntry = Exclude<
  * maps 1:1 to the data array in the SegmentPrefetchResponse the server returns.
  */
 export type SegmentBundle = {
-  // Null when the segment has prefetching disabled (instant = false).
-  // The bundle chain passes through it but no cache entry is created.
+  // Null when the segment has prefetching disabled entirely
+  // (prefetch: 'force-disabled' / instant = false; Partial Prefetching
+  // segments have static data and occupy a real node). The bundle chain
+  // passes through it but no cache entry is created.
   tree: RouteTree | null
   entry: SegmentCacheEntry | null
   parent: SegmentBundle | null
@@ -1091,7 +1112,7 @@ export function upsertSegmentEntry(
       return null
     }
 
-    // Ping any tasks blocked on the existing entry before evicting it so they
+    // Ping any tasks blocked on the existing entry before replacing it so they
     // re-run and pick up the new entry. Without this, tasks waiting on the
     // existing Empty/Pending entry would be stranded — the new fulfilled
     // candidate has no blockedTasks of its own.
@@ -1102,8 +1123,23 @@ export function upsertSegmentEntry(
       pingBlockedTasks(existingEntry)
     }
 
-    // Evict the existing entry from the cache.
-    deleteFromCacheMap(existingEntry)
+    // Replace the existing entry by writing the candidate over its keypath
+    // below (the same mechanism `overwriteRevalidatingSegmentCacheEntry`
+    // uses). We intentionally do NOT call `deleteFromCacheMap` first: deleting
+    // vacates the canonical slot, and `deleteMapEntry` promotes a pending
+    // Revalidation-slot entry into the vacated slot — which the immediate
+    // insert below would then silently overwrite. The in-flight revalidation
+    // would vanish from the map, so the next scheduler pass would find an
+    // empty revalidation slot and spawn a duplicate request instead of
+    // deduping against it. Replacing in place never vacates the slot, so
+    // promotion never runs and the pending revalidating entry stays in its
+    // Revalidation slot where `readOrCreateRevalidatingSegmentEntry`'s dedupe
+    // finds it.
+    //
+    // The displaced entry's map/LRU accounting is handled by the replacement
+    // itself: `setMapEntryValue` drops the displaced value's `ref` and
+    // `updateLruSize` swaps its size for the candidate's, which is exactly
+    // what delete-then-insert did.
   }
 
   const isRevalidation = false
@@ -1311,7 +1347,8 @@ export function attemptToFulfillDynamicSegmentFromBFCache(
       dynamicPrefetchStaleAt,
       isPartial,
       // bfcache data is concrete, never an ISR fallback.
-      false
+      false,
+      FetchStrategy.Full
     )
   }
   return null
@@ -1349,7 +1386,8 @@ export function attemptToUpgradeSegmentFromBFCache(
       dynamicPrefetchStaleAt,
       isPartial,
       // bfcache data is concrete, never an ISR fallback.
-      false
+      false,
+      FetchStrategy.Full
     )
     const segmentVaryPath = getSegmentVaryPathForRequest(
       FetchStrategy.Full,
@@ -1505,7 +1543,18 @@ function fulfillSegmentCacheEntry(
   // callers pass false. Always assigned (even when false) so that re-fulfilling
   // a previously-fallback entry with a concrete response clears the flag and
   // ends the retry loop.
-  isUpgradeableISRFallback: boolean
+  isUpgradeableISRFallback: boolean,
+  // The strategy tier describing the CONTENT this entry is fulfilled with —
+  // which comes from the response, not the tier the entry was requested at.
+  // Usually the two agree, but when a response's shell payload IS the full
+  // response (no shell/full split), shell-spawned entries are fulfilled with
+  // full-tier content and recorded as such (see the promotion in
+  // writeSegmentBundleResponse). Always assigned, replacing
+  // the spawn-time strategy set by upgradeToPendingSegment; the write walks'
+  // matching and keying decisions all happen against the spawn-time
+  // strategy, before fulfillment, so they are unaffected. See
+  // SegmentCacheEntryShared['fetchStrategy'].
+  fetchStrategy: FetchStrategy
 ): FulfilledSegmentCacheEntry {
   const fulfilledEntry: FulfilledSegmentCacheEntry = segmentCacheEntry as any
   fulfilledEntry.status = EntryStatus.Fulfilled
@@ -1513,6 +1562,7 @@ function fulfillSegmentCacheEntry(
   fulfilledEntry.staleAt = staleAt
   fulfilledEntry.isPartial = isPartial
   fulfilledEntry.isUpgradeableISRFallback = isUpgradeableISRFallback
+  fulfilledEntry.fetchStrategy = fetchStrategy
   // Resolve any listeners that were waiting for this data.
   if (segmentCacheEntry.promise !== null) {
     segmentCacheEntry.promise.resolve(fulfilledEntry)
@@ -2264,7 +2314,11 @@ export async function fetchSegmentsOnCacheMiss(
   routeKey: RouteCacheKey,
   tree: RouteTree,
   segments: SegmentBundle,
-  segmentCount: number
+  segmentCount: number,
+  // Which walk spawned the bundle's entries. The request on the wire is
+  // identical either way; this only decides which payload of the response
+  // fulfills the entries.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): Promise<PrefetchSubtaskResult<null> | null> {
   // This function is allowed to use async/await because it contains the actual
   // fetch that gets issued on a cache miss. Notice it writes the result to the
@@ -2303,16 +2357,17 @@ export async function fetchSegmentsOnCacheMiss(
     return null
   }
 
-  const { serverResponse, responseSize, closed } = result
+  const { serverResponse, shellResponse, responseSize, closed } = result
+  const now = Date.now()
 
-  // Write the decoded response into the cache, fulfilling the Pending entries
-  // this task owns.
-  writeSegmentBundleResponse(
+  writeSegmentBundleResponseVariants(
     serverResponse,
+    shellResponse,
     responseSize,
     segments,
     segmentCount,
-    Date.now()
+    now,
+    fetchStrategy
   )
 
   // If the server served an upgradeable fallback shell, drive a localized
@@ -2335,7 +2390,8 @@ export async function fetchSegmentsOnCacheMiss(
       routeKey,
       tree,
       segments,
-      segmentCount
+      segmentCount,
+      fetchStrategy
     )
   }
 
@@ -2367,6 +2423,12 @@ async function fetchSegmentsOnCacheMissImpl(
 ): Promise<{
   serverResponse: SegmentPrefetchResponse
   responseSize: number
+  // The shell payload of the response: `serverResponse` itself when the
+  // shell IS the full response (a fully static page — callers compare by
+  // reference), a second decode of the same bytes truncated at the shell
+  // byte boundary when the shell is a strict prefix, or `null` when no
+  // shell exists.
+  shellResponse: SegmentPrefetchResponse | null
   closed: Promise<void>
 } | null> {
   // Use the canonical URL to request the segment, not the original URL. These
@@ -2426,8 +2488,11 @@ async function fetchSegmentsOnCacheMissImpl(
   // buffered prefetch paths.
   const closed = createPromiseWithResolvers<void>()
 
-  const { stream: prefetchStream, size: responseSize } =
-    await createNonTaskyPrefetchResponseStream(response.body)
+  const {
+    stream: prefetchStream,
+    size: responseSize,
+    buffer,
+  } = await createNonTaskyPrefetchResponseStream(response.body)
   closed.resolve()
 
   // Parse the response. Always a SegmentPrefetchResponse with a build ID and a
@@ -2452,18 +2517,157 @@ async function fetchSegmentsOnCacheMissImpl(
     return null
   }
 
+  // Extract the shell payload, if the response carries a distinct one
+  // (positive shell byte offset): decode the buffered bytes a SECOND time,
+  // truncated at the boundary. The truncation is what produces the shell
+  // variant: each segment's param-dependent rows land past the boundary and
+  // decode as still-pending, which renders as the param fallback. It also
+  // rewinds the response's signals — `needsRuntimeRequest` and `isPartial`
+  // fulfillments past the boundary read as pending in this decode, so a
+  // post-shell runtime-data access doesn't mark the shell variant itself as
+  // needing a runtime request.
+  // (The offset is never legitimately pending or 0 in this decode: the full
+  // buffer is present, and the server only ever emits a positive offset or
+  // null. Reading 0 — the default for an unfulfilled `a` — therefore means a
+  // bug in Next.js itself, and is handled like an error: the response is
+  // treated as carrying no shell, and the scheduler skips the affected
+  // segments rather than falling back to a runtime request — see the
+  // `shellResponse === null` handling in writeSegmentBundleResponseVariants.
+  // Failing in that direction costs a shell prefetch but never leaks
+  // post-shell content into shell positions.)
+  const shellOffset = readFulfilledValue(serverResponse.a, 0)
+  let shellResponse: SegmentPrefetchResponse | null
+  if (shellOffset === null) {
+    shellResponse = serverResponse
+  } else if (shellOffset === 0) {
+    shellResponse = null
+  } else {
+    try {
+      shellResponse = await decodeBufferedStage<SegmentPrefetchResponse>(
+        buffer.subarray(0, shellOffset),
+        headers
+      )
+    } catch {
+      // The truncated prefix couldn't be decoded. Treat it as if no shell
+      // exists; the full payload is still usable. (For a StaticShell-spawned
+      // bundle this means the spawned entries are rejected — the scheduler
+      // then skips them rather than issuing a runtime substitute; see the
+      // no-shell branch in fetchSegmentsOnCacheMiss.)
+      shellResponse = null
+    }
+  }
+
   return {
     serverResponse,
     responseSize,
+    shellResponse,
     closed: closed.promise,
   }
 }
 
 /**
- * Writes a parsed segment-bundle response into the cache: distributes the
- * response size across the bundle, then walks the segments list and the
- * response array in parallel, fulfilling/upserting each entry. Any segments
- * the server didn't return are rejected so they don't stay Pending forever.
+ * Writes every payload of a parsed segment-bundle response into the cache.
+ * The bundle's entries are fulfilled by the payload matching the walk that
+ * spawned them; the other payload, when distinct, is written with a detached
+ * copy of the bundle. The full payload is written first so the shell write's
+ * shadow eviction sees the fresh concrete entry.
+ *
+ * Shared by the initial fetch (`fetchSegmentsOnCacheMiss`) and the localized
+ * fallback-retry loop. The retry's bundle entries are already settled, so
+ * for that caller every write is a detached upsert and the rejection below
+ * is a no-op (it only touches Pending entries).
+ */
+function writeSegmentBundleResponseVariants(
+  serverResponse: SegmentPrefetchResponse,
+  shellResponse: SegmentPrefetchResponse | null,
+  responseSize: number,
+  segments: SegmentBundle,
+  segmentCount: number,
+  now: number,
+  // Which walk spawned the bundle's entries; decides which payload fulfills
+  // them. See fetchSegmentsOnCacheMiss.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
+): void {
+  if (fetchStrategy === FetchStrategy.StaticShell) {
+    if (shellResponse !== serverResponse) {
+      writeSegmentBundleResponse(
+        serverResponse,
+        responseSize,
+        detachEntriesFromSegmentBundle(segments),
+        segmentCount,
+        now,
+        FetchStrategy.PPR,
+        FetchStrategy.PPR
+      )
+    }
+    if (shellResponse === null) {
+      // No shell exists. Reject the spawned entries so the task isn't
+      // stranded blocking on them. Note the scheduler does NOT fall back to
+      // a runtime request for rejected segments — it skips them outright (see
+      // the Rejected case in pingSegmentBundle in scheduler.ts), so these
+      // segments get no shell prefetch and no runtime substitute until the
+      // rejection's backoff expires.
+      rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+    } else {
+      writeSegmentBundleResponse(
+        shellResponse,
+        responseSize,
+        segments,
+        segmentCount,
+        now,
+        FetchStrategy.StaticShell,
+        // When the shell IS the full response (no shell/full split), the
+        // entries this write fulfills carry full-tier content, so PPR is
+        // the strategy that describes it. They're still keyed at the shell
+        // vary path: that's the reusable slot, and it serves concrete
+        // fallback reads correctly precisely because the shell and concrete
+        // variants coincide.
+        shellResponse === serverResponse
+          ? FetchStrategy.PPR
+          : FetchStrategy.StaticShell
+      )
+    }
+  } else {
+    writeSegmentBundleResponse(
+      serverResponse,
+      responseSize,
+      segments,
+      segmentCount,
+      now,
+      FetchStrategy.PPR,
+      FetchStrategy.PPR
+    )
+    if (shellResponse !== null && shellResponse !== serverResponse) {
+      writeSegmentBundleResponse(
+        shellResponse,
+        responseSize,
+        detachEntriesFromSegmentBundle(segments),
+        segmentCount,
+        now,
+        FetchStrategy.StaticShell,
+        FetchStrategy.StaticShell
+      )
+    }
+  }
+}
+
+/**
+ * Writes one payload of a parsed segment-bundle response into the cache:
+ * distributes the response size across the bundle, then walks the segments
+ * list and the response's `data` array in parallel, fulfilling/upserting
+ * each entry. Any segments the server didn't return are rejected so they
+ * don't stay Pending forever.
+ *
+ * `fetchStrategy` says which of the response's payloads this call is
+ * writing — StaticShell for the shell payload, PPR for the full payload —
+ * which determines the vary paths the entries are keyed at.
+ *
+ * The walk fulfills any Pending entry in `segments`, so the caller must
+ * pass the bundle only to the walk matching the entries' own strategy, and
+ * a detached copy to the other. In particular, fulfilling a spawned
+ * StaticShell entry with the concrete payload would leak param-dependent
+ * content into shell positions: during a navigation, a pending entry can be
+ * rendered as a promise that resolves to its eventual value.
  *
  * Shared by the initial fetch and the localized fallback-retry loop (which
  * re-issues the same request and upserts the upgraded result here).
@@ -2473,9 +2677,19 @@ function writeSegmentBundleResponse(
   responseSize: number,
   segments: SegmentBundle,
   segmentCount: number,
-  now: number
+  now: number,
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell,
+  // The strategy tier that describes this payload's CONTENT, recorded on
+  // the entries it fulfills. Differs from `fetchStrategy` (which drives
+  // matching and keying) in one case: a StaticShell write whose payload IS
+  // the full response (no shell/full split) records PPR — see
+  // writeSegmentBundleResponseVariants.
+  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): void {
   // Distribute the response size evenly across all segments in the bundle.
+  // (When a response produces two payload writes, each write distributes the
+  // full response size — intentionally double-charging the LRU for one wire
+  // response, since it produced two live entries per segment.)
   const averageSize = responseSize / segmentCount
   let sizeNode: SegmentBundle | null = segments
   while (sizeNode !== null) {
@@ -2493,13 +2707,34 @@ function writeSegmentBundleResponse(
   const responseIsUpgradeableISRFallback =
     serverResponse.isUpgradeableISRFallback
 
+  // Whether the render that produced this payload accessed runtime data
+  // (page-global; combined with each segment's `isPartial` below to decide
+  // the tier each entry records). Read from THIS decode's thenable status,
+  // which scopes it to the payload being written — see
+  // `SegmentPrefetchResponse['needsRuntimeRequest']` for the encoding.
+  //
+  // Reading it from the same decode that produced the entry's data is what
+  // makes the answer rewindable: a truncated shell decode reads a post-shell
+  // runtime access as pending, i.e. `false`, because the shell variant itself
+  // doesn't need that data.
+  //
+  // It is load-bearing in one direction only. A false `true` costs a wasted
+  // runtime request; a false `false` would record too high a tier and skip a
+  // runtime request that had more content.
+  const responseNeedsRuntimeRequest = readFulfilledValue(
+    serverResponse.needsRuntimeRequest,
+    false
+  )
+
   let node: SegmentBundle | null = segments
   let dataIndex = 0
   while (node !== null && dataIndex < serverDataArray.length) {
     const data = serverDataArray[dataIndex]
 
-    // Null data means this segment has prefetching disabled. Skip it
-    // without creating a cache entry.
+    // Null data means this segment has prefetching disabled
+    // (prefetch: 'force-disabled' — Partial Prefetching segments have static
+    // data, so the server emits a real slot for them). Skip it without
+    // creating a cache entry.
     if (data === null || node.tree === null) {
       // The server's and the client's prefetch-disabled hints normally agree,
       // so there shouldn't be a spawned entry for a segment the server
@@ -2518,7 +2753,8 @@ function writeSegmentBundleResponse(
     }
 
     // The segment's late-resolving metadata can be read synchronously
-    // because the response was fully buffered before it was decoded.
+    // because the payload was fully buffered before it was decoded (and, for
+    // a truncated shell decode, delivered as a single chunk).
     const entryStaleAt = readFulfilledStaleAt(now, data.staleTime)
     // Root params are emitted once at the top level of the response and
     // unioned into each segment's set here, same as for a route-level
@@ -2529,46 +2765,109 @@ function writeSegmentBundleResponse(
     )
     const isPartial = readFulfilledIsPartial(data.isPartial)
 
-    // Determine the canonical vary path for this segment. If the server
-    // tells us which params the segment varies by, re-key to a more
-    // generic path. Otherwise use the request vary path.
-    const canonicalVaryPath =
-      process.env.__NEXT_VARY_PARAMS && varyParams !== null
-        ? getFulfilledSegmentVaryPath(node.tree.varyPath, varyParams)
-        : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+    // A runtime prefetch can only provide more content than this entry if the
+    // render accessed runtime data AND this particular segment has holes — a
+    // fully static segment gains nothing from a runtime request no matter
+    // what the page accessed.
+    const needsRuntimeRequest = responseNeedsRuntimeRequest && isPartial
 
-    let fulfilled: FulfilledSegmentCacheEntry | null = null
+    // An entry records the tier of the content that actually satisfied it,
+    // which spans both axes: shell-vs-concrete AND static-vs-runtime.
+    //
+    // When this payload fully satisfied the segment — no runtime request
+    // needed — the content is as complete as a RUNTIME response of the same
+    // variant would have been, so it records that runtime tier. That's what
+    // lets the scheduler decide "would a runtime request return more?" by
+    // comparing tiers alone, with no separate signal to consult.
+    //
+    // Otherwise the content is only as complete as the static tier it was
+    // requested at, so a follow-up runtime request can still supersede it.
+    const recordedFetchStrategy = !needsRuntimeRequest
+      ? payloadFetchStrategy === FetchStrategy.StaticShell
+        ? FetchStrategy.RuntimeShell
+        : FetchStrategy.PPRRuntime
+      : fetchStrategy
+
+    // Determine the vary path to key the segment at. For the full payload,
+    // re-key to a more generic path if the server tells us which params the
+    // segment varies by.
+    const payloadVaryPath =
+      fetchStrategy === FetchStrategy.StaticShell
+        ? node.tree.shellVaryPath
+        : process.env.__NEXT_VARY_PARAMS && varyParams !== null
+          ? getFulfilledSegmentVaryPath(node.tree.varyPath, varyParams)
+          : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+
     const nodeEntry = node.entry
     if (nodeEntry !== null && nodeEntry.status === EntryStatus.Pending) {
       // We own this entry — fulfill it directly.
-      fulfilled = fulfillSegmentCacheEntry(
+      const fulfilledEntry = fulfillSegmentCacheEntry(
         nodeEntry as PendingSegmentCacheEntry,
         data.rsc,
         entryStaleAt,
         isPartial,
-        responseIsUpgradeableISRFallback
+        responseIsUpgradeableISRFallback,
+        recordedFetchStrategy
       )
+      if (fetchStrategy === FetchStrategy.StaticShell) {
+        // Re-key at the shell vary path, mirroring the RuntimeShell re-key
+        // in fulfillEntrySpawnedByRuntimePrefetch. Usually the entry already
+        // lives there, but the scheduler can also upgrade a pre-existing
+        // Empty entry at a more concrete path in place, so the re-key is
+        // load-bearing. The shadow eviction keeps a stale settled entry at
+        // a more specific path from hiding the shell entry (the just-written
+        // full payload's entry is preferred and survives it). Routed through
+        // the upsert rather than a bare set so the usual precedence rules
+        // apply: a concurrent task's response (e.g. a RuntimeShell entry)
+        // can land in the shell slot first, and this write must not
+        // downgrade it. (In the common case the slot already holds this
+        // very entry, which the upsert replaces in place.)
+        if (process.env.__NEXT_VARY_PARAMS) {
+          upsertSegmentEntry(
+            now,
+            node.tree.shellVaryPath,
+            fulfilledEntry,
+            node.tree.varyPath
+          )
+        }
+      } else {
+        // Set the fulfilled entry into the canonical cache slot. Pass the
+        // concrete lookup path — the most specific path a read for this
+        // segment position would use — so that if the canonical path is more
+        // generic (i.e. the server re-keyed the segment), any stale settled
+        // entry at a more specific path (e.g. a partial shell entry) that
+        // would shadow this one is evicted. See evictShadowingSegmentEntries.
+        upsertSegmentEntry(
+          now,
+          payloadVaryPath,
+          fulfilledEntry,
+          node.tree.varyPath
+        )
+      }
     } else {
-      // We don't own this entry. Create a detached entry and attempt
-      // to upsert it into the canonical slot.
+      // We don't own this entry. Create a detached entry and attempt to
+      // upsert it into this payload's slot.
       const detachedEntry = createDetachedSegmentCacheEntry(now)
-      fulfilled = fulfillSegmentCacheEntry(
-        // Response-write path, not a locked-navigation prefetch.
-        upgradeToPendingSegment(detachedEntry, FetchStrategy.PPR, null),
+      const fulfilledEntry = fulfillSegmentCacheEntry(
+        upgradeToPendingSegment(
+          detachedEntry,
+          fetchStrategy,
+          // Response-write path, not a locked-navigation prefetch.
+          null
+        ),
         data.rsc,
         entryStaleAt,
         isPartial,
-        responseIsUpgradeableISRFallback
+        responseIsUpgradeableISRFallback,
+        recordedFetchStrategy
+      )
+      upsertSegmentEntry(
+        now,
+        payloadVaryPath,
+        fulfilledEntry,
+        node.tree.varyPath
       )
     }
-
-    // Set the fulfilled entry into the canonical cache slot. Pass the
-    // concrete lookup path — the most specific path a read for this segment
-    // position would use — so that if the canonical path is more generic
-    // (i.e. the server re-keyed the segment), any stale settled entry at a
-    // more specific path (e.g. a partial shell entry) that would shadow this
-    // one is evicted. See evictShadowingSegmentEntries.
-    upsertSegmentEntry(now, canonicalVaryPath, fulfilled, node.tree.varyPath)
 
     node = node.parent
     dataIndex++
@@ -2582,7 +2881,41 @@ function writeSegmentBundleResponse(
 }
 
 /**
- * Reads a segment's partialness from its `isPartial` promise. The server
+ * Clones a SegmentBundle chain with every `entry` removed, so a write walk
+ * over it is pure detached upserts. Used for the payload that does NOT
+ * match the bundle's spawned entries (see writeSegmentBundleResponse).
+ */
+function detachEntriesFromSegmentBundle(
+  segments: SegmentBundle
+): SegmentBundle {
+  const head: SegmentBundle = {
+    tree: segments.tree,
+    entry: null,
+    parent: null,
+  }
+  let clonedTail = head
+  let node = segments.parent
+  while (node !== null) {
+    const clonedNode: SegmentBundle = {
+      tree: node.tree,
+      entry: null,
+      parent: null,
+    }
+    clonedTail.parent = clonedNode
+    clonedTail = clonedNode
+    node = node.parent
+  }
+  return head
+}
+
+// TODO: Consolidate the read* helpers below with the ones in
+// vary-params-decoding — they all perform a version of the same synchronous
+// read of a buffered decode's late-resolving values.
+
+/**
+ * Reads a segment's partialness from its `isPartial` promise. (Unlike the
+ * values read via `readFulfilledValue` below, the fulfillment value here is
+ * void — partialness is encoded as the ABSENCE of a fulfillment.) The server
  * fulfills it only for a fully-static segment and leaves it pending for a
  * partial one (see `SegmentPrefetch['isPartial']`), so partial == not
  * fulfilled. The read is synchronous because the response is fully buffered
@@ -2596,6 +2929,29 @@ function readFulfilledIsPartial(isPartial: Promise<void>): boolean {
   // stays non-fulfilled — read as partial, which is correct either way.
   thenable.then(noop, noop)
   return thenable.status !== 'fulfilled'
+}
+
+/**
+ * Reads a late-resolving value off a fully-buffered decode's thenable status,
+ * using the same trick as above. Returns `valueIfUnresolved` for a row that
+ * is pending or absent in this decode — e.g. one whose fulfillment landed
+ * past a truncated shell decode's boundary. That's what scopes a response's
+ * late-resolving signals to the payload being decoded.
+ */
+function readFulfilledValue<T>(
+  valueFromServer: Promise<T>,
+  valueIfUnresolved: T
+): T {
+  const thenable = valueFromServer as PromiseLike<T> & {
+    status?: string
+    value?: T
+  }
+  // Force Flight to unwrap a received-but-not-yet-settled row.
+  thenable.then(noop, noop)
+  if (thenable.status === 'fulfilled' && thenable.value !== undefined) {
+    return thenable.value
+  }
+  return valueIfUnresolved
 }
 
 /**
@@ -2667,7 +3023,11 @@ async function retryUpgradeableFallbackPrefetch(
   routeKey: RouteCacheKey,
   tree: RouteTree,
   segments: SegmentBundle,
-  segmentCount: number
+  segmentCount: number,
+  // The strategy the initial fetch wrote its payloads with; the upgraded
+  // result is written through the same payload fork so the same cache slots
+  // (including the shell paths) are upgraded.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): Promise<void> {
   for (let attempt = 0; attempt < MAX_FALLBACK_RETRIES; attempt++) {
     await new Promise<void>((resolve) =>
@@ -2699,16 +3059,23 @@ async function retryUpgradeableFallbackPrefetch(
     }
 
     // Success: the server returned the concrete (upgraded) version. Write it
-    // back through the same bundle — its entries were already fulfilled (with
-    // the fallback) by the initial fetch, so none are Pending and every segment
-    // takes the upsert path, replacing the fallback. Mark the loop fulfilled and
-    // ping the task; its other fallback segments are now allowed to revalidate.
-    writeSegmentBundleResponse(
-      result.serverResponse,
-      result.responseSize,
+    // back through the same payload fork as the initial fetch, so every slot
+    // the initial fetch wrote — including the shell paths, even when the
+    // upgraded response is fully static (shell === full) — is upgraded. The
+    // bundle's entries were already settled by the initial fetch, so every
+    // write is a detached upsert that replaces the fallback. Mark the loop
+    // fulfilled and ping the task; its other fallback segments are now
+    // allowed to revalidate.
+    const { serverResponse, shellResponse, responseSize } = result
+    const now = Date.now()
+    writeSegmentBundleResponseVariants(
+      serverResponse,
+      shellResponse,
+      responseSize,
       segments,
       segmentCount,
-      Date.now()
+      now,
+      fetchStrategy
     )
     task.fallbackRetryStatus = EntryStatus.Fulfilled
     pingPrefetchTask(task)
@@ -3402,13 +3769,29 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       staleAt,
       isPartial,
       // Dynamic-request (Full/Runtime) responses are not ISR fallbacks.
-      false
+      false,
+      fetchStrategy
     )
-    if (fulfilledVaryPath !== null) {
+    // Re-key the entry at its canonical path. When `varyParams` produced a
+    // generalized path above, use that; otherwise fall back to the request's
+    // own keying (this is load-bearing for entries spawned as revalidations:
+    // without the re-key they'd stay in their Revalidation slot forever,
+    // invisible to canonical reads, and the partial entry that prompted the
+    // revalidation would keep serving navigations). Full responses are
+    // excluded, matching the varyParams re-key: they're spawned as canonical
+    // entries at their final path, and their vary tracking can't be trusted
+    // for re-keying (see the fulfilledVaryPath derivation above).
+    const canonicalVaryPath =
+      fulfilledVaryPath !== null
+        ? fulfilledVaryPath
+        : fetchStrategy !== FetchStrategy.Full
+          ? getSegmentVaryPathForRequest(fetchStrategy, tree)
+          : null
+    if (canonicalVaryPath !== null) {
       const isRevalidation = false
       setInCacheMap(
         segmentCacheMap,
-        fulfilledVaryPath,
+        canonicalVaryPath,
         fulfilledEntry,
         isRevalidation
       )
@@ -3440,7 +3823,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         staleAt,
         isPartial,
         // Dynamic-request (Full/Runtime) responses are not ISR fallbacks.
-        false
+        false,
+        fetchStrategy
       )
       if (fulfilledVaryPath !== null) {
         const isRevalidation = false
@@ -3471,7 +3855,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         staleAt,
         isPartial,
         // Dynamic-request (Full/Runtime) responses are not ISR fallbacks.
-        false
+        false,
+        fetchStrategy
       )
       const varyPath =
         fulfilledVaryPath !== null
@@ -3529,6 +3914,11 @@ export async function createNonTaskyPrefetchResponseStream(
 ): Promise<{
   stream: ReadableStream<Uint8Array>
   size: number
+  // The materialized response bytes backing `stream`. Exposed so callers that
+  // need to decode the same response a second time (e.g. the static App Shell
+  // extraction, which re-decodes a truncated prefix of the buffer) don't have
+  // to buffer the body twice. Most callers only use `stream` and `size`.
+  buffer: Uint8Array
 }> {
   // Buffer the entire response before passing it to the Flight client. This
   // ensures that when Flight processes the stream, all model data is available
@@ -3590,7 +3980,7 @@ export async function createNonTaskyPrefetchResponseStream(
       controller.close()
     },
   })
-  return { stream, size }
+  return { stream, size, buffer }
 }
 
 /**
@@ -3655,7 +4045,13 @@ function addSegmentPathToUrlInOutputExportMode(
  *
  * Generally, when an app uses dynamic data, a "more specific" fetch strategy is expected to provide more content:
  * - `LoadingBoundary` only provides static layouts
- * - `PPR` can provide shells for each segment (even for segments that use dynamic data)
+ * - `StaticShell` provides the App Shell variant extracted from a static response —
+ *   param-dependent content reduced to pending fallbacks, and never any content that
+ *   depends on session data (cookies, headers)
+ * - `RuntimeShell` provides the App Shell rendered by a runtime request, which can
+ *   additionally include shell content that depends on session data
+ * - `PPR` can provide shells for each segment (even for segments that use dynamic data),
+ *   including prerendered param-dependent content at concrete paths
  * - `PPRRuntime` can additionally include content that uses searchParams, params, or cookies
  * - `Full` includes all the content, even if it uses dynamic data
  *

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -20,6 +20,7 @@ import {
   type RouteTree,
   fetchSegmentPrefetchesUsingDynamicRequest,
   type PendingSegmentCacheEntry,
+  type SegmentCacheEntry,
   type SegmentBundle,
   convertRouteTreeToFlightRouterState,
   readOrCreateRevalidatingSegmentEntry,
@@ -593,8 +594,8 @@ function processQueueInMicrotask() {
           // Finished prefetching the route tree. The two-phase (Shell then
           // Speculative) flow only applies to routes that have opted into
           // Partial Prefetching — either globally via the `partialPrefetching`
-          // config or per segment (`instant`, `prefetch: 'partial'`,
-          // `'unstable_eager'`, or `'allow-runtime'`), all surfaced as the
+          // config or per segment (`instant`, `prefetch: 'partial'`, or
+          // `'unstable_eager'`), all surfaced as the
           // `SubtreeHasPartialPrefetching` hint on the route tree. Every other
           // route skips the Shell phase and goes straight to Speculative.
           //
@@ -702,7 +703,13 @@ function background(task: PrefetchTask): boolean {
   return false
 }
 
-function pingRoute(now: number, task: PrefetchTask): PrefetchTaskExitStatus {
+function pingRoute(
+  now: number,
+  task: PrefetchTask
+):
+  | PrefetchTaskExitStatus.InProgress
+  | PrefetchTaskExitStatus.Blocked
+  | PrefetchTaskExitStatus.Done {
   const key = task.key
   const route = readOrCreateRouteCacheEntry(now, task, key)
   const exitStatus = pingRootRouteTree(now, task, route)
@@ -763,7 +770,10 @@ function pingRootRouteTree(
   now: number,
   task: PrefetchTask,
   route: RouteCacheEntry
-): PrefetchTaskExitStatus {
+):
+  | PrefetchTaskExitStatus.InProgress
+  | PrefetchTaskExitStatus.Blocked
+  | PrefetchTaskExitStatus.Done {
   switch (route.status) {
     case EntryStatus.Empty: {
       // Route is not yet cached, and there's no request already in progress.
@@ -860,26 +870,40 @@ function pingRootRouteTree(
           // Then, if there are any segments that need a runtime request,
           // do another pass to perform a runtime prefetch.
 
+          // Derive the static walk's parameters once per pass; the walk
+          // functions below receive them as arguments and are phase-agnostic.
+          // During the Shell phase the walk targets the App Shell variant of
+          // each segment (keyed at the shell vary paths); otherwise it's the
+          // ordinary per-segment static strategy. This is the only place the
+          // phase is consulted — everything below keys off the strategy.
+          const staticWalkStrategy =
+            task.phase === PrefetchPhase.Shell
+              ? FetchStrategy.StaticShell
+              : FetchStrategy.PPR
+
           if (
-            task.phase === PrefetchPhase.Speculative &&
+            staticWalkStrategy === FetchStrategy.PPR &&
             !subtreeHasSpeculativePrefetch(
               task.fetchStrategy,
               tree.prefetchHints
             )
           ) {
             // Nothing in the target route needs to be speculatively prefetched.
-            // Bail out.
+            // Bail out. (A PPR walk is the Speculative pass; same check as
+            // the per-subtree bail in pingNewPartOfCacheComponentsTree.)
             return PrefetchTaskExitStatus.Done
           }
 
-          pingStaticHead(now, task, route)
+          pingStaticHead(now, task, route, staticWalkStrategy)
+
           const exitStatus = pingSharedPartOfCacheComponentsTree(
             now,
             task,
             route,
             task.treeAtTimeOfPrefetch,
             tree,
-            null
+            null,
+            staticWalkStrategy
           )
           if (exitStatus === PrefetchTaskExitStatus.InProgress) {
             // Child yielded without finishing.
@@ -889,36 +913,24 @@ function pingRootRouteTree(
           // We may need to do a runtime prefetch for one or more segments.
           // Before checking, we can do some fast checks to bail out of this
           // branch early.
-          if (
-            // Do any segments have runtime prefetching configured? This is
-            // sent by the server as part of the prefetch hints.
-            tree.prefetchHints & PrefetchHint.SubtreeHasRuntimePrefetch ||
-            // Are we in the Shell prefetching phase? The Shell phase is
-            // allowed to perform runtime prefetches even without an explicit
-            // opt-in because the Shell for a given route is reusable across
-            // all given params, by definition. So it does not lead to an
-            // explosion in prefetching costs.
-            // TODO: The server now emits signals for skipping unnecessary
-            // runtime prefetch requests: an advisory
-            // PrefetchHint.ShouldAttemptStaticPrefetch bit on the route
-            // tree, and a load-bearing response-level `needsRuntimeRequest`
-            // promise on the static segment responses (fulfilled `true`
-            // visible in the decode means a runtime request would return
-            // more; rewindable at the shell boundary; combined with each
-            // segment's `isPartial`). They aren't consumed yet; wiring them
-            // up is left for a follow-up.
-            task.phase === PrefetchPhase.Shell
-          ) {
+          //
+          // Runtime prefetches are only issued for walks that require runtime
+          // completeness — the same per-pass predicate that produced the
+          // deopt registrations during the traversal above; see the decision
+          // point in pingNewPartOfCacheComponentsTree. Which segments
+          // actually need a runtime request — registered directly, or only
+          // as the fallback after an insufficient static attempt — was
+          // decided there.
+          if (walkRequiresRuntimeCompleteness(staticWalkStrategy, route)) {
             const runtimeStrategy =
-              task.phase === PrefetchPhase.Shell
+              staticWalkStrategy === FetchStrategy.StaticShell
                 ? FetchStrategy.RuntimeShell
                 : FetchStrategy.PPRRuntime
 
             // spawnedRuntimePrefetches was populated during the traversal
-            // above: every segment in the new part of the tree that is a
-            // candidate for runtime prefetching. It's derived purely from
-            // server hints, not cache state — it tells us whether a runtime
-            // request would be needed even if the cache were completely empty.
+            // above: every subtree in the new part of the tree that needs a
+            // runtime prefetch — plus, during the Shell phase, the head, if
+            // its static attempt was insufficient (see above).
             //
             // If it's null, nothing in the new part of the tree is a candidate
             // for runtime prefetching, and we don't fetch the head, either —
@@ -1011,25 +1023,56 @@ function pingRootRouteTree(
   return PrefetchTaskExitStatus.Done
 }
 
+/**
+ * Prefetches the Head data for a page (metadata, viewport). The Head is not
+ * really a route segment, in the sense that it doesn't appear in the route
+ * tree, but we store it in the cache as if it were, using a special key.
+ *
+ * Symmetric with the per-segment decision point in
+ * pingNewPartOfCacheComponentsTree: the head deopts to the runtime prefetch
+ * path either when it requires runtime completeness and no static attempt is
+ * happening, or when a fulfilled static head entry reported that a runtime
+ * request would return more content than the entry contains. Deopting
+ * registers the head under its metadata request key, which makes the runtime
+ * gate in pingRootRouteTree fire even when every tree segment was
+ * sufficient; pingRuntimeHead performs the actual head work.
+ */
 function pingStaticHead(
   now: number,
   task: PrefetchTask,
-  route: FulfilledRouteCacheEntry
+  route: FulfilledRouteCacheEntry,
+  // The per-pass static walk strategy; see pingRootRouteTree where
+  // it's derived.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): void {
-  // The Head data for a page (metadata, viewport) is not really a route
-  // segment, in the sense that it doesn't appear in the route tree. But we
-  // store it in the cache as if it were, using a special key.
+  // The head is subject to the same per-pass runtime-completeness contract
+  // as the route's segments: during an App Shell walk, and during any walk
+  // of a Partial Prefetching route, the head needs a response at least as
+  // complete as a runtime one.
+  const headRequiresRuntimeCompleteness = walkRequiresRuntimeCompleteness(
+    fetchStrategy,
+    route
+  )
   if (
-    // TODO: Currently static App Shell extraction is not implemented for
-    // per-segment prefetch responses. Instead, shell prefetches are only
-    // supported via a runtime prefetch request. The head will be prefetched
-    // as part of that request, so it's fine that we skip it here.
-    task.phase === PrefetchPhase.Shell ||
+    headRequiresRuntimeCompleteness &&
+    // The head is not a tree node — it hangs off the route root — so the
+    // static-attempt hint is read from the root's node. (Segments read the
+    // bit from their own node; see the decision point in
+    // pingNewPartOfCacheComponentsTree.)
+    (route.tree.prefetchHints & PrefetchHint.ShouldAttemptStaticPrefetch) === 0
+  ) {
+    // No static attempt: the head arrives via the runtime request instead.
+    addSpawnedRuntimePrefetch(task, route.metadata.requestKey)
+    return
+  }
+
+  if (
     // If the head was inlined into a page's bundle (HeadOutlined is NOT set
     // on the root), skip the standalone fetch — the head data will arrive
-    // as part of that page's response.
-    (process.env.__NEXT_PREFETCH_INLINING &&
-      !(route.tree.prefetchHints & PrefetchHint.HeadOutlined))
+    // as part of that page's response, and its runtime-completeness signal
+    // is carried by that page's own entries.
+    process.env.__NEXT_PREFETCH_INLINING &&
+    !(route.tree.prefetchHints & PrefetchHint.HeadOutlined)
   ) {
     return
   }
@@ -1038,13 +1081,125 @@ function pingStaticHead(
     tree: route.metadata,
     entry: readOrCreateSegmentCacheEntry(
       now,
-      FetchStrategy.PPR,
+      fetchStrategy,
       route.metadata,
       task._navigationLockPrefetch ?? null
     ),
     parent: null,
   }
-  pingSegmentBundle(now, task, route, task.key, route.metadata, segments)
+  const needsRuntimeRequest = pingSegmentBundle(
+    now,
+    task,
+    route,
+    task.key,
+    route.metadata,
+    segments,
+    fetchStrategy,
+    true
+  )
+  if (headRequiresRuntimeCompleteness && needsRuntimeRequest) {
+    // The static attempt was insufficient for the head. Deopt to a
+    // runtime prefetch. (Outside of runtime-completeness contexts the
+    // head's signal is unused — a partial static head is filled in by the
+    // navigation-time request, as with any other static segment.)
+    addSpawnedRuntimePrefetch(task, route.metadata.requestKey)
+  }
+}
+
+/**
+ * Whether the task needs a cache entry at least as complete as a runtime
+ * response for every segment it walks before the prefetch counts as done.
+ * Runtime completeness is the universal contract for Partial Prefetching,
+ * so the predicate is per pass, not per segment:
+ *
+ * - Every walk of a route that opts into Partial Prefetching (any segment
+ *   with a partial-prefetching config, or the global `partialPrefetching`
+ *   flag — both surfaced as SubtreeHasPartialPrefetching on the route
+ *   root), in both the Shell and Speculative phases.
+ * - Every App Shell (StaticShell) walk, because the App Shell must be
+ *   reusable across all params by definition. (In practice this is implied
+ *   by the first case — the Shell phase only runs for Partial Prefetching
+ *   routes.)
+ *
+ * Routes without Partial Prefetching keep the static-only contract: their
+ * walks prefetch static data and partial entries are acceptable — the
+ * dynamic holes are filled by the navigation-time request.
+ *
+ * Note that on a Partial Prefetching route, non-eager subtrees are still
+ * skipped by the Speculative pass of a default (auto) link — eagerness is
+ * unaffected by this predicate. But every segment the pass DOES walk (eager
+ * segments, and everything on a `prefetch={true}` walk) is held to the
+ * runtime-completeness contract. The contract is affordable because most
+ * routes carry the ShouldAttemptStaticPrefetch hint: their segments are
+ * prefetched statically and the responses' own sufficiency signal makes a
+ * runtime request rare. On a hint-unset route, a walked segment deopts
+ * directly to the batched runtime request — which then serves the segment's
+ * whole subtree, so navigations into it are complete without a
+ * navigation-time request.
+ *
+ * This is also the gate for the batched runtime request at the end of
+ * pingRootRouteTree; requiring runtime completeness does not itself mean a
+ * runtime request is issued for a given segment — see the decision point in
+ * pingNewPartOfCacheComponentsTree.
+ */
+function walkRequiresRuntimeCompleteness(
+  staticWalkStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell,
+  route: FulfilledRouteCacheEntry
+): boolean {
+  return (
+    staticWalkStrategy === FetchStrategy.StaticShell ||
+    (route.tree.prefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) !== 0
+  )
+}
+
+/**
+ * The runtime counterpart of a pass's static walk strategy: the strategy the
+ * batched runtime request uses if this walk deopts. Each phase has exactly one
+ * — the Shell phase escalates to a runtime App Shell, the Speculative phase to
+ * a per-link concrete runtime prefetch.
+ */
+function getRuntimeStrategyForWalk(
+  staticWalkStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
+): FetchStrategy.RuntimeShell | FetchStrategy.PPRRuntime {
+  return staticWalkStrategy === FetchStrategy.StaticShell
+    ? FetchStrategy.RuntimeShell
+    : FetchStrategy.PPRRuntime
+}
+
+/**
+ * Whether this phase's runtime request would return more content for a
+ * fulfilled entry than the entry already holds.
+ *
+ * An entry records the tier its CONTENT achieved, not the one it was requested
+ * at, and that tier spans both axes — so a static response that needed no
+ * runtime data records the runtime counterpart of its own variant (see
+ * `recordedFetchStrategy` in cache.ts). That makes this a pure tier
+ * comparison: an entry at or above the phase's runtime tier has nothing to
+ * gain from it.
+ */
+function wouldRuntimeRequestProvideMore(
+  entry: SegmentCacheEntry,
+  staticWalkStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
+): boolean {
+  return canNewFetchStrategyProvideMoreContent(
+    entry.fetchStrategy,
+    getRuntimeStrategyForWalk(staticWalkStrategy)
+  )
+}
+
+/**
+ * Register a subtree root (or the head's metadata key) for the batched
+ * runtime request issued by the gate at the end of pingRootRouteTree.
+ */
+function addSpawnedRuntimePrefetch(
+  task: PrefetchTask,
+  requestKey: SegmentRequestKey
+): void {
+  if (task.spawnedRuntimePrefetches === null) {
+    task.spawnedRuntimePrefetches = new Set([requestKey])
+  } else {
+    task.spawnedRuntimePrefetches.add(requestKey)
+  }
 }
 
 function pingRuntimeHead(
@@ -1081,8 +1236,11 @@ function pingSharedPartOfCacheComponentsTree(
   route: FulfilledRouteCacheEntry,
   oldTree: FlightRouterState,
   newTree: RouteTree,
-  parentBundle: SegmentBundle | null
-): PrefetchTaskExitStatus {
+  parentBundle: SegmentBundle | null,
+  // The per-pass static walk strategy; see pingRootRouteTree where
+  // it's derived.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
+): PrefetchTaskExitStatus.InProgress | PrefetchTaskExitStatus.Done {
   // When Cache Components is enabled (or PPR, or a fully static route when PPR
   // is disabled; those cases are treated equivalently to Cache Components), we
   // start by prefetching each segment individually. Once we reach the "new"
@@ -1094,13 +1252,21 @@ function pingSharedPartOfCacheComponentsTree(
   // "new" part of the tree, we switch to a different traversal,
   // pingNewPartOfCacheComponentsTree.
 
+  // The shared part of the tree always performs the ordinary static (PPR)
+  // prefetch, regardless of phase. Phase-specific strategies — the runtime
+  // shell request and the Shell phase's StaticShell walk — apply only to the
+  // new part of the tree, so the per-pass walk strategy is irrelevant here.
+  // (The needs-runtime signal is ignored: shared segments are already
+  // rendered on the current page, so a runtime prefetch has nothing to add.)
   const bundleInProgress = accumulateSegmentBundle(
     now,
     task,
     route,
     newTree,
-    parentBundle
-  )
+    parentBundle,
+    FetchStrategy.PPR,
+    true
+  ).bundle
 
   // Recursively ping the children.
   const oldTreeChildren = oldTree[1]
@@ -1140,17 +1306,35 @@ function pingSharedPartOfCacheComponentsTree(
           route,
           oldTreeChild,
           newTreeChild,
-          bundleForChild
+          bundleForChild,
+          fetchStrategy
         )
       } else {
         // We've entered the "new" part of the tree. Switch
         // traversal functions.
+        //
+        // Bundle chains must not cross the strategy boundary: the shared
+        // part walks at PPR while a Shell-phase new part walks at
+        // StaticShell, and a chain spanning both would fulfill the shared
+        // parent's concrete-path entry with shell-variant data. Nor may we
+        // finish the chain by fetching the new-part child at PPR here —
+        // that would prefetch new-part segments at the concrete tier
+        // during the Shell phase, which only the Speculative phase is
+        // allowed to do. So drop the bundle instead, exactly like the
+        // Speculative walk's subtree bail does when a chain crosses into a
+        // subtree it skips: nothing in a dropped chain was upgraded to
+        // Pending, so no entry is stranded, and the inlined shared data is
+        // fetched by the Speculative pass whenever its walk of the new
+        // part permits the child fetch.
+        const bundleForNewPart =
+          fetchStrategy === FetchStrategy.StaticShell ? null : bundleForChild
         childExitStatus = pingNewPartOfCacheComponentsTree(
           now,
           task,
           route,
           newTreeChild,
-          bundleForChild
+          bundleForNewPart,
+          fetchStrategy
         )
       }
       if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
@@ -1168,32 +1352,42 @@ function pingNewPartOfCacheComponentsTree(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   tree: RouteTree,
-  parentBundle: SegmentBundle | null
+  parentBundle: SegmentBundle | null,
+  // The per-pass static walk strategy; see pingRootRouteTree where
+  // it's derived.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): PrefetchTaskExitStatus.InProgress | PrefetchTaskExitStatus.Done {
-  // We're now prefetching in the "new" part of the tree, the part that doesn't
-  // exist on the current page. (In other words, we're deeper than the
-  // shared layouts.) Segments in here default to being prefetched statically.
-  // However, if the server instructs us to, we may switch to a runtime
-  // prefetch instead. Traverse the tree and check at each segment.
+  // We're now prefetching in the "new" part of the tree, the part that
+  // doesn't exist on the current page. (In other words, we're deeper than
+  // the shared layouts.) Segments in here default to being prefetched
+  // statically, at the per-pass strategy derived in pingRootRouteTree.
   //
-  // In the Shell phase, every new segment is treated as a runtime-prefetch
-  // boundary regardless of `HasRuntimePrefetch`, because the Shell is
-  // reusable across all params by definition (see the matching comment in
-  // the main scheduler loop).
+  // When the walk requires runtime completeness — an entry at least as
+  // complete as a runtime response for every segment before the prefetch
+  // can complete (see walkRequiresRuntimeCompleteness) — this function is
+  // also the per-segment decision point. If the segment's node carries the
+  // ShouldAttemptStaticPrefetch hint (the build-time prerender accessed no
+  // runtime data), its subtree is prefetched statically first,
+  // and the responses themselves decide whether that was enough: every
+  // fulfilled entry carries a needsRuntimeRequest signal. Pending responses
+  // block the task, so the attempt is serial, never raced: static attempt →
+  // observe → runtime only if needed. Without the hint, the segment deopts
+  // directly. Deopting registers the segment's request key in
+  // spawnedRuntimePrefetches; the runtime gate at the end of
+  // pingRootRouteTree issues a single batched runtime request for
+  // everything that accumulated, and that request re-fetches the whole
+  // subtree, so the walk stops descending at a deopt.
   //
-  // TODO: If we're reasonably confident that the shell does not depend on
-  // session data (cookies), we should attempt to prefetch the shell
-  // statically, instead of via a runtime prefetch. This is an optimization to skip a
-  // runtime shell request. For fully static pages, it doesn't matter since
-  // server will respond to even a runtime request with a static response. For
-  // a partially static page, we can send down a hint from the server.
-  // The server-side hints for this now exist
-  // (PrefetchHint.ShouldAttemptStaticPrefetch on the route tree, the
-  // `needsRuntimeRequest` promise + per-segment `isPartial` on static
-  // segment responses) but aren't consumed yet.
+  // Outside a runtime-completeness walk the same needsRuntimeRequest signal
+  // is routine and ignored — any partial entry of a page that accesses
+  // runtime data carries it, and the dynamic holes are filled by the
+  // navigation-time request.
 
   if (
-    task.phase === PrefetchPhase.Speculative &&
+    // Only the Speculative pass skips subtrees with nothing to speculatively
+    // prefetch. (It's also the only pass that walks at FetchStrategy.PPR;
+    // the Shell phase walks at StaticShell and covers the whole new tree.)
+    fetchStrategy === FetchStrategy.PPR &&
     !subtreeHasSpeculativePrefetch(task.fetchStrategy, tree.prefetchHints)
   ) {
     // Nothing in the new part of the tree needs to be speculatively prefetched.
@@ -1201,30 +1395,70 @@ function pingNewPartOfCacheComponentsTree(
     return PrefetchTaskExitStatus.Done
   }
 
-  if (
-    tree.prefetchHints & PrefetchHint.HasRuntimePrefetch ||
-    task.phase === PrefetchPhase.Shell
-  ) {
-    if (task.spawnedRuntimePrefetches === null) {
-      task.spawnedRuntimePrefetches = new Set([tree.requestKey])
-    } else {
-      task.spawnedRuntimePrefetches.add(tree.requestKey)
-    }
+  // Constant for the whole pass; recomputed here only because the walk is
+  // recursive and the check is cheap.
+  const segmentRequiresRuntimeCompleteness = walkRequiresRuntimeCompleteness(
+    fetchStrategy,
+    route
+  )
+  // TODO: The static-attempt hint reflects the build-time prerender's whole
+  // runtime-data tracking, so a page that always accesses
+  // runtime data after the shell stage never attempts a static prefetch —
+  // even though its shell variant is rewindable at the shell boundary and
+  // perfectly reusable. The server could emit a second bit derived from the
+  // shell-stage value ("a static SHELL attempt is worthwhile even though
+  // the page accesses runtime data post-shell") to let such pages attempt
+  // static, too.
+  // A force-disabled segment deliberately does NOT deopt here: disabling
+  // prefetch is passive. It never initiates a request — its accumulation
+  // below contributes nothing — and must never be the reason a runtime
+  // prefetch spawns, though it may ride along in a runtime response issued
+  // on another segment's behalf.
+  const attemptStaticPrefetchOfSegment =
+    (tree.prefetchHints & PrefetchHint.ShouldAttemptStaticPrefetch) !== 0
+
+  if (segmentRequiresRuntimeCompleteness && !attemptStaticPrefetchOfSegment) {
+    // Deopt directly to a runtime prefetch, without a static attempt.
+    addSpawnedRuntimePrefetch(task, tree.requestKey)
     // If there's a pending static bundle from a parent, we need to finish
     // prefetching it before bailing out to runtime prefetching.
     if (parentBundle !== null) {
-      finishStaticBundleOnRuntimeBailout(now, task, route, tree, parentBundle)
+      finishStaticBundleOnRuntimeBailout(
+        now,
+        task,
+        route,
+        tree,
+        parentBundle,
+        fetchStrategy
+      )
     }
     return PrefetchTaskExitStatus.Done
   }
 
-  const bundleInProgress = accumulateSegmentBundle(
+  // Prefetch this segment and its subtree statically, using the normal
+  // static bundling walk.
+  const accumulation = accumulateSegmentBundle(
     now,
     task,
     route,
     tree,
-    parentBundle
+    parentBundle,
+    fetchStrategy,
+    true
   )
+  const bundleInProgress = accumulation.bundle
+
+  if (segmentRequiresRuntimeCompleteness && accumulation.needsRuntimeRequest) {
+    // The static attempt for this segment was insufficient. Stop the walk
+    // and deopt — the runtime prefetch covers the whole subtree. (Unlike the
+    // direct deopt above, any open bundle is dropped rather than finished: a
+    // fulfilled InlinedIntoChild node can report a true signal while its
+    // chain is still open. That's safe — nothing in an un-pinged chain was
+    // upgraded to Pending, so no entry is stranded blocking the task, and
+    // Empty entries in the dropped chain are re-fetched by a later pass.)
+    addSpawnedRuntimePrefetch(task, tree.requestKey)
+    return PrefetchTaskExitStatus.Done
+  }
 
   if (tree.slots !== null) {
     if (!hasNetworkBandwidth(task)) {
@@ -1241,20 +1475,25 @@ function pingNewPartOfCacheComponentsTree(
         childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf
           ? bundleInProgress
           : null
-      const childExitStatus = pingNewPartOfCacheComponentsTree(
+      const childResult = pingNewPartOfCacheComponentsTree(
         now,
         task,
         route,
         childTree,
-        bundleForChild
+        bundleForChild,
+        fetchStrategy
       )
-      if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
+      if (childResult === PrefetchTaskExitStatus.InProgress) {
         // Child yielded without finishing.
         return PrefetchTaskExitStatus.InProgress
       }
     }
   }
-  // This segment and all its children have finished prefetching.
+
+  // The static attempt was sufficient for this segment (each child is its
+  // own decision point) — or parts of it are still in flight, in which case
+  // the task is blocked and the decision re-runs against the received
+  // responses.
   return PrefetchTaskExitStatus.Done
 }
 
@@ -1797,6 +2036,14 @@ function pingRuntimePrefetches(
 /**
  * Walk a SegmentBundle, apply status-based logic to each entry, and if any
  * entries need data, spawn a single fetch request for the whole bundle.
+ *
+ * Returns true if a fulfilled entry in the bundle reported that a runtime
+ * request would return more content than the entry contains
+ * (needsRuntimeRequest, derived at write time from the response that
+ * produced the entry). The callers surface this signal to the per-segment
+ * decision point in pingNewPartOfCacheComponentsTree (and its analog for
+ * the head in pingStaticHead), which uses it during a static attempt to
+ * decide whether to fall back to a runtime prefetch.
  */
 function pingSegmentBundle(
   now: number,
@@ -1804,10 +2051,23 @@ function pingSegmentBundle(
   route: FulfilledRouteCacheEntry,
   routeKey: RouteCacheKey,
   tree: RouteTree,
-  segments: SegmentBundle
-): void {
+  segments: SegmentBundle,
+  // Per-pass static walk strategy; see pingRootRouteTree where it's derived.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell,
+  // False when finishing an open bundle chain on a runtime-prefetch bailout
+  // (finishStaticBundleOnRuntimeBailout). The finish exists only to fetch
+  // data the batched runtime request won't cover — Empty entries in the
+  // chain — so it must not spawn revalidations over entries that are
+  // already settled or in flight: the chain's terminal segments are inside
+  // the deopted subtree, and re-fetching their static bundle would at best
+  // duplicate the runtime request and at worst replace a runtime-complete
+  // entry (e.g. a runtime App Shell) with a less complete static fallback
+  // response.
+  spawnRevalidations: boolean
+): boolean {
   let segmentCount = 0
   let needsFetch = false
+  let needsRuntimeRequest = false
   let node: SegmentBundle | null = segments
   while (node !== null) {
     segmentCount++
@@ -1821,7 +2081,7 @@ function pingSegmentBundle(
       case EntryStatus.Empty:
         upgradeToPendingSegment(
           nodeEntry,
-          FetchStrategy.PPR,
+          fetchStrategy,
           task._navigationLockPrefetch ?? null
         )
         needsFetch = true
@@ -1831,20 +2091,25 @@ function pingSegmentBundle(
         break
       case EntryStatus.Pending:
         if (
+          spawnRevalidations &&
+          // During a static shell attempt, never spawn revalidations — just
+          // wait for the in-flight response (blocked below); its sufficiency
+          // is checked on the re-run pass.
+          fetchStrategy === FetchStrategy.PPR &&
           canNewFetchStrategyProvideMoreContent(
             nodeEntry.fetchStrategy,
-            FetchStrategy.PPR
+            fetchStrategy
           )
         ) {
           const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
             now,
-            FetchStrategy.PPR,
+            fetchStrategy,
             nodeTree
           )
           if (revalidatingEntry.status === EntryStatus.Empty) {
             upgradeToPendingSegment(
               revalidatingEntry,
-              FetchStrategy.PPR,
+              fetchStrategy,
               task._navigationLockPrefetch ?? null
             )
             node.entry = revalidatingEntry
@@ -1862,20 +2127,31 @@ function pingSegmentBundle(
         break
       case EntryStatus.Rejected:
         if (
+          spawnRevalidations &&
+          // During a static shell attempt, a rejected entry is skipped
+          // outright: no retry revalidation, and — deliberately — no runtime
+          // fallback either (per-segment rejection semantics; the entry's
+          // staleAt governs when it may be retried). Note that the cache
+          // path encodes "no shell exists" (a static response whose shell
+          // byte offset is 0, i.e. the page wasn't produced by staged
+          // rendering) as a rejection too, so such segments get no shell
+          // prefetch at all — an edge that shouldn't occur for hint-set
+          // Cache Components routes.
+          fetchStrategy === FetchStrategy.PPR &&
           canNewFetchStrategyProvideMoreContent(
             nodeEntry.fetchStrategy,
-            FetchStrategy.PPR
+            fetchStrategy
           )
         ) {
           const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
             now,
-            FetchStrategy.PPR,
+            fetchStrategy,
             nodeTree
           )
           if (revalidatingEntry.status === EntryStatus.Empty) {
             upgradeToPendingSegment(
               revalidatingEntry,
-              FetchStrategy.PPR,
+              fetchStrategy,
               task._navigationLockPrefetch ?? null
             )
             node.entry = revalidatingEntry
@@ -1900,11 +2176,37 @@ function pingSegmentBundle(
         // entry itself — nothing ever pings a Rejected entry.
         break
       case EntryStatus.Fulfilled: {
-        // For shell entries (less specific than PPR), upgrade during the
-        // Speculative phase itself — no background deferral, since the
-        // whole point of the Speculative phase is to bring the cache up
-        // to the per-link-concrete tier. `isPartial` ensures a complete
-        // entry isn't re-fetched.
+        const runtimeWouldProvideMore = wouldRuntimeRequestProvideMore(
+          nodeEntry,
+          fetchStrategy
+        )
+        if (runtimeWouldProvideMore) {
+          // A runtime request would return more content for this segment
+          // than the entry contains. Surface it via the return value, so the
+          // caller can deopt this subtree to a runtime prefetch.
+          needsRuntimeRequest = true
+        }
+
+        // For entries below this phase's tier, upgrade during the phase
+        // itself — no background deferral, since the whole point of the
+        // Speculative phase is to bring the cache up to the
+        // per-link-concrete tier. `isPartial` ensures a complete entry isn't
+        // re-fetched.
+        //
+        // Exception: when a runtime request would return more AND this walk
+        // permits one, skip the static path entirely. The runtime request
+        // covers this segment and supersedes anything a static fetch could
+        // add, so a static upgrade would at best duplicate it — delivering
+        // the same content twice — and at worst replace runtime content with
+        // static content.
+        //
+        // When no runtime request is permitted, the signal is irrelevant:
+        // nothing can act on it, so it must not suppress the static upgrade.
+        // That's what keeps a link prefetching static content on top of a
+        // cached shell.
+        const willBeSupersededByRuntimeRequest =
+          runtimeWouldProvideMore &&
+          walkRequiresRuntimeCompleteness(fetchStrategy, route)
 
         // Check if we should attempt to upgrade a fallback ISR response to
         // a concrete version.
@@ -1921,22 +2223,24 @@ function pingSegmentBundle(
             task.fallbackRetryStatus === EntryStatus.Fulfilled)
 
         if (
-          (nodeEntry.isPartial &&
+          spawnRevalidations &&
+          !willBeSupersededByRuntimeRequest &&
+          ((nodeEntry.isPartial &&
             canNewFetchStrategyProvideMoreContent(
               nodeEntry.fetchStrategy,
-              FetchStrategy.PPR
+              fetchStrategy
             )) ||
-          isUpgradeableISRFallbackRetry
+            isUpgradeableISRFallbackRetry)
         ) {
           const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
             now,
-            FetchStrategy.PPR,
+            fetchStrategy,
             nodeTree
           )
           if (revalidatingEntry.status === EntryStatus.Empty) {
             upgradeToPendingSegment(
               revalidatingEntry,
-              FetchStrategy.PPR,
+              fetchStrategy,
               task._navigationLockPrefetch ?? null
             )
             node.entry = revalidatingEntry
@@ -1969,60 +2273,62 @@ function pingSegmentBundle(
     }
     node = node.parent
   }
-  if (!needsFetch) {
-    return
-  }
-  spawnPrefetchSubtask(
-    fetchSegmentsOnCacheMiss(
-      task,
-      route,
-      routeKey,
-      tree,
-      segments,
-      segmentCount
+  if (needsFetch) {
+    spawnPrefetchSubtask(
+      fetchSegmentsOnCacheMiss(
+        task,
+        route,
+        routeKey,
+        tree,
+        segments,
+        segmentCount,
+        fetchStrategy
+      )
     )
-  )
+  }
+  return needsRuntimeRequest
 }
 
 /**
  * During the tree walk, decide whether this segment should be added to the
  * in-progress bundle (if it has InlinedIntoChild) or finalize the bundle
- * and trigger a fetch (if it doesn't). Returns the updated bundle to pass
- * to children, or null if a fetch was triggered.
+ * and ping it, triggering a fetch if any of its entries need data (if it
+ * doesn't). Returns the updated bundle to pass to children (null if the
+ * bundle was finalized here), along with the needs-runtime signal from the
+ * bundle ping, if one happened (always false otherwise).
  */
 function accumulateSegmentBundle(
   now: number,
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   tree: RouteTree,
-  parentBundle: SegmentBundle | null
-): SegmentBundle | null {
-  // Static prefetching is disabled for this segment (runtime prefetch or
-  // instant = false). It participates in the bundle chain with null
-  // tree/entry — no cache entry is created, and the server emits null for
-  // this slot. This check is intentionally NOT gated by the prefetch
-  // inlining feature flag: we never statically prefetch segments that are
-  // runtime-prefetched or unprefetchable, regardless of bundling.
+  parentBundle: SegmentBundle | null,
+  // Per-pass static walk strategy; see pingRootRouteTree where it's derived.
+  // PPR for the normal static bundling walk; StaticShell during the Shell
+  // phase's static App Shell attempt, whose entries are keyed at the shell
+  // vary paths.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell,
+  // False when finishing a chain on a runtime-prefetch bailout; see
+  // pingSegmentBundle.
+  spawnRevalidations: boolean
+): { bundle: SegmentBundle | null; needsRuntimeRequest: boolean } {
+  // Prefetching is disabled for this segment (prefetch: 'force-disabled'):
+  // the server emits null for its slot, and it participates in the bundle
+  // chain with null tree/entry so the null-slot positions line up.
+  // (Partial Prefetching segments are NOT in this mask — the server emits
+  // static data for them unconditionally.) Intentionally not gated by the
+  // prefetch inlining flag: we never statically prefetch unprefetchable
+  // segments.
   if (tree.prefetchHints & StaticPrefetchDisabled) {
     return {
-      tree: null,
-      entry: null,
-      parent: parentBundle,
+      bundle: { tree: null, entry: null, parent: parentBundle },
+      needsRuntimeRequest: false,
     }
   }
 
-  if (task.phase === PrefetchPhase.Shell) {
-    // The static-bundle path is for per-segment static (PPR) prefetches.
-    // Shell phase issues a single combined RuntimeShell request via
-    // pingRoute's runtime gate block — it neither needs nor wants the
-    // static bundle entries (which would be Pending PPR at concrete
-    // keypaths, blocking the RuntimeShell request and missing the shell
-    // vary-path placement we need for Fallback reuse). Skip entirely.
-    return null
-  }
   const segment = readOrCreateSegmentCacheEntry(
     now,
-    task.fetchStrategy,
+    fetchStrategy,
     tree,
     task._navigationLockPrefetch ?? null
   )
@@ -2032,9 +2338,16 @@ function accumulateSegmentBundle(
     tree.prefetchHints & PrefetchHint.InlinedIntoChild
   ) {
     return {
-      tree,
-      entry: segment,
-      parent: parentBundle,
+      bundle: { tree, entry: segment, parent: parentBundle },
+      // No bundle ping happens here, but the node's own entry may already be
+      // fulfilled and insufficient. Report that signal directly: the chain
+      // ping only reaches the terminal descendant, and if that descendant is
+      // itself a decision point it consumes the signal for its own subtree,
+      // leaving this ancestor's insufficiency invisible to the decision
+      // point above it.
+      needsRuntimeRequest:
+        segment.status === EntryStatus.Fulfilled &&
+        wouldRuntimeRequestProvideMore(segment, fetchStrategy),
     }
   }
 
@@ -2050,7 +2363,7 @@ function accumulateSegmentBundle(
       tree: route.metadata,
       entry: readOrCreateSegmentCacheEntry(
         now,
-        FetchStrategy.PPR,
+        fetchStrategy,
         route.metadata,
         task._navigationLockPrefetch ?? null
       ),
@@ -2064,8 +2377,17 @@ function accumulateSegmentBundle(
     parent: effectiveParent,
   }
 
-  pingSegmentBundle(now, task, route, task.key, tree, segments)
-  return null
+  const needsRuntimeRequest = pingSegmentBundle(
+    now,
+    task,
+    route,
+    task.key,
+    tree,
+    segments,
+    fetchStrategy,
+    spawnRevalidations
+  )
+  return { bundle: null, needsRuntimeRequest }
 }
 
 function finishStaticBundleOnRuntimeBailout(
@@ -2073,24 +2395,38 @@ function finishStaticBundleOnRuntimeBailout(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   tree: RouteTree,
-  parentBundle: SegmentBundle
+  parentBundle: SegmentBundle,
+  // The same static walk strategy the parent bundle was accumulated with.
+  // Any needs-runtime signal from finishing the bundle is dropped: the
+  // caller is already deopting this subtree to a runtime prefetch.
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): void {
-  if (task.phase === PrefetchPhase.Shell) {
-    // Same reason as the gate in accumulateSegmentBundle: no static-bundle
-    // work during Shell phase. (Should already be unreachable since
-    // accumulateSegmentBundle returns null during Shell, leaving every
-    // parentBundle null at the runtime-bailout call site — gating here
-    // as defense in depth.)
-    return
-  }
-  const bundle = accumulateSegmentBundle(now, task, route, tree, parentBundle)
+  const bundle = accumulateSegmentBundle(
+    now,
+    task,
+    route,
+    tree,
+    parentBundle,
+    fetchStrategy,
+    // The batched runtime request covers the deopted subtree; only fetch
+    // Empty entries the chain would otherwise strand — never spawn
+    // revalidations over settled or in-flight ones. See pingSegmentBundle.
+    false
+  ).bundle
   if (bundle === null) {
     return
   }
   if (tree.slots !== null) {
     for (const childTree of tree.slots.values()) {
       if (childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf) {
-        finishStaticBundleOnRuntimeBailout(now, task, route, childTree, bundle)
+        finishStaticBundleOnRuntimeBailout(
+          now,
+          task,
+          route,
+          childTree,
+          bundle,
+          fetchStrategy
+        )
         return
       }
     }

--- a/packages/next/src/client/components/segment-cache/types.ts
+++ b/packages/next/src/client/components/segment-cache/types.ts
@@ -34,12 +34,26 @@ export const enum PrefetchPriority {
 export const enum FetchStrategy {
   // Deliberately ordered so we can easily compare two segments
   // and determine if one segment is "more specific" than another
-  // (i.e. if it's likely that it contains more data)
+  // (i.e. if it's likely that it contains more data). See
+  // canNewFetchStrategyProvideMoreContent in cache.ts for what each tier can
+  // contain relative to the others.
+  //
+  // These numeric values are client-internal and never cross the wire — the
+  // `next-router-prefetch` request header values are mapped explicitly in
+  // fetchSegmentPrefetchesUsingDynamicRequest (cache.ts) — so the members can
+  // be renumbered freely as long as the relative order is preserved.
   LoadingBoundary = 0,
-  RuntimeShell = 1,
-  PPR = 2,
-  PPRRuntime = 3,
-  Full = 4,
+  // The App Shell variant extracted from a static per-segment prefetch
+  // response: every segment's param-dependent content is reduced to pending
+  // references that render as the param fallback. Less complete than
+  // RuntimeShell — a static response can't include content that depends on
+  // session data (cookies, headers) — and less complete than PPR at concrete
+  // paths, which includes prerendered param-dependent content.
+  StaticShell = 1,
+  RuntimeShell = 2,
+  PPR = 3,
+  PPRRuntime = 4,
+  Full = 5,
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -299,11 +299,17 @@ export function getSegmentVaryPathForRequest(
   // params that can be treated as Fallback. (Or perhaps the inverse.)
   const originalVaryPath = tree.varyPath
 
-  if (fetchStrategy === FetchStrategy.RuntimeShell) {
-    // The Shell phase issues a runtime render with non-root params omitted. The
-    // resulting entry is reusable across all concrete values of those params, so
-    // we key it at the precomputed shell vary path (every non-root param
-    // substituted with Fallback; root params keep their concrete value).
+  if (
+    fetchStrategy === FetchStrategy.RuntimeShell ||
+    fetchStrategy === FetchStrategy.StaticShell
+  ) {
+    // Both shell strategies produce the App Shell variant of a segment —
+    // RuntimeShell via a runtime render with non-root params omitted,
+    // StaticShell by truncating a static per-segment response at the shell
+    // byte boundary. Either way, the resulting entry is reusable across all
+    // concrete values of the non-root params, so we key it at the precomputed
+    // shell vary path (every non-root param substituted with Fallback; root
+    // params keep their concrete value).
     return tree.shellVaryPath
   }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -88,8 +88,9 @@ export type TreePrefetch = {
  * walking the SegmentBundleNode linked list. The client's SegmentBundle
  * linked list is constructed in the same order during scheduling, so the
  * two are walked in parallel when the response arrives. A null element
- * indicates a disabled segment (runtime prefetch or instant=false) that
- * occupies a slot but carries no data.
+ * indicates a disabled segment (prefetch: 'force-disabled') that occupies a
+ * slot but carries no data. (Allow-runtime segments get real slots — the
+ * server emits static data for them unconditionally.)
  */
 export type SegmentPrefetchResponse = {
   buildId: string
@@ -575,13 +576,6 @@ export async function collectPrefetchHints(
 
   // Mutable accumulator: the first segment that accepts the head sets this
   // to true. Once set, subsequent segments skip the check.
-  //
-  // When the route has any runtime prefetch segment, the head is only
-  // assigned to a runtime segment (since the runtime response already
-  // includes it). Static pages are skipped to avoid duplication.
-  const rootHints = flightRouterState[4] ?? 0
-  const subtreeHasRuntimePrefetch =
-    (rootHints & PrefetchHint.SubtreeHasRuntimePrefetch) !== 0
   const headInlineState = { inlined: false }
 
   // Walk the tree with the parent-first, child-decides algorithm.
@@ -598,7 +592,6 @@ export async function collectPrefetchHints(
     maxBundleSize,
     headGzipSize,
     headInlineState,
-    subtreeHasRuntimePrefetch,
     rootVaryParamsIterable,
     needsRuntimeRequest,
     shellStageRelease
@@ -657,7 +650,6 @@ async function collectPrefetchHintsImpl(
   maxBundleSize: number,
   headGzipSize: number,
   headInlineState: { inlined: boolean },
-  routeHasRuntimePrefetch: boolean,
   rootVaryParamsIterable: VaryParamsIterable | null,
   needsRuntimeRequest: Promise<boolean>,
   shellStageRelease: Promise<boolean>
@@ -667,13 +659,18 @@ async function collectPrefetchHintsImpl(
   // subtree. Used by ancestors for budget checks.
   inlinedBytes: number
 }> {
-  // Check if static prefetching is disabled for this segment (runtime
-  // prefetch or instant = false). Such segments act as transparent
-  // pass-throughs in the bundle chain: they contribute zero bytes of their
-  // own and pass parent data through to children. However, they cannot be
-  // the terminal of a chain — if no child accepts the parent data, the
-  // parent cannot be inlined into this segment because there's no static
-  // response to carry it. See the ParentInlinedIntoSelf check below.
+  // Check if static prefetching is disabled for this segment
+  // (prefetch: 'force-disabled' / instant = false). Such segments act as
+  // transparent pass-throughs in the bundle chain: they contribute zero
+  // bytes of their own and pass parent data through to children. However,
+  // they cannot be the terminal of a chain — if no child accepts the parent
+  // data, the parent cannot be inlined into this segment because there's no
+  // static response to carry it. See the ParentInlinedIntoSelf check below.
+  //
+  // Runtime-prefetch segments (prefetch: 'allow-runtime') are NOT disabled:
+  // they have static data — emitted unconditionally, so the client can
+  // attempt a static prefetch before deciding whether the runtime request is
+  // needed — and are measured and inlined like any other segment.
   const isStaticPrefetchDisabled =
     ((route[4] ?? 0) & StaticPrefetchDisabled) !== 0
 
@@ -764,7 +761,6 @@ async function collectPrefetchHintsImpl(
       maxBundleSize,
       headGzipSize,
       headInlineState,
-      routeHasRuntimePrefetch,
       rootVaryParamsIterable,
       needsRuntimeRequest,
       shellStageRelease
@@ -813,39 +809,37 @@ async function collectPrefetchHintsImpl(
 
   // Determine which segment is responsible for the head (metadata/viewport).
   //
-  // When the route has any runtime prefetch segment, the head is only
-  // assigned to a runtime segment — the runtime response already includes
-  // the head, so assigning it to a static page would duplicate it.
+  // The head is assigned to the first page bundle terminal that has budget
+  // room; otherwise it's outlined as a standalone response (HeadOutlined,
+  // set by the caller). Head can only be inlined into a page, not a layout,
+  // because pages may access additional params (e.g. searchParams) that
+  // layouts cannot. It must be a bundle terminal because only bundle
+  // terminals emit a static response of their own (the head bundle is
+  // appended in collectSegmentDataImpl's standalone-task branch) —
+  // assigning the head to an inlined segment would leave it out of every
+  // static response.
   //
-  // When the route has no runtime prefetch segments, the head is assigned
-  // to the first static page terminal that has budget room. Head can only
-  // be inlined into a page, not a layout, because pages may access
-  // additional params (e.g. searchParams) that layouts cannot.
-  //
-  // A disabled segment with PrefetchDisabled (instant = false) is never a
-  // valid target — it has no response at all.
-  const hasRuntimePrefetch =
-    ((route[4] ?? 0) & PrefetchHint.HasRuntimePrefetch) !== 0
+  // A disabled segment (prefetch: 'force-disabled' / instant = false) is
+  // never a valid target — it has no response at all. A runtime-prefetch
+  // segment (prefetch: 'allow-runtime'), by contrast, DOES have a static
+  // response (see isStaticPrefetchDisabled above) and is an ordinary
+  // candidate. Runtime prefetching gets no special treatment here: whether
+  // the client will actually issue a runtime request can't be known at
+  // build time (a static prefetch attempt may prove sufficient and skip
+  // it), so the head must always be reachable through the static responses
+  // — inlined into one of them, or outlined.
   const isBundleTerminal = !didInlineIntoChild && !isStaticPrefetchDisabled
   const segment = route[0]
   const isPageSegment =
     typeof segment === 'string'
       ? segment === PAGE_SEGMENT_KEY
       : segment[0] === PAGE_SEGMENT_KEY
-  if (!headInlineState.inlined) {
-    if (hasRuntimePrefetch) {
-      // Runtime prefetch segment — the runtime response includes the head.
-      // No budget cost since it's already part of that response.
+  if (!headInlineState.inlined && isBundleTerminal && isPageSegment) {
+    // The head counts against the bundle budget.
+    if (inlinedBytes + headGzipSize < maxBundleSize) {
       hints |= PrefetchHint.HeadInlinedIntoSelf
+      inlinedBytes += headGzipSize
       headInlineState.inlined = true
-    } else if (isBundleTerminal && isPageSegment && !routeHasRuntimePrefetch) {
-      // Static page terminal — only used when no runtime segments exist.
-      // The head counts against the bundle budget.
-      if (inlinedBytes + headGzipSize < maxBundleSize) {
-        hints |= PrefetchHint.HeadInlinedIntoSelf
-        inlinedBytes += headGzipSize
-        headInlineState.inlined = true
-      }
     }
   }
 
@@ -1105,9 +1099,18 @@ function collectSegmentDataImpl(
   // response as-is. Root params are forwarded separately, once per response.
   const varyParams = seedData !== null ? seedData[4] : null
 
-  // If static prefetching is disabled for this segment (runtime prefetch or
-  // instant = false), it still participates in the bundle chain but with
-  // null data. The client will skip creating a cache entry for it.
+  // If static prefetching is disabled for this segment
+  // (prefetch: 'force-disabled' / instant = false), it still participates in
+  // the bundle chain but with null data. The client will skip creating a
+  // cache entry for it.
+  //
+  // Runtime-prefetch segments (prefetch: 'allow-runtime') are NOT disabled:
+  // their static data is emitted UNCONDITIONALLY — it can't be gated on the
+  // ShouldAttemptStaticPrefetch hint, because the client walks bundles
+  // positionally and the null-slot positions must be deterministic from
+  // build-time config alone. The client uses the data to attempt a static
+  // prefetch before deciding whether the segment's runtime request is
+  // actually needed.
   const staticPrefetchDisabled = (prefetchHints & StaticPrefetchDisabled) !== 0
   const rsc = seedData !== null && !staticPrefetchDisabled ? seedData[0] : null
 
@@ -1284,9 +1287,9 @@ async function renderSegmentPrefetch(
   while (node !== null) {
     const elementRsc = node.rsc
     if (elementRsc === null) {
-      // Static prefetching disabled (runtime prefetch or instant=false): a
-      // null placeholder keeps the array aligned with the client's bundle
-      // list, which skips a cache entry for the slot.
+      // Static prefetching disabled (prefetch: 'force-disabled'; allow-runtime
+      // segments carry real data): a null placeholder keeps the array aligned
+      // with the client's bundle list, which skips a cache entry for the slot.
       data.push(null)
     } else {
       // We can determine if a segment contains only partial data if it takes

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -125,7 +125,13 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   } else if (prefetchConfig === 'allow-runtime') {
     // 'allow-runtime' participates in the two-phase (Shell then Speculative)
     // prefetch flow, so it counts as Partial Prefetching. HasRuntimePrefetch
-    // additionally marks it as needing a runtime request pass.
+    // additionally marks the segment as requiring runtime completeness: the
+    // prefetch isn't done for this segment until an entry at least as
+    // complete as a runtime response exists. That doesn't disable static
+    // prefetching — the server emits static data for the segment
+    // unconditionally, and the scheduler may attempt a static prefetch first
+    // (per the ShouldAttemptStaticPrefetch hint), issuing the runtime
+    // request only if the static response proves insufficient.
     prefetchHints |=
       PrefetchHint.HasRuntimePrefetch |
       PrefetchHint.SubtreeHasPartialPrefetching

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -181,8 +181,16 @@ export type FlightRouterState = [
 export type CompressedRefreshState = [url: string, renderedSearch: string]
 
 export const enum PrefetchHint {
-  // This segment has a runtime prefetch enabled (via instant with
-  // prefetch: 'runtime'). Per-segment only, does not propagate to ancestors.
+  // This segment has runtime prefetching enabled (prefetch: 'allow-runtime';
+  // no other config maps to this bit). Marks the segment as requiring
+  // RUNTIME COMPLETENESS: a prefetch isn't considered done for this segment
+  // until an entry at least as complete as a runtime response exists. It
+  // does NOT mean the segment lacks static data — the server emits static
+  // data for these segments unconditionally, and the scheduler may attempt a
+  // static prefetch first (per ShouldAttemptStaticPrefetch), issuing the
+  // runtime request only if the static response's own `needsRuntimeRequest`
+  // signal says it would return more. Per-segment only, does not propagate
+  // to ancestors.
   HasRuntimePrefetch = 0b00001,
   // This segment or one of its descendants opts into Partial Prefetching, i.e.
   // uses the two-phase (Shell then Speculative) prefetch flow. Set when a
@@ -218,8 +226,16 @@ export const enum PrefetchHint {
   // re-fetched with correct hints. Only set during build-time prerendering,
   // never at runtime.
   InliningHintsStale = 0b1000000000,
-  // This segment has instant = false, opting out of all
-  // prefetching entirely (neither static nor runtime).
+  // This segment has prefetch = 'force-disabled'. The opt-out is passive
+  // and applies to this segment only: it never INITIATES a prefetch — no
+  // static data is emitted or fetched, and it's never the reason a runtime
+  // prefetch spawns — but it may ride along in a runtime response issued on
+  // another segment's behalf. Descendants prefetch normally.
+  //
+  // TODO: Also set as an internal fallback when the prefetch hints manifest
+  // is unavailable (see #91407 mitigations), which only means "no static
+  // prefetch data exists" — not a user opt-out. Split the fallback into its
+  // own bit so the two intents can diverge.
   PrefetchDisabled = 0b10000000000,
   // This segment or one of its descendants has runtime prefetch enabled
   // (HasRuntimePrefetch). Propagates upward so the root reflects the
@@ -262,16 +278,25 @@ export const enum PrefetchHint {
 }
 
 /**
- * Bitmask for checking whether a segment's static prefetch is skipped. Matches
- * if EITHER bit is set — i.e. the segment uses runtime prefetching
- * (HasRuntimePrefetch) OR prefetching is disabled entirely (PrefetchDisabled,
- * e.g. instant = false). The segment participates in the bundle chain
- * but with null data.
+ * Bitmask for checking whether a segment's static prefetch is skipped — i.e.
+ * the server emits no static data for it (its slot in a segment bundle is
+ * null, and it participates in the bundle chain only as a pass-through) and
+ * the client never issues a static request for it.
+ *
+ * Static prefetching is disabled ONLY by `prefetch: 'force-disabled'`
+ * (PrefetchDisabled). Notably, `prefetch: 'allow-runtime'`
+ * (HasRuntimePrefetch) segments DO have static data: the server emits it
+ * unconditionally — it can't be gated on the
+ * ShouldAttemptStaticPrefetch hint, because null-slot positions in segment
+ * bundles must be deterministic from build-time config. HasRuntimePrefetch
+ * instead marks runtime completeness: a runtime request may still be needed
+ * for the segment, but the scheduler may attempt a static prefetch first
+ * (per the ShouldAttemptStaticPrefetch hint) and skip the runtime request if
+ * the static response proves sufficient.
  *
  * Usage: `(hints & StaticPrefetchDisabled) !== 0`
  */
-export const StaticPrefetchDisabled =
-  PrefetchHint.HasRuntimePrefetch | PrefetchHint.PrefetchDisabled
+export const StaticPrefetchDisabled = PrefetchHint.PrefetchDisabled
 
 /**
  * The subset of PrefetchHint bits that propagate upward from a child segment to

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -27,17 +27,21 @@ describe('App Shell prefetching', () => {
 
     // Reveal the LinkAccordion for /posts/1. This caches the App Shell
     // for the route — the param-independent content of the page that's
-    // reusable for any /posts/[id]. The link uses the default (auto)
-    // prefetch, so under App Shells it prefetches only the shared shell;
-    // the per-link Speculative prefetch is skipped.
-    await act(
-      async () => {
-        await browser
-          .elementByCss('input[data-link-accordion="/posts/1"]')
-          .click()
-      },
-      { includes: 'App shell for posts' }
-    )
+    // reusable for any /posts/[id].
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/posts/1"]')
+        .click()
+    }, [
+      // Two runtime responses carry the shell text, in order: the Shell
+      // phase's runtime App Shell request, then the Speculative phase's
+      // batched per-link runtime prefetch. The route reads request data,
+      // so its static-attempt hint is unset and the prefetch deopts to
+      // runtime requests — the runtime-completeness contract of Partial
+      // Prefetching routes.
+      { includes: 'App shell for posts', kind: 'runtime' },
+      { includes: 'App shell for posts', kind: 'runtime' },
+    ])
 
     await act(async () => {
       // Click the link to /posts/124. This link is rendered with
@@ -66,7 +70,7 @@ describe('App Shell prefetching', () => {
     )
   })
 
-  it('skips the per-link Speculative prefetch for a non-eager (allow-runtime) route', async () => {
+  it('runtime-prefetches per-link content of a dynamic route whose static-attempt hint is unset', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       beforePageLoad(p: Playwright.Page) {
@@ -75,27 +79,42 @@ describe('App Shell prefetching', () => {
     })
     const act = createRouterAct(page, { includeAppShellRequests: true })
 
-    // Reveal /posts/1 (default/auto prefetch). The route is allow-runtime, which
-    // is NOT eager, so under App Shells only the shared App Shell is prefetched.
+    // Reveal /posts/1 (default/auto prefetch). The page itself is partial
+    // (non-eager), but the path segments above it are eager, so the
+    // Speculative pass still walks them. Unlike /partial (covered by the
+    // next test), this route is dynamic — it reads cookies — so its
+    // static-attempt hint is unset and the walked segments deopt to a
+    // per-link runtime prefetch, which serves the whole subtree, page
+    // included.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/posts/1"]')
+        .click()
+    }, [
+      // Two runtime responses carry the shell text, in order: the Shell
+      // phase's runtime App Shell request, then the Speculative phase's
+      // batched per-link runtime prefetch. The route reads request data,
+      // so its static-attempt hint is unset and the prefetch deopts to
+      // runtime requests — the runtime-completeness contract of Partial
+      // Prefetching routes.
+      { includes: 'App shell for posts', kind: 'runtime' },
+      { includes: 'App shell for posts', kind: 'runtime' },
+    ])
+
+    // Reveal /posts/2 — a different param that shares the same App Shell.
+    // The shell is already cached and is not re-fetched, but the hint-unset
+    // deopt issues a runtime prefetch for the new param's subtree, so the
+    // per-link content for param 2 arrives ahead of any navigation.
+    // Contrast with the /partial route in the next test, whose hint is set:
+    // there the cached shell satisfies the second link with no requests.
     await act(
       async () => {
         await browser
-          .elementByCss('input[data-link-accordion="/posts/1"]')
+          .elementByCss('input[data-link-accordion="/posts/2"]')
           .click()
       },
-      { includes: 'App shell for posts' }
+      { includes: 'Post 2', kind: 'runtime' }
     )
-
-    // Reveal /posts/2 — a different param that shares the same App Shell. The
-    // shell is already cached and the per-link Speculative prefetch is skipped,
-    // so this fires NO requests at all. This is the clearest signal that the
-    // Speculative phase was skipped: a subsequent link to the same route needs
-    // nothing from the server.
-    await act(async () => {
-      await browser
-        .elementByCss('input[data-link-accordion="/posts/2"]')
-        .click()
-    }, 'no-requests')
   })
 
   it('skips the per-link Speculative prefetch for a route with prefetch = "partial"', async () => {
@@ -300,14 +319,20 @@ describe('App Shell prefetching', () => {
     // shell, and one with a stale time of 60 seconds, which is excluded from
     // the shell so the shell can be reused on the client for longer than the
     // content's stale time.
-    await act(
-      async () => {
-        await browser
-          .elementByCss('input[data-link-accordion="/short-stale/1"]')
-          .click()
-      },
-      { includes: 'App shell for short-stale' }
-    )
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/short-stale/1"]')
+        .click()
+    }, [
+      // Two runtime responses carry the shell text, in order: the Shell
+      // phase's runtime App Shell request, then the Speculative phase's
+      // batched per-link runtime prefetch. The route reads request data,
+      // so its static-attempt hint is unset and the prefetch deopts to
+      // runtime requests — the runtime-completeness contract of Partial
+      // Prefetching routes.
+      { includes: 'App shell for short-stale', kind: 'runtime' },
+      { includes: 'App shell for short-stale', kind: 'runtime' },
+    ])
 
     await act(async () => {
       // Click the link to /short-stale/124. This link is rendered with
@@ -419,16 +444,28 @@ describe('App Shell prefetching', () => {
       // reusable for any /with-root-param/en/posts/[id]. The link uses the default (auto)
       // prefetch, so under App Shells it prefetches only the shared shell;
       // the per-link Speculative prefetch is skipped.
-      await act(
-        async () => {
-          await browser
-            .elementByCss(
-              'input[data-link-accordion="/with-root-param/en/posts/1"]'
-            )
-            .click()
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/with-root-param/en/posts/1"]'
+          )
+          .click()
+      }, [
+        // Two runtime responses carry the shell text, in order: the Shell
+        // phase's runtime App Shell request, then the Speculative phase's
+        // batched per-link runtime prefetch. The route reads request data,
+        // so its static-attempt hint is unset and the prefetch deopts to
+        // runtime requests — the runtime-completeness contract of Partial
+        // Prefetching routes.
+        {
+          includes: 'App shell for posts with root param: en',
+          kind: 'runtime',
         },
-        { includes: 'App shell for posts with root param: en' }
-      )
+        {
+          includes: 'App shell for posts with root param: en',
+          kind: 'runtime',
+        },
+      ])
 
       await act(async () => {
         // Click the link to /with-root-param/en/posts/124. This link is rendered with
@@ -528,16 +565,23 @@ describe('App Shell prefetching', () => {
       // reads request-time data (cookies), so its App Shell is a runtime shell.
       // The root param is available when the shell is prerendered, so it's
       // captured in the cached shell.
-      await act(
-        async () => {
-          await browser
-            .elementByCss(
-              'input[data-link-accordion="/with-root-param/en/root-param-via-params/with-session-data"]'
-            )
-            .click()
-        },
-        { includes: 'App shell for page with root param: en' }
-      )
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/with-root-param/en/root-param-via-params/with-session-data"]'
+          )
+          .click()
+      }, [
+        // Two runtime responses carry the shell text, in order: the Shell
+        // phase's runtime App Shell request, then the Speculative phase's
+        // per-link runtime prefetch (the page reads cookies, so the hint
+        // is unset and the prefetch deopts to a runtime request). Unlike
+        // the /posts routes, no static bundle fetch fires in between: the
+        // page has no non-root params, so its runtime App Shell entry is
+        // already as complete as any static response could be.
+        { includes: 'App shell for page with root param: en' },
+        { includes: 'App shell for page with root param: en' },
+      ])
 
       await act(async () => {
         // Navigate by clicking the link we just revealed. Only the App Shell
@@ -637,16 +681,28 @@ describe('App Shell prefetching', () => {
       // reusable for any /with-root-param/en/posts/[id]. The link uses the default (auto)
       // prefetch, so under App Shells it prefetches only the shared shell;
       // the per-link Speculative prefetch is skipped.
-      await act(
-        async () => {
-          await browser
-            .elementByCss(
-              'input[data-link-accordion="/with-root-param/en/posts/1"]'
-            )
-            .click()
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/with-root-param/en/posts/1"]'
+          )
+          .click()
+      }, [
+        // Two runtime responses carry the shell text, in order: the Shell
+        // phase's runtime App Shell request, then the Speculative phase's
+        // batched per-link runtime prefetch. The route reads request data,
+        // so its static-attempt hint is unset and the prefetch deopts to
+        // runtime requests — the runtime-completeness contract of Partial
+        // Prefetching routes.
+        {
+          includes: 'App shell for posts with root param: en',
+          kind: 'runtime',
         },
-        { includes: 'App shell for posts with root param: en' }
-      )
+        {
+          includes: 'App shell for posts with root param: en',
+          kind: 'runtime',
+        },
+      ])
 
       await act(async () => {
         const startingUrl = await browser.url()
@@ -687,16 +743,28 @@ describe('App Shell prefetching', () => {
       // shell.
       await browser.back()
 
-      await act(
-        async () => {
-          await browser
-            .elementByCss(
-              'input[data-link-accordion="/with-root-param/fr/posts/1"]'
-            )
-            .click()
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/with-root-param/fr/posts/1"]'
+          )
+          .click()
+      }, [
+        // Two runtime responses carry the shell text, in order: the Shell
+        // phase's runtime App Shell request, then the Speculative phase's
+        // batched per-link runtime prefetch. The route reads request data,
+        // so its static-attempt hint is unset and the prefetch deopts to
+        // runtime requests — the runtime-completeness contract of Partial
+        // Prefetching routes.
+        {
+          includes: 'App shell for posts with root param: fr',
+          kind: 'runtime',
         },
-        { includes: 'App shell for posts with root param: fr' }
-      )
+        {
+          includes: 'App shell for posts with root param: fr',
+          kind: 'runtime',
+        },
+      ])
 
       await act(async () => {
         // Navigate to an unprefetched post that shares the "fr" shell. The

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -31,6 +31,11 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
+          <LinkAccordion href="/test-runtime-bailout" prefetch={true}>
+            Runtime bailout (prefetch=true)
+          </LinkAccordion>
+        </li>
+        <li>
           <LinkAccordion href="/test-stale-hints/nested/deep">
             Stale hints
           </LinkAccordion>

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/layout.tsx
@@ -1,9 +1,10 @@
 import { ReactNode, Suspense } from 'react'
 
 // Small static layout. With prefetch inlining enabled, this layout's data
-// should be bundled into the child's response. But since the child page uses
-// runtime prefetching, the bundle needs to be flushed as a separate static
-// prefetch instead.
+// should be bundled into the child's response. The child page uses runtime
+// prefetching (allow-runtime), but it still has a static response — the
+// static parts that don't depend on runtime data — so the layout inlines
+// into that bundle.
 export default function RuntimeBailoutLayout({
   children,
 }: {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -537,17 +537,17 @@ describe('prefetch inlining', () => {
     )
   })
 
-  it('runtime prefetch: layout cannot inline into a runtime leaf', async () => {
-    // Root → small static layout → page with runtime prefetch. Root inlines
-    // into the layout (the layout accepts root's data). But the layout
-    // cannot inline into the runtime page — the page is a leaf with no
-    // static descendants, so there's no response to carry the layout's data.
-    // The layout remains outlined while root is inlined into it.
+  it('runtime prefetch: layout inlines into an allow-runtime leaf; content arrives via the batched runtime prefetch', async () => {
+    // Root → small static layout → page with runtime prefetch. The
+    // allow-runtime page has a static response — the parts of the page that
+    // don't depend on runtime data — so the build inlining pass can inline
+    // the static layout into the page's bundle. The whole chain collapses:
+    // root inlines into the layout, and the layout inlines into the page.
     const data = await fetchRouteTreePrefetch(next, '/test-runtime-bailout')
     expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
      "
               ⇣  root
-     outlined ■  └── "test-runtime-bailout"
+              ⇣  └── "test-runtime-bailout"
       runtime ◻      └── "__PAGE__" (+metadata)
      "
     `)
@@ -560,22 +560,43 @@ describe('prefetch inlining', () => {
     })
     const act = createRouterAct(page!)
 
+    // Reveal a default (auto) link to the route. The page is allow-runtime,
+    // so the prefetch attempts a static fetch first and, on discovering that
+    // the page needs runtime data, resorts to a runtime prefetch rooted at
+    // the layout. The runtime response serves the whole subtree, so the
+    // inlined layout content arrives in it. No separate static bundle
+    // request fires: once the entries in the bundle chain are runtime-
+    // complete, a runtime-prefetchable segment is never re-fetched by a
+    // static prefetch.
     await act(
       async () => {
         await browser
-          .elementByCss('input[data-link-accordion="/test-runtime-bailout"]')
+          .elementByCss(
+            'input[data-prefetch="auto"]' +
+              '[data-link-accordion="/test-runtime-bailout"]'
+          )
           .click()
       },
-      { includes: 'Static layout content' }
+      { includes: 'Static layout content', kind: 'runtime' }
     )
 
-    // Navigate to the route. The static layout was prefetched (and is cached),
-    // but the runtime leaf page has no static descendants and is not
-    // speculatively prefetched under App Shells — it is fetched here, on
-    // navigation.
+    // Reveal a prefetch={true} link to the same route. Everything is
+    // already runtime-cached at the per-link tier by the prefetch above, so
+    // opting in has nothing left to fetch.
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-prefetch="true"]' +
+            '[data-link-accordion="/test-runtime-bailout"]'
+        )
+        .click()
+    }, 'no-requests')
+
+    // Navigate to the route. The prefetches fetched everything, so the
+    // navigation is served entirely from the cache.
     await act(async () => {
       await browser.elementByCss('a[href="/test-runtime-bailout"]').click()
-    })
+    }, 'no-requests')
 
     expect(await browser.elementByCss('#layout-runtime-bailout').text()).toBe(
       'Static layout content'
@@ -598,9 +619,9 @@ describe('prefetch inlining', () => {
     expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
      "
               ⇣  root
-      runtime ◻  └── "test-runtime-passthrough" (+metadata)
+      runtime ◻  └── "test-runtime-passthrough"
               ⇣      └── "inner"
-     outlined ■          └── "__PAGE__"
+     outlined ■          └── "__PAGE__" (+metadata)
      "
     `)
 
@@ -612,21 +633,22 @@ describe('prefetch inlining', () => {
     })
     const act = createRouterAct(page!)
 
-    await act(async () => {
-      await browser
-        .elementByCss(
-          'input[data-link-accordion="/test-runtime-passthrough/inner"]'
-        )
-        .click()
-    }, [
-      { includes: 'Static page below runtime layout' },
-      // Appears twice: once in the static bundle and once in the
-      // runtime prefetch. Static segments below a runtime layout are
-      // not skipped — they participate in inlining normally because
-      // sub-navigations within the runtime layout may need them. The
-      // inlining thresholds ensure the duplication is worth the cost.
-      { includes: 'Static page below runtime layout' },
-    ])
+    await act(
+      async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/test-runtime-passthrough/inner"]'
+          )
+          .click()
+      },
+      // The runtime prefetch rooted at the runtime layout serves the whole
+      // subtree — the static inner layout and page ride along in that
+      // single runtime response. The static bundle is not fetched a second
+      // time: once the entries in the bundle chain are runtime-complete, a
+      // runtime-prefetchable segment is never re-fetched by a static
+      // prefetch, so the content arrives exactly once.
+      { includes: 'Static page below runtime layout', kind: 'runtime' }
+    )
 
     await act(async () => {
       await browser
@@ -696,9 +718,9 @@ describe('prefetch inlining', () => {
     expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
      "
               ⇣  root
-      runtime ◻  └── "test-runtime-parallel" (+metadata)
+      runtime ◻  └── "test-runtime-parallel"
               ⇣      ├── "inner"
-     outlined ■      │   └── "__PAGE__"
+     outlined ■      │   └── "__PAGE__" (+metadata)
      outlined ■      └── @sidebar/"__DEFAULT__"
      "
     `)
@@ -711,19 +733,20 @@ describe('prefetch inlining', () => {
     })
     const act = createRouterAct(page!)
 
-    await act(async () => {
-      await browser
-        .elementByCss(
-          'input[data-link-accordion="/test-runtime-parallel/inner"]'
-        )
-        .click()
-    }, [
-      { includes: 'Runtime parallel main content' },
-      // Appears twice: static bundle + runtime prefetch. Same as
-      // runtime passthrough — static segments below a runtime layout
-      // participate in inlining normally.
-      { includes: 'Runtime parallel main content' },
-    ])
+    await act(
+      async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/test-runtime-parallel/inner"]'
+          )
+          .click()
+      },
+      // Same as the runtime passthrough test: the runtime prefetch serves
+      // the whole subtree (both slots) in a single runtime response, and
+      // the runtime-complete entries are not re-fetched by a static bundle
+      // request — the content arrives exactly once.
+      { includes: 'Runtime parallel main content', kind: 'runtime' }
+    )
 
     await act(async () => {
       await browser
@@ -736,30 +759,26 @@ describe('prefetch inlining', () => {
     )
   })
 
-  it('independent head: param-dependent head is deferred to navigation, not speculatively prefetched', async () => {
+  it('independent head: param-dependent head rides along with the runtime prefetch', async () => {
     // The layout at /test-independent-head/[item] uses runtime prefetching
     // (reads cookies). The pages underneath it are static. The metadata
     // (head) accesses both the [item] param and searchParams, making it
     // depend on runtime data.
     //
-    // When we prefetch route A, the runtime layout and head are fetched
-    // together (the layout is a runtime segment in the new part of the
-    // tree, so a runtime request happens and the head rides along). When
-    // we then prefetch sibling route B, the runtime layout is already
-    // shared and cached, so the new part of the tree (the [item] page) is
-    // fully static and needs no runtime request. Because the head is
-    // param-dependent it is NOT part of the reusable App Shell, and we do
-    // not spawn a standalone runtime request just to prefetch it — it is
-    // deferred to navigation. This test verifies that a speculative
-    // per-link prefetch fetches the static page but not the param-dependent
-    // head.
+    // Because the route contains a runtime-prefetchable layout, each
+    // per-link prefetch resorts to a runtime prefetch for the parts that
+    // can't be served statically. The head is param-dependent, so it is
+    // NOT part of the reusable App Shell — but whenever a runtime prefetch
+    // fires for a segment, the head rides along in the same request. So
+    // each prefetched sibling gets its own param-specific head ahead of
+    // the navigation, without a standalone head request.
     const data = await fetchRouteTreePrefetch(next, '/test-independent-head/a')
     expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
      "
               ⇣  root
-      runtime ◻  └── "test-independent-head" (+metadata)
+      runtime ◻  └── "test-independent-head"
               ⇣      └── "item"
-     outlined ■          └── "__PAGE__"
+     outlined ■          └── "__PAGE__" (+metadata)
      "
     `)
 
@@ -772,7 +791,8 @@ describe('prefetch inlining', () => {
     const act = createRouterAct(page!)
 
     // Prefetch and navigate to route A. This caches the runtime layout,
-    // head, and static page, and makes A the current page.
+    // the static page, and A's head (riding along with the runtime
+    // prefetch), and makes A the current page.
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/test-independent-head/a"]')
@@ -784,33 +804,26 @@ describe('prefetch inlining', () => {
 
     // Now we're on route A. Reveal the sibling link to route B. The
     // runtime layout is shared between A and B, so it's already cached
-    // and won't be re-fetched. The only new segment is the [item] page,
-    // which is static, so it IS prefetched. But the head depends on the
-    // [item] param (and searchParams), so it is param-dependent and is NOT
-    // part of the App Shell. Under App Shells, a speculative per-link
-    // prefetch does not request the param-dependent head — it is deferred
-    // to navigation. So the static page is prefetched here, but the title
-    // for B is not.
+    // and won't be re-fetched. The only new segment is the [item] page.
+    // The prefetch resorts to a runtime request for it, and B's
+    // param-specific head rides along in the same request — no standalone
+    // head request is spawned.
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/test-independent-head/b"]')
         .click()
     }, [
-      // The static page below the runtime layout is prefetched.
-      { includes: 'page-independent-head' },
-      // The param-dependent head must NOT be prefetched — it is not part
-      // of the App Shell and arrives on navigation instead.
-      { includes: 'Independent Head Title: b', block: 'reject' },
+      // The page below the runtime layout arrives via the runtime prefetch.
+      { includes: 'page-independent-head', kind: 'runtime' },
+      // ...and B's head rides along in the same runtime response.
+      { includes: 'Independent Head Title: b', kind: 'runtime' },
     ])
 
-    // Navigate to route B. The param-dependent head was not prefetched, so
-    // it is fetched now, on navigation.
-    await act(
-      async () => {
-        await browser.elementByCss('a[href="/test-independent-head/b"]').click()
-      },
-      { includes: 'Independent Head Title: b' }
-    )
+    // Navigate to route B. Everything, including the param-dependent head,
+    // was prefetched, so the navigation is served entirely from the cache.
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-independent-head/b"]').click()
+    }, 'no-requests')
 
     expect(await browser.elementByCss('#page-independent-head').text()).toBe(
       'Independent head page'

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/dynamic-param/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/dynamic-param/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+
+type Params = { slug: string }
+
+// A fully static dynamic route: every param value is known via
+// `generateStaticParams` and the page accesses no runtime data, so each URL
+// is prerendered at build time and the route tree prefetch always carries
+// the static-prefetch hint — the Shell phase attempts static per-segment
+// prefetches for any URL of this route.
+//
+// The param-dependent content sits past the shell boundary of each
+// prerender, so the App Shell — everything above it — is identical for every
+// param value and is cached at a param-agnostic key. Prefetching ONE URL of
+// the route therefore populates shell entries that are cache hits for every
+// sibling URL: that cross-param reuse is what the consuming test pins.
+export async function generateStaticParams() {
+  return [{ slug: 'one' }, { slug: 'two' }]
+}
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <p id="page-content">Dynamic-param page shell text</p>
+      <Suspense fallback={<p id="slug-loading">Loading param content...</p>}>
+        <SlugContent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function SlugContent({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  return <p id="slug-content">{`Dynamic param content: ${slug}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/fully-static/page.tsx
@@ -1,0 +1,17 @@
+// A page that accesses no runtime data at all: no cookies, headers,
+// searchParams, params, or `connection()`. Every prerender of this route is
+// clean, so its route tree prefetch always carries the static-prefetch hint,
+// and the static per-segment responses are always complete (a runtime
+// request would return nothing more).
+//
+// Note the Shell phase is always permitted to issue a runtime shell request,
+// so the absence of one in the test is attributable to the static shell
+// attempt succeeding, not to configuration forbidding runtime requests.
+
+export default function Page() {
+  return (
+    <main>
+      <p id="page-content">Fully static page content</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>Root layout static text</div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/page.tsx
@@ -1,0 +1,54 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <p>
+        Each link below points to a route that exercises a different combination
+        of the static-prefetch hint on the route tree and the per-segment
+        sufficiency signal. The links are hidden behind LinkAccordion checkboxes
+        so the tests control exactly when each prefetch fires.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/fully-static">Fully static</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/uses-cookies">Uses cookies</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/uses-search-params?q=test">
+            Uses search params
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/uses-connection">Uses connection</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/dynamic-param/one">
+            Dynamic param one
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/dynamic-param/two">
+            Dynamic param two
+          </LinkAccordion>
+        </li>
+        {/* The speculative-* routes are allow-runtime (non-eager), so their
+            links use prefetch={true} to opt into the Speculative phase —
+            otherwise only their App Shell would be prefetched. */}
+        <li>
+          <LinkAccordion href="/speculative-static" prefetch={true}>
+            Speculative static
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/speculative-cookies" prefetch={true}>
+            Speculative cookies
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/layout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react'
+import { NoInline } from '../../components/no-inline'
+
+// A static layout inflated past the inlining size threshold so it stays
+// OUTLINED — it gets its own standalone static response instead of being
+// bundled into the page's. Without it, this route's small intermediate
+// segments would be bundled into the allow-runtime page's static response,
+// and fetching THEM statically would deliver the page's content along for
+// the ride — which would make the consuming test's "the page content must
+// not arrive in any static response" rejection indistinguishable from a
+// genuine static prefetch attempt of the page. Keeping the page's static
+// response to itself preserves what that rejection pins: with the hint
+// unset, the page segment is never statically prefetched.
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <NoInline />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// The Speculative-phase counterpart of app/uses-cookies/page.tsx: the page
+// reads cookies directly in the shell stage of every prerender, so the
+// route tree prefetch never carries the static-prefetch hint. With
+// RUNTIME prefetching enabled (`allow-runtime`) the page segment requires
+// runtime-completeness during the Speculative phase (which the consuming
+// test enters via a `prefetch={true}` link), and with the hint unset the
+// scheduler skips the static attempt entirely and issues the runtime
+// prefetch directly. Unlike the uses-cookies fixture, the runtime prefetch
+// of an allow-runtime segment RESOLVES the cookies() read, so the
+// cookie-derived content itself arrives in the runtime response.
+export const prefetch = 'allow-runtime'
+
+async function CookieContent() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return (
+    <div id="speculative-cookie-content">{`Speculative-cookies cookie: ${value}`}</div>
+  )
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="page-content">Speculative-cookies page shell text</p>
+      <Suspense
+        fallback={
+          <p id="speculative-cookie-loading">Loading speculative cookie...</p>
+        }
+      >
+        <CookieContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-static/page.tsx
@@ -1,0 +1,24 @@
+// The Speculative-phase counterpart of app/fully-static/page.tsx: a page
+// that accesses no runtime data at all, but opts into RUNTIME prefetching
+// (`allow-runtime`). Such a segment requires runtime-completeness in every
+// phase, and the Speculative phase only processes it when a link opts in
+// (the consuming test uses `prefetch={true}`; non-eager routes are otherwise
+// shell-only by design).
+//
+// Every prerender of this route is clean, so the route tree prefetch always
+// carries the static-prefetch hint: the Speculative phase attempts a static
+// prefetch of this segment instead of going straight to a runtime one. The
+// static responses are always complete (a runtime request would return
+// nothing more), so the attempt is sufficient and no runtime request fires
+// at all — even though the segment is configured for runtime prefetching.
+// (Note this relies on the server emitting static data for allow-runtime
+// segments, which it now does unconditionally.)
+export const prefetch = 'allow-runtime'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="page-content">Speculative-static page content</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-connection/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-connection/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// A page whose only non-static data source is `connection()`. Unlike cookies
+// or searchParams, `connection()` is *dynamic* data: it hangs during runtime
+// prerenders too, and its hole can only be filled by the navigation-time
+// dynamic request. It is therefore NOT recorded as a runtime-data access:
+// the route tree prefetch carries the static-prefetch hint, and the static
+// per-segment response — although partial — is sufficient (a runtime
+// prefetch would have the exact same hole), so no runtime fallback should
+// fire.
+
+async function DynamicContent() {
+  await connection()
+  return <div id="connection-content">Connection content</div>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="page-content">Connection page shell text</p>
+      <Suspense
+        fallback={<p id="connection-loading">Loading connection content...</p>}
+      >
+        <DynamicContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-cookies/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// A page that reads cookies directly in the shell: every prerender records a
+// runtime-data access during its shell stage, so the route tree prefetch
+// never carries the static-prefetch hint. The client should go straight to a
+// runtime shell prefetch without attempting a static one.
+
+async function CookieContent() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return <div id="cookie-content">{`Cookie value: ${value}`}</div>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="page-content">Cookies page shell text</p>
+      <Suspense fallback={<p id="cookie-loading">Loading cookie...</p>}>
+        <CookieContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-search-params/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+
+// A page that observes its searchParams: like cookies, search params hang
+// during a static prerender but resolve during a runtime one, so observing
+// them is recorded as a runtime-data access in the shell stage of every
+// prerender. The route tree prefetch never carries the static-prefetch hint
+// and the client should go straight to a runtime shell prefetch without
+// attempting a static one.
+
+async function SearchContent({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  return <div id="search-content">{`Query: ${q ?? 'none'}`}</div>
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  return (
+    <main>
+      <p id="page-content">Search params page shell text</p>
+      <Suspense fallback={<p id="search-loading">Loading query...</p>}>
+        <SearchContent searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/components/link-accordion.tsx
@@ -8,7 +8,7 @@ export function LinkAccordion({
   children,
   prefetch,
 }: {
-  href: LinkProps['href']
+  href: string
   children: React.ReactNode
   prefetch?: LinkProps['prefetch']
 }) {
@@ -20,30 +20,14 @@ export function LinkAccordion({
         checked={isVisible}
         onChange={() => setIsVisible(!isVisible)}
         data-link-accordion={href}
-        data-prefetch={getPrefetchKind(prefetch)}
       />
       {isVisible ? (
         <Link href={href} prefetch={prefetch}>
           {children}
         </Link>
       ) : (
-        `${children} (link is hidden)`
+        <>{children} (link is hidden)</>
       )}
     </>
   )
-}
-
-function getPrefetchKind(prefetch: LinkProps['prefetch']) {
-  switch (prefetch) {
-    case false:
-      return 'disabled'
-    case undefined:
-    case null:
-    case 'auto':
-      return 'auto'
-    case true:
-      return 'true'
-    default:
-      prefetch satisfies never
-  }
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/components/no-inline.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/components/no-inline.tsx
@@ -1,0 +1,23 @@
+'use cache'
+
+import { gzipSync } from 'zlib'
+import { randomBytes } from 'crypto'
+
+// Default size is 2 KB, the threshold used by Next to decide whether to inline
+// a segment into the route tree prefetch.
+export async function NoInline({ size = 2048 }: { size?: number }) {
+  let content = ''
+  let compressedLength = 0
+  let iterations = 0
+  while (compressedLength < size) {
+    const chunk =
+      iterations % 2 === 0
+        ? '**Arbitrary hidden content to prevent this component from being inlined** '
+        : randomBytes(128).toString('base64') + ' '
+    content += chunk
+    compressedLength = gzipSync(content).length
+    iterations++
+    if (iterations > 10000) break
+  }
+  return <div style={{ display: 'none' }}>{content}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  // Opt every route into Partial Prefetching globally: segments without a
+  // per-segment `prefetch` export default to 'partial'. The speculative-*
+  // fixtures override this with `prefetch = 'allow-runtime'`.
+  partialPrefetching: true,
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
@@ -1,0 +1,416 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+// This suite tests the static App Shell prefetch attempt.
+//
+// When a route's tree prefetch response carries the static-prefetch hint —
+// set iff the render that produced the tree accessed NO runtime data
+// (cookies, headers, searchParams, fallback params) — the client's Shell
+// prefetch phase attempts STATIC per-segment prefetches of the App Shell
+// instead of the runtime shell request it would otherwise issue. Each static
+// response signals whether a runtime request would return more than it did,
+// and when the responses arrive the scheduler checks that signal for each
+// shell segment:
+//
+// - If every shell segment is sufficient, the Shell phase completes with no
+//   runtime request. A segment can be sufficient even when it's partial, as
+//   long as its holes are *dynamic* (only fillable by the navigation-time
+//   dynamic request, e.g. `connection()`), not *runtime* (fillable by a
+//   runtime prefetch, e.g. cookies).
+// - If any shell segment is insufficient, the existing single batched
+//   runtime shell prefetch fires as a fallback. The attempt is serial,
+//   never raced: static attempt → observe → runtime only if needed.
+//
+// If the hint is unset, the client goes straight to the runtime shell
+// request (previous behavior).
+//
+// All of the above concerns the NEW part of the target tree — the segments
+// that differ from the current page. Segments shared with the current page
+// are outside the shell-attempt machinery entirely: the shared part of the
+// tree always performs the ordinary static per-segment prefetch, in every
+// phase, regardless of the hint — mirroring how runtime requests also cover
+// only the new part. In this suite the shared part is always just the root
+// layout (every link is prefetched from the home page), and its cache entry
+// is already populated from the initial page load's seed data, so the shared
+// walk is a cache hit and no request fires for it. What the tests can pin is
+// the other half of the model: runtime requests never cover the shared part
+// (see the layout rejection in the cookies test).
+//
+// The hint reflects the WHOLE render that produced the tree: any runtime-
+// data access unsets it, no matter how late in the render the access
+// happened. The per-segment signal is finer-grained: the shell variant of a
+// segment response covers only what rendered during the shell stage, so an
+// access recorded after that stage leaves the shell variant clean ("no
+// runtime request needed for the shell") even though the full response
+// records it.
+//
+// This suite asserts directly on App Shell prefetch responses, so every
+// `createRouterAct` call passes `{ includeAppShellRequests: true }` — by
+// default router-act excludes runtime shell requests from assertions.
+// Expectations additionally use `kind: 'static' | 'runtime'` to assert HOW a
+// piece of content arrived: 'static' matches per-segment static prefetch
+// requests (including the route tree prefetch), 'runtime' matches dynamic
+// prefetch requests (e.g. the runtime shell request).
+describe('static App Shell prefetch attempt', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    // The feature depends on build-time prerenders and ISR regeneration
+    // semantics that don't exist in dev.
+    it('is skipped', () => {})
+    return
+  }
+
+  it('prefetches a fully static route with static requests only, then navigates instantly from cache', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /fully-static. The route accesses no
+    // runtime data, so its tree carries the static-prefetch hint and the
+    // Shell phase attempts static per-segment prefetches. The static
+    // responses are complete, so no runtime shell request fires.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/fully-static"]')
+        .click()
+    }, [
+      // The shell content arrives in a static per-segment response...
+      { includes: 'Fully static page content', kind: 'static' },
+      // ...and must NOT arrive in a runtime prefetch response — the
+      // static attempt was sufficient, so no runtime request fires.
+      {
+        includes: 'Fully static page content',
+        kind: 'runtime',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to the prefetched route. Everything was cached by the static
+    // prefetch, so the navigation completes without any requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/fully-static"]').click()
+      expect(await browser.elementById('page-content').text()).toBe(
+        'Fully static page content'
+      )
+    }, 'no-requests')
+  })
+
+  it('goes straight to a runtime shell prefetch when the shell reads cookies (hint unset)', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /uses-cookies. The page reads cookies in
+    // the shell stage of every prerender, so the tree hint is unset and the
+    // Shell phase issues the runtime shell request for the new part of the
+    // tree directly, with no static shell attempt preceding it. (The shared
+    // part — the root layout — is outside the hint's scope: it always gets
+    // the ordinary static prefetch, which here is a cache hit against the
+    // initial page load's seed data, so no request fires for it.)
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/uses-cookies"]')
+        .click()
+    }, [
+      // The page (the new part) arrives in the runtime shell response.
+      // (The bare cookies() read itself isn't resolved by the runtime
+      // prerender — it stays a hole for the navigation-time dynamic
+      // request — so we only assert on the shell text.)
+      { includes: 'Cookies page shell text', kind: 'runtime' },
+      // No static attempt for the new part: the page content must not
+      // arrive in a static per-segment response. (The route tree prefetch
+      // is also `kind: 'static'`, but its response doesn't contain rendered
+      // page content, so it can't match this.)
+      {
+        includes: 'Cookies page shell text',
+        kind: 'static',
+        block: 'reject',
+      },
+      // The runtime shell request covers only the new part of the tree:
+      // the shared root layout's content must never arrive in a
+      // runtime response.
+      {
+        includes: 'Root layout static text',
+        kind: 'runtime',
+        block: 'reject',
+      },
+    ])
+  })
+
+  it('goes straight to a runtime shell prefetch when the shell reads searchParams (hint unset)', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /uses-search-params?q=test. Observing
+    // searchParams is a runtime-data access (search params hang during a
+    // static prerender but resolve during a runtime one), so like the
+    // cookies route the tree hint is unset and the Shell phase issues the
+    // runtime shell request directly.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/uses-search-params?q=test"]')
+        .click()
+    }, [
+      // The shell content arrives in the runtime shell response. (The
+      // query-dependent content is URL data, which is never part of an
+      // App Shell, so we only assert on the shell text.)
+      { includes: 'Search params page shell text', kind: 'runtime' },
+      // No static attempt for the new part preceded it.
+      {
+        includes: 'Search params page shell text',
+        kind: 'static',
+        block: 'reject',
+      },
+    ])
+  })
+
+  it('does not fall back to a runtime shell prefetch for a partial segment whose holes are dynamic (connection)', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /uses-connection. `connection()` is
+    // dynamic data (it hangs during runtime prerenders too), so it's not
+    // recorded as a runtime-data access: the tree hint is set, the static
+    // attempt fires, and although the page segment is partial, it's
+    // sufficient — a runtime prefetch would have the same hole. No runtime
+    // fallback fires.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/uses-connection"]')
+        .click()
+    }, [
+      { includes: 'Connection page shell text', kind: 'static' },
+      // Neither the shell nor the dynamic content may arrive in a runtime
+      // prefetch response — no runtime request should fire at all.
+      {
+        includes: 'Connection page shell text',
+        kind: 'runtime',
+        block: 'reject',
+      },
+      { includes: 'Connection content', kind: 'runtime', block: 'reject' },
+    ])
+
+    // Navigate. The prefetched shell renders instantly; the dynamic hole is
+    // filled by the navigation-time dynamic request, as always.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/uses-connection"]').click()
+
+        // While the navigation response is blocked (we're still inside the
+        // `act` scope), the prefetched shell is already visible, with the
+        // loading fallback in place of the dynamic content.
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Connection page shell text'
+        )
+        expect(await browser.elementById('connection-loading').text()).toBe(
+          'Loading connection content...'
+        )
+      },
+      // The dynamic content streams in with the navigation response.
+      { includes: 'Connection content' }
+    )
+    expect(await browser.elementById('connection-content').text()).toBe(
+      'Connection content'
+    )
+  })
+
+  it('reuses the static App Shell across different param values of a dynamic route', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /dynamic-param/one. Every URL of the
+    // route is prerendered at build time and accesses no runtime data, so
+    // the route tree prefetch carries the static-prefetch hint and the
+    // Shell phase attempts static per-segment prefetches. The static
+    // responses are sufficient, so no runtime request fires.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/dynamic-param/one"]')
+        .click()
+    }, [
+      // The shell content arrives in a static per-segment response. The
+      // response is the full prerender for this URL; the client extracts
+      // the param-agnostic shell prefix and caches it at a key shared by
+      // every param value of the route. (The response also carries this
+      // URL's param content — a fully static prerender isn't truncated —
+      // but that's incidental, so we don't assert on it.)
+      { includes: 'Dynamic-param page shell text', kind: 'static' },
+      // No runtime request fires — the static attempt was sufficient.
+      {
+        includes: 'Dynamic-param page shell text',
+        kind: 'runtime',
+        block: 'reject',
+      },
+    ])
+
+    // Reveal the LinkAccordion for /dynamic-param/two — a different param
+    // value of the same route. Everything this prefetch needs is already
+    // cached: the App Shell entries cached by the previous prefetch are
+    // param-agnostic, so they're cache hits for this URL too, and the
+    // earlier route tree prefetch also taught the client the route's shape
+    // and its statically-known param values, so even the target route is
+    // constructed locally. And because the route is non-eager, the per-URL
+    // content is left for the navigation-time dynamic request. So no request
+    // of any kind fires — in particular, nothing re-fetches the shared
+    // shell content.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/dynamic-param/two"]')
+        .click()
+    }, 'no-requests')
+
+    // Navigate to /dynamic-param/two. The App Shell reused from the other
+    // param's prefetch renders instantly, before the navigation response
+    // arrives; the param content streams in with the navigation response.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/dynamic-param/two"]').click()
+
+        // While the navigation response is blocked (we're still inside the
+        // `act` scope), the reused shell is already visible, with the
+        // loading fallback in place of the param content.
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Dynamic-param page shell text'
+        )
+        expect(await browser.elementById('slug-loading').text()).toBe(
+          'Loading param content...'
+        )
+      },
+      // The param content arrives with the navigation response.
+      { includes: 'Dynamic param content: two' }
+    )
+    expect(await browser.elementById('slug-content').text()).toBe(
+      'Dynamic param content: two'
+    )
+  })
+
+  // The two tests below exercise the SPECULATIVE half of the unified
+  // model: a segment with `prefetch = 'allow-runtime'` requires
+  // runtime-completeness in every phase, and the Speculative phase only
+  // processes such a segment when the link opts in (prefetch={true} — the
+  // speculative-* accordions on the home page set it; non-eager routes are
+  // otherwise shell-only by design). The same hint-gated attempt applies:
+  // hint set → the segment joins the normal static prefetch walk and each
+  // response's sufficiency signal decides whether the batched runtime
+  // fallback fires; hint unset → straight to the runtime prefetch. This
+  // relies on the server emitting static data for allow-runtime segments
+  // unconditionally.
+
+  it('speculative: prefetch={true} on an allow-runtime segment with the hint set prefetches statically with no runtime request', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the prefetch={true} LinkAccordion for /speculative-static. The
+    // route accesses no runtime data, so its tree carries the
+    // static-prefetch hint; both the Shell phase and the Speculative phase
+    // attempt static prefetches of the allow-runtime page segment, and the
+    // complete static responses make any runtime request unnecessary.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/speculative-static"]')
+        .click()
+    }, [
+      // The page content arrives in a static per-segment response...
+      { includes: 'Speculative-static page content', kind: 'static' },
+      // ...and must NOT arrive in a runtime prefetch response — the static
+      // attempt was sufficient, so neither the runtime shell request nor
+      // the Speculative phase's runtime prefetch fires, despite the
+      // segment's allow-runtime config.
+      {
+        includes: 'Speculative-static page content',
+        kind: 'runtime',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to the prefetched route. Everything was cached by the static
+    // prefetch, so the navigation completes without any requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/speculative-static"]').click()
+      expect(await browser.elementById('page-content').text()).toBe(
+        'Speculative-static page content'
+      )
+    }, 'no-requests')
+  })
+
+  it('speculative: goes straight to a runtime prefetch when the hint is unset', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the prefetch={true} LinkAccordion for /speculative-cookies. The
+    // page reads cookies in the shell stage of every prerender, so the tree
+    // hint is unset and the scheduler skips the static attempt entirely: the
+    // allow-runtime page segment is runtime prefetched directly, in both the
+    // Shell and Speculative phases.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/speculative-cookies"]')
+        .click()
+    }, [
+      // Two runtime responses arrive, in order, and each resolves the
+      // cookies() read (the runtime prefetch of an allow-runtime segment
+      // renders with the request's cookies):
+      //
+      // 1. The Shell phase's runtime shell request — the same direct
+      //    runtime shell behavior the hint-unset tests above exercise,
+      //    except that for an allow-runtime page the session content
+      //    resolves instead of remaining a hole.
+      { includes: 'Speculative-cookies page shell text', kind: 'runtime' },
+      { includes: 'Speculative-cookies cookie: none', kind: 'runtime' },
+      // 2. The Speculative phase's runtime prefetch of the page segment,
+      //    which re-delivers the page content. (It fires on top of the
+      //    runtime shell entry because a per-URL runtime prefetch can
+      //    provide content a URL-independent shell response cannot.)
+      { includes: 'Speculative-cookies page shell text', kind: 'runtime' },
+      { includes: 'Speculative-cookies cookie: none', kind: 'runtime' },
+      // No static attempt in either phase: the page content must not
+      // arrive in ANY static per-segment response. (The server does emit
+      // static data for allow-runtime segments — the shell text is in it —
+      // but with the hint unset nothing fetches it: this blanket rejection
+      // was verified empirically against the full request log. The route
+      // tree prefetch is also kind: 'static', but its response doesn't
+      // contain rendered page content, so it can't match this.)
+      {
+        includes: 'Speculative-cookies page shell text',
+        kind: 'static',
+        block: 'reject',
+      },
+    ])
+  })
+})

--- a/test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
@@ -751,14 +751,20 @@ describe('segment cache - vary params', () => {
       { includes: 'Page category:' }
     )
 
-    // Second prefetch: same category, different itemId.
-    // The page segment is a cache hit since it only varies on category.
-    await act(async () => {
-      const toggle = await browser.elementByCss(
-        'input[data-link-accordion="/runtime-prefetch-layout-split/electronics/tablet"]'
-      )
-      await toggle.click()
-    }, 'no-requests')
+    // Second prefetch: same category, different itemId. The page segment is a
+    // cache hit (it only varies on category), but the layout varies on itemId
+    // too, so it's a genuine miss and a runtime request is required for it.
+    // The page segment is not itself part of that batch — it rides along
+    // because rendering a segment on the server also renders its children.
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/runtime-prefetch-layout-split/electronics/tablet"]'
+        )
+        await toggle.click()
+      },
+      { includes: 'Layout: electronics/tablet' }
+    )
 
     // Different category triggers a new page segment fetch
     await act(

--- a/test/lib/router-act.ts
+++ b/test/lib/router-act.ts
@@ -16,6 +16,30 @@ import { equals } from '@jest/expect-utils'
 const NEXT_ROUTER_PREFETCH_HEADER = 'next-router-prefetch'
 const APP_SHELL_PREFETCH_VALUE = '3'
 
+// These headers/values classify each intercepted router request by the kind
+// of prefetch protocol it uses, so that expectations can assert on it via
+// the `kind` option:
+//
+// - 'static': per-segment static prefetches. These carry the
+//   `next-router-segment-prefetch` header (NEXT_ROUTER_SEGMENT_PREFETCH_HEADER
+//   in the client), which is sent both by the per-segment data fetch
+//   (`fetchSegmentsOnCacheMissImpl`) and the route tree fetch
+//   (`fetchRouteOnCacheMiss`).
+// - 'runtime': dynamic prefetch requests, issued by
+//   `fetchSegmentPrefetchesUsingDynamicRequest` in the client. These carry a
+//   FlightRouterState request tree and a `next-router-prefetch` header value
+//   of '2' (FetchStrategy.PPRRuntime) or '3' (FetchStrategy.RuntimeShell).
+//   The other strategies used by that path — LoadingBoundary ('1') and Full
+//   (no prefetch header) — send the same headers as plain prefetches and
+//   navigations respectively, so they cannot be demonstrably classified and
+//   are left unclassified.
+// - undefined: everything else — navigations, Server Actions, and plain
+//   prefetches. Expectations that specify a `kind` never claim these.
+const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER = 'next-router-segment-prefetch'
+const PPR_RUNTIME_PREFETCH_VALUE = '2'
+
+type ResponseKind = 'static' | 'runtime'
+
 type Batch = {
   pendingRequestChecks: Set<Promise<void>>
   pendingRequests: Set<PendingRSCRequest>
@@ -41,6 +65,10 @@ type PendingRSCRequest = {
   // assertion purposes (see note above). Always false when the caller passes
   // `includeAppShellRequests: true`.
   isAppShell: boolean
+  // The kind of prefetch protocol this request uses, derived from its headers
+  // (see the classification note above). undefined for navigations, Server
+  // Actions, and plain prefetches.
+  kind: ResponseKind | undefined
 }
 
 let currentBatch: Batch | null = null
@@ -48,6 +76,7 @@ let currentBatch: Batch | null = null
 type ExpectedResponseConfig = {
   includes: string
   block?: boolean | 'reject'
+  kind?: ResponseKind
 }
 
 /**
@@ -59,6 +88,16 @@ type ExpectedResponseConfig = {
  *   client. This option is only supported when nested inside an outer `act`
  *   scope. The blocked response will be fulfilled when the outer
  *   scope completes.
+ * - `kind` restricts which responses can satisfy the expectation, based on
+ *   the kind of prefetch request that produced them: 'static' matches only
+ *   per-segment static prefetches (those with a `next-router-segment-prefetch`
+ *   request header), and 'runtime' matches only dynamic prefetch requests
+ *   (those with a `next-router-prefetch` header value of '2' (PPRRuntime) or
+ *   '3' (RuntimeShell)). If omitted, any router response can satisfy the
+ *   expectation. Note that App Shell (RuntimeShell) responses are excluded
+ *   from assertion logic by default, so a `kind: 'runtime'` expectation that
+ *   should match an App Shell response additionally requires passing
+ *   `includeAppShellRequests: true` to `createRouterAct`.
  *
  * The list of expected responses does not need to be exhaustive — any
  * responses that don't match will proceed like normal. However, `act` will
@@ -292,6 +331,19 @@ export function createRouterAct(
           !includeAppShellRequests &&
           headers[NEXT_ROUTER_PREFETCH_HEADER] === APP_SHELL_PREFETCH_VALUE
 
+        // Classify the request by the kind of prefetch protocol it uses, so
+        // expectations can assert on it via the `kind` option. See the
+        // classification note at the top of this file.
+        let kind: ResponseKind | undefined
+        if (headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] !== undefined) {
+          kind = 'static'
+        } else if (
+          headers[NEXT_ROUTER_PREFETCH_HEADER] === PPR_RUNTIME_PREFETCH_VALUE ||
+          headers[NEXT_ROUTER_PREFETCH_HEADER] === APP_SHELL_PREFETCH_VALUE
+        ) {
+          kind = 'runtime'
+        }
+
         if (isRouterRequest) {
           // This request was initiated by the Next.js Router. Intercept it and
           // add it to the current batch.
@@ -299,6 +351,7 @@ export function createRouterAct(
             url: request.url(),
             route,
             isAppShell,
+            kind,
             // `act` controls the timing of when responses reach the client,
             // but it should not affect the timing of when requests reach the
             // server; we pass the request to the server the immediately.
@@ -441,6 +494,17 @@ export function createRouterAct(
 
       let claimedExpectations = new Set<ExpectedResponseConfig>()
 
+      // Expectations that specify a `kind` and whose expected substring did
+      // appear in a response — but a response of the wrong kind, so it could
+      // not be claimed. Maps the expectation to the kind of the response the
+      // substring appeared in (undefined for responses with no prefetch kind,
+      // like navigations). Used to produce a more helpful error message when
+      // such an expectation ends up unclaimed.
+      const wrongKindMatches = new Map<
+        ExpectedResponseConfig,
+        ResponseKind | undefined
+      >()
+
       while (batch.pendingRequests.size > 0) {
         const pending = batch.pendingRequests
         batch.pendingRequests = new Set()
@@ -488,12 +552,27 @@ ${fulfilled.body}
             }
             if (!item.isAppShell && forbiddenResponses !== null) {
               for (const forbiddenResponse of forbiddenResponses) {
+                // Like expectations, a rejection with `kind` only applies to
+                // responses of that kind: the same content may legitimately
+                // arrive in a response of a different kind (e.g. a test that
+                // asserts shell content arrives statically rejects it at
+                // kind: 'runtime' while claiming it at kind: 'static').
+                if (
+                  forbiddenResponse.kind !== undefined &&
+                  forbiddenResponse.kind !== item.kind
+                ) {
+                  continue
+                }
                 const includes = forbiddenResponse.includes
                 if (fulfilled.body.includes(includes)) {
                   error.message = `
 Received a response containing an unexpected substring:
 
-Rejected substring: ${includes}
+Rejected substring: ${includes}${
+                    forbiddenResponse.kind !== undefined
+                      ? `\nRejected kind: '${forbiddenResponse.kind}'`
+                      : ''
+                  }
 
 Response:
 ${fulfilled.body}
@@ -524,6 +603,25 @@ ${fulfilled.body}
                 const includes = expectedResponse.includes
                 const block = expectedResponse.block
                 if (!claimedExpectations.has(expectedResponse)) {
+                  if (
+                    expectedResponse.kind !== undefined &&
+                    expectedResponse.kind !== item.kind
+                  ) {
+                    // This expectation can only be claimed by a response of a
+                    // specific kind, and this response is a different kind. If
+                    // the expected substring nevertheless appears in this
+                    // response, remember that so we can include it in the
+                    // error message if the expectation ends up unclaimed.
+                    if (
+                      !wrongKindMatches.has(expectedResponse) &&
+                      entireResponseBody.includes(includes)
+                    ) {
+                      wrongKindMatches.set(expectedResponse, item.kind)
+                    }
+                    // Skip the duplicate-match check below — a wrong-kind
+                    // response is not a duplicate occurrence.
+                    continue
+                  }
                   // This expectation was not already claimed. Check if we
                   // can claim it.
                   if (remainingUnclaimedBody.includes(includes)) {
@@ -548,6 +646,19 @@ ${fulfilled.body}
                 // the server sent the same string multiple times. This is fine
                 // as long as there's a separate expectation for
                 // each occurrence.
+                //
+                // Like the unclaimed path above, a kind-scoped expectation
+                // only applies to responses of that kind: its substring
+                // appearing in a response of a different kind is not a
+                // duplicate occurrence. (E.g. shell content claimed at
+                // kind: 'static' may legitimately appear again in the
+                // runtime fallback response.)
+                if (
+                  expectedResponse.kind !== undefined &&
+                  expectedResponse.kind !== item.kind
+                ) {
+                  continue
+                }
                 if (
                   firstAlreadyClaimedMatch === null &&
                   remainingUnclaimedBody.includes(includes)
@@ -643,6 +754,8 @@ ${fulfilled.body}
                       // The target of a redirect is a navigation, not an App
                       // Shell prefetch.
                       isAppShell: false,
+                      // Navigations have no prefetch kind.
+                      kind: undefined,
                     })
                     batch.didReceiveRouterRequest = true
                     page.off('response', handleResponse)
@@ -708,6 +821,26 @@ ${fulfilled.body}
               'is missing, it may have actually appeared earlier in the ' +
               'sequence than expected. Make sure the order is correct.'
           }
+
+          // If any unclaimed expectation's substring did appear in a response,
+          // but a response of a different kind, call that out explicitly —
+          // it's the most likely explanation for the failure.
+          for (const [expectation, actualKind] of wrongKindMatches) {
+            if (claimedExpectations.has(expectation)) {
+              continue
+            }
+            const receivedIn =
+              actualKind === undefined
+                ? 'a response with no prefetch kind (a navigation, Server ' +
+                  'Action, or plain prefetch)'
+                : `a '${actualKind}' response`
+            error.message +=
+              '\n\n' +
+              `NOTE: The expected substring "${expectation.includes}" was ` +
+              `received in ${receivedIn}, but the expectation requires ` +
+              `kind: '${expectation.kind}'.`
+          }
+
           throw error
         }
       }


### PR DESCRIPTION
If we're reasonably confident that a segment can be prefetched statically without omitting data that would have been included during a runtime prefetch (e.g. cookies), the client should attempt prefetch the segment statically instead of going straight to a runtime request.

The decision for whether to do this is based on the ShouldAttemptStaticPrefetch added in previous steps.

If it turns out the static response is not sufficient, then it will fall back to a runtime request.

This makes prefetching cheaper for pages that are fully statically renderable. We can make the optimization better in the future with more reliable per-segment computation of the ShouldAttemptStaticPrefetch, but the current approach should at least work for fully static pages, which is what's most important.

This optimization applies during both the Shell phase and the Speculative phase of the prefetching algorithm.
