### PR TITLE
Remove inert experimental.viewTransition flag

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -336,7 +336,6 @@ export const experimentalSchema = {
   swcTraceProfiling: z.boolean().optional(),
   // NonNullable<webpack.Configuration['experiments']>['buildHttp']
   urlImports: z.any().optional(),
-  viewTransition: z.boolean().optional(),
   workerThreads: z.boolean().optional(),
   webVitalsAttribution: z
     .array(

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1136,11 +1136,6 @@ export interface ExperimentalConfig {
   lightningCssFeatures?: LightningCssFeatures
 
   /**
-   * Enables view transitions by using the {@link https://react.dev/reference/react/ViewTransition ViewTransition} Component.
-   */
-  viewTransition?: boolean
-
-  /**
    * Enables `fetch` requests to be proxied to the experimental test proxy server
    */
   testProxy?: boolean
@@ -2184,7 +2179,6 @@ export const defaultConfig = Object.freeze({
     optimizeServerReact: true,
     strictRouteTypes: false,
     useTypeScriptCli: false,
-    viewTransition: false,
     removeUncaughtErrorAndRejectionListeners: false,
     validateRSCRequestHeaders: true,
     staleTimes: {

--- a/test/e2e/app-dir/view-transitions/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/view-transitions/fixtures/default/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  experimental: {
-    viewTransition: true,
-  },
-}


### PR DESCRIPTION
## What

Removes `experimental.viewTransition` — the flag is inert. Code only; all docs changes ship in #96097 so the two can be reviewed independently.

## Why

Nothing in the runtime reads it: it appears only in config validation (`config-schema.ts`) and its type/default (`config-shared.ts`). `ViewTransition` ships in the bundled React canary, and every `<Link>` navigation already runs inside `React.startTransition`, so view transitions work with no configuration.

The flag was reserved for Next.js automatically adding transition types to navigations, which never landed (confirmed with the team — a new flag will gate that work when it's done properly). Historically it also switched the bundled React to the experimental channel, but that stopped being necessary when React released `ViewTransition` to canary; the experimental channel is now selected by other flags (`gestureTransition`, `blockingSSR`, `taint`, `transitionIndicator`).

## Changes

- `config-schema.ts` / `config-shared.ts`: schema entry, type + JSDoc, and default removed
- `test/e2e/app-dir/view-transitions` fixture: `next.config.js` deleted (it contained only the flag; the test never references it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
