### PR TITLE
Fast-path normalized relative URL parsing

### DIFF
--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts
@@ -8,6 +8,15 @@ describe('relative urls', () => {
     expect(parseRelativeUrl('//google.com').pathname).toBe('//google.com')
   })
 
+  it('should parse dot-relative urls against the server base', () => {
+    expect(parseRelativeUrl('./abc').pathname).toBe('/abc')
+    expect(parseRelativeUrl('../abc').pathname).toBe('/abc')
+
+    // Resolving a URL must not mutate the shared server base between calls.
+    expect(parseRelativeUrl('/one').pathname).toBe('/one')
+    expect(parseRelativeUrl('/two').pathname).toBe('/two')
+  })
+
   it('should throw for invalid pathname', () => {
     expect(() => parseRelativeUrl('http://example.com/abc')).toThrow()
   })

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts
@@ -8,13 +8,58 @@ describe('relative urls', () => {
     expect(parseRelativeUrl('//google.com').pathname).toBe('//google.com')
   })
 
-  it('should parse dot-relative urls against the server base', () => {
-    expect(parseRelativeUrl('./abc').pathname).toBe('/abc')
-    expect(parseRelativeUrl('../abc').pathname).toBe('/abc')
+  it('should preserve all fields for normalized path-only URLs', () => {
+    expect(parseRelativeUrl('/docs/v1.0/getting-started/~user')).toEqual({
+      auth: null,
+      host: null,
+      hostname: null,
+      pathname: '/docs/v1.0/getting-started/~user',
+      port: null,
+      protocol: null,
+      query: {},
+      search: '',
+      hash: '',
+      href: '/docs/v1.0/getting-started/~user',
+      slashes: null,
+    })
+  })
 
-    // Resolving a URL must not mutate the shared server base between calls.
-    expect(parseRelativeUrl('/one').pathname).toBe('/one')
-    expect(parseRelativeUrl('/two').pathname).toBe('/two')
+  it('should preserve the parseQuery false return shape', () => {
+    expect(parseRelativeUrl('/docs/api', undefined, false)).toStrictEqual({
+      auth: null,
+      host: null,
+      hostname: null,
+      pathname: '/docs/api',
+      port: null,
+      protocol: null,
+      query: undefined,
+      search: '',
+      hash: '',
+      href: '/docs/api',
+      slashes: null,
+    })
+  })
+
+  it.each([
+    ['/docs\n', '/docs'],
+    ['/docs\r', '/docs'],
+    ['/docs\u2028', '/docs%E2%80%A8'],
+    ['/docs\u2029', '/docs%E2%80%A9'],
+  ])(
+    'should continue to normalize a trailing line terminator in %p',
+    (url, expected) => {
+      const parsed = parseRelativeUrl(url)
+      expect(parsed.pathname).toBe(expected)
+      expect(parsed.href).toBe(expected)
+    }
+  )
+
+  it('should continue to normalize dot segments', () => {
+    expect(parseRelativeUrl('/docs/../api').pathname).toBe('/api')
+  })
+
+  it('should continue to validate an explicit base', () => {
+    expect(() => parseRelativeUrl('/abc', 'http://example.com')).toThrow()
   })
 
   it('should throw for invalid pathname', () => {

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
@@ -2,6 +2,8 @@ import type { ParsedUrlQuery } from 'querystring'
 import { getLocationOrigin } from '../../utils'
 import { searchParamsToUrlQuery } from './querystring'
 
+const DUMMY_ORIGIN_URL = new URL('http://n')
+
 export interface ParsedRelativeUrl {
   auth: string | null
   hash: string
@@ -37,16 +39,17 @@ export function parseRelativeUrl(
   base?: string,
   parseQuery = true
 ): ParsedRelativeUrl | Omit<ParsedRelativeUrl, 'query'> {
-  const globalBase = new URL(
-    typeof window === 'undefined' ? 'http://n' : getLocationOrigin()
-  )
+  const globalBase =
+    typeof window === 'undefined'
+      ? DUMMY_ORIGIN_URL
+      : new URL(getLocationOrigin())
 
   const resolvedBase = base
     ? new URL(base, globalBase)
     : url.startsWith('.')
-      ? new URL(
-          typeof window === 'undefined' ? 'http://n' : window.location.href
-        )
+      ? typeof window === 'undefined'
+        ? globalBase
+        : new URL(window.location.href)
       : globalBase
 
   const { pathname, searchParams, search, hash, href, origin } = url.startsWith(

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
@@ -2,7 +2,11 @@ import type { ParsedUrlQuery } from 'querystring'
 import { getLocationOrigin } from '../../utils'
 import { searchParamsToUrlQuery } from './querystring'
 
-const DUMMY_ORIGIN_URL = new URL('http://n')
+// Avoid constructing a URL for the common case where the input is already a
+// normalized, path-only URL. Limit this to unreserved URL characters and path
+// separators so the fast path does not need to reproduce WHATWG serialization.
+const nonSimplePathRegex = /[^A-Za-z0-9._~/-]/
+const serverBase = new URL('http://n')
 
 export interface ParsedRelativeUrl {
   auth: string | null
@@ -39,17 +43,38 @@ export function parseRelativeUrl(
   base?: string,
   parseQuery = true
 ): ParsedRelativeUrl | Omit<ParsedRelativeUrl, 'query'> {
+  if (
+    base === undefined &&
+    url.charCodeAt(0) === 47 &&
+    !url.includes('?') &&
+    !url.includes('#') &&
+    !url.includes('/.') &&
+    !nonSimplePathRegex.test(url)
+  ) {
+    return {
+      auth: null,
+      host: null,
+      hostname: null,
+      pathname: url,
+      port: null,
+      protocol: null,
+      query: parseQuery ? {} : undefined,
+      search: '',
+      hash: '',
+      href: url,
+      slashes: null,
+    }
+  }
+
   const globalBase =
-    typeof window === 'undefined'
-      ? DUMMY_ORIGIN_URL
-      : new URL(getLocationOrigin())
+    typeof window === 'undefined' ? serverBase : new URL(getLocationOrigin())
 
   const resolvedBase = base
     ? new URL(base, globalBase)
     : url.startsWith('.')
-      ? typeof window === 'undefined'
-        ? globalBase
-        : new URL(window.location.href)
+      ? new URL(
+          typeof window === 'undefined' ? 'http://n' : window.location.href
+        )
       : globalBase
 
   const { pathname, searchParams, search, hash, href, origin } = url.startsWith(


### PR DESCRIPTION
## What changed

- Return the final `ParsedRelativeUrl` shape directly when the input is already
  a normalized, path-only URL with no explicit base.
- Keep queries, hashes, dot segments, percent-encoding, Unicode, backslashes,
  malformed inputs, and explicit bases on the existing WHATWG `URL` path.
- Add focused coverage for the fast-path return shape, dot-segment
  normalization, and explicit-base validation.

## Why

`parseRelativeUrl` is on the production request path. The previous version of
this PR only reused the server-side base URL: it made the helper faster, but its
end-to-end request result was neutral. This narrower fast path avoids URL
construction for the common normalized-path case and produced a repeatable
whole-request improvement.

## Performance evidence

In a 32-run loaded App Route campaign with 40,000 requests per run:

- Throughput: **+1.731%**
- Mean latency: **-1.682%**
- p95 latency: **-2.356%**

A separate factorial experiment attributed **+1.795% throughput** to this
parser change. Sampled URL-helper CPU share fell from **2.901% to 0.449%**.

The expected application-level benefit is roughly 1%–2% for framework-heavy,
high-throughput App Route handlers. Workloads dominated by databases, network
I/O, or application CPU will see a smaller effect.

## Correctness and validation

- Differential oracle: **1,000,228 cases, zero mismatches**
- Focused Jest: 1 suite, 11 tests passed
- Next.js filtered build: 7/7 tasks passed, including declaration generation
- Prettier, ESLint, `git diff --check`
- Two-model autoreview: GPT-5.6 Sol xhigh + Claude Opus 5 xhigh

The differential corpus covers explicit bases, queries, hashes, dot segments,
encodings, Unicode, backslashes, and malformed inputs. The combined patch was
also previously applied and built on current canary.
