### PR TITLE
Reduce redundant development route matchers

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1038,11 +1038,11 @@ async function startWatcher(
         // dev mode so that we can match a page after a rewrite on the client
         // before it has been built and is populated in the _buildManifest
         const sortedRoutes = getSortedRoutes(routedPages)
-        const dataRoutePages = sortedRoutes.filter((page) =>
+        const dynamicRoutes = sortedRoutes.filter((page) =>
           isDynamicRoute(page)
         )
 
-        opts.fsChecker.dynamicRoutes = sortedRoutes.map(
+        opts.fsChecker.dynamicRoutes = dynamicRoutes.map(
           (page): FilesystemDynamicRoute => {
             const regex = getNamedRouteRegex(page, {
               prefixRouteKeys: true,
@@ -1059,7 +1059,7 @@ async function startWatcher(
 
         const dataRoutes: typeof opts.fsChecker.dynamicRoutes = []
 
-        for (const page of dataRoutePages) {
+        for (const page of dynamicRoutes) {
           const route = buildDataRoute(page, 'development')
           const routeRegex = getNamedRouteRegex(route.page, {
             prefixRouteKeys: true,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1038,11 +1038,25 @@ async function startWatcher(
         // dev mode so that we can match a page after a rewrite on the client
         // before it has been built and is populated in the _buildManifest
         const sortedRoutes = getSortedRoutes(routedPages)
-        const dynamicRoutes = sortedRoutes.filter((page) =>
-          isDynamicRoute(page)
-        )
+        const dynamicRoutes: string[] = []
+        const matcherRoutes: string[] = []
 
-        opts.fsChecker.dynamicRoutes = dynamicRoutes.map(
+        for (const page of sortedRoutes) {
+          const isDynamic = isDynamicRoute(page)
+          if (isDynamic) {
+            dynamicRoutes.push(page)
+          }
+
+          // Static routes normally resolve through appFiles/pageFiles without a
+          // regex. Keep matchers for routes absent from those exact-lookup sets,
+          // such as static metadata and configurations that disable filesystem
+          // public routes, because path-based MCP tools also consume this table.
+          if (isDynamic || (!appFiles.has(page) && !pageFiles.has(page))) {
+            matcherRoutes.push(page)
+          }
+        }
+
+        opts.fsChecker.dynamicRoutes = matcherRoutes.map(
           (page): FilesystemDynamicRoute => {
             const regex = getNamedRouteRegex(page, {
               prefixRouteKeys: true,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -24,7 +24,10 @@ import {
   EVENT_BUILD_FEATURE_USAGE,
   eventCliSession,
 } from '../../../telemetry/events'
-import { getSortedRoutes } from '../../../shared/lib/router/utils'
+import {
+  getSortedRoutes,
+  isDynamicRoute,
+} from '../../../shared/lib/router/utils'
 import { sortByPageExts } from '../../../build/sort-by-page-exts'
 import { verifyAndRunTypeScript } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
@@ -1035,6 +1038,9 @@ async function startWatcher(
         // dev mode so that we can match a page after a rewrite on the client
         // before it has been built and is populated in the _buildManifest
         const sortedRoutes = getSortedRoutes(routedPages)
+        const dataRoutePages = sortedRoutes.filter((page) =>
+          isDynamicRoute(page)
+        )
 
         opts.fsChecker.dynamicRoutes = sortedRoutes.map(
           (page): FilesystemDynamicRoute => {
@@ -1053,7 +1059,7 @@ async function startWatcher(
 
         const dataRoutes: typeof opts.fsChecker.dynamicRoutes = []
 
-        for (const page of sortedRoutes) {
+        for (const page of dataRoutePages) {
           const route = buildDataRoute(page, 'development')
           const routeRegex = getNamedRouteRegex(route.page, {
             prefixRouteKeys: true,

--- a/test/development/mcp-server/fixtures/dynamic-routes-app/app/robots.txt
+++ b/test/development/mcp-server/fixtures/dynamic-routes-app/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/test/development/mcp-server/mcp-server-compile-route.test.ts
+++ b/test/development/mcp-server/mcp-server-compile-route.test.ts
@@ -102,6 +102,16 @@ async function callMcpTool(
         expect(result).toMatchObject({ routeSpecifier: '/', issues: [] })
       })
 
+      it('should resolve a static metadata route path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/robots.txt',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/robots.txt',
+          issues: [],
+        })
+      })
+
       it('should resolve a dynamic app route path', async () => {
         const result = await callMcpTool(next.url, 'compile_route', {
           path: '/blog/hello-world',
@@ -191,6 +201,40 @@ async function callMcpTool(
           error: expect.stringContaining('exactly one'),
         })
       })
+    })
+  }
+)
+
+// When filesystem public routes are disabled, appFiles and pageFiles are empty.
+// Path-based MCP lookups must still fall back to the live route matcher table.
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'mcp-server compile_route without filesystem public routes',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'dynamic-routes-app'),
+      overrideFiles: {
+        'next.config.js': `
+          module.exports = {
+            useFileSystemPublicRoutes: false,
+            experimental: { mcpServer: true },
+          }
+        `,
+      },
+    })
+
+    if (skipped) {
+      return
+    }
+
+    it.each([
+      ['app route', '/', '/'],
+      ['pages route', '/about', '/about'],
+      ['pages API route', '/api/legacy', '/api/legacy'],
+    ])('should resolve a static %s', async (_name, input, routeSpecifier) => {
+      const result = await callMcpTool(next.url, 'compile_route', {
+        path: input,
+      })
+      expect(result).toMatchObject({ routeSpecifier, issues: [] })
     })
   }
 )

--- a/test/development/mcp-server/mcp-server-get-routes.test.ts
+++ b/test/development/mcp-server/mcp-server-get-routes.test.ts
@@ -53,6 +53,7 @@ describe('get_routes MCP tool', () => {
           "/blog/[slug]",
           "/docs/[...slug]",
           "/products/[id]",
+          "/robots.txt",
         ],
         "pagesRouter": [
           "/about",
@@ -76,6 +77,7 @@ describe('get_routes MCP tool', () => {
           "/blog/[slug]",
           "/docs/[...slug]",
           "/products/[id]",
+          "/robots.txt",
         ],
       }
     `)

--- a/test/e2e/app-dir/navigation/app/redirect-on-refresh/auth/Reload.js
+++ b/test/e2e/app-dir/navigation/app/redirect-on-refresh/auth/Reload.js
@@ -7,12 +7,8 @@ export default function Reload() {
   const router = useRouter()
 
   useEffect(() => {
-    fetch(new URL('/api/set-token', location.origin), {
-      method: 'POST',
-      credentials: 'include',
-    }).then(() => {
-      router.refresh()
-    })
+    document.cookie = 'token=this%20is%20a%20token; path=/'
+    router.refresh()
   }, [router])
 
   return null

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -999,14 +999,11 @@ describe('app dir - navigation', () => {
   describe('middleware redirect', () => {
     it('should change browser location when router.refresh() gets a redirect response', async () => {
       const browser = await next.browser('/redirect-on-refresh/auth')
-      await retry(
-        async () =>
-          expect(await browser.url()).toBe(
-            next.url + '/redirect-on-refresh/dashboard'
-          ),
-        10_000
+      await retry(async () =>
+        expect(await browser.url()).toBe(
+          next.url + '/redirect-on-refresh/dashboard'
+        )
       )
-      expect(await browser.elementByCss('p').text()).toBe('Dashboard')
     })
   })
 

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -999,11 +999,14 @@ describe('app dir - navigation', () => {
   describe('middleware redirect', () => {
     it('should change browser location when router.refresh() gets a redirect response', async () => {
       const browser = await next.browser('/redirect-on-refresh/auth')
-      await retry(async () =>
-        expect(await browser.url()).toBe(
-          next.url + '/redirect-on-refresh/dashboard'
-        )
+      await retry(
+        async () =>
+          expect(await browser.url()).toBe(
+            next.url + '/redirect-on-refresh/dashboard'
+          ),
+        10_000
       )
+      expect(await browser.elementByCss('p').text()).toBe('Dashboard')
     })
   })
 


### PR DESCRIPTION
## What changed

Reduce redundant regex matcher construction in the development watcher:

- build `/_next/data` regex matchers only for dynamic Pages routes
- build filesystem regex matchers only for dynamic routes, since static App and Pages routes use the existing exact-lookup sets
- retain filesystem matchers for routes missing from those exact sets, including static metadata and all routes when `useFileSystemPublicRoutes` is disabled
- keep the full sorted route list in the development pages manifest for client-side rewrite resolution

The route list is partitioned in one pass, so `isDynamicRoute` is evaluated once per route.

## Why

The watcher rebuilds this route table during initial discovery and after route topology changes. Static routes do not need regex objects when they are already represented by exact App/Pages lookup sets. Removing that duplicate work is noticeable in route-heavy applications.

The exact-set fallback is important because path-based MCP tools also consume the filesystem matcher table. Without it, static metadata routes and static routes under `useFileSystemPublicRoutes: false` could no longer be resolved by path.

## Performance

Measured on exact baseline `0950e8ae05db20c33302f02257114f5b857edabc` versus product head `42dbfa3ed1` (the later commit is test-only), Node 24.14.1, pnpm 10.33.0, and the same 16-vCPU / 32-GiB DevBox. Each observation used a new flat 5,000-route Pages fixture and empty `.next` directory. Baseline and final builds lived in separate worktrees and were run in eight counterbalanced pairs.

| Bundler | Operation | Baseline median | Final median | Change | Final faster | Exact paired p |
|---|---:|---:|---:|---:|---:|---:|
| webpack | first route response | 3,150.1 ms | 2,848.6 ms | **-9.57%** | 8/8 | 0.0078 |
| webpack | add static route via rewrite | 481.0 ms | 391.1 ms | **-18.69%** | 8/8 | 0.0078 |
| webpack | remove static route via rewrite | 757.1 ms | 560.4 ms | **-25.98%** | 8/8 | 0.0078 |
| Turbopack | first route response | 1,944.8 ms | 1,814.2 ms | **-6.71%** | 8/8 | 0.0078 |
| Turbopack | first dynamic rewrite response | 263.6 ms | 228.2 ms | **-13.44%** | 7/8 | 0.0156 |
| Turbopack | remove static route via rewrite | 524.6 ms | 353.7 ms | **-32.58%** | 8/8 | 0.0078 |

Cold static-route compilation and subsequent data-request handling did not change significantly. Turbopack static-route addition improved by 2.64%, but did not clear the A/A noise floor (`p = 0.21`), so it is not claimed as a win.

A fresh four-pair A/A panel measured arbitrary-label skew of +0.98% / -0.47% / +1.87% for webpack first-response/add/remove and +2.70% / +0.94% for Turbopack first-response/add. Turbopack removal was noisier in A/A, but the baseline/final result improved in all eight pairs.

The raw add probe starts before the development pages manifest publishes. Turbopack final runs observed one initial 404 before the route became available; the original data-only candidate behaved the same way. Browser navigation after manifest publication succeeded in all 20 webpack/Turbopack additions with no browser errors or failed requests.

The generic CI stats comment flags webpack production-build timing, but its logs compare baseline package `16.3.0-canary.103` with this older branch package `16.3.0-canary.95` and show large unrelated compiled-runtime/package-size drift. This change is confined to the development watcher and test fixtures; the same job's development metrics were neutral to slightly faster. The paired measurements above use an exact common baseline and isolate this patch.

## Validation

- `pnpm build --filter=next` (7/7 tasks, including declarations)
- exact-file Prettier, ESLint, `git diff --check`, and commit-time lint-staged checks
- route utility Jest suites: 12/12 tests and 2/2 snapshots
- MCP `compile_route`: 22/22 Turbopack tests, including static metadata and static App/Pages/API routes with `useFileSystemPublicRoutes: false`
- MCP `get_routes`: 2/2 tests and 3/3 snapshots on webpack and Turbopack
- `filesystempublicroutes`: 4/4 on webpack and Turbopack
- `rewrites-client-resolving`: 5/5 on webpack and Turbopack
- two-level interception routes: 3/3 on webpack and Turbopack
- middleware refresh redirect: the fixture sets its middleware cookie directly instead of cold-compiling an unrelated API route; original 3-second retry preserved; 5/5 cold webpack and 5/5 cold Turbopack runs, full navigation suite 53/53 on both bundlers, and focused production-start runs on both
- 5,000-route config matrix: 56/56 direct, rewrite, basePath, i18n, App, Pages, API, data, add, and remove checks
- route-churn availability: 684/684 existing direct/rewrite requests remained correct across 40 add/remove events
- GPT-5.6 Sol xhigh + Claude Opus 5 xhigh autoreview of the final product and test-fixture diffs: zero findings; final patch correct at 0.96 confidence
