### PR TITLE
docs(preventing-flash): cover reconciling state 

### DIFF
--- a/docs/01-app/02-guides/preventing-flash-before-hydration.mdx
+++ b/docs/01-app/02-guides/preventing-flash-before-hydration.mdx
@@ -479,6 +479,35 @@ export function Accordion() {
 
 The inline script and the lazy `useState` initializer both read from `localStorage`. They always agree, so React's initial state matches the DOM.
 
+## Re-applying attributes in development
+
+The inline script sets the attribute during parsing, which is all a production build needs. In development, though, [React's Strict Mode](https://react.dev/reference/react/StrictMode) remounts components once to surface bugs, and on that remount it resets `<html>`, `<head>`, and `<body>` to only the attributes it manages from JSX, clearing the one the script set. The page then renders without the attribute, ignoring the value's source of truth.
+
+One way to fix this is to do what you would do without the inline script at all. Read the stored value on the client and apply it, in the component that owns the theme, in a [`useLayoutEffect`](https://react.dev/reference/react/useLayoutEffect) that runs [before paint](#why-not-useeffect):
+
+```tsx filename="app/components/theme-toggle.tsx"
+'use client'
+
+import { useLayoutEffect } from 'react'
+
+export function ThemeToggle() {
+  // Re-apply after React clears it on the dev remount; a no-op in production.
+  useLayoutEffect(() => {
+    const theme = localStorage.getItem('theme')
+    if (theme) document.documentElement.setAttribute('data-theme', theme)
+  }, [])
+
+  function toggle() {
+    const next =
+      (localStorage.getItem('theme') ?? 'light') === 'dark' ? 'light' : 'dark'
+    localStorage.setItem('theme', next)
+    document.documentElement.setAttribute('data-theme', next)
+  }
+
+  return <button onClick={toggle}>Toggle theme</button>
+}
+```
+
 ## When to use other approaches
 
 | Situation                                       | Approach                                                                                                                                                             |

--- a/docs/01-app/02-guides/preventing-flash-before-hydration.mdx
+++ b/docs/01-app/02-guides/preventing-flash-before-hydration.mdx
@@ -491,7 +491,7 @@ One way to fix this is to do what you would do without the inline script at all.
 import { useLayoutEffect } from 'react'
 
 export function ThemeToggle() {
-  // Re-apply after React clears it on the dev remount; a no-op in production.
+  // Re-apply after React clears it on the dev remount. This is a no-op in production.
   useLayoutEffect(() => {
     const theme = localStorage.getItem('theme')
     if (theme) document.documentElement.setAttribute('data-theme', theme)


### PR DESCRIPTION
We got feedback for one case where, in dev mode, Strict Mode caused removed the attributes added to the HTML tag by the injection script.

