### PR TITLE
Store RouteTree slots in a Map to keep slot access monomorphic

### DIFF
--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts
@@ -56,8 +56,7 @@ export function isNavigatingToNewRootLayout(
   const slots = nextTree.slots
   const currentTreeChildren = currentTree[1]
   if (slots !== null) {
-    for (const slot in slots) {
-      const nextTreeChild = slots[slot]
+    for (const [slot, nextTreeChild] of slots) {
       const currentTreeChild = currentTreeChildren[slot]
       if (
         currentTreeChild === undefined ||

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -491,8 +491,7 @@ function updateCacheNodeOnNavigation(
 
     newCacheNode.slots = newCacheNodeSlots = {}
     taskChildren = new Map()
-    for (let parallelRouteKey in newSlots) {
-      let newRouteTreeChild: RouteTree = newSlots[parallelRouteKey]
+    for (let [parallelRouteKey, newRouteTreeChild] of newSlots) {
       const oldRouterStateChild: FlightRouterState | void =
         oldRouterStateChildren[parallelRouteKey]
       if (oldRouterStateChild === undefined) {
@@ -720,8 +719,7 @@ function createCacheNodeOnNavigation(
   if (newSlots !== null) {
     newCacheNode.slots = newCacheNodeSlots = {}
     taskChildren = new Map()
-    for (let parallelRouteKey in newSlots) {
-      const newRouteTreeChild: RouteTree = newSlots[parallelRouteKey]
+    for (const [parallelRouteKey, newRouteTreeChild] of newSlots) {
       const seedDataChild: CacheNodeSeedData | void | null =
         seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
 
@@ -2000,8 +1998,7 @@ function writeDynamicDataIntoNavigationTask(
 
   if (taskChildren !== null) {
     if (serverChildren !== null) {
-      for (const parallelRouteKey in serverChildren) {
-        const serverRouteTreeChild: RouteTree = serverChildren[parallelRouteKey]
+      for (const [parallelRouteKey, serverRouteTreeChild] of serverChildren) {
         const dynamicDataChild: CacheNodeSeedData | null | void =
           dynamicDataChildren !== null
             ? dynamicDataChildren[parallelRouteKey]

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -154,9 +154,11 @@ type RouteTreeShared = {
   // don't have to recompute it on every shell request.
   shellVaryPath: SegmentVaryPath
   refreshState: RefreshState | null
-  slots: null | {
-    [parallelRouteKey: string]: RouteTree
-  }
+  // Keyed by parallel route slot name. Stored as a Map rather than a plain
+  // object because slot names are app-defined; with a plain object, every
+  // distinct combination of slot names creates a different hidden class,
+  // making keyed access to the slots megamorphic.
+  slots: null | Map<string, RouteTree>
   // Bitmask of PrefetchHint flags. Encodes route structure metadata:
   // root layout, loading boundaries, instant configs, and runtime prefetch
   // hints.
@@ -812,15 +814,14 @@ function deprecated_createOptimisticRouteTree(
   // Create a new route tree that identical to the original one except for
   // the rendered search string, which is contained in the vary path.
 
-  let clonedSlots: Record<string, RouteTree> | null = null
+  let clonedSlots: Map<string, RouteTree> | null = null
   const originalSlots = tree.slots
   if (originalSlots !== null) {
-    clonedSlots = {}
-    for (const parallelRouteKey in originalSlots) {
-      const childTree = originalSlots[parallelRouteKey]
-      clonedSlots[parallelRouteKey] = deprecated_createOptimisticRouteTree(
-        childTree,
-        newRenderedSearch
+    clonedSlots = new Map()
+    for (const [parallelRouteKey, childTree] of originalSlots) {
+      clonedSlots.set(
+        parallelRouteKey,
+        deprecated_createOptimisticRouteTree(childTree, newRenderedSearch)
       )
     }
   }
@@ -1447,7 +1448,7 @@ function convertTreePrefetchToRouteTree(
   // it once instead of on every access. This same cache key is also used to
   // request the segment from the server.
 
-  let slots: { [parallelRouteKey: string]: RouteTree } | null = null
+  let slots: Map<string, RouteTree> | null = null
   let isPage: boolean
   let varyPath: SegmentVaryPath
   const prefetchSlots = prefetch.slots
@@ -1455,7 +1456,7 @@ function convertTreePrefetchToRouteTree(
     isPage = false
     varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
 
-    slots = {}
+    slots = new Map()
     for (let parallelRouteKey in prefetchSlots) {
       const childPrefetch = prefetchSlots[parallelRouteKey]
       const childSegmentName = childPrefetch.name
@@ -1528,15 +1529,18 @@ function convertTreePrefetchToRouteTree(
         parallelRouteKey,
         childRequestKeyPart
       )
-      slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
-        childPrefetch,
-        childSegment,
-        childPartialVaryPath,
-        childRequestKey,
-        pathnameParts,
-        childPathnamePartsIndex,
-        renderedSearch,
-        acc
+      slots.set(
+        parallelRouteKey,
+        convertTreePrefetchToRouteTree(
+          childPrefetch,
+          childSegment,
+          childPartialVaryPath,
+          childRequestKey,
+          pathnameParts,
+          childPathnamePartsIndex,
+          renderedSearch,
+          acc
+        )
       )
     }
   } else {
@@ -1723,7 +1727,7 @@ function convertFlightRouterStateToRouteTree(
     }
   }
 
-  let slots: { [parallelRouteKey: string]: RouteTree } | null = null
+  let slots: Map<string, RouteTree> | null = null
 
   const parallelRoutes = flightRouterState[1]
   for (let parallelRouteKey in parallelRoutes) {
@@ -1746,12 +1750,9 @@ function convertFlightRouterStateToRouteTree(
       acc
     )
     if (slots === null) {
-      slots = {
-        [parallelRouteKey]: childTree,
-      }
-    } else {
-      slots[parallelRouteKey] = childTree
+      slots = new Map()
     }
+    slots.set(parallelRouteKey, childTree)
   }
 
   return {
@@ -1776,11 +1777,11 @@ export function convertRouteTreeToFlightRouterState(
   routeTree: RouteTree
 ): FlightRouterState {
   const parallelRoutes: Record<string, FlightRouterState> = {}
-  if (routeTree.slots !== null) {
-    for (const parallelRouteKey in routeTree.slots) {
-      parallelRoutes[parallelRouteKey] = convertRouteTreeToFlightRouterState(
-        routeTree.slots[parallelRouteKey]
-      )
+  const slots = routeTree.slots
+  if (slots !== null) {
+    for (const [parallelRouteKey, childTree] of slots) {
+      parallelRoutes[parallelRouteKey] =
+        convertRouteTreeToFlightRouterState(childTree)
     }
   }
   const flightRouterState: FlightRouterState = [
@@ -2966,8 +2967,9 @@ export function writeDynamicRenderResponseIntoCache(
       let tree = routeTree
       for (let i = 0; i < segmentPath.length; i += 2) {
         const parallelRouteKey: string = segmentPath[i]
-        if (tree?.slots?.[parallelRouteKey] !== undefined) {
-          tree = tree.slots[parallelRouteKey]
+        const childTree = tree?.slots?.get(parallelRouteKey)
+        if (childTree !== undefined) {
+          tree = childTree
         } else {
           if (spawnedEntries !== null) {
             rejectSegmentEntriesIfStillPending(spawnedEntries, now + 10 * 1000)
@@ -3080,8 +3082,7 @@ function writeSeedDataIntoCache(
   const slots = tree.slots
   if (slots !== null) {
     const seedDataChildren = seedData[1]
-    for (const parallelRouteKey in slots) {
-      const childTree = slots[parallelRouteKey]
+    for (const [parallelRouteKey, childTree] of slots) {
       const childSeedData: CacheNodeSeedData | null | void =
         seedDataChildren[parallelRouteKey]
       if (childSeedData !== null && childSeedData !== undefined) {

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -491,8 +491,7 @@ function discoverKnownRoutePart(
   const slots = routeTree.slots
   let resultFromChildren: FulfilledRouteCacheEntry | null = null
   if (slots !== null) {
-    for (const parallelRouteKey in slots) {
-      const childRouteTree = slots[parallelRouteKey]
+    for (const childRouteTree of slots.values()) {
       // Skip branches with refreshState set - these were reused from a
       // different route (e.g., a "default" parallel slot) and don't represent
       // the actual route structure for this URL.
@@ -921,16 +920,20 @@ function reifyRouteTree(
   }
 
   // Recurse into children with the (possibly updated) partial vary path
-  let newSlots: Record<string, RouteTree> | null = null
-  if (pattern.slots !== null) {
-    newSlots = {}
-    for (const key in pattern.slots) {
-      newSlots[key] = reifyRouteTree(
-        pattern.slots[key],
-        resolvedParams,
-        search,
-        partialVaryPath,
-        acc
+  let newSlots: Map<string, RouteTree> | null = null
+  const patternSlots = pattern.slots
+  if (patternSlots !== null) {
+    newSlots = new Map()
+    for (const [key, childPattern] of patternSlots) {
+      newSlots.set(
+        key,
+        reifyRouteTree(
+          childPattern,
+          resolvedParams,
+          search,
+          partialVaryPath,
+          acc
+        )
       )
     }
   }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -1058,12 +1058,11 @@ function pingSharedPartOfCacheComponentsTree(
   const oldTreeChildren = oldTree[1]
   const newTreeChildren = newTree.slots
   if (newTreeChildren !== null) {
-    for (const parallelRouteKey in newTreeChildren) {
+    for (const [parallelRouteKey, newTreeChild] of newTreeChildren) {
       if (!hasNetworkBandwidth(task)) {
         // Stop prefetching segments until there's more bandwidth.
         return PrefetchTaskExitStatus.InProgress
       }
-      const newTreeChild = newTreeChildren[parallelRouteKey]
       const newTreeChildSegment = newTreeChild.segment
       const oldTreeChild: FlightRouterState | void =
         oldTreeChildren[parallelRouteKey]
@@ -1181,8 +1180,7 @@ function pingNewPartOfCacheComponentsTree(
       return PrefetchTaskExitStatus.InProgress
     }
     // Recursively ping the children.
-    for (const parallelRouteKey in tree.slots) {
-      const childTree = tree.slots[parallelRouteKey]
+    for (const childTree of tree.slots.values()) {
       // Only pass the bundle to the child that accepts it. A parent is
       // only ever bundled into one child.
       const bundleForChild =
@@ -1233,8 +1231,7 @@ function diffRouteTreeAgainstCurrent(
   const newTreeChildren = newTree.slots
   let requestTreeChildren: Record<string, FlightRouterState> = {}
   if (newTreeChildren !== null) {
-    for (const parallelRouteKey in newTreeChildren) {
-      const newTreeChild = newTreeChildren[parallelRouteKey]
+    for (const [parallelRouteKey, newTreeChild] of newTreeChildren) {
       const newTreeChildSegment = newTreeChild.segment
       const oldTreeChild: FlightRouterState | void =
         oldTreeChildren[parallelRouteKey]
@@ -1450,8 +1447,7 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
   }
   const requestTreeChildren: Record<string, FlightRouterState> = {}
   if (tree.slots !== null) {
-    for (const parallelRouteKey in tree.slots) {
-      const childTree = tree.slots[parallelRouteKey]
+    for (const [parallelRouteKey, childTree] of tree.slots) {
       requestTreeChildren[parallelRouteKey] =
         pingPPRDisabledRouteTreeUpToLoadingBoundary(
           now,
@@ -1590,8 +1586,7 @@ function pingRouteTreeAndIncludeDynamicData(
   }
   const requestTreeChildren: Record<string, FlightRouterState> = {}
   if (tree.slots !== null) {
-    for (const parallelRouteKey in tree.slots) {
-      const childTree = tree.slots[parallelRouteKey]
+    for (const [parallelRouteKey, childTree] of tree.slots) {
       requestTreeChildren[parallelRouteKey] =
         pingRouteTreeAndIncludeDynamicData(
           now,
@@ -1656,8 +1651,7 @@ function pingRuntimePrefetches(
   let requestTreeChildren: Record<string, FlightRouterState> = {}
   const slots = tree.slots
   if (slots !== null) {
-    for (const parallelRouteKey in slots) {
-      const childTree = slots[parallelRouteKey]
+    for (const [parallelRouteKey, childTree] of slots) {
       requestTreeChildren[parallelRouteKey] = pingRuntimePrefetches(
         now,
         task,
@@ -1947,8 +1941,7 @@ function finishStaticBundleOnRuntimeBailout(
     return
   }
   if (tree.slots !== null) {
-    for (const parallelRouteKey in tree.slots) {
-      const childTree = tree.slots[parallelRouteKey]
+    for (const childTree of tree.slots.values()) {
       if (childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf) {
         finishStaticBundleOnRuntimeBailout(now, task, route, childTree, bundle)
         return


### PR DESCRIPTION
### Root cause

Parallel route slot names are app-defined, so a `RouteTree.slots` stored as a plain object has an unbounded set of hidden classes: every distinct combination of slot names (`{children}`, `{children, side}`, ...) produces a different shape. Keyed access over these objects makes the inline cache megamorphic. This was the single `ic-megamorphic` finding reported by `pnpm bench:deopt --scenario segment-cache`, at the keyed store in `convertTreePrefetchToRouteTree` (`cache.ts:1531`, keys `children`, `side`).

This PR converts `RouteTree.slots` from `{ [parallelRouteKey: string]: RouteTree }` to `Map<string, RouteTree>`. All reads, writes, and iterations over RouteTree slots now go through monomorphic `Map` method calls, and iteration order is preserved (Map iterates in insertion order, matching plain-object string-key order).

### Scope

This was an approved design decision: `RouteTree` is an in-memory-only structure, so only it changes. `CacheNode.slots` (spread into JSX props) and the wire formats (`TreePrefetch.slots`, `FlightRouterState[1]`) remain plain objects; the existing conversion functions bridge them into and out of the Map.

### Before/after findings diff

```diff
--- bench/deopt/artifacts/slots-map-before/findings.txt
+++ bench/deopt/artifacts/slots-map-after/findings.txt
@@
-high  ic-megamorphic  packages/next/src/client/components/segment-cache/cache.ts  e  keys: children, side
+high  ic-megamorphic  packages/next/src/client/components/segment-cache/scheduler.ts  e  keys: children, side
@@
+info  deopt-dependency-change  packages/next/src/client/components/segment-cache/scheduler.ts  pingSharedPartOfCacheComponentsTree  dependent prototype chain changed
+info  deopt-eager  packages/next/src/client/components/segment-cache/scheduler.ts  _heapIndex  Insufficient type feedback for generic named access
+info  deopt-eager  packages/next/src/client/components/segment-cache/scheduler.ts  cancelPrefetchTask  Insufficient type feedback for generic named access
+info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eR  keys: push
```

The targeted finding at `cache.ts:1531` is cleared. The remaining megamorphic site (stable across two runs) is `scheduler.ts:1068:23` in `pingSharedPartOfCacheComponentsTree` — the keyed load `oldTreeChildren[parallelRouteKey]`, where `oldTreeChildren` is `FlightRouterState[1]`, i.e. the wire-format plain object that is intentionally out of scope for this change. That access existed before this PR; previously the `for...in` loop key qualified the sibling load for V8's fast enum-cache path, and with Map iteration keys it now surfaces as a generic keyed load. Eliminating it would require changing the `FlightRouterState` children format, which is a separate decision. The new info-level lines are one-time warm-up/prototype-registration deopts from the introduced `Map` usage, not steady-state IC misses.

### Tests

- `test/e2e/app-dir/segment-cache/basic` (start-turbo): 10 passed, 1 skipped
- `test/e2e/app-dir/segment-cache/optimistic-routing-parallel-slot-catchall-regression` (start-turbo): 1 passed
- `test/e2e/app-dir/segment-cache/cached-navigations` (start-turbo): 16 passed
- `pnpm --filter=next types` passes (also re-run after rebasing onto canary)
