### PR TITLE
Keep optimistic-route param handling monomorphic

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache/cache-key.ts
@@ -29,3 +29,33 @@ export function createCacheKey(
   } as RouteCacheKey
   return cacheKey
 }
+
+/**
+ * Splits a pathname into its non-empty parts. Equivalent to
+ * `pathname.split('/').filter((p) => p !== '')` — empty tokens produced by
+ * leading, trailing, or consecutive slashes are skipped.
+ *
+ * We use a manual loop instead of `split` + `filter` because
+ * `String.prototype.split` can return arrays with either the packed or holey
+ * elements kind depending on internal fast paths, and `filter`/`slice`
+ * propagate the kind. Mixing holey and packed arrays at the same call sites
+ * makes downstream array method loads (`slice`, `join`, `length`) polymorphic
+ * and causes repeated "wrong map" deoptimizations in hot route-matching code.
+ * Pushing into an array literal guarantees a packed elements kind.
+ */
+export function splitPathnameIntoParts(pathname: string): Array<string> {
+  const parts: Array<string> = []
+  let start = 0
+  for (let i = 0; i < pathname.length; i++) {
+    if (pathname.charCodeAt(i) === 47 /* '/' */) {
+      if (i > start) {
+        parts.push(pathname.slice(start, i))
+      }
+      start = i + 1
+    }
+  }
+  if (start < pathname.length) {
+    parts.push(pathname.slice(start))
+  }
+  return parts
+}

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -67,6 +67,7 @@ import type {
   RouteCacheKey,
 } from './cache-key'
 import { createCacheKey as createPrefetchRequestKey } from './cache-key'
