### PR TITLE
Give RouteCacheEntry a single hidden class across its lifecycle

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -186,6 +186,18 @@ type RouteCacheEntryShared = {
   // received a response from the server.
   couldBeIntercepted: boolean
 
+  // When true, this entry should not be used as a template for route
+  // prediction. Set when we discover that the URL was rewritten by middleware
+  // to a different route structure (e.g., /foo was rewritten to /bar). Since
+  // rewrite behavior can vary by param value, we can't safely predict the
+  // route structure for other URLs matching this pattern.
+  //
+  // This is declared on every entry variant (not just fulfilled entries) so
+  // that all RouteCacheEntry objects share a single hidden class; it is
+  // pre-initialized to `false` when the entry is created and only meaningful
+  // once the entry is fulfilled.
+  hasDynamicRewrite: boolean
+
   // Map-related fields.
   ref: UnknownMapEntry | null
   size: number
@@ -221,12 +233,6 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
-  // When true, this entry should not be used as a template for route
-  // prediction. Set when we discover that the URL was rewritten by middleware
-  // to a different route structure (e.g., /foo was rewritten to /bar). Since
-  // rewrite behavior can vary by param value, we can't safely predict the
-  // route structure for other URLs matching this pattern.
-  hasDynamicRewrite: boolean
 }
 
 export type RouteCacheEntry =
@@ -637,6 +643,7 @@ function createDetachedRouteCacheEntry(): PendingRouteCacheEntry {
     couldBeIntercepted: true,
     // Similarly, we don't yet know if the route supports PPR.
     supportsPerSegmentPrefetching: false,
+    hasDynamicRewrite: false,
     renderedSearch: null,
 
     // Map-related fields


### PR DESCRIPTION
## Root cause

`RouteCacheEntry` objects cycled through three hidden classes over their lifecycle, found by running `pnpm bench:deopt --scenario segment-cache`: (A) the pending object literal in `createDetachedRouteCacheEntry`, which did not declare `hasDynamicRewrite`; (B) that shape plus `hasDynamicRewrite` appended post-construction by `fulfillRouteCacheEntry`, a shape transition that also deprecates the original map; and (C) the two fulfilled-entry literals (`deprecated_requestOptimisticRouteCacheEntry` in `cache.ts` and the synthetic entry in `matchKnownRoute` in `optimistic-routes.ts`) which declare `hasDynamicRewrite` in a different key position, between `supportsPerSegmentPrefetching` and `renderedSearch`. Every property access on a route cache entry in the hot navigation/prefetch paths was therefore polymorphic.

This PR pre-declares `hasDynamicRewrite: false` in `createDetachedRouteCacheEntry` at the same key position as the fulfilled literals, collapsing all three shapes into one hidden class, and moves the `hasDynamicRewrite: boolean` type declaration from `FulfilledRouteCacheEntry` to `RouteCacheEntryShared` to match. The `fulfilledEntry.hasDynamicRewrite = false` store in `fulfillRouteCacheEntry` is left in place; it is now an in-place store rather than a shape transition, and it re-clears the flag on re-fulfillment.

## Behavior neutrality

The field is pre-initialized to `false` on pending/empty entries and semantics are identical: no runtime code reads `hasDynamicRewrite` from an unfulfilled entry, and there are no `in` checks, `Object.keys`, or `delete` operations on these entries — only property reads. `pnpm --filter=next types` passes with the field declared on the shared type.

## Verification

Measured with `pnpm bench:deopt --scenario segment-cache` (fixture force-rebuilt against the patched build). The `hasDynamicRewrite` polymorphic IC cleared, along with ~24 entry-field polymorphic IC lines across `navigation.ts`, `optimistic-routes.ts`, `scheduler.ts`, and `cache.ts` (status, tree, canonicalUrl, renderedSearch, metadata, couldBeIntercepted, supportsPerSegmentPrefetching, staleAt, version, size). Total `ic-polymorphic` findings dropped from 84 lines to 60. Results were confirmed stable across a second run.

Before/after `findings.txt` diff:

```diff
6,7d5
< high  deopt-eager  packages/next/src/client/components/segment-cache/scheduler.ts  _heapIndex  Insufficient type feedback for generic named access
< high  deopt-eager  packages/next/src/client/components/segment-cache/scheduler.ts  cancelPrefetchTask  Insufficient type feedback for generic named access
8a7
> high  deopt-eager  packages/next/src/client/components/segment-cache/scheduler.ts  isPrefetchTaskDirty  Insufficient type feedback for generic named access
16d14
< info  deopt-lazy  packages/next/src/client/components/segment-cache/scheduler.ts  pingSharedPartOfCacheComponentsTree  (unknown)
29d26
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eR  keys: push
37d33
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eg  keys: canonicalUrl
47,51d42
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/navigation.ts  v  keys: canonicalUrl
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/navigation.ts  v  keys: metadata
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/navigation.ts  v  keys: renderedSearch
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/navigation.ts  v  keys: status
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/navigation.ts  v  keys: tree
53d43
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: hasDynamicRewrite
63d52
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: couldBeIntercepted
65d53
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: size
67,70d54
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: staleAt
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: supportsPerSegmentPrefetching
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: tree
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: version
75,78d58
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  <anonymous>  keys: status
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  <anonymous>  keys: supportsPerSegmentPrefetching
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  <anonymous>  keys: tree
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  F  keys: metadata, tree
80,81d59
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  I  keys: metadata
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  L  keys: renderedSearch
86,87d63
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: 0
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: 1
93,94d68
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  j  keys: status
< info  ic-polymorphic  packages/next/src/client/components/segment-cache/scheduler.ts  j  keys: tree
```

Two high-severity `wrong map` lines remain and are explicitly NOT claimed by this PR: the `cache-map.ts` `isValueExpired` line reads the intentionally 3-typed route|segment|bfcache map-value union, and the `optimistic-routes.ts` residual (now attributed to the `hasDynamicRewrite` read at 791:26) is a one-time map-deprecation deopt caused by in-place fulfillment generalizing null-initialized field types. The latter is tracked separately with a possible follow-up that fulfills entries via fresh literals instead of mutation.

## Tests

- `test/e2e/app-dir/segment-cache/optimistic-routing-rewrite-detection-regression` (test-start-turbo): 3 passed
- `test/e2e/app-dir/segment-cache/staleness` (test-start-turbo): 4 passed, 5 skipped (mode skips)

## Note on base branch