### PR TITLE
fix(sandbox): release one-shot timeout ids after they run

### DIFF
--- a/packages/next/src/server/web/sandbox/resource-managers.test.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.test.ts
@@ -1,0 +1,70 @@
+import { timeoutsManager } from './resource-managers'
+
+describe('sandbox resource managers', () => {
+  afterEach(() => {
+    timeoutsManager.removeAll()
+  })
+
+  it('does not retain one-shot timeouts after they run', async () => {
+    const context = {}
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+
+    try {
+      await Promise.all(
+        [0, 1, 2].map(
+          () =>
+            new Promise<void>((resolve) => {
+              timeoutsManager.add([context, resolve, 0] as any)
+            })
+        )
+      )
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(3)
+
+      timeoutsManager.removeAll()
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(3)
+    } finally {
+      clearTimeoutSpy.mockRestore()
+    }
+  })
+
+  it('clears timeouts when they are removed explicitly', () => {
+    const context = {}
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
+    const timeout = timeoutsManager.add([context, () => {}, 1000] as any)
+
+    try {
+      timeoutsManager.remove(timeout)
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timeout)
+    } finally {
+      clearTimeoutSpy.mockRestore()
+    }
+  })
+
+  it('preserves timeout callback arguments that are functions', async () => {
+    const context = {}
+    const callbackArg = () => 'value'
+    const callback = jest.fn(function (this: unknown, arg: () => string) {
+      expect(this).toBe(context)
+      expect(arg).toBe(callbackArg)
+      expect(arg()).toBe('value')
+    })
+
+    await new Promise<void>((resolve) => {
+      timeoutsManager.add([
+        context,
+        function (this: unknown, ...args: Parameters<typeof callback>) {
+          callback.apply(this, args)
+          resolve()
+        },
+        0,
+        callbackArg,
+      ] as any)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/next/src/server/web/sandbox/resource-managers.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.ts
@@ -1,23 +1,29 @@
 abstract class ResourceManager<T, Args> {
-  private resources: T[] = []
+  private resources = new Set<T>()
 
   abstract create(resourceArgs: Args): T
   abstract destroy(resource: T): void
 
   add(resourceArgs: Args) {
     const resource = this.create(resourceArgs)
-    this.resources.push(resource)
+    this.resources.add(resource)
     return resource
   }
 
   remove(resource: T) {
-    this.resources = this.resources.filter((r) => r !== resource)
+    this.release(resource)
     this.destroy(resource)
   }
 
   removeAll() {
-    this.resources.forEach(this.destroy)
-    this.resources = []
+    for (const resource of this.resources) {
+      this.destroy(resource)
+    }
+    this.resources.clear()
+  }
+
+  protected release(resource: T) {
+    this.resources.delete(resource)
   }
 }
 
@@ -40,8 +46,24 @@ class TimeoutsManager extends ResourceManager<
   Parameters<typeof webSetTimeoutPolyfill>
 > {
   create(args: Parameters<typeof webSetTimeoutPolyfill>) {
+    const [globalObject, callback, ms, ...timerArgs] = args
+    const manager = this
+    let timeout: number
+
     // TODO: use the edge runtime provided `setTimeout` instead
-    return webSetTimeoutPolyfill(...args)
+    timeout = webSetTimeoutPolyfill(
+      globalObject,
+      function (this: GlobalObject, ...callbackArgs) {
+        try {
+          return callback.apply(this, callbackArgs)
+        } finally {
+          manager.release(timeout)
+        }
+      },
+      ms,
+      ...timerArgs
+    )
+    return timeout
   }
 
   destroy(timeout: number) {

--- a/packages/next/src/server/web/sandbox/resource-managers.ts
+++ b/packages/next/src/server/web/sandbox/resource-managers.ts
@@ -11,8 +11,17 @@ abstract class ResourceManager<T, Args> {
   }
 
   remove(resource: T) {
-    this.release(resource)
+    this.untrack(resource)
     this.destroy(resource)
+  }
+
+  /**
+   * Stop tracking a resource without destroying it. Used when a resource has
+   * already been released by other means (e.g. a one-shot timeout that ran to
+   * completion) so it should no longer be retained by this manager.
+   */
+  protected untrack(resource: T) {
+    this.resources.delete(resource)
   }
 
   removeAll() {
@@ -22,12 +31,13 @@ abstract class ResourceManager<T, Args> {
     this.resources.clear()
   }
 
-  protected release(resource: T) {
-    this.resources.delete(resource)
+  /** Number of resources currently tracked. Exposed for observability/tests. */
+  get size() {
+    return this.resources.size
   }
 }
 
-class IntervalsManager extends ResourceManager<
+export class IntervalsManager extends ResourceManager<
   number,
   Parameters<typeof webSetIntervalPolyfill>
 > {
@@ -41,29 +51,35 @@ class IntervalsManager extends ResourceManager<
   }
 }
 
-class TimeoutsManager extends ResourceManager<
+export class TimeoutsManager extends ResourceManager<
   number,
   Parameters<typeof webSetTimeoutPolyfill>
 > {
   create(args: Parameters<typeof webSetTimeoutPolyfill>) {
-    const [globalObject, callback, ms, ...timerArgs] = args
-    const manager = this
-    let timeout: number
-
     // TODO: use the edge runtime provided `setTimeout` instead
-    timeout = webSetTimeoutPolyfill(
+    const [globalObject, callback, ms, ...rest] = args
+
+    // A one-shot timeout releases itself from tracking once its callback has
+    // run. Otherwise fire-and-forget timeouts (whose ids user code never
+    // passes to `clearTimeout`) would accumulate for the lifetime of the
+    // module context and leak memory in long-lived server processes.
+    // See: https://github.com/vercel/next.js/issues/95094
+    let timeoutId: number
+    const callbackWithRelease = (...callbackArgs: typeof rest) => {
+      try {
+        return callback.apply(globalObject, callbackArgs)
+      } finally {
+        this.untrack(timeoutId)
+      }
+    }
+
+    timeoutId = webSetTimeoutPolyfill(
       globalObject,
-      function (this: GlobalObject, ...callbackArgs) {
-        try {
-          return callback.apply(this, callbackArgs)
-        } finally {
-          manager.release(timeout)
-        }
-      },
+      callbackWithRelease,
       ms,
-      ...timerArgs
+      ...rest
     )
-    return timeout
+    return timeoutId
   }
 
   destroy(timeout: number) {

--- a/test/unit/web-sandbox-resource-managers.test.ts
+++ b/test/unit/web-sandbox-resource-managers.test.ts
@@ -1,0 +1,123 @@
+/* eslint-env jest */
+import {
+  IntervalsManager,
+  TimeoutsManager,
+} from '../../packages/next/src/server/web/sandbox/resource-managers'
+
+// A fake edge-runtime global object; the managers only use it as the `this`
+// value passed to timer callbacks.
+const globalObject = {} as any
+
+async function waitFor(condition: () => boolean, timeoutMs = 1000) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
+describe('web sandbox TimeoutsManager', () => {
+  it('releases one-shot timeout ids after they run (regression: #95094)', async () => {
+    const manager = new TimeoutsManager()
+
+    let ran = 0
+    const increment = () => {
+      ran++
+    }
+    const count = 50
+    for (let i = 0; i < count; i++) {
+      // Fire-and-forget: the returned id is never passed to clearTimeout,
+      // matching common middleware usage.
+      manager.add([globalObject, increment, 0])
+    }
+
+    // All are tracked before they fire.
+    expect(manager.size).toBe(count)
+
+    // After they complete naturally, tracking must drop back to zero even
+    // though user code never called clearTimeout.
+    await waitFor(() => ran === count)
+    await waitFor(() => manager.size === 0)
+    expect(manager.size).toBe(0)
+  })
+
+  it('does not grow tracked resources across successive fire-and-forget timeouts', async () => {
+    const manager = new TimeoutsManager()
+
+    for (let round = 0; round < 5; round++) {
+      for (let i = 0; i < 20; i++) {
+        manager.add([globalObject, () => {}, 0])
+      }
+      await waitFor(() => manager.size === 0)
+    }
+
+    expect(manager.size).toBe(0)
+  })
+
+  it('invokes the callback with the provided extra args and global `this`', async () => {
+    const manager = new TimeoutsManager()
+
+    let observedThis: unknown
+    const observedArgs: unknown[] = []
+    manager.add([
+      globalObject,
+      function (this: unknown, ...args: unknown[]) {
+        observedThis = this
+        observedArgs.push(...args)
+      },
+      0,
+      'a',
+      'b',
+    ])
+
+    await waitFor(() => observedArgs.length > 0)
+    expect(observedThis).toBe(globalObject)
+    expect(observedArgs).toEqual(['a', 'b'])
+    expect(manager.size).toBe(0)
+  })
+
+  it('remove() cancels a pending timeout and stops tracking it', async () => {
+    const manager = new TimeoutsManager()
+
+    let ran = false
+    const id = manager.add([globalObject, () => (ran = true), 50])
+    expect(manager.size).toBe(1)
+
+    manager.remove(id)
+    expect(manager.size).toBe(0)
+
+    // Give the original delay time to elapse; the callback must not run.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(ran).toBe(false)
+  })
+
+  it('removeAll() clears everything', async () => {
+    const manager = new TimeoutsManager()
+    manager.add([globalObject, () => {}, 1000])
+    manager.add([globalObject, () => {}, 1000])
+    expect(manager.size).toBe(2)
+
+    manager.removeAll()
+    expect(manager.size).toBe(0)
+  })
+})
+
+describe('web sandbox IntervalsManager', () => {
+  it('keeps tracking intervals until they are explicitly removed', async () => {
+    const manager = new IntervalsManager()
+
+    let ticks = 0
+    const id = manager.add([globalObject, () => ticks++, 10])
+    expect(manager.size).toBe(1)
+
+    // Intervals fire repeatedly, so they must remain tracked (unlike one-shot
+    // timeouts) even after several ticks have run.
+    await waitFor(() => ticks >= 3)
+    expect(manager.size).toBe(1)
+
+    manager.remove(id)
+    expect(manager.size).toBe(0)
+  })
+})

--- a/test/unit/web-sandbox-resource-managers.test.ts
+++ b/test/unit/web-sandbox-resource-managers.test.ts
@@ -78,6 +78,46 @@ describe('web sandbox TimeoutsManager', () => {
     expect(manager.size).toBe(0)
   })
 
+  it('releases the id even when the callback throws', () => {
+    jest.useFakeTimers()
+    try {
+      const manager = new TimeoutsManager()
+      const id = manager.add([
+        globalObject,
+        () => {
+          throw new Error('boom')
+        },
+        0,
+      ])
+      expect(typeof id).toBe('number')
+      expect(manager.size).toBe(1)
+
+      expect(() => jest.runAllTimers()).toThrow('boom')
+      expect(manager.size).toBe(0)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('clearing an already-fired timeout is a no-op', async () => {
+    const manager = new TimeoutsManager()
+
+    let ran = false
+    const firedId = manager.add([globalObject, () => (ran = true), 0])
+    const pendingId = manager.add([globalObject, () => {}, 1000])
+    await waitFor(() => ran)
+    await waitFor(() => manager.size === 1)
+
+    // Matches user code that calls clearTimeout inside the callback (the
+    // documented workaround for #95094); must not throw or affect other
+    // tracked timeouts.
+    manager.remove(firedId)
+    expect(manager.size).toBe(1)
+
+    manager.remove(pendingId)
+    expect(manager.size).toBe(0)
+  })
+
   it('remove() cancels a pending timeout and stops tracking it', async () => {
     const manager = new TimeoutsManager()
 


### PR DESCRIPTION
### What?

Fire-and-forget `setTimeout` calls in the Edge runtime sandbox (e.g. from middleware) are tracked forever by Next.js's sandbox `TimeoutsManager`, even after the timeout has run. In a long-lived standalone/self-hosted server this makes tracked timeout resources grow monotonically, producing step-like heap growth and eventual OOM.

### Why?

`TimeoutsManager.add()` pushes each timeout id into a `resources` array. When a one-shot timeout fires naturally, `webSetTimeoutPolyfill`'s `finally` clears the underlying Node timer (the workaround for nodejs/node#53335) but never removes the id from the manager. The id is dropped only if user code calls `clearTimeout(id)` or the whole module context is torn down (`clearModuleContext`, introduced in #57235). The natural-completion path — module context stays alive, timeout finishes on its own — was missing, so ids accumulate for the lifetime of the process.

### How?

- `TimeoutsManager.create()` now wraps the callback so the timeout untracks its own id once it has run. The Node-timer workaround and the `this`/args binding in `webSetTimeoutPolyfill` are preserved.
- Refactored the base `ResourceManager.remove()` into `untrack()` (stop tracking) + `destroy()`, so natural completion can release tracking without a redundant `clearTimeout`.
- Intervals are intentionally unchanged: they fire repeatedly and must remain tracked until `clearInterval`/`removeAll`.
- Added a unit test covering natural release, no monotonic growth across repeated rounds, the `clearTimeout`/`remove` path, callback `this`/args binding, and that intervals stay tracked.

Verified: `pnpm --filter=next types` clean, prettier/eslint clean, and the new unit test fails on the current behavior (reverting only the release logic) and passes with the fix.

Fixes #95094

---

**Update:** this branch now lands @berry95's commit from #94794 first (`Set`-based resource tracking, which also makes `untrack`/`remove` O(1)), with the fix rebased on top.
