### PR TITLE
[ci] Background some steps in build_reusable to reduce setup overhead, remove unneeded lld installation

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,13 +16,6 @@ runs:
         rustflags: ''
         cache: false
 
-    - name: 'Install LLD (LLVM Linker) for Linux'
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get -y -o DPkg::Lock::Timeout=60 update
-        sudo apt-get -o DPkg::Lock::Timeout=60 -y install lld
-
     - name: 'Install cargo-binstall'
       uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -182,6 +182,13 @@ jobs:
           fetch-depth: 25
           persist-credentials: false
 
+      # Depends on rust-toolchain.toml in the checkout
+      - name: Install Rust
+        id: install-rust
+        uses: ./.github/actions/setup-rust
+        background: true
+        if: ${{ inputs.uploadNativeArtifact || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
+
       - name: Install fnm
         run: |
           FNM_VERSION=v1.39.0
@@ -250,22 +257,6 @@ jobs:
           node --version
           pnpm --version
 
-      - name: Get pnpm store directory
-        id: get-store-path
-        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
-
-      # local action -> needs to run after checkout
-      - name: Install Rust
-        uses: ./.github/actions/setup-rust
-        if: ${{ inputs.uploadNativeArtifact || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
-
-      - name: Install nextest
-        if: ${{ inputs.needsNextest == 'yes' }}
-        run: cargo binstall --no-confirm --locked cargo-nextest@0.9.133
-
-      - run: rustc --version
-        if: ${{ inputs.uploadNativeArtifact || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
-
       - run: corepack prepare --activate yarn@1.22.19 && npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
       # clean up any previous artifacts to avoid hitting disk space limits
@@ -280,6 +271,16 @@ jobs:
       # normalize versions before build-native for better cache hits
       - run: node scripts/normalize-version-bump.js
         name: normalize versions
+
+      - name: Wait for Rust toolchain
+        wait: install-rust
+
+      - name: Install nextest
+        if: ${{ inputs.needsNextest == 'yes' }}
+        run: cargo binstall --no-confirm --locked cargo-nextest@0.9.133
+
+      - run: rustc --version
+        if: ${{ inputs.uploadNativeArtifact || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
       - name: Start sccache
         uses: ./.github/actions/sccache
@@ -340,6 +341,10 @@ jobs:
       - run: git checkout .
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
+      - name: Get pnpm store directory
+        id: get-store-path
+        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
+
       - name: Cache pnpm store
         # conditions must be subset of runs executing pnpm install, otherwise we
         # risk caching an incomplete store
@@ -353,6 +358,7 @@ jobs:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
           key: pnpm-store-root-v1-${{ hashFiles('pnpm-lock.yaml') }}
           # Do not use restore-keys since it leads to indefinite growth of the cache.
+
       - run: pnpm install
         # condititions must be superset of cache step, otherwise we risk running install without a cache and then caching the incomplete store.
         if: ${{ inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes' }}
@@ -362,10 +368,8 @@ jobs:
         working-directory: turbopack/crates/turbopack-tracing/tests/node-file-trace
         run: pnpm install --recursive
 
-      - run: ANALYZE=1 pnpm build
-        if: ${{ inputs.skipInstallBuild != 'yes' }}
-
       - name: Install Playwright browsers
+        background: true
         if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' }}
         env:
           PLAYWRIGHT_BROWSERS: ${{ inputs.browser }}
@@ -391,8 +395,12 @@ jobs:
           echo "Test timings loaded ($(wc -c < test-timings.json) bytes)"
 
       - name: Fetch test timings via turbo
+        background: true
         if: ${{ inputs.testTimingsArtifact == '' }}
         run: pnpm dlx turbo@${TURBO_VERSION} run get-test-timings -- --build ${{ github.sha }}
+
+      - run: ANALYZE=1 pnpm build
+        if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - name: Normalize input step names into path key
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -411,6 +419,9 @@ jobs:
           key: next-test-passed-${{ steps.var.outputs.input_step_key }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
           restore-keys: |
             next-test-passed-${{ steps.var.outputs.input_step_key }}-${{ github.run_id }}-
+
+      - name: Wait for background setup steps
+        wait-all:
 
       - run: ${{ inputs.afterBuild }}
         id: after-build


### PR DESCRIPTION
This is a pretty minor win, but it can save a few seconds per job.

https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

Also remove the installation of `lld` for rustc with `apt-get`. It's very slow, and rustc should already ship with `lld` these days? The composite action to install the rust toolchain isn't run often (test shards download a prebuilt native binary), but `build-native` it can block other jobs from running and become a bottleneck.

Testing the full `build-and-deploy` job, which uses the rust install action: https://github.com/vercel/next.js/actions/runs/30138483769