### PR TITLE
Retry the source map lookup with a plain path

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -243,6 +243,25 @@ function getSourcemappedFrameIfPossible(
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined
     try {
       maybeSourceMapPayload = findSourceMapPayload(sourceURL)
+
+      if (
+        maybeSourceMapPayload === undefined &&
+        sourceURL.startsWith('file://')
+      ) {
+        // Devirtualizing React's fake frame URL decodes the path, while Node.js
+        // keys its source map cache by the `pathToFileURL` encoding of the same
+        // path, so a path containing characters that encoding escapes (such as
+        // the brackets in Turbopack's `[root-of-the-server]` chunks) misses
+        // above. Node.js also accepts the plain path, which is unambiguous for
+        // both interpretations, so retry with that before giving up.
+        //
+        // TODO(veil): Making React's fake frame URLs reversible, as proposed in
+        // https://github.com/react/react/pull/37105, would let the first lookup
+        // succeed on its own and retire this retry.
+        maybeSourceMapPayload = findSourceMapPayload(
+          url.fileURLToPath(sourceURL)
+        )
+      }
     } catch (cause) {
       // We should not log an actual error instance here because that will re-enter
       // this codepath during error inspection and could lead to infinite recursion.

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/dynamic/page.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/dynamic/page.tsx
@@ -1,0 +1,5 @@
+export default async function DynamicPage() {
+  const { readCookie } = await import('./read-cookie')
+
+  return <p id="value">{await readCookie()}</p>
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/dynamic/read-cookie.ts
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/dynamic/read-cookie.ts
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export async function readCookie(): Promise<string> {
+  const store = await cookies()
+  return store.get('probe')?.value ?? 'none'
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/layout.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/page.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/static/page.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/static/page.tsx
@@ -1,0 +1,5 @@
+import { readCookie } from './read-cookie'
+
+export default async function StaticPage() {
+  return <p id="value">{await readCookie()}</p>
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/static/read-cookie.ts
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/static/read-cookie.ts
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export async function readCookie(): Promise<string> {
+  const store = await cookies()
+  return store.get('probe')?.value ?? 'none'
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/dev-validation-worker-source-maps.test.ts
+++ b/test/development/app-dir/dev-validation-worker-source-maps/dev-validation-worker-source-maps.test.ts
@@ -1,0 +1,114 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getDevCliValidationOutput } from 'e2e-utils/instant-validation'
+
+// The dev validation worker symbolicates the frames it logs on its own thread,
+// where Node.js caches source maps only for the chunk files that thread loaded.
+// The worker never renders server components, and the built entry reaches
+// segment modules through lazy getters, so it holds maps only for what
+// `loadComponents` pulled in. Maps are cached per chunk file rather than per
+// module, so code that stays in the route's own chunk still resolves, while a
+// module the bundler splits into a chunk of its own does not. Each route below
+// owns its copy of the module, because a module shared between routes lands in
+// whichever chunk the first compiled route put it in, which would make these
+// snapshots depend on the order the routes run in.
+describe('dev-validation-worker-source-maps', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    env: { NEXT_TEST_LOG_VALIDATION: '1' },
+  })
+
+  it('symbolicates a cookie read in a statically imported module', async () => {
+    const browser = await next.browser('/static')
+
+    // The module stays in the route's own chunk, which the worker loads, so its
+    // frames resolve the same way they do for in-process validation.
+    expect(
+      await getDevCliValidationOutput(await browser.url(), () => next.cliOutput)
+    ).toMatchInlineSnapshot(`
+     "Error: Route "/static": Next.js encountered runtime data during prerendering.
+
+     \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+     Ways to fix this:
+       - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+       - [block] Set \`export const instant = false\` to allow a blocking route
+
+     Learn more: https://nextjs.org/docs/messages/blocking-prerender-runtime
+         at readCookie (app/static/read-cookie.ts:4:30)
+         at StaticPage (app/static/page.tsx:4:41)
+       2 |
+       3 | export async function readCookie(): Promise<string> {
+     > 4 |   const store = await cookies()
+         |                              ^
+       5 |   return store.get('probe')?.value ?? 'none'
+       6 | }
+       7 |"
+    `)
+  })
+
+  it('symbolicates a cookie read in a dynamically imported module', async () => {
+    const browser = await next.browser('/dynamic')
+    const output = await getDevCliValidationOutput(
+      await browser.url(),
+      () => next.cliOutput
+    )
+
+    // The module lands in a chunk of its own, which the worker never loads, so
+    // it cannot map the frame. In-process validation resolves it, so this is a
+    // regression from running validation on a worker.
+    if (isTurbopack) {
+      // Turbopack loses the location entirely.
+      //
+      // TODO(veil): Give the worker a source map lookup that does not depend on
+      // the chunk having been evaluated on its thread, by reading the `.map`
+      // Turbopack writes next to the chunk, so that this frame reads like the
+      // statically imported one above.
+      expect(output).toMatchInlineSnapshot(`
+       "Error: Route "/dynamic": Next.js encountered runtime data during prerendering.
+
+       \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+       Ways to fix this:
+         - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+         - [block] Set \`export const instant = false\` to allow a blocking route
+
+       Learn more: https://nextjs.org/docs/messages/blocking-prerender-runtime
+           at readCookie (<next-dist-dir>)
+           at DynamicPage (app/dynamic/page.tsx:4:31)
+         2 |   const { readCookie } = await import('./read-cookie')
+         3 |
+       > 4 |   return <p id="value">{await readCookie()}</p>
+           |                               ^
+         5 | }
+         6 |"
+      `)
+    } else {
+      // Webpack keeps the module path but reports the position it has in the
+      // compiled output. It holds its dev source maps in the compiler rather
+      // than writing them next to the chunks, so unlike for Turbopack there is
+      // nothing on disk for the worker to read instead.
+      //
+      // TODO(veil): Turn `experimental.devValidationWorker` off for Webpack
+      // until the worker can resolve these frames.
+      expect(output).toMatchInlineSnapshot(`
+       "Error: Route "/dynamic": Next.js encountered runtime data during prerendering.
+
+       \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+       Ways to fix this:
+         - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+         - [block] Set \`export const instant = false\` to allow a blocking route
+
+       Learn more: https://nextjs.org/docs/messages/blocking-prerender-runtime
+           at readCookie (webpack-internal:///(rsc)/./app/dynamic/read-cookie.ts:8:78)
+           at DynamicPage (app/dynamic/page.tsx:4:31)
+         2 |   const { readCookie } = await import('./read-cookie')
+         3 |
+       > 4 |   return <p id="value">{await readCookie()}</p>
+           |                               ^
+         5 | }
+         6 |"
+      `)
+    }
+  })
+})

--- a/test/development/app-dir/dev-validation-worker-source-maps/next.config.js
+++ b/test/development/app-dir/dev-validation-worker-source-maps/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Running `test/e2e/app-dir/instant-validation/suspense-boundaries.test.ts` locally on Node.js 24 currently fails in the two "missing suspense around search params" cases: stacks that should read `app/…/page.tsx:40:18` are logged as raw `about://React/Prefetch/file:///…/%5Broot-of-the-server%5D…` URLs, so the validation errors printed to the terminal no longer point at any source. CI is green on the same commit, because it runs Node.js 20. The dev validation worker (#96153) and the switch to `file:` source maps for Turbopack (#95946) landed hours apart, and the worker's branch predated the source map change, so the two first met on canary, where the older Node.js hid the result.

Symbolicating a frame that React spliced in from another environment means decoding the chunk path out of its `about://React/…` URL and asking Node.js for that chunk's source map. Decoding returns the path as written, while Node.js keys its cache by the `pathToFileURL` encoding of the same path, and from Node.js 22 on that encoding escapes the brackets in Turbopack's `[root-of-the-server]` chunk names, so the lookup misses. Node.js 20 leaves brackets alone, which is why the same code resolves there.

PR #95946 anticipated the mismatch and left it as a follow-up, because on the main thread a miss is only wasteful: Turbopack hands back the chunk's map instead, which means parsing one the process had already parsed and cached. The validation worker runs on its own thread with no access to the Turbopack project, so there the miss is final. Node.js also accepts the plain path as a cache key, unambiguously for both a CommonJS absolute path and an ESM `file:` URL, so we retry with it before giving up. Making React's fake frame URLs reversible, as proposed in https://github.com/react/react/pull/37105, would let the first lookup succeed on its own and retire the retry.

The test added here pins down what the worker can symbolicate at all. It caches maps per chunk file in its own isolate and never renders server components, so a statically imported module sits in a chunk it has already loaded and resolves, while a dynamically imported one gets a chunk of its own that is never loaded and does not. The snapshots for that second route record broken output on purpose: in-process validation resolves the frame, so losing it is a regression from moving validation onto a worker, and it affects Turbopack (no location) and Webpack (compiled positions) alike. Follow-ups address each.

The snapshots are recorded with the retry applied rather than before it. Without it Turbopack's output differs between Node.js 20 and 22, and the broken URLs embed the test's temporary install directory, which changes on every run, so no stable recording exists. One consequence is that CI cannot fail on a regression of the retry itself; that was checked by running the new suite under Node.js 24.