### PR TITLE
[refactor] Prepare dev validation for running on a worker thread

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4573,7 +4573,7 @@ function runDevValidationInBackground(
             validationErrors !== undefined &&
             !validationAbortSignal.aborted
           ) {
-            logMessagesAndSendErrorsToBrowser(validationErrors, ctx)
+            await logMessagesAndSendErrorsToBrowser(validationErrors, ctx)
           }
         }
       )

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -84,6 +84,7 @@ import { createMetadataContext } from '../../lib/metadata/metadata-context'
 import { createRequestStoreForRender } from '../async-storage/request-store'
 import { isRSCRequestHeader } from '../lib/is-rsc-request'
 import { createWorkStore } from '../async-storage/work-store'
+import { formatValidationEvent } from './dev-validation-events'
 import {
   getAccessFallbackErrorTypeByStatus,
   getAccessFallbackHTTPStatus,
@@ -336,6 +337,15 @@ export type AppRenderContext = {
   parsedRequestHeaders: ParsedRequestHeaders
   getDynamicParamFromSegment: GetDynamicParamFromSegment
   interpolatedParams: Params
+  /**
+   * The request's fallback route params (the same ones
+   * `getDynamicParamFromSegment` closes over). Kept on the context so the dev
+   * validation worker can rebuild an identical `getDynamicParamFromSegment`;
+   * the depth-loop segment keys are derived from it, so it must match what
+   * produced the seed render's Flight, not the separate fallback set validation
+   * uses to mark params unknown in its stores.
+   */
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
   query: NextParsedUrlQuery
   isPrefetch: boolean
   isPossibleServerAction: boolean
@@ -2732,6 +2742,7 @@ async function renderToHTMLOrFlightImpl(
     parsedRequestHeaders,
     getDynamicParamFromSegment,
     interpolatedParams,
+    fallbackRouteParams,
     query,
     isPrefetch: isPrefetchRequest,
     isPossibleServerAction: isPossibleActionRequest,
@@ -4539,14 +4550,32 @@ function runDevValidationInBackground(
         return
       }
 
-      return runValidationInDev(
-        prefetchMode,
-        instantInputs,
-        staticInputs,
+      // Validation computes the errors; the caller delivers them to the dev
+      // overlay. `runWithDevValidationLogging` encloses both the render and the
+      // delivery in the test-mode lifecycle markers so tests that assert the
+      // delivered error between `validation_start` and `validation_end` capture
+      // it.
+      await runWithDevValidationLogging(
         ctx,
-        fallbackRouteParams,
-        devRenderDidError,
-        validationAbortSignal
+        validationAbortSignal,
+        async () => {
+          const validationErrors = await runValidationInDev(
+            prefetchMode,
+            instantInputs,
+            staticInputs,
+            toValidationRenderContext(ctx),
+            fallbackRouteParams,
+            devRenderDidError,
+            validationAbortSignal
+          )
+
+          if (
+            validationErrors !== undefined &&
+            !validationAbortSignal.aborted
+          ) {
+            logMessagesAndSendErrorsToBrowser(validationErrors, ctx)
+          }
+        }
       )
     })
     // The catch keeps a failed render, or anything thrown inside validation,
@@ -5994,14 +6023,10 @@ function logValidationSkipped(ctx: AppRenderContext) {
     const requestId = ctx.requestId
     const url = ctx.url.href
     console.log(
-      '<VALIDATION_MESSAGE>' +
-        JSON.stringify({ type: 'validation_start', requestId, url }) +
-        '</VALIDATION_MESSAGE>'
+      formatValidationEvent({ type: 'validation_start', requestId, url })
     )
     console.log(
-      '<VALIDATION_MESSAGE>' +
-        JSON.stringify({ type: 'validation_end', requestId, url }) +
-        '</VALIDATION_MESSAGE>'
+      formatValidationEvent({ type: 'validation_end', requestId, url })
     )
   }
 }
@@ -6011,76 +6036,127 @@ function logValidationAborted(ctx: AppRenderContext) {
     const requestId = ctx.requestId
     const url = ctx.url.href
     console.log(
-      '<VALIDATION_MESSAGE>' +
-        JSON.stringify({ type: 'validation_aborted', requestId, url }) +
-        '</VALIDATION_MESSAGE>'
+      formatValidationEvent({ type: 'validation_aborted', requestId, url })
     )
   }
 }
 
