### PR TITLE
Improve root detection to handle worktrees, more workspaces & stray lockfiles

### DIFF
--- a/packages/next/src/lib/find-root.test.ts
+++ b/packages/next/src/lib/find-root.test.ts
@@ -1,0 +1,343 @@
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'fs/promises'
+import * as os from 'os'
+import { join } from 'path'
+import * as Log from '../build/output/log'
+import { findRootDirAndLockFiles, warnRootBoundary } from './find-root'
+
+jest.mock('../build/output/log', () => ({
+  warnOnce: jest.fn(),
+}))
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: jest.fn(jest.requireActual('os').homedir),
+}))
+
+const PACKAGE_LOCK = JSON.stringify({
+  lockfileVersion: 3,
+  packages: { '': { name: 'test' } },
+})
+
+const temporaryDirectories: string[] = []
+const actualHome = jest.requireActual<typeof os>('os').homedir()
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(join(os.tmpdir(), 'next-find-root-'))
+  temporaryDirectories.push(directory)
+  // the temporary directory itself may sit behind a symlink (macOS resolves
+  // `/var` to `/private/var`), which the boundary checks resolve away.
+  return realpath(directory)
+}
+
+async function writePackage(directory: string, packageJson = {}) {
+  await mkdir(directory, { recursive: true })
+  await writeFile(
+    join(directory, 'package.json'),
+    JSON.stringify({ name: 'test', ...packageJson })
+  )
+}
+
+async function writePackageLock(directory: string) {
+  await writePackage(directory)
+  await writeFile(join(directory, 'package-lock.json'), PACKAGE_LOCK)
+}
+
+afterEach(async () => {
+  jest.clearAllMocks()
+  jest.mocked(os.homedir).mockReturnValue(actualHome)
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  )
+})
+
+describe('findRootDirAndLockFiles', () => {
+  it('continues to select the outermost valid lockfile', async () => {
+    const directory = await temporaryDirectory()
+    const workspace = join(directory, 'workspace')
+    const app = join(workspace, 'apps', 'web')
+    await writePackageLock(workspace)
+    await writePackageLock(app)
+
+    expect(findRootDirAndLockFiles(app)).toEqual({
+      boundary: undefined,
+      lockFiles: [
+        join(app, 'package-lock.json'),
+        join(workspace, 'package-lock.json'),
+      ],
+      rootDir: workspace,
+    })
+  })
+
+  it('does not leave a Git worktree', async () => {
+    const directory = await temporaryDirectory()
+    const worktree = join(directory, 'worktree')
+    const gitDirectory = join(directory, 'repo', '.git', 'worktrees', 'test')
+    const app = join(worktree, 'app')
+    await writePackageLock(directory)
+    await writePackageLock(worktree)
+    await mkdir(app, { recursive: true })
+    await mkdir(gitDirectory, { recursive: true })
+    await writeFile(join(gitDirectory, 'commondir'), '../..')
+    await writeFile(join(worktree, '.git'), `gitdir: ${gitDirectory}`)
+
+    expect(findRootDirAndLockFiles(app)).toEqual({
+      boundary: undefined,
+      lockFiles: [join(worktree, 'package-lock.json')],
+      rootDir: worktree,
+    })
+  })
+
+  it('escapes a Git submodule to the parent repository', async () => {
+    const directory = await temporaryDirectory()
+    const repository = join(directory, 'repository')
+    const submodule = join(repository, 'submodule')
+    const app = join(submodule, 'app')
+    await writePackageLock(repository)
+    await writePackageLock(submodule)
+    await mkdir(join(repository, '.git', 'modules', 'submodule'), {
+      recursive: true,
+    })
+    await mkdir(app, { recursive: true })
+    await writeFile(
+      join(submodule, '.git'),
+      'gitdir: ../.git/modules/submodule'
+    )
+
+    expect(findRootDirAndLockFiles(app)).toEqual({
+      boundary: undefined,
+      lockFiles: [
+        join(submodule, 'package-lock.json'),
+        join(repository, 'package-lock.json'),
+      ],
+      rootDir: repository,
+    })
+  })
+
+  it('rolls back at a Git repository boundary', async () => {
+    const directory = await temporaryDirectory()
+    const repository = join(directory, 'repository')
+    const app = join(repository, 'app')
+    await writePackageLock(directory)
+    await writePackageLock(repository)
+    await mkdir(join(repository, '.git'), { recursive: true })
+    await mkdir(app, { recursive: true })
+
+    expect(findRootDirAndLockFiles(app)).toEqual({
+      boundary: {
+        boundary: repository,
+        marker: join(directory, 'package-lock.json'),
+        root: directory,
+        type: 'repository',
+      },
+      lockFiles: [join(repository, 'package-lock.json')],
+      rootDir: repository,
+    })
+  })
+
+  it('uses the app when the only lockfile is outside its Git repository', async () => {
+    const directory = await temporaryDirectory()
+    const repository = join(directory, 'repository')
+    const app = join(repository, 'app')
+    await writePackageLock(directory)
+    await mkdir(join(repository, '.git'), { recursive: true })
+    await mkdir(app, { recursive: true })
+
+    expect(findRootDirAndLockFiles(app)).toEqual({
+      boundary: {
+        boundary: repository,
+        marker: join(directory, 'package-lock.json'),
+        root: directory,
+        type: 'repository',
+      },
+      lockFiles: [],
+      rootDir: app,
+    })
+  })
+
+  it('does not infer the home directory as the root', async () => {
+    const directory = await temporaryDirectory()
+    const home = join(directory, 'home')
+    const app = join(home, 'app')
+    jest.mocked(os.homedir).mockReturnValue(home)
+    await writePackageLock(home)
+    await writePackageLock(app)
+
+    expect(findRootDirAndLockFiles(app)).toEqual({
+      boundary: {
+        boundary: home,
+        marker: join(home, 'package-lock.json'),
+        root: home,
+        type: 'home',
+      },
+      lockFiles: [join(app, 'package-lock.json')],
+      rootDir: app,
+    })
+  })
+
+  it('allows the home directory when the Next.js app is there', async () => {
+    const directory = await temporaryDirectory()
+    const home = join(directory, 'home')
+    jest.mocked(os.homedir).mockReturnValue(home)
+    await writePackageLock(directory)
+    await writePackageLock(home)
+
+    expect(findRootDirAndLockFiles(home)).toEqual({
+      boundary: {
+        boundary: home,
+        marker: join(directory, 'package-lock.json'),
+        root: directory,
+        type: 'home',
+      },
+      lockFiles: [join(home, 'package-lock.json')],
+      rootDir: home,
+    })
+  })
+
+  it('resolves symlinks before the home-directory check', async () => {
+    const directory = await temporaryDirectory()
+    const realHome = join(directory, 'real-home')
+    const linkHome = join(directory, 'link-home')
+    const app = join(realHome, 'app')
+    await writePackageLock(realHome)
+    await writePackageLock(app)
+    // `os.homedir()` reports a symlink to the real home directory. a lexical
+    // comparison would decide `real-home` is not inside `link-home` and climb
+    // straight past the home boundary.
+    await symlink(realHome, linkHome)
+    jest.mocked(os.homedir).mockReturnValue(linkHome)
+
+    expect(findRootDirAndLockFiles(app)).toMatchObject({
+      boundary: {
+        boundary: realHome,
+        root: realHome,
+        type: 'home',
+      },
+      lockFiles: [join(app, 'package-lock.json')],
+      rootDir: app,
+    })
+  })
+
+  it('reports the root in the same form the caller used', async () => {
+    const directory = await temporaryDirectory()
+    const real = join(directory, 'real')
+    const link = join(directory, 'link')
+    const app = join(link, 'app')
+    await writePackageLock(real)
+    await writePackageLock(join(real, 'app'))
+    await symlink(real, link)
+
+    // callers derive paths relative to this root, so resolving symlinks away
+    // here would leave the root pointing somewhere the caller never named.
+    expect(findRootDirAndLockFiles(app)).toMatchObject({
+      lockFiles: [
+        join(app, 'package-lock.json'),
+        join(link, 'package-lock.json'),
+      ],
+      rootDir: link,
+    })
+  })
+
+  it.each([
+    ['pnpm-workspace.yaml', 'packages:\n  - apps/*\n'],
+    ['lerna.json', '{"packages":["apps/*"]}'],
+  ])('recognizes %s as a workspace marker', async (name, contents) => {
+    const directory = await temporaryDirectory()
+    const workspace = join(directory, 'workspace')
+    const app = join(workspace, 'apps', 'web')
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(workspace, name), contents)
+    await writePackageLock(app)
+
+    expect(findRootDirAndLockFiles(app)).toMatchObject({
+      lockFiles: [],
+      rootDir: workspace,
+    })
+  })
+
+  it.each([
+    ['an array', ['apps/*']],
+    ['an object', { packages: ['apps/*'] }],
+  ])(
+    'recognizes package.json workspaces declared as %s',
+    async (_name, workspaces) => {
+      const directory = await temporaryDirectory()
+      const workspace = join(directory, 'workspace')
+      const app = join(workspace, 'apps', 'web')
+      await writePackage(workspace, { workspaces })
+      await writePackageLock(app)
+
+      expect(findRootDirAndLockFiles(app)).toMatchObject({
+        lockFiles: [],
+        rootDir: workspace,
+      })
+    }
+  )
+
+  it('does not climb above a workspace marker to a stray lockfile', async () => {
+    const directory = await temporaryDirectory()
+    const workspace = join(directory, 'workspace')
+    const app = join(workspace, 'apps', 'web')
+    // a lockfile sits above the workspace root, but the workspace marker is
+    // authoritative: the root must not escape past it.
+    await writePackageLock(directory)
+    await mkdir(workspace, { recursive: true })
+    await writeFile(
+      join(workspace, 'pnpm-workspace.yaml'),
+      'packages:\n  - apps/*\n'
+    )
+    await writePackageLock(app)
+
+    expect(findRootDirAndLockFiles(app)).toMatchObject({
+      lockFiles: [],
+      rootDir: workspace,
+    })
+  })
+
+  it('keeps workspace precedence across multiple levels', async () => {
+    const directory = await temporaryDirectory()
+    const workspace = join(directory, 'workspace')
+    const middle = join(workspace, 'packages')
+    const nestedWorkspace = join(middle, 'nested')
+    const app = join(nestedWorkspace, 'app')
+    await mkdir(workspace, { recursive: true })
+    await writeFile(join(workspace, 'pnpm-workspace.yaml'), 'packages: []')
+    await writePackageLock(middle)
+    await mkdir(nestedWorkspace, { recursive: true })
+    await writeFile(join(nestedWorkspace, 'lerna.json'), '{"packages":[]}')
+    await writePackageLock(app)
+
+    expect(findRootDirAndLockFiles(app)).toMatchObject({
+      lockFiles: [],
+      rootDir: workspace,
+    })
+  })
+
+  it.each(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lock'])(
+    'selects a %s as the root',
+    async (name) => {
+      const directory = await temporaryDirectory()
+      const app = join(directory, 'app')
+      await writePackage(app)
+      await writeFile(join(app, name), '')
+
+      expect(findRootDirAndLockFiles(app)).toMatchObject({
+        lockFiles: [join(app, name)],
+        rootDir: app,
+      })
+    }
+  )
+})
+
+it('warns when a soft boundary changes the inferred root', () => {
+  warnRootBoundary({
+    boundary: '/repo',
+    marker: '/parent/package-lock.json',
+    root: '/parent',
+    type: 'repository',
+  })
+
+  expect(Log.warnOnce).toHaveBeenCalledWith(
+    expect.stringContaining('outside the current Git repository')
+  )
+})

