### PR TITLE
Reuse unchanged dev API and App Route matchers

### DIFF
--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.test.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.test.ts
@@ -83,5 +83,43 @@ describe.each(['webpack', 'turbopack'])(
         }
       )
     })
+
+    it('reuses unchanged matchers and evicts removed files', async () => {
+      const ignored = `${dir}/page.ts`
+      const one = `${dir}/one/route.ts`
+      const two = `${dir}/two/route.ts`
+      const metadata = `${dir}/sitemap.ts`
+      let files: ReadonlyArray<string> = [ignored, one, metadata]
+      const reader: FileReader = { read: jest.fn(() => files) }
+      const provider = new DevAppRouteRouteMatcherProvider(
+        dir,
+        extensions,
+        reader,
+        isTurbopack
+      )
+
+      const initial = await provider.matchers()
+      expect(initial).toHaveLength(3)
+
+      files = [ignored, one, two, metadata]
+      const expanded = await provider.matchers()
+      expect(expanded).toHaveLength(4)
+      expect(expanded[0]).toBe(initial[0])
+      expect(expanded[2]).toBe(initial[1])
+      expect(expanded[3]).toBe(initial[2])
+
+      files = [ignored, two, metadata]
+      const reduced = await provider.matchers()
+      expect(reduced[0]).toBe(expanded[1])
+      expect(reduced[1]).toBe(initial[1])
+      expect(reduced[2]).toBe(initial[2])
+
+      files = [ignored, one, two, metadata]
+      const readded = await provider.matchers()
+      expect(readded[0]).not.toBe(initial[0])
+      expect(readded[1]).toBe(expanded[1])
+      expect(readded[2]).toBe(initial[1])
+      expect(readded[3]).toBe(initial[2])
+    })
   }
 )

--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -22,6 +22,12 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
   private readonly appDir: string
   private readonly isTurbopack: boolean
 
+  // Matchers depend only on the immutable provider configuration and filename.
+  private readonly matcherCache = new Map<
+    string,
+    ReadonlyArray<AppRouteRouteMatcher>
+  >()
+
   constructor(
     appDir: string,
     extensions: ReadonlyArray<string>,
@@ -39,19 +45,37 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
     files: ReadonlyArray<string>
   ): Promise<ReadonlyArray<AppRouteRouteMatcher>> {
     const matchers: Array<AppRouteRouteMatcher> = []
+    const retained = this.matcherCache.size > 0 ? new Set<string>() : undefined
+
     for (const filename of files) {
+      retained?.add(filename)
+      const cached = this.matcherCache.get(filename)
+      if (cached) {
+        matchers.push(...cached)
+        continue
+      }
+
+      const matcherStart = matchers.length
+
       // Skip static metadata files as they are served from filesystem.
       if (isStaticMetadataFile(filename.replace(this.appDir, ''))) {
+        this.matcherCache.set(filename, [])
         continue
       }
 
       let page = this.normalizers.page.normalize(filename)
 
       // If the file isn't a match for this matcher, then skip it.
-      if (!isAppRouteRoute(page)) continue
+      if (!isAppRouteRoute(page)) {
+        this.matcherCache.set(filename, [])
+        continue
+      }
 
       // Validate that this is not an ignored page.
-      if (page.includes('/_')) continue
+      if (page.includes('/_')) {
+        this.matcherCache.set(filename, [])
+        continue
+      }
 
       // Turbopack uses the correct page name with the underscore normalized.
       // TODO: Move implementation to packages/next/src/server/normalizers/built/app/app-page-normalizer.ts.
@@ -130,6 +154,14 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
             filename,
           })
         )
+      }
+
+      this.matcherCache.set(filename, matchers.slice(matcherStart))
+    }
+
+    if (retained) {
+      for (const filename of this.matcherCache.keys()) {
+        if (!retained.has(filename)) this.matcherCache.delete(filename)
       }
     }
 

--- a/packages/next/src/server/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.test.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.test.ts
@@ -86,4 +86,36 @@ describe('DevPagesAPIRouteMatcherProvider', () => {
       }
     )
   })
+
+  it('reuses unchanged matchers and evicts removed files', async () => {
+    const ignored = normalizeSlashes(`${dir}/index.ts`)
+    const one = normalizeSlashes(`${dir}/api/one.ts`)
+    const two = normalizeSlashes(`${dir}/api/two.ts`)
+    const three = normalizeSlashes(`${dir}/api/three.ts`)
+    let files: ReadonlyArray<string> = [ignored, one, two]
+    const reader: FileReader = { read: jest.fn(() => files) }
+    const provider = new DevPagesAPIRouteMatcherProvider(
+      dir,
+      extensions,
+      reader
+    )
+
+    const initial = await provider.matchers()
+
+    files = [ignored, one, two, three]
+    const expanded = await provider.matchers()
+    expect(expanded[0]).toBe(initial[0])
+    expect(expanded[1]).toBe(initial[1])
+
+    files = [ignored, one, three]
+    const reduced = await provider.matchers()
+    expect(reduced[0]).toBe(initial[0])
+    expect(reduced[1]).toBe(expanded[2])
+
+    files = [ignored, one, two, three]
+    const readded = await provider.matchers()
+    expect(readded[0]).toBe(initial[0])
+    expect(readded[1]).not.toBe(initial[1])
+    expect(readded[2]).toBe(expanded[2])
+  })
 })

--- a/packages/next/src/server/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-pages-api-route-matcher-provider.ts
@@ -13,6 +13,9 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
   private readonly expression: RegExp
   private readonly normalizers: DevPagesNormalizers
 
