### PR TITLE
Fulfill route cache entries with fresh objects to avoid map deprecation

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache-map.ts
+++ b/packages/next/src/client/components/segment-cache/cache-map.ts
@@ -418,6 +418,38 @@ function setMapEntryValue(entry: UnknownMapEntry, value: MapValue): void {
   }
 }
 
+/**
+ * Replaces the value stored in the cache map with a new value, in place. The
+ * new value takes over the old value's slot (and its position in the LRU),
+ * and the `ref` back-pointer is transferred.
+ *
+ * This is used when fulfilling a pending entry: rather than mutating the
+ * pending object's fields in place (which would change the pending object's
+ * hidden class), the fulfilled entry is constructed as a fresh object and
+ * swapped into the map slot.
+ *
+ * The caller is responsible for carrying over `size` to the new value so the
+ * LRU accounting stays consistent.
+ *
+ * No-op if the old value is not (or is no longer) in the map, e.g. because it
+ * was lazily evicted while a request was in flight.
+ */
+export function replaceCacheMapValue(
+  oldValue: MapValue,
+  newValue: MapValue
+): void {
+  const entry = oldValue.ref
+  oldValue.ref = null
+  if (entry === null || entry.value !== oldValue) {
+    // The old value is not a member of any map. (The second check handles a
+    // stale back-pointer: lazy eviction clears the map entry's value without
+    // clearing the value's `ref`.)
+    return
+  }
+  entry.value = newValue
+  newValue.ref = entry
+}
+
 export function deleteFromCacheMap(value: MapValue): void {
   const entry = value.ref
   if (entry === null) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -80,6 +80,7 @@ import {
   setInCacheMap,
   setSizeInCacheMap,
   deleteFromCacheMap,
+  replaceCacheMapValue,
   isValueExpired,
   EntryStatus,
   type CacheMap,
@@ -776,29 +777,20 @@ export function deprecated_requestOptimisticRouteCacheEntry(
   )
 
   // Clone the base route tree, and override the relevant fields with our
-  // optimistic values.
-  const optimisticEntry: FulfilledRouteCacheEntry = {
-    canonicalUrl: optimisticCanonicalUrl,
-
-    status: EntryStatus.Fulfilled,
-    // This isn't cloned because it's instance-specific
-    blockedTasks: null,
-    tree: optimisticRouteTree,
-    metadata: optimisticMetadataTree,
-    couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
-    supportsPerSegmentPrefetching:
-      routeWithNoSearchParams.supportsPerSegmentPrefetching,
-    hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
-
-    // Override the rendered search with the optimistic value.
-    renderedSearch: optimisticRenderedSearch,
-
-    // Map-related fields
-    ref: null,
-    size: 0,
-    staleAt: routeWithNoSearchParams.staleAt,
-    version: routeWithNoSearchParams.version,
-  }
+  // optimistic values. The rendered search is overridden with the
+  // optimistic value.
+  const optimisticEntry = createFulfilledRouteCacheEntry(
+    optimisticCanonicalUrl,
+    optimisticRouteTree,
+    optimisticMetadataTree,
+    routeWithNoSearchParams.couldBeIntercepted,
+    routeWithNoSearchParams.supportsPerSegmentPrefetching,
+    routeWithNoSearchParams.hasDynamicRewrite,
+    optimisticRenderedSearch,
+    0,
+    routeWithNoSearchParams.staleAt,
+    routeWithNoSearchParams.version
+  )
 
   // Do not insert this entry into the cache. It only exists so we can
   // perform the current navigation. Just return it to the caller.
@@ -1264,6 +1256,46 @@ export function createMetadataRouteTree(
   return metadata
 }
 
+/**
+ * The single allocation site for all FulfilledRouteCacheEntry objects. Every
+ * fulfilled route entry — whether fulfilled from a server response, predicted
+ * via the known route tree (matchKnownRoute), or constructed optimistically —
+ * must be created here so they all share a single hidden class. Do not create
+ * fulfilled entries with inline object literals elsewhere; a second allocation
+ * site produces a second hidden class and deoptimizes every code path that
+ * reads route entries.
+ */
+export function createFulfilledRouteCacheEntry(
+  canonicalUrl: string,
+  tree: RouteTree,
+  metadata: RouteTree,
+  couldBeIntercepted: boolean,
+  supportsPerSegmentPrefetching: boolean,
+  hasDynamicRewrite: boolean,
+  renderedSearch: NormalizedSearch,
+  size: number,
+  staleAt: number,
+  version: number
+): FulfilledRouteCacheEntry {
+  return {
+    canonicalUrl,
+    status: EntryStatus.Fulfilled,
+    blockedTasks: null,
+    tree,
+    metadata,
+    couldBeIntercepted,
+    supportsPerSegmentPrefetching,
+    hasDynamicRewrite,
+    renderedSearch,
+
+    // Map-related fields
+    ref: null,
+    size,
+    staleAt,
+    version,
+  }
+}
+
 export function fulfillRouteCacheEntry(
   now: number,
   entry: PendingRouteCacheEntry,
@@ -1276,10 +1308,7 @@ export function fulfillRouteCacheEntry(
   // Get the rendered search from the vary path
   const renderedSearch =
     getRenderedSearchFromVaryPath(metadataVaryPath) ?? ('' as NormalizedSearch)
-  const fulfilledEntry: FulfilledRouteCacheEntry = entry as any
-  fulfilledEntry.status = EntryStatus.Fulfilled
-  fulfilledEntry.tree = tree
-  fulfilledEntry.metadata = createMetadataRouteTree(metadataVaryPath)
+
   // Route structure is essentially static — it only changes on deploy.
   // Always use the static stale time.
   // NOTE: An exception is rewrites/redirects in middleware or proxy, which can
@@ -1290,16 +1319,48 @@ export function fulfillRouteCacheEntry(
   // immediately expire the entry so it gets re-fetched with correct hints.
   // The segment data itself is still valid — only the route tree (which
   // contains the hint bits) needs to be re-fetched.
-  if (tree.prefetchHints & PrefetchHint.InliningHintsStale) {
-    fulfilledEntry.staleAt = -1
-  } else {
-    fulfilledEntry.staleAt = now + STATIC_STALETIME_MS
-  }
-  fulfilledEntry.couldBeIntercepted = couldBeIntercepted
-  fulfilledEntry.canonicalUrl = canonicalUrl
-  fulfilledEntry.renderedSearch = renderedSearch
-  fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
-  fulfilledEntry.hasDynamicRewrite = false
+  //
+  // NOTE: The already-expired value is `now - 1` rather than -1 so that
+  // `staleAt` is always a double. A mix of Smi (-1) and double timestamps in
+  // the same field would generalize the field's representation, deprecating
+  // the fulfilled entries' hidden class and deoptimizing readers.
+  const staleAt =
+    tree.prefetchHints & PrefetchHint.InliningHintsStale
+      ? now - 1
+      : now + STATIC_STALETIME_MS
+
+  // Construct the fulfilled entry as a fresh object and swap it into the
+  // pending entry's cache map slot, rather than mutating the pending entry's
+  // fields in place. In-place fulfillment would generalize the pending
+  // shape's null-initialized fields (null → object/string) and add new
+  // fields, deprecating the hidden class shared by all pending entries and
+  // deoptimizing code that reads route entries. Using a fresh object keeps
+  // both the pending and fulfilled shapes stable.
+  //
+  // `size` may have been set by setSizeInCacheMap while the request was in
+  // flight, and `version` preserves any invalidation that happened after the
+  // pending entry was created.
+  const fulfilledEntry = createFulfilledRouteCacheEntry(
+    canonicalUrl,
+    tree,
+    createMetadataRouteTree(metadataVaryPath),
+    couldBeIntercepted,
+    supportsPerSegmentPrefetching,
+    false, // hasDynamicRewrite
+    renderedSearch,
+    entry.size,
+    staleAt,
+    entry.version
+  )
+
+  // Swap the fulfilled entry into the pending entry's map slot (no-op if the
+  // pending entry was detached or already evicted). All other readers access
+  // route entries through the cache map: blocked tasks are re-queued below
+  // and re-read the map on their next ping, and navigations always perform a
+  // fresh lookup. The only caller that holds the pending entry across this
+  // boundary is fetchRouteOnCacheMiss, which uses the entry returned from
+  // this function (via discoverKnownRoute) for any subsequent re-keying.
+  replaceCacheMapValue(entry, fulfilledEntry)
   pingBlockedTasks(entry)
   return fulfilledEntry
 }
@@ -1934,6 +1995,12 @@ export async function fetchRouteOnCacheMiss(
       // because all data is static in this mode.
       isOutputExportMode
 
+    // Fulfilling a route cache entry swaps its identity: the pending entry is
+    // replaced in the cache map by a freshly constructed fulfilled entry (see
+    // fulfillRouteCacheEntry). Track the latest version here so the re-keying
+    // logic below operates on the current entry, not the stale pending one.
+    let latestEntry: RouteCacheEntry = entry
+
     if (routeIsPPREnabled) {
       const { stream: prefetchStream, size: responseSize } =
         await createNonTaskyPrefetchResponseStream(response.body)
@@ -1980,7 +2047,7 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
-      discoverKnownRoute(
+      latestEntry = discoverKnownRoute(
         Date.now(),
         pathname,
         search,
@@ -2026,7 +2093,7 @@ export async function fetchRouteOnCacheMiss(
       // CacheNodeSeedData; the root iterable is threaded down so each segment
       // unions it too.
       const headVaryParams = readVaryParams(serverData.h, serverData.r)
-      writeDynamicTreeResponseIntoCache(
+      latestEntry = writeDynamicTreeResponseIntoCache(
         Date.now(),
         // The non-PPR response format is what we'd get if we prefetched these segments
         // using the LoadingBoundary fetch strategy, so mark their cache entries accordingly.
@@ -2064,7 +2131,12 @@ export async function fetchRouteOnCacheMiss(
         couldBeIntercepted
       )
       const isRevalidation = false
-      setInCacheMap(routeCacheMap, fulfilledVaryPath, entry, isRevalidation)
+      setInCacheMap(
+        routeCacheMap,
+        fulfilledVaryPath,
+        latestEntry,
+        isRevalidation
+      )
     }
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
@@ -2819,7 +2891,12 @@ function writeDynamicTreeResponseIntoCache(
   originalPathname: string,
   originalSearch: NormalizedSearch,
   nextUrl: string | null
-): void {
+  // Returns the latest version of the route cache entry: the freshly
+  // constructed fulfilled entry on success, or the original (now rejected)
+  // entry on failure. Fulfillment swaps the entry's identity (see
+  // fulfillRouteCacheEntry), so the caller must use the returned entry for
+  // any further operations rather than the pending entry it passed in.
+): RouteCacheEntry {
   const renderedSearch = getRenderedSearch(response)
 
   const normalizedFlightDataResult = normalizeFlightData(serverData.f)
@@ -2830,13 +2907,13 @@ function writeDynamicTreeResponseIntoCache(
     normalizedFlightDataResult.length !== 1
   ) {
     rejectRouteCacheEntry(entry, now + 10 * 1000)
-    return
+    return entry
   }
   const flightData = normalizedFlightDataResult[0]
   if (!flightData.isRootRender) {
     // Unexpected response format.
     rejectRouteCacheEntry(entry, now + 10 * 1000)
-    return
+    return entry
   }
 
   const flightRouterState = flightData.tree
@@ -2860,10 +2937,10 @@ function writeDynamicTreeResponseIntoCache(
   const metadataVaryPath = acc.metadataVaryPath
   if (metadataVaryPath === null) {
     rejectRouteCacheEntry(entry, now + 10 * 1000)
-    return
+    return entry
   }
 
-  discoverKnownRoute(
+  const fulfilledEntry = discoverKnownRoute(
     now,
     originalPathname,
     originalSearch,
@@ -2903,6 +2980,8 @@ function writeDynamicTreeResponseIntoCache(
     navigationSeed,
     null
   )
+
+  return fulfilledEntry
 }
 
 function rejectSegmentEntriesIfStillPending(

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -47,9 +47,9 @@ import type { DynamicParamTypesShort } from '../../../shared/lib/app-router-type
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
 import type { RouteTree, FulfilledRouteCacheEntry } from './cache'
 import {
-  EntryStatus,
   writeRouteIntoCache,
   fulfillRouteCacheEntry,
+  createFulfilledRouteCacheEntry,
   getCurrentRouteCacheVersion,
   type PendingRouteCacheEntry,
   createMetadataRouteTree,
@@ -671,21 +671,18 @@ export function matchKnownRoute(
   // different pathname due to dynamic rewrite), the entry gets marked with
   // hasDynamicRewrite. Future predictions for this route will see the flag
   // and bail out to server resolution instead of making the same mistake.
-  const syntheticEntry: FulfilledRouteCacheEntry = {
-    canonicalUrl: pathname + search,
-    status: EntryStatus.Fulfilled,
-    blockedTasks: null,
-    tree: reifiedTree,
-    metadata: reifiedMetadata,
-    couldBeIntercepted: pattern.couldBeIntercepted,
-    supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
-    hasDynamicRewrite: false,
-    renderedSearch: search,
-    ref: null,
-    size: pattern.size,
-    staleAt: pattern.staleAt,
-    version: pattern.version,
-  }
+  const syntheticEntry = createFulfilledRouteCacheEntry(
+    pathname + search,
+    reifiedTree,
+    reifiedMetadata,
+    pattern.couldBeIntercepted,
+    pattern.supportsPerSegmentPrefetching,
+    false, // hasDynamicRewrite
+    search,
+    pattern.size,
+    pattern.staleAt,
+    pattern.version
+  )
 
   matchedPart.pattern = syntheticEntry
 


### PR DESCRIPTION
## Root cause

`fulfillRouteCacheEntry` fulfilled a pending `RouteCacheEntry` by mutating its null-initialized fields in place (`tree`, `canonicalUrl`, `metadata`, `renderedSearch`, ...) and adding a new `hasDynamicRewrite` field. The first fulfillment in an isolate generalized the pending shape's field representations (null → object/string), deprecating the hidden class shared by all route cache entries. Every optimized reader of route entries then hit a one-time wrong-map deopt, and readers of fulfilled entries stayed permanently polymorphic because entries fulfilled in place had a different hidden class than the fulfilled-entry literals in `matchKnownRoute` and `deprecated_requestOptimisticRouteCacheEntry`.

Observed with `pnpm bench:deopt --scenario segment-cache`: `map,Deprecate` of the route entry chain fires mid-workload, immediately followed by the `hasDynamicRewrite` LoadIC going polymorphic (`1->P`), plus polymorphic ICs on `tree`, `metadata`, `status`, `canonicalUrl`, `renderedSearch`, `staleAt`, `couldBeIntercepted`, `supportsPerSegmentPrefetching`, and `version` across `navigation.ts`, `scheduler.ts`, and `optimistic-routes.ts`.

## Fix

- `fulfillRouteCacheEntry` now constructs the fulfilled entry as a fresh object and swaps it into the pending entry's cache map slot via a new `replaceCacheMapValue` helper (transfers the `ref` back-pointer and LRU slot; no-op if the entry was detached or lazily evicted). The pending shape is never generalized.
- All fulfilled entries are allocated through a single factory, `createFulfilledRouteCacheEntry` (also used by `matchKnownRoute` and `deprecated_requestOptimisticRouteCacheEntry`), so every fulfilled entry shares one hidden class regardless of how it was created.
- The `InliningHintsStale` already-expired timestamp is `now - 1` instead of `-1`, so `staleAt` is always a double and never flips the field's representation from Smi.
- Scope is route entries only. Segment entries still fulfill in place and are a possible follow-up.

## Identity-swap safety audit

Every holder of a pending route entry across the fulfillment boundary was audited:

- **Cache map slot + `ref` back-pointer** (`cache-map.ts`): the swap choke point; handled by `replaceCacheMapValue`.
- **`fetchRouteOnCacheMiss` local `entry`**: the only caller holding the pending entry across the boundary. Its single post-fulfillment use (the `!couldBeIntercepted` re-key) now uses the entry returned from `discoverKnownRoute` / `writeDynamicTreeResponseIntoCache` (which now returns the latest entry; on rejection it returns the original entry, matching the previous re-key behavior).
- **`blockedTasks` waiters**: tasks never hold the entry; `pingBlockedTasks` consumes the old entry's set and re-queued tasks re-read via `readOrCreateRouteCacheEntry` on the next ping.
- **Scheduler locals** (`pingRoute`, `pingRootRouteTree`): used synchronously within a single ping; fulfillment only happens in async continuations, so no interleaving. Status mutations in the Empty branch stay on the pending shape (Smi/number stores, no generalization).
- **Navigation** (`navigation.ts`): reads the map synchronously at navigation time; pending entries are not retained.
- **`knownRoutePart.pattern`** (`optimistic-routes.ts`): only ever assigned fulfilled entries, always from the factory's return value.
- Rejection (`rejectRouteCacheEntry`) keeps identity: it only writes `status`/`staleAt` (Smi/double into existing fields), which does not change the hidden class.
- No WeakMap/WeakSet keys, no `===` identity comparisons on route entries, no bfcache or navigation-testing-lock references (those track segment entries only), and no consumers outside `segment-cache/` + `router-reducer/` handle route entry objects.

## Before/after (bench:deopt, segment-cache scenario)

```
BEFORE (canary + in-place fulfillment)
  Findings: 102 matching filters (ic-polymorphic: 88)
  hasDynamicRewrite LoadIC: 0->1, then 1->P (two maps) right after map,Deprecate of the route entry chain mid-workload
  Polymorphic ICs on fulfilled-entry fields in navigation.ts, scheduler.ts, optimistic-routes.ts:
    canonicalUrl, tree, metadata, status, renderedSearch, hasDynamicRewrite,
    couldBeIntercepted, supportsPerSegmentPrefetching, staleAt, size, version

AFTER (this PR)
  Findings: 80 matching filters (ic-polymorphic: 66-69 across runs)
  hasDynamicRewrite LoadIC: 0->1 only (single map, monomorphic for the whole workload)
  All fulfilled-entry field ICs above: cleared (monomorphic)
  Route-entry map deprecations during the workload: none
    (only the init-time literal boilerplate setup at first allocation, before any code is optimized)
```

The `matchKnownRoutePart wrong map` line still appears in the findings snapshot, but its cause changed: the V8 log shows the IC stays monomorphic and no route-entry map is deprecated during the workload. The residual 1x deopt is the first-allocated instance lazily migrating from the literal boilerplate's initial map chain (an unavoidable per-isolate warm-up artifact of object literals), not the recurring deprecation + polymorphism this PR removes. `isValueExpired wrong map` also remains: that site is inherently polymorphic across route/segment/bfcache entry kinds and was not triggered by route entry deprecation alone. No new high-severity findings.

## Tests

- `test/e2e/app-dir/segment-cache/basic` (test-start-turbo): 10 passed, 1 skipped
- `test/e2e/app-dir/segment-cache/revalidation` (test-start-turbo): 6 passed
- `pnpm --filter=next types`: pass
