### PR TITLE
Add option to control dev memory threshold restarts

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -239,7 +239,7 @@ export const experimentalSchema = {
       }),
     ])
     .optional(),
-  disableDevMemoryThreshold: z.boolean().optional(),
+  devMemoryThresholdRestart: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),
   disablePostcssPresetEnv: z.boolean().optional(),
   cacheComponents: z.boolean().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -239,6 +239,7 @@ export const experimentalSchema = {
       }),
     ])
     .optional(),
+  disableDevMemoryThreshold: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),
   disablePostcssPresetEnv: z.boolean().optional(),
   cacheComponents: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -601,10 +601,10 @@ export interface ExperimentalConfig {
    */
   cssChunking?: CssChunkingConfig
   /**
-   * Disables the development server's automatic restart when its heap usage
-   * exceeds the memory threshold.
+   * Controls whether the development server automatically restarts when its
+   * heap usage exceeds the memory threshold. Defaults to `true`.
    */
-  disableDevMemoryThreshold?: boolean
+  devMemoryThresholdRestart?: boolean
   disablePostcssPresetEnv?: boolean
   cpus?: number
   memoryBasedWorkersCount?: boolean
@@ -2161,7 +2161,7 @@ export const defaultConfig = Object.freeze({
     nextScriptWorkers: false,
     scrollRestoration: false,
     externalDir: false,
-    disableDevMemoryThreshold: false,
+    devMemoryThresholdRestart: true,
     disableOptimizedLoading: false,
     gzipSize: true,
     craCompat: false,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -600,6 +600,11 @@ export interface ExperimentalConfig {
    *       styles at the expense of more requests overall.
    */
   cssChunking?: CssChunkingConfig
+  /**
+   * Disables the development server's automatic restart when its heap usage
+   * exceeds the memory threshold.
+   */
+  disableDevMemoryThreshold?: boolean
   disablePostcssPresetEnv?: boolean
   cpus?: number
   memoryBasedWorkersCount?: boolean
@@ -2156,6 +2161,7 @@ export const defaultConfig = Object.freeze({
     nextScriptWorkers: false,
     scrollRestoration: false,
     externalDir: false,
+    disableDevMemoryThreshold: false,
     disableOptimizedLoading: false,
     gzipSize: true,
     craCompat: false,

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -26,8 +26,8 @@ export type ServerInitResult = {
   partialPrefetching?: boolean | 'unstable_eager'
   // Whether AGENTS.md / CLAUDE.md auto-generation is enabled (default true)
   agentRules?: boolean
-  // Whether the development server memory threshold restart is disabled
-  disableDevMemoryThreshold: boolean
+  // Whether the development server memory threshold restart is enabled
+  devMemoryThresholdRestart: boolean
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
@@ -108,7 +108,7 @@ async function initializeImpl(opts: {
   experimentalFeatures: ConfiguredExperimentalFeature[]
   cacheComponents: boolean
   partialPrefetching?: boolean | 'unstable_eager'
-  disableDevMemoryThreshold: boolean
+  devMemoryThresholdRestart: boolean
 }): Promise<ServerInitResult> {
   const type = process.env.__NEXT_PRIVATE_RENDER_WORKER
   if (type) {
@@ -188,7 +188,7 @@ async function initializeImpl(opts: {
     experimentalFeatures: opts.experimentalFeatures,
     cacheComponents: opts.cacheComponents,
     partialPrefetching: opts.partialPrefetching,
-    disableDevMemoryThreshold: opts.disableDevMemoryThreshold,
+    devMemoryThresholdRestart: opts.devMemoryThresholdRestart,
   }
 }
 

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -26,6 +26,8 @@ export type ServerInitResult = {
   partialPrefetching?: boolean | 'unstable_eager'
   // Whether AGENTS.md / CLAUDE.md auto-generation is enabled (default true)
   agentRules?: boolean
+  // Whether the development server memory threshold restart is disabled
+  disableDevMemoryThreshold: boolean
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
@@ -106,6 +108,7 @@ async function initializeImpl(opts: {
   experimentalFeatures: ConfiguredExperimentalFeature[]
   cacheComponents: boolean
   partialPrefetching?: boolean | 'unstable_eager'
+  disableDevMemoryThreshold: boolean
 }): Promise<ServerInitResult> {
   const type = process.env.__NEXT_PRIVATE_RENDER_WORKER
   if (type) {
@@ -185,6 +188,7 @@ async function initializeImpl(opts: {
     experimentalFeatures: opts.experimentalFeatures,
     cacheComponents: opts.cacheComponents,
     partialPrefetching: opts.partialPrefetching,
+    disableDevMemoryThreshold: opts.disableDevMemoryThreshold,
   }
 }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -233,8 +233,8 @@ export async function initialize(opts: {
       config: developmentConfig,
     }
   }
-  const disableDevMemoryThreshold =
-    development?.config.experimental.disableDevMemoryThreshold === true
+  const devMemoryThresholdRestart =
+    development?.config.experimental.devMemoryThresholdRestart !== false
 
   renderServer.instance =
     require('./render-server') as typeof import('./render-server')
@@ -830,7 +830,7 @@ export async function initialize(opts: {
     experimentalFeatures,
     cacheComponents: config.cacheComponents,
     partialPrefetching: config.partialPrefetching,
-    disableDevMemoryThreshold,
+    devMemoryThresholdRestart,
   }
   renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
 
@@ -1012,6 +1012,6 @@ export async function initialize(opts: {
     cacheComponents: config.cacheComponents,
     partialPrefetching: config.partialPrefetching,
     agentRules: config.agentRules,
-    disableDevMemoryThreshold,
+    devMemoryThresholdRestart,
   }
 }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -122,11 +122,6 @@ export async function initialize(opts: {
       },
     }
   )
-  const disableDevMemoryThreshold = opts.dev
-    ? (config as NextConfigComplete).experimental.disableDevMemoryThreshold ===
-      true
-    : false
-
   if (bundlerBeforeConfig !== undefined) {
     finalizeBundlerFromConfig(bundlerBeforeConfig)
   }
@@ -238,6 +233,8 @@ export async function initialize(opts: {
       config: developmentConfig,
     }
   }
+  const disableDevMemoryThreshold =
+    development?.config.experimental.disableDevMemoryThreshold === true
 
   renderServer.instance =
     require('./render-server') as typeof import('./render-server')

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -122,6 +122,10 @@ export async function initialize(opts: {
       },
     }
   )
+  const disableDevMemoryThreshold = opts.dev
+    ? (config as NextConfigComplete).experimental.disableDevMemoryThreshold ===
+      true
+    : false
 
   if (bundlerBeforeConfig !== undefined) {
     finalizeBundlerFromConfig(bundlerBeforeConfig)
@@ -829,6 +833,7 @@ export async function initialize(opts: {
     experimentalFeatures,
     cacheComponents: config.cacheComponents,
     partialPrefetching: config.partialPrefetching,
+    disableDevMemoryThreshold,
   }
   renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
 
@@ -1010,5 +1015,6 @@ export async function initialize(opts: {
     cacheComponents: config.cacheComponents,
     partialPrefetching: config.partialPrefetching,
     agentRules: config.agentRules,
+    disableDevMemoryThreshold,
   }
 }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -18,7 +18,7 @@ import os from 'os'
 import { exec } from 'child_process'
 import * as Log from '../../build/output/log'
 import setupDebug from 'next/dist/compiled/debug'
-import { RESTART_EXIT_CODE } from './utils'
+import { getMemoryRestartStats, RESTART_EXIT_CODE } from './utils'
 import { formatHostname } from './format-hostname'
 import { initialize } from './router-server'
 import {
@@ -229,6 +229,7 @@ export async function startServer(
   }
 
   let nextServer: NextServer | undefined
+  let disableDevMemoryThreshold = false
 
   // setup server listener as fast as possible
   if (selfSignedCertificate && !isDev) {
@@ -250,23 +251,21 @@ export async function startServer(
       Log.error(`Failed to handle request for ${req.url}`)
       console.error(err)
     } finally {
-      if (isDev) {
-        if (
-          v8.getHeapStatistics().used_heap_size >
-          0.8 * v8.getHeapStatistics().heap_size_limit
-        ) {
-          Log.warn(
-            `Server is approaching the used memory threshold, restarting...`
-          )
-          trace('server-restart-close-to-memory-threshold', undefined, {
-            'memory.heapSizeLimit': String(
-              v8.getHeapStatistics().heap_size_limit
-            ),
-            'memory.heapUsed': String(v8.getHeapStatistics().used_heap_size),
-          }).stop()
-          await flushAllTraces()
-          process.exit(RESTART_EXIT_CODE)
-        }
+      const memoryRestartStats = getMemoryRestartStats(
+        isDev,
+        disableDevMemoryThreshold,
+        v8.getHeapStatistics
+      )
+      if (memoryRestartStats) {
+        Log.warn(
+          `Server is approaching the used memory threshold, restarting...`
+        )
+        trace('server-restart-close-to-memory-threshold', undefined, {
+          'memory.heapSizeLimit': String(memoryRestartStats.heap_size_limit),
+          'memory.heapUsed': String(memoryRestartStats.used_heap_size),
+        }).stop()
+        await flushAllTraces()
+        process.exit(RESTART_EXIT_CODE)
       }
     }
   }
@@ -495,6 +494,7 @@ export async function startServer(
           experimentalHttpsServer: !!selfSignedCertificate,
           serverFastRefresh,
         })
+        disableDevMemoryThreshold = initResult.disableDevMemoryThreshold
         requestHandler = initResult.requestHandler
         upgradeHandler = initResult.upgradeHandler
         nextServer = initResult.server

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -229,7 +229,7 @@ export async function startServer(
   }
 
   let nextServer: NextServer | undefined
-  let disableDevMemoryThreshold = false
+  let devMemoryThresholdRestart = true
 
   // setup server listener as fast as possible
   if (selfSignedCertificate && !isDev) {
@@ -253,7 +253,7 @@ export async function startServer(
     } finally {
       const memoryRestartStats = getMemoryRestartStats(
         isDev,
-        disableDevMemoryThreshold,
+        devMemoryThresholdRestart,
         v8.getHeapStatistics
       )
       if (memoryRestartStats) {
@@ -494,7 +494,7 @@ export async function startServer(
           experimentalHttpsServer: !!selfSignedCertificate,
           serverFastRefresh,
         })
-        disableDevMemoryThreshold = initResult.disableDevMemoryThreshold
+        devMemoryThresholdRestart = initResult.devMemoryThresholdRestart
         requestHandler = initResult.requestHandler
         upgradeHandler = initResult.upgradeHandler
         nextServer = initResult.server

--- a/packages/next/src/server/lib/utils.test.ts
+++ b/packages/next/src/server/lib/utils.test.ts
@@ -87,16 +87,16 @@ describe('getMemoryRestartStats', () => {
 
   it('returns heap statistics above the threshold in development', () => {
     expect(
-      getMemoryRestartStats(false, false, () => aboveThreshold)
+      getMemoryRestartStats(false, true, () => aboveThreshold)
     ).toBeUndefined()
-    expect(getMemoryRestartStats(true, false, () => aboveThreshold)).toBe(
+    expect(getMemoryRestartStats(true, true, () => aboveThreshold)).toBe(
       aboveThreshold
     )
   })
 
   it('does not return heap statistics at the threshold', () => {
     expect(
-      getMemoryRestartStats(true, false, () => ({
+      getMemoryRestartStats(true, true, () => ({
         used_heap_size: 80,
         heap_size_limit: 100,
       }))
@@ -106,7 +106,9 @@ describe('getMemoryRestartStats', () => {
   it('does not read heap statistics when the threshold is disabled', () => {
     const getHeapStatistics = jest.fn(() => aboveThreshold)
 
-    expect(getMemoryRestartStats(true, true, getHeapStatistics)).toBeUndefined()
+    expect(
+      getMemoryRestartStats(true, false, getHeapStatistics)
+    ).toBeUndefined()
     expect(getHeapStatistics).not.toHaveBeenCalled()
   })
 })

--- a/packages/next/src/server/lib/utils.test.ts
+++ b/packages/next/src/server/lib/utils.test.ts
@@ -4,6 +4,7 @@ import {
   formatNodeOptions,
   tokenizeArgs,
   getParsedNodeOptions,
+  getMemoryRestartStats,
 } from './utils'
 
 const originalNodeOptions = process.env.NODE_OPTIONS
@@ -75,6 +76,38 @@ describe('formatNodeOptions', () => {
         '--experimental-inspector-network-resource',
       ],
     })
+  })
+})
+
+describe('getMemoryRestartStats', () => {
+  const aboveThreshold = {
+    used_heap_size: 81,
+    heap_size_limit: 100,
+  }
+
+  it('returns heap statistics above the threshold in development', () => {
+    expect(
+      getMemoryRestartStats(false, false, () => aboveThreshold)
+    ).toBeUndefined()
+    expect(getMemoryRestartStats(true, false, () => aboveThreshold)).toBe(
+      aboveThreshold
+    )
+  })
+
+  it('does not return heap statistics at the threshold', () => {
+    expect(
+      getMemoryRestartStats(true, false, () => ({
+        used_heap_size: 80,
+        heap_size_limit: 100,
+      }))
+    ).toBeUndefined()
+  })
+
+  it('does not read heap statistics when the threshold is disabled', () => {
+    const getHeapStatistics = jest.fn(() => aboveThreshold)
+
+    expect(getMemoryRestartStats(true, true, getHeapStatistics)).toBeUndefined()
+    expect(getHeapStatistics).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -289,6 +289,31 @@ export function parseValidPositiveInteger(value: string): number {
 
 export const RESTART_EXIT_CODE = 77
 
+type HeapStatistics = {
+  used_heap_size: number
+  heap_size_limit: number
+}
+
+/**
+ * @internal
+ */
+export function getMemoryRestartStats<T extends HeapStatistics>(
+  isDev: boolean,
+  disableDevMemoryThreshold: boolean,
+  getHeapStatistics: () => T
+): T | undefined {
+  if (!isDev || disableDevMemoryThreshold) {
+    return undefined
+  }
+
+  const heapStatistics = getHeapStatistics()
+  if (heapStatistics.used_heap_size > 0.8 * heapStatistics.heap_size_limit) {
+    return heapStatistics
+  }
+
+  return undefined
+}
+
 export type NodeInspectType = 'inspect' | 'inspect-brk' | undefined
 
 /**

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -299,10 +299,10 @@ type HeapStatistics = {
  */
 export function getMemoryRestartStats<T extends HeapStatistics>(
   isDev: boolean,
-  disableDevMemoryThreshold: boolean,
+  devMemoryThresholdRestart: boolean,
   getHeapStatistics: () => T
 ): T | undefined {
-  if (!isDev || disableDevMemoryThreshold) {
+  if (!isDev || !devMemoryThresholdRestart) {
     return undefined
   }
 

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -70,7 +70,7 @@ describe('config', () => {
         customConfig: {},
       }
     )
-    expect(defaultConfig.experimental.disableDevMemoryThreshold).toBe(false)
+    expect(defaultConfig.experimental.devMemoryThresholdRestart).toBe(true)
 
     const disabledConfig = await loadConfig(
       PHASE_DEVELOPMENT_SERVER,
@@ -78,12 +78,12 @@ describe('config', () => {
       {
         customConfig: {
           experimental: {
-            disableDevMemoryThreshold: true,
+            devMemoryThresholdRestart: false,
           },
         },
       }
     )
-    expect(disabledConfig.experimental.disableDevMemoryThreshold).toBe(true)
+    expect(disabledConfig.experimental.devMemoryThresholdRestart).toBe(false)
   })
 
   it('Should allow setting objects which do not have defaults', async () => {

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -62,6 +62,30 @@ describe('config', () => {
     expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
   })
 
+  it('Should configure the development memory threshold opt-out', async () => {
+    const defaultConfig = await loadConfig(
+      PHASE_DEVELOPMENT_SERVER,
+      '<rootDir>-memory-threshold-default',
+      {
+        customConfig: {},
+      }
+    )
+    expect(defaultConfig.experimental.disableDevMemoryThreshold).toBe(false)
+
+    const disabledConfig = await loadConfig(
+      PHASE_DEVELOPMENT_SERVER,
+      '<rootDir>-memory-threshold-disabled',
+      {
+        customConfig: {
+          experimental: {
+            disableDevMemoryThreshold: true,
+          },
+        },
+      }
+    )
+    expect(disabledConfig.experimental.disableDevMemoryThreshold).toBe(true)
+  })
+
   it('Should allow setting objects which do not have defaults', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
       customConfig: {


### PR DESCRIPTION
## Summary

Adds `experimental.devMemoryThresholdRestart`, defaulting to `true`, so projects can set it to `false` to opt out of the development server restart that occurs when V8 heap usage exceeds 80%. The option has no effect on `next start`.

## Verification

- Focused config-loading and memory-threshold unit suites passed
- `pnpm --filter=next build` completed JavaScript compilation, then failed on pre-existing `sharp` and `@vercel/detect-agent` declaration errors unrelated to this change

<!-- NEXT_JS_LLM -->