### PR TITLE
fix: remove deprecated url.parse() from custom-server example

### DIFF
--- a/examples/custom-server/server.ts
+++ b/examples/custom-server/server.ts
@@ -1,5 +1,4 @@
 import { createServer } from "http";
-import { parse } from "url";
 import next from "next";
 
 const port = parseInt(process.env.PORT || "3000", 10);
@@ -9,8 +8,7 @@ const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url!, true);
-    handle(req, res, parsedUrl);
+    handle(req, res);
   }).listen(port);
 
   console.log(


### PR DESCRIPTION
Fixes #86951

Removes the deprecated legacy `url.parse()` API (DEP0169) from the custom-server example. The `parsedUrl` parameter is optional, so the simplest fix is to remove the `parse()` call and pass only `(req, res)` to the handler, matching the docs code block that was already updated in #86986.