### PR TITLE
Run Cache Components dev validation on a worker thread

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -116,6 +116,10 @@ const bundleTypes = {
       __dirname,
       'dist/esm/server/dev/use-cache-probe-worker.js'
     ),
+    'dev-validation-worker': path.join(
+      __dirname,
+      'dist/esm/server/dev/dev-validation-worker.js'
+    ),
   },
 }
 
@@ -142,6 +146,28 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
 
       if (request.match(/(server\/image-optimizer|experimental\/testmode)/)) {
         callback(null, 'commonjs ' + request)
+        return
+      }
+
+      // The dev validation worker calls `installBindings()` /
+      // `installCodeFrameSupport()` so its logged errors render source-mapped
+      // code frames. Those pull in the native SWC binding graph (`build/swc` →
+      // `trace` → `telemetry`), which isn't present under `dist/esm`. Resolve
+      // it from the installed `next/dist` tree at runtime instead of bundling
+      // it into the worker, exactly as the unbundled build worker loads it.
+      // Scoped to the `app-worker` bundle; the probe worker in the same group
+      // doesn't import it.
+      if (
+        bundleType === 'app-worker' &&
+        request.match(/[\\/]build[\\/]swc(?:[\\/]install-bindings)?(?:\.js)?$/)
+      ) {
+        const resolve = getResolve()
+        const resolved = await resolve(context, request)
+        const relative = path.relative(
+          path.join(__dirname, '..'),
+          resolved.replace('esm' + path.sep, '')
+        )
+        callback(null, `commonjs ${relative}`)
         return
       }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -81,10 +81,20 @@ import {
   NEXT_HTML_REQUEST_ID_HEADER,
 } from '../../client/components/app-router-headers'
 import { createMetadataContext } from '../../lib/metadata/metadata-context'
-import { createRequestStoreForRender } from '../async-storage/request-store'
+import {
+  createRequestStore as createRequestStoreFromInputs,
+  createRequestStoreForRender,
+} from '../async-storage/request-store'
 import { isRSCRequestHeader } from '../lib/is-rsc-request'
 import { createWorkStore } from '../async-storage/work-store'
 import { formatValidationEvent } from './dev-validation-events'