+  // A matcher depends only on the immutable provider configuration and filename.
+  private readonly matcherCache = new Map<string, PagesAPIRouteMatcher | null>()
+
   constructor(
     private readonly pagesDir: string,
     private readonly extensions: ReadonlyArray<string>,
@@ -54,17 +57,27 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
     files: ReadonlyArray<string>
   ): Promise<ReadonlyArray<PagesAPIRouteMatcher>> {
     const matchers: Array<PagesAPIRouteMatcher> = []
+    const retained = this.matcherCache.size > 0 ? new Set<string>() : undefined
+
     for (const filename of files) {
+      retained?.add(filename)
+      const cached = this.matcherCache.get(filename)
+      if (cached !== undefined) {
+        if (cached) matchers.push(cached)
+        continue
+      }
+
       // If the file isn't a match for this matcher, then skip it.
-      if (!this.test(filename)) continue
+      if (!this.test(filename)) {
+        this.matcherCache.set(filename, null)
+        continue
+      }
 
       const pathname = this.normalizers.pathname.normalize(filename)
       const page = this.normalizers.page.normalize(filename)
       const bundlePath = this.normalizers.bundlePath.normalize(filename)
-
-      if (this.localeNormalizer) {
-        matchers.push(
-          new PagesAPILocaleRouteMatcher({
+      const matcher = this.localeNormalizer
+        ? new PagesAPILocaleRouteMatcher({
             kind: RouteKind.PAGES_API,
             pathname,
             page,
@@ -72,17 +85,21 @@ export class DevPagesAPIRouteMatcherProvider extends FileCacheRouteMatcherProvid
             filename,
             i18n: {},
           })
-        )
-      } else {
-        matchers.push(
-          new PagesAPIRouteMatcher({
+        : new PagesAPIRouteMatcher({
             kind: RouteKind.PAGES_API,
             pathname,
             page,
             bundlePath,
             filename,
           })
-        )
+
+      this.matcherCache.set(filename, matcher)
+      matchers.push(matcher)
+    }
+
+    if (retained) {
+      for (const filename of this.matcherCache.keys()) {
+        if (!retained.has(filename)) this.matcherCache.delete(filename)
       }
     }
 


### PR DESCRIPTION
## What changed

- reuse filename-derived matchers in the development Pages API and App Route providers when unrelated routes are added or removed
- cache negative entries for files that do not belong to either provider
- retain both matchers emitted by a dynamic App metadata file while preserving file order
- evict removed filenames immediately so re-added routes receive fresh matcher objects
- cover identity reuse, negative entries, metadata pairs, eviction, and re-add behavior for webpack and Turbopack

## Why

`CachedRouteMatcherProvider` can reuse its complete matcher array only while the complete file list is equal. Adding or removing one route invalidates that cache, so both providers normalize every filename and allocate every matching route definition again before the matcher manager reloads.

These route definitions depend only on the provider's immutable configuration and filename, not file contents or neighboring routes. Reusing the filename-local results avoids reconstructing unaffected definitions without changing matcher order or route semantics. The App Page provider is intentionally excluded because its matchers carry cross-file `appPaths` state.

## Performance

Measured on exact parent commit `0950e8ae05db20c33302f02257114f5b857edabc` in one persistent 16-vCPU / 32-GiB Vercel DevBox with Node 24.14.1 and pnpm 10.33.0. Each fixture contains 5,000 routes and runs a real Turbopack development server from a removed `.next`, opens existing routes, removes one known route, observes 404, then re-adds it and verifies its marker. Baseline and candidate used the same compiled binary; each route kind received a 16-run A/A panel followed by a 32-run A/B panel in eight balanced ABBA/BAAB blocks.

Pages API:

- remove end-to-end: 1,126.873 ms → 1,070.568 ms, **5.00% faster** (`p = 0.00000119`)
- re-add end-to-end: 369.196 ms → 325.352 ms, **11.88% faster** (`p = 0.0000226`)
- remove provider transform: 64.204 ms → 3.347 ms, **94.79% faster** (`p = 0.00000119`)
- re-add provider transform: 62.021 ms → 2.762 ms, **95.55% faster** (`p = 0.00000119`)
- readiness and cold request were neutral: +0.12% (`p = 0.842`) and +0.08% (`p = 0.787`)

App Route:

- remove end-to-end: 2,102.523 ms → 2,043.530 ms, **2.81% faster** (`p = 0.00536`)
- re-add end-to-end: 1,104.266 ms → 1,055.301 ms, **4.43% faster** (`p = 0.0000488`)
- remove provider transform: 70.115 ms → 3.880 ms, **94.47% faster** (`p = 0.00000119`)
- re-add provider transform: 73.470 ms → 3.227 ms, **95.61% faster** (`p = 0.00000119`)
- readiness and cold request were neutral: +0.20% (`p = 0.822`) and -0.25% (`p = 0.807`)

Populating each cache increased the initial provider transform by about 3.6–4.0 ms in the gated experiment, but this did not produce a measurable readiness or cold-request regression. Four final-source reruns per route kind reproduced repeated provider transforms of 2.96–4.04 ms.

## Validation

- `pnpm --filter=next build`, including declaration generation
- focused provider Jest suites: 16/16 tests passed
- exact-file Prettier and ESLint
- `git diff --check`
- every benchmark run verified existing route content, 404 after removal, and the expected marker after re-addition
- GPT-5.6 Sol xhigh and Claude Opus 5 xhigh autoreview: zero actionable findings, overall correctness confidence 0.96
