### PR TITLE
docs(view-transitions): fix the skill install command

### DIFF
--- a/docs/01-app/02-guides/view-transitions.mdx
+++ b/docs/01-app/02-guides/view-transitions.mdx
@@ -12,20 +12,20 @@ React's `<ViewTransition>` component integrates with the browser's [View Transit
 
 This guide walks through four patterns that cover the most common cases: morphing shared elements, animating loading states, adding directional navigation, and crossfading content within the same route.
 
-## Use the react-view-transitions skill
+## Use the vercel-react-view-transitions skill
 
-The [`react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) skill teaches a coding agent the patterns in this guide, plus the CSS recipes and troubleshooting for applying them to an existing app.
+The [`vercel-react-view-transitions`](https://github.com/vercel-labs/agent-skills/tree/main/skills/react-view-transitions) skill teaches a coding agent the patterns in this guide, plus the CSS recipes and troubleshooting for applying them to an existing app.
 
 Install the skill:
 
 ```bash filename="Terminal"
-npx skills add vercel-labs/agent-skills --skill react-view-transitions
+npx skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-view-transitions
 ```
 
 Then give the agent this prompt:
 
 ```prompt
-Add view transitions to this app using the react-view-transitions skill.
+Add view transitions to this app using the vercel-react-view-transitions skill.
 ```
 
 To apply the patterns yourself, follow the walkthrough below.


### PR DESCRIPTION
### What?

Fix the skill install command in the view transitions guide.

### Why?

The skill's registered name is `vercel-react-view-transitions` (the repo directory is `react-view-transitions`), so the documented `npx skills add vercel-labs/agent-skills --skill react-view-transitions` fails to resolve the skill.

### How?

Use the verified command (`npx skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-view-transitions`) and align the heading, link text, and agent prompt with the real skill name. The directory link is unchanged.
