### PR TITLE
fix: avoid async iterator for server HMR events

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -781,6 +781,23 @@ function bindingToApi(
       )
     }
 
+    hmrEventsSubscribe(
+      chunkName: string,
+      target: HmrTarget.Server,
+      callback: (
+        err: Error | undefined,
+        update: TurbopackResult<NodeJsHmrUpdate> | undefined
+      ) => void
+    ) {
+      const task = binding.projectHmrEvents(
+        this._nativeProject,
+        chunkName,
+        target,
+        callback
+      )
+      return () => binding.rootTaskDispose(task)
+    }
+
     /**
      * Subscribe to the list of output chunk paths that can receive HMR updates.
      * Chunk paths are output file paths like "server/chunks/ssr/..._.js" for server

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -330,6 +330,19 @@ export interface Project {
     target: import('./index').HmrTarget.Server
   ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
 
+  /**
+   * Subscribe directly to server HMR events without allocating an async
+   * iterator promise for every update.
+   */
+  hmrEventsSubscribe(
+    identifier: string,
+    target: import('./index').HmrTarget.Server,
+    callback: (
+      err: Error | undefined,
+      update: TurbopackResult<NodeJsHmrUpdate> | undefined
+    ) => void
+  ): () => void
+
   hmrChunkNamesSubscribe(
     target: import('./index').HmrTarget
   ): AsyncIterableIterator<TurbopackResult<HmrChunkNames>>

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -176,13 +176,23 @@ function setupServerHmr(
       return
     }
 
