### PR TITLE
Count key length in remaining byte-budgeted LRUs

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -195,9 +195,11 @@ export default class DevServer extends Server {
     this.staticPathsCache = new LRUCache(
       // 5MB
       5 * 1024 * 1024,
-      function length(value) {
+      function length(value, cacheKey) {
         // Ensure minimum size of 1 for LRU eviction to work correctly
-        return JSON.stringify(value.staticPaths)?.length || 1
+        return (
+          cacheKey.length + (JSON.stringify(value.staticPaths)?.length || 1)
+        )
       }
     )
 
@@ -214,8 +216,8 @@ export default class DevServer extends Server {
       )
       this.serverComponentsHmrCache = new LRUCache(
         hmrCacheSize,
-        function length(value) {
-          return JSON.stringify(value).length
+        function length(value, cacheKey) {
+          return cacheKey.length + JSON.stringify(value).length
         }
       )
     }

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -58,7 +58,7 @@ export function createDefaultCacheHandler(maxSize: number): CacheHandler {
 
   const memoryCache = new LRUCache<PrivateCacheEntry>(
     maxSize,
-    (entry) => entry.size
+    (entry, cacheKey) => entry.size + cacheKey.length
   )
   const pendingSets = new Map<string, Promise<void>>()
 

--- a/packages/next/src/server/lib/incremental-cache/memory-cache.external.ts
+++ b/packages/next/src/server/lib/incremental-cache/memory-cache.external.ts
@@ -24,30 +24,37 @@ function getSegmentDataSize(segmentData: Map<string, Buffer> | undefined) {
 
 export function getMemoryCache(maxMemoryCacheSize: number) {
   if (!memoryCache) {
-    memoryCache = new LRUCache(maxMemoryCacheSize, function length({ value }) {
+    memoryCache = new LRUCache(maxMemoryCacheSize, function length(
+      { value },
+      cacheKey
+    ) {
+      let valueSize: number
+
       if (!value) {
-        return 25
+        valueSize = 25
       } else if (value.kind === CachedRouteKind.REDIRECT) {
-        return JSON.stringify(value.props).length
+        valueSize = JSON.stringify(value.props).length
       } else if (value.kind === CachedRouteKind.IMAGE) {
         throw new Error('invariant image should not be incremental-cache')
       } else if (value.kind === CachedRouteKind.FETCH) {
-        return JSON.stringify(value.data || '').length
+        valueSize = JSON.stringify(value.data || '').length
       } else if (value.kind === CachedRouteKind.APP_ROUTE) {
-        return value.body.length
-      }
-      // rough estimate of size of cache value
-      if (value.kind === CachedRouteKind.APP_PAGE) {
-        return Math.max(
+        valueSize = value.body.length
+      } else if (value.kind === CachedRouteKind.APP_PAGE) {
+        // rough estimate of size of cache value
+        valueSize = Math.max(
           1,
           value.html.length +
             getBufferSize(value.rscData) +
             (value.postponed?.length || 0) +
             getSegmentDataSize(value.segmentData)
         )
+      } else {
+        valueSize =
+          value.html.length + (JSON.stringify(value.pageData)?.length || 0)
       }
 
-      return value.html.length + (JSON.stringify(value.pageData)?.length || 0)
+      return cacheKey.length + valueSize
     })
   }
 

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -215,13 +215,13 @@ function bundlerFindSourceMapURL(scriptNameOrSourceURL: string): string | null {
 const invalidSourceMap = Symbol('invalid-source-map')
 const sourceMapURLs = new LRUCache<string | typeof invalidSourceMap>(
   512 * 1024 * 1024,
-  (url) =>
-    url === invalidSourceMap
-      ? // Ideally we'd account for key length. So we just guestimate a small source map
-        // so that we don't create a huge cache with empty source maps.
+  (url, sourceURL) =>
+    sourceURL.length +
+    (url === invalidSourceMap
+      ? // Guestimate a small source map so invalid entries don't fill the cache.
         8 * 1024
       : // these URLs contain only ASCII characters so .length is equal to Buffer.byteLength
-        url.length
+        url.length)
 )
 export function findSourceMapURLDEV(
   scriptNameOrSourceURL: string


### PR DESCRIPTION
Applies the key accounting from #96229 to the other in-memory LRUs with byte budgets:

- the incremental memory cache
- the default `use cache` handler
- the dev `staticPathsCache` and `serverComponentsHmrCache`
- the dev source-map URL cache.

Keys were free against each budget in the same way; unlike the filesystem route cache there are no production leak reports for these, so this is preventative and kept separate. Count-based caches and the disk-byte LRU are unchanged.

## Test Plan

Each size callback change adds `cacheKey.length` to whatever it returned before. The memory cache callback is also restructured from early returns into if/else chains; each `CachedRouteKind` branch returns the same value as before, plus the key length.

To see the change do something, run this against the built memory cache:

```js
const { getMemoryCache } = require('next/dist/server/lib/incremental-cache/memory-cache.external')
const cache = getMemoryCache(1024 * 1024) // 1 MB budget
for (let i = 0; i < 20000; i++) {
  cache.set('/api/data?' + 'p'.repeat(1000) + i, {
    value: { kind: 'FETCH', data: { body: 'ok' } },
    lastModified: 1,
  })
}
console.log(cache.size, cache.currentSize)
```

Before this change, all 20,000 entries are admitted: the cache counts 260 KB against its 1 MB budget while the keys alone hold ~20 MB, and it keeps growing as long as new keys arrive. After, it holds 1,020 entries and the counted size stops at the budget.

For regressions: `test/production/app-dir/revalidate` and `test/e2e/app-dir/use-cache-default-handler-expire-zero` pass in prod mode (these exercise the fetch cache and the default `use cache` handler), plus the `packages/next/src/server/lib` jest suites and `pnpm --filter=next types`.

