### PR TITLE
refactor(examples): remove unnecessary key attribute from NavigationList

### DIFF
--- a/examples/cms-sitecore-xmcloud/src/components/Navigation.tsx
+++ b/examples/cms-sitecore-xmcloud/src/components/Navigation.tsx
@@ -82,7 +82,6 @@ const NavigationList = (props: NavigationProps) => {
       className={props.fields.Styles.concat(
         "rel-level" + props.relativeLevel,
       ).join(" ")}
-      key={props.fields.Id}
       tabIndex={0}
     >
       <div className="navigation-title">


### PR DESCRIPTION
## Summary

While reviewing the examples in the Next.js repository for potential improvements, I noticed that the `key` attribute is applied to the `<li>` element inside `NavigationList`.

Since `NavigationList` is already assigned a `key` where it is rendered in the parent component's `map()` call, the `key` on the nested `<li>` is unnecessary and has no effect on React's reconciliation.

## Changes

* Removed the unnecessary `key` attribute from the `<li>` element in `NavigationList`.
* No functional changes to the component.

## Testing

* Verified the component renders as expected after the cleanup.
