### PR TITLE
perf: index static route matchers by pathname

### DIFF
--- a/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.test.ts
+++ b/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.test.ts
@@ -168,6 +168,62 @@ describe('DefaultRouteMatcherManager', () => {
     const match = await manager.match('/en-US/some/path', options)
     expect(match?.definition).toBe(definition)
   })
+
+  it('only validates static matchers for the requested pathname', async () => {
+    const manager = new DefaultRouteMatcherManager()
+    const unrelated = new RouteMatcher({
+      kind: RouteKind.PAGES,
+      filename: 'unrelated.js',
+      bundlePath: 'unrelated',
+      page: '/unrelated',
+      pathname: '/unrelated',
+    })
+    const expected = new RouteMatcher({
+      kind: RouteKind.PAGES,
+      filename: 'expected.js',
+      bundlePath: 'expected',
+      page: '/expected',
+      pathname: '/expected',
+    })
+    const unrelatedMatch = jest.spyOn(unrelated, 'match')
+
+    manager.push({ matchers: async () => [unrelated, expected] })
+    await manager.reload()
+
+    await expect(manager.match('/expected', {})).resolves.toEqual({
+      definition: expected.definition,
+      params: undefined,
+    })
+    expect(unrelatedMatch).not.toHaveBeenCalled()
+  })
+
+  it('preserves the order of duplicate static matchers', async () => {
+    const manager = new DefaultRouteMatcherManager()
+    const first = new RouteMatcher({
+      kind: RouteKind.PAGES,
+      filename: 'first.js',
+      bundlePath: 'first',
+      page: '/same',
+      pathname: '/same',
+    })
+    const second = new RouteMatcher({
+      kind: RouteKind.APP_PAGE,
+      filename: 'second.js',
+      bundlePath: 'second',
+      page: '/same',
+      pathname: '/same',
+      appPaths: ['/same/page'],
+    })
+
+    manager.push({ matchers: async () => [first, second] })
+    await manager.reload()
+
+    const filenames: string[] = []
+    for await (const match of manager.matchAll('/same', {})) {
+      filenames.push(match.definition.filename)
+    }
+    expect(filenames).toEqual(['first.js', 'second.js'])
+  })
 })
 
 // TODO: port tests

--- a/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
@@ -11,7 +11,7 @@ import { ensureLeadingSlash } from '../../shared/lib/page-path/ensure-leading-sl
 import { DetachedPromise } from '../../lib/detached-promise'
 
 interface RouteMatchers {
-  static: ReadonlyArray<RouteMatcher>
+  static: ReadonlyMap<string, ReadonlyArray<RouteMatcher>>
   dynamic: ReadonlyArray<RouteMatcher>
   duplicates: Record<string, ReadonlyArray<RouteMatcher>>
 }
@@ -19,7 +19,7 @@ interface RouteMatchers {
 export class DefaultRouteMatcherManager implements RouteMatcherManager {
   private readonly providers: Array<RouteMatcherProvider> = []
   protected readonly matchers: RouteMatchers = {
-    static: [],
+    static: new Map(),
     dynamic: [],
     duplicates: {},
   }
@@ -118,11 +118,27 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
       }
       this.previousMatchers = matchers
 
-      // For matchers that are for static routes, filter them now.
-      this.matchers.static = matchers.filter((matcher) => !matcher.isDynamic)
+      // Index static matchers by pathname so exact route matches don't need
+      // to scan every static route on each request.
+      const staticMatchers = new Map<string, RouteMatcher[]>()
+      const dynamic: RouteMatcher[] = []
+      for (const matcher of matchers) {
+        if (matcher.isDynamic) {
+          dynamic.push(matcher)
+          continue
+        }
 
-      // For matchers that are for dynamic routes, filter them and sort them now.
-      const dynamic = matchers.filter((matcher) => matcher.isDynamic)
+        const pathname = matcher.definition.pathname
+        const pathnameMatchers = staticMatchers.get(pathname)
+        if (pathnameMatchers) {
+          pathnameMatchers.push(matcher)
+        } else {
+          staticMatchers.set(pathname, [matcher])
+        }
+      }
+      this.matchers.static = staticMatchers
+
+      // Sort the dynamic route matchers.
 
       // As `getSortedRoutes` only takes an array of strings, we need to create
       // a map of the pathnames (used for sorting) and the matchers. When we
@@ -266,7 +282,10 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
     // that when a route like `/user/[id]` is encountered, it doesn't just match
     // with the list of normalized routes.
     if (!isDynamicRoute(pathname)) {
-      for (const matcher of this.matchers.static) {
+      const staticPathname = options.i18n?.pathname
+        ? ensureLeadingSlash(options.i18n.pathname)
+        : pathname
+      for (const matcher of this.matchers.static.get(staticPathname) ?? []) {
         const match = this.validate(pathname, matcher, options)
         if (!match) continue
 


### PR DESCRIPTION
### What?

Index non-dynamic route matchers by their definition pathname when the matcher manager reloads, then validate only the exact-path bucket for a static request.

This also adds focused tests showing that unrelated static matchers are not validated and that duplicate static matchers retain provider order.

### Why?

The static request path currently scans every static matcher before finding a match or returning a miss. That makes static route matching O(number of static routes) per request.

A focused warm-process benchmark used an A1/B1/B2/A2 sequence on three identical 8-vCPU/16-GiB Vercel Sandbox workers at the same commit, toolchain, and cache state. At 10,000 static routes, median matcher-call time changed as follows:

| Lookup | Baseline | Candidate | Improvement |
| --- | ---: | ---: | ---: |
| middle | 183,647 ns | 792 ns | 99.557% (229.49x) |
| last | 364,223 ns | 771 ns | 99.783% (461.58x) |
| miss | 336,203 ns | 412 ns | 99.878% (817.35x) |

All three workers agreed directionally for those scenarios. First-route lookup was unchanged within A/A noise and is not claimed as a win.

The tradeoff is additional work during matcher-manager reload: at 10,000 static routes, median reload time increased from 1.667 ms to 2.496 ms (+0.829 ms). This is paid once per reload rather than on each request.

### How?

The matcher manager now builds a `Map<string, RouteMatcher[]>` for static routes in the existing reload pass while collecting dynamic routes separately. Matching uses the locale-normalized pathname, preserving the existing i18n behavior, and keeps arrays in provider order so duplicate handling remains stable. Dynamic route sorting and matching are unchanged.

Validation:

- focused matcher-manager unit tests: 9/9
- `pnpm --filter=next types`
- targeted Prettier and ESLint checks
- `pnpm --filter=next build`
- independent GPT-5.6 Sol xhigh and Claude Opus 4.8 xhigh review: no findings
