### PR TITLE
Skip reader task locking for immutable Turbo Tasks reads

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -679,7 +679,12 @@ impl TurboTasksBackend {
 
         let reader_description = reader_task
             .as_ref()
-            .map(|r| EventDescription::new(|| r.get_task_desc_fn()));
+            .map(|r| EventDescription::new(|| r.get_task_desc_fn()))
+            .or_else(|| {
+                need_reader_task.map(|reader_id| {
+                    EventDescription::new(move || move || format!("{reader_id:?}"))
+                })
+            });
         if let Some(value) = check_in_progress(&task, reader_description.clone(), options.tracking)
         {
             return value;
@@ -825,11 +830,16 @@ impl TurboTasksBackend {
         } = options;
 
         let mut ctx = self.execute_context(turbo_tasks);
-        let (mut task, reader_task) = if self.should_track_dependencies()
+        let need_reader_task = if self.should_track_dependencies()
             && !matches!(tracking, ReadCellTracking::Untracked)
             && let Some(reader_id) = reader
             && reader_id != task_id
         {
+            Some(reader_id)
+        } else {
+            None
+        };
+        let (mut task, reader_task) = if let Some(reader_id) = need_reader_task {
             // Immutable tasks never need dependency edges and can never be invalidated. Avoid
             // locking the reader too in that common case. When the task is still mutable, drop
             // the speculative lock and reacquire both locks together to preserve the invalidation
@@ -867,7 +877,7 @@ impl TurboTasksBackend {
             Some(InProgressState::InProgress(..) | InProgressState::Scheduled { .. })
         ) {
             return Ok(Err(self
-                .listen_to_cell(&mut task, task_id, &reader_task, cell)
+                .listen_to_cell(&mut task, task_id, need_reader_task, &reader_task, cell)
                 .0));
         }
         let is_cancelled = matches!(in_progress, Some(InProgressState::Canceled));
@@ -901,7 +911,8 @@ impl TurboTasksBackend {
         }
 
         // Listen to the cell and potentially schedule the task
-        let (listener, new_listener) = self.listen_to_cell(&mut task, task_id, &reader_task, cell);
+        let (listener, new_listener) =
+            self.listen_to_cell(&mut task, task_id, need_reader_task, &reader_task, cell);
         drop(reader_task);
         if !new_listener {
             return Ok(Err(listener));
@@ -927,6 +938,7 @@ impl TurboTasksBackend {
         &self,
         task: &mut impl TaskGuard,
         task_id: TaskId,
+        reader: Option<TaskId>,
         reader_task: &Option<impl TaskGuard>,
         cell: CellId,
     ) -> (EventListener, bool) {
@@ -935,6 +947,8 @@ impl TurboTasksBackend {
             move || {
                 if let Some(reader_desc) = reader_desc.as_ref() {
                     format!("try_read_task_cell (in progress) from {}", (reader_desc)())
+                } else if let Some(reader_id) = reader {
+                    format!("try_read_task_cell (in progress) from {reader_id:?}")
                 } else {
                     "try_read_task_cell (in progress, untracked)".to_string()
                 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -452,7 +452,15 @@ fn lock_task_and_optional_reader<'e, C: ExecuteContext<'e>>(
         // invalidation that races with dependency edge insertion.
         // TODO(sokra): solve this more performantly for mutable tasks.
         let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-        (task, Some(reader))
+        // The task can become immutable between the speculative task lock and the pair lock.
+        // Recheck under the final lock so callers can rely on a reader guard only being returned
+        // when dependency edges may still be added.
+        if task.immutable() && !cfg!(feature = "verify_immutable") {
+            drop(reader);
+            (task, None)
+        } else {
+            (task, Some(reader))
+        }
     }
 }
 
@@ -468,15 +476,12 @@ impl TurboTasksBackend {
         self.assert_not_persistent_calling_transient(reader, task_id, /* cell_id */ None);
 
         let mut ctx = self.execute_context(turbo_tasks);
-        let need_reader_task = if self.should_track_dependencies()
-            && !matches!(options.tracking, ReadTracking::Untracked)
-            && let Some(reader_id) = reader
-            && reader_id != task_id
-        {
-            Some(reader_id)
-        } else {
-            None
-        };
+        let need_reader_task = reader.and_then(|reader_id| {
+            (self.should_track_dependencies()
+                && !matches!(options.tracking, ReadTracking::Untracked)
+                && reader_id != task_id)
+                .then_some(reader_id)
+        });
         let (mut task, mut reader_task) =
             lock_task_and_optional_reader(&mut ctx, task_id, need_reader_task);
 
@@ -710,7 +715,6 @@ impl TurboTasksBackend {
             };
             if let Some(mut reader_task) = reader_task.take()
                 && options.tracking.should_track(result.is_err())
-                && (!task.immutable() || cfg!(feature = "verify_immutable"))
             {
                 #[cfg(feature = "trace_task_output_dependencies")]
                 let _span = tracing::trace_span!(
@@ -804,9 +808,7 @@ impl TurboTasksBackend {
             cell: CellId,
             key: Option<u64>,
         ) {
-            if let Some(mut reader_task) = reader_task
-                && (!task.immutable() || cfg!(feature = "verify_immutable"))
-            {
+            if let Some(mut reader_task) = reader_task {
                 let reader = reader.unwrap();
                 let reverse = CellRef { task: reader, cell };
                 if let Some(k) = key {
@@ -842,15 +844,12 @@ impl TurboTasksBackend {
         } = options;
 
         let mut ctx = self.execute_context(turbo_tasks);
-        let need_reader_task = if self.should_track_dependencies()
-            && !matches!(tracking, ReadCellTracking::Untracked)
-            && let Some(reader_id) = reader
-            && reader_id != task_id
-        {
-            Some(reader_id)
-        } else {
-            None
-        };
+        let need_reader_task = reader.and_then(|reader_id| {
+            (self.should_track_dependencies()
+                && !matches!(tracking, ReadCellTracking::Untracked)
+                && reader_id != task_id)
+                .then_some(reader_id)
+        });
         let (mut task, reader_task) =
             lock_task_and_optional_reader(&mut ctx, task_id, need_reader_task);
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -452,11 +452,18 @@ impl TurboTasksBackend {
             None
         };
         let (mut task, mut reader_task) = if let Some(reader_id) = need_reader_task {
-            // Having a task_pair here is not optimal, but otherwise this would lead to a race
-            // condition. See below.
-            // TODO(sokra): solve that in a more performant way.
-            let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-            (task, Some(reader))
+            // Immutable tasks never need dependency edges and can never be invalidated. Avoid
+            // locking the reader too in that common case. When the task is still mutable, drop
+            // the speculative lock and reacquire both locks together to preserve the invalidation
+            // race guarantee described below.
+            let task = ctx.task(task_id, TaskDataCategory::All);
+            if task.immutable() && !cfg!(feature = "verify_immutable") {
+                (task, None)
+            } else {
+                drop(task);
+                let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
+                (task, Some(reader))
+            }
         } else {
             (ctx.task(task_id, TaskDataCategory::All), None)
         };
@@ -823,11 +830,18 @@ impl TurboTasksBackend {
             && let Some(reader_id) = reader
             && reader_id != task_id
         {
-            // Having a task_pair here is not optimal, but otherwise this would lead to a race
-            // condition. See below.
-            // TODO(sokra): solve that in a more performant way.
-            let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-            (task, Some(reader))
+            // Immutable tasks never need dependency edges and can never be invalidated. Avoid
+            // locking the reader too in that common case. When the task is still mutable, drop
+            // the speculative lock and reacquire both locks together to preserve the invalidation
+            // race guarantee described below.
+            let task = ctx.task(task_id, TaskDataCategory::All);
+            if task.immutable() && !cfg!(feature = "verify_immutable") {
+                (task, None)
+            } else {
+                drop(task);
+                let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
+                (task, Some(reader))
+            }
         } else {
             (ctx.task(task_id, TaskDataCategory::All), None)
         };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -430,6 +430,32 @@ struct TaskExecutionCompletePrepareResult {
     pub is_session_dependent: bool,
 }
 
+fn lock_task_and_optional_reader<'e, C: ExecuteContext<'e>>(
+    ctx: &mut C,
+    task_id: TaskId,
+    reader_id: Option<TaskId>,
+) -> (C::TaskGuardImpl, Option<C::TaskGuardImpl>) {
+    let Some(reader_id) = reader_id else {
+        return (ctx.task(task_id, TaskDataCategory::All), None);
+    };
+
+    // Immutable tasks never need dependency edges and can never be invalidated. Avoid locking the
+    // reader too in that common case. When the task is still mutable, drop the speculative lock
+    // and reacquire both locks together to preserve the invalidation race guarantee.
+    let task = ctx.task(task_id, TaskDataCategory::All);
+    if task.immutable() && !cfg!(feature = "verify_immutable") {
+        (task, None)
+    } else {
+        drop(task);
+
+        // Having a task_pair here is not optimal, but locking the reader separately could lose an
+        // invalidation that races with dependency edge insertion.
+        // TODO(sokra): solve this more performantly for mutable tasks.
+        let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
+        (task, Some(reader))
+    }
+}
+
 // Operations
 impl TurboTasksBackend {
     fn try_read_task_output(
@@ -451,22 +477,8 @@ impl TurboTasksBackend {
         } else {
             None
         };
-        let (mut task, mut reader_task) = if let Some(reader_id) = need_reader_task {
-            // Immutable tasks never need dependency edges and can never be invalidated. Avoid
-            // locking the reader too in that common case. When the task is still mutable, drop
-            // the speculative lock and reacquire both locks together to preserve the invalidation
-            // race guarantee described below.
-            let task = ctx.task(task_id, TaskDataCategory::All);
-            if task.immutable() && !cfg!(feature = "verify_immutable") {
-                (task, None)
-            } else {
-                drop(task);
-                let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-                (task, Some(reader))
-            }
-        } else {
-            (ctx.task(task_id, TaskDataCategory::All), None)
-        };
+        let (mut task, mut reader_task) =
+            lock_task_and_optional_reader(&mut ctx, task_id, need_reader_task);
 
         fn listen_to_done_event(
             reader_description: Option<EventDescription>,
@@ -839,22 +851,8 @@ impl TurboTasksBackend {
         } else {
             None
         };
-        let (mut task, reader_task) = if let Some(reader_id) = need_reader_task {
-            // Immutable tasks never need dependency edges and can never be invalidated. Avoid
-            // locking the reader too in that common case. When the task is still mutable, drop
-            // the speculative lock and reacquire both locks together to preserve the invalidation
-            // race guarantee described below.
-            let task = ctx.task(task_id, TaskDataCategory::All);
-            if task.immutable() && !cfg!(feature = "verify_immutable") {
-                (task, None)
-            } else {
-                drop(task);
-                let (task, reader) = ctx.task_pair(task_id, reader_id, TaskDataCategory::All);
-                (task, Some(reader))
-            }
-        } else {
-            (ctx.task(task_id, TaskDataCategory::All), None)
-        };
+        let (mut task, reader_task) =
+            lock_task_and_optional_reader(&mut ctx, task_id, need_reader_task);
 
         let content = if final_read_hint {
             task.remove_cell_data(&cell, &get_value_type(cell.type_id()).persistence)


### PR DESCRIPTION
## What changed

Tracked output and cell reads now acquire the target task first. If the target is already immutable, the read skips locking the reader task because no dependency edge can be added and the target cannot be invalidated. Mutable targets drop the speculative target lock and reacquire the target/reader pair together, preserving the existing invalidation-race guarantee.

`verify_immutable` deliberately retains the pair-lock path. Listener diagnostics also preserve the tracked reader ID when the fast path skips its guard.

The separate current-task ID cache is in #96180. This PR is now backend-only so the lock-ordering change can receive focused backend review.

## Why

The previous path locked both the target and reader task for every tracked read. That synchronization is necessary for mutable targets but redundant once the target is immutable. Instrumentation found that 1,541,880 of 4,501,364 sampled tracked reads (34.254%) could use the bypass.

## Performance evidence

Measured at `0950e8ae05db20c33302f02257114f5b857edabc` on a dedicated 8-vCPU/16-GiB Vercel Sandbox with frozen side-by-side binaries.

These measurements are directional evidence, not precise estimates. Small percentage changes are difficult to resolve reliably. This campaign and #96180's incremental campaign used separate run sets: the absolute endpoint here does not match #96180's starting point, which demonstrates cross-campaign noise. The values must not be compared across PRs, and their percentages must not be added.

### Browser-driven HMR, 30-second B/C/C/B

- Evaluation: 20.771360 → 19.176645 ms (**-7.677%**)
- Commit: 21.714832 → 20.371425 ms (**-6.187%**)

### Production builds

- First 12-campaign matrix: **-1.931%**
- Complementary 12-campaign matrix: **-1.990%**
- Combined 24-campaign aggregate: **-1.959%**

Five of six balanced blocks favored the candidate. The conservative six-block 95% interval was -4.042% to +0.248%, so the production estimate is supporting evidence rather than a precise claim.

### Causal profiles

- HMR `Storage::access_pair_mut` self time fell from 3.19%/3.19% to 1.21%/1.18%.
- HMR voluntary context switches fell 32.898%.
- Production pair-access self time and voluntary context switches also fell; production voluntary switches changed -14.552%.
- All accepted perf captures reported zero lost samples.

## Validation

On the exact backend-only head (`9ccfd6753526f716466a9584fba8c8753b7d83bf`):

- Complete `turbo-tasks-backend` package tests, integrations, and doctests
- Complete backend package matrix with `--features verify_immutable`
- `cargo fmt --check -p turbo-tasks-backend`
- `cargo clippy -p turbo-tasks-backend --all-targets -- -D warnings`
- `git diff --check`
- Conflict-free merge-tree check against current `canary` (`5cdcbbb05b`)
