### PR TITLE
Serve cached misses from the filesystem route cache

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -123,6 +123,10 @@ function flatKeyCopy(key: string): string {
   return JSON.parse(JSON.stringify(key))
 }
 
+// Cached result for paths that resolve to nothing. Not null, so that a
+// cached miss can't be conflated with an uncached key (undefined).
+const notFound = Symbol('not-found')
+
 export async function setupFsCheck(opts: {
   dir: string
   dev: boolean
@@ -130,12 +134,12 @@ export async function setupFsCheck(opts: {
   config: NextConfigRuntime
 }) {
   const getItemsLru = !opts.dev
-    ? new LRUCache<FsOutput | null>(FS_LRU_MAX_SIZE, function length(
+    ? new LRUCache<FsOutput | typeof notFound>(FS_LRU_MAX_SIZE, function length(
         value,
         key
       ) {
         const size = FS_LRU_ENTRY_OVERHEAD + key.length
-        if (!value) {
+        if (value === notFound) {
           // Negative cache entries only retain their key.
           return size
         }
@@ -491,9 +495,8 @@ export async function setupFsCheck(opts: {
       const itemKey = originalItemPath
       const lruResult = getItemsLru?.get(itemKey)
 
-      // null is a cached miss; undefined means the key is not cached.
       if (lruResult !== undefined) {
-        return lruResult
+        return lruResult === notFound ? null : lruResult
       }
 
       const { basePath } = opts.config
@@ -756,7 +759,7 @@ export async function setupFsCheck(opts: {
         }
       }
 
-      getItemsLru?.set(flatKeyCopy(itemKey), null)
+      getItemsLru?.set(flatKeyCopy(itemKey), notFound)
       return null
     },
     getDynamicRoutes() {

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -491,7 +491,8 @@ export async function setupFsCheck(opts: {
       const itemKey = originalItemPath
       const lruResult = getItemsLru?.get(itemKey)
 
-      if (lruResult) {
+      // null is a cached miss; undefined means the key is not cached.
+      if (lruResult !== undefined) {
         return lruResult
       }
 


### PR DESCRIPTION
`getItem` stores `null` for paths that don't resolve, but checks the cached value with `if (lruResult)`, so a cached `null` is never served: every request for an unknown path — including every dynamic-route request — re-runs the lookup. It's been this way since the cache was introduced in #52492.

Return the cached entry whenever the key is present. This can't go stale: in production the item sets are only populated during `setupFsCheck`, and the LRU is disabled in dev.

Cached misses are stored as a dedicated sentinel instead of `null`. Since serving a cached miss has no observable effect, no test can catch this regressing — that is also why it went unnoticed. With the sentinel it's a type error instead: reintroducing the truthy check fails `pnpm types` (verified). Same pattern as `invalidSourceMap` in `source-maps.ts`.

Stacked on #96229, which bounds what negative entries can retain.

## Test Plan

No direct test: the change is unobservable by design, and the existing e2e suites assert that it stays that way. The regression guard is the type system, as above. `test/e2e/app-dir/not-found/basic` passes in prod mode (14/14), exercising the negative-cache path.


