### PR TITLE
[CI] Make next-stats benchmarks use the locally built SWC binaries again

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -153,7 +153,25 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
         })
         .catch(console.error)
 
-      process.env.NEXT_TEST_NATIVE_DIR = nativeDir
+      const nativeBindings = (await fs.readdir(nativeDir).catch(() => [])) //
+        .filter((file) => file.endsWith('.node'))
+
+      if (nativeBindings.length > 0) {
+        process.env.NEXT_TEST_NATIVE_DIR = nativeDir
+      } else {
+        const message =
+          `No native @next/swc binaries found in ${nativeDir}. ` +
+          `Without them, the stats app builds download the binaries from npm, ` +
+          `which fails when the version isn't published (yet), and can be ` +
+          `incompatible with the PR's JS when it changes the bindings.`
+
+        // Local runs may not have built binaries; downloading is fine there.
+        if (actionInfo.isLocal) {
+          logger(message)
+        } else {
+          throw new Error(message)
+        }
+      }
 
       logger(`Packing packages in ${dir}`)
       const turboJsonPath = path.join(dir, 'turbo.json')

--- a/.github/actions/next-stats-action/src/util/exec.js
+++ b/.github/actions/next-stats-action/src/util/exec.js
@@ -3,17 +3,22 @@ const { promisify } = require('util')
 const { exec: execOrig, spawn: spawnOrig } = require('child_process')
 
 const execP = promisify(execOrig)
-const env = {
-  ...process.env,
-  GITHUB_TOKEN: '',
-  PR_STATS_COMMENT_TOKEN: '',
+
+// Computed per call, so that variables assigned to `process.env` after this
+// module was loaded (e.g. NEXT_TEST_NATIVE_DIR) reach the child processes.
+function getEnv() {
+  return {
+    ...process.env,
+    GITHUB_TOKEN: '',
+    PR_STATS_COMMENT_TOKEN: '',
+  }
 }
 
 function exec(command, noLog = false, opts = {}) {
   if (!noLog) logger(`exec: ${command}`)
   return execP(command, {
     ...opts,
-    env: { ...env, ...opts.env },
+    env: { ...getEnv(), ...opts.env },
   })
 }
 
@@ -22,7 +27,7 @@ exec.spawn = function spawn(command = '', opts = {}) {
   const child = spawnOrig('/bin/bash', ['-c', command], {
     ...opts,
     env: {
-      ...env,
+      ...getEnv(),
       ...opts.env,
     },
     stdio: opts.stdio || 'inherit',

--- a/.github/next-stats-action.Dockerfile
+++ b/.github/next-stats-action.Dockerfile
@@ -33,5 +33,9 @@ WORKDIR /next-stats
 
 COPY --from=pnpm-deploy /next-stats .
 
+# `pnpm deploy` applies packing rules, and the .gitignore in native/ makes it
+# drop the binaries that the workflow copied there, so copy them in directly.
+COPY actions/next-stats-action/native/ native/
+
 COPY actions/next-stats-action/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The stats workflow builds the native SWC binary as an artifact and hands it to the stats action so the benchmark builds never depend on npm. That handoff was broken in two independent places, so every stats run silently downloaded the published binary instead:

- The Dockerfile packages the action with `pnpm deploy`, which applies packing rules — and the `.gitignore` in `native/` (ignoring everything) makes it drop the binaries the workflow copied there. The deployed image's `native/` directory contained only the `.gitignore`.
- The action's `exec` util snapshots `process.env` at module load time, but `NEXT_TEST_NATIVE_DIR` is assigned later, so child processes (including the stats app's `next build`) never saw it.

Consequences: the Stats job hard-failed on unrelated PRs whenever the current canary's binaries weren't published yet — a 404 on the download, e.g. https://github.com/vercel/next.js/actions/runs/30179600812/job/89734960717 — and PRs that change the bindings surface built their JS against a published binary that doesn't match it. (The main-vs-PR deltas were otherwise unaffected: both sides share one binary by design, downloaded or not.)

The fix: copy `native/` into the image explicitly, compute the child env per call, and if the binaries are ever missing again, fail early with a clear message instead of falling back to the download (CI only — local runs just log and keep the download fallback, since built binaries may legitimately be absent there).

Verified locally:

- `pnpm deploy --filter=next-stats-action --production` reproduces the dropped binaries (deployed `native/` contains only the `.gitignore`).
- `docker build` of the action image now contains a binary placed in `native/` (`ls /next-stats/native` in the final stage).
- An `exec` smoke test: an env var assigned after the module loads now reaches the child, and the `GITHUB_TOKEN` scrub still applies.

Additionally, this PR's own Stats jobs are an end-to-end test: they run this branch's action code while `16.3.0-canary.97` binaries are still unpublished, so they only pass if the built binaries are actually used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)