### PR TITLE
Preserve metadata tree shape during PPR resume

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -40,7 +40,6 @@ export function createMetadataComponents({
   metadataContext,
   interpolatedParams,
   errorType,
-  serveStreamingMetadata,
 }: {
   tree: LoaderTree
   pathname: string
@@ -48,7 +47,6 @@ export function createMetadataComponents({
   metadataContext: MetadataContext
   interpolatedParams: Params
   errorType?: MetadataErrorType | 'redirect'
-  serveStreamingMetadata: boolean
 }): {
   Viewport: React.ComponentType
   Metadata: React.ComponentType
@@ -126,16 +124,9 @@ export function createMetadataComponents({
   Metadata.displayName = 'Next.Metadata'
 
   function MetadataWrapper() {
-    // TODO: We shouldn't change what we render based on whether we are streaming or not.
-    // If we aren't streaming we should just block the response until we have resolved the
-    // metadata.
-    if (!serveStreamingMetadata) {
-      return (
-        <MetadataBoundary>
-          <Metadata />
-        </MetadataBoundary>
-      )
-    }
+    // Keep this tree identical across streaming and blocking responses so a
+    // postponed prerender can always resume the same structure. Blocking is
+    // enforced by delaying the HTML stream until all content is ready.
     return (
       <div hidden>
         <MetadataBoundary>
@@ -160,12 +151,8 @@ export function createMetadataComponents({
       getResolvedViewport(tree, searchParams, interpolatedParams, errorType),
     ]).then(() => null)
 
-    // TODO: We shouldn't change what we render based on whether we are streaming or not.
-    // If we aren't streaming we should just block the response until we have resolved the
-    // metadata.
-    if (!serveStreamingMetadata) {
-      return <OutletBoundary>{pendingOutlet}</OutletBoundary>
-    }
+    // This boundary must also remain identical between the prerender and its
+    // resume. See the matching stream gate in app-render.
     return (
       <OutletBoundary>
         <Suspense name="Next.MetadataOutlet">{pendingOutlet}</Suspense>

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -653,8 +653,6 @@ async function generateDynamicRSCPayload(
     url,
   } = ctx
 
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
-
   if (!options?.skipPageRendering) {
     const preloadCallbacks: PreloadCallbacks = []
     const requestStore = workUnitAsyncStorage.getStore()
@@ -677,7 +675,6 @@ async function generateDynamicRSCPayload(
       pathname: url.pathname,
       metadataContext: createMetadataContext(ctx.renderOpts),
       interpolatedParams: ctx.interpolatedParams,
-      serveStreamingMetadata,
     })
 
     const rscHead = createElement(
@@ -2064,7 +2061,6 @@ async function getRSCPayload(
     getDynamicParamFromSegment,
     query
   )
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
   const hasGlobalNotFound = !!tree[2]['global-not-found']
 
   const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
@@ -2079,7 +2075,6 @@ async function getRSCPayload(
     pathname: url.pathname,
     metadataContext: createMetadataContext(ctx.renderOpts),
     interpolatedParams: ctx.interpolatedParams,
-    serveStreamingMetadata,
   })
 
   const preloadCallbacks: PreloadCallbacks = []
@@ -2217,7 +2212,6 @@ async function getErrorRSCPayload(
   let Viewport: ComponentType | null = null
   let Metadata: ComponentType | null = null
   if (shouldRenderMetadataAndViewport) {
-    const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
     const metadataComponents = createMetadataComponents({
       tree,
       parsedQuery: query,
@@ -2225,7 +2219,6 @@ async function getErrorRSCPayload(
       metadataContext: createMetadataContext(ctx.renderOpts),
       errorType,
       interpolatedParams: ctx.interpolatedParams,
-      serveStreamingMetadata: serveStreamingMetadata,
     })
     Viewport = metadataComponents.Viewport
     Metadata = metadataComponents.Metadata
@@ -3263,6 +3256,7 @@ async function renderToStream(
     cacheComponents,
   } = renderOpts
 
+  const shouldBlockMetadata = renderOpts.serveStreamingMetadata === false
   const { cachedNavigations } = renderOpts.experimental
 
   const { ServerInsertedHTMLProvider, renderServerInsertedHTML } =
@@ -3857,7 +3851,9 @@ async function renderToStream(
         })
 
         const generateStaticHTML =
-          supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+          supportsDynamicResponse !== true ||
+          !!shouldWaitOnAllReady ||
+          shouldBlockMetadata
 
         const appElement = (
           <App
@@ -4001,7 +3997,9 @@ async function renderToStream(
         })
 
         const generateStaticHTML =
-          supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+          supportsDynamicResponse !== true ||
+          !!shouldWaitOnAllReady ||
+          shouldBlockMetadata
 
         const appElement = (
           <App
@@ -4179,7 +4177,9 @@ async function renderToStream(
 
         try {
           const generateStaticHTML =
-            supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+            supportsDynamicResponse !== true ||
+            !!shouldWaitOnAllReady ||
+            shouldBlockMetadata
 
           const { stream: errorHtmlStream, allReady: errorAllReady } =
             await workUnitAsyncStorage.run(
@@ -4278,7 +4278,9 @@ async function renderToStream(
 
         try {
           const generateStaticHTML =
-            supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+            supportsDynamicResponse !== true ||
+            !!shouldWaitOnAllReady ||
+            shouldBlockMetadata
 
           const { stream: errorHtmlStream, allReady: errorAllReady } =
             await workUnitAsyncStorage.run(

--- a/test/production/app-dir/ppr-resume-bot-metadata/app/dynamic/loading.tsx
+++ b/test/production/app-dir/ppr-resume-bot-metadata/app/dynamic/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>loading...</p>
+}

--- a/test/production/app-dir/ppr-resume-bot-metadata/app/dynamic/page.tsx
+++ b/test/production/app-dir/ppr-resume-bot-metadata/app/dynamic/page.tsx
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  await connection()
+
+  return {
+    title: 'dynamic-metadata-title',
+  }
+}
+
+export default async function Page() {
+  const store = await cookies()
+
+  return <p id="content">dynamic content {store.size}</p>
+}

--- a/test/production/app-dir/ppr-resume-bot-metadata/app/error/loading.tsx
+++ b/test/production/app-dir/ppr-resume-bot-metadata/app/error/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>loading...</p>
+}

--- a/test/production/app-dir/ppr-resume-bot-metadata/app/error/page.tsx
+++ b/test/production/app-dir/ppr-resume-bot-metadata/app/error/page.tsx
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers'
+import { notFound } from 'next/navigation'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  await connection()
+
+  return {
+    title: 'error-metadata-title',
+  }
+}
+
+export default async function Page() {
+  await cookies()
+  return notFound()
+}

--- a/test/production/app-dir/ppr-resume-bot-metadata/app/layout.tsx
+++ b/test/production/app-dir/ppr-resume-bot-metadata/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/ppr-resume-bot-metadata/next.config.js
+++ b/test/production/app-dir/ppr-resume-bot-metadata/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/ppr-resume-bot-metadata/ppr-resume-bot-metadata.test.ts
+++ b/test/production/app-dir/ppr-resume-bot-metadata/ppr-resume-bot-metadata.test.ts
@@ -1,0 +1,42 @@
+import { nextTestSetup } from 'e2e-utils'
+
+const HTML_LIMITED_BOT_UA = 'Twitterbot'
+
+describe('PPR resume bot metadata', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // This test directly emulates the platform's internal resume request using
+    // locally generated postponed state and private runtime switches.
+    skipDeployment: true,
+    env: {
+      NEXT_PRIVATE_TEST_HEADERS: '1',
+      NEXT_PRIVATE_MINIMAL_MODE: '1',
+    },
+  })
+
+  it('preserves the prerender metadata tree for an HTML-limited bot', async () => {
+    const { postponed } = await next.readJSON('.next/server/app/dynamic.meta')
+    expect(postponed).toEqual(expect.any(String))
+    expect(postponed.length).toBeGreaterThan(0)
+
+    const outputIndex = next.cliOutput.length
+    const response = await next.fetch('/dynamic', {
+      method: 'POST',
+      headers: {
+        'next-resume': '1',
+        'x-matched-path': '/dynamic',
+        'user-agent': HTML_LIMITED_BOT_UA,
+      },
+      body: postponed,
+    })
+
+    expect(response.status).toBe(200)
+
+    const html = await response.text()
+    expect(html).toContain('dynamic content')
+    expect(html).toContain('dynamic-metadata-title')
+    expect(
+      next.cliOutput.slice(outputIndex).match(/Expected the resume to render/)
+    ).toBeNull()
+  })
+})

--- a/test/production/app-dir/ppr-resume-bot-metadata/ppr-resume-bot-metadata.test.ts
+++ b/test/production/app-dir/ppr-resume-bot-metadata/ppr-resume-bot-metadata.test.ts
@@ -39,4 +39,53 @@ describe('PPR resume bot metadata', () => {
       next.cliOutput.slice(outputIndex).match(/Expected the resume to render/)
     ).toBeNull()
   })
+
+  it('preserves the prerender metadata tree for an RSC prefetch', async () => {
+    const { postponed } = await next.readJSON('.next/server/app/dynamic.meta')
+    expect(postponed).toEqual(expect.any(String))
+    expect(postponed.length).toBeGreaterThan(0)
+
+    const outputIndex = next.cliOutput.length
+    const response = await next.fetch('/dynamic', {
+      method: 'POST',
+      headers: {
+        'next-resume': '1',
+        'next-router-prefetch': '2',
+        rsc: '1',
+        'x-matched-path': '/dynamic',
+        'user-agent': HTML_LIMITED_BOT_UA,
+      },
+      body: postponed,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/x-component')
+    expect(await response.text()).toContain('dynamic content')
+    expect(
+      next.cliOutput.slice(outputIndex).match(/Expected the resume to render/)
+    ).toBeNull()
+  })
+
+  it('preserves the prerender metadata tree during not-found recovery', async () => {
+    const { postponed } = await next.readJSON('.next/server/app/error.meta')
+    expect(postponed).toEqual(expect.any(String))
+    expect(postponed.length).toBeGreaterThan(0)
+
+    const outputIndex = next.cliOutput.length
+    const response = await next.fetch('/error', {
+      method: 'POST',
+      headers: {
+        'next-resume': '1',
+        'x-matched-path': '/error',
+        'user-agent': HTML_LIMITED_BOT_UA,
+      },
+      body: postponed,
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('error-metadata-title')
+    expect(
+      next.cliOutput.slice(outputIndex).match(/Expected the resume to render/)
+    ).toBeNull()
+  })
 })


### PR DESCRIPTION
### Why?

Cache Components prerenders produce a streaming metadata tree. When a bot request resumes that postponed render, applying the bot-specific blocking metadata policy changes the tree shape and makes React abandon the resume for client rendering.

### How?

Keep streaming metadata enabled whenever postponed state is being resumed, including document, runtime RSC prefetch, and error-recovery payloads. Add standalone minimal-mode coverage using real postponed state for browser, DOM-bot, and HTML-limited-bot requests, with structural metadata assertions.

### Test plan

- Let the internal deployment checks exercise the platform resume-routing boundary; those checks are unavailable on fork branches.

<!-- NEXT_JS_LLM -->