### PR TITLE
Only advance the Turbopack HMR hash when compiled output actually changed

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1619,13 +1619,13 @@ export async function createHotReloaderTurbopack(
     },
 
     getServerComponentsHmrRefreshHash() {
-      // The current server-components generation. Only the change subscription
-      // (an actual recompile) advances `hmrHash`; reloads and config
-      // invalidations don't, so the value stays stable across requests until a
-      // real edit. Returned unconditionally (`"0"` before the first edit) so
-      // `"use cache"` keys are present and consistent for every request,
-      // mirroring webpack's always-present `stats.hash`.
-      return String(hmrHash)
+      // Only the change subscription (an actual recompile) advances `hmrHash`;
+      // reloads and config invalidations don't, so the value stays stable
+      // across requests until a real edit. `sessionId` stands in for a key
+      // derived from the compiled implementation, which would let entries
+      // outlive a restart when the code didn't change (see the note on Action
+      // IDs in `use-cache-wrapper.ts`).
+      return `${sessionId}-${hmrHash}`
     },
 
     sendToLegacyClients(action) {
@@ -1762,10 +1762,7 @@ export async function createHotReloaderTurbopack(
       }
       return errors
     },
-    async invalidate({
-      // .env files or tsconfig/jsconfig change
-      reloadAfterInvalidation,
-    }) {
+    async invalidate({ reloadAfterInvalidation }) {
       if (reloadAfterInvalidation) {
         for (const [key, entrypoint] of currentWrittenEntrypoints) {
           clearRequireCache(key, entrypoint, { force: true })

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -358,6 +358,26 @@ function getSourceMapURLFromTurbopack(
   return pathToFileURL(scriptPath + '.map').href
 }
 
+/**
+ * A digest of the endpoint's compiled server-side output. `writeToDisk()` is
+ * incremental, so calling it when nothing has changed is cheap and returns
+ * the same content hashes. Returns null when the output can't be computed
+ * (e.g. the endpoint fails to build).
+ */
+async function getServerContentDigest(
+  endpoint: Endpoint
+): Promise<string | null> {
+  try {
+    const { serverPaths } = await endpoint.writeToDisk()
+    return serverPaths
+      .map(({ path, contentHash }) => `${path}:${contentHash}`)
+      .sort()
+      .join('\n')
+  } catch {
+    return null
+  }
+}
+
 export async function createHotReloaderTurbopack(
   opts: SetupOpts & { isSrcDir: boolean },
   serverFields: ServerFields,
@@ -938,10 +958,30 @@ export async function createHotReloaderTurbopack(
     try {
       const changed = await changedPromise
 
+      // `hmrHash` is folded into every `"use cache"` key, so advancing it
+      // discards all cached entries. The subscription emits whenever the
+      // entry *may* have changed — including once for the entry's own
+      // initial build, and possibly coalescing several changes into one
+      // emission — so emissions can't be counted directly. Instead, compare
+      // the entry's compiled output and only advance the hash when it
+      // actually changed.
+      let contentDigest = await getServerContentDigest(endpoint)
+
       for await (const change of changed) {
         processIssues(currentEntryIssues, key, change, false, true)
-        // TODO: Get an actual content hash from Turbopack.
-        const message = await createMessage(change, String(++hmrHash))
+        const nextContentDigest = await getServerContentDigest(endpoint)
+        // When the digest can't be computed (null), err on the side of
+        // invalidating. An empty digest means the entry was removed; that
+        // can't affect other entries' cached data, and its own entries are
+        // unreachable.
+        if (
+          nextContentDigest === null ||
+          (nextContentDigest !== contentDigest && nextContentDigest !== '')
+        ) {
+          contentDigest = nextContentDigest
+          hmrHash++
+        }
+        const message = await createMessage(change, String(hmrHash))
         if (message) {
           sendHmr(key, message)
         }

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -259,12 +259,15 @@ export interface NextJsHotReloaderInterface {
    */
   sendToLegacyClients(action: HmrMessageSentToBrowser): void
   /**
-   * The hash of the most recent server component change, or `undefined` if no
-   * server component change has occurred yet. In dev, this is included in `"use
-   * cache"` cache keys so that cached entries are revalidated after an edit,
-   * for every client, regardless of whether it runs the HMR client.
+   * Identifies the current generation of the compiled server components. It is
+   * included in `"use cache"` cache keys so that cached entries are revalidated
+   * after an edit, for every client, regardless of whether it runs the HMR
+   * client. It is present from the first request on, so that entries created
+   * before the first edit are keyed by it too, and it differs between dev
+   * server runs, so that a cache handler that persists entries doesn't serve
+   * them for code that changed while the server was down.
    */
-  getServerComponentsHmrRefreshHash(): string | undefined
+  getServerComponentsHmrRefreshHash(): string
   setCacheStatus(status: ServerCacheStatus, htmlRequestId: string): void
   setReactDebugChannel(
     debugChannel: ReactDebugChannelForBrowser,
@@ -282,6 +285,13 @@ export interface NextJsHotReloaderInterface {
       context: { isLegacyClient: boolean }
     ) => void
   ): void
+  /**
+   * Rebuilds so that a changed configuration reaches the bundles. Pass
+   * `reloadAfterInvalidation` only when the change can also affect what a
+   * render produces: it makes connected clients refetch server components, and
+   * advances `getServerComponentsHmrRefreshHash`, discarding `"use cache"`
+   * entries.
+   */
   invalidate({
     reloadAfterInvalidation,
   }: {

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -15,6 +15,7 @@ import {
 } from './middleware-webpack'
 import { WebpackHotMiddleware } from './hot-middleware'
 import * as inspector from 'inspector'
+import { randomUUID } from 'crypto'
 import { join, relative, isAbsolute, posix, dirname } from 'path'
 import {
   createEntrypoints,
@@ -126,6 +127,9 @@ function diff(a: Set<any>, b: Set<any>) {
 }
 
 const wsServer = new ws.Server({ noServer: true })
+
+// Folded into the HMR refresh hash to make it differ between dev server runs.
+const devServerSessionId = randomUUID()
 
 export async function renderScriptError(
   res: ServerResponse,
@@ -440,8 +444,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     })
   }
 
-  public getServerComponentsHmrRefreshHash(): string | undefined {
-    return this.serverComponentsHmrRefreshHash
+  public getServerComponentsHmrRefreshHash(): string {
+    return `${devServerSessionId}-${this.serverComponentsHmrRefreshHash ?? '0'}`
   }
 
   public onHMR(

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -417,12 +417,15 @@ async function startWatcher(
     let enabledTypeScript = await verifyTypeScript(opts)
     let previousClientRouterFilters: any
     let previousConflictingPagePaths: Set<string> = new Set()
+    let hadInitialScan = false
 
     const routeTypesFilePath = path.join(distDir, 'types', 'routes.d.ts')
     const validatorFilePath = path.join(distDir, 'types', 'validator.ts')
 
     let initialWatchTime = performance.now() + performance.timeOrigin
     wp.on('aggregated', async () => {
+      const isInitialScan = !hadInitialScan
+      hadInitialScan = true
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
       let middlewareMatchers: ProxyMatcher[] | undefined
@@ -440,7 +443,8 @@ async function startWatcher(
       const layoutRoutes: RouteInfo[] = []
       const slots: SlotInfo[] = []
 
-      let envChange = false
+      let envFileChange = false
+      let clientRouterFiltersChange = false
       let tsconfigChange = false
       let conflictingPageChange = 0
       let hasRootAppNotFound = false
@@ -513,7 +517,7 @@ async function startWatcher(
 
         if (envFiles.includes(fileName)) {
           if (fileChanged) {
-            envChange = true
+            envFileChange = true
           }
           continue
         }
@@ -794,15 +798,19 @@ async function startWatcher(
           JSON.stringify(previousClientRouterFilters) !==
             JSON.stringify(clientRouterFilters)
         ) {
-          envChange = true
+          clientRouterFiltersChange = true
           previousClientRouterFilters = clientRouterFilters
         }
       }
 
-      if (envChange || tsconfigChange) {
-        if (envChange) {
-          writeEnvDefinitions = true
+      // Also set on the initial scan, so that typed env definitions exist
+      // from startup.
+      if (envFileChange || isInitialScan) {
+        writeEnvDefinitions = true
+      }
 
+      if (envFileChange || clientRouterFiltersChange || tsconfigChange) {
+        if (envFileChange) {
           await propagateServerField(opts, 'loadEnvConfig', [
             { dev: true, forceReload: true },
           ])
@@ -905,7 +913,7 @@ async function startWatcher(
               })
             }
 
-            if (envChange) {
+            if (envFileChange || clientRouterFiltersChange) {
               config.plugins?.forEach((plugin: any) => {
                 // we look for the DefinePlugin definitions so we can
                 // update them on the active compilers
@@ -943,7 +951,10 @@ async function startWatcher(
           })
         }
         await hotReloader.invalidate({
-          reloadAfterInvalidation: envChange,
+          // A router-filter change only requires the updated define to be
+          // compiled into the bundles; unlike env, it can't affect rendered
+          // output or cached data.
+          reloadAfterInvalidation: envFileChange,
         })
       }
 

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
@@ -1,0 +1,228 @@
+import { nextTestSetup, type NextInstance, type Playwright } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import * as nodeFs from 'node:fs'
+import * as nodePath from 'node:path'
+
+// In dev, `"use cache"` entries must only be discarded when something they
+// can depend on changes (their code, or env) — and, conversely, they must
+// never survive into a different dev server run, where the code may have
+// changed while the server was down.
+
+async function readCachedValue(browser: Playwright) {
+  return browser.elementById('cached-value').text()
+}
+
+// Right after the dev server starts, it may still be settling (e.g.
+// finishing startup compiles), so wait until the cached value is stable
+// across reloads before asserting anything about invalidation.
+async function waitForStableCachedValue(
+  next: NextInstance,
+  browser: Playwright
+) {
+  let stableValue: string = ''
+  await retry(async () => {
+    await browser.loadPage(next.url + '/')
+    const first = await readCachedValue(browser)
+    await browser.loadPage(next.url + '/')
+    const second = await readCachedValue(browser)
+    expect(second).toBe(first)
+    stableValue = second
+  }, 15_000)
+  return stableValue
+}
+
+describe('cache-components-spurious-cache-invalidation', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/default'),
+  })
+
+  // Serving the added page requires the file watcher to have processed
+  // everything up to and including this addition, plus a compile — so any
+  // invalidation that an earlier change could have caused has landed by now,
+  // and a negative ("the cached value didn't change") can be asserted right
+  // after, instead of waiting out an arbitrary settling period.
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `app${pathname}/page.tsx`,
+      `export default function Page() { return <p>${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  it('keeps use cache entries when an unrelated page is added and removed', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    try {
+      await addPageAndWaitUntilServable('/unrelated')
+
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+
+      await next.deleteFile('app/unrelated/page.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/unrelated')).status).toBe(404)
+      }, 15_000)
+
+      // Removal doesn't compile anything we could wait for, so push another
+      // page addition through as a barrier before asserting.
+      await addPageAndWaitUntilServable('/unrelated-barrier')
+
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+    } finally {
+      for (const dir of ['app/unrelated', 'app/unrelated-barrier']) {
+        if (nodeFs.existsSync(nodePath.join(next.testDir, dir))) {
+          await next.deleteFile(`${dir}/page.tsx`)
+        }
+      }
+    }
+  })
+
+  // Turbopack-only: on webpack, adding a page recompiles the server bundle
+  // (the compiled-in client router filter changes), which replaces the
+  // serving module instances, so module state doesn't survive there.
+  if (isTurbopack) {
+    it('keeps module state when an unrelated page is added', async () => {
+      async function readRenderCount() {
+        const html = await (await next.fetch('/')).text()
+        const match = html.match(/id="render-count">(\d+)</)
+        expect(match).not.toBeNull()
+        return Number(match![1])
+      }
+
+      const first = await readRenderCount()
+      const second = await readRenderCount()
+      expect(second).toBeGreaterThan(first)
+
+      try {
+        await addPageAndWaitUntilServable('/unrelated')
+        await waitFor(2000)
+        // If the page add re-evaluated the module, the counter restarted
+        // from zero.
+        expect(await readRenderCount()).toBeGreaterThan(second)
+        await waitFor(2000)
+        expect(await readRenderCount()).toBeGreaterThan(second)
+      } finally {
+        if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/unrelated'))) {
+          await next.deleteFile('app/unrelated/page.tsx')
+        }
+      }
+    })
+  }
+
+  it('discards use cache entries when an env file changes', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    // The page reads this var, so its output depends on the change.
+    await next.patchFile('.env', 'NEXT_PUBLIC_CACHE_BUSTER=busted')
+
+    try {
+      await retry(async () => {
+        await browser.loadPage(next.url + '/')
+        expect(await browser.elementById('env-value').text()).toBe('busted')
+        expect(await readCachedValue(browser)).not.toBe(stableValue)
+      }, 15_000)
+    } finally {
+      await next.deleteFile('.env')
+    }
+  })
+
+  it('refetches server components when an env change does not affect compiled output', async () => {
+    const browser = await next.browser('/')
+    await waitForStableCachedValue(next, browser)
+
+    await browser.loadPage(next.url + '/')
+    expect(await browser.elementById('runtime-env-value').text()).toBe('unset')
+
+    // This var is only read at render time, so the rebuild after the env
+    // change is a no-op.
+    await next.patchFile('.env', 'RUNTIME_GREETING=hello')
+
+    try {
+      await retry(async () => {
+        // Deliberately no reload here.
+        expect(await browser.elementById('runtime-env-value').text()).toBe(
+          'hello'
+        )
+      }, 15_000)
+    } finally {
+      await next.deleteFile('.env')
+    }
+  })
+})
+
+describe('cache-components-spurious-cache-invalidation - persistent cache handler', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/persistent-handler'),
+  })
+
+  it('discards use cache entries across dev server restarts', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    await next.stop()
+
+    // The custom cache handler persists entries on disk. Ensure they're
+    // actually there — otherwise a fresh value after the restart wouldn't
+    // prove anything (it could just mean nothing was persisted).
+    const persistedEntries = nodeFs.readdirSync(
+      nodePath.join(next.testDir, '.file-system-cache')
+    )
+    expect(persistedEntries.length).toBeGreaterThan(0)
+
+    await next.start()
+
+    const newBrowser = await next.browser('/')
+    const newStableValue = await waitForStableCachedValue(next, newBrowser)
+    expect(newStableValue).not.toBe(stableValue)
+  })
+
+  it('discards use cache entries when a previous run made the same edit', async () => {
+    const browser = await next.browser('/')
+    await waitForStableCachedValue(next, browser)
+
+    const originalPage = await next.readFile('app/page.tsx')
+    const editedPage = originalPage.replace(
+      '<main>',
+      '<main><p id="edited-marker">edited</p>'
+    )
+    expect(editedPage).not.toBe(originalPage)
+
+    async function waitForMarker(b: Playwright, present: boolean) {
+      await retry(async () => {
+        await b.loadPage(next.url + '/')
+        expect(await b.hasElementByCssSelector('#edited-marker')).toBe(present)
+      }, 15_000)
+    }
+
+    try {
+      await next.patchFile('app/page.tsx', editedPage)
+      await waitForMarker(browser, true)
+      const editedValue = await waitForStableCachedValue(next, browser)
+
+      await next.stop()
+      await next.start()
+
+      // Even though the previous run persisted an entry for this exact code,
+      // it must not be served: entries never carry over between runs.
+      const newBrowser = await next.browser('/')
+      await next.patchFile('app/page.tsx', originalPage)
+      await waitForMarker(newBrowser, false)
+      await next.patchFile('app/page.tsx', editedPage)
+      await waitForMarker(newBrowser, true)
+
+      const newEditedValue = await waitForStableCachedValue(next, newBrowser)
+      expect(newEditedValue).not.toBe(editedValue)
+    } finally {
+      await next.patchFile('app/page.tsx', originalPage)
+    }
+  })
+})

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/layout.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/page.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/page.tsx
@@ -1,0 +1,39 @@
+// Incremented on every render. Module state must survive anything that
+// doesn't change this module's code: if this resets, the server re-evaluated
+// the module.
+let renderCount = 0
+
+async function getCachedData() {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}
+
+export default async function Page() {
+  renderCount++
+  const data = await getCachedData()
+  return (
+    <main>
+      <p>
+        This page renders cached data. The cached value must be stable across
+        reloads unless this page (or the data it depends on) is edited.
+      </p>
+      <dl>
+        <dt>Cached Data</dt>
+        <dd id="cached-value">{data}</dd>
+        <dt>Env</dt>
+        <dd id="env-value">
+          {process.env.NEXT_PUBLIC_CACHE_BUSTER ?? 'unset'}
+        </dd>
+        <dt>Render Count</dt>
+        <dd id="render-count">{renderCount}</dd>
+        <dt>Runtime Env</dt>
+        {/* Not prefixed with NEXT_PUBLIC_, so it's read at render time and
+            changing it doesn't affect the compiled output. */}
+        <dd id="runtime-env-value">
+          {process.env.RUNTIME_GREETING ?? 'unset'}
+        </dd>
+      </dl>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/next.config.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/layout.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/page.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/page.tsx
@@ -1,0 +1,25 @@
+async function getCachedData() {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}
+
+export default async function Page() {
+  const data = await getCachedData()
+  return (
+    <main>
+      <p>
+        This page renders cached data. The cached value must be stable across
+        reloads unless this page (or the data it depends on) is edited.
+      </p>
+      <dl>
+        <dt>Cached Data</dt>
+        <dd id="cached-value">{data}</dd>
+        <dt>Env</dt>
+        <dd id="env-value">
+          {process.env.NEXT_PUBLIC_CACHE_BUSTER ?? 'unset'}
+        </dd>
+      </dl>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/handler.js
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/handler.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+// A minimal cache handler that persists entries on disk, so they survive dev
+// server restarts (like any custom cache handler backed by external storage).
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+
+const cacheDir = path.join(__dirname, '.file-system-cache')
+
+function filePathForKey(cacheKey) {
+  const hash = crypto.createHash('sha256').update(cacheKey).digest('hex')
+  return path.join(cacheDir, `${hash}.json`)
+}
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey) {
+    const filePath = filePathForKey(cacheKey)
+    if (!fs.existsSync(filePath)) {
+      return undefined
+    }
+    const { value, ...metadata } = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    const bytes = new Uint8Array(Buffer.from(value, 'base64'))
+    return {
+      ...metadata,
+      value: new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      }),
+    }
+  },
+
+  async set(cacheKey, pendingEntry) {
+    const { value, ...metadata } = await pendingEntry
+    const chunks = []
+    const reader = value.getReader()
+    while (true) {
+      const { done, value: chunk } = await reader.read()
+      if (done) break
+      chunks.push(chunk)
+    }
+    fs.mkdirSync(cacheDir, { recursive: true })
+    fs.writeFileSync(
+      filePathForKey(cacheKey),
+      JSON.stringify({
+        ...metadata,
+        value: Buffer.concat(chunks).toString('base64'),
+      })
+    )
+  },
+
+  async refreshTags() {},
+
+  async getExpiration() {
+    return 0
+  },
+
+  async updateTags() {},
+}
+
+module.exports = cacheHandler

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/next.config.js
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  cacheHandlers: {
+    default: require.resolve('./handler.js'),
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -223,7 +223,7 @@ describe('route-change-refetch - App Router refetch count', () => {
     return browser.eval(() => (window as any).__refetches)
   }
 
-  it('refetches an open tab exactly twice when a page is added', async () => {
+  it('refetches an open tab exactly once when a page is added', async () => {
     const browser = await next.browser('/counted')
     expect(await browser.elementById('counted').text()).toBe('counted')
     await startCountingRefetches(browser)
@@ -236,12 +236,11 @@ describe('route-change-refetch - App Router refetch count', () => {
       expect((await next.fetch('/zz-added')).status).toBe(200)
     }, 15_000)
     await retry(async () => {
-      // TODO: Stop counting a page add as an env change, then it'll be 1.
-      expect(await countRefetches(browser)).toBe(2)
+      expect(await countRefetches(browser)).toBe(1)
     }, 15_000)
     // A later one would mean the change was announced more than once.
     await waitFor(1000)
-    expect(await countRefetches(browser)).toBe(2)
+    expect(await countRefetches(browser)).toBe(1)
   })
 })
 


### PR DESCRIPTION
Stacked on #96235.

Addresses [this TODO](https://github.com/vercel/next.js/pull/96245#discussion_r3659708308).

The Turbopack HMR refresh hash that dev folds into every `"use cache"` key was a counter, incremented once per change-subscription emission:

```ts
// TODO: Get an actual content hash from Turbopack.
const message = await createMessage(change, String(++hmrHash))
```

A subscription emission does not always mean code changed: a newly added page's subscription emits once for the entry's own initial build, and a removed page's subscription emits one final time on the way out. Before this fix, those emissions incremented the counter like any other — and one stray increment discards every cached entry, because the counter is part of every key.

Whether those emissions actually got counted depends on timing. On the July canary this stack started from, they did — visiting a newly added page reliably threw all cached data away under CPU load:

```
value: 0.485620
value: 0.485620
$ echo '...' > app/unrelated/page.tsx
$ curl localhost:3000/unrelated          # first visit builds the page
value: 0.890276                          # cached entry gone
```

On the current base I could not reproduce this: the extra emissions now arrive early enough to be folded into the initial emission that the subscription already skips, and the page add/remove test from #96235 passes on Turbopack as-is (13 runs under CPU load, plus a scripted loop of 15 add/remove cycles, all clean). But that depends entirely on emission timing, which has already shifted once between July and now. The counter still counts emissions rather than changes, so a future shift can bring the bug back. This PR removes the dependence on timing: the hash advances only when the compiled output actually changed. The content comparison it introduces is also what the next PR builds on.

## Fix

On each emission, digest the content hashes of the endpoint's written server files (`writeToDisk()` returns them), and increment only when the digest differs from the last one. An empty digest means the entry was removed, which can't affect other entries' cached data, so it doesn't increment either. If the digest can't be computed, err on the side of invalidating.

This is cheaper than it looks: the subscription itself is computed from the endpoint's output (`server_changed` walks the output assets' contents to decide whether to emit), and `writeToDisk()` returns that same memoized output. The middleware subscription already calls `writeToDisk()` on every emission today.

Skipping the first emission by position instead would be wrong: emissions coalesce, so an initial-build emission that arrives late can already include a real change. I observed this with an `.env` edit folded into the first emission — skipping by position served stale cached entries for code that had changed.

## Test plan

The page add/remove test from #96235 runs on Turbopack and keeps guarding this: it catches the counter bug whenever timing exposes it, as it did on the July base. Green with the fix, idle and under CPU load: `cache-components-spurious-cache-invalidation` (6), `server-components-hmr-cache` (17 — edits and env changes must still invalidate), `cache-components-dev-warmup`, and the basic `hmr` suites, which cover the subscription loop this changes.
