### PR TITLE
refactor(examples): remove unused key prop from LinkListItemProps

### DIFF
--- a/examples/cms-sitecore-xmcloud/src/components/LinkList.tsx
+++ b/examples/cms-sitecore-xmcloud/src/components/LinkList.tsx
@@ -31,7 +31,6 @@ type LinkListProps = {
 };
 
 type LinkListItemProps = {
-  key: string;
   index: number;
   total: number;
   field: LinkField;


### PR DESCRIPTION
## Summary

While reviewing the examples in the Next.js repository for potential improvements, I noticed that `LinkListItemProps` declares a `key` prop that is never used.

Since `key` is a special React prop used internally for list reconciliation and is not passed to components, it doesn't need to be included in the component's props type.

## Changes

* Removed the unused `key` property from `LinkListItemProps`.
* No functional changes to the component.

## Testing

* Verified the component renders as expected after the type cleanup.
