### PR TITLE
Optimize app render asset set allocation

### DIFF
--- a/packages/next/src/server/app-render/get-css-inlined-link-tags.tsx
+++ b/packages/next/src/server/app-render/get-css-inlined-link-tags.tsx
@@ -1,6 +1,8 @@
 import type { CssResource } from '../../build/webpack/plugins/flight-manifest-plugin'
 import { getClientReferenceManifest } from './manifests-singleton'
 
+const EMPTY_SET: ReadonlySet<never> = new Set()
+
 /**
  * Get external stylesheet link hrefs based on server CSS manifest.
  */
@@ -11,8 +13,8 @@ export function getLinkAndScriptTags(
   collectNewImports?: boolean
 ): { styles: ReadonlySet<CssResource>; scripts: ReadonlySet<string> } {
   const filePathWithoutExt = filePath.replace(/\.[^.]+$/, '')
-  const cssChunks = new Set<CssResource>()
-  const jsChunks = new Set<string>()
+  let cssChunks: Set<CssResource> | undefined
+  let jsChunks: Set<string> | undefined
   const { entryCSSFiles, entryJSFiles } = getClientReferenceManifest()
   const cssFiles = entryCSSFiles[filePathWithoutExt]
   const jsFiles = entryJSFiles?.[filePathWithoutExt]
@@ -22,6 +24,9 @@ export function getLinkAndScriptTags(
       if (!injectedCSS.has(css.path)) {
         if (collectNewImports) {
           injectedCSS.add(css.path)
+        }
+        if (!cssChunks) {
+          cssChunks = new Set()
         }
         cssChunks.add(css)
       }
@@ -34,10 +39,16 @@ export function getLinkAndScriptTags(
         if (collectNewImports) {
           injectedScripts.add(file)
         }
+        if (!jsChunks) {
+          jsChunks = new Set()
+        }
         jsChunks.add(file)
       }
     }
   }
 
-  return { styles: cssChunks, scripts: jsChunks }
+  return {
+    styles: cssChunks ?? EMPTY_SET,
+    scripts: jsChunks ?? EMPTY_SET,
+  }
 }


### PR DESCRIPTION
## What

Allocate CSS and script result sets only when the first new asset is found.
Missing or already-injected assets reuse an internal read-only empty set.

Insertion order, duplicate handling, and `collectNewImports` mutations are
preserved. The intentional observable change is that empty results may share a
`ReadonlySet` identity; all in-repository consumers only iterate or pass these
sets as read-only values.

## Correctness

The candidate was compared with the original eager-allocation implementation
over **1,648,112 cases on each of Node 20.9.0, Node 22.23.1, and Node
24.14.1**:

- 699,040 exhaustive CSS-manifest sequence/injected-mask/collection cases;
- 699,040 exhaustive JavaScript-manifest sequence/injected-mask/collection
  cases;
- 250,000 deterministic randomized combined manifests;
- 32 targeted cases.

The matrix covers missing manifest keys, an absent `entryJSFiles` map, empty
arrays, file paths with no/multiple/hidden/Unicode/malformed-UTF-16 extensions,
duplicate object identities, duplicate CSS paths and script strings, every
injected-asset mask, both values of `collectNewImports`, and lists up to 32
assets in the randomized corpus.

Returned values, Set iteration order, and post-call `injectedCSS` /
`injectedScripts` contents matched exactly in all **4,944,336 runtime-cases**.

## Performance

Pinned CPU 4 on a 16-vCPU / 32-GiB Vercel DevBox. The acceptance matrix used
22 representative scenarios, 41 interleaved rounds, approximately 250 ms per
non-mutating lane, two identical baseline lanes as an A/A control, and garbage
collection outside each timed lane. It covers empty, new, injected, asymmetric,
partially injected, duplicate/collecting, realistic mixed, and 64+64-asset
tails.