+import { createSnapshot } from './async-local-storage'
+import {
+  getDevValidationWorker,
+  type DevValidationWorkerMessage,
+  type SerializedValidationInputs,
+} from './dev-validation-worker-globals'
+import { buildDevValidationSnapshot } from './dev-validation-worker-snapshot'
 import {
   getAccessFallbackErrorTypeByStatus,
   getAccessFallbackHTTPStatus,
@@ -291,7 +301,10 @@ import {
   type DebugChannelPair,
   type NodeDebugChannelPair,
 } from './debug-channel-server'
-import { createNodeStreamWithLateRelease } from './instant-validation/stream-utils'
+import {
+  createNodeStreamFromChunks,
+  createNodeStreamWithLateRelease,
+} from './instant-validation/stream-utils'
 
 import {
   createValidationBoundaryTracking,
@@ -4401,7 +4414,7 @@ interface StagedDevRenderResult {
  * the request store and the debug channel. Carries no `syncInterruptReason`:
  * the resolution step has already surfaced and bailed on any sync interrupt.
  */
-interface ResolvedValidationInputs extends StagedDevRenderArtifacts {
+export interface ResolvedValidationInputs extends StagedDevRenderArtifacts {
   readonly requestStore: RequestStore
   readonly debugChannelClient: AnyStream | undefined
 }
@@ -4415,7 +4428,7 @@ interface ResolvedValidationInputs extends StagedDevRenderArtifacts {
  * resolution step surfaces and bails on the interrupted case, so the depth loop
  * only ever sees `ResolvedValidationInputs`.
  */
-type DevValidationInputs =
+export type DevValidationInputs =
   | ResolvedValidationInputs
   | SyncInterruptedStagedDevRender
 
@@ -4550,33 +4563,74 @@ function runDevValidationInBackground(
         return
       }
 
-      // Validation computes the errors; the caller delivers them to the dev
-      // overlay. `runWithDevValidationLogging` encloses both the render and the
-      // delivery in the test-mode lifecycle markers so tests that assert the
-      // delivered error between `validation_start` and `validation_end` capture
-      // it.
-      await runWithDevValidationLogging(
-        ctx,
-        validationAbortSignal,
-        async () => {
-          const validationErrors = await runValidationInDev(
-            prefetchMode,
-            instantInputs,
-            staticInputs,
-            toValidationRenderContext(ctx),
-            fallbackRouteParams,
-            devRenderDidError,
-            validationAbortSignal
-          )
+      // Hand the whole validation to the worker when one is installed. It runs
+      // on a worker thread (off the main thread), emits its own lifecycle
+      // markers, logs code frames on its piped stdio, and returns the overlay
+      // Flight bytes for the main thread to forward. The worker is absent when
+      // `experimental.devValidationWorker` is false, and validation runs
+      // in-process instead.
+      const devValidationWorker = getDevValidationWorker()
 
-          if (
-            validationErrors !== undefined &&
-            !validationAbortSignal.aborted
-          ) {
-            await logMessagesAndSendErrorsToBrowser(validationErrors, ctx)
+      if (devValidationWorker) {
+        const snapshot = await buildDevValidationSnapshot(
+          ctx,
+          instantInputs,
+          staticInputs,
+          prefetchMode,
+          fallbackRouteParams,
+          devRenderDidError
+        )
+
+        const chunks = await devValidationWorker(
+          snapshot,
+          validationAbortSignal
+        )
+
+        // A newer navigation may have superseded this validation while the
+        // worker ran; don't surface stale insights for a page the user left.
+        if (chunks && !validationAbortSignal.aborted) {
+          const { sendErrorsToBrowser } = ctx.renderOpts
+          if (!sendErrorsToBrowser) {
+            throw new InvariantError(
+              'Expected `sendErrorsToBrowser` to be defined in renderOpts.'
+            )
           }
+          sendErrorsToBrowser(
+            createNodeStreamFromChunks(chunks),
+            ctx.htmlRequestId
+          )
         }
-      )
+      } else {
+        // In-process path, taken when `experimental.devValidationWorker` is
+        // false or no worker is installed (e.g. during a build). Validation
+        // computes the errors; the caller delivers them to the dev overlay.
+        // `runWithDevValidationLogging` encloses both the render and the
+        // delivery in the test-mode lifecycle markers so tests that assert the
+        // delivered error between `validation_start` and `validation_end`
+        // capture it.
+        await runWithDevValidationLogging(
+          ctx,
+          validationAbortSignal,
+          async () => {
+            const validationErrors = await runValidationInDev(
+              prefetchMode,
+              instantInputs,
+              staticInputs,
+              toValidationRenderContext(ctx),
+              fallbackRouteParams,
+              devRenderDidError,
+              validationAbortSignal
+            )
+
+            if (
+              validationErrors !== undefined &&
+              !validationAbortSignal.aborted
+            ) {
+              await logMessagesAndSendErrorsToBrowser(validationErrors, ctx)
+            }
+          }
+        )
+      }
     })
     // The catch keeps a failed render, or anything thrown inside validation,
     // from surfacing as an unhandled rejection.
@@ -4913,7 +4967,7 @@ interface StagedDevRenderSetup {
   readonly environmentName: () => string
 }
 
-enum PrefetchingMode {
+export enum PrefetchingMode {
   LegacySpeculative = 1,
   Partial = 2,
 }
@@ -6158,6 +6212,173 @@ export function toValidationRenderContext(
     },
     isDebugChannelEnabled: !!ctx.renderOpts.setReactDebugChannel,
   }
+}
+
+/**
+ * Rebuilds the `WorkStore` the worker's dev validation runs under from the
+ * transported snapshot, carrying only the fields the validation passes read.
+ * `after()` callbacks are routed into a throwaway `AfterContext` whose hooks
+ * no-op, because the validation render must not repeat those side effects, and
+ * `after()` can't affect the rendered output.
+ */
+function buildDevValidationWorkStore(
+  message: DevValidationWorkerMessage
+): WorkStore {
+  const { AfterContext } =
+    require('../after/after-context') as typeof import('../after/after-context')
+
+  const noopAfterContext = new AfterContext({
+    waitUntil(promise) {
+      promise.catch(() => {})
+    },
+    onClose() {},
+    onTaskError() {},
+  })
+
+  return {
+    isStaticGeneration: false,
+    page: message.page,
+    route: message.route,
+    forceStatic: message.forceStatic,
+    isDraftMode: message.request.isDraftMode,
+    useCacheTimeout: message.nextConfigSerializable.useCacheTimeout,
+    staticPageGenerationTimeout:
+      message.nextConfigSerializable.staticPageGenerationTimeout,
+    cacheLifeProfiles: message.nextConfigSerializable.cacheLifeProfiles,
+    buildId: message.buildId,
+    deploymentId: message.deploymentId,
+    previouslyRevalidatedTags: [],
+    refreshTagsByCacheKind: new Map(),
+    runInCleanSnapshot: createSnapshot(),
+    shouldTrackFetchMetrics: false,
+    reactServerErrorsByDigest: new Map(),
+    afterContext: noopAfterContext,
+    // Dev validation only ever runs under Cache Components.
+    cacheComponentsEnabled: true,
+    validationLevel: message.validationLevel,
+  }
+}
+
+/**
+ * Revives one serialized validation input into the in-memory shape
+ * `runValidationInDev` consumes, binding it to the rebuilt request store.
+ */
+function toDevValidationInputs(
+  serialized: SerializedValidationInputs,
+  requestStore: RequestStore
+): ResolvedValidationInputs {
+  return {
+    accumulatedChunks: serialized.accumulatedChunks,
+    startTime: serialized.startTime,
+    staticStageEndTime: serialized.staticStageEndTime,
+    runtimeStageEndTime: serialized.runtimeStageEndTime,
+    requestStore,
+    debugChannelClient: serialized.debugChunks
+      ? createNodeStreamFromChunks(serialized.debugChunks)
+      : undefined,
+  }
+}
+
+/**
+ * Worker entry point for Cached Components dev validation, reached from the
+ * validation worker via `ComponentMod.routeModule.runValidationInDev`. The
+ * worker reloads the route's compiled module and calls this so the entire
+ * validation (Flight re-encodes and the client prerenders) runs inside the
+ * app-page bundle's single React instance, alongside the user's client
+ * components. It rebuilds the render context, work store, and request store
+ * from the transported snapshot (the live objects can't cross a thread) and
+ * returns the validation errors for the worker to serialize and the main thread
+ * to deliver.
+ */
+export async function runValidationInDevFromSnapshot(
+  message: DevValidationWorkerMessage,
+  componentMod: AppPageModule,
+  abortSignal: AbortSignal
+): Promise<Array<unknown> | undefined> {
+  // Expose the reloaded route's bundler `require` / `loadChunk` on `globalThis`
+  // so `react-server-dom-*` can resolve client references during the validation
+  // prerenders, exactly as the main render does after loading its module.
+  if (componentMod.__next_app__) {
+    installGlobalModuleLoadingHandlers(componentMod, true, false)
+  }
+
+  // The request's fallback params reproduce `ctx.getDynamicParamFromSegment`
+  // exactly, so the depth-loop segment keys match the seed render's Flight. The
+  // validation set (below) is separate and only marks params unknown in the
+  // prerender stores.
+  //
+  // TODO: Those two fallback params sets are very confusing in the whole code
+  // base. We should maybe refactor this to make their different roles clearer.
+  const requestFallbackRouteParams = message.requestFallbackRouteParams
+    ? new Map(message.requestFallbackRouteParams)
+    : null
+
+  const fallbackRouteParams = message.fallbackRouteParams
+    ? new Map(message.fallbackRouteParams)
+    : null
+
+  const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
+    message.interpolatedParams,
+    requestFallbackRouteParams,
+    message.optimisticRouting
+  )
+
+  const implicitTags: ImplicitTags = {
+    tags: message.implicitTags,
+    expirationsByCacheKind: new Map(),
+  }
+
+  const workStore = buildDevValidationWorkStore(message)
+
+  const ctx: ValidationRenderContext = {
+    componentMod,
+    getDynamicParamFromSegment,
+    query: message.query,
+    implicitTags,
+    nonce: message.nonce,
+    workStore,
+    renderOpts: {
+      images: message.renderOpts.images,
+      allowEmptyStaticShell: message.renderOpts.allowEmptyStaticShell,
+    },
+    isDebugChannelEnabled: message.isDebugChannelEnabled,
+  }
+
+  const requestStore = createRequestStoreFromInputs({
+    phase: 'render',
+    headers: new Headers(message.request.headers),
+    onUpdateCookies: undefined,
+    url: {
+      pathname: message.request.urlPathname,
+      search: message.request.urlSearch,
+    },
+    rootParams: message.request.rootParams,
+    implicitTags,
+    resumeDataCache: null,
+    previewProps: undefined,
+    isHmrRefresh: message.request.isHmrRefresh,
+    hmrRefreshHash: message.request.hmrRefreshHash,
+    serverComponentsHmrCache: undefined,
+    fallbackParams: requestFallbackRouteParams,
+  })
+
+  const staticInputs = toDevValidationInputs(message.staticInputs, requestStore)
+
+  const instantInputs = message.instantInputs
+    ? toDevValidationInputs(message.instantInputs, requestStore)
+    : null
+
+  return workAsyncStorage.run(
+    workStore,
+    runValidationInDev,
+    message.prefetchMode,
+    instantInputs,
+    staticInputs,
+    ctx,
+    fallbackRouteParams,
+    message.devRenderDidError,
+    abortSignal
+  )
 }
 
 /**

--- a/packages/next/src/server/app-render/dev-validation-error-delivery.ts
+++ b/packages/next/src/server/app-render/dev-validation-error-delivery.ts
@@ -1,0 +1,48 @@
+import type { AppPageModule } from '../route-modules/app-page/module'
+import { renderToNodeFlightStream } from './stream-ops'
+import { getClientReferenceManifest } from './manifests-singleton'
+import { extractNextErrorCode } from '../../lib/error-telemetry-utils'
+
+const filterStackFrame =
+  process.env.NODE_ENV !== 'production'
+    ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+        .filterStackFrameDEV
+    : undefined
+
+/**
+ * Encodes dev-validation errors into the RSC Flight bytes the dev overlay
+ * revives. Must run in the runtime that produced the errors (the in-process
+ * render or the validation worker) so the encode uses the matching
+ * client-reference manifest and captures the live `Error` objects with their
+ * stacks and digests. The error codes ride along in a side-channel `Map`
+ * because React doesn't revive `__NEXT_ERROR_CODE` during RSC deserialization;
+ * RSC preserves object identity, so the revived map keys reference the same
+ * errors.
+ */
+export async function serializeValidationErrorsToFlight(
+  componentMod: AppPageModule,
+  errors: Error[]
+): Promise<Uint8Array[]> {
+  const errorCodes = new Map<Error, string>()
+  for (const err of errors) {
+    const code = extractNextErrorCode(err)
+    if (code !== undefined) {
+      errorCodes.set(err, code)
+    }
+  }
+
+  const { clientModules } = getClientReferenceManifest()
+
+  const stream = renderToNodeFlightStream(
+    componentMod,
+    { errors, errorCodes },
+    clientModules,
+    { filterStackFrame }
+  )
+
+  const chunks: Uint8Array[] = []
+  for await (const chunk of stream) {
+    chunks.push(chunk)
+  }
+  return chunks
+}

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -92,6 +92,14 @@ export interface DevValidationSnapshot {
   forceStatic: boolean | undefined
   validationLevel: ValidationLevel
   implicitTags: string[]
+  /**
+   * Pages whose client reference manifests supplied client references to the
+   * render being validated, beyond the validated route's own manifest (see
+   * `WorkStore.additionalClientReferenceManifestPages`). The worker registers
+   * these so the same references resolve in its thread. Empty for all but the
+   * rare renders that React's I/O tracking carries a reference into.
+   */
+  additionalClientReferenceManifestPages: string[]
   isDebugChannelEnabled: boolean
   renderOpts: {
     images: ImageConfigComplete

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -1,0 +1,162 @@
+import type { Params } from '../request/params'
+import type { OpaqueFallbackRouteParamEntries } from '../request/fallback-params'
+import type { NextParsedUrlQuery } from '../request-meta'
+import type { PrefetchingMode } from './app-render'
+import type { NextConfigComplete, ValidationLevel } from '../config-shared'
+import type { ImageConfigComplete } from '../../shared/lib/image-config'
+
+/**
+ * Cross-module handoff for the dev validation worker (client-module warmup,
+ * static-shell validation, and instant-config validation all run on it). A
+ * symbol on `globalThis` decouples the dev-server entry point (which installs
+ * the jest-worker pool) from the read site in `runDevValidationInBackground`
+ * inside `app-render.tsx`, avoiding a direct import of dev-only pool code from
+ * the render module. When the symbol is not set (e.g. because the feature flag
+ * is disabled), `getDevValidationWorker()` returns undefined and the caller
+ * runs validation in process instead.
+ */
+const SYMBOL: unique symbol = Symbol.for('next.dev.validationWorker')
+
+/**
+ * Per-stage RSC chunks, the serializable form of `AccumulatedStreamChunks` that
+ * the worker replays. No live streams cross the boundary.
+ */
+export interface SerializedAccumulatedChunks {
+  shellStaticChunks: Uint8Array[]
+  staticChunks: Uint8Array[]
+  shellRuntimeChunks: Uint8Array[]
+  runtimeChunks: Uint8Array[]
+  dynamicChunks: Uint8Array[]
+}
+
+/**
+ * Serializable view of one validation input (the shape `DevValidationInputs`
+ * carries), with the live streams already drained to chunks. The stage-end
+ * timings are replayed into the per-depth Flight re-encodes so the worker
+ * reconstructs the same partial-stage boundaries the main render observed.
+ */
+export interface SerializedValidationInputs {
+  accumulatedChunks: SerializedAccumulatedChunks
+  debugChunks: Uint8Array[] | null
+  startTime: number
+  staticStageEndTime: number
+  runtimeStageEndTime: number
+}
+
+/**
+ * Serializable view of the request, rebuilt into a `RequestStore` on the worker
+ * so `cookies()` / `headers()` / `draftMode()` behave as in the real render.
+ */
+export interface DevValidationRequestSnapshot {
+  headers: [string, string][]
+  urlPathname: string
+  urlSearch: string
+  rootParams: Params
+  isDraftMode: boolean
+  isHmrRefresh: boolean
+  hmrRefreshHash: string | undefined
+}
+
+/**
+ * Everything the worker needs to rebuild the render context and inputs and run
+ * `runValidationInDev`. Built on the main thread from the settled render; the
+ * pool augments it with install-time fields (`distDir`, `buildId`, …).
+ */
+export interface DevValidationSnapshot {
+  page: string
+  route: string
+  requestId: string
+  responseFinished: boolean
+  prefetchMode: PrefetchingMode
+  devRenderDidError: boolean
+  nonce: string | undefined
+  query: NextParsedUrlQuery
+  request: DevValidationRequestSnapshot
+  // The interpolated route params, the routing seed the worker rebuilds
+  // `getDynamicParamFromSegment` from (together with the fallback params
+  // below).
+  interpolatedParams: Params
+  // The request's fallback params, the set `ctx.getDynamicParamFromSegment`
+  // closed over. The worker rebuilds `getDynamicParamFromSegment` from these
+  // (with `interpolatedParams` and `optimisticRouting`), so the depth-loop
+  // segment keys match the seed render's Flight. It is null for a request whose
+  // params all resolve to concrete values. Carried as map entries (like
+  // `fallbackRouteParams`) so both survive structured-clone transport.
+  requestFallbackRouteParams: OpaqueFallbackRouteParamEntries | null
+  // The validation fallback params, passed to `runValidationInDev` and its
+  // prerender stores. They mark params unknown so that accessing one during the
+  // simulated prefetch is treated as dynamic. This set may include params that
+  // `requestFallbackRouteParams` does not.
+  fallbackRouteParams: OpaqueFallbackRouteParamEntries | null
+  optimisticRouting: boolean
+  forceStatic: boolean | undefined
+  validationLevel: ValidationLevel
+  implicitTags: string[]
+  isDebugChannelEnabled: boolean
+  renderOpts: {
+    images: ImageConfigComplete
+    allowEmptyStaticShell: boolean | undefined
+  }
+  instantInputs: SerializedValidationInputs | null
+  staticInputs: SerializedValidationInputs
+}
+
+/**
+ * Install-time fields the dev server's worker pool augments the snapshot with
+ * so the worker can reload the route (`distDir`; `page` comes from the
+ * snapshot) and rebuild the work store (`buildId`, `deploymentId`, the config
+ * slice).
+ */
+export interface DevValidationInstallFields {
+  distDir: string
+  buildId: string
+  deploymentId: string
+  nextConfigSerializable: {
+    httpAgentOptions: NextConfigComplete['httpAgentOptions']
+    cacheLifeProfiles: NextConfigComplete['cacheLife']
+    useCacheTimeout: number
+    staticPageGenerationTimeout: number
+  }
+}
+
+/**
+ * The full message the worker receives and forwards into the in-bundle entry:
+ * the main-thread snapshot plus the pool's install-time fields.
+ */
+export type DevValidationWorkerMessage = DevValidationSnapshot &
+  DevValidationInstallFields
+
+/**
+ * The RSC-encoded `{ errors, errorCodes }` Flight chunks for the dev overlay,
+ * or null when validation produced no errors or was aborted. The worker also
+ * logs the errors to its own stderr (piped to the parent) with code frames.
+ */
+export type DevValidationWorkerResult = Uint8Array[] | null
+
+/**
+ * Worker hook installed by the dev server. Given the render snapshot and the
+ * validation abort signal, runs validation on a worker thread and resolves to
+ * the validation error Flight chunks to deliver on the main thread. On an abort
+ * the pool relays the aborted signal to the worker thread through a shared
+ * flag, so the in-flight run aborts mid-run; validation always runs as a thread
+ * (never a child process), which is what makes that cross-thread abort
+ * possible.
+ */
+export type DevValidationWorker = (
+  snapshot: DevValidationSnapshot,
+  validationAbortSignal: AbortSignal
+) => Promise<DevValidationWorkerResult>
+
+interface WorkerHolder {
+  [SYMBOL]?: DevValidationWorker
+}
+
+export function setDevValidationWorker(
+  fn: DevValidationWorker | undefined
+): void {
+  ;(globalThis as WorkerHolder)[SYMBOL] = fn
+}
+
+export function getDevValidationWorker(): DevValidationWorker | undefined {
+  return (globalThis as WorkerHolder)[SYMBOL]
+}

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -1,0 +1,101 @@
+import type { AppRenderContext, ResolvedValidationInputs } from './app-render'
+import type { PrefetchingMode } from './app-render'
+import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
+import type { AnyStream } from './stream-ops'
+import type {
+  DevValidationSnapshot,
+  SerializedValidationInputs,
+} from './dev-validation-worker-globals'
+
+import { isNodeNextResponse } from '../base-http/helpers'
+
+/**
+ * Builds the serializable snapshot the dev validation worker needs to rebuild
+ * the render context and inputs and run `runValidationInDev` on the worker
+ * thread. Reads only serializable data from the settled render; the live
+ * objects (`componentMod`, the async-storage stores,
+ * `getDynamicParamFromSegment`) are reconstructed on the worker from this seed.
+ * Draining the debug channels is async, so this returns a promise.
+ */
+export async function buildDevValidationSnapshot(
+  ctx: AppRenderContext,
+  instantInputs: ResolvedValidationInputs | null,
+  staticInputs: ResolvedValidationInputs,
+  prefetchMode: PrefetchingMode,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  devRenderDidError: boolean
+): Promise<DevValidationSnapshot> {
+  const requestStore = staticInputs.requestStore
+  const responseFinished =
+    !isNodeNextResponse(ctx.res) || ctx.res.originalResponse.writableFinished
+
+  // The instant and static inputs may share one debug channel, so drain each
+  // channel only once.
+  const chunksByChannel = new WeakMap<AnyStream, Uint8Array[]>()
+  const getDebugChunksOnce = async (
+    channel: AnyStream | undefined
+  ): Promise<Uint8Array[] | null> => {
+    if (!channel) {
+      return null
+    }
+    let chunks = chunksByChannel.get(channel)
+    if (!chunks) {
+      chunks = []
+      for await (const chunk of channel) {
+        chunks.push(chunk)
+      }
+      chunksByChannel.set(channel, chunks)
+    }
+    return chunks
+  }
+
+  const toSerializedInputs = async (
+    inputs: ResolvedValidationInputs
+  ): Promise<SerializedValidationInputs> => ({
+    accumulatedChunks: inputs.accumulatedChunks,
+    debugChunks: await getDebugChunksOnce(inputs.debugChannelClient),
+    startTime: inputs.startTime,
+    staticStageEndTime: inputs.staticStageEndTime,
+    runtimeStageEndTime: inputs.runtimeStageEndTime,
+  })
+
+  return {
+    page: ctx.workStore.page,
+    route: ctx.workStore.route,
+    requestId: ctx.requestId,
+    responseFinished,
+    prefetchMode,
+    devRenderDidError,
+    nonce: ctx.nonce,
+    query: ctx.query,
+    request: {
+      headers: [...requestStore.headers.entries()],
+      urlPathname: requestStore.url.pathname,
+      urlSearch: requestStore.url.search,
+      rootParams: requestStore.rootParams,
+      isDraftMode: requestStore.draftMode.isEnabled,
+      isHmrRefresh: requestStore.isHmrRefresh ?? false,
+      hmrRefreshHash: requestStore.hmrRefreshHash,
+    },
+    interpolatedParams: ctx.interpolatedParams,
+    requestFallbackRouteParams: ctx.fallbackRouteParams
+      ? [...ctx.fallbackRouteParams.entries()]
+      : null,
+    fallbackRouteParams: fallbackRouteParams
+      ? [...fallbackRouteParams.entries()]
+      : null,
+    optimisticRouting: ctx.renderOpts.experimental.optimisticRouting,
+    forceStatic: ctx.workStore.forceStatic,
+    validationLevel: ctx.workStore.validationLevel,
+    implicitTags: ctx.implicitTags.tags,
+    isDebugChannelEnabled: !!ctx.renderOpts.setReactDebugChannel,
+    renderOpts: {
+      images: ctx.renderOpts.images,
+      allowEmptyStaticShell: ctx.renderOpts.allowEmptyStaticShell,
+    },
+    instantInputs: instantInputs
+      ? await toSerializedInputs(instantInputs)
+      : null,
+    staticInputs: await toSerializedInputs(staticInputs),
+  }
+}

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -88,6 +88,10 @@ export async function buildDevValidationSnapshot(
     forceStatic: ctx.workStore.forceStatic,
     validationLevel: ctx.workStore.validationLevel,
     implicitTags: ctx.implicitTags.tags,
+    additionalClientReferenceManifestPages: ctx.workStore
+      .additionalClientReferenceManifestPages
+      ? [...ctx.workStore.additionalClientReferenceManifestPages]
+      : [],
     isDebugChannelEnabled: !!ctx.renderOpts.setReactDebugChannel,
     renderOpts: {
       images: ctx.renderOpts.images,

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -54,10 +54,21 @@ const TRUNCATED_SERVER_REFERENCE_ID_LENGTH = 90
 // AsyncLocalStorage as it might happen at the module level.
 const MANIFESTS_SINGLETON = Symbol.for('next.server.manifests')
 
+interface RegisteredClientReferenceManifest {
+  /**
+   * The page the manifest was registered with. Routes are normalized app paths,
+   * which is lossy (route groups, parallel slots and the trailing `/page` are
+   * stripped), so this is kept alongside for consumers that need to address the
+   * manifest on disk again rather than reversing the normalization.
+   */
+  readonly page: string
+  readonly clientReferenceManifest: DeepReadonly<ClientReferenceManifest>
+}
+
 interface ManifestsSingleton {
   readonly clientReferenceManifestsPerRoute: Map<
     string,
-    DeepReadonly<ClientReferenceManifest>
+    RegisteredClientReferenceManifest
   >
   readonly proxiedClientReferenceManifest: DeepReadonly<ClientReferenceManifest>
   serverActionsManifest: DeepReadonly<ActionManifest>
@@ -80,7 +91,7 @@ const globalThisWithManifests = globalThis as GlobalThisWithManifests
 function createProxiedClientReferenceManifest(
   clientReferenceManifestsPerRoute: Map<
     string,
-    DeepReadonly<ClientReferenceManifest>
+    RegisteredClientReferenceManifest
   >
 ): DeepReadonly<ClientReferenceManifest> {
   const createMappingProxy = (prop: ClientReferenceManifestMappingProp) => {
@@ -93,7 +104,7 @@ function createProxiedClientReferenceManifest(
           if (workStore) {
             const currentManifest = clientReferenceManifestsPerRoute.get(
               workStore.route
-            )
+            )?.clientReferenceManifest
 
             if (currentManifest?.[prop][id]) {
               return currentManifest[prop][id]
@@ -112,15 +123,24 @@ function createProxiedClientReferenceManifest(
             if (process.env.NODE_ENV !== 'production') {
               for (const [
                 route,
-                manifest,
+                { page, clientReferenceManifest },
               ] of clientReferenceManifestsPerRoute) {
                 if (route === workStore.route) {
                   continue
                 }
 
-                const entry = manifest[prop][id]
+                const entry = clientReferenceManifest[prop][id]
 
                 if (entry !== undefined) {
+                  if (process.env.__NEXT_DEV_SERVER) {
+                    // The dev validation worker rebuilds this registry in its
+                    // own thread, seeded with only the route it validates, so
+                    // it has to be told which other manifests it needs.
+                    workStore.additionalClientReferenceManifestPages ??=
+                      new Set()
+                    workStore.additionalClientReferenceManifestPages.add(page)
+                  }
+
                   return entry
                 }
               }
@@ -132,8 +152,10 @@ function createProxiedClientReferenceManifest(
             // might also use client components which need to be serialized by
             // Flight, and therefore client references need to be resolvable. In
             // that case we search all page manifests to find the module.
-            for (const manifest of clientReferenceManifestsPerRoute.values()) {
-              const entry = manifest[prop][id]
+            for (const {
+              clientReferenceManifest,
+            } of clientReferenceManifestsPerRoute.values()) {
+              const entry = clientReferenceManifest[prop][id]
 
               if (entry !== undefined) {
                 return entry
@@ -168,17 +190,17 @@ function createProxiedClientReferenceManifest(
               )
             }
 
-            const currentManifest = clientReferenceManifestsPerRoute.get(
+            const registeredManifest = clientReferenceManifestsPerRoute.get(
               workStore.route
             )
 
-            if (!currentManifest) {
+            if (!registeredManifest) {
               throw new InvariantError(
                 `The client reference manifest for route "${workStore.route}" does not exist.`
               )
             }
 
-            return currentManifest[prop]
+            return registeredManifest.clientReferenceManifest[prop]
           }
           case 'clientModules':
           case 'rscModuleMapping':
@@ -323,6 +345,7 @@ export function setManifestsSingleton({
   serverActionsManifest: DeepReadonly<ActionManifest>
 }) {
   const existingSingleton = globalThisWithManifests[MANIFESTS_SINGLETON]
+  const route = normalizeAppPath(page)
 
   const serverActionsManifest: DeepReadonly<ActionManifest> = {
     encryptionKey: rawServerActionsManifest.encryptionKey,
@@ -333,17 +356,17 @@ export function setManifestsSingleton({
   }
 
   if (existingSingleton) {
-    existingSingleton.clientReferenceManifestsPerRoute.set(
-      normalizeAppPath(page),
-      clientReferenceManifest
-    )
+    existingSingleton.clientReferenceManifestsPerRoute.set(route, {
+      page,
+      clientReferenceManifest,
+    })
 
     existingSingleton.serverActionsManifest = serverActionsManifest
   } else {
     const clientReferenceManifestsPerRoute = new Map<
       string,
-      DeepReadonly<ClientReferenceManifest>
-    >([[normalizeAppPath(page), clientReferenceManifest]])
+      RegisteredClientReferenceManifest
+    >([[route, { page, clientReferenceManifest }]])
 
     const proxiedClientReferenceManifest = createProxiedClientReferenceManifest(
       clientReferenceManifestsPerRoute

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -144,6 +144,17 @@ export interface WorkStore {
   validationLevel: ValidationLevel
 
   /**
+   * Pages, other than the one being rendered, whose client reference manifest
+   * supplied a client reference for this render. Only populated by the dev
+   * server, where React's I/O tracking can carry a reference from another page
+   * into this render, which `createProxiedClientReferenceManifest` resolves by
+   * searching the other pages' manifests. The dev validation worker rebuilds
+   * that registry in its own thread from the route it validates, so it relies
+   * on this to know which other manifests to register.
+   */
+  additionalClientReferenceManifestPages?: Set<string>
+
+  /**
    * Run the given function inside a clean AsyncLocalStorage snapshot. This is
    * useful when generating cache entries, to ensure that the cache generation
    * cannot read anything from the context we're currently executing in, which

--- a/packages/next/src/server/dev/dev-validation-worker-pool.ts
+++ b/packages/next/src/server/dev/dev-validation-worker-pool.ts
@@ -1,0 +1,181 @@
+import type { NextConfigComplete } from '../config-shared'
+import type { runDevValidation } from './dev-validation-worker'
+import type {
+  DevValidationSnapshot,
+  DevValidationWorkerMessage,
+  DevValidationWorkerResult,
+} from '../app-render/dev-validation-worker-globals'
+
+import { Worker } from 'next/dist/compiled/jest-worker'
+import { setDevValidationWorker } from '../app-render/dev-validation-worker-globals'
+import { onCacheInvalidation } from './require-cache'
+import { getFormattedNodeOptionsWithoutInspect } from '../lib/utils'
+import { needsExperimentalReact } from '../../lib/needs-experimental-react'
+
+interface InstallOptions {
+  distDir: string
+  buildId: string
+  deploymentId: string
+  nextConfig: NextConfigComplete
+}
+
+type ValidationPool = { [key: string]: any } & {
+  runDevValidation: typeof runDevValidation
+}
+
+/**
+ * Wire up the dev-server's validation worker: register the HMR teardown
+ * listener and install the hook that `runDevValidationInBackground` calls once
+ * a render has settled. The worker thread is spawned lazily, so nothing is
+ * created until the first navigation actually validates.
+ */
+export function installDevValidationWorker(options: InstallOptions): void {
+  const { distDir, buildId, deploymentId, nextConfig } = options
+
+  // A single worker, not a pool. Validation for one navigation runs its depth
+  // loop sequentially, and a newer navigation supersedes the previous one
+  // (aborting it mid-run) rather than running concurrently, so there's no
+  // per-request fan-out to parallelize (unlike the `'use cache'` probe, where
+  // one request fans out into concurrent probes). One worker already frees the
+  // main thread, which is the whole point; it also keeps each request's CLI
+  // marker block contiguous in the piped output. Torn down on HMR (stale user
+  // modules) and on crash.
+  //
+  // TODO(dev-validation-worker): raise `numWorkers` if concurrent navigations
+  // across independent requests (e.g. multiple tabs) show a validation-latency
+  // tail.
+  let pool: ValidationPool | undefined
+
+  const getPool = (): ValidationPool => {
+    if (pool) {
+      return pool
+    }
+    // Strip `--inspect` from any inherited `NODE_OPTIONS` so the worker doesn't
+    // fight the parent for the same debug port.
+    const workerNodeOptions = getFormattedNodeOptionsWithoutInspect()
+
+    // The worker is shipped as four pre-bundled dev-only artifacts
+    // ({webpack,turbopack} × {stable,experimental}), one per combination of the
+    // user's bundler and vendored React channel. Pick the matching artifact
+    // from runtime env so the worker stays in lockstep with the user's app
+    // bundle. `needsExperimentalReact` is the same predicate `define-env.ts`
+    // uses to wire `__NEXT_EXPERIMENTAL_REACT`.
+    const turbo = process.env.TURBOPACK ? '-turbo' : ''
+    const channel = needsExperimentalReact(nextConfig) ? '-experimental' : ''
+    const workerPath = require.resolve(
+      `next/dist/compiled/next-server/dev-validation-worker${turbo}${channel}.runtime.dev.js`
+    )
+
+    const worker = new Worker(workerPath, {
+      maxRetries: 0,
+      numWorkers: 1,
+      // Always worker-threads, regardless of `experimental.workerThreads`.
+      // Unlike the `'use cache'` probe (which follows the flag), validation has
+      // no reason to prefer a child process: it doesn't need process-level
+      // isolation (a worker thread already has its own V8 heap and module
+      // registry, so the reloaded route is isolated from the main thread), and
+      // threads let a superseded validation be aborted mid-run through a shared
+      // `SharedArrayBuffer`, which a separate process can't receive. Threads
+      // also carry the transported Flight bytes as typed arrays via structured
+      // clone, with no JSON round-trip to corrupt them.
+      enableWorkerThreads: true,
+      // Listing the method explicitly tells jest-worker to skip the discovery
+      // `require()` it would otherwise do in the parent process to enumerate
+      // the module's exports. This worker's top-level imports (`require-hook`,
+      // `node-environment`) run runtime setup meant only for the isolated
+      // worker thread, so they must not be evaluated in the parent.
+      exposedMethods: ['runDevValidation'],
+      forkOptions: {
+        env: {
+          ...process.env,
+          NODE_OPTIONS: workerNodeOptions,
+        },
+      },
+    }) as Worker & ValidationPool
+    worker.getStdout().pipe(process.stdout)
+    worker.getStderr().pipe(process.stderr)
+    pool = worker
+    return worker
+  }
+
+  const tearDownPool = async (): Promise<void> => {
+    const current = pool
+    if (!current) {
+      return
+    }
+    pool = undefined
+    await current.end().catch(() => {
+      // The worker thread exits on its own once its work settles; a failed
+      // `.end()` here just means we couldn't wait for it cleanly.
+    })
+  }
+
+  const runValidation = async (
+    snapshot: DevValidationSnapshot,
+    validationAbortSignal: AbortSignal
+  ): Promise<DevValidationWorkerResult> => {
+    let activePool: ValidationPool
+    try {
+      activePool = getPool()
+    } catch {
+      return null
+    }
+
+    const message: DevValidationWorkerMessage = {
+      ...snapshot,
+      distDir,
+      buildId,
+      deploymentId,
+      nextConfigSerializable: {
+        httpAgentOptions: nextConfig.httpAgentOptions,
+        cacheLifeProfiles: nextConfig.cacheLife,
+        useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+        staticPageGenerationTimeout: nextConfig.staticPageGenerationTimeout,
+      },
+    }
+
+    // The worker runs as a thread (see `enableWorkerThreads` above), so an
+    // abort reaches it through a one-slot shared flag rather than the abort
+    // signal directly (a signal can't cross the thread boundary). Mirror an
+    // abort of `validationAbortSignal` into the buffer and wake the worker's
+    // `Atomics.waitAsync` on it, so it aborts the in-flight run at its next
+    // depth boundary.
+    const abortBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
+    const abortFlag = new Int32Array(abortBuffer)
+    const propagateAbort = () => {
+      Atomics.store(abortFlag, 0, 1)
+      Atomics.notify(abortFlag, 0)
+    }
+    if (validationAbortSignal.aborted) {
+      propagateAbort()
+    } else {
+      validationAbortSignal.addEventListener('abort', propagateAbort, {
+        once: true,
+      })
+    }
+
+    try {
+      return await activePool.runDevValidation(message, abortBuffer)
+    } catch {
+      // Worker crash or IPC error: tear down so the next validation starts
+      // fresh. The main thread treats a missing result as "nothing to deliver."
+      await tearDownPool()
+      return null
+    } finally {
+      // `once` only auto-removes the listener if it fired, so remove it
+      // explicitly to bound its lifetime to this run when validation completed
+      // without being superseded.
+      validationAbortSignal.removeEventListener('abort', propagateAbort)
+    }
+  }
+
+  // The dev server can't reach into the worker to clear its `require.cache` or
+  // manifest caches, so we drop the worker whenever the parent's caches are
+  // invalidated (HMR, route recompile). The next validation lazy-spawns a fresh
+  // worker with empty caches.
+  onCacheInvalidation(() => {
+    void tearDownPool()
+  })
+
+  setDevValidationWorker(runValidation)
+}

--- a/packages/next/src/server/dev/dev-validation-worker.ts
+++ b/packages/next/src/server/dev/dev-validation-worker.ts
@@ -1,0 +1,209 @@
+import type { AppPageModule } from '../route-modules/app-page/module'
+import type {
+  DevValidationWorkerMessage,
+  DevValidationWorkerResult,
+} from '../app-render/dev-validation-worker-globals'
+
+import '../require-hook'
+import '../node-environment'
+
+import { installBindings } from '../../build/swc/install-bindings'
+import { installCodeFrameSupport } from '../lib/install-code-frame'
+import { loadComponents } from '../load-components'
+import { setHttpClientAndAgentOptions } from '../setup-http-agent-env'
+import { serializeValidationErrorsToFlight } from '../app-render/dev-validation-error-delivery'
+import { formatValidationEvent } from '../app-render/dev-validation-events'
+
+// Match the main dev server (`next-dev-server.ts`), which raises this so the
+// server captures deeper stacks. React's owner-stack capture during the
+// validation prerenders depends on it, so without it the worker's errors lose
+// their owner-stack source attribution.
+try {
+  Error.stackTraceLimit = 50
+} catch {}
+
+// The lifecycle markers E2E tests read from the CLI. Emitted on the worker's
+// stdout (piped to the parent) so they interleave with the parent's captured
+// output the same way the in-process `runWithDevValidationLogging` markers do.
+// Gated on the same test env that path checks.
+const isTestLoggingEnabled = !!(
+  process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION
+)
+
+/**
+ * Adapts the pool's supersede flag into an `AbortSignal` the validation passes
+ * check at their depth/yield boundaries. The pool shares an `Int32Array`-backed
+ * `SharedArrayBuffer` whose first slot the main thread flips to non-zero (with
+ * `Atomics.store` + `Atomics.notify`) when a newer navigation supersedes this
+ * one. We wait for that notification with `Atomics.waitAsync`, which is
+ * event-driven rather than polled. A validation that finishes without being
+ * superseded calls `cleanup()`, which wakes our own still-pending wait so it
+ * leaves no waiter (and no retained buffer) behind.
+ */
+function createSupersedeSignal(abortBuffer: SharedArrayBuffer): {
+  signal: AbortSignal
+  cleanup: () => void
+} {
+  const controller = new AbortController()
+  const flag = new Int32Array(abortBuffer)
+
+  if (Atomics.load(flag, 0) !== 0) {
+    controller.abort()
+    return { signal: controller.signal, cleanup: () => {} }
+  }
+
+  let settled = false
+  const wait = Atomics.waitAsync(flag, 0, 0)
+  if (wait.async) {
+    wait.value.then(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      // Woken either by a real supersede or by `cleanup()`; only the former
+      // leaves the flag set.
+      if (Atomics.load(flag, 0) !== 0) {
+        controller.abort()
+      }
+    })
+  } else if (Atomics.load(flag, 0) !== 0) {
+    // The flag flipped between the load above and the wait.
+    controller.abort()
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (!settled) {
+        Atomics.notify(flag, 0)
+      }
+    },
+  }
+}
+
+/**
+ * Waits out the test-only validation delay, resolving early if the render is
+ * superseded. Mirrors the delay in `runWithDevValidationLogging` so scheduler
+ * tests observe the same in-flight window on the worker path.
+ */
+async function applyTestValidationDelay(signal: AbortSignal): Promise<void> {
+  const delayMs = Number(process.env.NEXT_TEST_DEV_VALIDATION_DELAY_MS)
+  if (!Number.isFinite(delayMs) || delayMs <= 0 || signal.aborted) {
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    const finishDelay = () => {
+      clearTimeout(timeout)
+      signal.removeEventListener('abort', finishDelay)
+      resolve()
+    }
+    const timeout = setTimeout(finishDelay, delayMs)
+    signal.addEventListener('abort', finishDelay, { once: true })
+  })
+}
+
+/**
+ * Runs the dev instant/static-shell validation passes off the main thread.
+ * Reloads the route's compiled module, then delegates the whole validation to
+ * that module via `ComponentMod.routeModule.runValidationInDev`, so every
+ * render (flight re-encodes and client prerenders) runs inside the app-page
+ * bundle's single React instance. Logs any returned errors to the worker's
+ * stderr with source-mapped code frames, then encodes them as RSC Flight bytes
+ * for the main thread to forward to the dev overlay. Returns `null` when
+ * validation was superseded or produced no errors.
+ */
+export async function runDevValidation(
+  message: DevValidationWorkerMessage,
+  abortBuffer: SharedArrayBuffer
+): Promise<DevValidationWorkerResult> {
+  // Load the native SWC bindings and wire the code-frame renderer so the errors
+  // logged below render with a source-mapped code frame, matching the
+  // in-process dev output (the E2E tests snapshot the CLI text between the
+  // validation markers). The `build/swc` graph these pull in is bundled as a
+  // runtime external (see `next-runtime.webpack-config.js`), so it resolves
+  // from the installed `next/dist` tree rather than being compiled into this
+  // worker bundle, the same way the unbundled build worker loads it.
+  await installBindings()
+  installCodeFrameSupport()
+  setHttpClientAndAgentOptions({
+    httpAgentOptions: message.nextConfigSerializable.httpAgentOptions,
+  })
+
+  // Populates the manifests singleton for the route via `setManifestsSingleton`
+  // inside `loadComponents`, exactly as a real request does. The pool tears the
+  // worker down on HMR / route recompile so the next validation reloads from a
+  // clean require cache.
+  const { ComponentMod } = await loadComponents<AppPageModule>({
+    distDir: message.distDir,
+    page: message.page,
+    isAppPath: true,
+    isDev: true,
+    sriEnabled: false,
+    needsManifestsForLegacyReasons: true,
+  })
+
+  const { signal, cleanup } = createSupersedeSignal(abortBuffer)
+
+  if (isTestLoggingEnabled) {
+    console.log(
+      formatValidationEvent({
+        type: 'validation_start',
+        requestId: message.requestId,
+        url: message.request.urlPathname + message.request.urlSearch,
+        responseFinished: message.responseFinished,
+      })
+    )
+  }
+
+  try {
+    if (isTestLoggingEnabled) {
+      await applyTestValidationDelay(signal)
+    }
+
+    if (signal.aborted) {
+      return null
+    }
+
+    // Crossing into the app-page bundle: the entire validation runs there, so
+    // the client prerenders use the same React the user's client components
+    // resolve through `ComponentMod`.
+    const validationErrors = await ComponentMod.routeModule.runValidationInDev(
+      ComponentMod,
+      message,
+      signal
+    )
+
+    if (validationErrors === undefined || signal.aborted) {
+      return null
+    }
+
+    const errors: Error[] = []
+    for (const validationError of validationErrors) {
+      // Log to the worker's stderr; `node-environment` +
+      // `installCodeFrameSupport` render the source-mapped stack and code frame
+      // there, matching the in-process CLI output.
+      console.error(validationError)
+      if (validationError instanceof Error) {
+        errors.push(validationError)
+      }
+    }
+
+    if (errors.length === 0) {
+      return null
+    }
+
+    return await serializeValidationErrorsToFlight(ComponentMod, errors)
+  } finally {
+    cleanup()
+    if (isTestLoggingEnabled) {
+      console.log(
+        formatValidationEvent({
+          type: signal.aborted ? 'validation_aborted' : 'validation_end',
+          requestId: message.requestId,
+          url: message.request.urlPathname + message.request.urlSearch,
+        })
+      )
+    }
+  }
+}

--- a/packages/next/src/server/dev/dev-validation-worker.ts
+++ b/packages/next/src/server/dev/dev-validation-worker.ts
@@ -9,10 +9,17 @@ import '../node-environment'
 
 import { installBindings } from '../../build/swc/install-bindings'
 import { installCodeFrameSupport } from '../lib/install-code-frame'
-import { loadComponents } from '../load-components'
+import {
+  loadClientReferenceManifestForPage,
+  loadComponents,
+} from '../load-components'
 import { setHttpClientAndAgentOptions } from '../setup-http-agent-env'
 import { serializeValidationErrorsToFlight } from '../app-render/dev-validation-error-delivery'
 import { formatValidationEvent } from '../app-render/dev-validation-events'
+import {
+  getServerActionsManifest,
+  setManifestsSingleton,
+} from '../app-render/manifests-singleton'
 
 // Match the main dev server (`next-dev-server.ts`), which raises this so the
 // server captures deeper stacks. React's owner-stack capture during the
@@ -104,6 +111,46 @@ async function applyTestValidationDelay(signal: AbortSignal): Promise<void> {
 }
 
 /**
+ * Registers the client reference manifests of the pages that supplied client
+ * references to the render being validated, beyond the validated route's own
+ * manifest. This thread has its own manifests singleton, which `loadComponents`
+ * seeds with only the validated route, so without these the dev-only cross-page
+ * lookup in `createProxiedClientReferenceManifest` has no other manifest to
+ * search and decoding the transported payload fails. Usually a no-op, since the
+ * main thread only records a page when React's I/O tracking actually carried a
+ * reference across pages.
+ */
+async function registerAdditionalClientReferenceManifests(
+  distDir: string,
+  pages: string[]
+): Promise<void> {
+  if (pages.length === 0) {
+    return
+  }
+
+  // Set by `loadComponents`. One server actions manifest covers the whole app,
+  // so the pages registered here share the validated route's.
+  const serverActionsManifest = getServerActionsManifest()
+
+  await Promise.all(
+    pages.map(async (page) => {
+      const clientReferenceManifest = await loadClientReferenceManifestForPage(
+        distDir,
+        page
+      )
+
+      if (clientReferenceManifest) {
+        setManifestsSingleton({
+          page,
+          clientReferenceManifest,
+          serverActionsManifest,
+        })
+      }
+    })
+  )
+}
+
+/**
  * Runs the dev instant/static-shell validation passes off the main thread.
  * Reloads the route's compiled module, then delegates the whole validation to
  * that module via `ComponentMod.routeModule.runValidationInDev`, so every
@@ -142,6 +189,11 @@ export async function runDevValidation(
     sriEnabled: false,
     needsManifestsForLegacyReasons: true,
   })
+
+  await registerAdditionalClientReferenceManifests(
+    message.distDir,
+    message.additionalClientReferenceManifestPages
+  )
 
   const { signal, cleanup } = createSupersedeSignal(abortBuffer)
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -26,6 +26,7 @@ import * as React from 'react'
 import fs from 'fs'
 import { Worker } from 'next/dist/compiled/jest-worker'
 import { installUseCacheProbe } from './use-cache-probe-pool'
+import { installDevValidationWorker } from './dev-validation-worker-pool'
 import { join as pathJoin } from 'path'
 import { PUBLIC_DIR_MIDDLEWARE_CONFLICT } from '../../lib/constants'
 import { findPagesDir } from '../../lib/find-pages-dir'
@@ -225,6 +226,20 @@ export default class DevServer extends Server {
       deploymentId: this.deploymentId,
       nextConfig: this.nextConfig,
     })
+
+    // Runs Cache Components dev validation on a worker thread, off the main
+    // thread, so validation renders don't block the event loop during rapid
+    // navigation. Gated by `experimental.devValidationWorker`. The worker is
+    // spawned lazily on the first navigation that validates, so this install is
+    // free when a project doesn't use Cache Components.
+    if (this.nextConfig.experimental.devValidationWorker !== false) {
+      installDevValidationWorker({
+        distDir: this.distDir,
+        buildId: this.buildId,
+        deploymentId: this.deploymentId,
+        nextConfig: this.nextConfig,
+      })
+    }
   }
 
   protected override getServerComponentsHmrCache() {

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -142,11 +142,26 @@ export async function evalManifestWithRetries<T extends object>(
   }
 }
 
-async function tryLoadClientReferenceManifest(
-  manifestPath: string,
-  entryName: string,
+/**
+ * Loads the client reference manifest that the bundler emitted for an app page,
+ * or returns undefined if there is none. Both the manifest file and the entry
+ * inside it are addressed by the page with `%5F` decoded back to `_`, so
+ * callers pass the page as-is and this resolves both.
+ */
+export async function loadClientReferenceManifestForPage(
+  distDir: string,
+  page: string,
   attempts?: number
 ): Promise<DeepReadonly<ClientReferenceManifest> | undefined> {
+  const entryName = page.replace(/%5F/g, '_')
+
+  const manifestPath = join(
+    /* turbopackIgnore: true */ distDir,
+    'server',
+    'app',
+    entryName + '_' + CLIENT_REFERENCE_MANIFEST + '.js'
+  )
+
   try {
     const context = await evalManifestWithRetries<{
       __RSC_MANIFEST: { [key: string]: ClientReferenceManifest }
@@ -252,17 +267,9 @@ async function loadComponentsImpl<
             manifestLoadAttempts
           ).catch(() => undefined),
       isAppPath && hasClientManifest
-        ? tryLoadClientReferenceManifest(
-            join(
-              /* turbopackIgnore: true */ distDir,
-              'server',
-              'app',
-              page.replace(/%5F/g, '_') +
-                '_' +
-                CLIENT_REFERENCE_MANIFEST +
-                '.js'
-            ),
-            page.replace(/%5F/g, '_'),
+        ? loadClientReferenceManifestForPage(
+            distDir,
+            page,
             manifestLoadAttempts
           )
         : undefined,

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -37,10 +37,20 @@ type CodeFrameRenderer = (
   colors: boolean
 ) => string | null
 
-let codeFrameRenderer: CodeFrameRenderer | undefined
+// The code-frame renderer is stored on `globalThis` rather than in a module
+// variable because this module is bundled into several runtimes (the dev
+// server, the app-page runtime bundle, and the dev worker bundles) that each
+// get their own copy. `Error.prepareStackTrace` is a single process-global, so
+// whichever copy patched it last is the one that renders errors, which may not
+// be the copy `setCodeFrameRenderer` was called on. Sharing the renderer
+// through a `globalThis` symbol lets any copy install it and any copy read it.
+const CODE_FRAME_RENDERER = Symbol.for('next.dev.codeFrameRenderer')
+type GlobalWithCodeFrameRenderer = typeof globalThis & {
+  [CODE_FRAME_RENDERER]?: CodeFrameRenderer
+}
 
 export function setCodeFrameRenderer(renderer: CodeFrameRenderer): void {
-  codeFrameRenderer = renderer
+  ;(globalThis as GlobalWithCodeFrameRenderer)[CODE_FRAME_RENDERER] = renderer
 }
 
 function getOriginalCodeFrame(
@@ -48,6 +58,9 @@ function getOriginalCodeFrame(
   source: string | null,
   colors: boolean = process.stdout.isTTY
 ): string | null {
+  const codeFrameRenderer = (globalThis as GlobalWithCodeFrameRenderer)[
+    CODE_FRAME_RENDERER
+  ]
   if (!codeFrameRenderer) {
     // No renderer available - gracefully degrade
     return null

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -7,8 +7,10 @@ import type { PrerenderManifest } from '../../../build'
 
 import {
   renderToHTMLOrFlight,
+  runValidationInDevFromSnapshot,
   type AppSharedContext,
 } from '../../app-render/app-render'
+import type { DevValidationWorkerMessage } from '../../app-render/dev-validation-worker-globals'
 import {
   RouteModule,
   type RouteModuleOptions,
@@ -167,6 +169,24 @@ export class AppPageRouteModule extends RouteModule<
       context.serverComponentsHmrCache,
       context.sharedContext
     )
+  }
+
+  /**
+   * Worker entry point for dev Cache Components dev validation. The dev
+   * validation worker reloads this route's module and calls this so the whole
+   * validation runs inside the app-page bundle's React instance (the same one
+   * the user's client components resolve through `componentMod`), rebuilding
+   * the render context from the transported `message`. `componentMod` is the
+   * reloaded module the worker holds; it's passed in because the route module
+   * has no back-reference to it. Returns the validation errors for the worker
+   * to serialize and the main thread to deliver to the dev overlay.
+   */
+  public runValidationInDev(
+    componentMod: AppPageModule,
+    message: DevValidationWorkerMessage,
+    abortSignal: AbortSignal
+  ): Promise<Array<unknown> | undefined> {
+    return runValidationInDevFromSnapshot(message, componentMod, abortSignal)
   }
 
   private pathCouldBeIntercepted(

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -3030,10 +3030,10 @@ export async function next_bundle_server(task, opts) {
   })
 }
 
-// The `app-worker` bundle currently has only one entry, the use-cache probe
-// worker, which is dev-only. We therefore build just the four dev variants
-// (turbo × experimental). If a future worker entry needs to run in prod,
-// add the matching prod tasks then.
+// The `app-worker` bundle holds the dev-only worker entries (the use-cache
+// probe worker and the dev validation worker). We therefore build just the four
+// dev variants (turbo × experimental). If a future worker entry needs to run in
+// prod, add the matching prod tasks then.
 export async function next_bundle_app_worker_dev(task, opts) {
   await task.source('dist').webpack({
     watch: opts.dev,

--- a/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
+++ b/test/development/app-dir/hmr-rsc-cancellation/hmr-rsc-cancellation.test.ts
@@ -1,6 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry, assertNoConsoleErrors } from 'next-test-utils'
-import { parseValidationMessages } from 'e2e-utils/instant-validation'
+import {
+  parseValidationMessages,
+  waitForValidation,
+} from 'e2e-utils/instant-validation'
 import type { Playwright } from 'next-webdriver'
 
 const cacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
@@ -258,6 +261,14 @@ describe('hmr-rsc-cancellation', () => {
     await retry(async () => {
       expect(await browser.elementById('dynamic').text()).toBe('initial')
     })
+    if (cacheComponentsEnabled) {
+      // Loading the page triggers a validation, which is detached from the
+      // response and can write its markers long after the page has rendered.
+      // Wait for it to finish before recording the CLI position below,
+      // otherwise those markers can land in the window the assertions read and
+      // the expected sequence of refresh events no longer matches.
+      await waitForValidation(await browser.url(), () => next.cliOutput)
+    }
     await instrumentBrowser(browser)
     const cliStart = next.cliOutput.length
 

--- a/test/e2e/app-dir/instant-validation/client.util.ts
+++ b/test/e2e/app-dir/instant-validation/client.util.ts
@@ -474,6 +474,14 @@ export function registerClientTests(ctx: InstantValidationCaseContext) {
           '/suspense-in-root/static/invalid-client-error-in-parent-sibling'
         )
 
+        // Wait for validation to finish before snapshotting. Unlike the other
+        // client-error cases, this page also throws a client error during the
+        // render itself, which opens the redbox before validation reports its
+        // own errors. Without waiting, the snapshot can race the
+        // (asynchronously delivered) validation errors and capture only the
+        // render error.
+        await waitForValidation(await browser.url(), getCliOutputSinceMark)
+
         if (isClientNav) {
           // In a client navigation, the redbox will be collapsed.
           await openRedbox(browser)


### PR DESCRIPTION
This moves the dev-mode Cache Components validation renders off the dev server's main thread onto a worker thread, so rapid navigation no longer starves the event loop. The worker crosses into the app-page bundle exactly once, calling a new `ComponentMod.routeModule.runValidationInDev` entry that rebuilds the render context, work store, and request store from a serializable snapshot and runs the whole validation there, so the client prerender and the user's client components resolve the single app-page React instance rather than a second copy.

A thin worker shell (`dev-validation-worker.ts`) plus a single-worker pool (`dev-validation-worker-pool.ts`) load the user bundle via `loadComponents`, install code-frame support for CLI output, and forward the validation errors back as Flight bytes; the main thread only delivers them to the overlay through `sendErrorsToBrowser`. The snapshot, the globalThis-symbol handoff, and the shared error-delivery helpers live in their own modules. The dev server installs the worker when `experimental.devValidationWorker` is not `false`, and `runDevValidationInBackground` uses it when present, falling back to the in-process path otherwise. A one-slot `SharedArrayBuffer` propagates a supersede abort into the worker so a newer navigation cancels an in-flight validation.

The runtime bundle gains an `app-worker` entry for the worker with the `build/swc` boundary externalized for the code-frame native binding, and `patch-error-inspect.ts` now backs its code-frame renderer with a globalThis symbol so all copies of the module share it across the thread.

The synthetic `bench/dev-validation` benchmark navigates back-to-back, so every click lands inside the validation window — the worst case for main-thread contention. Browser-observed navigation TTFB in that window, worker vs in-process:

| Route  | Worker (p50/p95/max) | In-process (p50/p95/max) |
| ------ | -------------------- | ------------------------ |
| client | 19 / 24 / 27 ms      | 40 / 66 / 7762 ms        |
| server | 42 / 45 / 46 ms      | 122 / 158 / 252 ms       |
| sprite | 109 / 117 / 169 ms   | 196 / 208 / 299 ms       |

The steady-state difference is only tens of milliseconds; the effect that matters is the tail. In-process, a navigation that collides with an in-flight validation render can stall for seconds (this run peaked at ~7.8s on the client route, and the peak varies run to run) because a staged render does not yield until it finishes; off-thread the main thread stays free and that stall disappears.

Read these as an upper bound, not a speedup that generalizes. The work moved off-thread is the validation render's CPU — bounded, route-dependent, and free of IO — so it does not grow with the main render's cost. In an app whose main render is dominated by IO the same absolute saving is a small fraction of the request, and it only appears when a navigation lands in the brief validation window; at ordinary click speed it is largely invisible. This is a dev-only responsiveness improvement whose benefit varies widely with the app and the navigation pattern.

As a follow-up, the validation work that still runs on the main thread could move to the worker as well. When the main render can't be reused for validation (for example after a cache miss), the validation re-renders on the main thread to produce its inputs, resuming from the Resume Data Cache (RDC) the main render already filled, and only then hands the resulting Flight chunks to the worker. A later iteration could run those renders inside the worker too, transporting the (serializable) RDC so the worker can resume from the filled caches rather than reading them back on the main thread.

closes NAR-895