### PR TITLE
Classify Instant Insights as internal in Request Insights

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -12,6 +12,13 @@
   font-size: var(--size-14);
 }
 
+.request-insights-list-empty {
+  padding: 16px 20px;
+  color: var(--color-gray-900);
+  font-size: var(--size-12);
+  line-height: 1.5;
+}
+
 .request-insights-list {
   border-right: 1px solid var(--color-gray-400);
   overflow: auto;
@@ -38,6 +45,14 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+}
+
+.request-insights-settings-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--color-red-800);
 }
 
 .request-insights-settings-trigger {
@@ -164,6 +179,33 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-row[data-internal='true'] .request-insights-route-label {
+  color: var(--color-gray-900);
+  font-weight: 400;
+}
+
+.request-insights-row[data-nested='true'] .request-insights-route {
+  padding-left: 18px;
+}
+
+.request-insights-nested-arrow {
+  flex-shrink: 0;
+  color: var(--color-gray-700);
+}
+
+.request-insights-internal-badge {
+  flex-shrink: 0;
+  margin-right: 6px;
+  border: 1px solid var(--color-gray-500);
+  border-radius: 999px;
+  padding: 1px 6px;
+  color: var(--color-gray-800);
+  font-size: var(--size-10);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .request-insights-page-load {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -12,7 +12,12 @@ import { saveDevToolsConfig } from '../../utils/save-devtools-config'
 import { CopyButton } from '../copy-button'
 import GearIcon from '../../icons/gear-icon'
 import { formatDuration } from './format-duration'
-import { getActiveRequestKey, isPageLoadRequest } from './request-list'
+import {
+  getActiveRequestKey,
+  getRequestListEntries,
+  isInternalRequestInsight,
+  isPageLoadRequest,
+} from './request-list'
 import {
   getTraceItems,
   getTracePosition,
@@ -29,24 +34,47 @@ export function RequestInsightsPanel() {
     () => [...state.requestInsights].reverse(),
     [state.requestInsights]
   )
-  const { verbose } = state.requestInsightsConfig
-  const setVerbose = (checked: boolean) => {
-    const requestInsights = { verbose: checked }
+  const { showInternal, verbose } = state.requestInsightsConfig
+  const setRequestInsightsConfig = (patch: {
+    showInternal?: boolean
+    verbose?: boolean
+  }) => {
     dispatch({
       type: ACTION_DEVTOOLS_CONFIG,
-      devToolsConfig: { requestInsights },
+      devToolsConfig: { requestInsights: patch },
     })
-    saveDevToolsConfig({ requestInsights })
+    saveDevToolsConfig({ requestInsights: patch })
   }
-  const [selectedRequestKey, setSelectedRequestKey] = useState<string | null>(
-    () => getActiveRequestKey(requests, null)
+  const listEntries = useMemo(
+    () => getRequestListEntries(requests, showInternal),
+    [requests, showInternal]
   )
-  const activeRequestKey = getActiveRequestKey(requests, selectedRequestKey)
+  const visibleRequests = useMemo(
+    () => listEntries.map((entry) => entry.request),
+    [listEntries]
+  )
+  const [selectedRequestKey, setSelectedRequestKey] = useState<string | null>(
+    () => getActiveRequestKey(visibleRequests, null)
+  )
+  const activeRequestKey = getActiveRequestKey(
+    visibleRequests,
+    selectedRequestKey
+  )
   const selectedRequest =
-    requests.find(
+    visibleRequests.find(
       (request) => getRequestInsightKey(request) === activeRequestKey
     ) ?? null
   const initialRequestId = self.__next_r
+  const internalRequests = useMemo(
+    () => requests.filter((request) => isInternalRequestInsight(request)),
+    [requests]
+  )
+  const hiddenInternalErrorCount = showInternal
+    ? 0
+    : internalRequests.filter((request) => request.status === 'error').length
+  // Only offer the internal-activity toggle once the session has captured
+  // internal activity to reveal.
+  const showInternalToggle = internalRequests.length > 0
 
   if (requests.length === 0) {
     return (
@@ -62,6 +90,14 @@ export function RequestInsightsPanel() {
         <div className="request-insights-list-toolbar">
           <strong>Requests</strong>
           <div className="request-insights-settings">
+            {hiddenInternalErrorCount > 0 ? (
+              <span
+                aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
+                className="request-insights-settings-dot"
+                data-status="error"
+                role="img"
+              />
+            ) : null}
             <Menu.Root delay={0} modal={false}>
               <Menu.Trigger
                 aria-label="Request list settings"
@@ -77,11 +113,31 @@ export function RequestInsightsPanel() {
                   sideOffset={4}
                 >
                   <Menu.Popup className="request-insights-settings-menu">
+                    {showInternalToggle ? (
+                      <Menu.CheckboxItem
+                        checked={showInternal}
+                        className="request-insights-settings-item"
+                        closeOnClick={false}
+                        onCheckedChange={(checked) =>
+                          setRequestInsightsConfig({ showInternal: checked })
+                        }
+                      >
+                        <span
+                          className="request-insights-settings-checkbox"
+                          data-checked={showInternal || undefined}
+                        >
+                          {showInternal ? <CheckIcon /> : null}
+                        </span>
+                        Internal activity
+                      </Menu.CheckboxItem>
+                    ) : null}
                     <Menu.CheckboxItem
                       checked={verbose}
                       className="request-insights-settings-item"
                       closeOnClick={false}
-                      onCheckedChange={setVerbose}
+                      onCheckedChange={(checked) =>
+                        setRequestInsightsConfig({ verbose: checked })
+                      }
                     >
                       <span
                         className="request-insights-settings-checkbox"
@@ -97,18 +153,26 @@ export function RequestInsightsPanel() {
             </Menu.Root>
           </div>
         </div>
-        {requests.map((request) => {
-          const requestKey = getRequestInsightKey(request)
-          return (
-            <RequestRow
-              key={requestKey}
-              request={request}
-              pageLoad={isPageLoadRequest(request, initialRequestId)}
-              selected={requestKey === activeRequestKey}
-              onSelect={() => setSelectedRequestKey(requestKey)}
-            />
-          )
-        })}
+        {listEntries.length === 0 ? (
+          <div className="request-insights-list-empty">
+            Only internal activity has been captured. Enable “Internal activity”
+            to view it.
+          </div>
+        ) : (
+          listEntries.map(({ request, nested }) => {
+            const requestKey = getRequestInsightKey(request)
+            return (
+              <RequestRow
+                key={requestKey}
+                nested={nested}
+                request={request}
+                pageLoad={isPageLoadRequest(request, initialRequestId)}
+                selected={requestKey === activeRequestKey}
+                onSelect={() => setSelectedRequestKey(requestKey)}
+              />
+            )
+          })
+        )}
       </div>
 
       {selectedRequest && (
@@ -120,11 +184,13 @@ export function RequestInsightsPanel() {
 
 function RequestRow({
   request,
+  nested,
   pageLoad,
   selected,
   onSelect,
 }: {
   request: RequestInsight
+  nested: boolean
   pageLoad: boolean
   selected: boolean
   onSelect: () => void
@@ -136,6 +202,8 @@ function RequestRow({
   return (
     <button
       className="request-insights-row"
+      data-internal={isInstantInsights || undefined}
+      data-nested={nested || undefined}
       data-page-load={pageLoad}
       data-selected={selected}
       onClick={onSelect}
@@ -143,10 +211,14 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
+        {nested ? <NestedArrowIcon /> : null}
+        {isInstantInsights && !nested ? (
+          <span className="request-insights-internal-badge">Internal</span>
+        ) : null}
         <span className="request-insights-route-label">
           {isInstantInsights ? 'Instant Insights' : route}
         </span>
-        {isInstantInsights ? (
+        {isInstantInsights && !nested ? (
           <span className="request-insights-item-context">{route}</span>
         ) : pageLoad ? (
           <span className="request-insights-page-load">Page load</span>
@@ -164,6 +236,25 @@ function RequestRow({
           : 'No fetches'}
       </span>
     </button>
+  )
+}
+
+function NestedArrowIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="request-insights-nested-arrow"
+      fill="none"
+      height="12"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      viewBox="0 0 16 16"
+      width="12"
+    >
+      <path d="M4 3v5.5A2.5 2.5 0 0 0 6.5 11H12M12 11l-3-3m3 3-3 3" />
+    </svg>
   )
 }
 

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -94,7 +94,6 @@ export function RequestInsightsPanel() {
               <span
                 aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
                 className="request-insights-settings-dot"
-                data-status="error"
                 role="img"
               />
             ) : null}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -63,8 +63,9 @@ export function getRequestListEntries(
   const entries: RequestListEntry[] = []
   for (const request of requests) {
     if (isInternalRequestInsight(request)) {
-      // Orphans (no parent request in the list) keep their original position;
-      // nested internal records are emitted under their request below.
+      // Orphans (no parent request in the list) remain top-level and preserve
+      // their ordering relative to other top-level records. Nested internal
+      // records are emitted under their request below.
       if (!parentRequestIds.has(request.requestId)) {
         entries.push({ request, nested: false })
       }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -22,6 +22,66 @@ export function getActiveRequestKey(
   return request ? getRequestInsightKey(request) : null
 }
 
+export function isInternalRequestInsight(
+  request: Pick<RequestInsight, 'kind'>
+): boolean {
+  return getRequestInsightKind(request) !== 'request'
+}
+
+export type RequestListEntry = {
+  request: RequestInsight
+  nested: boolean
+}
+
+export function getRequestListEntries(
+  requests: readonly RequestInsight[],
+  showInternal: boolean
+): RequestListEntry[] {
+  if (!showInternal) {
+    return requests
+      .filter((request) => !isInternalRequestInsight(request))
+      .map((request) => ({ request, nested: false }))
+  }
+
+  // Group internal records by the request they belong to, and record which
+  // request ids have a parent (non-internal) record present, both in one pass.
+  const internalByRequestId = new Map<string, RequestInsight[]>()
+  const parentRequestIds = new Set<string>()
+  for (const request of requests) {
+    if (isInternalRequestInsight(request)) {
+      const group = internalByRequestId.get(request.requestId)
+      if (group) {
+        group.push(request)
+      } else {
+        internalByRequestId.set(request.requestId, [request])
+      }
+    } else {
+      parentRequestIds.add(request.requestId)
+    }
+  }
+
+  const entries: RequestListEntry[] = []
+  for (const request of requests) {
+    if (isInternalRequestInsight(request)) {
+      // Orphans (no parent request in the list) keep their original position;
+      // nested internal records are emitted under their request below.
+      if (!parentRequestIds.has(request.requestId)) {
+        entries.push({ request, nested: false })
+      }
+      continue
+    }
+
+    entries.push({ request, nested: false })
+    const nested = internalByRequestId.get(request.requestId)
+    if (nested) {
+      for (const internalRequest of nested) {
+        entries.push({ request: internalRequest, nested: true })
+      }
+    }
+  }
+  return entries
+}
+
 export function isPageLoadRequest(
   request: Pick<RequestInsight, 'requestId' | 'kind'>,
   initialRequestId: string | undefined

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -91,7 +91,7 @@ describe('request insights trace viewer', () => {
     ])
   })
 
-  it('keeps orphaned internal records at their original position', () => {
+  it('keeps orphaned internal records top-level and in root ordering', () => {
     const request = createRequest({ requestId: 'present' })
     const presentInstantInsights = createRequest({
       requestId: 'present',

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -1,5 +1,9 @@
 import type { RequestInsight } from '../../../shared/request-insights'
-import { getActiveRequestKey, isPageLoadRequest } from './request-list'
+import {
+  getActiveRequestKey,
+  getRequestListEntries,
+  isPageLoadRequest,
+} from './request-list'
 import { getTraceItems, getTracePosition, getTraceRange } from './trace-viewer'
 
 function createRequest(
@@ -43,6 +47,76 @@ describe('request insights trace viewer', () => {
     expect(
       getActiveRequestKey([request, instantInsights], 'instant-insights:shared')
     ).toBe('instant-insights:shared')
+  })
+
+  it('hides internal records from the request list by default', () => {
+    const request = createRequest({ requestId: 'shared' })
+    const instantInsights = createRequest({
+      requestId: 'shared',
+      kind: 'instant-insights',
+    })
+
+    expect(getRequestListEntries([instantInsights, request], false)).toEqual([
+      { request, nested: false },
+    ])
+  })
+
+  it('nests internal records directly after their request row', () => {
+    const newerRequest = createRequest({ requestId: 'newer' })
+    const olderRequest = createRequest({ requestId: 'older' })
+    const newerInstantInsights = createRequest({
+      requestId: 'newer',
+      kind: 'instant-insights',
+    })
+    const olderInstantInsights = createRequest({
+      requestId: 'older',
+      kind: 'instant-insights',
+    })
+
+    expect(
+      getRequestListEntries(
+        [
+          newerInstantInsights,
+          newerRequest,
+          olderInstantInsights,
+          olderRequest,
+        ],
+        true
+      )
+    ).toEqual([
+      { request: newerRequest, nested: false },
+      { request: newerInstantInsights, nested: true },
+      { request: olderRequest, nested: false },
+      { request: olderInstantInsights, nested: true },
+    ])
+  })
+
+  it('keeps orphaned internal records at their original position', () => {
+    const request = createRequest({ requestId: 'present' })
+    const presentInstantInsights = createRequest({
+      requestId: 'present',
+      kind: 'instant-insights',
+    })
+    const orphanInstantInsights = createRequest({
+      requestId: 'evicted',
+      kind: 'instant-insights',
+    })
+
+    const entries = getRequestListEntries(
+      [presentInstantInsights, orphanInstantInsights, request],
+      true
+    )
+
+    expect(entries).toEqual([
+      { request: orphanInstantInsights, nested: false },
+      { request, nested: false },
+      { request: presentInstantInsights, nested: true },
+    ])
+    // Every record appears exactly once.
+    expect(new Set(entries.map((entry) => entry.request)).size).toBe(
+      entries.length
+    )
+    expect(entries).toHaveLength(3)
   })
 
   it('only marks the exact initial document request as the page load', () => {

--- a/packages/next/src/next-devtools/dev-overlay/shared.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.ts
@@ -30,6 +30,7 @@ export type DevToolsConfig = {
   scale?: number
   hideShortcut?: string | null
   requestInsights?: {
+    showInternal?: boolean
     verbose?: boolean
   }
 }
@@ -87,6 +88,7 @@ export interface OverlayState {
   readonly instantNavs: boolean
   readonly requestInsights: readonly RequestInsight[]
   readonly requestInsightsConfig: Readonly<{
+    showInternal: boolean
     verbose: boolean
   }>
 }
@@ -392,7 +394,7 @@ export const INITIAL_OVERLAY_STATE: Omit<
   hideShortcut: null,
   instantNavs: hasInstantNavsCookie,
   requestInsights: [],
-  requestInsightsConfig: { verbose: false },
+  requestInsightsConfig: { showInternal: false, verbose: false },
 }
 
 function getInitialState(
@@ -607,6 +609,9 @@ export function useErrorOverlayReducer(
               hideShortcut !== undefined ? hideShortcut : state.hideShortcut,
             requestInsightsConfig: requestInsightsConfig
               ? {
+                  showInternal:
+                    requestInsightsConfig.showInternal ??
+                    state.requestInsightsConfig.showInternal,
                   verbose:
                     requestInsightsConfig.verbose ??
                     state.requestInsightsConfig.verbose,

--- a/packages/next/src/next-devtools/shared/devtools-config-schema.ts
+++ b/packages/next/src/next-devtools/shared/devtools-config-schema.ts
@@ -20,6 +20,7 @@ export const devToolsConfigSchema: z.ZodType<DevToolsConfig> = z.object({
   hideShortcut: z.string().nullable().optional(),
   requestInsights: z
     .object({
+      showInternal: z.boolean().optional(),
       verbose: z.boolean().optional(),
     })
     .optional(),

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -252,7 +252,9 @@ describe('request insights', () => {
     }> {
       return browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
-        const item = root?.querySelector('.request-insights-settings-item')
+        const item = Array.from(
+          root?.querySelectorAll('.request-insights-settings-item') ?? []
+        ).find((candidate) => candidate.textContent?.includes('Verbose traces'))
         return {
           open: !!root?.querySelector('.request-insights-settings-menu'),
           checked:
@@ -348,6 +350,131 @@ describe('request insights', () => {
         await next.readFile('build/dev/cache/next-devtools-config.json')
       )
       expect(config.requestInsights?.verbose).toBe(false)
+    })
+  })
+
+  it('hides internal activity behind the settings menu', async () => {
+    const browser = await next.browser('/instant-insights')
+
+    async function openRequestInsightsPanel() {
+      await toggleDevToolsIndicatorPopover(browser)
+      await browser.elementByCss('[data-request-insights]').click()
+      await browser.waitForElementByCss('.request-insights-list-toolbar')
+      await retry(async () => {
+        const selectorMenuGone = await browser.eval(() => {
+          const root = document.querySelector('nextjs-portal')?.shadowRoot
+          return !root?.querySelector('#nextjs-dev-tools-menu')
+        })
+        expect(selectorMenuGone).toBe(true)
+      })
+    }
+
+    function getSettingsMenuItems(): Promise<
+      Array<{ label: string | undefined; checked: string | null }>
+    > {
+      return browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-settings-item') ?? []
+        ).map((item) => ({
+          label: item.textContent?.trim(),
+          checked:
+            item
+              .querySelector('.request-insights-settings-checkbox')
+              ?.getAttribute('data-checked') ?? null,
+        }))
+      })
+    }
+
+    await openRequestInsightsPanel()
+
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const rows = Array.from(
+          root?.querySelectorAll('.request-insights-row') ?? []
+        )
+        return {
+          rowCount: rows.length,
+          hasInstantInsightsRow: rows.some((row) =>
+            row.textContent?.includes('Instant Insights')
+          ),
+        }
+      })
+
+      expect(state.rowCount).toBeGreaterThan(0)
+      expect(state.hasInstantInsightsRow).toBe(false)
+    })
+
+    await browser.elementByCss('.request-insights-settings-trigger').click()
+    await retry(async () => {
+      expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Internal activity', checked: null },
+        { label: 'Verbose traces', checked: null },
+      ])
+    })
+
+    await browser
+      .elementByCss(
+        '.request-insights-settings-item:has-text("Internal activity")'
+      )
+      .click()
+
+    await retry(async () => {
+      const nestedRows = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-row[data-nested="true"]') ??
+            []
+        ).map((row) => ({
+          internal: row.getAttribute('data-internal'),
+          hasArrow: !!row.querySelector('.request-insights-nested-arrow'),
+          label: row.textContent ?? '',
+        }))
+      })
+
+      expect((await getSettingsMenuItems())[0]).toEqual({
+        label: 'Internal activity',
+        checked: 'true',
+      })
+      expect(nestedRows.length).toBeGreaterThan(0)
+      for (const row of nestedRows) {
+        expect(row.internal).toBe('true')
+        expect(row.hasArrow).toBe(true)
+        expect(row.label).toContain('Instant Insights')
+      }
+    })
+
+    await retry(async () => {
+      const config = JSON.parse(
+        await next.readFile('build/dev/cache/next-devtools-config.json')
+      )
+      expect(config.requestInsights?.showInternal).toBe(true)
+    })
+
+    await browser.elementByCss('.request-insights-details').click()
+    await browser.refresh()
+    await openRequestInsightsPanel()
+    await browser.elementByCss('.request-insights-settings-trigger').click()
+
+    await retry(async () => {
+      expect((await getSettingsMenuItems())[0]).toEqual({
+        label: 'Internal activity',
+        checked: 'true',
+      })
+    })
+
+    // Restore the default so this test does not affect later assertions.
+    await browser
+      .elementByCss(
+        '.request-insights-settings-item:has-text("Internal activity")'
+      )
+      .click()
+    await retry(async () => {
+      const config = JSON.parse(
+        await next.readFile('build/dev/cache/next-devtools-config.json')
+      )
+      expect(config.requestInsights?.showInternal).toBe(false)
     })
   })
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -52,6 +52,49 @@ describe('request insights', () => {
     }
   }
 
+  async function openRequestInsightsPanel(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await toggleDevToolsIndicatorPopover(browser)
+    await browser.elementByCss('[data-request-insights]').click()
+    await browser.waitForElementByCss('.request-insights-list-toolbar')
+    // The panel selector menu stays mounted for its exit animation and its
+    // click-outside handler would close the freshly opened panel. Wait for
+    // it to fully unmount before interacting with the panel.
+    await retry(async () => {
+      const selectorMenuGone = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return !root?.querySelector('#nextjs-dev-tools-menu')
+      })
+      expect(selectorMenuGone).toBe(true)
+    })
+  }
+
+  async function patchRequestInsightsConfig(patch: {
+    showInternal?: boolean
+    verbose?: boolean
+  }) {
+    const response = await next.fetch('/__nextjs_devtools_config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requestInsights: patch }),
+    })
+    expect(response.status).toBe(204)
+  }
+
+  let shouldResetRequestInsightsConfig = false
+  afterEach(async () => {
+    if (!shouldResetRequestInsightsConfig) {
+      return
+    }
+
+    await patchRequestInsightsConfig({
+      showInternal: false,
+      verbose: false,
+    })
+    shouldResetRequestInsightsConfig = false
+  })
+
   async function runWithResponse(body: unknown, args: string[] = []) {
     const requestedPaths: string[] = []
     const server = createServer((req, res) => {
@@ -229,22 +272,7 @@ describe('request insights', () => {
 
   it('persists verbose trace settings', async () => {
     const browser = await next.browser('/instant-insights')
-
-    async function openRequestInsightsPanel() {
-      await toggleDevToolsIndicatorPopover(browser)
-      await browser.elementByCss('[data-request-insights]').click()
-      await browser.waitForElementByCss('.request-insights-list-toolbar')
-      // The panel selector menu stays mounted for its exit animation and its
-      // click-outside handler would close the freshly opened panel. Wait for
-      // it to fully unmount before interacting with the panel.
-      await retry(async () => {
-        const selectorMenuGone = await browser.eval(() => {
-          const root = document.querySelector('nextjs-portal')?.shadowRoot
-          return !root?.querySelector('#nextjs-dev-tools-menu')
-        })
-        expect(selectorMenuGone).toBe(true)
-      })
-    }
+    shouldResetRequestInsightsConfig = true
 
     function getSettingsMenuState(): Promise<{
       open: boolean
@@ -272,7 +300,7 @@ describe('request insights', () => {
       })
     }
 
-    await openRequestInsightsPanel()
+    await openRequestInsightsPanel(browser)
     await retry(async () => {
       const selectedRegularRequest = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
@@ -329,7 +357,7 @@ describe('request insights', () => {
     })
 
     await browser.refresh()
-    await openRequestInsightsPanel()
+    await openRequestInsightsPanel(browser)
     await browser.elementByCss('.request-insights-settings-trigger').click()
 
     await retry(async () => {
@@ -338,36 +366,11 @@ describe('request insights', () => {
         checked: 'true',
       })
     })
-
-    // Restore the default so this test does not affect later assertions.
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Verbose traces")'
-      )
-      .click()
-    await retry(async () => {
-      const config = JSON.parse(
-        await next.readFile('build/dev/cache/next-devtools-config.json')
-      )
-      expect(config.requestInsights?.verbose).toBe(false)
-    })
   })
 
   it('hides internal activity behind the settings menu', async () => {
     const browser = await next.browser('/instant-insights')
-
-    async function openRequestInsightsPanel() {
-      await toggleDevToolsIndicatorPopover(browser)
-      await browser.elementByCss('[data-request-insights]').click()
-      await browser.waitForElementByCss('.request-insights-list-toolbar')
-      await retry(async () => {
-        const selectorMenuGone = await browser.eval(() => {
-          const root = document.querySelector('nextjs-portal')?.shadowRoot
-          return !root?.querySelector('#nextjs-dev-tools-menu')
-        })
-        expect(selectorMenuGone).toBe(true)
-      })
-    }
+    shouldResetRequestInsightsConfig = true
 
     function getSettingsMenuItems(): Promise<
       Array<{ label: string | undefined; checked: string | null }>
@@ -386,7 +389,7 @@ describe('request insights', () => {
       })
     }
 
-    await openRequestInsightsPanel()
+    await openRequestInsightsPanel(browser)
 
     await retry(async () => {
       const state = await browser.eval(() => {
@@ -419,6 +422,11 @@ describe('request insights', () => {
         '.request-insights-settings-item:has-text("Internal activity")'
       )
       .click()
+    await browser
+      .elementByCss(
+        '.request-insights-settings-item:has-text("Verbose traces")'
+      )
+      .click()
 
     await retry(async () => {
       const nestedRows = await browser.eval(() => {
@@ -433,10 +441,10 @@ describe('request insights', () => {
         }))
       })
 
-      expect((await getSettingsMenuItems())[0]).toEqual({
-        label: 'Internal activity',
-        checked: 'true',
-      })
+      expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Internal activity', checked: 'true' },
+        { label: 'Verbose traces', checked: 'true' },
+      ])
       expect(nestedRows.length).toBeGreaterThan(0)
       for (const row of nestedRows) {
         expect(row.internal).toBe('true')
@@ -449,32 +457,22 @@ describe('request insights', () => {
       const config = JSON.parse(
         await next.readFile('build/dev/cache/next-devtools-config.json')
       )
-      expect(config.requestInsights?.showInternal).toBe(true)
+      expect(config.requestInsights).toEqual({
+        showInternal: true,
+        verbose: true,
+      })
     })
 
     await browser.elementByCss('.request-insights-details').click()
     await browser.refresh()
-    await openRequestInsightsPanel()
+    await openRequestInsightsPanel(browser)
     await browser.elementByCss('.request-insights-settings-trigger').click()
 
     await retry(async () => {
-      expect((await getSettingsMenuItems())[0]).toEqual({
-        label: 'Internal activity',
-        checked: 'true',
-      })
-    })
-
-    // Restore the default so this test does not affect later assertions.
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Internal activity")'
-      )
-      .click()
-    await retry(async () => {
-      const config = JSON.parse(
-        await next.readFile('build/dev/cache/next-devtools-config.json')
-      )
-      expect(config.requestInsights?.showInternal).toBe(false)
+      expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Internal activity', checked: 'true' },
+        { label: 'Verbose traces', checked: 'true' },
+      ])
     })
   })
 


### PR DESCRIPTION
## Summary

- Classifies Instant Insights records as internal and hides them by default.
- Adds a persisted “Internal activity” toggle.
- Nests internal records below their matching foreground request.
- Preserves orphaned internal records exactly once.
- Signals hidden internal errors without littering the main request list.
- Raw endpoint and CLI data remain complete; filtering is UI-only.

## Verification

```bash
pnpm build-all
pnpm --filter=next types
pnpm --filter=next build
pnpm test-unit --runTestsByPath packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts
pnpm test-dev-webpack test/development/app-dir/request-insights/request-insights.test.ts
```

<!-- NEXT_JS_LLM -->
