### PR TITLE
[sourcemaps] Reuse source map payloads and consumers across stack frames

### DIFF
--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -47,6 +47,31 @@ export interface BasicSourceMapPayload {
 
 export type ModernSourceMapPayload = BasicSourceMapPayload | IndexSourceMap
 
+// `SourceMap#payload` deep-clones the payload on every access — expensive
+// for large chunk maps — so the clone is shared per `SourceMap` instance,
+// which Node.js memoizes per script.
+const sourceMapPayloads = new WeakMap<SourceMap, ModernSourceMapPayload>()
+
+/**
+ * Like `module.findSourceMap`, but returns the source map's payload without
+ * cloning it on every call. Callers must not mutate the returned payload.
+ * Throws like `module.findSourceMap` does on invalid source maps.
+ */
+export function findSourceMapPayload(
+  sourceURL: string
+): ModernSourceMapPayload | undefined {
+  const sourceMap = findSourceMap(sourceURL)
+  if (sourceMap === undefined) {
+    return undefined
+  }
+  let payload = sourceMapPayloads.get(sourceMap)
+  if (payload === undefined) {
+    payload = sourceMap.payload as ModernSourceMapPayload
+    sourceMapPayloads.set(sourceMap, payload)
+  }
+  return payload
+}
+
 export function sourceMapIgnoreListsEverything(
   sourceMap: BasicSourceMapPayload
 ): boolean {
@@ -125,16 +150,15 @@ export function filterStackFrameDEV(
     // Node.js loads source maps eagerly so this call is cheap.
     // TODO: ESM sourcemaps are O(1) but CommonJS sourcemaps are O(Number of CJS modules).
     // Make sure this doesn't adversely affect performance when CJS is used by Next.js.
-    const sourceMap = findSourceMap(sourceURL)
-    if (sourceMap === undefined) {
-      // No source map assoicated.
-      // TODO: Node.js types should reflect that `findSourceMap` can return `undefined`.
+    const payload = findSourceMapPayload(sourceURL)
+    if (payload === undefined) {
+      // No source map associated.
       return true
     }
     const sourceMapPayload = findApplicableSourceMapPayload(
       line1 - 1,
       column1 - 1,
-      sourceMap.payload
+      payload
     )
     if (sourceMapPayload === undefined) {
       // No source map section applicable to the frame.
@@ -219,7 +243,7 @@ export function findSourceMapURLDEV(
   if (sourceMapURL === undefined) {
     let sourceMapPayload: ModernSourceMapPayload | undefined
     try {
-      sourceMapPayload = findSourceMap(scriptNameOrSourceURL)?.payload
+      sourceMapPayload = findSourceMapPayload(scriptNameOrSourceURL)
     } catch (cause) {
       console.error(
         `${scriptNameOrSourceURL}: Invalid source map. Only conformant source maps can be used to find the original code. Cause: ${cause}`

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -1,4 +1,3 @@
-import { findSourceMap as nativeFindSourceMap } from 'module'
 import * as path from 'path'
 import * as url from 'url'
 import type * as util from 'util'
@@ -7,6 +6,7 @@ import {
   type ModernSourceMapPayload,
   devirtualizeReactServerURL,
   findApplicableSourceMapPayload,
+  findSourceMapPayload,
   ignoreListAnonymousStackFramesIfSandwiched as ignoreListAnonymousStackFramesIfSandwichedGeneric,
   sourceMapIgnoreListsEverything,
 } from './lib/source-maps'
@@ -59,6 +59,38 @@ type SourceMapCache = Map<
   string,
   null | { map: SyncSourceMapConsumer; payload: ModernSourceMapPayload }
 >
+
+// Constructing a consumer indexes the whole payload — expensive for large
+// chunk maps and previously paid per frame — so consumers are shared across
+// all frames and errors whose lookups returned the same payload. The inner
+// key is the URL the consumer resolves relative `sources` against.
+const sourceMapConsumers = new WeakMap<
+  ModernSourceMapPayload,
+  Map<string, SyncSourceMapConsumer>
+>()
+
+function getOrCreateSourceMapConsumer(
+  payload: ModernSourceMapPayload,
+  sourceMapURL: string
+): SyncSourceMapConsumer {
+  let consumersByURL = sourceMapConsumers.get(payload)
+  let consumer = consumersByURL?.get(sourceMapURL)
+  if (consumer === undefined) {
+    consumer = new SyncSourceMapConsumer(
+      payload,
+      // @ts-expect-error: our typings don't include this parameter but it is here.
+      sourceMapURL
+    )
+    if (consumersByURL === undefined) {
+      consumersByURL = new Map()
+      // Throws for payloads that aren't objects; those are invalid source
+      // maps anyway, and the caller reports them.
+      sourceMapConsumers.set(payload, consumersByURL)
+    }
+    consumersByURL.set(sourceMapURL, consumer)
+  }
+  return consumer
+}
 
 function frameToString(
   methodName: string | null,
@@ -197,8 +229,7 @@ function getSourcemappedFrameIfPossible(
     }
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined
     try {
-      const sourceMap = nativeFindSourceMap(sourceURL)
-      maybeSourceMapPayload = sourceMap?.payload
+      maybeSourceMapPayload = findSourceMapPayload(sourceURL)
     } catch (cause) {
       // We should not log an actual error instance here because that will re-enter
       // this codepath during error inspection and could lead to infinite recursion.
@@ -234,9 +265,8 @@ function getSourcemappedFrameIfPossible(
       // URI. `sourceURL` is already devirtualized so that relative `sources`
       // resolve against the real chunk URL, not React's virtual one.
       const sourceMapURL = sourceURL + '.map'
-      sourceMapConsumer = new SyncSourceMapConsumer(
+      sourceMapConsumer = getOrCreateSourceMapConsumer(
         sourceMapPayload,
-        // @ts-expect-error: our typings don't include this parameter but it is here.
         sourceMapURL
       )
     } catch (cause) {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/95946.

Every fake stack frame is eval'd as its own script, so error formatting resolved a source map once per frame. This sucks for two reasons: `SourceMap#payload` returns a deep clone of the payload *on every access*, and constructing a `SyncSourceMapConsumer` indexes the whole payload. So an error with 50 fake frames pointing into one chunk cloned that chunk's map 50 times and indexed it 50 times.

This change caches both steps per map instead of per script. `findSourceMapPayload` wraps `module.findSourceMap` and reads payload only once per `SourceMap` instance. This works because Node.js keeps one instance per script, so the instance is a reliable identity for "same map". (This also helps `filterStackFrameDEV`, which cloned the payload for every frame it filtered.) Consumers are cached in a WeakMap with (payload, base URL) pairs as a key since that's what they vary by. (Note that consumer sharing only works because the payload memo makes references stable, that's why they're in one commit.)

This lets us share computation for identical sourcemaps despite them being used by different virtual frames.

I previously tried to do this by keying a map from a physical filename to the sourcemap, but as noted in https://github.com/vercel/next.js/pull/95946#discussion_r3613450061, each fake frame could technically receive a different map, even if we don't do that. Caching based on returned value's identity lets us preserve the ability to be more granular later without worrying that the cache will start behaving incorrectly.

## Test Plan

Microbench (20 errors × 20 fake frames, 5.6MB map, native path): canary 688.2 ms/error → this commit 0.2 ms/error. 

On a real devserver route with an artificially deep error (50-deep stacks in a chunk with a 19MB map), the route serve time goes down from ~400ms to ~70ms.