### PR TITLE
Cache filesystem operations during output tracing

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -42,6 +42,19 @@ export const makeIgnoreFn = (root: string, ignores: string[]) => {
   }
 }
 
+function cacheFileOperation<T>(
+  cache: Map<string, Promise<T>>,
+  file: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  let promise = cache.get(file)
+  if (!promise) {
+    promise = operation()
+    cache.set(file, promise)
+  }
+  return promise
+}
+
 function shouldIgnore(
   file: string,
   serverIgnoreFn: (file: string) => boolean,
@@ -301,48 +314,64 @@ export async function collectBuildTraces({
           ...serverEntries,
           ...minimalServerEntries,
         ]
+        const readFileCache = new Map<string, Promise<string>>()
+        const readlinkCache = new Map<string, Promise<string | null>>()
+        const statCache = new Map<string, Promise<import('fs').Stats | null>>()
+
         const result = await nodeFileTrace(chunksToTrace, {
           base: outputFileTracingRoot,
           processCwd: dir,
           mixedModules: true,
           moduleSyncCatchall: true,
-          async readFile(p) {
-            try {
-              return await fs.readFile(p, 'utf8')
-            } catch (e) {
-              if (isError(e) && (e.code === 'ENOENT' || e.code === 'EISDIR')) {
-                // since tracing runs in parallel with static generation server
-                // files might be removed from that step so tolerate ENOENT
-                // errors gracefully
-                return ''
+          readFile(p) {
+            return cacheFileOperation(readFileCache, p, async () => {
+              try {
+                return await fs.readFile(p, 'utf8')
+              } catch (e) {
+                if (
+                  isError(e) &&
+                  (e.code === 'ENOENT' || e.code === 'EISDIR')
+                ) {
+                  // since tracing runs in parallel with static generation server
+                  // files might be removed from that step so tolerate ENOENT
+                  // errors gracefully
+                  return ''
+                }
+                throw e
               }
-              throw e
-            }
+            })
           },
-          async readlink(p) {
-            try {
-              return await fs.readlink(p)
-            } catch (e) {
-              if (
-                isError(e) &&
-                (e.code === 'EINVAL' ||
-                  e.code === 'ENOENT' ||
-                  e.code === 'UNKNOWN')
-              ) {
-                return null
+          readlink(p) {
+            return cacheFileOperation(readlinkCache, p, async () => {
+              try {
+                return await fs.readlink(p)
+              } catch (e) {
+                if (
+                  isError(e) &&
+                  (e.code === 'EINVAL' ||
+                    e.code === 'ENOENT' ||
+                    e.code === 'UNKNOWN')
+                ) {
+                  return null
+                }
+                throw e
               }
-              throw e
-            }
+            })
           },
-          async stat(p) {
-            try {
-              return await fs.stat(p)
-            } catch (e) {
-              if (isError(e) && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) {
-                return null
+          stat(p) {
+            return cacheFileOperation(statCache, p, async () => {
+              try {
+                return await fs.stat(p)
+              } catch (e) {
+                if (
+                  isError(e) &&
+                  (e.code === 'ENOENT' || e.code === 'ENOTDIR')
+                ) {
+                  return null
+                }
+                throw e
               }
-              throw e
-            }
+            })
           },
           // handle shared ignores at top-level as it
           // avoids over-tracing when we don't need to


### PR DESCRIPTION
## What changed

Cache the `readFile`, `readlink`, and `stat` promises used by the final `nodeFileTrace` pass for the lifetime of that pass.

The custom callbacks and their tolerated errors are unchanged. Storing the promise before returning it also deduplicates concurrent operations for the same path.

## Why

`@vercel/nft` normally caches these filesystem operations, but `collectBuildTraces` replaces NFT's methods with custom callbacks so Next can tolerate `EISDIR` reads and `ENOTDIR` stats. That replacement bypassed NFT's cache and repeated the same physical operations many times.

On a representative trace replay, caching changed:

- `readFile`: 3,754 → 1,314 calls
- `readlink`: 148,988 → 6,615 calls
- `stat`: 26,311 → 4,262 calls

The normalized 1,680,526-byte trace graph remained byte-identical across all 20 direct A/A and A/B observations.

## Performance

Exact commit `0950e8ae...`, Node 24.14.1, pnpm 10.33.0, 16 vCPU / 32 GiB, cold `.next`, 100 page groups / 300 static leaf routes, explicit webpack builds.

Four identical-baseline builds established a 0.92% arbitrary-label wall difference. Eight ABBA–BAAB builds then measured:

| Metric | Baseline | Candidate | Reduction |
|---|---:|---:|---:|
| Whole build wall | 90.945 s | 82.790 s | 8.97% |
| `collect-build-traces` | 28.352 s | 19.467 s | 31.34% |
| `node-file-trace-build` | 28.204 s | 19.319 s | 31.50% |
| User CPU | 156.305 s | 146.508 s | 6.27% |
| System CPU | 14.723 s | 12.575 s | 14.59% |

Both four-run blocks agreed (8.88% and 9.05% whole-build reductions). All four candidate walls were below all four baselines; exact two-sided permutation p = 0.0286. Peak RSS was neutral (-0.23%, p = 0.514).

## Validation

- `pnpm --filter=next build`
- `pnpm --filter=next types`
- focused Prettier and ESLint
- webpack `build-trace-extra-entries` production integration test
- webpack `build-trace-extra-entries-monorepo` production integration test
- 4/4 A/A and 8/8 A/B production builds, each with all 302 static pages
- GPT-5.6 Sol xhigh + Claude Opus 4.8 xhigh review: zero findings; patch classified correct at 0.97 confidence
