### PR TITLE
Only advance the Turbopack HMR hash when compiled output actually changed

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -82,7 +82,7 @@ use crate::{
         all_asset_paths, all_paths_in_root, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
-    project::{BaseAndFullModuleGraph, Project},
+    project::{BaseAndFullModuleGraph, OptionContentHash, Project},
     route::{
         AppPageRoute, Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs, Route, Routes,
     },
@@ -2195,6 +2195,15 @@ impl Endpoint for AppEndpoint {
             .app_project
             .project()
             .server_changed(self.output().server_assets()))
+    }
+
+    #[turbo_tasks::function]
+    async fn server_content_hash(self: Vc<Self>) -> Result<Vc<OptionContentHash>> {
+        Ok(self
+            .await?
+            .app_project
+            .project()
+            .server_content_hash(self.output().server_assets()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/empty.rs
+++ b/crates/next-api/src/empty.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{Completion, ResolvedVc, Vc};
 use turbopack_core::module_graph::GraphEntries;
 
 use crate::{
-    project::Project,
+    project::{OptionContentHash, Project},
     route::{Endpoint, EndpointOutput, ModuleGraphs},
 };
 
@@ -31,6 +31,11 @@ impl Endpoint for EmptyEndpoint {
     #[turbo_tasks::function]
     fn server_changed(self: Vc<Self>) -> Vc<Completion> {
         Completion::new()
+    }
+
+    #[turbo_tasks::function]
+    fn server_content_hash(self: Vc<Self>) -> Vc<OptionContentHash> {
+        Vc::cell(None)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -32,7 +32,7 @@ use crate::{
     paths::{
         all_asset_paths, get_js_paths_from_root, get_wasm_paths_from_root, wasm_paths_to_bindings,
     },
-    project::Project,
+    project::{OptionContentHash, Project},
     route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs},
 };
 
@@ -246,6 +246,14 @@ impl Endpoint for InstrumentationEndpoint {
     #[turbo_tasks::function]
     async fn server_changed(self: Vc<Self>) -> Result<Vc<Completion>> {
         Ok(self.await?.project.server_changed(self.output_assets()))
+    }
+
+    #[turbo_tasks::function]
+    async fn server_content_hash(self: Vc<Self>) -> Result<Vc<OptionContentHash>> {
+        Ok(self
+            .await?
+            .project
+            .server_content_hash(self.output_assets()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -35,7 +35,7 @@ use crate::{
         all_asset_paths, all_paths_in_root, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
-    project::Project,
+    project::{OptionContentHash, Project},
     route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs},
 };
 
@@ -394,6 +394,14 @@ impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
     async fn server_changed(self: Vc<Self>) -> Result<Vc<Completion>> {
         Ok(self.await?.project.server_changed(self.output_assets()))
+    }
+
+    #[turbo_tasks::function]
+    async fn server_content_hash(self: Vc<Self>) -> Result<Vc<OptionContentHash>> {
+        Ok(self
+            .await?
+            .project
+            .server_content_hash(self.output_assets()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -81,7 +81,7 @@ use crate::{
         all_asset_paths, all_paths_in_root, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
-    project::Project,
+    project::{OptionContentHash, Project},
     route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs, Route, Routes},
     service_worker::service_worker_output_assets,
     sri_manifest::get_sri_manifest_asset,
@@ -1737,6 +1737,15 @@ impl Endpoint for PageEndpoint {
             .pages_project
             .project()
             .server_changed(self.output().server_assets()))
+    }
+
+    #[turbo_tasks::function]
+    async fn server_content_hash(self: Vc<Self>) -> Result<Vc<OptionContentHash>> {
+        Ok(self
+            .await?
+            .pages_project
+            .project()
+            .server_content_hash(self.output().server_assets()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -48,6 +48,7 @@ use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystem, FileSystemPath, VirtualFileSystem,
     canonicalize_to_rcstr, invalidation,
 };
+use turbo_tasks_hash::{HashAlgorithm, hash_xxh3_hash64};
 use turbo_unix_path::join_path;
 use turbopack::{
     ModuleAssetContext, evaluate_context::node_build_environment, externals_tracing_module_context,
@@ -55,6 +56,7 @@ use turbopack::{
 };
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME,
+    asset::{Asset, no_hash_salt},
     changed::content_changed,
     chunk::{
         ChunkingContext, EvaluatableAssets, UnusedReferences,
@@ -2716,6 +2718,17 @@ impl Project {
         Ok(any_output_changed(roots, path, true))
     }
 
+    /// A hash of the contents of the same output assets that `server_changed`
+    /// watches. None when there are no assets (e.g. the entry was removed).
+    #[turbo_tasks::function]
+    pub async fn server_content_hash(
+        self: Vc<Self>,
+        roots: Vc<OutputAssets>,
+    ) -> Result<Vc<OptionContentHash>> {
+        let path = self.node_root().owned().await?;
+        Ok(output_assets_content_hash(roots, path, true))
+    }
+
     /// Completion when client side changes are detected in output assets
     /// referenced from the roots
     #[turbo_tasks::function]
@@ -2961,18 +2974,21 @@ pub struct BaseAndFullModuleGraph {
     pub binding_usage_info: Option<OperationVc<BindingUsageInfo>>,
 }
 
-#[turbo_tasks::function]
-async fn any_output_changed(
+/// The output assets that change detection watches: everything reachable
+/// from the roots, minus source maps and (on the server) CSS, limited to
+/// assets inside `path`. Used by both `any_output_changed` and
+/// `output_assets_content_hash` so they can't drift apart.
+async fn watched_output_assets(
     roots: Vc<OutputAssets>,
     path: FileSystemPath,
     server: bool,
-) -> Result<Vc<Completion>> {
+) -> Result<Vec<(ReadRef<FileSystemPath>, ResolvedVc<Box<dyn OutputAsset>>)>> {
     let all_assets = expand_output_assets(
         roots.await?.into_iter().map(ExpandOutputAssetsInput::Asset),
         true,
     )
     .await?;
-    let completions = all_assets
+    all_assets
         .into_iter()
         .map(|m| {
             let path = path.clone();
@@ -2983,20 +2999,70 @@ async fn any_output_changed(
                     && (!server || !asset_path.path.ends_with(".css"))
                     && asset_path.is_inside_ref(&path)
                 {
-                    anyhow::Ok(Some(
-                        content_changed(*ResolvedVc::upcast(m))
-                            .to_resolved()
-                            .await?,
-                    ))
+                    anyhow::Ok(Some((asset_path, m)))
                 } else {
                     Ok(None)
                 }
             }
         })
         .try_flat_join()
+        .await
+}
+
+#[turbo_tasks::function]
+async fn any_output_changed(
+    roots: Vc<OutputAssets>,
+    path: FileSystemPath,
+    server: bool,
+) -> Result<Vc<Completion>> {
+    let completions = watched_output_assets(roots, path, server)
+        .await?
+        .into_iter()
+        .map(|(_, m)| async move { content_changed(*ResolvedVc::upcast(m)).to_resolved().await })
+        .try_join()
         .await?;
 
     Ok(Vc::<Completions>::cell(completions).completed())
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionContentHash(Option<RcStr>);
+
+/// Hashes the contents of the same output assets that `any_output_changed`
+/// watches. Returns None when no assets qualify.
+#[turbo_tasks::function]
+async fn output_assets_content_hash(
+    roots: Vc<OutputAssets>,
+    path: FileSystemPath,
+    server: bool,
+) -> Result<Vc<OptionContentHash>> {
+    let mut entries = watched_output_assets(roots, path, server)
+        .await?
+        .into_iter()
+        .map(|(asset_path, m)| async move {
+            let hash = m
+                .content()
+                .hash(no_hash_salt(), HashAlgorithm::Xxh3Hash128Hex)
+                .owned()
+                .await?;
+            anyhow::Ok((asset_path.path.clone(), hash))
+        })
+        .try_join()
+        .await?;
+    if entries.is_empty() {
+        return Ok(Vc::cell(None));
+    }
+    entries.sort();
+    let mut joined = String::new();
+    for (asset_path, hash) in entries {
+        joined.push_str(&asset_path);
+        joined.push(':');
+        joined.push_str(&hash);
+        joined.push('\n');
+    }
+    Ok(Vc::cell(Some(
+        format!("{:016x}", hash_xxh3_hash64(joined.as_bytes())).into(),
+    )))
 }
 
 #[turbo_tasks::function(operation, root)]

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -13,7 +13,11 @@ use turbopack_core::{
     output::OutputAssets,
 };
 
-use crate::{operation::OptionEndpoint, paths::AssetPath, project::Project};
+use crate::{
+    operation::OptionEndpoint,
+    paths::AssetPath,
+    project::{OptionContentHash, Project},
+};
 
 #[derive(
     TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Clone, Debug, NonLocalValue, Encode, Decode,
@@ -52,6 +56,10 @@ pub trait Endpoint {
     // fn write_to_disk(self: Vc<Self>) -> Vc<EndpointOutputPaths>;
     #[turbo_tasks::function]
     fn server_changed(self: Vc<Self>) -> Vc<Completion>;
+    /// A hash of the endpoint's compiled server-side output (the same assets
+    /// `server_changed` watches). None when the endpoint has no output.
+    #[turbo_tasks::function]
+    fn server_content_hash(self: Vc<Self>) -> Vc<OptionContentHash>;
     #[turbo_tasks::function]
     fn client_changed(self: Vc<Self>) -> Vc<Completion>;
     /// The entry modules for the modules graph.
@@ -265,6 +273,17 @@ pub async fn endpoint_server_changed_operation(
         endpoint.server_changed()
     } else {
         Completion::new()
+    })
+}
+
+#[turbo_tasks::function(operation, root)]
+pub async fn endpoint_server_content_hash_operation(
+    endpoint: OperationVc<OptionEndpoint>,
+) -> Result<Vc<OptionContentHash>> {
+    Ok(if let Some(endpoint) = *endpoint.connect().await? {
+        endpoint.server_content_hash()
+    } else {
+        Vc::cell(None)
     })
 }
 

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -9,7 +9,8 @@ use next_api::{
     paths::AssetPath,
     route::{
         Endpoint, EndpointOutputPaths, endpoint_client_changed_operation,
-        endpoint_server_changed_operation, endpoint_write_to_disk_operation,
+        endpoint_server_changed_operation, endpoint_server_content_hash_operation,
+        endpoint_write_to_disk_operation,
     },
 };
 use tracing::Instrument;
@@ -177,6 +178,27 @@ pub async fn endpoint_write_to_disk(
     })
 }
 
+#[tracing::instrument(level = "info", name = "get endpoint server content hash", skip_all)]
+#[napi]
+pub async fn endpoint_server_content_hash(
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
+) -> napi::Result<Option<String>> {
+    let ctx = endpoint.turbopack_ctx();
+    let endpoint_op = ***endpoint;
+    let hash = endpoint
+        .turbopack_ctx()
+        .turbo_tasks()
+        .run(async move {
+            let read = endpoint_server_content_hash_operation(endpoint_op)
+                .read_strongly_consistent()
+                .await?;
+            Ok((*read).clone())
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+    Ok(hash.map(|h| h.to_string()))
+}
+
 #[tracing::instrument(level = "info", name = "get server-side endpoint changes", skip_all)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_server_changed_subscribe(
@@ -202,21 +224,32 @@ pub fn endpoint_server_changed_subscribe(
         |ctx| {
             let EndpointIssuesAndDiags {
                 changed: _,
+                server_content_hash,
                 issues,
                 effects: _,
             } = &*ctx.value;
 
             Ok(vec![TurbopackResult {
-                result: (),
+                result: NapiServerChanged {
+                    content_hash: server_content_hash.as_ref().map(|h| h.to_string()),
+                },
                 issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
             }])
         },
     )
 }
 
+#[napi(object)]
+pub struct NapiServerChanged {
+    /// A hash of the endpoint's compiled server-side output, or None when the
+    /// endpoint has no output (e.g. it was removed).
+    pub content_hash: Option<String>,
+}
+
 #[turbo_tasks::value(shared, serialization = "skip", eq = "manual")]
 struct EndpointIssuesAndDiags {
     changed: Option<ReadRef<Completion>>,
+    server_content_hash: Option<RcStr>,
     issues: Arc<Vec<ReadRef<PlainIssue>>>,
     effects: Arc<Effects>,
 }
@@ -227,7 +260,8 @@ impl PartialEq for EndpointIssuesAndDiags {
             (Some(a), Some(b)) => ReadRef::ptr_eq(a, b),
             (None, None) => true,
             (None, Some(_)) | (Some(_), None) => false,
-        }) && self.issues == other.issues
+        }) && self.server_content_hash == other.server_content_hash
+            && self.issues == other.issues
     }
 }
 
@@ -248,8 +282,18 @@ async fn subscribe_issues_and_diags_operation(
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (changed_value, issues, effects) =
         strongly_consistent_catch_collectables(changed_op, &filter).await?;
+    // Reads the same asset contents that `server_changed` already depends on,
+    // so this doesn't create additional subscription triggers. Errors are
+    // already captured as issues by the read above; a failed hash read simply
+    // yields None.
+    let server_content_hash = endpoint_server_content_hash_operation(endpoint_op)
+        .read_strongly_consistent()
+        .await
+        .ok()
+        .and_then(|v| (*v).clone());
     Ok(EndpointIssuesAndDiags {
         changed: changed_value,
+        server_content_hash,
         issues: if should_include_issues {
             issues
         } else {

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -171,11 +171,21 @@ export interface NapiWrittenEndpoint {
 export declare function endpointWriteToDisk(endpoint: {
   __napiType: 'Endpoint'
 }): Promise<TurbopackResult>
+export declare function endpointServerContentHash(endpoint: {
+  __napiType: 'Endpoint'
+}): Promise<string | null>
 export declare function endpointServerChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
   issues: boolean,
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
+export interface NapiServerChanged {
+  /**
+   * A hash of the endpoint's compiled server-side output, or None when the
+   * endpoint has no output (e.g. it was removed).
+   */
+  contentHash?: string
+}
 export declare function endpointClientChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
   func: (...args: any[]) => any

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -40,6 +40,7 @@ import type {
   Update,
   UpdateMessage,
   WrittenEndpoint,
+  ServerChanged,
 } from './types'
 import { runLoaderWorkerPool } from './loaderWorkerPool'
 
@@ -892,8 +893,8 @@ function bindingToApi(
 
     async serverChanged(
       includeIssues: boolean
-    ): Promise<AsyncIterableIterator<TurbopackResult>> {
-      const serverSubscription = subscribe<TurbopackResult>(
+    ): Promise<AsyncIterableIterator<TurbopackResult<ServerChanged>>> {
+      const serverSubscription = subscribe<TurbopackResult<ServerChanged>>(
         false,
         async (callback) =>
           binding.endpointServerChangedSubscribe(
@@ -904,6 +905,12 @@ function bindingToApi(
       )
       await serverSubscription.next()
       return serverSubscription
+    }
+
+    async serverContentHash(): Promise<string | null> {
+      return (
+        (await binding.endpointServerContentHash(this._nativeEndpoint)) ?? null
+      )
     }
   }
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -423,7 +423,22 @@ export interface Endpoint {
    */
   serverChanged(
     includeIssues: boolean
-  ): Promise<AsyncIterableIterator<TurbopackResult>>
+  ): Promise<AsyncIterableIterator<TurbopackResult<ServerChanged>>>
+
+  /**
+   * A hash of the endpoint's compiled server-side output (the same assets
+   * `serverChanged` watches). Null when the endpoint has no output (e.g. it
+   * was removed).
+   */
+  serverContentHash(): Promise<string | null>
+}
+
+export interface ServerChanged {
+  /**
+   * A hash of the endpoint's compiled server-side output, or null when the
+   * endpoint has no output (e.g. it was removed).
+   */
+  contentHash: string | null
 }
 
 interface EndpointConfig {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1621,13 +1621,13 @@ export async function createHotReloaderTurbopack(
     },
 
     getServerComponentsHmrRefreshHash() {
-      // The current server-components generation. Only the change subscription
-      // (an actual recompile) advances `hmrHash`; reloads and config
-      // invalidations don't, so the value stays stable across requests until a
-      // real edit. Returned unconditionally (`"0"` before the first edit) so
-      // `"use cache"` keys are present and consistent for every request,
-      // mirroring webpack's always-present `stats.hash`.
-      return String(hmrHash)
+      // Only the change subscription (an actual recompile) advances `hmrHash`;
+      // reloads and config invalidations don't, so the value stays stable
+      // across requests until a real edit. `sessionId` stands in for a key
+      // derived from the compiled implementation, which would let entries
+      // outlive a restart when the code didn't change (see the note on Action
+      // IDs in `use-cache-wrapper.ts`).
+      return `${sessionId}-${hmrHash}`
     },
 
     sendToLegacyClients(action) {
@@ -1764,10 +1764,7 @@ export async function createHotReloaderTurbopack(
       }
       return errors
     },
-    async invalidate({
-      // .env files or tsconfig/jsconfig change
-      reloadAfterInvalidation,
-    }) {
+    async invalidate({ reloadAfterInvalidation }) {
       if (reloadAfterInvalidation) {
         for (const [key, entrypoint] of currentWrittenEntrypoints) {
           clearRequireCache(key, entrypoint, { force: true })

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -789,6 +789,7 @@ export async function createHotReloaderTurbopack(
   // advancing there would both churn the hash without an edit and fail to
   // advance it at all when no client is connected.
   let hmrHash = 0
+  let previousRouteKeys: Set<string> | undefined
 
   // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every
   // foreground-job cycle, including empty no-op recompiles scheduled by
@@ -1041,18 +1042,14 @@ export async function createHotReloaderTurbopack(
       }
 
       const routes = entrypoints.routes
-      const existingRoutes = [
-        ...currentEntrypoints.app.keys(),
-        ...currentEntrypoints.page.keys(),
-      ]
-      const newRoutes = [...routes.keys()]
-
-      const addedRoutes = newRoutes.filter(
-        (route) =>
-          !currentEntrypoints.app.has(route) &&
-          !currentEntrypoints.page.has(route)
-      )
-      const removedRoutes = existingRoutes.filter((route) => !routes.has(route))
+      const prevRouteKeys = previousRouteKeys
+      const addedRoutes = prevRouteKeys
+        ? [...routes.keys()].filter((route) => !prevRouteKeys.has(route))
+        : []
+      const removedRoutes = prevRouteKeys
+        ? [...prevRouteKeys].filter((route) => !routes.has(route))
+        : []
+      previousRouteKeys = new Set(routes.keys())
 
       await handleEntrypoints({
         entrypoints: entrypoints as any,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -21,6 +21,7 @@ import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import type {
   Update as TurbopackUpdate,
   Endpoint,
+  ServerChanged,
   WrittenEndpoint,
   TurbopackResult,
   Project,
@@ -917,14 +918,60 @@ export async function createHotReloaderTurbopack(
     sendEnqueuedMessagesDebounce()
   }
 
+  /**
+   * `hmrHash` is folded into every `"use cache"` key, so advancing it discards
+   * all cached entries. The subscription emits whenever the entry *may* have
+   * changed — including once for the entry's own initial build, and possibly
+   * coalescing several changes into one emission — so emissions can't be
+   * counted directly. Instead, compare the entry's compiled output and only
+   * advance the hash when it actually changed.
+   */
+  async function* serverChanges(
+    changedPromise: Promise<
+      AsyncIterableIterator<TurbopackResult<ServerChanged>>
+    >,
+    endpoint: Endpoint
+  ) {
+    const changed = await changedPromise
+    let contentHash = await endpoint.serverContentHash()
+
+    for await (const change of changed) {
+      // A null hash means the entry has no compiled output (it was removed,
+      // or it failed to build); that can't affect other entries' cached data,
+      // and its own entries are unreachable.
+      let contentChanged = false
+      if (change.contentHash !== null) {
+        contentChanged = change.contentHash !== contentHash
+        contentHash = change.contentHash
+        if (contentChanged) {
+          hmrHash++
+        }
+      }
+      yield { change, contentChanged }
+    }
+  }
+
+  /** Client-side output can't affect cached server data. */
+  async function* clientChanges(
+    changedPromise: Promise<AsyncIterableIterator<TurbopackResult>>
+  ) {
+    for await (const change of await changedPromise) {
+      yield { change, contentChanged: false }
+    }
+  }
+
   async function subscribeToClientChanges(
     key: EntryKey,
     includeIssues: boolean,
     endpoint: Endpoint,
     createMessage: (
       change: TurbopackResult,
-      hash: string
-    ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void,
+      hash: string,
+      contentChanged: boolean
+    ) =>
+      | Promise<HmrMessageSentToBrowser | void>
+      | HmrMessageSentToBrowser
+      | void,
     onError?: (
       error: Error
     ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void
@@ -935,15 +982,28 @@ export async function createHotReloaderTurbopack(
 
     const { side } = splitEntryKey(key)
 
-    const changedPromise = endpoint[`${side}Changed`](includeIssues)
-    changeSubscriptions.set(key, changedPromise)
-    try {
-      const changed = await changedPromise
+    let changes: AsyncIterable<{
+      change: TurbopackResult
+      contentChanged: boolean
+    }>
+    if (side === 'server') {
+      const changedPromise = endpoint.serverChanged(includeIssues)
+      changeSubscriptions.set(key, changedPromise)
+      changes = serverChanges(changedPromise, endpoint)
+    } else {
+      const changedPromise = endpoint.clientChanged()
+      changeSubscriptions.set(key, changedPromise)
+      changes = clientChanges(changedPromise)
+    }
 
-      for await (const change of changed) {
+    try {
+      for await (const { change, contentChanged } of changes) {
         processIssues(currentEntryIssues, key, change, false, true)
-        // TODO: Get an actual content hash from Turbopack.
-        const message = await createMessage(change, String(++hmrHash))
+        const message = await createMessage(
+          change,
+          String(hmrHash),
+          contentChanged
+        )
         if (message) {
           sendHmr(key, message)
         }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -966,7 +966,6 @@ export async function createHotReloaderTurbopack(
     endpoint: Endpoint,
     createMessage: (
       change: TurbopackResult,
-      hash: string,
       contentChanged: boolean
     ) =>
       | Promise<HmrMessageSentToBrowser | void>
@@ -999,11 +998,7 @@ export async function createHotReloaderTurbopack(
     try {
       for await (const { change, contentChanged } of changes) {
         processIssues(currentEntryIssues, key, change, false, true)
-        const message = await createMessage(
-          change,
-          String(hmrHash),
-          contentChanged
-        )
+        const message = await createMessage(change, contentChanged)
         if (message) {
           sendHmr(key, message)
         }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -789,6 +789,8 @@ export async function createHotReloaderTurbopack(
   // advancing there would both churn the hash without an edit and fail to
   // advance it at all when no client is connected.
   let hmrHash = 0
+  // Undefined until the first entrypoints emission. That one has nothing to
+  // compare against, so every route it lists would look added.
   let previousRouteKeys: Set<string> | undefined
 
   // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -259,12 +259,15 @@ export interface NextJsHotReloaderInterface {
    */
   sendToLegacyClients(action: HmrMessageSentToBrowser): void
   /**
-   * The hash of the most recent server component change, or `undefined` if no
-   * server component change has occurred yet. In dev, this is included in `"use
-   * cache"` cache keys so that cached entries are revalidated after an edit,
-   * for every client, regardless of whether it runs the HMR client.
+   * Identifies the current generation of the compiled server components. It is
+   * included in `"use cache"` cache keys so that cached entries are revalidated
+   * after an edit, for every client, regardless of whether it runs the HMR
+   * client. It is present from the first request on, so that entries created
+   * before the first edit are keyed by it too, and it differs between dev
+   * server runs, so that a cache handler that persists entries doesn't serve
+   * them for code that changed while the server was down.
    */
-  getServerComponentsHmrRefreshHash(): string | undefined
+  getServerComponentsHmrRefreshHash(): string
   setCacheStatus(status: ServerCacheStatus, htmlRequestId: string): void
   setReactDebugChannel(
     debugChannel: ReactDebugChannelForBrowser,
@@ -282,6 +285,13 @@ export interface NextJsHotReloaderInterface {
       context: { isLegacyClient: boolean }
     ) => void
   ): void
+  /**
+   * Rebuilds so that a changed configuration reaches the bundles. Pass
+   * `reloadAfterInvalidation` only when the change can also affect what a
+   * render produces: it makes connected clients refetch server components, and
+   * advances `getServerComponentsHmrRefreshHash`, discarding `"use cache"`
+   * entries.
+   */
   invalidate({
     reloadAfterInvalidation,
   }: {

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -15,6 +15,7 @@ import {
 } from './middleware-webpack'
 import { WebpackHotMiddleware } from './hot-middleware'
 import * as inspector from 'inspector'
+import { randomUUID } from 'crypto'
 import { join, relative, isAbsolute, posix, dirname } from 'path'
 import {
   createEntrypoints,
@@ -126,6 +127,9 @@ function diff(a: Set<any>, b: Set<any>) {
 }
 
 const wsServer = new ws.Server({ noServer: true })
+
+// Folded into the HMR refresh hash to make it differ between dev server runs.
+const devServerSessionId = randomUUID()
 
 export async function renderScriptError(
   res: ServerResponse,
@@ -440,8 +444,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     })
   }
 
-  public getServerComponentsHmrRefreshHash(): string | undefined {
-    return this.serverComponentsHmrRefreshHash
+  public getServerComponentsHmrRefreshHash(): string {
+    return `${devServerSessionId}-${this.serverComponentsHmrRefreshHash ?? '0'}`
   }
 
   public onHMR(

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -106,8 +106,9 @@ export type StartChangeSubscription = (
   endpoint: Endpoint,
   createMessage: (
     change: TurbopackResult,
-    hash: string
-  ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void,
+    hash: string,
+    contentChanged: boolean
+  ) => Promise<HmrMessageSentToBrowser | void> | HmrMessageSentToBrowser | void,
   onError?: (
     e: Error
   ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void
@@ -790,7 +791,13 @@ export async function handleEntrypoints({
         key,
         /** includeIssues=*/ false,
         endpoint,
-        async () => {
+        async (_change, _hash, contentChanged) => {
+          // The subscription also emits when nothing changed (e.g. for the
+          // middleware's own initial build); the middleware was already
+          // processed then, so there is nothing to update.
+          if (!contentChanged) {
+            return
+          }
           const finishBuilding = dev.hooks.startBuilding(
             triggerName,
             undefined,

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -106,7 +106,6 @@ export type StartChangeSubscription = (
   endpoint: Endpoint,
   createMessage: (
     change: TurbopackResult,
-    hash: string,
     contentChanged: boolean
   ) => Promise<HmrMessageSentToBrowser | void> | HmrMessageSentToBrowser | void,
   onError?: (
@@ -791,7 +790,7 @@ export async function handleEntrypoints({
         key,
         /** includeIssues=*/ false,
         endpoint,
-        async (_change, _hash, contentChanged) => {
+        async (_change, contentChanged) => {
           // The subscription also emits when nothing changed (e.g. for the
           // middleware's own initial build); the middleware was already
           // processed then, so there is nothing to update.

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -351,6 +351,7 @@ async function startWatcher(
 
   let resolved = false
   let prevSortedRoutes: string[] = []
+  let hasComputedSortedRoutes = false
 
   await new Promise<void>(async (resolve, reject) => {
     if (pagesDir) {
@@ -1089,9 +1090,11 @@ async function startWatcher(
           // otherwise it sends the event too early.
           await propagateServerField(opts, 'reloadMatchers', undefined)
 
-          if (
-            !prevSortedRoutes?.every((val, idx) => val === sortedRoutes[idx])
-          ) {
+          const sortedRoutesChanged =
+            prevSortedRoutes.length !== sortedRoutes.length ||
+            prevSortedRoutes.some((route, idx) => route !== sortedRoutes[idx])
+
+          if (hasComputedSortedRoutes && sortedRoutesChanged) {
             const addedRoutes = sortedRoutes.filter(
               (route) => !prevSortedRoutes.includes(route)
             )
@@ -1125,6 +1128,7 @@ async function startWatcher(
           }
         }
         prevSortedRoutes = sortedRoutes
+        hasComputedSortedRoutes = true
 
         if (enabledTypeScript) {
           // Using === false to make the check clearer.

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -417,12 +417,15 @@ async function startWatcher(
     let enabledTypeScript = await verifyTypeScript(opts)
     let previousClientRouterFilters: any
     let previousConflictingPagePaths: Set<string> = new Set()
+    let hadInitialScan = false
 
     const routeTypesFilePath = path.join(distDir, 'types', 'routes.d.ts')
     const validatorFilePath = path.join(distDir, 'types', 'validator.ts')
 
     let initialWatchTime = performance.now() + performance.timeOrigin
     wp.on('aggregated', async () => {
+      const isInitialScan = !hadInitialScan
+      hadInitialScan = true
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
       let middlewareMatchers: ProxyMatcher[] | undefined
@@ -440,7 +443,8 @@ async function startWatcher(
       const layoutRoutes: RouteInfo[] = []
       const slots: SlotInfo[] = []
 
-      let envChange = false
+      let envFileChange = false
+      let clientRouterFiltersChange = false
       let tsconfigChange = false
       let conflictingPageChange = 0
       let hasRootAppNotFound = false
@@ -513,7 +517,7 @@ async function startWatcher(
 
         if (envFiles.includes(fileName)) {
           if (fileChanged) {
-            envChange = true
+            envFileChange = true
           }
           continue
         }
@@ -794,15 +798,19 @@ async function startWatcher(
           JSON.stringify(previousClientRouterFilters) !==
             JSON.stringify(clientRouterFilters)
         ) {
-          envChange = true
+          clientRouterFiltersChange = true
           previousClientRouterFilters = clientRouterFilters
         }
       }
 
-      if (envChange || tsconfigChange) {
-        if (envChange) {
-          writeEnvDefinitions = true
+      // Also set on the initial scan, so that typed env definitions exist
+      // from startup.
+      if (envFileChange || isInitialScan) {
+        writeEnvDefinitions = true
+      }
 
+      if (envFileChange || clientRouterFiltersChange || tsconfigChange) {
+        if (envFileChange) {
           await propagateServerField(opts, 'loadEnvConfig', [
             { dev: true, forceReload: true },
           ])
@@ -905,7 +913,7 @@ async function startWatcher(
               })
             }
 
-            if (envChange) {
+            if (envFileChange || clientRouterFiltersChange) {
               config.plugins?.forEach((plugin: any) => {
                 // we look for the DefinePlugin definitions so we can
                 // update them on the active compilers
@@ -943,7 +951,10 @@ async function startWatcher(
           })
         }
         await hotReloader.invalidate({
-          reloadAfterInvalidation: envChange,
+          // A router-filter change only requires the updated define to be
+          // compiled into the bundles; unlike env, it can't affect rendered
+          // output or cached data.
+          reloadAfterInvalidation: envFileChange,
         })
       }
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1094,6 +1094,8 @@ async function startWatcher(
             prevSortedRoutes.length !== sortedRoutes.length ||
             prevSortedRoutes.some((route, idx) => route !== sortedRoutes[idx])
 
+          // The first aggregation has nothing to compare against, so every
+          // route would look added to a client that is already connected.
           if (hasComputedSortedRoutes && sortedRoutesChanged) {
             const addedRoutes = sortedRoutes.filter(
               (route) => !prevSortedRoutes.includes(route)

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
@@ -1,0 +1,194 @@
+import { nextTestSetup, type NextInstance, type Playwright } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import * as nodeFs from 'node:fs'
+import * as nodePath from 'node:path'
+
+// In dev, `"use cache"` entries must only be discarded when something they
+// can depend on changes (their code, or env) — and, conversely, they must
+// never survive into a different dev server run, where the code may have
+// changed while the server was down.
+
+async function readCachedValue(browser: Playwright) {
+  return browser.elementById('cached-value').text()
+}
+
+// Right after the dev server starts, it may still be settling (e.g.
+// finishing startup compiles), so wait until the cached value is stable
+// across reloads before asserting anything about invalidation.
+async function waitForStableCachedValue(
+  next: NextInstance,
+  browser: Playwright
+) {
+  let stableValue: string = ''
+  await retry(async () => {
+    await browser.loadPage(next.url + '/')
+    const first = await readCachedValue(browser)
+    await browser.loadPage(next.url + '/')
+    const second = await readCachedValue(browser)
+    expect(second).toBe(first)
+    stableValue = second
+  }, 15_000)
+  return stableValue
+}
+
+describe('cache-components-spurious-cache-invalidation', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/default'),
+  })
+
+  // Serving the added page requires the file watcher to have processed
+  // everything up to and including this addition, plus a compile — so any
+  // invalidation that an earlier change could have caused has landed by now,
+  // and a negative ("the cached value didn't change") can be asserted right
+  // after, instead of waiting out an arbitrary settling period.
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `app${pathname}/page.tsx`,
+      `export default function Page() { return <p>${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  // Turbopack-only: on webpack, adding a page recompiles the server bundle
+  // (the compiled-in client router filter changes), which replaces the
+  // serving module instances, so module state doesn't survive there.
+  if (isTurbopack) {
+    it('keeps module state when an unrelated page is added', async () => {
+      async function readRenderCount() {
+        const html = await (await next.fetch('/')).text()
+        const match = html.match(/id="render-count">(\d+)</)
+        expect(match).not.toBeNull()
+        return Number(match![1])
+      }
+
+      const first = await readRenderCount()
+      const second = await readRenderCount()
+      expect(second).toBeGreaterThan(first)
+
+      try {
+        await addPageAndWaitUntilServable('/unrelated')
+        await waitFor(2000)
+        // If the page add re-evaluated the module, the counter restarted
+        // from zero.
+        expect(await readRenderCount()).toBeGreaterThan(second)
+        await waitFor(2000)
+        expect(await readRenderCount()).toBeGreaterThan(second)
+      } finally {
+        if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/unrelated'))) {
+          await next.deleteFile('app/unrelated/page.tsx')
+        }
+      }
+    })
+  }
+
+  it('discards use cache entries when an env file changes', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    // The page reads this var, so its output depends on the change.
+    await next.patchFile('.env', 'NEXT_PUBLIC_CACHE_BUSTER=busted')
+
+    try {
+      await retry(async () => {
+        await browser.loadPage(next.url + '/')
+        expect(await browser.elementById('env-value').text()).toBe('busted')
+        expect(await readCachedValue(browser)).not.toBe(stableValue)
+      }, 15_000)
+    } finally {
+      await next.deleteFile('.env')
+    }
+  })
+
+  it('refetches server components when an env change does not affect compiled output', async () => {
+    const browser = await next.browser('/')
+    await waitForStableCachedValue(next, browser)
+
+    await browser.loadPage(next.url + '/')
+    expect(await browser.elementById('runtime-env-value').text()).toBe('unset')
+
+    // This var is only read at render time, so the rebuild after the env
+    // change is a no-op.
+    await next.patchFile('.env', 'RUNTIME_GREETING=hello')
+
+    try {
+      await retry(async () => {
+        // Deliberately no reload here.
+        expect(await browser.elementById('runtime-env-value').text()).toBe(
+          'hello'
+        )
+      }, 15_000)
+    } finally {
+      await next.deleteFile('.env')
+    }
+  })
+})
+
+describe('cache-components-spurious-cache-invalidation - persistent cache handler', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/persistent-handler'),
+  })
+
+  it('discards use cache entries across dev server restarts', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    await next.stop()
+
+    // The custom cache handler persists entries on disk. Ensure they're
+    // actually there — otherwise a fresh value after the restart wouldn't
+    // prove anything (it could just mean nothing was persisted).
+    const persistedEntries = nodeFs.readdirSync(
+      nodePath.join(next.testDir, '.file-system-cache')
+    )
+    expect(persistedEntries.length).toBeGreaterThan(0)
+
+    await next.start()
+
+    const newBrowser = await next.browser('/')
+    const newStableValue = await waitForStableCachedValue(next, newBrowser)
+    expect(newStableValue).not.toBe(stableValue)
+  })
+
+  it('discards use cache entries when a previous run made the same edit', async () => {
+    const browser = await next.browser('/')
+    await waitForStableCachedValue(next, browser)
+
+    const originalPage = await next.readFile('app/page.tsx')
+    const editedPage = originalPage.replace(
+      '<main>',
+      '<main><p id="edited-marker">edited</p>'
+    )
+    expect(editedPage).not.toBe(originalPage)
+
+    async function waitForMarker(b: Playwright, present: boolean) {
+      await retry(async () => {
+        await b.loadPage(next.url + '/')
+        expect(await b.hasElementByCssSelector('#edited-marker')).toBe(present)
+      }, 15_000)
+    }
+
+    try {
+      await next.patchFile('app/page.tsx', editedPage)
+      await waitForMarker(browser, true)
+      const editedValue = await waitForStableCachedValue(next, browser)
+
+      await next.stop()
+      await next.start()
+
+      // Even though the previous run persisted an entry for this exact code,
+      // it must not be served: entries never carry over between runs.
+      const newBrowser = await next.browser('/')
+      await next.patchFile('app/page.tsx', originalPage)
+      await waitForMarker(newBrowser, false)
+      await next.patchFile('app/page.tsx', editedPage)
+      await waitForMarker(newBrowser, true)
+
+      const newEditedValue = await waitForStableCachedValue(next, newBrowser)
+      expect(newEditedValue).not.toBe(editedValue)
+    } finally {
+      await next.patchFile('app/page.tsx', originalPage)
+    }
+  })
+})

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/cache-components-spurious-cache-invalidation.test.ts
@@ -51,6 +51,40 @@ describe('cache-components-spurious-cache-invalidation', () => {
     }, 15_000)
   }
 
+  it('keeps use cache entries when an unrelated page is added and removed', async () => {
+    const browser = await next.browser('/')
+    const stableValue = await waitForStableCachedValue(next, browser)
+
+    try {
+      await addPageAndWaitUntilServable('/unrelated')
+
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+
+      await next.deleteFile('app/unrelated/page.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/unrelated')).status).toBe(404)
+      }, 15_000)
+
+      // Removal doesn't compile anything we could wait for, so push another
+      // page addition through as a barrier before asserting.
+      await addPageAndWaitUntilServable('/unrelated-barrier')
+
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+      await browser.loadPage(next.url + '/')
+      expect(await readCachedValue(browser)).toBe(stableValue)
+    } finally {
+      for (const dir of ['app/unrelated', 'app/unrelated-barrier']) {
+        if (nodeFs.existsSync(nodePath.join(next.testDir, dir))) {
+          await next.deleteFile(`${dir}/page.tsx`)
+        }
+      }
+    }
+  })
+
   // Turbopack-only: on webpack, adding a page recompiles the server bundle
   // (the compiled-in client router filter changes), which replaces the
   // serving module instances, so module state doesn't survive there.

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/layout.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/page.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/app/page.tsx
@@ -1,0 +1,39 @@
+// Incremented on every render. Module state must survive anything that
+// doesn't change this module's code: if this resets, the server re-evaluated
+// the module.
+let renderCount = 0
+
+async function getCachedData() {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}
+
+export default async function Page() {
+  renderCount++
+  const data = await getCachedData()
+  return (
+    <main>
+      <p>
+        This page renders cached data. The cached value must be stable across
+        reloads unless this page (or the data it depends on) is edited.
+      </p>
+      <dl>
+        <dt>Cached Data</dt>
+        <dd id="cached-value">{data}</dd>
+        <dt>Env</dt>
+        <dd id="env-value">
+          {process.env.NEXT_PUBLIC_CACHE_BUSTER ?? 'unset'}
+        </dd>
+        <dt>Render Count</dt>
+        <dd id="render-count">{renderCount}</dd>
+        <dt>Runtime Env</dt>
+        {/* Not prefixed with NEXT_PUBLIC_, so it's read at render time and
+            changing it doesn't affect the compiled output. */}
+        <dd id="runtime-env-value">
+          {process.env.RUNTIME_GREETING ?? 'unset'}
+        </dd>
+      </dl>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/next.config.ts
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/default/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/layout.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/page.tsx
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/app/page.tsx
@@ -1,0 +1,25 @@
+async function getCachedData() {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}
+
+export default async function Page() {
+  const data = await getCachedData()
+  return (
+    <main>
+      <p>
+        This page renders cached data. The cached value must be stable across
+        reloads unless this page (or the data it depends on) is edited.
+      </p>
+      <dl>
+        <dt>Cached Data</dt>
+        <dd id="cached-value">{data}</dd>
+        <dt>Env</dt>
+        <dd id="env-value">
+          {process.env.NEXT_PUBLIC_CACHE_BUSTER ?? 'unset'}
+        </dd>
+      </dl>
+    </main>
+  )
+}

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/handler.js
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/handler.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+// A minimal cache handler that persists entries on disk, so they survive dev
+// server restarts (like any custom cache handler backed by external storage).
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+
+const cacheDir = path.join(__dirname, '.file-system-cache')
+
+function filePathForKey(cacheKey) {
+  const hash = crypto.createHash('sha256').update(cacheKey).digest('hex')
+  return path.join(cacheDir, `${hash}.json`)
+}
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey) {
+    const filePath = filePathForKey(cacheKey)
+    if (!fs.existsSync(filePath)) {
+      return undefined
+    }
+    const { value, ...metadata } = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    const bytes = new Uint8Array(Buffer.from(value, 'base64'))
+    return {
+      ...metadata,
+      value: new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes)
+          controller.close()
+        },
+      }),
+    }
+  },
+
+  async set(cacheKey, pendingEntry) {
+    const { value, ...metadata } = await pendingEntry
+    const chunks = []
+    const reader = value.getReader()
+    while (true) {
+      const { done, value: chunk } = await reader.read()
+      if (done) break
+      chunks.push(chunk)
+    }
+    fs.mkdirSync(cacheDir, { recursive: true })
+    fs.writeFileSync(
+      filePathForKey(cacheKey),
+      JSON.stringify({
+        ...metadata,
+        value: Buffer.concat(chunks).toString('base64'),
+      })
+    )
+  },
+
+  async refreshTags() {},
+
+  async getExpiration() {
+    return 0
+  },
+
+  async updateTags() {},
+}
+
+module.exports = cacheHandler

--- a/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/next.config.js
+++ b/test/development/app-dir/cache-components-spurious-cache-invalidation/fixtures/persistent-handler/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  cacheHandlers: {
+    default: require.resolve('./handler.js'),
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/counted/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/counted/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="counted">counted</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/existing/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/existing/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="existing">existing</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/layout.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">home</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/posts/[id]/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/posts/[id]/page.tsx
@@ -1,0 +1,4 @@
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const { id } = await props.params
+  return <p id="dynamic">dynamic {id}</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/renamed-a/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/renamed-a/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="renamed">renamed</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/pages/pages/existing.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/pages/pages/existing.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="existing">existing</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/pages/pages/index.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/pages/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">home</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/pages/pages/posts/[id].tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/pages/pages/posts/[id].tsx
@@ -1,0 +1,6 @@
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const router = useRouter()
+  return <p id="dynamic">dynamic {String(router.query.id)}</p>
+}

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -309,7 +309,7 @@ describe('route-change-refetch - App Router refetch count', () => {
     return browser.eval(() => (window as any).__refetches)
   }
 
-  it('refetches an open tab exactly twice when a page is added', async () => {
+  it('refetches an open tab exactly once when a page is added', async () => {
     const browser = await next.browser('/counted')
     expect(await browser.elementById('counted').text()).toBe('counted')
     await startCountingRefetches(browser)
@@ -322,12 +322,11 @@ describe('route-change-refetch - App Router refetch count', () => {
       expect((await next.fetch('/zz-added')).status).toBe(200)
     }, 15_000)
     await retry(async () => {
-      // TODO: Stop counting a page add as an env change, then it'll be 1.
-      expect(await countRefetches(browser)).toBe(2)
+      expect(await countRefetches(browser)).toBe(1)
     }, 15_000)
     // A later one would mean the change was announced more than once.
     await waitFor(1000)
-    expect(await countRefetches(browser)).toBe(2)
+    expect(await countRefetches(browser)).toBe(1)
   })
 })
 

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -1,8 +1,37 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 import type { Playwright } from 'next-webdriver'
+import type { Page } from 'playwright'
 import * as nodeFs from 'node:fs'
 import * as nodePath from 'node:path'
+
+// The client decides whether an announcement is about the page it's showing by
+// comparing the announced name against its pathname, so the name has to be the
+// route ("/zz-added"), not the entrypoint ("/zz-added/page").
+function recordRouteAnnouncements(announcements: string[]) {
+  return (page: Page) => {
+    page.on('websocket', (ws) => {
+      if (!ws.url().includes('/_next/hmr')) {
+        return
+      }
+      ws.on('framereceived', (frame) => {
+        const payload =
+          typeof frame.payload === 'string'
+            ? frame.payload
+            : frame.payload.toString('utf8')
+        let message: { type?: string; data?: unknown[] }
+        try {
+          message = JSON.parse(payload)
+        } catch {
+          return
+        }
+        if (message.type === 'addedPage' || message.type === 'removedPage') {
+          announcements.push(`${message.type} ${message.data?.[0]}`)
+        }
+      })
+    })
+  }
+}
 
 describe('route-change-refetch - App Router', () => {
   const { next } = nextTestSetup({
@@ -30,6 +59,27 @@ describe('route-change-refetch - App Router', () => {
       }, 15_000)
     }
   }
+
+  it('announces an added page under its route name, and announces nothing else', async () => {
+    const announcements: string[] = []
+    const browser = await next.browser('/existing', {
+      beforePageLoad: recordRouteAnnouncements(announcements),
+    })
+    expect(await browser.elementById('existing').text()).toBe('existing')
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      await retry(async () => {
+        expect(announcements).toEqual(['addedPage /zz-added'])
+      }, 15_000)
+      // Announcing a route that didn't change makes every tab showing it
+      // refetch for nothing.
+      await waitFor(1000)
+      expect(announcements).toEqual(['addedPage /zz-added'])
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
 
   it('updates a tab showing a 404 when that page is added', async () => {
     // Regression test: a route that sorts after all existing ones used to
@@ -60,7 +110,10 @@ describe('route-change-refetch - App Router', () => {
   })
 
   it('updates a tab showing a page when that page is removed', async () => {
-    const browser = await next.browser('/existing')
+    const announcements: string[] = []
+    const browser = await next.browser('/existing', {
+      beforePageLoad: recordRouteAnnouncements(announcements),
+    })
     expect(await browser.elementById('existing').text()).toBe('existing')
 
     try {
@@ -70,6 +123,7 @@ describe('route-change-refetch - App Router', () => {
           'This page could not be found'
         )
       }, 15_000)
+      expect(announcements).toEqual(['removedPage /existing'])
     } finally {
       if (
         nodeFs.existsSync(nodePath.join(next.testDir, 'app/existing/page.bak'))
@@ -77,6 +131,38 @@ describe('route-change-refetch - App Router', () => {
         await next.renameFile('app/existing/page.bak', 'app/existing/page.tsx')
         await retry(async () => {
           expect((await next.fetch('/existing')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('updates a tab showing a page that is renamed', async () => {
+    // A rename keeps the number of routes the same, so a diff that only
+    // compares how many there are sees no change at all.
+    const announcements: string[] = []
+    const browser = await next.browser('/renamed-a', {
+      beforePageLoad: recordRouteAnnouncements(announcements),
+    })
+    expect(await browser.elementById('renamed').text()).toBe('renamed')
+
+    try {
+      await next.renameFile('app/renamed-a', 'app/renamed-b')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain(
+          'This page could not be found'
+        )
+      }, 15_000)
+      await retry(async () => {
+        expect([...announcements].sort()).toEqual([
+          'addedPage /renamed-b',
+          'removedPage /renamed-a',
+        ])
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/renamed-b'))) {
+        await next.renameFile('app/renamed-b', 'app/renamed-a')
+        await retry(async () => {
+          expect((await next.fetch('/renamed-a')).status).toBe(200)
         }, 15_000)
       }
     }

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -1,0 +1,358 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import type { Playwright } from 'next-webdriver'
+import * as nodeFs from 'node:fs'
+import * as nodePath from 'node:path'
+
+describe('route-change-refetch - App Router', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/app'),
+  })
+
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `app${pathname}/page.tsx`,
+      `export default function Page() { return <p id="added">${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  // Wait for the removal to land. A change that's still propagating when the
+  // test ends gets announced during the next test, which makes that test's tab
+  // refetch when it never asked for it.
+  async function cleanupAddedPage() {
+    if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/zz-added'))) {
+      await next.deleteFile('app/zz-added/page.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/zz-added')).status).toBe(404)
+      }, 15_000)
+    }
+  }
+
+  it('updates a tab showing a 404 when that page is added', async () => {
+    // Regression test: a route that sorts after all existing ones used to
+    // not be announced.
+    const browser = await next.browser('/zz-added')
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      // If the tab reacts to the announcement before the server can serve
+      // the page, it gets the 404 again and stays there — a pre-existing
+      // bug that's being fixed separately. Editing the page makes the
+      // server announce again, now that the page can be served.
+      // TODO: Remove these edits (in the tests below too) once that bug is
+      // fixed; these tests then cover it directly.
+      await next.patchFile(
+        'app/zz-added/page.tsx',
+        `export default function Page() { return <p id="added" data-rev="2">/zz-added</p> }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('/zz-added')
+      }, 15_000)
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
+
+  it('updates a tab showing a page when that page is removed', async () => {
+    const browser = await next.browser('/existing')
+    expect(await browser.elementById('existing').text()).toBe('existing')
+
+    try {
+      await next.renameFile('app/existing/page.tsx', 'app/existing/page.bak')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain(
+          'This page could not be found'
+        )
+      }, 15_000)
+    } finally {
+      if (
+        nodeFs.existsSync(nodePath.join(next.testDir, 'app/existing/page.bak'))
+      ) {
+        await next.renameFile('app/existing/page.bak', 'app/existing/page.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/existing')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('updates a tab showing a 404 when a dynamic route that matches is added', async () => {
+    const browser = await next.browser('/docs/abc')
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    try {
+      await next.patchFile(
+        'app/docs/[slug]/page.tsx',
+        `export default async function Page(props: {
+          params: Promise<{ slug: string }>
+        }) {
+          const { slug } = await props.params
+          return <p id="added">{slug}</p>
+        }`
+      )
+      await retry(async () => {
+        expect((await next.fetch('/docs/abc')).status).toBe(200)
+      }, 15_000)
+      await next.patchFile(
+        'app/docs/[slug]/page.tsx',
+        `export default async function Page(props: {
+          params: Promise<{ slug: string }>
+        }) {
+          const { slug } = await props.params
+          return <p id="added" data-rev="2">{slug}</p>
+        }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('abc')
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/docs'))) {
+        await next.deleteFile('app/docs/[slug]/page.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/docs/abc')).status).toBe(404)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('updates a tab showing a 404 when a page in a route group is added', async () => {
+    const browser = await next.browser('/grouped')
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    try {
+      await next.patchFile(
+        'app/(group)/grouped/page.tsx',
+        `export default function Page() { return <p id="added">grouped</p> }`
+      )
+      await retry(async () => {
+        expect((await next.fetch('/grouped')).status).toBe(200)
+      }, 15_000)
+      await next.patchFile(
+        'app/(group)/grouped/page.tsx',
+        `export default function Page() { return <p id="added" data-rev="2">grouped</p> }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('grouped')
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/(group)'))) {
+        await next.deleteFile('app/(group)/grouped/page.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/grouped')).status).toBe(404)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('switches a tab between a dynamic route and a more specific page', async () => {
+    const browser = await next.browser('/posts/123')
+    expect(await browser.elementById('dynamic').text()).toBe('dynamic 123')
+
+    try {
+      // Adding a static page that takes precedence for the URL the tab is
+      // showing must switch the tab to it.
+      await next.patchFile(
+        'app/posts/123/page.tsx',
+        `export default function Page() { return <p id="static">static 123</p> }`
+      )
+      await retry(async () => {
+        expect(await (await next.fetch('/posts/123')).text()).toContain(
+          'id="static"'
+        )
+      }, 15_000)
+      await next.patchFile(
+        'app/posts/123/page.tsx',
+        `export default function Page() { return <p id="static" data-rev="2">static 123</p> }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('static').text()).toBe('static 123')
+      }, 15_000)
+
+      // Removing it must switch the tab back to the dynamic route.
+      await next.deleteFile('app/posts/123/page.tsx')
+      await retry(async () => {
+        expect(await browser.elementById('dynamic').text()).toBe('dynamic 123')
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/posts/123'))) {
+        await next.deleteFile('app/posts/123/page.tsx')
+        await retry(async () => {
+          const html = await (await next.fetch('/posts/123')).text()
+          expect(html).toContain('id="dynamic"')
+          expect(html).not.toContain('id="static"')
+        }, 15_000)
+      }
+    }
+  })
+})
+
+describe('route-change-refetch - App Router refetch count', () => {
+  // Its own server: how often a change makes a tab refetch depends on what
+  // has been compiled so far, and on tabs other tests leave open.
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/app'),
+  })
+
+  // A refetch the dev server asked for carries the HMR refresh header, which
+  // tells it apart from a navigation or a prefetch.
+  async function startCountingRefetches(browser: Playwright) {
+    await browser.eval(() => {
+      const win = window as any
+      win.__refetches = 0
+      const originalFetch = win.fetch
+      win.fetch = (input: any, init: any) => {
+        if (new Headers(init?.headers).get('next-hmr-refresh') === '1') {
+          win.__refetches++
+        }
+        return originalFetch(input, init)
+      }
+    })
+  }
+
+  function countRefetches(browser: Playwright): Promise<number> {
+    return browser.eval(() => (window as any).__refetches)
+  }
+
+  it('refetches an open tab exactly twice when a page is added', async () => {
+    const browser = await next.browser('/counted')
+    expect(await browser.elementById('counted').text()).toBe('counted')
+    await startCountingRefetches(browser)
+
+    await next.patchFile(
+      'app/zz-added/page.tsx',
+      `export default function Page() { return <p id="added">/zz-added</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch('/zz-added')).status).toBe(200)
+    }, 15_000)
+    await retry(async () => {
+      // TODO: Stop counting a page add as an env change, then it'll be 1.
+      expect(await countRefetches(browser)).toBe(2)
+    }, 15_000)
+    // A later one would mean the change was announced more than once.
+    await waitFor(1000)
+    expect(await countRefetches(browser)).toBe(2)
+  })
+})
+
+describe('route-change-refetch - Pages Router', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/pages'),
+  })
+
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `pages${pathname}.tsx`,
+      `export default function Page() { return <p id="added">${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  async function cleanupAddedPage() {
+    if (nodeFs.existsSync(nodePath.join(next.testDir, 'pages/zz-added.tsx'))) {
+      await next.deleteFile('pages/zz-added.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/zz-added')).status).toBe(404)
+      }, 15_000)
+    }
+  }
+
+  it('reloads a tab showing a 404 when that page is added', async () => {
+    const browser = await next.browser('/zz-added')
+    expect(await browser.elementByCss('body').text()).toContain('404')
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('/zz-added')
+      }, 15_000)
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
+
+  it('reloads a tab showing a page when that page is removed', async () => {
+    // The client only reloads when the removed page is the one it's showing,
+    // which it decides by comparing the route name in the message against
+    // its pathname. This also pins the naming.
+    const browser = await next.browser('/existing')
+    expect(await browser.elementById('existing').text()).toBe('existing')
+
+    try {
+      await next.renameFile('pages/existing.tsx', 'pages/existing.bak')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain('404')
+      }, 15_000)
+    } finally {
+      if (
+        nodeFs.existsSync(nodePath.join(next.testDir, 'pages/existing.bak'))
+      ) {
+        await next.renameFile('pages/existing.bak', 'pages/existing.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/existing')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('reloads a tab showing a dynamic route when that route is removed', async () => {
+    // The client decides whether the removed page is the one it's showing by
+    // comparing the route name in the message against its pathname, which
+    // for dynamic routes is the pattern ("/posts/[id]"). This pins that the
+    // announced name is the pattern too.
+    const browser = await next.browser('/posts/123')
+    expect(await browser.elementById('dynamic').text()).toBe('dynamic 123')
+
+    try {
+      await next.renameFile('pages/posts/[id].tsx', 'pages/posts/id.bak')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain('404')
+      }, 15_000)
+    } finally {
+      if (
+        nodeFs.existsSync(nodePath.join(next.testDir, 'pages/posts/id.bak'))
+      ) {
+        await next.renameFile('pages/posts/id.bak', 'pages/posts/[id].tsx')
+        await retry(async () => {
+          expect((await next.fetch('/posts/123')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('refetches the route manifest exactly once when a page is added', async () => {
+    const manifestRequests: string[] = []
+    const browser = await next.browser('/existing', {
+      beforePageLoad(page: any) {
+        page.on('request', (request: any) => {
+          if (request.url().includes('_devPagesManifest')) {
+            manifestRequests.push(request.url())
+          }
+        })
+      },
+    })
+    expect(await browser.elementById('existing').text()).toBe('existing')
+    const baseline = manifestRequests.length
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      await retry(async () => {
+        expect(manifestRequests.length).toBe(baseline + 1)
+      }, 15_000)
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
+})


### PR DESCRIPTION
Stacked on #96235. Supersedes #96245, which did the same thing with a JS-side digest.

Addresses [this TODO](https://github.com/vercel/next.js/pull/96245#discussion_r3659708308).

The Turbopack HMR refresh hash that dev folds into every `"use cache"` key was a counter, incremented once per change-subscription emission:

```ts
// TODO: Get an actual content hash from Turbopack.
const message = await createMessage(change, String(++hmrHash))
```

A subscription emission does not always mean code changed: a newly added page's subscription emits once for the entry's own initial build, and a removed page's subscription emits one final time on the way out. Those emissions increment the counter like any other — and one stray increment discards every cached entry, because the counter is part of every key.

Whether those emissions actually get counted depends on timing. On the July canary this stack started from, they did — visiting a newly added page reliably threw all cached data away under CPU load:

```
value: 0.485620
value: 0.485620
$ echo '...' > app/unrelated/page.tsx
$ curl localhost:3000/unrelated          # first visit builds the page
value: 0.890276                          # cached entry gone
```

On the current base it's intermittent instead: the extra emissions usually arrive early enough to be folded into the initial emission that the subscription already skips. The first commit adds a test for it, which failed one run in five in CI's flake detection on the base and passes on every run here.

The counter counts emissions rather than changes, so how often it's wrong is a scheduling detail, and it has already shifted once between July and now.

## Fix

The hash advances only when the compiled output actually changed. Turbopack already reads every output asset's content just to decide whether to emit, so the hash is computed right there:

- `Project::server_content_hash` hashes the contents of the same assets that `server_changed` watches. The filter is a shared helper (`watched_output_assets`) that `any_output_changed` now also uses, so the two can't drift apart.
- Each endpoint gets a `server_content_hash()` method that mirrors its `server_changed`. It returns None when the endpoint has no output anymore (the entry was removed). The subscriber treats that as "not a change".
- Every emission now carries the hash, and a new `endpointServerContentHash()` binding returns it on demand. The hot reloader calls that once at subscribe time and uses the result as the baseline, so a first emission that arrives late and already contains a real change is still detected as a change.
- The JS side compares two strings.

Skipping the first emission by position instead would be wrong: emissions coalesce, so an initial-build emission that arrives late can already include a real change. I observed this with an `.env` edit folded into the first emission — skipping by position served stale cached entries for code that had changed.

The same change is applied to middleware for consistency.

A last commit removes the hash argument that change-subscription callbacks were passed: no callback ever read it, and the messages that need the current hash read `hmrHash` where they're built.

## Test plan

Verified with a locally built binding, idle and under CPU load (`for i in $(seq 1 12); do yes > /dev/null & done`):

- `cache-components-spurious-cache-invalidation`: 6 of 6 on Turbopack, 5 of 5 on webpack, idle and in repeated loaded runs. This includes the page add/remove test this PR adds, and the env test that catches a real change folded into a subscription's first emission.
- `server-components-hmr-cache` (17 tests — edits and env changes must still invalidate), `middleware-dev-update` (4 tests — middleware edits must still reprocess and apply), `cache-components-dev-warmup`, the basic `hmr` suites, and `route-change-refetch` (10 tests, plus 10 consecutive full-suite Turbopack runs) all pass.

To confirm emissions behave the same before and after, I logged every subscription emission while scripting the same sequence against both builds on the original base — boot, add a page and visit it, edit the page, edit `.env`, remove the page. The logs came out identical: one emission for the page edit, one for the env edit, nothing else.