--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -1,94 +1,279 @@
-import { dirname } from 'path'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'path'
+import { existsSync, readFileSync, realpathSync, statSync } from 'fs'
+import { homedir } from 'os'
 import findUp from 'next/dist/compiled/find-up'
 import * as Log from '../build/output/log'
 
-function findWorkRoot(cwd: string) {
-  // Find-up evaluates the list of files at each level.
-  // For pnpm-workspace.yaml we first want to look up before searching for lockfiles as those can be included in the application directory by accident.
-  const pnpmWorkspaceFile = findUp.sync(
-    'pnpm-workspace.yaml',
+export type RootBoundary = {
+  boundary: string
+  marker: string
+  root: string
+  type: 'repository' | 'home'
+}
 
-    {
-      cwd,
-    }
-  )
+// folders that are git checkouts / git worktrees are a good indicator
+// of the folder that someone's project is contained in.
+type GitBoundary =
+  | { type: 'repository'; dir: string }
+  | { type: 'worktree'; dir: string }
 
-  if (pnpmWorkspaceFile) {
-    return pnpmWorkspaceFile
+function toRealPath(path: string): string {
+  try {
+    return realpathSync.native(path)
+  } catch {
+    return path
+  }
+}
+
+// `homedir()` throws when it cannot determine a home directory, and returns an
+// empty string on some platforms. an empty value would match every directory,
+// so treat both as "no home directory".
+function findHomeDir(): string | undefined {
+  try {
+    return toRealPath(homedir()) || undefined
+  } catch {
+    return undefined
+  }
+}
+
+// if `descendant` is inside of `ancestor` or `descendant` == `ancestor`
+function isAncestorOrSelf(ancestor: string, descendant: string): boolean {
+  const rel = relative(ancestor, descendant)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+// if `descendant` is inside of `ancestor`
+function isStrictAncestor(ancestor: string, descendant: string): boolean {
+  const rel = relative(ancestor, descendant)
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+}
+
+// true for a git worktree (its git dir has a `commondir` file);
+// this method returns false for a submodule.
+function isGitWorktree(dir: string, gitFile: string): boolean {
+  let contents: string
+  try {
+    contents = readFileSync(gitFile, 'utf8')
+  } catch {
+    return false
   }
 
-  return findUp.sync(
-    [
-      'pnpm-lock.yaml',
-      'package-lock.json',
-      'yarn.lock',
-      'bun.lock',
-      'bun.lockb',
-    ],
-    {
-      cwd,
-    }
+  // Match the behavior in git:
+  // https://github.com/git/git/blob/13c7afec212fc97ce257d15601659314c6673d6c/setup.c#L1007-L1018
+  const match = /^gitdir: (.+?)[\r\n]*$/s.exec(contents)
+  if (!match) return false
+
+  const gitDir = resolve(dir, match[1])
+  return existsSync(join(gitDir, 'commondir'))
+}
+
+// finds the first git repository or git worktree above the
+// current working directory. we limit the project root to
+// inside a worktree or git repository. this is because if
+// you use worktrees, you may have lock files from the
+// parent git repo that are in folders that are not relevant
+// to watch.
+function findGitBoundary(cwd: string): GitBoundary | undefined {
+  let isWorktree = false
+  const gitDir = findUp.sync(
+    (dir) => {
+      const candidate = join(dir, '.git')
+      const isDirectory = statSync(candidate, {
+        throwIfNoEntry: false,
+      })?.isDirectory()
+
+      isWorktree = !isDirectory && isGitWorktree(dir, candidate)
+      return isDirectory || isWorktree ? dir : undefined
+    },
+    { cwd, type: 'directory' }
   )
+  if (!gitDir) return undefined
+
+  return {
+    type: isWorktree ? 'worktree' : 'repository',
+    dir: toRealPath(gitDir),
+  }
+}
+
+const LOCK_FILES = [
+  'pnpm-lock.yaml',
+  'package-lock.json',
+  'yarn.lock',
+  'bun.lock',
+  'bun.lockb',
+]
+
+// Dedicated workspace-root files. pnpm and Lerna declare the root this way.
+const WORKSPACE_MARKERS = ['pnpm-workspace.yaml', 'lerna.json']
+
+// npm, Yarn, and Bun declare the root via a package.json `workspaces` field,
+// which may be an array or an object (e.g. Yarn's `{ packages: [...] }`).
+function hasWorkspacesField(packageJson: string): boolean {
+  try {
+    return JSON.parse(readFileSync(packageJson, 'utf8')).workspaces != null
+  } catch {
+    return false
+  }
+}
+
+function findWorkspaceMarker(directory: string): string | undefined {
+  for (const name of WORKSPACE_MARKERS) {
+    const markerPath = join(directory, name)
+    if (existsSync(markerPath)) {
+      return markerPath
+    }
+  }
+
+  const packageJson = join(directory, 'package.json')
+  return hasWorkspacesField(packageJson) ? packageJson : undefined
+}
+
+type RootCandidate = { path: string; isWorkspaceMarker: boolean }
+
+function findNextRootCandidate(cwd: string): RootCandidate | undefined {
+  // a workspace marker takes precedence over lockfiles, which can be included in
+  // the application directory by accident.
+  const marker = findUp.sync(findWorkspaceMarker, { cwd })
+  if (marker) {
+    return { path: marker, isWorkspaceMarker: true }
+  }
+
+  const lockFile = findUp.sync(LOCK_FILES, { cwd })
+  return lockFile ? { path: lockFile, isWorkspaceMarker: false } : undefined
 }
 
 export function findRootDirAndLockFiles(cwd: string): {
   lockFiles: string[]
   rootDir: string
+  boundary?: RootBoundary
 } {
-  const lockFile = findWorkRoot(cwd)
-  if (!lockFile)
+  const initialCandidate = findNextRootCandidate(cwd)
+  if (!initialCandidate)
     return {
       lockFiles: [],
       rootDir: cwd,
     }
 
-  const lockFiles = [lockFile]
+  const candidates = [initialCandidate.path]
+  let foundWorkspaceMarker = initialCandidate.isWorkspaceMarker
   while (true) {
-    const lastLockFile = lockFiles[lockFiles.length - 1]
-    const currentDir = dirname(lastLockFile)
+    const lastCandidate = candidates[candidates.length - 1]
+    const currentDir = dirname(lastCandidate)
     const parentDir = dirname(currentDir)
 
     // dirname('/')==='/' so if we happen to reach the FS root (as might happen in a container we need to quit to avoid looping forever
     if (parentDir === currentDir) break
 
-    const newLockFile = findWorkRoot(parentDir)
+    const nextCandidate = findNextRootCandidate(parentDir)
 
-    if (!newLockFile) break
+    if (!nextCandidate) break
 
-    lockFiles.push(newLockFile)
+    // findNextRootCandidate searches for markers all the way up, so a non-marker
+    // here means there is no higher marker: nothing above can extend the root.
+    if (foundWorkspaceMarker && !nextCandidate.isWorkspaceMarker) break
+
+    candidates.push(nextCandidate.path)
+    foundWorkspaceMarker ||= nextCandidate.isWorkspaceMarker
+  }
+
+  // filter out candidates that would push the root past a
+  // git boundary or into the home directory.
+  const homeDir = findHomeDir()
+  const gitBoundary = findGitBoundary(cwd)
+
+  const acceptedCandidates: string[] = []
+  let boundary: RootBoundary | undefined
+
+  for (const candidate of candidates) {
+    const dir = dirname(candidate)
+
+    // the app's own directory is always a valid root. even if it
+    // is the home directory.
+    if (dir !== cwd) {
+      const resolvedDir = toRealPath(dir)
+
+      // `dir` sits above the repo or worktree that contains the app.
+      if (gitBoundary && isStrictAncestor(resolvedDir, gitBoundary.dir)) {
+        // add a warning for going beyond a repository
+        if (gitBoundary.type === 'repository') {
+          boundary = {
+            boundary: gitBoundary.dir,
+            marker: candidate,
+            root: dir,
+            type: 'repository',
+          }
+        }
+        break
+      }
+
+      // never treat the home directory (or above) as the root.
+      if (homeDir && isAncestorOrSelf(resolvedDir, homeDir)) {
+        boundary = {
+          boundary: homeDir,
+          marker: candidate,
+          root: dir,
+          type: 'home',
+        }
+        break
+      }
+    }
+
+    acceptedCandidates.push(candidate)
   }
 
   return {
-    lockFiles,
-    rootDir: dirname(lockFiles[lockFiles.length - 1]),
+    lockFiles: acceptedCandidates.filter((candidate) =>
+      LOCK_FILES.includes(basename(candidate))
+    ),
+    rootDir: acceptedCandidates.length
+      ? dirname(acceptedCandidates[acceptedCandidates.length - 1])
+      : cwd,
+    boundary,
   }
 }
 
 export function warnDuplicatedLockFiles(lockFiles: string[]) {
-  if (lockFiles.length > 1) {
-    const additionalLockFiles = lockFiles
-      .slice(0, -1)
-      .map((str) => `\n   * ${str}`)
-      .join('')
+  if (lockFiles.length <= 1) return
 
-    if (process.env.TURBOPACK) {
-      Log.warnOnce(
-        `Warning: Next.js inferred your workspace root, but it may not be correct.\n` +
-          ` We detected multiple lockfiles and selected the directory of ${lockFiles[lockFiles.length - 1]} as the root directory.\n` +
-          ` To silence this warning, set \`turbopack.root\` in your Next.js config, or consider ` +
-          `removing one of the lockfiles if it's not needed.\n` +
-          `   See https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory for more information.\n` +
-          ` Detected additional lockfiles: ${additionalLockFiles}\n`
-      )
-    } else {
-      Log.warnOnce(
-        `Warning: Next.js inferred your workspace root, but it may not be correct.\n` +
-          ` We detected multiple lockfiles and selected the directory of ${lockFiles[lockFiles.length - 1]} as the root directory.\n` +
-          ` To silence this warning, set \`outputFileTracingRoot\` in your Next.js config, or consider ` +
-          `removing one of the lockfiles if it's not needed.\n` +
-          `   See https://nextjs.org/docs/app/api-reference/config/next-config-js/output#caveats for more information.\n` +
-          ` Detected additional lockfiles: ${additionalLockFiles}\n`
-      )
-    }
-  }
+  const config = process.env.TURBOPACK
+    ? 'turbopack.root'
+    : 'outputFileTracingRoot'
+  const docs = process.env.TURBOPACK
+    ? 'https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory'
+    : 'https://nextjs.org/docs/app/api-reference/config/next-config-js/output#caveats'
+
+  const rootLockFile = lockFiles[lockFiles.length - 1]
+  const additionalLockFiles = lockFiles
+    .slice(0, -1)
+    .map((str) => `\n   * ${str}`)
+    .join('')
+
+  Log.warnOnce(
+    `Warning: Next.js inferred your workspace root, but it may not be correct.\n` +
+      ` We detected multiple lockfiles and selected the directory of ${rootLockFile} as the root directory.\n` +
+      ` To silence this warning, set \`${config}\` in your Next.js config, or consider ` +
+      `removing one of the lockfiles if it's not needed.\n` +
+      `   See ${docs} for more information.\n` +
+      ` Detected additional lockfiles: ${additionalLockFiles}\n`
+  )
+}
+
+export function warnRootBoundary({
+  boundary,
+  marker,
+  root,
+  type,
+}: RootBoundary) {
+  const config = process.env.TURBOPACK
+    ? 'turbopack.root'
+    : 'outputFileTracingRoot'
+  const reason =
+    type === 'repository'
+      ? `it is outside the current Git repository (${boundary})`
+      : `it would include your home directory (${boundary})`
+
+  Log.warnOnce(
+    `Warning: Next.js ignored ${basename(marker)} in ${root} because ${reason}.\n` +
+      ` To use this directory, set \`${config}\` in your Next.js config.\n`
+  )
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -33,6 +33,7 @@ import { flushTelemetry } from '../telemetry/flush-telemetry'
 import {
   findRootDirAndLockFiles,
   warnDuplicatedLockFiles,
+  warnRootBoundary,
 } from '../lib/find-root'
 import { setHttpClientAndAgentOptions } from './setup-http-agent-env'
 import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
@@ -1158,11 +1159,10 @@ function assignDefaultsAndValidate(
   const turbopackRoot = result?.turbopack?.root
 
   let repoRoot = process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT
-  let lockFiles: string[] | undefined = undefined
+  let rootDirResult: ReturnType<typeof findRootDirAndLockFiles> | undefined
   if (!repoRoot) {
-    const rootDirResult = findRootDirAndLockFiles(dir)
+    rootDirResult = findRootDirAndLockFiles(dir)
     repoRoot = rootDirResult.rootDir
-    lockFiles = rootDirResult.lockFiles
   }
   ;(result as NextConfigComplete).repoRoot = repoRoot
 
@@ -1176,8 +1176,11 @@ function assignDefaultsAndValidate(
   let rootDir = tracingRoot || turbopackRoot
   if (!rootDir) {
     rootDir = repoRoot
-    if (lockFiles && !silent) {
-      warnDuplicatedLockFiles(lockFiles)
+    if (rootDirResult && !silent) {
+      if (rootDirResult.boundary) {
+        warnRootBoundary(rootDirResult.boundary)
+      }
+      warnDuplicatedLockFiles(rootDirResult.lockFiles)
     }
   }
   if (!rootDir) {

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -9,10 +9,15 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
       'next.config.js': `module.exports = { outputFileTracingRoot: __dirname }`,
       // Write a package-lock.json file to the parent directory to simulate
       // multiple lockfiles.
+      '../package.json': JSON.stringify({
+        name: 'parent-workspace',
+        version: '1.0.0',
+      }),
       '../package-lock.json': JSON.stringify({
         name: 'parent-workspace',
         version: '1.0.0',
         lockfileVersion: 3,
+        packages: { '': { name: 'parent-workspace', version: '1.0.0' } },
       }),
     },
     // So that ../package-lock.json doesn't leave the isolated testDir

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -9,10 +9,15 @@ describe('multiple-lockfiles - has-turbo-root', () => {
       'next.config.js': `module.exports = { turbopack: { root: __dirname } }`,
       // Write a package-lock.json file to the parent directory to simulate
       // multiple lockfiles.
+      '../package.json': JSON.stringify({
+        name: 'parent-workspace',
+        version: '1.0.0',
+      }),
       '../package-lock.json': JSON.stringify({
         name: 'parent-workspace',
         version: '1.0.0',
         lockfileVersion: 3,
+        packages: { '': { name: 'parent-workspace', version: '1.0.0' } },
       }),
     },
     // So that ../package-lock.json doesn't leave the isolated testDir

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -8,10 +8,15 @@ describe('multiple-lockfiles', () => {
       app: new FileRef(join(__dirname, 'app')),
       // Write a package-lock.json file to the parent directory to simulate
       // multiple lockfiles.
+      '../package.json': JSON.stringify({
+        name: 'parent-workspace',
+        version: '1.0.0',
+      }),
       '../package-lock.json': JSON.stringify({
         name: 'parent-workspace',
         version: '1.0.0',
         lockfileVersion: 3,
+        packages: { '': { name: 'parent-workspace', version: '1.0.0' } },
       }),
     },
     // So that ../package-lock.json doesn't leave the isolated testDir

--- a/test/production/adapter-root/adapter-root.test.ts
+++ b/test/production/adapter-root/adapter-root.test.ts
@@ -19,10 +19,15 @@ describe('adapter-root', () => {
       overrideFiles: setEnvVar
         ? undefined
         : {
+            '../package.json': JSON.stringify({
+              name: 'parent-workspace',
+              version: '1.0.0',
+            }),
             '../package-lock.json': JSON.stringify({
               name: 'parent-workspace',
               version: '1.0.0',
               lockfileVersion: 3,
+              packages: { '': { name: 'parent-workspace', version: '1.0.0' } },
             }),
           },
     })


### PR DESCRIPTION
Watching too many files can hurt performance, and impacts how much work Turbopack is doing. See for example the conversation around https://github.com/vercel/next.js/pull/94597.

This PR handles the following four cases:

- Git worktrees: we can include a guard to prevent exiting a worktree (by looking at the `.git` file).
- Git repository boundaries: we can include a guard to prevent us from exiting a checked-out repository and watching the repository’s parent directory.
    - We will log a warning if this happens.
- Empty / bogus `package.lock` files & `package-lock.json` files (and equivalents using other package managers): if we spot a `package-lock.json` file but it has no packages or a `package-lock.json` w/o an associated `package.json` file. We can ignore them. This handles the case of accidentally running `npm install` in any directory.
- Home directory detection: we can detect if we’re going to start watching your home dir and rollback up if this is the case.
    - We will log a warning if this happens.
    - If your Next config is in your home dir, we will still run your app there as Next config is the furthest we can rollback
- NPM, Yarn, Lerna & Bun workspaces: based on the `workspaces` field in the `package.json` or `lerna.json`

I would recommend using split-view to review. I also cleaned up the `warnDuplicatedLockFiles()` function because it was a bit unnecessary to repeat the full message.

Closes https://github.com/vercel/next.js/issues/92978