-    let unsubscribe: (() => void) | undefined
-    let subscriptionFailed = false
+    let unsubscribeNative: (() => void) | undefined
+    let disposed = false
+    let isClearing = false
+    const queuedUpdates: NodeJsHmrUpdate[] = []
+
+    function dispose() {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      queuedUpdates.length = 0
+      unsubscribeNative?.()
+    }
 
     function handleSubscriptionError(err: unknown) {
       console.error('[Server HMR] Subscription error:', err)
-      subscriptionFailed = true
-      unsubscribe?.()
+      dispose()
       serverHmrSubscriptions.delete(chunkPath)
       try {
         const clearResult = clear()
@@ -196,11 +206,68 @@ function setupServerHmr(
       }
     }
 
+    function applyUpdate(update: NodeJsHmrUpdate) {
+      // Fully re-evaluate all chunks from disk. Clears the module cache and
+      // notifies browsers to refetch RSC.
+      if (update.type === 'restart') {
+        return clear()
+      }
+
+      if (update.type !== 'partial') {
+        return
+      }
+
+      const instruction = update.instruction
+      if (!instruction || instruction.type !== 'EcmascriptMergedUpdate') {
+        return
+      }
+
+      if (typeof __turbopack_server_hmr_apply__ === 'function') {
+        const applied = __turbopack_server_hmr_apply__(update)
+        if (!applied) {
+          return clear()
+        }
+      }
+    }
+
+    function handleClearComplete() {
+      isClearing = false
+      const queuedUpdate = queuedUpdates.shift()
+      if (queuedUpdate) {
+        processUpdate(queuedUpdate)
+      }
+    }
+
+    function processUpdate(update: NodeJsHmrUpdate) {
+      if (isClearing) {
+        queuedUpdates.push(update)
+        return
+      }
+
+      try {
+        let nextUpdate: NodeJsHmrUpdate | undefined = update
+        while (nextUpdate) {
+          const clearResult = applyUpdate(nextUpdate)
+          if (clearResult) {
+            isClearing = true
+            clearResult.then(handleClearComplete, handleSubscriptionError)
+            return
+          }
+          nextUpdate = queuedUpdates.shift()
+        }
+      } catch (subscriptionError) {
+        handleSubscriptionError(subscriptionError)
+      }
+    }
+
     let initialized = false
-    unsubscribe = project.hmrEventsSubscribe(
+    unsubscribeNative = project.hmrEventsSubscribe(
       chunkPath,
       HmrTarget.Server,
       (err, result) => {
+        if (disposed) {
+          return
+        }
         if (err) {
           handleSubscriptionError(err)
           return
@@ -213,46 +280,13 @@ function setupServerHmr(
           return
         }
 
-        try {
-          const update = result as NodeJsHmrUpdate
-
-          // Fully re-evaluate all chunks from disk. Clears the module cache and
-          // notifies browsers to refetch RSC.
-          if (update.type === 'restart') {
-            const clearResult = clear()
-            if (clearResult) {
-              clearResult.catch(handleSubscriptionError)
-            }
-            return
-          }
-
-          if (update.type !== 'partial') {
-            return
-          }
-
-          const instruction = update.instruction
-          if (!instruction || instruction.type !== 'EcmascriptMergedUpdate') {
-            return
-          }
-
-          if (typeof __turbopack_server_hmr_apply__ === 'function') {
-            const applied = __turbopack_server_hmr_apply__(update)
-            if (!applied) {
-              const clearResult = clear()
-              if (clearResult) {
-                clearResult.catch(handleSubscriptionError)
-              }
-            }
-          }
-        } catch (subscriptionError) {
-          handleSubscriptionError(subscriptionError)
-        }
+        processUpdate(result as NodeJsHmrUpdate)
       }
     )
-    if (subscriptionFailed) {
-      unsubscribe()
+    if (disposed) {
+      unsubscribeNative()
     } else {
-      serverHmrSubscriptions.set(chunkPath, unsubscribe)
+      serverHmrSubscriptions.set(chunkPath, dispose)
     }
   }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -155,10 +155,7 @@ declare const __turbopack_server_hmr_apply__:
   | ((update: NodeJsPartialHmrUpdate) => boolean)
   | undefined
 
-type ServerHmrSubscriptions = Map<
-  string,
-  AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
->
+type ServerHmrSubscriptions = Map<string, () => void>
 
 function setupServerHmr(
   project: Project,
@@ -179,45 +176,84 @@ function setupServerHmr(
       return
     }
 
-    const subscription = project.hmrEvents(chunkPath, HmrTarget.Server)
-    serverHmrSubscriptions.set(chunkPath, subscription)
+    let unsubscribe: (() => void) | undefined
+    let subscriptionFailed = false
 
-    // Start listening for changes in background
-    ;(async () => {
-      // Skip initial state
-      await subscription.next()
+    function handleSubscriptionError(err: unknown) {
+      console.error('[Server HMR] Subscription error:', err)
+      subscriptionFailed = true
+      unsubscribe?.()
+      serverHmrSubscriptions.delete(chunkPath)
+      try {
+        const clearResult = clear()
+        if (clearResult) {
+          clearResult.catch((clearError) => {
+            console.error('[Server HMR] Failed to clear caches:', clearError)
+          })
+        }
+      } catch (clearError) {
+        console.error('[Server HMR] Failed to clear caches:', clearError)
+      }
+    }
 
-      for await (const result of subscription) {
-        const update = result as NodeJsHmrUpdate
-
-        // Fully re-evaluate all chunks from disk. Clears the module cache and
-        // notifies browsers to refetch RSC.
-        if (update.type === 'restart') {
-          await clear()
-          continue
+    let initialized = false
+    unsubscribe = project.hmrEventsSubscribe(
+      chunkPath,
+      HmrTarget.Server,
+      (err, result) => {
+        if (err) {
+          handleSubscriptionError(err)
+          return
+        }
+        if (!result) {
+          return
+        }
+        if (!initialized) {
+          initialized = true
+          return
         }
 
-        if (update.type !== 'partial') {
-          continue
-        }
+        try {
+          const update = result as NodeJsHmrUpdate
 
-        const instruction = update.instruction
-        if (!instruction || instruction.type !== 'EcmascriptMergedUpdate') {
-          continue
-        }
-
-        if (typeof __turbopack_server_hmr_apply__ === 'function') {
-          const applied = __turbopack_server_hmr_apply__(update)
-          if (!applied) {
-            await clear()
+          // Fully re-evaluate all chunks from disk. Clears the module cache and
+          // notifies browsers to refetch RSC.
+          if (update.type === 'restart') {
+            const clearResult = clear()
+            if (clearResult) {
+              clearResult.catch(handleSubscriptionError)
+            }
+            return
           }
+
+          if (update.type !== 'partial') {
+            return
+          }
+
+          const instruction = update.instruction
+          if (!instruction || instruction.type !== 'EcmascriptMergedUpdate') {
+            return
+          }
+
+          if (typeof __turbopack_server_hmr_apply__ === 'function') {
+            const applied = __turbopack_server_hmr_apply__(update)
+            if (!applied) {
+              const clearResult = clear()
+              if (clearResult) {
+                clearResult.catch(handleSubscriptionError)
+              }
+            }
+          }
+        } catch (subscriptionError) {
+          handleSubscriptionError(subscriptionError)
         }
       }
-    })().catch(async (err) => {
-      console.error('[Server HMR] Subscription error:', err)
-      serverHmrSubscriptions.delete(chunkPath)
-      await clear()
-    })
+    )
+    if (subscriptionFailed) {
+      unsubscribe()
+    } else {
+      serverHmrSubscriptions.set(chunkPath, unsubscribe)
+    }
   }
 
   // Listen to the Rust bindings update us on changing server HMR chunk paths
@@ -242,8 +278,7 @@ function setupServerHmr(
         }
 
         for (const chunkPath of chunkPathsToRemove) {
-          const subscription = serverHmrSubscriptions.get(chunkPath)
-          subscription?.return?.()
+          serverHmrSubscriptions.get(chunkPath)?.()
           serverHmrSubscriptions.delete(chunkPath)
         }
 

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -367,6 +367,81 @@ describe('next.rs api', () => {
     )
   })
 
+  it('should deliver server HMR updates without an async iterator', async () => {
+    const entrypointsSubscription = project.entrypointsSubscribe()
+    const entrypoints = (await entrypointsSubscription.next()).value
+    await entrypointsSubscription.return()
+    if (!('routes' in entrypoints)) {
+      throw new Error('Entrypoints not available due to compilation errors')
+    }
+
+    const route = entrypoints.routes.get('/app')
+    if (route.type !== 'app-page') {
+      throw new Error('Expected an app page route')
+    }
+    await route.pages[0].htmlEndpoint.writeToDisk()
+
+    const chunkNamesSubscription = project.hmrChunkNamesSubscribe(
+      HmrTarget.Server
+    )
+    let chunkNames: string[] = []
+    while (chunkNames.length === 0) {
+      const chunkNamesResult = await chunkNamesSubscription.next()
+      if (chunkNamesResult.done) {
+        throw new Error('Server HMR chunk names subscription ended')
+      }
+      chunkNames = chunkNamesResult.value.chunkNames
+    }
+    await chunkNamesSubscription.return()
+
+    let resolveUpdate!: (value: TurbopackResult) => void
+    let rejectUpdate!: (error: Error) => void
+    const updateReceived = new Promise<TurbopackResult>((resolve, reject) => {
+      resolveUpdate = resolve
+      rejectUpdate = reject
+    })
+    const initialized: Promise<void>[] = []
+    const unsubscribe = chunkNames.map((chunkName) => {
+      let resolveInitialized!: () => void
+      let rejectInitialized!: (error: Error) => void
+      initialized.push(
+        new Promise<void>((resolve, reject) => {
+          resolveInitialized = resolve
+          rejectInitialized = reject
+        })
+      )
+      let isInitialized = false
+      return project.hmrEventsSubscribe(
+        chunkName,
+        HmrTarget.Server,
+        (err, update) => {
+          if (err) {
+            rejectInitialized(err)
+            rejectUpdate(err)
+          } else if (!isInitialized) {
+            isInitialized = true
+            resolveInitialized()
+          } else if (update?.type === 'partial') {
+            resolveUpdate(update)
+          }
+        }
+      )
+    })
+    const file = 'app/app/page.tsx'
+    const originalContent = await next.readFile(file)
+    try {
+      await Promise.all(initialized)
+      await next.patchFile(file, appPageCode('callback update'))
+      await expect(updateReceived).resolves.toMatchObject({
+        type: 'partial',
+        issues: [],
+      })
+    } finally {
+      unsubscribe.forEach((dispose) => dispose())
+      await next.patchFile(file, originalContent)
+    }
+  })
+
   it('should detect the correct routes', async () => {
     const entrypointsSubscription = project.entrypointsSubscribe()
     const entrypoints = await entrypointsSubscription.next()


### PR DESCRIPTION
### What?

This change adds a direct callback-based subscription for Turbopack server HMR events and uses it in the server hot reloader.

The existing async iterator remains unchanged for client HMR and other consumers. Server subscriptions now retain a small cleanup function that disposes the native root task when the chunk is removed.

A native integration regression test verifies that server HMR updates are delivered through the callback subscription.

### Why?

The previous server HMR path kept one async iterator per server chunk and processed every update through `for await`. This creates async-generator and Promise resources that React Flight's development `async_hooks` instrumentation tracks.

In long-running Turbopack development sessions, that additional async ancestry can contribute to the `pendingOperations` map reaching V8's limit, producing a crash whose stack ends in `createIterator.next` with `RangeError: Map maximum size exceeded`.

Using the native callback directly removes async-iterator Promise allocation from the server HMR update path while preserving the existing iterator behavior everywhere else.

This change is intentionally scoped to the server HMR iterator path. It does not claim to solve every possible source of React Flight async-debug retention.

Related to #85666 and #96140. Alternative approach to #91704.

### How?

The regression test was confirmed to fail before the implementation because the callback subscription API did not exist.

Validation performed on Node.js 20.20.2 with pnpm 10.33.0:

- `next-rs-api.test.ts`: 27 tests passed, 1 existing test skipped, and 15 snapshots passed.
- `server-hmr.test.ts` with Turbopack: 11 tests passed.
- Prettier check passed.
- ESLint passed for all changed files.
- The `next` package type generation and release build passed.
- The commit is cryptographically signed and reported as `Verified` by GitHub.

<!-- NEXT_JS_LLM -->
