### PR TITLE
Make reifyRouteTree object literals match the canonical RouteTree key order

### DIFF
--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -955,11 +955,10 @@ function reifyRouteTree(
       segment: newSegment,
       shellVaryPath: getShellSegmentVaryPath(newVaryPath),
       refreshState: pattern.refreshState,
-      slots: newSlots,
-
-      prefetchHints: pattern.prefetchHints,
-      isPage: true,
       varyPath: newVaryPath,
+      isPage: true,
+      slots: newSlots,
+      prefetchHints: pattern.prefetchHints,
     }
   } else {
     // Layout segment: finalize without search params
@@ -972,11 +971,10 @@ function reifyRouteTree(
       segment: newSegment,
       shellVaryPath: getShellSegmentVaryPath(newVaryPath),
       refreshState: pattern.refreshState,
-      slots: newSlots,
-
-      prefetchHints: pattern.prefetchHints,
-      isPage: false,
       varyPath: newVaryPath,
+      isPage: false,
+      slots: newSlots,
+      prefetchHints: pattern.prefetchHints,
     }
   }
 }


### PR DESCRIPTION
The segment cache's `RouteTree` objects were being created with two different hidden-class families: the two object literals returned by `reifyRouteTree` in `optimistic-routes.ts` listed their keys in a different order (`slots`, `prefetchHints`, `isPage`, `varyPath` last) than every other `RouteTree` constructor site in `cache.ts` (`varyPath`, `isPage`, `slots`, `prefetchHints` last). In V8, object literals with different key orders get different hidden classes (maps), so every code path that touches both optimistically-reified trees and server-derived trees saw polymorphic shapes. Found with `pnpm bench:deopt --scenario segment-cache` (the V8 deopt detection tooling from the base branch).

This change is behavior-neutral: it only reorders the keys in the two `reifyRouteTree` object literals to match the canonical order used by `cache.ts`. No values, types, or logic change.

With all `RouteTree` literals collapsed to one hidden class, the fix eliminates the polymorphic `RouteTree`-field inline caches: 22 findings removed across `optimistic-routes.ts`, `scheduler.ts`, `cache.ts`, and `vary-path.ts` in the before/after diff below (keys `requestKey`/`segment`/`refreshState`/`prefetchHints`/`slots`/`isPage`/`varyPath`). Note: the two remaining `wrong map` deopts at `optimistic-routes.ts:904` and `scheduler.ts:1058` are different object families — resolved-param values (string vs string[] at `newValue.join`) and `FlightRouterState` tuples (`oldTree[1]`) respectively — and are tracked separately. This PR does not claim to fix them.

Before/after `findings.txt` diff (`bench:deopt --scenario segment-cache`, after run with `--force-build`):

```diff
9a10
> high  ic-megamorphic  packages/next/src/client/components/segment-cache/cache.ts  eA  keys: done, value
26,27c27
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eA  keys: done, value
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  e_  keys: varyPath
---
> info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eR  keys: push
35d34
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eg  keys: requestKey
38d36
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  q  keys: varyPath
51d48
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: isPage
54,57d50
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: prefetchHints
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: refreshState
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: requestKey
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: segment
59d51
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: slots
71d62
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  <anonymous>  keys: prefetchHints
76d66
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  F  keys: prefetchHints
79,86d68
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  M  keys: prefetchHints
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  M  keys: segment, 0
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  M  keys: slots
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: prefetchHints
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: segment
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: segment, 0
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: slots
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  j  keys: prefetchHints
93,94d74
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/vary-path.ts  g  keys: isPage
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/vary-path.ts  g  keys: varyPath
```