### PR TITLE
Fix dev overlay symbolication for project paths needing percent-encoding

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2343,10 +2343,8 @@ async fn project_trace_source_operation(
 
     let (original_file, line, column, method_name, is_ignored) = match token {
         Token::Original(token) => (
-            match urlencoding::decode(&token.original_file)? {
-                Cow::Borrowed(_) => token.original_file,
-                Cow::Owned(original_file) => RcStr::from(original_file),
-            },
+            // Still percent-encoded, like the URIs it's compared against.
+            token.original_file,
             // JS stack frames are 1-indexed, source map tokens are 0-indexed
             Some(token.original_line + 1),
             Some(token.original_column + 1),
@@ -2361,36 +2359,51 @@ async fn project_trace_source_operation(
         }
     };
 
+    // Turns a percent-encoded URI fragment back into a path for output.
+    fn decode_uri_fragment(value: &str) -> Result<RcStr> {
+        Ok(match urlencoding::decode(value)? {
+            Cow::Borrowed(borrowed) => RcStr::from(borrowed),
+            Cow::Owned(owned) => RcStr::from(owned),
+        })
+    }
+
     let project_root_uri =
         uri_from_file(container.project().project_root_path().owned().await?, None).await? + "/";
+    // Relative paths are computed on decoded inputs: they come from
+    // different encoders that disagree on characters like `[` vs `%5B`.
+    let current_directory_path = decode_uri_fragment(&current_directory_file_url)?;
     let (file, original_file) =
         if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
             // Client code uses file://
             (
                 RcStr::from(
-                    get_relative_path_to(&current_directory_file_url, &original_file)
-                        // TODO(sokra) remove this to include a ./ here to make it a relative path
-                        .trim_start_matches("./"),
-                ),
-                Some(RcStr::from(source_file)),
-            )
-        } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT) {
-            // Server code uses turbopack:///[project]
-            // TODO should this also be file://?
-            (
-                RcStr::from(
                     get_relative_path_to(
-                        &current_directory_file_url,
-                        &format!("{project_root_uri}{source_file}"),
+                        &current_directory_path,
+                        &decode_uri_fragment(&original_file)?,
                     )
                     // TODO(sokra) remove this to include a ./ here to make it a relative path
                     .trim_start_matches("./"),
                 ),
-                Some(RcStr::from(source_file)),
+                Some(decode_uri_fragment(source_file)?),
+            )
+        } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT) {
+            // Server code uses turbopack:///[project]
+            // TODO should this also be file://?
+            let source_file = decode_uri_fragment(source_file)?;
+            (
+                RcStr::from(
+                    get_relative_path_to(
+                        &current_directory_path,
+                        &format!("{}{}", decode_uri_fragment(&project_root_uri)?, source_file),
+                    )
+                    // TODO(sokra) remove this to include a ./ here to make it a relative path
+                    .trim_start_matches("./"),
+                ),
+                Some(source_file),
             )
         } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX) {
             // TODO(veil): Should the protocol be preserved?
-            (RcStr::from(source_file), None)
+            (decode_uri_fragment(source_file)?, None)
         } else {
             bail!(
                 "Original file ({}) outside project ({})",

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -130,7 +130,16 @@ function parseFile(fileParam: string | null): string | undefined {
     return undefined
   }
 
-  return devirtualizeReactServerURL(fileParam)
+  const file = devirtualizeReactServerURL(fileParam)
+  // React virtualizes filenames as `'file://' + path`, which is malformed
+  // for paths that need percent-encoding (e.g. a space in the project path)
+  // and then fails both Turbopack's `traceSource` and Node.js' source map
+  // cache lookups. Re-encode through WHATWG URL parsing.
+  // TODO(veil): Revisit if React's virtualization round-trips losslessly.
+  if (file.startsWith('file://') && URL.canParse(file)) {
+    return new URL(file).href
+  }
+  return file
 }
 
 function createStackFrames(

--- a/test/development/app-dir/special-project-paths/fixtures/app/layout.js
+++ b/test/development/app-dir/special-project-paths/fixtures/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/special-project-paths/fixtures/app/ssr-throw/Thrower.js
+++ b/test/development/app-dir/special-project-paths/fixtures/app/ssr-throw/Thrower.js
@@ -1,0 +1,10 @@
+'use client'
+
+function throwError() {
+  throw new Error('ssr-throw')
+}
+
+export function Thrower() {
+  throwError()
+  return null
+}

--- a/test/development/app-dir/special-project-paths/fixtures/app/ssr-throw/page.js
+++ b/test/development/app-dir/special-project-paths/fixtures/app/ssr-throw/page.js
@@ -1,0 +1,5 @@
+import { Thrower } from './Thrower'
+
+export default function Page() {
+  return <Thrower />
+}

--- a/test/development/app-dir/special-project-paths/fixtures/next.config.js
+++ b/test/development/app-dir/special-project-paths/fixtures/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/development/app-dir/special-project-paths/special-project-paths.test.ts
+++ b/test/development/app-dir/special-project-paths/special-project-paths.test.ts
@@ -1,0 +1,90 @@
+import * as path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import stripAnsi from 'strip-ansi'
+import { getRedboxSource, retry } from 'next-test-utils'
+
+function setup(subDir: string) {
+  return nextTestSetup({
+    files: path.join(__dirname, 'fixtures'),
+    subDir,
+  })
+}
+
+async function assertSymbolicatedSSRError(
+  next: ReturnType<typeof setup>['next']
+) {
+  const outputIndex = next.cliOutput.length
+  const browser = await next.browser('/ssr-throw')
+
+  await retry(() => {
+    expect(next.cliOutput.slice(outputIndex)).toContain('Error: ssr-throw')
+  })
+
+  const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+  expect(cliOutput).toContain(
+    '⨯ Error: ssr-throw' +
+      '\n    at throwError (app/ssr-throw/Thrower.js:4:9)' +
+      '\n    at Thrower (app/ssr-throw/Thrower.js:8:3)'
+  )
+
+  let redboxSource: string | null = null
+  await retry(async () => {
+    redboxSource = await getRedboxSource(browser)
+    expect(redboxSource).not.toBeNull()
+  })
+  expect(redboxSource).toContain('app/ssr-throw/Thrower.js (4:9) @ throwError')
+  expect(redboxSource).toContain("throw new Error('ssr-throw')")
+}
+
+// Symbolication must work in project directories whose absolute path
+// contains characters that need percent-encoding in URLs.
+describe('special project paths', () => {
+  describe('in "space dir"', () => {
+    const { skipped, next } = setup('space dir')
+    if (skipped) return
+
+    it('symbolicates thrown SSR errors', async () => {
+      await assertSymbolicatedSSRError(next)
+    })
+  })
+
+  describe('in "ünïcode-dir"', () => {
+    const { skipped, next } = setup('ünïcode-dir')
+    if (skipped) return
+
+    it('symbolicates thrown SSR errors', async () => {
+      await assertSymbolicatedSSRError(next)
+    })
+  })
+
+  describe('in "bracket [dir]"', () => {
+    const { skipped, next } = setup('bracket [dir]')
+    if (skipped) return
+
+    it('symbolicates thrown SSR errors', async () => {
+      await assertSymbolicatedSSRError(next)
+    })
+  })
+
+  // TODO(veil): The remaining directory names need React's fake stack frame
+  // filename virtualization to round-trip losslessly. When they start
+  // passing, `it.failing` will fail and remind us to promote them.
+
+  describe('in "percent%20dir"', () => {
+    const { skipped, next } = setup('percent%20dir')
+    if (skipped) return
+
+    it.failing('symbolicates thrown SSR errors', async () => {
+      await assertSymbolicatedSSRError(next)
+    })
+  })
+
+  describe('in "hash#dir"', () => {
+    const { skipped, next } = setup('hash#dir')
+    if (skipped) return
+
+    it.failing('symbolicates thrown SSR errors', async () => {
+      await assertSymbolicatedSSRError(next)
+    })
+  })
+})


### PR DESCRIPTION
In a project whose absolute path contains characters that percent-encode in URLs — e.g. a space — the dev overlay showed no code frame and raw `file://` URLs instead of source locations for server frames.

Two encoding mismatches caused this:

- Turbopack's `trace_source` percent-decoded the source map's original file URL before comparing it against the still-encoded project root URI, so the containment check failed ("Original file ... outside project") for any project path with such characters. The comparisons now stay in the encoded domain and only the outputs are decoded back into paths.

- React synthesizes stack frame `file:` URLs by prepending the scheme to a filesystem path, so the overlay receives URLs with e.g. raw spaces. These aren't well-formed, and they don't match the `url.pathToFileURL` form Node.js keys its source map cache by. The overlay middleware now re-encodes them through WHATWG URL parsing, which tolerates such input.

## Test Plan

New tests.

Known cases that remain broken are commented out with a TODO.
These could be resolved if https://github.com/react/react/pull/37105 or equivalent lands.

## Before

<img width="825" height="732" alt="Screenshot 2026-07-25 at 14 39 18" src="https://github.com/user-attachments/assets/0f119e52-ec86-495a-bf5c-5339faa1d606" />


## After

<img width="1126" height="733" alt="Screenshot 2026-07-25 at 14 58 14" src="https://github.com/user-attachments/assets/a263ee8a-4cfe-4358-9a8e-2e58b4b16aa5" />
