### PR TITLE
Pass fallback params to the dev validation worker as maps

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6302,20 +6302,14 @@ export async function runValidationInDevFromSnapshot(
     installGlobalModuleLoadingHandlers(componentMod, true, false)
   }
 
-  // The request's fallback params reproduce `ctx.getDynamicParamFromSegment`
-  // exactly, so the depth-loop segment keys match the seed render's Flight. The
-  // validation set (below) is separate and only marks params unknown in the
+  // `requestFallbackRouteParams` reproduces `ctx.getDynamicParamFromSegment`
+  // exactly, so the depth-loop segment keys match the seed render's Flight.
+  // `fallbackRouteParams` is separate and only marks params unknown in the
   // prerender stores.
   //
   // TODO: Those two fallback params sets are very confusing in the whole code
   // base. We should maybe refactor this to make their different roles clearer.
-  const requestFallbackRouteParams = message.requestFallbackRouteParams
-    ? new Map(message.requestFallbackRouteParams)
-    : null
-
-  const fallbackRouteParams = message.fallbackRouteParams
-    ? new Map(message.fallbackRouteParams)
-    : null
+  const { requestFallbackRouteParams, fallbackRouteParams } = message
 
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
     message.interpolatedParams,

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -1,5 +1,5 @@
 import type { Params } from '../request/params'
-import type { OpaqueFallbackRouteParamEntries } from '../request/fallback-params'
+import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 import type { NextParsedUrlQuery } from '../request-meta'
 import type { PrefetchingMode } from './app-render'
 import type { NextConfigComplete, ValidationLevel } from '../config-shared'
@@ -80,14 +80,13 @@ export interface DevValidationSnapshot {
   // closed over. The worker rebuilds `getDynamicParamFromSegment` from these
   // (with `interpolatedParams` and `optimisticRouting`), so the depth-loop
   // segment keys match the seed render's Flight. It is null for a request whose
-  // params all resolve to concrete values. Carried as map entries (like
-  // `fallbackRouteParams`) so both survive structured-clone transport.
-  requestFallbackRouteParams: OpaqueFallbackRouteParamEntries | null
+  // params all resolve to concrete values.
+  requestFallbackRouteParams: OpaqueFallbackRouteParams | null
   // The validation fallback params, passed to `runValidationInDev` and its
   // prerender stores. They mark params unknown so that accessing one during the
   // simulated prefetch is treated as dynamic. This set may include params that
   // `requestFallbackRouteParams` does not.
-  fallbackRouteParams: OpaqueFallbackRouteParamEntries | null
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
   optimisticRouting: boolean
   forceStatic: boolean | undefined
   validationLevel: ValidationLevel

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -78,12 +78,8 @@ export async function buildDevValidationSnapshot(
       hmrRefreshHash: requestStore.hmrRefreshHash,
     },
     interpolatedParams: ctx.interpolatedParams,
-    requestFallbackRouteParams: ctx.fallbackRouteParams
-      ? [...ctx.fallbackRouteParams.entries()]
-      : null,
-    fallbackRouteParams: fallbackRouteParams
-      ? [...fallbackRouteParams.entries()]
-      : null,
+    requestFallbackRouteParams: ctx.fallbackRouteParams,
+    fallbackRouteParams,
     optimisticRouting: ctx.renderOpts.experimental.optimisticRouting,
     forceStatic: ctx.workStore.forceStatic,
     validationLevel: ctx.workStore.validationLevel,


### PR DESCRIPTION
The dev validation snapshot flattened both fallback param sets into arrays of entries before handing them to the worker, and the worker rebuilt a `Map` from each one on the other side. Neither step is needed, because the structured clone that carries the snapshot across the `worker_threads` boundary supports `Map` natively, so the maps can travel as they are. Dropping the conversion on both ends also lets the two snapshot fields be typed as `OpaqueFallbackRouteParams` directly, and it makes them consistent with `rootParams` and `implicitTags`, which the snapshot already passes through untouched.

The neighbouring `headers` spread stays as it is, because `Headers` is not a structured-cloneable type and those entries genuinely do have to be materialized before the snapshot is sent.