### PR TITLE
Restore partial fallback shell upgrade coverage

### DIFF
--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/next.config.js
@@ -3,6 +3,7 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  partialPrefetching: true,
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -34,6 +34,8 @@ function createSplitHTMLFetcher(next: NextInstance) {
 
 describe('partial-fallback-shell-upgrade', () => {
   const { next, isNextDev } = nextTestSetup({
+    // Deployed shell upgrades require `partialFallback` metadata, which the
+    // adapter only emits when Partial Prefetching is enabled in the fixture.
     files: path.join(__dirname, 'fixtures', 'default'),
     // The latest changes to support this behavior on deployed infra are available in the adapter,
     // and are not being backported to the CLI


### PR DESCRIPTION
### Why?

Deployment tests for `partial-fallback-shell-upgrade` repeatedly fail after #96074 because the fixture still expects partial fallback shell upgrades without opting into Partial Prefetching. #96074 intentionally emits `partialFallback` metadata only when `partialPrefetching` is enabled.

Failed deployment test: https://github.com/vercel/next.js/actions/runs/30008120037/job/89223758358#step:32:464

Passed: https://github.com/vercel/next.js/actions/runs/30031537314/job/89297370591#step:32:107

<!-- NEXT_JS_LLM -->