### PR TITLE
Forward dev invalid dynamic usage errors from the render, not validation

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4429,10 +4429,9 @@ function forwardInvalidDynamicUsageError(
 function runDevValidationInBackground(
   prefetchMode: PrefetchingMode,
   navigationKind: DevNavigationKind,
-  resultPromise: Promise<StagedDevRenderResult>,
+  result: StagedDevRenderResult,
   requestStore: RequestStore,
   validationDebugChannel: AnyStream | undefined,
-  cacheSignal: CacheSignal,
   ctx: AppRenderContext,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
@@ -4446,17 +4445,6 @@ function runDevValidationInBackground(
 
   void consoleAsyncStorage
     .run({ dim: true }, async () => {
-      const result = await resultPromise
-
-      // If the request was aborted, or a newer render superseded its
-      // validation, re-rendering and analyzing it would only waste server
-      // work. In-flight `'use cache'` fills are left running (we don't await
-      // `cacheReady` below).
-      if (validationAbortSignal.aborted) {
-        logValidationAborted(ctx)
-        return
-      }
-
       // Validation is detached diagnostic work, but the renders and error
       // formatting it performs can still monopolize the event loop. Wait until
       // the response has finished so that work cannot delay Flight delivery or
@@ -4477,30 +4465,6 @@ function runDevValidationInBackground(
       // Read whether the streamed render errored only now that it has fully
       // settled.
       const devRenderDidError = getDevRenderDidError()
-
-      // A cache-miss render records its `invalidDynamicUsageError` while
-      // filling, so its verdict isn't final until the fills settle. Wait for
-      // that (a no-op when the render didn't miss) before planning, which reads
-      // the work store.
-      if (result.hadCacheMiss) {
-        await cacheSignal.cacheReady()
-      }
-
-      if (validationAbortSignal.aborted) {
-        logValidationAborted(ctx)
-        return
-      }
-
-      // If the initial render recorded invalid dynamic usage errors
-      // (e.g. from caught errors inside "use cache"), we skip validation altogether.
-      if (
-        forwardInvalidDynamicUsageError(
-          ctx.workStore.invalidDynamicUsageError,
-          ctx
-        )
-      ) {
-        return
-      }
 
       const lazyInputs = await prepareValidationInputs(
         prefetchMode,
@@ -5547,7 +5511,6 @@ async function stagedRenderWithCachesInDev({
   const validationGeneration = shouldValidate
     ? beginDevValidation(ctx.htmlRequestId)
     : undefined
-  let validationWasScheduled = false
 
   try {
     const { setReactDebugChannel } = ctx.renderOpts
@@ -5587,46 +5550,66 @@ async function stagedRenderWithCachesInDev({
       requestAbortSignal,
     })
 
-    if (validationGeneration !== undefined) {
-      runDevValidationInBackground(
-        prefetchMode,
-        navigationKind,
-        resultPromise,
-        requestStore,
-        validationDebugChannel,
-        cacheSignal,
-        ctx,
-        fallbackRouteParams,
-        prerenderResumeDataCache,
-        getDevRenderDidError,
-        createRequestStore,
-        getPayload,
-        onError,
-        validationGeneration
-      )
-      validationWasScheduled = true
-    } else {
+    if (validationGeneration === undefined) {
       logValidationSkipped(ctx)
-
-      // We don't validate, but the render may still record an invalid dynamic
-      // usage error (e.g. a request API used inside `'use cache'`). `result`
-      // resolves once the full stream (incl. the dynamic stage) has finished, so
-      // any such error is final by then; forward it to the dev overlay.
-      resultPromise.then(
-        () =>
-          forwardInvalidDynamicUsageError(
-            ctx.workStore.invalidDynamicUsageError,
-            ctx
-          ),
-        () => {}
-      )
     }
+
+    // The render may record an invalid dynamic usage error (e.g. a request API
+    // used inside `'use cache'`). A cache-miss render records it while filling,
+    // so the verdict isn't final until the fills settle. Once the render has
+    // settled, forward any such error to the dev overlay: it's a real error
+    // from the render the user received, so it surfaces whether or not the
+    // route validates. When there is one the render isn't prod-representative,
+    // so validating it is pointless and we skip it; otherwise validation runs
+    // in the background (deferred there until the response has finished).
+    void resultPromise.then(
+      async (result) => {
+        if (result.hadCacheMiss) {
+          await cacheSignal.cacheReady()
+        }
+
+        const hadInvalidDynamicUsage = forwardInvalidDynamicUsageError(
+          ctx.workStore.invalidDynamicUsageError,
+          ctx
+        )
+
+        if (validationGeneration === undefined) {
+          return
+        }
+
+        if (hadInvalidDynamicUsage || validationGeneration.signal.aborted) {
+          if (validationGeneration.signal.aborted) {
+            logValidationAborted(ctx)
+          }
+          validationGeneration.finish()
+          return
+        }
+
+        runDevValidationInBackground(
+          prefetchMode,
+          navigationKind,
+          result,
+          requestStore,
+          validationDebugChannel,
+          ctx,
+          fallbackRouteParams,
+          prerenderResumeDataCache,
+          getDevRenderDidError,
+          createRequestStore,
+          getPayload,
+          onError,
+          validationGeneration
+        )
+      },
+      () => {
+        // The render itself rejected; there's nothing to forward or validate.
+        validationGeneration?.finish()
+      }
+    )
 
     return { stream, debugChannel }
   } catch (err) {
-    if (!validationWasScheduled) {
-      validationGeneration?.finish()
-    }
+    validationGeneration?.finish()
     throw err
   }
 }


### PR DESCRIPTION
In dev, a render that uses a request-time API inside `'use cache'` records an invalid dynamic usage error on its work store. This is an error in the render the user received, not a validation insight, yet it was forwarded to the dev overlay from inside `runDevValidationInBackground`, entangled with the validation lifecycle, and a separate non-validating code path forwarded the same error a second way.

This change moves the forwarding, together with the `cacheReady()` wait that finalizes the error's verdict, out to the render's completion handler, where it runs once the render has settled regardless of whether the route validates. Validation becomes a pure consumer of the settled render: `runDevValidationInBackground` no longer reads or forwards the error, takes the settled render result rather than its promise, and is simply not scheduled when the render recorded such an error, since there is then nothing worth validating. Deferring the scheduling until the render has settled costs nothing, because validation already waits for the response to finish before it does any work, by which point the render result is always available. Consolidating the forwarding into one place at the render level disentangles this main-render concern from validation and prepares the ground for the upstack refactor that remodels the render-result types without the validation task reaching into them.
