### PR TITLE
fix(app-router): preserve middleware rewrite query parameters in App Route request.nextUrl

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2540,7 +2540,10 @@ export default abstract class Server<
     // literal dynamic route ('/[slug]') instead of actual URL, so overwriting to initPathname
     // will transform back the resolved url to the dynamic route pathname.
     if (!(this.minimalMode && isErrorPathname)) {
-      request.url = `${initPathname}${parsedInitUrl.search || ''}`
+      request.url =
+        routeModule && isAppRouteRouteModule(routeModule)
+          ? formatUrl({ pathname, query })
+          : `${initPathname}${parsedInitUrl.search || ''}`
     }
 
     // propagate the request context for dev

--- a/test/e2e/middleware-rewrites/app/app/api/rewrite-query/edge/route.js
+++ b/test/e2e/middleware-rewrites/app/app/api/rewrite-query/edge/route.js
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export function GET(request) {
+  return Response.json(Object.fromEntries(request.nextUrl.searchParams))
+}

--- a/test/e2e/middleware-rewrites/app/app/api/rewrite-query/node/route.js
+++ b/test/e2e/middleware-rewrites/app/app/api/rewrite-query/node/route.js
@@ -1,0 +1,3 @@
+export function GET(request) {
+  return Response.json(Object.fromEntries(request.nextUrl.searchParams))
+}

--- a/test/e2e/middleware-rewrites/app/middleware.js
+++ b/test/e2e/middleware-rewrites/app/middleware.js
@@ -67,6 +67,13 @@ export async function middleware(request) {
     )
   }
 
+  if (url.pathname.startsWith('/rewrite-query/')) {
+    const rewriteUrl = request.nextUrl.clone()
+    rewriteUrl.pathname = `/api${url.pathname}`
+    rewriteUrl.searchParams.set('added', '1')
+    return NextResponse.rewrite(rewriteUrl)
+  }
+
   if (url.pathname === '/foo/bar') {
     const rewriteUrl = request.nextUrl.clone()
     rewriteUrl.pathname = '/api/proxy/bar/'

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -12,6 +12,7 @@ const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
 describe('Middleware Rewrite', () => {
   const { next, isNextDeploy } = nextTestSetup({
     files: {
+      app: new FileRef(join(__dirname, '../app/app')),
       pages: new FileRef(join(__dirname, '../app/pages')),
       'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
       'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
@@ -115,6 +116,26 @@ describe('Middleware Rewrite', () => {
           extra: '2',
           slug: ['bar'],
         },
+      })
+    })
+
+    it('should preserve middleware rewrite query in App Routes', async () => {
+      const [nodeResponse, edgeResponse] = await Promise.all(
+        ['node', 'edge'].map((runtime) =>
+          next.fetch(`/rewrite-query/${runtime}?key=value`)
+        )
+      )
+
+      expect(nodeResponse.status).toBe(200)
+      expect(edgeResponse.status).toBe(200)
+
+      await expect(nodeResponse.json()).resolves.toEqual({
+        key: 'value',
+        added: '1',
+      })
+      await expect(edgeResponse.json()).resolves.toEqual({
+        key: 'value',
+        added: '1',
       })
     })
 


### PR DESCRIPTION
## Summary

This PR resolves an issue where query parameters added or modified during a middleware rewrite were missing from `request.nextUrl` when handling App Route requests in the default (Node.js) runtime.

With this fix, query parameters attached during middleware rewrites are properly reflected in `request.nextUrl` for App Routes across both Node.js and Edge runtimes.

---

## Scope & Intentional Limits

* **Targeted Scope:** This change is intentionally limited to **App Routes** (`request.nextUrl`).
* **Unchanged Behavior:** Pages API routes and raw `req.url` behavior remain untouched to avoid breaking changes or unexpected side effects in legacy paradigms.

---

## What Changed

* **App Route Query Handling:** Fixed query parameter propagation so `request.nextUrl` accurately reflects rewrite parameters in default-runtime App Routes.
* **Test Coverage:**
* Added new integration tests covering middleware rewrite queries for App Routes in both **Node.js** and **Edge** runtimes.
* Retained and verified existing regression test coverage for Pages API rewrite-query behavior.



---

## Validation

* Executed focused Webpack App Route and Pages API test suites against current `canary`.
* All targeted integration tests passed cleanly with no regressions detected.

---

## References

* Fixes #64776﻿﻿
