### PR TITLE
Turbopack: support import.meta.glob caseSensitive option

### DIFF
--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -152,7 +152,10 @@ pub async fn trace_endpoint(
                 .map(|(root, globs)| {
                     let glob = Glob::new(
                         format!("{{{}}}", globs.join(",")).into(),
-                        GlobOptions { contains: true },
+                        GlobOptions {
+                            contains: true,
+                            ..Default::default()
+                        },
                     );
                     get_glob_includes(root, glob)
                 })
@@ -254,7 +257,10 @@ pub async fn tracing_exclude_glob(
                         .join(",")
                 )
                 .into(),
-                GlobOptions { contains: true },
+                GlobOptions {
+                    contains: true,
+                    ..Default::default()
+                },
             )
             .to_resolved()
             .await?;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1795,7 +1795,10 @@ impl OutputFileTracingIncludesExcludes {
                     .map(async |(route_pattern, file_patterns)| {
                         let route_pattern = Glob::new(
                             RcStr::from(route_pattern.clone()),
-                            GlobOptions { contains: true },
+                            GlobOptions {
+                                contains: true,
+                                ..Default::default()
+                            },
                         )
                         .to_resolved()
                         .await?;

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -234,12 +234,13 @@ const eager = import.meta.glob('./dir/*.ts', { eager: true })
 
 ### Options reference
 
-| Option   | Type                                          | Default     | Description                                                            |
-| -------- | --------------------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `eager`  | `boolean`                                     | `false`     | Import modules synchronously instead of returning thunks.              |
-| `import` | `string`                                      | `undefined` | Named export to select from each matched module (e.g. `'default'`).    |
-| `query`  | `string \| Record<string, string \| boolean>` | `undefined` | Query string (or object) to append to each import.                     |
-| `base`   | `string`                                      | `undefined` | Override the base path used for resolving patterns and keying results. |
+| Option          | Type                                          | Default     | Description                                                            |
+| --------------- | --------------------------------------------- | ----------- | ---------------------------------------------------------------------- |
+| `eager`         | `boolean`                                     | `false`     | Import modules synchronously instead of returning thunks.              |
+| `import`        | `string`                                      | `undefined` | Named export to select from each matched module (e.g. `'default'`).    |
+| `query`         | `string \| Record<string, string \| boolean>` | `undefined` | Query string (or object) to append to each import.                     |
+| `base`          | `string`                                      | `undefined` | Override the base path used for resolving patterns and keying results. |
+| `caseSensitive` | `boolean`                                     | `true`      | Match glob patterns case-sensitively. Set to `false` to ignore case.   |
 
 > **Note:** The `as` option (deprecated in Vite 5) is not supported. Use `query: '?raw'` or `query: '?url'` instead. The legacy `import.meta.globEager()` API is also not supported — use `import.meta.glob('...', { eager: true })` instead.
 

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -234,13 +234,13 @@ const eager = import.meta.glob('./dir/*.ts', { eager: true })
 
 ### Options reference
 
-| Option          | Type                                          | Default     | Description                                                            |
-| --------------- | --------------------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `eager`         | `boolean`                                     | `false`     | Import modules synchronously instead of returning thunks.              |
-| `import`        | `string`                                      | `undefined` | Named export to select from each matched module (e.g. `'default'`).    |
-| `query`         | `string \| Record<string, string \| boolean>` | `undefined` | Query string (or object) to append to each import.                     |
-| `base`          | `string`                                      | `undefined` | Override the base path used for resolving patterns and keying results. |
-| `caseSensitive` | `boolean`                                     | `true`      | Match glob patterns case-sensitively. Set to `false` to ignore case.   |
+| Option          | Type                                          | Default     | Description                                                                |
+| --------------- | --------------------------------------------- | ----------- | -------------------------------------------------------------------------- |
+| `eager`         | `boolean`                                     | `false`     | Import modules synchronously instead of returning thunks.                  |
+| `import`        | `string`                                      | `undefined` | Named export to select from each matched module (e.g. `'default'`).        |
+| `query`         | `string \| Record<string, string \| boolean>` | `undefined` | Query string (or object) to append to each import.                         |
+| `base`          | `string`                                      | `undefined` | Override the base path used for resolving patterns and keying results.     |
+| `caseSensitive` | `boolean`                                     | `true`      | Match glob patterns case-sensitively. Set to `false` to ignore ASCII case. |
 
 > **Note:** The `as` option (deprecated in Vite 5) is not supported. Use `query: '?raw'` or `query: '?url'` instead. The legacy `import.meta.globEager()` API is also not supported — use `import.meta.glob('...', { eager: true })` instead.
 

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -96,6 +96,8 @@ interface ImportMetaGlobOptions {
   query?: string | Record<string, string | boolean>
   /** Override the base path used for resolving patterns and keying results. */
   base?: string
+  /** Whether glob matching is case-sensitive. Default: `true`. */
+  caseSensitive?: boolean
 }
 
 interface ImportMeta {

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -156,6 +156,7 @@ impl Glob {
 
 fn new_regex(pattern: &str, opts: GlobOptions) -> Regex {
     RegexBuilder::new(pattern)
+        // Because we aren't setting the `unicode` flag, this is only ASCII case-insensitive.
         .case_insensitive(opts.case_insensitive)
         .dot_matches_new_line(true)
         .build()

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -40,7 +40,7 @@ pub struct Glob {
 
 impl PartialEq for Glob {
     fn eq(&self, other: &Self) -> bool {
-        self.glob == other.glob
+        self.glob == other.glob && self.opts == other.opts
     }
 }
 
@@ -79,6 +79,8 @@ pub struct GlobOptions {
     /// match `foo_node_modules/package_name_bar` If you want to match a _directory_ named
     /// `node_modules/package_name` you should use `**/node_modules/package_name/**`
     pub contains: bool,
+    /// Whether matching should ignore ASCII case differences.
+    pub case_insensitive: bool,
 }
 
 impl Glob {
@@ -99,8 +101,8 @@ impl Glob {
 
     pub fn parse(input: RcStr, opts: GlobOptions) -> Result<Glob> {
         let (glob_re, directory_match_re) = parse(&input, opts)?;
-        let regex = new_regex(glob_re.as_str());
-        let directory_match_regex = new_regex(directory_match_re.as_str());
+        let regex = new_regex(glob_re.as_str(), opts);
+        let directory_match_regex = new_regex(directory_match_re.as_str(), opts);
 
         Ok(Glob {
             glob: input,
@@ -152,8 +154,9 @@ impl Glob {
     }
 }
 
-fn new_regex(pattern: &str) -> Regex {
+fn new_regex(pattern: &str, opts: GlobOptions) -> Regex {
     RegexBuilder::new(pattern)
+        .case_insensitive(opts.case_insensitive)
         .dot_matches_new_line(true)
         .build()
         .expect("A successfully parsed glob should produce a valid regex")
@@ -256,6 +259,40 @@ mod tests {
         assert!(!glob.matches(path));
     }
 
+    #[test]
+    fn glob_case_insensitive_matching() {
+        let case_sensitive =
+            Glob::parse(rcstr!("case-dir/module*.js"), GlobOptions::default()).unwrap();
+        let case_insensitive = Glob::parse(
+            rcstr!("case-dir/module*.js"),
+            GlobOptions {
+                case_insensitive: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(!case_sensitive.matches("Case-Dir/Module.js"));
+        assert!(case_insensitive.matches("Case-Dir/Module.js"));
+    }
+
+    #[test]
+    fn glob_case_insensitive_directory_matching() {
+        let case_sensitive =
+            Glob::parse(rcstr!("case-dir/module*.js"), GlobOptions::default()).unwrap();
+        let case_insensitive = Glob::parse(
+            rcstr!("case-dir/module*.js"),
+            GlobOptions {
+                case_insensitive: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(!case_sensitive.can_match_in_directory("Case-Dir"));
+        assert!(case_insensitive.can_match_in_directory("Case-Dir"));
+    }
+
     #[rstest]
     #[case::dir_and_file_partial("dir/file.js", "dir")]
     #[case::dir_star_partial("dir/*.js", "dir")]
@@ -293,7 +330,14 @@ mod tests {
     // This is a possibly surprising case.
     #[case::dir_match("node_modules/foo", "my_node_modules/foobar")]
     fn partial_glob_match(#[case] glob: &str, #[case] path: &str) {
-        let glob = Glob::parse(RcStr::from(glob), GlobOptions { contains: true }).unwrap();
+        let glob = Glob::parse(
+            RcStr::from(glob),
+            GlobOptions {
+                contains: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         println!("{glob:?} {path}");
 
@@ -307,7 +351,14 @@ mod tests {
     // This is a possibly surprising case
     #[case::dir_match("/node_modules/", "node_modules/")]
     fn partial_glob_not_matching(#[case] glob: &str, #[case] path: &str) {
-        let glob = Glob::parse(RcStr::from(glob), GlobOptions { contains: true }).unwrap();
+        let glob = Glob::parse(
+            RcStr::from(glob),
+            GlobOptions {
+                contains: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         println!("{glob:?} {path}");
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -74,6 +74,8 @@ pub struct ImportMetaGlobOptions {
     pub query: Option<RcStr>,
     /// Base path for resolving and keying modules.
     pub base: Option<RcStr>,
+    /// Whether glob matching is case-sensitive.
+    pub case_sensitive: bool,
 }
 
 /// Parse the arguments of an `import.meta.glob(patterns, options?)` call.
@@ -150,6 +152,7 @@ pub fn parse_import_meta_glob(
     let mut import = None;
     let mut query = None;
     let mut base = None;
+    let mut case_sensitive = true;
 
     if let Some(opts) = args.get(1) {
         match opts {
@@ -261,6 +264,18 @@ pub fn parse_import_meta_glob(
                                     );
                                 }
                             }
+                            Some("caseSensitive") => {
+                                if let Some(b) = val.as_bool() {
+                                    case_sensitive = b;
+                                } else {
+                                    handler.span_warn_with_code(
+                                        span,
+                                        "import.meta.glob() 'caseSensitive' option must be a \
+                                         constant boolean (true or false), defaulting to true",
+                                        diagnostic_id.clone(),
+                                    );
+                                }
+                            }
                             // The `as` option was deprecated in Vite 5 in favor of `query`.
                             // We don't support it; users should use `query` instead.
                             Some("as") => {
@@ -276,7 +291,8 @@ pub fn parse_import_meta_glob(
                                     span,
                                     &format!(
                                         "import.meta.glob() unsupported option '{other}'. \
-                                         Supported options are: eager, import, query, base"
+                                         Supported options are: eager, import, query, base, \
+                                         caseSensitive"
                                     ),
                                     diagnostic_id.clone(),
                                 );
@@ -309,6 +325,7 @@ pub fn parse_import_meta_glob(
         import,
         query,
         base,
+        case_sensitive,
     })
 }
 
@@ -551,6 +568,7 @@ fn modifier(
     import: &Option<RcStr>,
     query: &Option<RcStr>,
     base: &Option<RcStr>,
+    case_sensitive: bool,
 ) -> RcStr {
     let mut s = format!("import.meta.glob {}", patterns.join(", "));
     if eager {
@@ -568,6 +586,9 @@ fn modifier(
         s.push_str(" base=");
         s.push_str(b);
     }
+    if !case_sensitive {
+        s.push_str(" case-insensitive");
+    }
     s.into()
 }
 
@@ -579,6 +600,7 @@ pub struct ImportMetaGlobAsset {
     pub import: Option<RcStr>,
     pub query: Option<RcStr>,
     pub base: Option<RcStr>,
+    pub case_sensitive: bool,
     pub issue_source: Option<IssueSource>,
     pub error_mode: ResolveErrorMode,
 }
@@ -608,13 +630,17 @@ impl ImportMetaGlobAsset {
         // Negative patterns start with `!`; the `!` prefix is stripped.
         let (positive_raw, negative_raw): (Vec<_>, Vec<_>) =
             self.patterns.iter().partition(|p| !p.starts_with('!'));
+        let glob_options = GlobOptions {
+            case_insensitive: !self.case_sensitive,
+            ..Default::default()
+        };
 
         // Build the positive Glob. Turbopack's Glob operates on paths relative
         // to the scan directory (no leading `./`), so strip that prefix. For
         // multiple patterns, use `Glob::alternatives` to combine them.
         let positive_globs: Vec<Vc<Glob>> = positive_raw
             .iter()
-            .map(|p| Glob::new(strip_relative_prefix(p).into(), GlobOptions::default()))
+            .map(|p| Glob::new(strip_relative_prefix(p).into(), glob_options))
             .collect();
 
         let positive_glob = if positive_globs.len() == 1 {
@@ -631,7 +657,7 @@ impl ImportMetaGlobAsset {
                 .map(|p| {
                     let stripped = p.strip_prefix('!').unwrap_or(p);
                     let stripped = strip_relative_prefix(stripped);
-                    Glob::new(stripped.into(), GlobOptions::default())
+                    Glob::new(stripped.into(), glob_options)
                 })
                 .collect();
 
@@ -670,6 +696,7 @@ impl Module for ImportMetaGlobAsset {
                 &self.import,
                 &self.query,
                 &self.base,
+                self.case_sensitive,
             ))
             .into_vc())
     }
@@ -881,6 +908,7 @@ impl ImportMetaGlobAssetReference {
         import: Option<RcStr>,
         query: Option<RcStr>,
         base: Option<RcStr>,
+        case_sensitive: bool,
         issue_source: Option<IssueSource>,
         error_mode: ResolveErrorMode,
     ) -> Self {
@@ -891,6 +919,7 @@ impl ImportMetaGlobAssetReference {
             import,
             query,
             base,
+            case_sensitive,
             issue_source,
             error_mode,
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2297,6 +2297,7 @@ where
                     options.import,
                     options.query,
                     options.base,
+                    options.case_sensitive,
                     Some(issue_source(source, span)),
                     error_mode,
                 ),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/CaseDir/Module.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/CaseDir/Module.js
@@ -1,0 +1,1 @@
+export default 'mixed case'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js
@@ -11,6 +11,11 @@ const unknown = import.meta.glob(['./dir/*.js', './dir2/*.js'], {
   exhaust: true,
 })
 
+// Warning: non-constant caseSensitive — should default to case-sensitive matching
+const nonConstCaseSensitive = import.meta.glob('./casedir/*.js', {
+  caseSensitive: 'false',
+})
+
 it('should still produce a lazy glob when "as" option is used', () => {
   const keys = Object.keys(withAs).sort()
   expect(keys).toEqual(['./dir/bar.js', './dir/foo.js'])
@@ -29,4 +34,8 @@ it('should ignore unknown options and still produce a valid glob', () => {
   const keys = Object.keys(unknown).sort()
   expect(keys).toEqual(['./dir/bar.js', './dir/foo.js', './dir2/qux.js'])
   expect(typeof unknown['./dir/foo.js']).toBe('function')
+})
+
+it('should default to case-sensitive matching when caseSensitive is invalid', () => {
+  expect(Object.keys(nonConstCaseSensitive)).toEqual([])
 })

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/issues/__l___TP1008__ import.meta.glob() 'caseSensitive' -77ba63.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/issues/__l___TP1008__ import.meta.glob() 'caseSensitive' -77ba63.txt
@@ -1,0 +1,22 @@
+warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js:15:30  TP1008 import.meta.glob() 'caseSensitive' option must be a constant boolean (true or false), defaulting to true
+  
+      11 |   exhaust: true,
+      12 | })
+      13 | 
+      14 | // Warning: non-constant caseSensitive — should default to case-sensitive matching
+         |                               v-----------------------------------
+      15 + const nonConstCaseSensitive = import.meta.glob('./casedir/*.js', {
+      16 +   caseSensitive: 'false',
+      17 + })
+         +--^
+      18 | 
+      19 | it('should still produce a lazy glob when "as" option is used', () => {
+      20 |   const keys = Object.keys(withAs).sort()
+      21 |   expect(keys).toEqual(['./dir/bar.js', './dir/foo.js'])
+  
+  
+  
+  Import trace:
+    test:
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js
+      ./turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/issues/__l___TP1008__ import.meta.glob() unsupported opti-23340f.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/issues/__l___TP1008__ import.meta.glob() unsupported opti-23340f.txt
@@ -1,4 +1,4 @@
-warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js:10:16  TP1008 import.meta.glob() unsupported option 'exhaust'. Supported options are: eager, import, query, base
+warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob-warnings/input/index.js:10:16  TP1008 import.meta.glob() unsupported option 'exhaust'. Supported options are: eager, import, query, base, caseSensitive
   
        6 |   eager: Math.random() > -1,
        7 | })
@@ -10,9 +10,9 @@ warning - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack
       12 + })
          +--^
       13 | 
-      14 | it('should still produce a lazy glob when "as" option is used', () => {
-      15 |   const keys = Object.keys(withAs).sort()
-      16 |   expect(keys).toEqual(['./dir/bar.js', './dir/foo.js'])
+      14 | // Warning: non-constant caseSensitive — should default to case-sensitive matching
+      15 | const nonConstCaseSensitive = import.meta.glob('./casedir/*.js', {
+      16 |   caseSensitive: 'false',
   
   
   

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/CaseDir/ModuleUpper.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/CaseDir/ModuleUpper.js
@@ -1,0 +1,1 @@
+export default 'upper'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/CaseDir/module-lower.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/CaseDir/module-lower.js
@@ -1,0 +1,1 @@
+export default 'lower'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/import-meta-glob/input/index.js
@@ -112,6 +112,8 @@ it('should include dotfile directories with wildcard patterns', () => {
   const keys = Object.keys(dotfileGlob).sort()
   expect(keys).toEqual([
     './.foo/hidden.js',
+    './CaseDir/ModuleUpper.js',
+    './CaseDir/module-lower.js',
     './dir/bar.js',
     './dir/foo.js',
     './other/baz.js',
@@ -124,4 +126,59 @@ const dotfileExplicit = import.meta.glob('./.foo/*.js', { eager: true })
 it('should include dotfile directories when explicitly targeted', () => {
   const keys = Object.keys(dotfileExplicit)
   expect(keys).toEqual(['./.foo/hidden.js'])
+})
+
+const caseSensitiveDefault = import.meta.glob('./CaseDir/module*.js', {
+  eager: true,
+})
+const caseSensitiveExplicit = import.meta.glob('./CaseDir/Module*.js', {
+  eager: true,
+  caseSensitive: true,
+})
+const caseInsensitive = import.meta.glob('./CaseDir/module*.js', {
+  eager: true,
+  caseSensitive: false,
+})
+const caseInsensitiveDirectory = import.meta.glob('./casedir/module*.js', {
+  eager: true,
+  caseSensitive: false,
+})
+const caseInsensitiveNegative = import.meta.glob(
+  ['./casedir/*.js', '!./casedir/moduleupper.js'],
+  {
+    eager: true,
+    caseSensitive: false,
+  }
+)
+
+it('should match case-sensitively by default and when explicitly enabled', () => {
+  expect(Object.keys(caseSensitiveDefault)).toEqual([
+    './CaseDir/module-lower.js',
+  ])
+  expect(Object.keys(caseSensitiveExplicit)).toEqual([
+    './CaseDir/ModuleUpper.js',
+  ])
+})
+
+it('should match file names case-insensitively when disabled', () => {
+  const keys = Object.keys(caseInsensitive).sort()
+  expect(keys).toEqual([
+    './CaseDir/ModuleUpper.js',
+    './CaseDir/module-lower.js',
+  ])
+  expect(caseInsensitive['./CaseDir/ModuleUpper.js'].default).toBe('upper')
+})
+
+it('should traverse directories case-insensitively when disabled', () => {
+  const keys = Object.keys(caseInsensitiveDirectory).sort()
+  expect(keys).toEqual([
+    './CaseDir/ModuleUpper.js',
+    './CaseDir/module-lower.js',
+  ])
+})
+
+it('should apply case-insensitive matching to negative patterns', () => {
+  expect(Object.keys(caseInsensitiveNegative)).toEqual([
+    './CaseDir/module-lower.js',
+  ])
 })


### PR DESCRIPTION
## Summary

Add Vite-compatible `caseSensitive` support to `import.meta.glob()`. Matching remains case-sensitive by default, while `caseSensitive: false` applies case-insensitive matching to directory traversal, filenames, positive patterns, and negative patterns.

The option is included in matcher equality and non-default virtual module identity, and is exposed through diagnostics, TypeScript declarations, and the Turbopack options reference.

## Verification

- `cargo test -p turbo-tasks-fs glob`
- `cargo nextest run -p turbopack-tests -E "test(import_meta_glob) and not test(import_meta_glob_errors)"`
- `cargo fmt --all -- --check`
- `pnpm build-all` and `pnpm --filter=next types` are blocked by current-canary `sharp.default` type errors in `packages/next/src/server/image-optimizer.ts`

<!-- NEXT_JS_LLM -->