+import { splitPathnameIntoParts } from './cache-key'
 import {
   doesStaticSegmentAppearInURL,
   getCacheKeyForDynamicParam,
@@ -1416,7 +1417,7 @@ function convertRootTreePrefetchToRouteTree(
   acc: RouteTreeAccumulator
 ) {
   // Remove trailing and leading slashes
-  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
+  const pathnameParts = splitPathnameIntoParts(renderedPathname)
   const index = 0
   const rootSegment = ROOT_SEGMENT_REQUEST_KEY
   return convertTreePrefetchToRouteTree(

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -57,6 +57,7 @@ import {
 import { isValueExpired } from './cache-map'
 import { doesStaticSegmentAppearInURL } from '../../route-params'
 import type { NormalizedPathname, NormalizedSearch } from './cache-key'
+import { splitPathnameIntoParts } from './cache-key'
 import {
   appendLayoutVaryPath,
   finalizeLayoutVaryPath,
@@ -136,10 +137,13 @@ type KnownRoutePart =
 
 /**
  * Param values extracted during URL matching. Used to reify the template.
- * - string for regular dynamic [param]
- * - string[] for catch-all [...param] and optional catch-all [[...param]]
+ * Values are always strings: catch-all [...param] and optional catch-all
+ * [[...param]] values are joined with '/' at the time they're resolved, which
+ * matches how the rest of the system models catch-all cache keys (an empty
+ * optional catch-all is the empty string). Keeping a single value type keeps
+ * reads of this map monomorphic.
  */
-type ResolvedParams = Map<string, string | string[]>
+type ResolvedParams = Map<string, string>
 
 /**
  * Read the pattern from a KnownRoutePart, evicting it if expired.
@@ -211,7 +215,7 @@ export function discoverKnownRoute(
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
-  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const pathnameParts = splitPathnameIntoParts(pathname)
 
   if (pendingEntry !== null) {
     // Fulfill the pending entry first
@@ -609,7 +613,7 @@ export function matchKnownRoute(
   pathname: string,
   search: NormalizedSearch
 ): FulfilledRouteCacheEntry | null {
-  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const pathnameParts = splitPathnameIntoParts(pathname)
   const resolvedParams: ResolvedParams = new Map()
   const match = matchKnownRoutePart(
     now,
@@ -791,7 +795,10 @@ function matchKnownRoutePart(
           !dynamicPattern.hasDynamicRewrite &&
           urlPart !== null
         ) {
-          resolvedParams.set(paramName, pathnameParts.slice(partIndex))
+          resolvedParams.set(
+            paramName,
+            pathnameParts.slice(partIndex).join('/')
+          )
           return { part: dynamicPart, pattern: dynamicPattern }
         }
         break
@@ -799,14 +806,17 @@ function matchKnownRoutePart(
         // Optional catch-all [[...param]]: consumes 0+ URL parts
         if (dynamicPattern !== null && !dynamicPattern.hasDynamicRewrite) {
           if (urlPart !== null) {
-            resolvedParams.set(paramName, pathnameParts.slice(partIndex))
+            resolvedParams.set(
+              paramName,
+              pathnameParts.slice(partIndex).join('/')
+            )
             return { part: dynamicPart, pattern: dynamicPattern }
           }
           // urlPart is null - can match with zero parts, but a direct pattern
           // (e.g., page.tsx alongside [[...param]]) takes precedence.
           const directPattern = readPattern(now, part)
           if (directPattern === null || directPattern.hasDynamicRewrite) {
-            resolvedParams.set(paramName, [])
+            resolvedParams.set(paramName, '')
             return { part: dynamicPart, pattern: dynamicPattern }
           }
         }
@@ -900,9 +910,9 @@ function reifyRouteTree(
     const staticSiblings = originalSegment[3]
     const newValue = resolvedParams.get(paramName)
     if (newValue !== undefined) {
-      const newCacheKey = Array.isArray(newValue)
-        ? newValue.join('/')
-        : newValue
+      // Catch-all values are already joined into a single string when they're
+      // resolved in matchKnownRoutePart, so the value can be used directly.
+      const newCacheKey = newValue
       newSegment = [paramName, newCacheKey, paramType, staticSiblings]
       partialVaryPath = appendLayoutVaryPath(
         parentPartialVaryPath,


### PR DESCRIPTION
Found by `pnpm bench:deopt --scenario segment-cache` (V8 deopt/IC analysis of the client segment cache), with map-level IC evidence. Two related sources of megamorphism in the optimistic route matching path: (1) `String.prototype.split` returns arrays whose elements kind alternates between PACKED_ELEMENTS and HOLEY_ELEMENTS depending on internal fast paths, and `filter`/`slice` propagate the kind, so the arrays flowing through `matchKnownRoutePart` and `reifyRouteTree` had unstable maps, causing repeated "wrong map" eager deopts at the `slice` site in `matchKnownRoutePart` and the `join` site in `reifyRouteTree` (which runs once per tree node on every optimistic match); and (2) the private `ResolvedParams` map typed as `Map<string, string | string[]>` forced a polymorphic `Array.isArray`/`join` branch on every dynamic segment during reification.

Semantics are preserved exactly. Catch-all param values are now joined into a single string at the moment they are resolved in `matchKnownRoutePart` instead of at read time in `reifyRouteTree` — the value was only ever read once and immediately collapsed to a joined string cache key, and the empty optional catch-all case writes `''`, which is identical to `[].join('/')`. The new `splitPathnameIntoParts` helper is byte-for-byte equivalent to `pathname.split('/').filter((p) => p !== '')`: empty tokens from leading, trailing, or consecutive slashes are skipped, but the parts array is built by pushing into an array literal so it always has a packed elements kind.

Before/after `findings.txt` diff from the bench scenario:

```diff
-high  deopt-eager  packages/next/src/client/components/segment-cache/optimistic-routes.ts  matchKnownRoutePart  wrong map
-high  deopt-eager  packages/next/src/client/components/segment-cache/optimistic-routes.ts  reifyRouteTree  wrong map
-info  deopt-lazy  packages/next/src/client/components/segment-cache/optimistic-routes.ts  matchKnownRoutePart  (unknown)
-info  deopt-lazy  packages/next/src/client/components/segment-cache/optimistic-routes.ts  reifyRouteTree  (unknown)
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eh  keys: filter
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache.ts  eh  keys: split
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: join
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: length
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  e  keys: slice
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: filter
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  g  keys: split
-info  ic-polymorphic  packages/next/src/client/components/segment-cache/optimistic-routes.ts  h  keys: split
+info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache-key.ts  u  keys: charCodeAt
+info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache-key.ts  u  keys: length
+info  ic-polymorphic  packages/next/src/client/components/segment-cache/cache-key.ts  u  keys: slice
```

Both high-severity wrong-map deopts in `optimistic-routes.ts` are gone (confirmed across two independent after-runs); the remaining new lines are info-level string-receiver ICs inside the splitter helper. Total ic-polymorphic findings dropped from 90 to 80.

Tests (all passing, `test-start-turbo`):

- `test/e2e/app-dir/segment-cache/optimistic-route-cache-keying-regression` — 1 passed
- `test/e2e/app-dir/segment-cache/optimistic-routing-parallel-slot-catchall-regression` — 1 passed
- `test/e2e/app-dir/segment-cache/encoded-slash-params` — 2 passed
