### PR TITLE
Avoid deep-cloning parsed URLs during rewrite handling

### DIFF
--- a/packages/next/src/server/server-utils.test.ts
+++ b/packages/next/src/server/server-utils.test.ts
@@ -72,6 +72,46 @@ describe('getParamsFromRouteMatches', () => {
   })
 })
 
+describe('handleRewrites', () => {
+  it('does not mutate the original URL or query', () => {
+    const { handleRewrites } = getServerUtils({
+      page: '/destination',
+      basePath: '',
+      rewrites: {
+        beforeFiles: [
+          {
+            source: '/source',
+            destination: '/destination?added=value&shared=updated',
+          },
+        ],
+      },
+      i18n: undefined,
+      pageIsDynamic: false,
+      caseSensitive: false,
+    })
+    const shared = ['one', 'two']
+    const parsedUrl = {
+      pathname: '/source',
+      query: { keep: 'yes', shared },
+    }
+
+    const { rewrittenParsedUrl } = handleRewrites(
+      {} as Parameters<typeof handleRewrites>[0],
+      parsedUrl
+    )
+
+    expect(parsedUrl).toEqual({
+      pathname: '/source',
+      query: { keep: 'yes', shared: ['one', 'two'] },
+    })
+    expect(parsedUrl.query.shared).toBe(shared)
+    expect(rewrittenParsedUrl).toMatchObject({
+      pathname: '/destination',
+      query: { keep: 'yes', shared: 'updated', added: 'value' },
+    })
+  })
+})
+
 describe('normalizeDynamicRouteParams', () => {
   it('should reject encoded default placeholders for dynamic params', () => {
     const { normalizeDynamicRouteParams } = getServerUtils({

--- a/packages/next/src/server/server-utils.test.ts
+++ b/packages/next/src/server/server-utils.test.ts
@@ -1,3 +1,4 @@
+import { parseUrl } from '../shared/lib/router/utils/parse-url'
 import { getServerUtils } from './server-utils'
 
 describe('getParamsFromRouteMatches', () => {
@@ -89,21 +90,16 @@ describe('handleRewrites', () => {
       pageIsDynamic: false,
       caseSensitive: false,
     })
-    const shared = ['one', 'two']
-    const parsedUrl = {
-      pathname: '/source',
-      query: { keep: 'yes', shared },
-    }
+    const parsedUrl = parseUrl('/source?keep=yes&shared=one&shared=two')
+    const shared = parsedUrl.query.shared
+    const originalUrl = structuredClone(parsedUrl)
 
     const { rewrittenParsedUrl } = handleRewrites(
       {} as Parameters<typeof handleRewrites>[0],
       parsedUrl
     )
 
-    expect(parsedUrl).toEqual({
-      pathname: '/source',
-      query: { keep: 'yes', shared: ['one', 'two'] },
-    })
+    expect(parsedUrl).toEqual(originalUrl)
     expect(parsedUrl.query.shared).toBe(shared)
     expect(rewrittenParsedUrl).toMatchObject({
       pathname: '/destination',

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -250,11 +250,13 @@ export function getServerUtils({
     req: BaseNextRequest | IncomingMessage,
     parsedUrl: DeepReadonly<NextUrlWithParsedQuery>
   ) {
-    // Here we deep clone the parsedUrl to avoid mutating the original. We also
-    // cast this to a mutable type so we can mutate it within this scope.
-    const rewrittenParsedUrl = structuredClone(
-      parsedUrl
-    ) as NextUrlWithParsedQuery
+    // Clone the URL and query before applying rewrites so the original is not
+    // mutated. Rewrite processing only changes top-level query properties, so
+    // cloning nested values would be unnecessary work on every request.
+    const rewrittenParsedUrl = {
+      ...parsedUrl,
+      query: { ...parsedUrl.query },
+    } as NextUrlWithParsedQuery
     const rewriteParams: Record<string, string> = {}
     let fsPathname = rewrittenParsedUrl.pathname
 


### PR DESCRIPTION
## What

Replace `structuredClone(parsedUrl)` in `handleRewrites` with a shallow clone of the URL and its query object.

Rewrite handling only assigns or deletes top-level URL/query properties. Query values are strings or string arrays and are never mutated in place, so recursively cloning them adds work on every request without providing additional isolation.

The focused test covers the mutation boundary with a fully parsed URL fixture: the returned URL and query are rewritten while the complete original URL, query object, and query array remain unchanged.

## Performance

Measured on a pinned core of a 16-vCPU / 32-GiB Vercel DevBox at `cf10c50a651f8fcbef11ef9976a8155f36a06f65`, Node 24.14.1.

### Full `handleRewrites` path

The benchmark calls the compiled production function, not only the clone expression. It uses 31 interleaved rounds per scenario and reports paired candidate deltas with bootstrap 95% confidence intervals for the median.

| Scenario | Baseline median | Candidate median | Paired delta |
| --- | ---: | ---: | ---: |
| No rewrite, empty query | 3,065 ns | 140 ns | **-95.40%** `[-95.52%, -94.36%]` |
| No rewrite, realistic query | 6,450 ns | 167 ns | **-97.42%** `[-97.46%, -97.39%]` |
| No rewrite, 64 query keys | 19,883 ns | 299 ns | **-98.48%** `[-98.71%, -98.44%]` |
| One rewrite, small query | 41,739 ns | 31,000 ns | **-25.19%** `[-27.19%, -24.12%]` |
| One rewrite, 32 query keys | 65,726 ns | 46,281 ns | **-29.91%** `[-31.49%, -27.14%]` |
| Dynamic after-file rewrite | 74,676 ns | 58,622 ns | **-20.99%** `[-22.58%, -19.72%]` |
| Query/header condition | 56,744 ns | 39,406 ns | **-30.34%** `[-32.29%, -29.64%]` |

The longest three-rewrite chain received a separate 61-round precision run: **114,606 ns → 97,867 ns**, a **-14.20%** paired median `[-16.80%, -12.48%]`, with 53/61 candidate wins. Its same-function A/A control was -2.40% `[-4.12%, +1.02%]`.

An implementation-variant matrix also confirmed that the submitted nested object spreads are the fastest safe form tested. `Object.assign` was 58-239% slower than the spreads, while copying every nested query array added 5-77% overhead depending on query shape.

### Production render pipeline

Matched production CPU profiles used the `e2e` Node-stream scenario with 1,000 serial and 10,000 concurrent-load requests:

| Attribution | Baseline | Candidate |
| --- | ---: | ---: |
| Total sampled CPU | 20,534.6 ms | 20,164.0 ms |
| Next runtime sampled CPU | 7,786.1 ms | 7,770.6 ms |
| `server-utils.ts` | 174.9 ms (2.25%) | 42.5 ms (0.55%) |
| `handleRewrites` | 145.2 ms (1.86%) | below top-50 symbol threshold |

This is a **75.70% reduction** in source-attributed `server-utils.ts` CPU. Each profile was symbolized against its matching production runtime source map.

Seven interleaved end-to-end pairs, each restored from immutable baseline/candidate build archives, showed neutral saturated throughput (+0.275% median paired delta, -0.031% mean). That result is inside the workload's measured 2.56% throughput CV, so this PR does not claim a separately resolvable request-throughput improvement.

## Correctness

- Differentially compared the compiled baseline and candidate across **100,000 cases** and 16 rewrite families: no rewrite, before/after/fallback chains, dynamic and catch-all routes, base path, i18n, trailing slash, case sensitivity, external destinations, query/header/cookie conditions, missing conditions, repeated query values, and destination interpolation.
- Inputs, query objects, and nested arrays were recursively frozen. The candidate produced zero mutations and **zero semantic mismatches**.
- Audited both callers plus `prepareDestination`, `matchHas`, and query-normalization helpers. Query arrays are read, mapped, or replaced, never mutated in place.
- Repeated the one unrelated browser test that failed in the first CI run using fresh isolated installs: baseline **5/5 passed**, candidate **6/6 passed**. This rules out the clone change as its cause.

## Validation

- `pnpm --filter=next build`
- `pnpm --filter=next typescript`
- `pnpm testonly packages/next/src/server/server-utils.test.ts` (10/10 tests)
- `pnpm test-dev test/e2e/app-dir/navigation/navigation.test.ts -t "should change browser location when router.refresh"` (11/11 aggregate baseline/candidate control runs)
- `pnpm exec prettier --check packages/next/src/server/server-utils.ts packages/next/src/server/server-utils.test.ts`
- `pnpm exec eslint packages/next/src/server/server-utils.ts packages/next/src/server/server-utils.test.ts`
- Final Codex GPT-5.6 Sol xhigh + Claude Opus 4.8 xhigh autoreview panel: clean, zero findings
