### PR TITLE
Fix use cache over- and under-invalidation in dev

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1621,13 +1621,13 @@ export async function createHotReloaderTurbopack(
     },
 
     getServerComponentsHmrRefreshHash() {
-      // The current server-components generation. Only the change subscription
-      // (an actual recompile) advances `hmrHash`; reloads and config
-      // invalidations don't, so the value stays stable across requests until a
-      // real edit. Returned unconditionally (`"0"` before the first edit) so
-      // `"use cache"` keys are present and consistent for every request,
-      // mirroring webpack's always-present `stats.hash`.
-      return String(hmrHash)
+      // Only the change subscription (an actual recompile) advances `hmrHash`;
+      // reloads and config invalidations don't, so the value stays stable
+      // across requests until a real edit. `sessionId` stands in for a key
+      // derived from the compiled implementation, which would let entries
+      // outlive a restart when the code didn't change (see the note on Action
+      // IDs in `use-cache-wrapper.ts`).
+      return `${sessionId}-${hmrHash}`
     },
 
     sendToLegacyClients(action) {
@@ -1764,10 +1764,7 @@ export async function createHotReloaderTurbopack(
       }
       return errors
     },
-    async invalidate({
-      // .env files or tsconfig/jsconfig change
-      reloadAfterInvalidation,
-    }) {
+    async invalidate({ reloadAfterInvalidation }) {
       if (reloadAfterInvalidation) {
         for (const [key, entrypoint] of currentWrittenEntrypoints) {
           clearRequireCache(key, entrypoint, { force: true })

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -259,12 +259,15 @@ export interface NextJsHotReloaderInterface {
    */
   sendToLegacyClients(action: HmrMessageSentToBrowser): void
   /**
-   * The hash of the most recent server component change, or `undefined` if no
-   * server component change has occurred yet. In dev, this is included in `"use
-   * cache"` cache keys so that cached entries are revalidated after an edit,
-   * for every client, regardless of whether it runs the HMR client.
+   * Identifies the current generation of the compiled server components. It is
+   * included in `"use cache"` cache keys so that cached entries are revalidated
+   * after an edit, for every client, regardless of whether it runs the HMR
+   * client. It is present from the first request on, so that entries created
+   * before the first edit are keyed by it too, and it differs between dev
+   * server runs, so that a cache handler that persists entries doesn't serve
+   * them for code that changed while the server was down.
    */
-  getServerComponentsHmrRefreshHash(): string | undefined
+  getServerComponentsHmrRefreshHash(): string
   setCacheStatus(status: ServerCacheStatus, htmlRequestId: string): void
   setReactDebugChannel(
     debugChannel: ReactDebugChannelForBrowser,
@@ -282,6 +285,13 @@ export interface NextJsHotReloaderInterface {
       context: { isLegacyClient: boolean }
     ) => void
   ): void
+  /**
+   * Rebuilds so that a changed configuration reaches the bundles. Pass
+   * `reloadAfterInvalidation` only when the change can also affect what a
+   * render produces: it makes connected clients refetch server components, and
+   * advances `getServerComponentsHmrRefreshHash`, discarding `"use cache"`
+   * entries.
+   */
   invalidate({
     reloadAfterInvalidation,
   }: {

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -15,6 +15,7 @@ import {
 } from './middleware-webpack'
 import { WebpackHotMiddleware } from './hot-middleware'
 import * as inspector from 'inspector'
+import { randomUUID } from 'crypto'
 import { join, relative, isAbsolute, posix, dirname } from 'path'
 import {
   createEntrypoints,
@@ -126,6 +127,9 @@ function diff(a: Set<any>, b: Set<any>) {
 }
 
 const wsServer = new ws.Server({ noServer: true })
+
+// Folded into the HMR refresh hash to make it differ between dev server runs.
+const devServerSessionId = randomUUID()
 
 export async function renderScriptError(
   res: ServerResponse,
@@ -440,8 +444,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     })
   }
 
-  public getServerComponentsHmrRefreshHash(): string | undefined {
-    return this.serverComponentsHmrRefreshHash
+  public getServerComponentsHmrRefreshHash(): string {
+    return `${devServerSessionId}-${this.serverComponentsHmrRefreshHash ?? '0'}`
   }
 
   public onHMR(

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -417,12 +417,15 @@ async function startWatcher(
     let enabledTypeScript = await verifyTypeScript(opts)
     let previousClientRouterFilters: any
     let previousConflictingPagePaths: Set<string> = new Set()
+    let hadInitialScan = false
 
     const routeTypesFilePath = path.join(distDir, 'types', 'routes.d.ts')
     const validatorFilePath = path.join(distDir, 'types', 'validator.ts')
 
     let initialWatchTime = performance.now() + performance.timeOrigin
     wp.on('aggregated', async () => {
+      const isInitialScan = !hadInitialScan
+      hadInitialScan = true
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
       let middlewareMatchers: ProxyMatcher[] | undefined
@@ -440,7 +443,8 @@ async function startWatcher(
       const layoutRoutes: RouteInfo[] = []
       const slots: SlotInfo[] = []
 
-      let envChange = false
+      let envFileChange = false
+      let clientRouterFiltersChange = false
       let tsconfigChange = false
       let conflictingPageChange = 0
       let hasRootAppNotFound = false
@@ -513,7 +517,7 @@ async function startWatcher(
 
         if (envFiles.includes(fileName)) {
           if (fileChanged) {
-            envChange = true
+            envFileChange = true
           }
           continue
         }
@@ -794,15 +798,19 @@ async function startWatcher(
           JSON.stringify(previousClientRouterFilters) !==
             JSON.stringify(clientRouterFilters)
         ) {
-          envChange = true
+          clientRouterFiltersChange = true
           previousClientRouterFilters = clientRouterFilters
         }
       }
 
-      if (envChange || tsconfigChange) {
-        if (envChange) {
-          writeEnvDefinitions = true
+      // Also set on the initial scan, so that typed env definitions exist
+      // from startup.
+      if (envFileChange || isInitialScan) {
+        writeEnvDefinitions = true
+      }
 
+      if (envFileChange || clientRouterFiltersChange || tsconfigChange) {
+        if (envFileChange) {
           await propagateServerField(opts, 'loadEnvConfig', [
             { dev: true, forceReload: true },
           ])
@@ -905,7 +913,7 @@ async function startWatcher(
               })
             }
 
-            if (envChange) {
+            if (envFileChange || clientRouterFiltersChange) {
               config.plugins?.forEach((plugin: any) => {
                 // we look for the DefinePlugin definitions so we can
                 // update them on the active compilers
@@ -943,7 +951,10 @@ async function startWatcher(
           })
         }
         await hotReloader.invalidate({
-          reloadAfterInvalidation: envChange,
+          // A router-filter change only requires the updated define to be
+          // compiled into the bundles; unlike env, it can't affect rendered
+          // output or cached data.
+          reloadAfterInvalidation: envFileChange,
         })
       }
 

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
@@ -1,0 +1,194 @@
+import { nextTestSetup, type NextInstance, type Playwright } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import * as nodeFs from 'node:fs'
+import * as nodePath from 'node:path'
+
+// In dev, `"use cache"` entries must only be discarded when something they
+// can depend on changes (their code, or env) — and, conversely, they must
+// never survive into a different dev server run, where the code may have
+// changed while the server was down.
+
+async function readCachedValue(browser: Playwright) {
+  return browser.elementById('cached-value').text()
+}
+
+// Right after the dev server starts, it may still be settling (e.g.
+// finishing startup compiles), so wait until the cached value is stable
+// across reloads before asserting anything about invalidation.
+async function waitForStableCachedValue(
+  next: NextInstance,
+  browser: Playwright
+) {
+  let stableValue: string = ''
+  await retry(async () => {
+    await browser.loadPage(next.url + '/')
+    const first = await readCachedValue(browser)
+    await browser.loadPage(next.url + '/')
+    const second = await readCachedValue(browser)
+    expect(second).toBe(first)
+    stableValue = second
+  }, 15_000)
+  return stableValue
+}
+
+describe('cache-components-spurious-cache-invalidation', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/default'),
+  })
+
+  // Serving the added page requires the file watcher to have processed
+  // everything up to and including this addition, plus a compile — so any
+  // invalidation that an earlier change could have caused has landed by now,
+  // and a negative ("the cached value didn't change") can be asserted right
+  // after, instead of waiting out an arbitrary settling period.
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `app${pathname}/page.tsx`,
+      `export default function Page() { return <p>${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  // Turbopack-only: on webpack, adding a page recompiles the server bundle
+  // (the compiled-in client router filter changes), which replaces the
+  // serving module instances, so module state doesn't survive there.
+  if (isTurbopack) {
+    it('keeps module state when an unrelated page is added', async () => {
+      async function readRenderCount() {
+        const html = await (await next.fetch('/')).text()
+        const match = html.match(/id="render-count">(\d+)</)
+        expect(match).not.toBeNull()
+        return Number(match![1])
+      }
+
+      const first = await readRenderCount()
+      const second = await readRenderCount()
+      expect(second).toBeGreaterThan(first)
+
+      try {
+        await addPageAndWaitUntilServable('/unrelated')
+        await waitFor(2000)
+        // If the page add re-evaluated the module, the counter restarted
+        // from zero.
+        expect(await readRenderCount()).toBeGreaterThan(second)
+        await waitFor(2000)
+        expect(await readRenderCount()).toBeGreaterThan(second)
+      } finally {
+        if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/unrelated'))) {
+          await next.deleteFile('app/unrelated/page.tsx')
+        }
+      }
+    })
+  }
+
+  it('discards use cache entries when an env file changes', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    // The page reads this var, so its output depends on the change.
+    await next.patchFile('.env', 'NEXT_PUBLIC_CACHE_BUSTER=busted')
+
+    try {
+      await retry(async () => {
+        await browser.loadPage(next.url + '/')
+        expect(await browser.elementById('env-value').text()).toBe('busted')
+        expect(await readCachedValue(browser)).not.toBe(stableValue)
+      }, 15_000)
+    } finally {
+      await next.deleteFile('.env')
+    }
+  })
+
+  it('refetches server components when an env change does not affect compiled output', async () => {
+    const browser = await next.browser('/')
+    await waitForStableCachedValue(next, browser)
+
+    await browser.loadPage(next.url + '/')
+    expect(await browser.elementById('runtime-env-value').text()).toBe('unset')
+
+    // This var is only read at render time, so the rebuild after the env
+    // change is a no-op.
+    await next.patchFile('.env', 'RUNTIME_GREETING=hello')
+
+    try {
+      await retry(async () => {
+        // Deliberately no reload here.
+        expect(await browser.elementById('runtime-env-value').text()).toBe(
+          'hello'
+        )
+      }, 15_000)
+    } finally {
+      await next.deleteFile('.env')
+    }
+  })
+})
+
+describe('cache-components-spurious-cache-invalidation - persistent cache handler', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/persistent-handler'),
+  })
+
+  it('discards use cache entries across dev server restarts', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    await next.stop()
+
+    // The custom cache handler persists entries on disk. Ensure they're
+    // actually there — otherwise a fresh value after the restart wouldn't
+    // prove anything (it could just mean nothing was persisted).
+    const persistedEntries = nodeFs.readdirSync(
+      nodePath.join(next.testDir, '.file-system-cache')
+    )
+    expect(persistedEntries.length).toBeGreaterThan(0)
+
+    await next.start()
+
+    const newBrowser = await next.browser('/')
+    const newStableValue = await waitForStableCachedValue(next, newBrowser)
+    expect(newStableValue).not.toBe(stableValue)
+  })
+
+  it('discards use cache entries when a previous run made the same edit', async () => {
+    const browser = await next.browser('/')
+    await waitForStableCachedValue(next, browser)
+
+    const originalPage = await next.readFile('app/page.tsx')
+    const editedPage = originalPage.replace(
+      '<main>',
+      '<main><p id="edited-marker">edited</p>'
+    )
+    expect(editedPage).not.toBe(originalPage)
+
+    async function waitForMarker(b: Playwright, present: boolean) {
+      await retry(async () => {
+        await b.loadPage(next.url + '/')
+        expect(await b.hasElementByCssSelector('#edited-marker')).toBe(present)
+      }, 15_000)
+    }
+
+    try {
+      await next.patchFile('app/page.tsx', editedPage)
+      await waitForMarker(browser, true)
+      const editedValue = await waitForStableCachedValue(next, browser)
+
+      await next.stop()
+      await next.start()
+
+      // Even though the previous run persisted an entry for this exact code,
+      // it must not be served: entries never carry over between runs.
+      const newBrowser = await next.browser('/')
+      await next.patchFile('app/page.tsx', originalPage)
+      await waitForMarker(newBrowser, false)
+      await next.patchFile('app/page.tsx', editedPage)
+      await waitForMarker(newBrowser, true)
+
+      const newEditedValue = await waitForStableCachedValue(next, newBrowser)
+      expect(newEditedValue).not.toBe(editedValue)
+    } finally {
+      await next.patchFile('app/page.tsx', originalPage)
+    }
+  })
+})

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/layout.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/page.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/page.tsx
@@ -1,0 +1,39 @@
+// Incremented on every render. Module state must survive anything that
+// doesn't change this module's code: if this resets, the server re-evaluated
+// the module.
+let renderCount = 0
+
+async function getCachedData() {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}
+
+export default async function Page() {
+  renderCount++
+  const data = await getCachedData()
+  return (
+    <main>
+      <p>
+        This page renders cached data. The cached value must be stable across
+        reloads unless this page (or the data it depends on) is edited.
+      </p>
+      <dl>
+        <dt>Cached Data</dt>
+        <dd id="cached-value">{data}</dd>
+        <dt>Env</dt>
+        <dd id="env-value">
+          {process.env.NEXT_PUBLIC_CACHE_BUSTER ?? 'unset'}
+        </dd>
+        <dt>Render Count</dt>
+        <dd id="render-count">{renderCount}</dd>
+        <dt>Runtime Env</dt>
+        {/* Not prefixed with NEXT_PUBLIC_, so it's read at render time and
+            changing it doesn't affect the compiled output. */}
+        <dd id="runtime-env-value">
+          {process.env.RUNTIME_GREETING ?? 'unset'}
+        </dd>
+      </dl>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/next.config.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/layout.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/page.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/page.tsx
@@ -1,0 +1,25 @@
+async function getCachedData() {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}
+
+export default async function Page() {
+  const data = await getCachedData()
+  return (
+    <main>
+      <p>
+        This page renders cached data. The cached value must be stable across
+        reloads unless this page (or the data it depends on) is edited.
+      </p>
+      <dl>
+        <dt>Cached Data</dt>
+        <dd id="cached-value">{data}</dd>
+        <dt>Env</dt>
+        <dd id="env-value">
+          {process.env.NEXT_PUBLIC_CACHE_BUSTER ?? 'unset'}
+        </dd>
+      </dl>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/handler.js
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/handler.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+// A minimal cache handler that persists entries on disk, so they survive dev
+// server restarts (like any custom cache handler backed by external storage).
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+
+const cacheDir = path.join(__dirname, '.file-system-cache')
+
+function filePathForKey(cacheKey) {
+  const hash = crypto.createHash('sha256').update(cacheKey).digest('hex')
+  return path.join(cacheDir, `${hash}.json`)
+}
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey) {
+    const filePath = filePathForKey(cacheKey)
+    if (!fs.existsSync(filePath)) {
+      return undefined
+    }
+    const { value, ...metadata } = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    const bytes = new Uint8Array(Buffer.from(value, 'base64'))
+    return {
+      ...metadata,
+      value: new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      }),
+    }
+  },
+
+  async set(cacheKey, pendingEntry) {
+    const { value, ...metadata } = await pendingEntry
+    const chunks = []
+    const reader = value.getReader()
+    while (true) {
+      const { done, value: chunk } = await reader.read()
+      if (done) break
+      chunks.push(chunk)
+    }
+    fs.mkdirSync(cacheDir, { recursive: true })
+    fs.writeFileSync(
+      filePathForKey(cacheKey),
+      JSON.stringify({
+        ...metadata,
+        value: Buffer.concat(chunks).toString('base64'),
+      })
+    )
+  },
+
+  async refreshTags() {},
+
+  async getExpiration() {
+    return 0
+  },
+
+  async updateTags() {},
+}
+
+module.exports = cacheHandler

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/next.config.js
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  cacheHandlers: {
+    default: require.resolve('./handler.js'),
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -309,7 +309,7 @@ describe('route-change-refetch - App Router refetch count', () => {
     return browser.eval(() => (window as any).__refetches)
   }
 
-  it('refetches an open tab exactly twice when a page is added', async () => {
+  it('refetches an open tab exactly once when a page is added', async () => {
     const browser = await next.browser('/counted')
     expect(await browser.elementById('counted').text()).toBe('counted')
     await startCountingRefetches(browser)
@@ -322,12 +322,11 @@ describe('route-change-refetch - App Router refetch count', () => {
       expect((await next.fetch('/zz-added')).status).toBe(200)
     }, 15_000)
     await retry(async () => {
-      // TODO: Stop counting a page add as an env change, then it'll be 1.
-      expect(await countRefetches(browser)).toBe(2)
+      expect(await countRefetches(browser)).toBe(1)
     }, 15_000)
     // A later one would mean the change was announced more than once.
     await waitFor(1000)
-    expect(await countRefetches(browser)).toBe(2)
+    expect(await countRefetches(browser)).toBe(1)
   })
 })
 


### PR DESCRIPTION
In dev, `"use cache"` entries are keyed by an HMR refresh hash so that edits invalidate cached data.

This hash was managed wrong in both directions:

- webpack refreshed the hash at moments when no code changed: on dev server startup, and when a page file was added or removed. Each refresh threw away all cached data for nothing.

- The hash never distinguished one dev server run from another. That matters with a custom cache handler that persists entries: a restarted server would serve data cached by the previous run, whose code may have changed while the server was down.

To fix this:

- Adding or removing a page no longer refreshes webpack's hash. Edits and env file changes still do.
- The hash now includes a random per-run value.

This fixes the `cache-components-dev-warmup` flakes.

## How to reproduce

Here's the first problem in action, on webpack. Render a cached `Math.random()` on a page, then create an unrelated page file:

```
value: 0.199426
value: 0.199426
$ echo '...' > app/unrelated/page.tsx    # never visited
value: 0.990973                          # cached entry gone a second later
```

Adding the page threw the cached data away.

Starting the dev server throws it away too, once, shortly after boot. That one is a race: normally the cache is still empty when it fires, so nobody notices — but if the first page request gets in before it, everything that request cached is thrown away and the next reload is silently cold. That race is the cause of the `dev-warmup` flakes on loaded machines, and it's how I found this.

The hash refresh is specific to webpack, so Turbopack doesn't lose cached data this way. On Turbopack, these events instead clear the server's module cache. Whether the next render picks up a fresh module instance is a race, so module-scope state can reset. Turbopack also has a separate bug in this area — it advances its hash once per change-subscription emission, and an added or removed page can produce an emission without any edit — which #96248, stacked on this PR, fixes by deriving the hash from compiled output.

## Underlying cause

Next computes a "client router filter" (a bloom filter over the app's routes, used by the client-side router), and a filter change is treated like an env file change. An env change means cached data might be stale, so the reaction is strong: the browser is told to re-fetch, and on webpack the hash is refreshed, which discards every cached entry. But the filter is derived from the routes, so it "changes" whenever you add or remove a page — and once right after startup, because the first computation has nothing to compare against. Neither makes cached data stale.

The second problem is the opposite: dev server runs share cache keys. The hash starts from the same value on every run (unset on webpack, `"0"` on Turbopack), so a restarted server generates the same keys as the old one. With the default in-memory handler that's moot, but a custom cache handler that persists entries will serve entries written by the previous run. webpack can also hit this after edits: its hash is derived from compiled output, so re-applying an edit that a previous run also made lands on that run's keys.

Judging by the code (?), dev cache reuse was only ever meant to last a single run: every dev cache mechanism is in-memory, and #75474 takes it for granted that restarting the dev server clears cached content. So I treat cross-run reuse as a bug. Not sure I got this constraint right — in particular, #75474 deliberately made reverting an edit reuse previously cached data, and this PR keeps that working within a run but stops it from working across runs.

## Fix

Two changes:

- A filter change is no longer treated as an env change. It still updates the compiled-in filter value (the part that's actually needed), but it no longer refreshes the hash, and on Turbopack it no longer wipes the server's module cache. Real env file changes still trigger the full reaction.

- The hash now starts from a random per-run value on both bundlers. So it exists before the first request and never matches another run's keys.

The per-run value is deliberately conservative: it also prevents reuse across restarts where *nothing* changed. Allowing exactly that reuse safely needs keys derived from the cached function's implementation (the existing TODO in `use-cache-wrapper.ts`), which would replace the per-run value.

## Test plan

The first commit adds five tests (`test/development/app-dir/cache-components-spurious-cache-invalidation`). They run on both bundlers, except the module-state test, which is Turbopack-only: on webpack, adding a page recompiles the server bundle, which replaces the module instances regardless. So Turbopack runs five and webpack four.

Before the fix, these fail:

```
webpack:    ✕ discards use cache entries when a previous run made the same edit
            ✕ discards use cache entries across dev server restarts   (most runs — see below)
Turbopack:  ✕ keeps module state when an unrelated page is added
            ✕ discards use cache entries across dev server restarts
```

The webpack restart test does not fail every run. The start-time refresh replaces the unset hash with a content-derived one at an unpredictable moment. When one server run caches before its refresh and the other reads after its own, the keys don't collide, so there is no cross-run reuse for the test to catch that run.

The webpack side of the over-invalidation fix is covered by the refetch count below rather than by a cached-value test: the equivalent test on Turbopack depends on emission timing, so it lands with #96248, which removes that dependence.

The same commit also tightens the refetch count in the test from #96250 below: since a page add is no longer an env change, adding a page refetches an open tab once instead of twice, on both bundlers. Before the fix, both bundlers fail that expectation (`Expected: 1, Received: 2`).

To reproduce the flake this PR fixes, run the dev-warmup suites under CPU load (`for i in $(seq 1 12); do yes > /dev/null & done`). Before the fix, 6–8 of the 11 tests fail per run on webpack (`Prerender` flips to `Server` on warm reloads). After the fix, all 11 pass. Turbopack passes before and after. Also still green: `typed-env` (env definitions were previously only written at boot via the false positive this removes; now they're written on the initial scan explicitly), `env-config`, `use-cache-custom-handler`, and `pages-to-app-routing` (it exercises the router filter update path).

