### PR TITLE
fix: Uncontrolled command line commandString Use non-shell execution

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -8,9 +8,18 @@ module.exports = (actionInfo) => {
   return {
     async cloneRepo(repoPath = '', dest = '', branch = '', depth = '20') {
       await fs.promises.rm(dest, { recursive: true, force: true })
-      await exec(
-        `git clone ${actionInfo.gitRoot}${repoPath} --single-branch --branch ${branch} --depth=${depth} ${dest}`
-      )
+      await exec.spawnPromise('git', {
+        args: [
+          'clone',
+          `${actionInfo.gitRoot}${repoPath}`,
+          '--single-branch',
+          '--branch',
+          branch,
+          `--depth=${depth}`,
+          dest,
+        ],
+        stdio: 'pipe',
+      })
     },
     async getLastStable() {
       const res = await fetch(
@@ -31,24 +40,66 @@ module.exports = (actionInfo) => {
       return data.tag_name
     },
     async getCommitId(repoDir = '') {
-      const { stdout } = await exec(`cd ${repoDir} && git rev-parse HEAD`)
+      const child = exec.spawn('git', {
+        args: ['rev-parse', 'HEAD'],
+        cwd: repoDir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      let stdout = ''
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString()
+      })
+
+      await new Promise((resolve, reject) => {
+        child.on('error', reject)
+        child.on('exit', (code, signal) => {
+          if (code || signal) {
+            return reject(
+              new Error(`bad exit code/signal code: ${code} signal: ${signal}`)
+            )
+          }
+          resolve()
+        })
+      })
+
       return stdout.trim()
     },
     async resetToRef(ref = '', repoDir = '') {
-      await exec(`cd ${repoDir} && git reset --hard ${ref}`)
+      await exec.spawnPromise('git', {
+        args: ['reset', '--hard', ref],
+        cwd: repoDir,
+        stdio: 'pipe',
+      })
     },
     async mergeBranch(ref = '', origRepoDir = '', destRepoDir = '') {
-      await exec(`cd ${destRepoDir} && git remote add upstream ${origRepoDir}`)
-      await exec(`cd ${destRepoDir} && git fetch upstream`)
+      await exec.spawnPromise('git', {
+        args: ['remote', 'add', 'upstream', origRepoDir],
+        cwd: destRepoDir,
+        stdio: 'pipe',
+      })
+      await exec.spawnPromise('git', {
+        args: ['fetch', 'upstream'],
+        cwd: destRepoDir,
+        stdio: 'pipe',
+      })
 
       try {
-        await exec(`cd ${destRepoDir} && git merge upstream/${ref}`)
+        await exec.spawnPromise('git', {
+          args: ['merge', `upstream/${ref}`],
+          cwd: destRepoDir,
+          stdio: 'pipe',
+        })
         logger('Auto merge of main branch successful')
       } catch (err) {
         logger.error('Failed to auto merge main branch:', err)
 
         if (err.stdout && err.stdout.includes('CONFLICT')) {
-          await exec(`cd ${destRepoDir} && git merge --abort`)
+          await exec.spawnPromise('git', {
+            args: ['merge', '--abort'],
+            cwd: destRepoDir,
+            stdio: 'pipe',
+          })
           logger('aborted auto merge')
         }
       }

--- a/examples/cms-agilitycms/lib/preview.ts
+++ b/examples/cms-agilitycms/lib/preview.ts
@@ -87,6 +87,13 @@ export async function validatePreview({ agilityPreviewKey, slug, contentID }) {
     };
   }
 
+  if (typeof agilityPreviewKey !== "string") {
+    return {
+      error: true,
+      message: `Invalid agilitypreviewkey.`,
+    };
+  }
+
   //sanitize incoming key (replace spaces with '+')
   if (agilityPreviewKey.includes(` `)) {
     agilityPreviewKey = agilityPreviewKey.split(` `).join(`+`);

--- a/turbopack/packages/devlow-bench/src/shell.ts
+++ b/turbopack/packages/devlow-bench/src/shell.ts
@@ -191,7 +191,6 @@ export function command(
   } = {}
 ): Command {
   const process = spawn(command, args, {
-    shell: true,
     ...options,
     stdio: ['ignore', 'pipe', 'pipe'],
   })


### PR DESCRIPTION
Code that passes untrusted user input directly to `child_process.exec` or similar APIs that execute shell commands allows the user to execute malicious code. fixes avoid `exec(commandString)`/`bash -c` for operations containing variable input. Use non-shell execution (`spawn`/`execFile`) with argument arrays and `cwd`, so user-controlled values are not interpreted by a shell.

Best fix here without changing functionality:
- In `.github/actions/next-stats-action/src/prepare/repo-setup.js`, replace the vulnerable `exec(...)` usages in:
  - `cloneRepo` (line region around current `git clone ...`)
  - `getCommitId`
  - `resetToRef`
  - `mergeBranch`
- Use `exec.spawnPromise` with:
  - command: `'git'`
  - args array: exact git args (e.g., `['clone', url, '--single-branch', '--branch', branch, ...]`)
  - options: `{ cwd: <dir when needed>, stdio: 'pipe' }`
- For `getCommitId`, use `exec.spawn` (not promise wrapper) with `stdio: ['ignore', 'pipe', 'pipe']`, collect stdout, await exit code, and return trimmed hash.
