### PR TITLE
Optimize URI path encoding across asset path shapes

### DIFF
--- a/packages/next/src/shared/lib/encode-uri-path.ts
+++ b/packages/next/src/shared/lib/encode-uri-path.ts
@@ -1,6 +1,27 @@
+function isEncodeURIPathSafeCode(code: number) {
+  return (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) || // a-z
+    code === 33 || // !
+    code === 39 || // '
+    code === 40 || // (
+    code === 41 || // )
+    code === 42 || // *
+    code === 45 || // -
+    code === 46 || // .
+    code === 47 || // /
+    code === 95 || // _
+    code === 126 // ~
+  )
+}
+
 export function encodeURIPath(file: string) {
+  for (let i = 0; i < file.length; i++) {
+    if (!isEncodeURIPathSafeCode(file.charCodeAt(i))) {
+      return encodeURIComponent(file).replaceAll('%2F', '/')
+    }
+  }
+
   return file
-    .split('/')
-    .map((p) => encodeURIComponent(p))
-    .join('/')
 }

--- a/packages/next/src/shared/lib/encode-uri-path.ts
+++ b/packages/next/src/shared/lib/encode-uri-path.ts
@@ -1,27 +1,31 @@
-function isEncodeURIPathSafeCode(code: number) {
-  return (
-    (code >= 48 && code <= 57) || // 0-9
-    (code >= 65 && code <= 90) || // A-Z
-    (code >= 97 && code <= 122) || // a-z
-    code === 33 || // !
-    code === 39 || // '
-    code === 40 || // (
-    code === 41 || // )
-    code === 42 || // *
-    code === 45 || // -
-    code === 46 || // .
-    code === 47 || // /
-    code === 95 || // _
-    code === 126 // ~
-  )
+const unsafeURIPathCharacter = /[^A-Za-z0-9_.!~*'()\u002f-]/
+const nonAsciiCharacter = /[\x80-\uFFFF]/
+
+function encodeURIPathBySegment(file: string) {
+  let slash = file.indexOf('/')
+  if (slash === -1) {
+    return encodeURIComponent(file)
+  }
+
+  let encoded = ''
+  let start = 0
+  do {
+    encoded += encodeURIComponent(file.slice(start, slash)) + '/'
+    start = slash + 1
+    slash = file.indexOf('/', start)
+  } while (slash !== -1)
+
+  return encoded + encodeURIComponent(file.slice(start))
 }
 
 export function encodeURIPath(file: string) {
-  for (let i = 0; i < file.length; i++) {
-    if (!isEncodeURIPathSafeCode(file.charCodeAt(i))) {
-      return encodeURIComponent(file).replaceAll('%2F', '/')
-    }
+  if (!unsafeURIPathCharacter.test(file)) {
+    return file
   }
 
-  return file
+  if (file.length >= 128 && !nonAsciiCharacter.test(file)) {
+    return encodeURIComponent(file).replaceAll('%2F', '/')
+  }
+
+  return encodeURIPathBySegment(file)
 }

--- a/test/unit/encode-uri-path.test.ts
+++ b/test/unit/encode-uri-path.test.ts
@@ -29,11 +29,33 @@ describe('encodeURIPath', () => {
     expect(encodeURIPath(input)).toBe(referenceEncodeURIPath(input))
   })
 
-  it.each(['\uD800', 'prefix/\uDC00/suffix'])(
-    'preserves URI errors for malformed surrogate input %j',
-    (input) => {
-      expect(() => referenceEncodeURIPath(input)).toThrow(URIError)
-      expect(() => encodeURIPath(input)).toThrow(URIError)
-    }
-  )
+  it.each([
+    {
+      name: 'multiple unsafe segments',
+      input: 'one/two three/four?five/six#seven',
+    },
+    { name: 'unsafe input below the crossover', input: `${'a'.repeat(62)} ` },
+    { name: 'unsafe input at length 127', input: `${'a'.repeat(126)} ` },
+    { name: 'unsafe input at length 128', input: `${'a'.repeat(127)} ` },
+    { name: 'slash-dense unsafe input', input: `${'a/'.repeat(64)} ` },
+    {
+      name: 'ASCII escape before non-ASCII input',
+      input: `space before unicode/${'a'.repeat(128)}/東京`,
+    },
+    { name: 'long safe input', input: 'safe/'.repeat(2048) },
+  ])('matches the reference for $name', ({ input }) => {
+    expect(encodeURIPath(input)).toBe(referenceEncodeURIPath(input))
+  })
+
+  it.each([
+    { name: 'isolated high surrogate', input: '\uD800' },
+    { name: 'isolated low surrogate', input: 'prefix/\uDC00/suffix' },
+    {
+      name: 'late isolated high surrogate',
+      input: `${'safe/'.repeat(256)}\uD800`,
+    },
+  ])('preserves URI errors for $name', ({ input }) => {
+    expect(() => referenceEncodeURIPath(input)).toThrow(URIError)
+    expect(() => encodeURIPath(input)).toThrow(URIError)
+  })
 })

--- a/test/unit/encode-uri-path.test.ts
+++ b/test/unit/encode-uri-path.test.ts
@@ -1,0 +1,39 @@
+import { encodeURIPath } from 'next/dist/shared/lib/encode-uri-path'
+
+const referenceEncodeURIPath = (file: string) =>
+  file
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/')
+
+describe('encodeURIPath', () => {
+  it.each([
+    ['', ''],
+    ['simple/path.js', 'simple/path.js'],
+    ['multiple//slashes/', 'multiple//slashes/'],
+    ["AZaz09-_.!~*'()/", "AZaz09-_.!~*'()/"],
+    ['space here/file.js', 'space%20here/file.js'],
+    ['café/東京/😀', 'caf%C3%A9/%E6%9D%B1%E4%BA%AC/%F0%9F%98%80'],
+    ['literal/%2F', 'literal/%252F'],
+    ['reserved/?#[]@&=+$,;:', 'reserved/%3F%23%5B%5D%40%26%3D%2B%24%2C%3B%3A'],
+  ])('encodes %j as %j', (input, expected) => {
+    expect(encodeURIPath(input)).toBe(expected)
+  })
+
+  it.each([
+    '\u0000/control\ncharacters',
+    'already%20encoded/%E6%9D%B1%E4%BA%AC',
+    'astral/𐐷/🧑‍💻',
+    '/leading/and/trailing/',
+  ])('matches segment-by-segment encoding for %j', (input) => {
+    expect(encodeURIPath(input)).toBe(referenceEncodeURIPath(input))
+  })
+
+  it.each(['\uD800', 'prefix/\uDC00/suffix'])(
+    'preserves URI errors for malformed surrogate input %j',
+    (input) => {
+      expect(() => referenceEncodeURIPath(input)).toThrow(URIError)
+      expect(() => encodeURIPath(input)).toThrow(URIError)
+    }
+  )
+})


### PR DESCRIPTION
## What

Optimize `encodeURIPath` for both the generated asset paths that dominate its call sites and the unsafe/public-file tail, while preserving the original segment-by-segment behavior.

The previous draft used a JavaScript code-unit loop and whole-string encoding. Exhaustive follow-up measurement found that loop regressed long safe paths by 29–49%, Unicode-heavy paths by 115%, and late escapes by up to 12%. This revision replaces it with a measured adaptive design:

1. use a native regex to return `encodeURIComponent`-safe ASCII plus `/` unchanged;
2. for unsafe ASCII paths at least 128 code units long, encode once and restore `%2F` separators;
3. otherwise encode segments with an allocation-light `indexOf` loop.

The 128-code-unit crossover is measured rather than guessed. It avoids the short late-escape regressions of whole-string encoding while avoiding the long-path regressions of manual segmentation.

## Correctness

The emitted `packages/next/dist/shared/lib/encode-uri-path.js` was compared against the original `split('/').map(encodeURIComponent).join('/')` reference over **1,364,125 inputs**, twice:

- every UTF-16 code unit: 65,536 cases;
- every valid surrogate pair: 1,048,576 cases;
- 250,000 deterministic random strings, including malformed surrogates, astral characters, controls, reserved characters, percent sequences, and repeated slashes;
- 13 targeted extremes, including million-character strings and long malformed inputs.

Both runs completed with **0 mismatches**. Value results and `URIError` name/message behavior were compared.

## Performance

Environment: pinned CPU 4 on a 16-vCPU / 32-GiB Vercel DevBox, Node 24.14.1 / V8 13.6. Each scenario used 31 interleaved rounds with two identical baseline lanes (A/A control), adaptive iterations, and p05/p25/p50/p75/p95/p99 reporting. The corpus includes safe lengths 0–8192, slash densities, one escape at front/middle/end, unsafe rates 0–100%, realistic asset paths, Unicode-heavy paths, and malformed-surrogate errors.

Quiet repeat against the emitted module:

| Corpus | Median delta | p05–p95 |
| --- | ---: | ---: |
| Realistic assets, all (37.5% unsafe) | **-45.72%** | -58.68% to -44.34% |
| Realistic assets, safe | **-87.81%** | -88.17% to -87.65% |
| Realistic assets, unsafe only | **-11.44%** | -15.53% to -8.89% |
| Seeded unsafe rate 5% | **-4.94%** | -6.45% to -3.33% |
| Seeded unsafe rate 20% | **-4.55%** | -9.75% to -2.38% |
| Seeded unsafe rate 50% | **-4.34%** | -6.56% to -2.14% |
| Seeded unsafe rate 100% | **-4.73%** | -16.42% to -2.89% |
| Unicode-heavy | **-3.79%** | -5.64% to -1.55% |
| Malformed-surrogate error path | +0.30% | -0.73% to +6.33% (A/A median +0.61%) |

A separate emitted-module run reproduced realistic all/safe/unsafe at -44.55% / -87.86% / -10.71%.

Inspector heap-allocation sampling (five repeats, median sampled bytes):

| Corpus | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Safe realistic assets, 1M calls | 555,106,904 | 0 | **-100%** |
| Unsafe realistic assets, 500k calls | 288,253,832 | 250,350,064 | **-13.15%** |
| Mixed 95%-safe, 500k calls | 381,110,736 | 372,921,344 | **-2.15%** |

### Runtime and crossover portability

The full threshold-64 predecessor matrix was also run under the exact minimum Node 20.9.0 and Node 22.23.1 runtimes. It improved realistic all/safe/unsafe by -50.82% / -91.01% / -18.34% on Node 20 and -49.93% / -90.64% / -17.59% on Node 22, with zero correctness mismatches.

A focused 54-case, 41-round interleaved comparison selected threshold 128 over 64 across lengths 48–127, slash/no-slash inputs, and front/middle/end escapes:

| Runtime | Clear threshold-128 wins | Clear threshold-64 wins | Delta across lengths 64–127 |
| --- | ---: | ---: | ---: |
| Node 20.9.0 | 36 | 0 | -42.51% to -1.62% |
| Node 22.23.1 | 36 | 0 | -40.03% to -4.46% |
| Node 24.14.1 | 39 | 0 | -43.55% to -2.66% |

Below 64, both variants execute identical code and measured within roughly 1% wrapper/JIT noise. Threshold 256 was rejected because it regressed a 128-character middle/end escape by 3.24% / 8.61%.

## Alternatives tested and rejected

- JavaScript safe-character loop (previous draft): long-safe +29–49%, Unicode +115%.
- Anchored safe regex + original fallback: unsafe paths +7–33%.
- Replace unsafe runs: dense unsafe paths +26–91%.
- Replace every segment with a regex callback: broad +2–23% regressions.
- Unsafe-segment lookahead: long and dense inputs +17–39%.
- Regex guard + original fallback: unsafe realistic paths +3.86%.
- Whole-string ASCII hybrid: malformed-surrogate errors +14.99%.
- Regex `exec` hybrid: extra match allocations and unsafe sampled-node regression.
- No-slash shortcut: realistic aggregate +3.59%.
- Manual segmentation alone: realistic -18.30%, but slash-dense long inputs +4.15%.
- Guarded in-place split array: unsafe realistic paths +10.00%.

All variants used the same exhaustive correctness oracle and 37-scenario percentile/allocation harness.

## Validation

- `pnpm exec jest test/unit/encode-uri-path.test.ts --runInBand` — 22/22 passed
- `pnpm exec prettier --check packages/next/src/shared/lib/encode-uri-path.ts test/unit/encode-uri-path.test.ts`
- `pnpm eslint packages/next/src/shared/lib/encode-uri-path.ts test/unit/encode-uri-path.test.ts`
- `pnpm --filter next types`
- `pnpm --filter next build`
- `pnpm build-all` — 18/18 tasks successful, including `@vercel/turbopack-next` type checks
- Live `pnpm --filter next dev` watcher rebuilt CJS, ESM, bundles, and declarations with 0 TypeScript errors
- Correctly scoped Codex GPT-5.6 Sol xhigh review: clean, 0.98 correctness confidence
- Correctly scoped Claude Opus 4.8 xhigh review: clean, 0.90 correctness confidence

A mistakenly broad unit command also ran 264 suites: 262 suites / 2,498 tests passed; three unrelated existing timing/error-message assertions failed in `fast-set-immediate.external.test.ts` and `base-http/web.test.ts`. The directly targeted suite is green.
