### PR TITLE
[RSC HMR] Fix a flurry of refetches when a editing component imported from many routes

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -720,6 +720,25 @@ export async function createHotReloaderTurbopack(
     client.send(data)
   }
 
+  let updateInProgress = false
+  let pendingServerComponentChanges = false
+
+  function sendServerComponentChanges() {
+    sendHmr('server-component-changes', {
+      type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+    })
+  }
+
+  // Each announcement makes every client refetch its page, so an update's
+  // changes are announced once, on the update's end.
+  function handleServerComponentChanges() {
+    if (updateInProgress) {
+      pendingServerComponentChanges = true
+    } else {
+      sendServerComponentChanges()
+    }
+  }
+
   function sendEnqueuedMessages() {
     for (const [, issueMap] of currentEntryIssues) {
       if (
@@ -1829,6 +1848,7 @@ export async function createHotReloaderTurbopack(
                 subscribeToChanges: subscribeToChanges
                   ? subscribeToClientChanges
                   : ((async () => {}) as StartChangeSubscription),
+                handleServerComponentChanges,
                 handleWrittenEndpoint: (id, result, forceDeleteCache) => {
                   currentWrittenEntrypoints.set(id, result)
                   assetMapper.setPathsForKey(id, result.clientPaths)
@@ -1880,6 +1900,7 @@ export async function createHotReloaderTurbopack(
     for await (const updateMessage of project.updateInfoSubscribe(30)) {
       switch (updateMessage.updateType) {
         case 'start': {
+          updateInProgress = true
           hotReloader.send({ type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING })
           // Mark that HMR has started and we need to call the callback after it settles
           // This ensures onBeforeDeferredEntries will be called again during HMR
@@ -1891,6 +1912,11 @@ export async function createHotReloaderTurbopack(
           break
         }
         case 'end': {
+          updateInProgress = false
+          if (pendingServerComponentChanges) {
+            pendingServerComponentChanges = false
+            sendServerComponentChanges()
+          }
           sendEnqueuedMessages()
 
           function addToErrorsMap(

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -141,6 +141,7 @@ export type ClientStateMap = WeakMap<ws, ClientState>
 type HandleRouteTypeHooks = {
   handleWrittenEndpoint: HandleWrittenEndpoint
   subscribeToChanges: StartChangeSubscription
+  handleServerComponentChanges?: () => void
 }
 
 export async function handleRouteType({
@@ -356,7 +357,7 @@ export async function handleRouteType({
           key,
           /** includeIssues=*/ true,
           route.rscHmrEndpoint,
-          (change, hash) => {
+          (change) => {
             if (change.issues.some((issue) => issue.severity === 'error')) {
               // Ignore any updates that has errors
               // There will be another update without errors eventually
@@ -364,10 +365,7 @@ export async function handleRouteType({
             }
             // Report the next compilation again
             readyIds?.delete(pathname)
-            return {
-              type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-              hash,
-            }
+            hooks?.handleServerComponentChanges?.()
           },
           (e) => {
             return {

--- a/test/development/app-dir/hmr-refetch-coalescing/app/a/page.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/a/page.js
@@ -1,0 +1,5 @@
+import { Banner } from '../shared/banner'
+
+export default function Page() {
+  return <Banner route="a" />
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/b/page.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/b/page.js
@@ -1,0 +1,5 @@
+import { Banner } from '../shared/banner'
+
+export default function Page() {
+  return <Banner route="b" />
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/c/page.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/c/page.js
@@ -1,0 +1,5 @@
+import { Banner } from '../shared/banner'
+
+export default function Page() {
+  return <Banner route="c" />
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/d/page.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/d/page.js
@@ -1,0 +1,5 @@
+import { Banner } from '../shared/banner'
+
+export default function Page() {
+  return <Banner route="d" />
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/e/page.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/e/page.js
@@ -1,0 +1,5 @@
+import { Banner } from '../shared/banner'
+
+export default function Page() {
+  return <Banner route="e" />
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/f/page.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/f/page.js
@@ -1,0 +1,5 @@
+import { Banner } from '../shared/banner'
+
+export default function Page() {
+  return <Banner route="f" />
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/layout.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/app/shared/banner.js
+++ b/test/development/app-dir/hmr-refetch-coalescing/app/shared/banner.js
@@ -1,0 +1,3 @@
+export function Banner({ route }) {
+  return <h1>{route}: rev-0</h1>
+}

--- a/test/development/app-dir/hmr-refetch-coalescing/hmr-refetch-coalescing.test.ts
+++ b/test/development/app-dir/hmr-refetch-coalescing/hmr-refetch-coalescing.test.ts
@@ -1,0 +1,99 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+describe('hmr-refetch-coalescing', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (!isTurbopack) {
+    it('is a Turbopack-only test', () => {})
+    return
+  }
+
+  function countHmrRefetches(counter: { count: number }) {
+    return {
+      beforePageLoad(page: any) {
+        page.on('request', (request: any) => {
+          if ('next-hmr-refresh' in request.headers()) {
+            counter.count++
+          }
+        })
+      },
+    }
+  }
+
+  it('refetches a page once per edit regardless of how many routes the edit affects', async () => {
+    // Build the other routes that import the shared component. Each built
+    // route registers a server-side change subscription for its endpoint.
+    for (const route of ['/b', '/c', '/d', '/e', '/f']) {
+      const res = await next.fetch(route)
+      expect(res.status).toBe(200)
+    }
+
+    const refetches = { count: 0 }
+    const browser = await next.browser('/a', countHmrRefetches(refetches))
+    expect(await browser.elementByCss('h1').text()).toBe('a: rev-0')
+
+    await next.patchFile('app/shared/banner.js', (content) =>
+      content.replace(/rev-\d+/, 'rev-1')
+    )
+
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('a: rev-1')
+    })
+    // Let any trailing (redundant) refetches land before counting.
+    await waitFor(2000)
+
+    // One edit must result in exactly one refetch of the page, no matter how
+    // many route endpoints the edited file is part of. Server-side change
+    // events arrive per affected endpoint; without coalescing, this client
+    // would refetch once per affected route (6 with this fixture).
+    expect(refetches.count).toBe(1)
+
+    // A second edit announces again.
+    await next.patchFile('app/shared/banner.js', (content) =>
+      content.replace(/rev-\d+/, 'rev-2')
+    )
+
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('a: rev-2')
+    })
+    await waitFor(2000)
+
+    expect(refetches.count).toBe(2)
+
+    await browser.close()
+  })
+
+  it('does not refetch for an edit with a compilation error, and refetches once for the fix', async () => {
+    const original = await next.readFile('app/shared/banner.js')
+
+    const refetches = { count: 0 }
+    const browser = await next.browser('/a', countHmrRefetches(refetches))
+    const initialText = await browser.elementByCss('h1').text()
+
+    await next.patchFile(
+      'app/shared/banner.js',
+      (content) => content + '\nconst broken = ;\n'
+    )
+    // The errored update must not be announced; wait long enough that a
+    // refetch would have happened.
+    await waitFor(2000)
+    expect(refetches.count).toBe(0)
+
+    await next.patchFile('app/shared/banner.js', () =>
+      original.replace(/rev-\d+/, 'rev-9')
+    )
+
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).not.toBe(initialText)
+      expect(await browser.elementByCss('h1').text()).toContain('rev-9')
+    })
+    await waitFor(2000)
+
+    expect(refetches.count).toBe(1)
+
+    await browser.close()
+  })
+})


### PR DESCRIPTION
Fixes a flurry of requests when doing server HMR.

To reproduce the issue, create a server component imported from multiple routes:

- Route `/a` imports that component
- Route `/b` imports that component
- Route `/c` imports that component
- (...and so on...)

Then edit that server component.

Expected: one request in terminal per open tab.
Actual: a flurry of requests.

There's two separate causes for the flurry of requests:

- The "server component updated" messages were emitted once per already-compiled route, so a single tab would receive a flurry of messages one right after another, and process them all.
- Also, the `debounce` for these messages is broken (it always fires instead of delaying) due to a wrong condition inside it. So if we tried coalescing messages by key, we'd still see multiple requests per tab.
  - We should probably fix `debounce` but that's more risky because I don't know if either existing caller could rely on the bug. Luckily, for the fix below this doesn't matter.

Anyway, to get the desired behavior (one refresh per page), we switch to expressing server component changes as a final message that gets sent at the end of the update using a dirty flag. Then we don't need to worry about how they get deduped or how many of them gets received.

There are probably other ways to factor this but this one seemed fine to me.

## Before

A flurry of requests.

https://github.com/user-attachments/assets/337183e9-6fe2-4633-858d-6c1db6779618

## After

One request per open tab.

https://github.com/user-attachments/assets/3543619e-7ab3-4b74-bbdf-2151e16e2c2b
