### PR TITLE
Fix dev server readiness racing the initial pages scan

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1218,17 +1218,11 @@ async function startWatcher(
       }
     }
 
-    // The initial scan emits change events for every pre-existing file
-    // (because of `startTime: 0`), and `aggregated` fires `aggregateTimeout`
-    // ms after the last event. Under I/O pressure the scan can pause for
-    // longer than `aggregateTimeout`, firing an aggregation whose
-    // `getTimeInfoEntries()` is missing part of the pages tree. Processing
-    // that partial snapshot would build an incomplete dynamic-route table
-    // and — on the first aggregation, which resolves this promise — report
-    // the server ready while dynamic routes 404. Wait until every directory
-    // watcher finished its initial scan before processing, and coalesce
-    // aggregations that arrive while a run is queued (a queued run reads
-    // fresh state when it starts, so their changes are not lost).
+    // `aggregated` can fire while the initial scan is still in flight (any
+    // event lull longer than `aggregateTimeout` triggers it), which would
+    // build the route tables from a partial file list and report the server
+    // ready while dynamic routes 404. Wait for the scan to finish before
+    // processing, and coalesce events that arrive while a run is queued.
     let aggregationQueued = false
     let aggregationChain: Promise<void> = Promise.resolve()
     wp.on('aggregated', () => {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -30,6 +30,7 @@ import { verifyAndRunTypeScript } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
 import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
 import { buildDataRoute } from './build-data-route'
+import { waitForInitialScan } from './watchpack-initial-scan'
 import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { createClientRouterFilter } from '../../../lib/create-client-router-filter'
@@ -421,7 +422,7 @@ async function startWatcher(
     const validatorFilePath = path.join(distDir, 'types', 'validator.ts')
 
     let initialWatchTime = performance.now() + performance.timeOrigin
-    wp.on('aggregated', async () => {
+    const processAggregatedChanges = async () => {
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
       let middlewareMatchers: ProxyMatcher[] | undefined
@@ -1215,6 +1216,31 @@ async function startWatcher(
           Log.warn('Failed to reload dynamic routes:', e)
         }
       }
+    }
+
+    // The initial scan emits change events for every pre-existing file
+    // (because of `startTime: 0`), and `aggregated` fires `aggregateTimeout`
+    // ms after the last event. Under I/O pressure the scan can pause for
+    // longer than `aggregateTimeout`, firing an aggregation whose
+    // `getTimeInfoEntries()` is missing part of the pages tree. Processing
+    // that partial snapshot would build an incomplete dynamic-route table
+    // and — on the first aggregation, which resolves this promise — report
+    // the server ready while dynamic routes 404. Wait until every directory
+    // watcher finished its initial scan before processing, and coalesce
+    // aggregations that arrive while a run is queued (a queued run reads
+    // fresh state when it starts, so their changes are not lost).
+    let aggregationQueued = false
+    let aggregationChain: Promise<void> = Promise.resolve()
+    wp.on('aggregated', () => {
+      if (aggregationQueued) {
+        return
+      }
+      aggregationQueued = true
+      aggregationChain = aggregationChain.then(async () => {
+        aggregationQueued = false
+        await waitForInitialScan(wp)
+        await processAggregatedChanges()
+      })
     })
 
     wp.watch({ directories: [dir], startTime: 0 })

--- a/packages/next/src/server/lib/router-utils/watchpack-initial-scan.ts
+++ b/packages/next/src/server/lib/router-utils/watchpack-initial-scan.ts
@@ -1,27 +1,5 @@
 import type Watchpack from 'next/dist/compiled/watchpack'
 
-/**
- * Watchpack's initial directory scan runs asynchronously after `watch()`.
- * When watching with a `startTime` in the past (e.g. `startTime: 0`), the
- * scan emits one change event per pre-existing file, and the `aggregated`
- * event fires `aggregateTimeout` ms after the *last* change event. That means
- * `aggregated` can fire while the initial scan is still in flight (any event
- * lull longer than `aggregateTimeout` mid-scan triggers it), in which case
- * `getTimeInfoEntries()` is missing part of the watched tree.
- *
- * Watchpack has no public signal for scan completion, but every internal
- * `DirectoryWatcher` carries an `initialScan` flag that flips to `false` once
- * its first scan of that directory level finishes (including on scan errors).
- * Nested directories get their own `DirectoryWatcher`, created by the parent
- * while the parent's flag is still `true`. Therefore "no reachable watcher
- * has `initialScan === true`" implies the whole watched tree has been
- * scanned.
- *
- * The traversal below reads watchpack internals, so it is deliberately
- * defensive: anything with an unexpected shape is treated as "not pending",
- * which degrades to the previous behavior instead of blocking the watcher.
- */
-
 interface InternalDirectoryWatcher {
   initialScan?: boolean
   closed?: boolean
@@ -32,6 +10,12 @@ interface InternalWatcherHandle {
   directoryWatcher?: InternalDirectoryWatcher
 }
 
+// Watchpack has no public signal for when the asynchronous initial scan has
+// finished, but each internal DirectoryWatcher flips `initialScan` to false
+// once its directory level is scanned (including on scan errors), and nested
+// watchers are created while the parent's flag is still true — so no reachable
+// watcher pending means the whole tree has been scanned. Reading internals is
+// deliberately defensive: an unexpected shape counts as "not pending".
 export function hasPendingInitialScan(watchpack: Watchpack): boolean {
   const wp = watchpack as any
   const queue: InternalDirectoryWatcher[] = []

--- a/packages/next/src/server/lib/router-utils/watchpack-initial-scan.ts
+++ b/packages/next/src/server/lib/router-utils/watchpack-initial-scan.ts
@@ -1,0 +1,81 @@
+import type Watchpack from 'next/dist/compiled/watchpack'
+
+/**
+ * Watchpack's initial directory scan runs asynchronously after `watch()`.
+ * When watching with a `startTime` in the past (e.g. `startTime: 0`), the
+ * scan emits one change event per pre-existing file, and the `aggregated`
+ * event fires `aggregateTimeout` ms after the *last* change event. That means
+ * `aggregated` can fire while the initial scan is still in flight (any event
+ * lull longer than `aggregateTimeout` mid-scan triggers it), in which case
+ * `getTimeInfoEntries()` is missing part of the watched tree.
+ *
+ * Watchpack has no public signal for scan completion, but every internal
+ * `DirectoryWatcher` carries an `initialScan` flag that flips to `false` once
+ * its first scan of that directory level finishes (including on scan errors).
+ * Nested directories get their own `DirectoryWatcher`, created by the parent
+ * while the parent's flag is still `true`. Therefore "no reachable watcher
+ * has `initialScan === true`" implies the whole watched tree has been
+ * scanned.
+ *
+ * The traversal below reads watchpack internals, so it is deliberately
+ * defensive: anything with an unexpected shape is treated as "not pending",
+ * which degrades to the previous behavior instead of blocking the watcher.
+ */
+
+interface InternalDirectoryWatcher {
+  initialScan?: boolean
+  closed?: boolean
+  directories?: Map<string, InternalWatcherHandle | true>
+}
+
+interface InternalWatcherHandle {
+  directoryWatcher?: InternalDirectoryWatcher
+}
+
+export function hasPendingInitialScan(watchpack: Watchpack): boolean {
+  const wp = watchpack as any
+  const queue: InternalDirectoryWatcher[] = []
+
+  for (const watchers of [wp.fileWatchers, wp.directoryWatchers]) {
+    if (typeof watchers?.values !== 'function') {
+      continue
+    }
+    for (const watcher of watchers.values()) {
+      const directoryWatcher = watcher?.watcher?.directoryWatcher
+      if (directoryWatcher) {
+        queue.push(directoryWatcher)
+      }
+    }
+  }
+
+  const visited = new Set<InternalDirectoryWatcher>()
+  while (queue.length > 0) {
+    const directoryWatcher = queue.pop()!
+    if (visited.has(directoryWatcher) || directoryWatcher.closed) {
+      continue
+    }
+    visited.add(directoryWatcher)
+    if (directoryWatcher.initialScan) {
+      return true
+    }
+    const directories = directoryWatcher.directories
+    if (typeof directories?.values !== 'function') {
+      continue
+    }
+    for (const nested of directories.values()) {
+      const nestedDirectoryWatcher = (nested as InternalWatcherHandle)
+        ?.directoryWatcher
+      if (nestedDirectoryWatcher) {
+        queue.push(nestedDirectoryWatcher)
+      }
+    }
+  }
+
+  return false
+}
+
+export async function waitForInitialScan(watchpack: Watchpack): Promise<void> {
+  while (hasPendingInitialScan(watchpack)) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10))
+  }
+}

--- a/test/unit/watchpack-initial-scan.test.ts
+++ b/test/unit/watchpack-initial-scan.test.ts
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+import Watchpack from 'next/dist/compiled/watchpack'
+import {
+  hasPendingInitialScan,
+  waitForInitialScan,
+} from 'next/dist/server/lib/router-utils/watchpack-initial-scan'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const FILES_PER_DIR = 40
+const DIR_COUNT = 50
+
+describe('watchpack-initial-scan', () => {
+  let dir: string
+  let expectedFiles: string[]
+  let wp: Watchpack | undefined
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'watchpack-initial-scan-'))
+    expectedFiles = []
+    for (let d = 0; d < DIR_COUNT; d++) {
+      const nested = path.join(dir, `dir-${d}`, 'nested')
+      fs.mkdirSync(nested, { recursive: true })
+      for (let f = 0; f < FILES_PER_DIR; f++) {
+        const file = path.join(nested, `file-${f}.js`)
+        fs.writeFileSync(file, `// ${d}/${f}`)
+        expectedFiles.push(file)
+      }
+    }
+  })
+
+  afterEach(() => {
+    wp?.close()
+    wp = undefined
+  })
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reports a pending scan right after watch() and completes with the full tree', async () => {
+    wp = new Watchpack({ aggregateTimeout: 5 })
+    wp.watch({ directories: [dir], startTime: 0 })
+
+    // The scan is asynchronous (watchpack defers it with process.nextTick),
+    // so nothing has been scanned yet at this point.
+    expect(hasPendingInitialScan(wp)).toBe(true)
+
+    await waitForInitialScan(wp)
+
+    expect(hasPendingInitialScan(wp)).toBe(false)
+    const known = wp.getTimeInfoEntries()
+    for (const file of expectedFiles) {
+      expect(known.has(file)).toBe(true)
+    }
+  })
+
+  it('sees the complete tree even when aggregated fires mid-scan', async () => {
+    // With an aggregateTimeout of 0 the aggregated event fires on the first
+    // event-loop lull of the scan, which for a tree of this size is reliably
+    // before the scan has finished — the situation a loaded machine produces
+    // with the production 5ms timeout.
+    wp = new Watchpack({ aggregateTimeout: 0 })
+    wp.watch({ directories: [dir], startTime: 0 })
+
+    await new Promise<void>((resolve) => wp!.once('aggregated', resolve))
+
+    await waitForInitialScan(wp)
+
+    const known = wp.getTimeInfoEntries()
+    for (const file of expectedFiles) {
+      expect(known.has(file)).toBe(true)
+    }
+  })
+})