| Runtime | Clear wins | Clear losses | Neutral/crossing | Seeded realistic mix |
| --- | ---: | ---: | ---: | ---: |
| Node 20.9.0 / V8 11.3 | 15 | 1 | 6 | **-6.42%** (-9.36% to -3.96%) |
| Node 22.23.1 / V8 12.4 | 15 | 0 | 7 | **-7.16%** (-12.55% to -3.42%) |
| Node 24.14.1 / V8 13.6 | 15 | 1 | 6 | **-7.67%** (-11.32% to -6.03%) |

Selected Node 24 p05–p95 results:

| Scenario | Median change | p05–p95 |
| --- | ---: | ---: |
| Missing manifest key | **-21.30%** | -24.39% to -18.72% |
| Empty manifest arrays | **-20.11%** | -22.06% to -18.32% |
| One new CSS asset | **-7.13%** | -9.26% to -3.58% |
| One new script asset | **-7.47%** | -13.11% to -5.42% |
| One already-injected CSS asset | **-18.20%** | -20.70% to -16.21% |
| One already-injected script asset | **-17.34%** | -19.16% to -14.38% |
| Both already injected | **-16.43%** | -18.64% to -14.46% |
| CSS new, script injected | **-6.22%** | -8.28% to -4.45% |
| CSS injected, script new | **-6.21%** | -8.10% to -4.43% |
| One new CSS + one new script | **+2.34%** | +0.04% to +4.10% |
| Four new CSS + four new scripts | +3.32% | -0.09% to +5.83% |
| 64 new CSS + 64 new scripts | +0.69% | -0.99% to +3.33% |

The small all-new cost is runtime-dependent: Node 20's only clear loss was the
64+64 all-new tail (+2.80%, +0.21% to +4.56%), Node 22 had no clear loss, and
Node 24's only clear loss was the one+one all-new case above. The realistic mix
improved clearly on every runtime.

### Allocation sampling

Node 24 inspector heap sampling, five repeats, median sampled bytes:

| Corpus | Original | Candidate | Change |
| --- | ---: | ---: | ---: |
| Missing manifest, 1M calls | 429,745,568 | 126,243,328 | **-70.62%** |
| All injected, 500k calls | 213,531,592 | 64,630,184 | **-69.73%** |
| New CSS only, 500k calls | 219,633,072 | 139,293,560 | **-36.58%** |
| New CSS and JS, 250k calls | 107,683,384 | 107,191,088 | -0.46% |
| Seeded realistic mix, 500k calls | 216,121,448 | 120,619,824 | **-44.19%** |

### Production profile

A matched render profile covering 1,000 serial plus 10,000 loaded requests
reduced `getLinkAndScriptTags` sampled CPU from 66.6 ms to 55.5 ms
(**-16.67%**). Aggregate request throughput remained inside the established
noise floor, so this PR makes no end-to-end throughput claim.

### Alternative rejected

I also tested sharing the entire empty return object. It matched returned
values and side effects and reduced sampled bytes another 31% on empty calls,
but was clearly slower in seven of eight focused cases: +3.87% to +21.76%.
The realistic mix was neutral/slower (+1.72%, -0.93% to +4.51%). It would also
expose a writable shared outer object through the current return type. It was
rejected.

## Validation

- exhaustive oracle: 1,648,112 cases, zero mismatches on each of Node 20, 22,
  and 24
- `pnpm prettier --check
  packages/next/src/server/app-render/get-css-inlined-link-tags.tsx`
- `pnpm eslint
  packages/next/src/server/app-render/get-css-inlined-link-tags.tsx`
- `pnpm --filter next types`
- `pnpm --filter next build`
- `pnpm testonly-start-turbo
  test/e2e/app-dir/app-rendering/rendering.test.ts` — 6 passed, 1 skipped
- `pnpm build-all` — 18/18 tasks successful, including
  `@vercel/turbopack-next`
- Codex GPT-5.6 Sol xhigh + Claude Opus 4.8 xhigh branch review — zero
  actionable findings, 0.98 overall correctness confidence
- GitHub CI — 113 passing, 15 skipped, zero failing or pending
