### PR TITLE
refactor(examples): remove unnecessary duplicate key props

### DIFF
--- a/examples/cms-sitecore-xmcloud/src/components/ColumnSplitter.tsx
+++ b/examples/cms-sitecore-xmcloud/src/components/ColumnSplitter.tsx
@@ -50,12 +50,8 @@ export const Default = (props: ComponentProps): JSX.Element => {
 
         return (
           <div key={index} className={phStyles}>
-            <div key={index} className="row">
-              <Placeholder
-                key={index}
-                name={phKey}
-                rendering={props.rendering}
-              />
+            <div className="row">
+              <Placeholder name={phKey} rendering={props.rendering} />
             </div>
           </div>
         );

--- a/examples/cms-sitecore-xmcloud/src/components/RowSplitter.tsx
+++ b/examples/cms-sitecore-xmcloud/src/components/RowSplitter.tsx
@@ -38,13 +38,9 @@ export const Default = (props: ComponentProps): JSX.Element => {
 
         return (
           <div key={index} className={`container-fluid ${phStyles}`.trimEnd()}>
-            <div key={index}>
-              <div key={index} className="row">
-                <Placeholder
-                  key={index}
-                  name={phKey}
-                  rendering={props.rendering}
-                />
+            <div>
+              <div className="row">
+                <Placeholder name={phKey} rendering={props.rendering} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

While reviewing the examples in the Next.js repository for potential improvements, I noticed that some components apply the `key` prop to multiple nested elements inside a `map()` callback.

This PR removes the unnecessary duplicate `key` props and keeps the `key` only on the outermost element returned from the list, which is the element React uses for reconciliation.

## Changes

* Removed unnecessary duplicate `key` props from nested JSX elements in the affected example components.
* Kept the `key` on the top-level element returned by the `map()` callback.
* No functional changes.

## Testing

* Verified the affected example components render as expected after the cleanup.
