### PR TITLE
Add the `experimental.devValidationWorker` config flag

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -436,6 +436,7 @@ export const experimentalSchema = {
         .optional(),
     })
     .optional(),
+  devValidationWorker: z.boolean().optional(),
   staticGenerationRetryCount: z.number().int().optional(),
   staticGenerationMaxConcurrency: z.number().int().optional(),
   staticGenerationMinPagesPerWorker: z.number().int().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1186,6 +1186,17 @@ export interface ExperimentalConfig {
   }
 
   /**
+   * Runs development Cache Components validation on a worker thread rather than
+   * the main thread, keeping the dev server's event loop responsive during
+   * rapid navigation. This covers static-shell validation (which runs on
+   * initial load and HMR refresh) as well as instant-navigation validation
+   * (when `instant` is configured). Enabled by default; set to `false` to run
+   * validation in-process, as an escape hatch to isolate a problem or fall back
+   * if the worker misbehaves.
+   */
+  devValidationWorker?: boolean
+
+  /**
    * The number of times to retry static generation (per page) before giving up.
    */
   staticGenerationRetryCount?: number
@@ -2115,6 +2126,7 @@ export const defaultConfig = Object.freeze({
   experimental: {
     appNewScrollHandler: true,
     coldCacheBadge: false,
+    devValidationWorker: true,
     useSkewCookie: false,
     cssChunking: true,
     multiZoneDraftMode: false,


### PR DESCRIPTION
This adds the `experimental.devValidationWorker` boolean option: its type in `config-shared.ts` and its schema entry in `config-schema.ts`. The flag is the configuration seam for running development Cache Components validation on a worker thread rather than the dev server's main thread, which keeps the event loop responsive during rapid navigation. It is enabled by default, and setting it to `false` runs validation in-process, as an escape hatch to isolate a problem or fall back if the worker misbehaves.

We land the flag on its own, ahead of the preparatory refactor, the benchmark, and the worker implementation that follow in the stack, so those changes can reference and toggle it. On its own the option is recognized by config validation but is not yet read anywhere. Because the flag is consumed only server-side in `next dev`, it needs no `define-env.ts` wiring for user-bundled code, nor `renderOpts` plumbing.