-async function runValidationInDev(
-  ...args: Parameters<typeof runValidationInDevImpl>
-) {
-  if (process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION) {
-    const ctx: AppRenderContext = args[3]
-    const requestId = ctx.requestId
-    const url = ctx.url.href
-    const responseFinished =
-      !isNodeNextResponse(ctx.res) || ctx.res.originalResponse.writableFinished
-    console.log(
-      '<VALIDATION_MESSAGE>' +
-        JSON.stringify({
-          type: 'validation_start',
-          requestId,
-          url,
-          responseFinished,
-        }) +
-        '</VALIDATION_MESSAGE>'
-    )
-    try {
-      const validationAbortSignal: AbortSignal = args[6]
-      // Keep validation in flight for scheduler E2E tests without relying on
-      // timing-sensitive user code. Aborts end the delay immediately.
-      const validationDelay = Number(
-        process.env.NEXT_TEST_DEV_VALIDATION_DELAY_MS
-      )
-      if (
-        Number.isFinite(validationDelay) &&
-        validationDelay > 0 &&
-        !validationAbortSignal.aborted
-      ) {
-        await new Promise<void>((resolve) => {
-          let timeout: NodeJS.Timeout
-          const finishDelay = () => {
-            clearTimeout(timeout)
-            validationAbortSignal.removeEventListener('abort', finishDelay)
-            resolve()
-          }
-          timeout = setTimeout(finishDelay, validationDelay)
-          validationAbortSignal.addEventListener('abort', finishDelay, {
-            once: true,
-          })
-        })
-      }
+/**
+ * Runs a dev validation `run` callback (the render plus the error delivery),
+ * enclosing it in the `validation_start` / `validation_end` /
+ * `validation_aborted` lifecycle markers that E2E tests read from the CLI
+ * output. The markers must enclose delivery as well as the render, so tests
+ * that assert the error between the markers capture it. Also applies the
+ * `NEXT_TEST_DEV_VALIDATION_DELAY_MS` hook that keeps validation in flight for
+ * scheduler tests. All of this is test-mode only; otherwise `run` is invoked
+ * directly.
+ */
+async function runWithDevValidationLogging(
+  ctx: AppRenderContext,
+  validationAbortSignal: AbortSignal,
+  run: () => Promise<void>
+): Promise<void> {
+  if (!(process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION)) {
+    return run()
+  }
 
-      if (validationAbortSignal.aborted) {
-        return
-      }
-      return await runValidationInDevImpl(...args)
-    } finally {
-      const validationAbortSignal: AbortSignal = args[6]
-      if (validationAbortSignal.aborted) {
-        logValidationAborted(ctx)
-      } else {
-        console.log(
-          '<VALIDATION_MESSAGE>' +
-            JSON.stringify({ type: 'validation_end', requestId, url }) +
-            '</VALIDATION_MESSAGE>'
-        )
-      }
+  const requestId = ctx.requestId
+  const url = ctx.url.href
+  const responseFinished =
+    !isNodeNextResponse(ctx.res) || ctx.res.originalResponse.writableFinished
+
+  console.log(
+    formatValidationEvent({
+      type: 'validation_start',
+      requestId,
+      url,
+      responseFinished,
+    })
+  )
+
+  try {
+    // Keep validation in flight for scheduler E2E tests without relying on
+    // timing-sensitive user code. Aborts end the delay immediately.
+    const validationDelay = Number(
+      process.env.NEXT_TEST_DEV_VALIDATION_DELAY_MS
+    )
+
+    if (
+      Number.isFinite(validationDelay) &&
+      validationDelay > 0 &&
+      !validationAbortSignal.aborted
+    ) {
+      await new Promise<void>((resolve) => {
+        let timeout: NodeJS.Timeout
+        const finishDelay = () => {
+          clearTimeout(timeout)
+          validationAbortSignal.removeEventListener('abort', finishDelay)
+          resolve()
+        }
+        timeout = setTimeout(finishDelay, validationDelay)
+        validationAbortSignal.addEventListener('abort', finishDelay, {
+          once: true,
+        })
+      })
     }
-  } else {
-    return await runValidationInDevImpl(...args)
+
+    if (!validationAbortSignal.aborted) {
+      await run()
+    }
+  } finally {
+    if (validationAbortSignal.aborted) {
+      logValidationAborted(ctx)
+    } else {
+      console.log(
+        formatValidationEvent({ type: 'validation_end', requestId, url })
+      )
+    }
+  }
+}
+
+/**
+ * The slice of the render context the dev/build validation passes read. Both
+ * the in-process callers and the validation worker build one of these, so it
+ * names exactly what validation depends on and nothing else: no live
+ * request/response objects that can't be rebuilt off the main thread.
+ * `isDebugChannelEnabled` is the derived flag validation uses in place of the
+ * main render's `setReactDebugChannel` callback (validation only ever read that
+ * callback's presence as a boolean).
+ */
+export type ValidationRenderContext = Pick<
+  AppRenderContext,
+  | 'componentMod'
+  | 'getDynamicParamFromSegment'
+  | 'query'
+  | 'implicitTags'
+  | 'nonce'
+  | 'workStore'
+> & {
+  renderOpts: Pick<RenderOpts, 'images' | 'allowEmptyStaticShell'>
+  isDebugChannelEnabled: boolean
+}
+
+/**
+ * Projects a full app render context down to the slice validation reads. The
+ * in-process dev and build callers hold an `AppRenderContext` and use this to
+ * hand validation exactly what it needs; the worker builds the same shape from
+ * its snapshot instead.
+ */
+export function toValidationRenderContext(
+  ctx: AppRenderContext
+): ValidationRenderContext {
+  return {
+    componentMod: ctx.componentMod,
+    getDynamicParamFromSegment: ctx.getDynamicParamFromSegment,
+    query: ctx.query,
+    implicitTags: ctx.implicitTags,
+    nonce: ctx.nonce,
+    workStore: ctx.workStore,
+    renderOpts: {
+      images: ctx.renderOpts.images,
+      allowEmptyStaticShell: ctx.renderOpts.allowEmptyStaticShell,
+    },
+    isDebugChannelEnabled: !!ctx.renderOpts.setReactDebugChannel,
   }
 }
 
@@ -6090,15 +6166,15 @@ async function runValidationInDev(
  * prerender semantics to prerenderToStream and should update it
  * in conjunction with any changes to that function.
  */
-async function runValidationInDevImpl(
+async function runValidationInDev(
   prefetchMode: PrefetchingMode,
   instantInputs: ResolvedValidationInputs | null,
   staticInputs: ResolvedValidationInputs,
-  ctx: AppRenderContext,
+  ctx: ValidationRenderContext,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   devRenderDidError: boolean,
   validationAbortSignal: AbortSignal
-): Promise<void> {
+): Promise<Array<unknown> | undefined> {
   const { componentMod: ComponentMod, getDynamicParamFromSegment } = ctx
   const loaderTree = ComponentMod.routeModule.userland.loaderTree
   const rootParams = getRootParams(loaderTree, getDynamicParamFromSegment)
@@ -6195,7 +6271,7 @@ async function runValidationInDevImpl(
       if (!(await yieldToForegroundRequest(validationAbortSignal))) {
         return
       }
-      return logMessagesAndSendErrorsToBrowser(result, ctx)
+      return result
     }
   }
 
@@ -6237,7 +6313,7 @@ async function runValidationInDevImpl(
       if (!(await yieldToForegroundRequest(validationAbortSignal))) {
         return
       }
-      return logMessagesAndSendErrorsToBrowser(result, ctx)
+      return result
     }
   }
 }
@@ -6252,7 +6328,7 @@ async function collectDebugChunksFromClientChannel(debugChannel: AnyStream) {
 
 async function validateStaticShell(
   inputs: ResolvedValidationInputs,
-  ctx: AppRenderContext,
+  ctx: ValidationRenderContext,
   rootParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   debugChunks: Uint8Array[] | null,
@@ -6330,7 +6406,7 @@ async function warmupClientModulesForStagedValidation(
   allServerChunks: Array<Uint8Array>,
   rootParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  ctx: AppRenderContext,
+  ctx: ValidationRenderContext,
   validationSamples: ValidationStoreClient['validationSamples'],
   validationSampleTracking: ValidationStoreClient['validationSampleTracking'],
   validationAbortSignal?: AbortSignal
@@ -6510,7 +6586,7 @@ async function validateStagedShell(
   rootParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   allowEmptyStaticShell: boolean,
-  ctx: AppRenderContext,
+  ctx: ValidationRenderContext,
   hmrRefreshHash: string | undefined,
   trackDynamicHole:
     | typeof trackDynamicHoleInStaticShell
@@ -6683,7 +6759,7 @@ async function validateInstantConfigs(
   startTime: number,
   rootParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  ctx: AppRenderContext,
+  ctx: ValidationRenderContext,
   hmrRefreshHash: string | undefined,
   validationSamples: ValidationStoreClient['validationSamples'] | null,
   devRenderDidError: boolean,
@@ -6735,8 +6811,7 @@ async function validateInstantConfigs(
     createDebugChannel
   )
 
-  const { implicitTags, nonce, workStore } = ctx
-  const isDebugChannelEnabled = !!ctx.renderOpts.setReactDebugChannel
+  const { implicitTags, nonce, workStore, isDebugChannelEnabled } = ctx
 
   async function validateAtDepth(
     prefetchKind: ValidationPrefetchKind,
@@ -7387,28 +7462,16 @@ async function validateInstantConfigsInBuild(
     // We want consistent ordering of these messages and other console.error calls,
     // so we use console.error here as well. Using console.log leads to non-deterministic
     // log order, likely stdout/stderr can interleave in non-deterministic ways.
-    const requestId = Date.now()
+    const requestId = String(Date.now())
     const route = ctx.workStore.route
     console.error(
-      '<VALIDATION_MESSAGE>' +
-        JSON.stringify({
-          type: 'validation_start',
-          requestId,
-          url: route,
-        }) +
-        '</VALIDATION_MESSAGE>'
+      formatValidationEvent({ type: 'validation_start', requestId, url: route })
     )
     try {
       return await run()
     } finally {
       console.error(
-        '<VALIDATION_MESSAGE>' +
-          JSON.stringify({
-            type: 'validation_end',
-            requestId,
-            url: route,
-          }) +
-          '</VALIDATION_MESSAGE>'
+        formatValidationEvent({ type: 'validation_end', requestId, url: route })
       )
     }
   } else {
@@ -7605,6 +7668,7 @@ async function validateInstantConfigInBuildWithSample(
       parsedRequestHeaders: outerCtx.parsedRequestHeaders,
       getDynamicParamFromSegment,
       interpolatedParams: sampleParams,
+      fallbackRouteParams,
       query: sampleQuery,
       isPrefetch: false,
       isPossibleServerAction: false,
@@ -7743,13 +7807,14 @@ async function validateInstantConfigInBuildWithSample(
     // the Dynamic stage, they're Runtime at best.
 
     const warmupValidationSamplesTracking = createValidationSampleTracking()
+    const validationRenderCtx = toValidationRenderContext(validationCtx)
     await warmupClientModulesForStagedValidation(
       'validation-client',
       accumulatedChunks.dynamicChunks,
       accumulatedChunks.dynamicChunks,
       sampleRootParams,
       fallbackRouteParams,
-      validationCtx,
+      validationRenderCtx,
       validationSamples,
       warmupValidationSamplesTracking
     )
@@ -7764,7 +7829,7 @@ async function validateInstantConfigInBuildWithSample(
       startTime,
       sampleRootParams,
       fallbackRouteParams,
-      validationCtx,
+      validationRenderCtx,
       undefined, // hmrRefreshHash,
       validationSamples,
       false // build has no shared dev render that would surface errors

--- a/packages/next/src/server/app-render/dev-validation-events.ts
+++ b/packages/next/src/server/app-render/dev-validation-events.ts
@@ -1,0 +1,54 @@
+/**
+ * The lifecycle events Cache Components validation emits so E2E tests can
+ * locate the validation window in the CLI output. Each is serialized between
+ * `<VALIDATION_MESSAGE>` delimiters (see `formatValidationEvent`) and parsed
+ * back by the test harness. Produced by the in-process validation in
+ * `app-render.tsx` (both dev and build) and by the validation worker, which is
+ * why the shape lives here rather than in a single producer.
+ *
+ * `requestId` correlates a start with its matching end/aborted. Dev and worker
+ * validation use the render's request id; build validation, which has no such
+ * id, uses a stringified timestamp instead.
+ */
+export type ValidationEvent =
+  | ValidationStartEvent
+  | ValidationEndEvent
+  | ValidationAbortedEvent
+
+export type ValidationStartEvent = {
+  type: 'validation_start'
+  requestId: string
+  url: string
+  /**
+   * Only reported for development validation.
+   */
+  responseFinished?: boolean
+}
+
+export type ValidationEndEvent = {
+  type: 'validation_end'
+  requestId: string
+  url: string
+}
+
+/**
+ * Emitted when detached validation is aborted. It can appear without a start
+ * when cancellation happens before validation runs, or after a start instead of
+ * an end when in-flight validation is cancelled.
+ */
+export type ValidationAbortedEvent = {
+  type: 'validation_aborted'
+  requestId: string
+  url: string
+}
+
+/**
+ * Wraps a validation event in the `<VALIDATION_MESSAGE>` delimiters the test
+ * harness scans for. The caller chooses the output stream (dev validation logs
+ * to stdout; build validation uses stderr for deterministic ordering).
+ */
+export function formatValidationEvent(event: ValidationEvent): string {
+  return (
+    '<VALIDATION_MESSAGE>' + JSON.stringify(event) + '</VALIDATION_MESSAGE>'
+  )
+}

--- a/test/development/app-dir/instant-validation-scheduling/instant-validation-scheduling.test.ts
+++ b/test/development/app-dir/instant-validation-scheduling/instant-validation-scheduling.test.ts
@@ -3,8 +3,8 @@ import {
   parseValidationMessages,
   waitForValidationEnd,
   waitForValidationStart,
-  type ValidationEvent,
 } from 'e2e-utils/instant-validation'
+import type { ValidationEvent } from 'next/dist/server/app-render/dev-validation-events'
 import { retry } from 'next-test-utils'
 import { createRouterAct } from 'router-act'
 import type * as Playwright from 'playwright'

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from '../../../lib/next-test-utils'
+import { retry } from 'next-test-utils'
+import type { ValidationEvent } from 'next/dist/server/app-render/dev-validation-events'
 
 describe('instant validation causes', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
@@ -26,10 +27,6 @@ describe('instant validation causes', () => {
     }
     return next.cliOutput.slice(currentCliOutputIndex)
   }
-
-  type ValidationEvent =
-    | { type: 'validation_start'; requestId: string; url: string }
-    | { type: 'validation_end'; requestId: string; url: string }
 
   function parseValidationMessages(output: string): ValidationEvent[] {
     const messageRe = /<VALIDATION_MESSAGE>(.*?)<\/VALIDATION_MESSAGE>/g

--- a/test/lib/e2e-utils/instant-validation.ts
+++ b/test/lib/e2e-utils/instant-validation.ts
@@ -1,32 +1,11 @@
 import { retry } from '../next-test-utils'
 import { getDeterministicOutput } from '../../e2e/app-dir/cache-components-errors/utils'
 import { inspect } from 'util'
-
-export type ValidationEvent =
-  | ValidationStartEvent
-  | ValidationEndEvent
-  | ValidationAbortedEvent
-
-type ValidationStartEvent = {
-  type: 'validation_start'
-  requestId: string
-  url: string
-  /** Only reported for development validation. */
-  responseFinished?: boolean
-}
-type ValidationEndEvent = {
-  type: 'validation_end'
-  requestId: string
-  url: string
-}
-// Emitted when detached validation is aborted. It can appear without a start
-// when cancellation happens before validation runs, or after a start instead
-// of an end when in-flight validation is cancelled.
-type ValidationAbortedEvent = {
-  type: 'validation_aborted'
-  requestId: string
-  url: string
-}
+import type {
+  ValidationEvent,
+  ValidationStartEvent,
+  ValidationEndEvent,
+} from 'next/dist/server/app-render/dev-validation-events'
 
 export function parseValidationMessages(output: string): ValidationEvent[] {
   const messageRe = /<VALIDATION_MESSAGE>(.*?)<\/VALIDATION_MESSAGE>/g


### PR DESCRIPTION
This is a behavior-preserving refactor of the dev-mode Cache Components validation, ahead of the change that moves it onto a worker thread. In-process behavior is unchanged.

It narrows the context the validation functions require. `runValidationInDev` and its helpers (`validateStaticShell`, `warmupClientModulesForStagedValidation`, `validateStagedShell`, `validateInstantConfigs`) now take a `ValidationRenderContext` (a `Pick` of `AppRenderContext` plus the two `renderOpts` fields and the debug-channel flag they actually read) instead of the full render context, with `toValidationRenderContext` mapping the in-process and build-time callers. The worker cannot reconstruct a full `AppRenderContext` from a serialized snapshot, so narrowing the contract to what validation genuinely consumes is what lets the same code run there.

It also separates computing the validation errors from delivering them. `runValidationInDev` now returns the errors instead of sending them to the dev overlay inline, and the caller `runDevValidationInBackground` delivers them via `logMessagesAndSendErrorsToBrowser`. The test-mode lifecycle markers and delay move into `runWithDevValidationLogging`, which brackets both the render and the delivery. When validation runs on the worker, the worker computes the errors but the main thread still delivers them (delivery needs the response object), so splitting the two halves is a prerequisite.

Finally, it extracts the test-only validation lifecycle markers into a shared `dev-validation-events` module. The `<VALIDATION_MESSAGE>` wrapping and the event shape had been hand-rolled at each emission site in `app-render.tsx` and duplicated again in the test harness; they now live in one place as `formatValidationEvent` and an exported `ValidationEvent` union that the in-process emitters call and the test utilities import rather than redeclare. The worker emits the same markers through the same helper once it is added, so a single definition keeps every producer and the test parser in sync. Build validation's marker `requestId`, previously the numeric `Date.now()`, is stringified to fit the shared `string` type; it appears only in the logged marker payload, which nothing matches on, so this too is unobservable.
