### PR TITLE
[test] Unflake a prefetch-related race

### DIFF
--- a/test/e2e/app-dir/navigation/app/hash/page.js
+++ b/test/e2e/app-dir/navigation/app/hash/page.js
@@ -30,7 +30,14 @@ export default function HashPage() {
         To non-existent
       </Link>
       <div>
-        <Link href="?with-query-param#hash-160" id="link-to-query-param">
+        <Link
+          href="?with-query-param#hash-160"
+          id="link-to-query-param"
+          // The test asserts that hash-only navigations never request this
+          // query's RSC payload; prefetching this link would race that
+          // assertion.
+          prefetch={false}
+        >
           To 160 (with query param)
         </Link>
       </div>

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -148,13 +148,20 @@ describe('app dir - navigation', () => {
 
   describe('hash', () => {
     it('should scroll to the specified hash', async () => {
-      const rscRequestUrls = new Set<string>()
+      // Requests made to navigate, excluding prefetches: a hash-only
+      // navigation is same-document and must not fetch data, while
+      // prefetch heuristics are free to fire at any time.
+      const navigationRscRequestUrls = new Set<string>()
       const browser = await next.browser('/hash', {
         beforePageLoad(page) {
           page.on('request', (req) => {
             const headers = req.headers()
-            if (headers['rsc']) {
-              rscRequestUrls.add(req.url())
+            if (
+              headers['rsc'] &&
+              !headers['next-router-prefetch'] &&
+              !headers['next-router-segment-prefetch']
+            ) {
+              navigationRscRequestUrls.add(req.url())
             }
           })
         },
@@ -178,8 +185,8 @@ describe('app dir - navigation', () => {
       }
 
       // Wait for all network requests to finish, and then initialize the flag
-      // used to determine if any query-param RSC requests are made.
-      rscRequestUrls.clear()
+      // used to determine if any navigation RSC requests are made.
+      navigationRscRequestUrls.clear()
 
       await checkLink(6, 128)
       await checkLink(50, 744)
@@ -190,21 +197,16 @@ describe('app dir - navigation', () => {
       await checkLink('non-existent', 0)
 
       if (!isNextDev) {
-        // Hash-only navigations should not request the query-param payload.
-        // In some runtimes, hash-only transitions can still trigger RSC
-        // requests for /hash itself, so we assert on query-param payloads.
-        const hasQueryParamRscRequest = Array.from(rscRequestUrls).some((url) =>
-          url.includes('with-query-param')
-        )
-        expect(hasQueryParamRscRequest).toBe(false)
+        // Hash-only navigations must not fetch any data.
+        expect(Array.from(navigationRscRequestUrls)).toEqual([])
       }
 
       await checkLink('query-param', 2284)
       await browser.waitForIdleNetwork()
 
       // There should be an RSC request if the query param is changed
-      const hasQueryParamRscRequest = Array.from(rscRequestUrls).some((url) =>
-        url.includes('with-query-param')
+      const hasQueryParamRscRequest = Array.from(navigationRscRequestUrls).some(
+        (url) => url.includes('with-query-param')
       )
       expect(hasQueryParamRscRequest).toBe(true)
     })


### PR DESCRIPTION
Test-only.

The test assertion was racy: it asserted no with-query-param RSC request during hash-only navigations, but a late prefetch of the `#link-to-query-param` link makes exactly that request (failed 3/3 on a prod CI shard).

Assert the actual invariants instead:

- hash-only navigations issue no navigation RSC requests at all (prefetches, identified by their headers, are ignored)
- a query change *does* issue one — with `prefetch={false}` on the link so it can't be served from the prefetch cache.