--- a/test/unit/watchpack-initial-scan.test.ts
+++ b/test/unit/watchpack-initial-scan.test.ts
@@ -43,8 +43,7 @@ describe('watchpack-initial-scan', () => {
     wp = new Watchpack({ aggregateTimeout: 5 })
     wp.watch({ directories: [dir], startTime: 0 })
 
-    // The scan is asynchronous (watchpack defers it with process.nextTick),
-    // so nothing has been scanned yet at this point.
+    // The scan is deferred with process.nextTick, so nothing is scanned yet.
     expect(hasPendingInitialScan(wp)).toBe(true)
 
     await waitForInitialScan(wp)
@@ -57,10 +56,8 @@ describe('watchpack-initial-scan', () => {
   })
 
   it('sees the complete tree even when aggregated fires mid-scan', async () => {
-    // With an aggregateTimeout of 0 the aggregated event fires on the first
-    // event-loop lull of the scan, which for a tree of this size is reliably
-    // before the scan has finished — the situation a loaded machine produces
-    // with the production 5ms timeout.
+    // With aggregateTimeout 0 the aggregated event reliably fires mid-scan
+    // for a tree of this size — what a loaded machine produces with 5ms.
     wp = new Watchpack({ aggregateTimeout: 0 })
     wp.watch({ directories: [dir], startTime: 0 })
 


### PR DESCRIPTION
### What?

Fixes a race where `next dev` reports ready (and resolves `prepare()` for custom servers) before the watcher's initial pages-directory scan has finished. When that happens the dynamic-route table is built from a partial file list, so every dynamic pages-router route returns a 404 while static routes keep working, until a later file event rebuilds the table.

### Why?

The dev watcher builds its route tables inside watchpack's `aggregated` callback. Watchpack's initial scan runs asynchronously, emits one change event per pre-existing file, and fires `aggregated` `aggregateTimeout` ms after the last event. Since #83628 lowered `aggregateTimeout` to 5ms, any >5ms event loop block mid-scan (I/O contention, GC pause) fires the first aggregation while the scan is still in flight. `getTimeInfoEntries()` is then missing part of the pages tree. The first aggregation is also what resolves `startWatcher`'s promise, so the server can come up with a partial or empty `fsChecker.dynamicRoutes`. Reproduction linked in https://github.com/vercel/next.js/issues/96139.

### How?

- Before processing an aggregation, wait until every watchpack `DirectoryWatcher` reachable from the instance has finished its initial scan. The traversal reads watchpack internals, so it is deliberately defensive: an unexpected shape degrades to the previous behavior instead of blocking.
- Coalesce `aggregated` events that arrive while a run is already queued.
- After boot the pending-scan check is a cheap synchronous walk, the boot-time win from #83628 is kept.

Verified with the reproduction from the issue: with `aggregateTimeout` forced to `0` (making the race deterministic), the stock build processes a first aggregation with 0–1 of 5003 pages, while with this fix every processed aggregation sees all 5003 pages and dynamic routes respond 200 immediately at ready.

Unit tests added as well.

I'm not sure this is the best way to solve this, but it works. Please advise.

Fixes #96139
