### PR TITLE
Fix which pages the dev server announces, and when

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -789,6 +789,7 @@ export async function createHotReloaderTurbopack(
   // advancing there would both churn the hash without an edit and fail to
   // advance it at all when no client is connected.
   let hmrHash = 0
+  let previousRouteKeys: Set<string> | undefined
 
   // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every
   // foreground-job cycle, including empty no-op recompiles scheduled by
@@ -1041,18 +1042,14 @@ export async function createHotReloaderTurbopack(
       }
 
       const routes = entrypoints.routes
-      const existingRoutes = [
-        ...currentEntrypoints.app.keys(),
-        ...currentEntrypoints.page.keys(),
-      ]
-      const newRoutes = [...routes.keys()]
-
-      const addedRoutes = newRoutes.filter(
-        (route) =>
-          !currentEntrypoints.app.has(route) &&
-          !currentEntrypoints.page.has(route)
-      )
-      const removedRoutes = existingRoutes.filter((route) => !routes.has(route))
+      const prevRouteKeys = previousRouteKeys
+      const addedRoutes = prevRouteKeys
+        ? [...routes.keys()].filter((route) => !prevRouteKeys.has(route))
+        : []
+      const removedRoutes = prevRouteKeys
+        ? [...prevRouteKeys].filter((route) => !routes.has(route))
+        : []
+      previousRouteKeys = new Set(routes.keys())
 
       await handleEntrypoints({
         entrypoints: entrypoints as any,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -789,6 +789,8 @@ export async function createHotReloaderTurbopack(
   // advancing there would both churn the hash without an edit and fail to
   // advance it at all when no client is connected.
   let hmrHash = 0
+  // Undefined until the first entrypoints emission. That one has nothing to
+  // compare against, so every route it lists would look added.
   let previousRouteKeys: Set<string> | undefined
 
   // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -351,6 +351,7 @@ async function startWatcher(
 
   let resolved = false
   let prevSortedRoutes: string[] = []
+  let hasComputedSortedRoutes = false
 
   await new Promise<void>(async (resolve, reject) => {
     if (pagesDir) {
@@ -1089,9 +1090,11 @@ async function startWatcher(
           // otherwise it sends the event too early.
           await propagateServerField(opts, 'reloadMatchers', undefined)
 
-          if (
-            !prevSortedRoutes?.every((val, idx) => val === sortedRoutes[idx])
-          ) {
+          const sortedRoutesChanged =
+            prevSortedRoutes.length !== sortedRoutes.length ||
+            prevSortedRoutes.some((route, idx) => route !== sortedRoutes[idx])
+
+          if (hasComputedSortedRoutes && sortedRoutesChanged) {
             const addedRoutes = sortedRoutes.filter(
               (route) => !prevSortedRoutes.includes(route)
             )
@@ -1125,6 +1128,7 @@ async function startWatcher(
           }
         }
         prevSortedRoutes = sortedRoutes
+        hasComputedSortedRoutes = true
 
         if (enabledTypeScript) {
           // Using === false to make the check clearer.

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1094,6 +1094,8 @@ async function startWatcher(
             prevSortedRoutes.length !== sortedRoutes.length ||
             prevSortedRoutes.some((route, idx) => route !== sortedRoutes[idx])
 
+          // The first aggregation has nothing to compare against, so every
+          // route would look added to a client that is already connected.
           if (hasComputedSortedRoutes && sortedRoutesChanged) {
             const addedRoutes = sortedRoutes.filter(
               (route) => !prevSortedRoutes.includes(route)

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/counted/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/counted/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="counted">counted</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/existing/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/existing/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="existing">existing</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/layout.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">home</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/posts/[id]/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/posts/[id]/page.tsx
@@ -1,0 +1,4 @@
+export default async function Page(props: { params: Promise<{ id: string }> }) {
+  const { id } = await props.params
+  return <p id="dynamic">dynamic {id}</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/app/app/renamed-a/page.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/app/app/renamed-a/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="renamed">renamed</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/pages/pages/existing.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/pages/pages/existing.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="existing">existing</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/pages/pages/index.tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/pages/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">home</p>
+}

--- a/test/development/app-dir/route-change-refetch/fixtures/pages/pages/posts/[id].tsx
+++ b/test/development/app-dir/route-change-refetch/fixtures/pages/pages/posts/[id].tsx
@@ -1,0 +1,6 @@
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const router = useRouter()
+  return <p id="dynamic">dynamic {String(router.query.id)}</p>
+}

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -1,8 +1,37 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 import type { Playwright } from 'next-webdriver'
+import type { Page } from 'playwright'
 import * as nodeFs from 'node:fs'
 import * as nodePath from 'node:path'
+
+// The client decides whether an announcement is about the page it's showing by
+// comparing the announced name against its pathname, so the name has to be the
+// route ("/zz-added"), not the entrypoint ("/zz-added/page").
+function recordRouteAnnouncements(announcements: string[]) {
+  return (page: Page) => {
+    page.on('websocket', (ws) => {
+      if (!ws.url().includes('/_next/hmr')) {
+        return
+      }
+      ws.on('framereceived', (frame) => {
+        const payload =
+          typeof frame.payload === 'string'
+            ? frame.payload
+            : frame.payload.toString('utf8')
+        let message: { type?: string; data?: unknown[] }
+        try {
+          message = JSON.parse(payload)
+        } catch {
+          return
+        }
+        if (message.type === 'addedPage' || message.type === 'removedPage') {
+          announcements.push(`${message.type} ${message.data?.[0]}`)
+        }
+      })
+    })
+  }
+}
 
 describe('route-change-refetch - App Router', () => {
   const { next } = nextTestSetup({
@@ -30,6 +59,27 @@ describe('route-change-refetch - App Router', () => {
       }, 15_000)
     }
   }
+
+  it('announces an added page under its route name, and announces nothing else', async () => {
+    const announcements: string[] = []
+    const browser = await next.browser('/existing', {
+      beforePageLoad: recordRouteAnnouncements(announcements),
+    })
+    expect(await browser.elementById('existing').text()).toBe('existing')
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      await retry(async () => {
+        expect(announcements).toEqual(['addedPage /zz-added'])
+      }, 15_000)
+      // Announcing a route that didn't change makes every tab showing it
+      // refetch for nothing.
+      await waitFor(1000)
+      expect(announcements).toEqual(['addedPage /zz-added'])
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
 
   it('updates a tab showing a 404 when that page is added', async () => {
     // Regression test: a route that sorts after all existing ones used to
@@ -60,7 +110,10 @@ describe('route-change-refetch - App Router', () => {
   })
 
   it('updates a tab showing a page when that page is removed', async () => {
-    const browser = await next.browser('/existing')
+    const announcements: string[] = []
+    const browser = await next.browser('/existing', {
+      beforePageLoad: recordRouteAnnouncements(announcements),
+    })
     expect(await browser.elementById('existing').text()).toBe('existing')
 
     try {
@@ -70,6 +123,7 @@ describe('route-change-refetch - App Router', () => {
           'This page could not be found'
         )
       }, 15_000)
+      expect(announcements).toEqual(['removedPage /existing'])
     } finally {
       if (
         nodeFs.existsSync(nodePath.join(next.testDir, 'app/existing/page.bak'))
@@ -77,6 +131,38 @@ describe('route-change-refetch - App Router', () => {
         await next.renameFile('app/existing/page.bak', 'app/existing/page.tsx')
         await retry(async () => {
           expect((await next.fetch('/existing')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('updates a tab showing a page that is renamed', async () => {
+    // A rename keeps the number of routes the same, so a diff that only
+    // compares how many there are sees no change at all.
+    const announcements: string[] = []
+    const browser = await next.browser('/renamed-a', {
+      beforePageLoad: recordRouteAnnouncements(announcements),
+    })
+    expect(await browser.elementById('renamed').text()).toBe('renamed')
+
+    try {
+      await next.renameFile('app/renamed-a', 'app/renamed-b')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain(
+          'This page could not be found'
+        )
+      }, 15_000)
+      await retry(async () => {
+        expect([...announcements].sort()).toEqual([
+          'addedPage /renamed-b',
+          'removedPage /renamed-a',
+        ])
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/renamed-b'))) {
+        await next.renameFile('app/renamed-b', 'app/renamed-a')
+        await retry(async () => {
+          expect((await next.fetch('/renamed-a')).status).toBe(200)
         }, 15_000)
       }
     }

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -1,0 +1,358 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import type { Playwright } from 'next-webdriver'
+import * as nodeFs from 'node:fs'
+import * as nodePath from 'node:path'
+
+describe('route-change-refetch - App Router', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/app'),
+  })
+
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `app${pathname}/page.tsx`,
+      `export default function Page() { return <p id="added">${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  // Wait for the removal to land. A change that's still propagating when the
+  // test ends gets announced during the next test, which makes that test's tab
+  // refetch when it never asked for it.
+  async function cleanupAddedPage() {
+    if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/zz-added'))) {
+      await next.deleteFile('app/zz-added/page.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/zz-added')).status).toBe(404)
+      }, 15_000)
+    }
+  }
+
+  it('updates a tab showing a 404 when that page is added', async () => {
+    // Regression test: a route that sorts after all existing ones used to
+    // not be announced.
+    const browser = await next.browser('/zz-added')
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      // If the tab reacts to the announcement before the server can serve
+      // the page, it gets the 404 again and stays there — a pre-existing
+      // bug that's being fixed separately. Editing the page makes the
+      // server announce again, now that the page can be served.
+      // TODO: Remove these edits (in the tests below too) once that bug is
+      // fixed; these tests then cover it directly.
+      await next.patchFile(
+        'app/zz-added/page.tsx',
+        `export default function Page() { return <p id="added" data-rev="2">/zz-added</p> }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('/zz-added')
+      }, 15_000)
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
+
+  it('updates a tab showing a page when that page is removed', async () => {
+    const browser = await next.browser('/existing')
+    expect(await browser.elementById('existing').text()).toBe('existing')
+
+    try {
+      await next.renameFile('app/existing/page.tsx', 'app/existing/page.bak')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain(
+          'This page could not be found'
+        )
+      }, 15_000)
+    } finally {
+      if (
+        nodeFs.existsSync(nodePath.join(next.testDir, 'app/existing/page.bak'))
+      ) {
+        await next.renameFile('app/existing/page.bak', 'app/existing/page.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/existing')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('updates a tab showing a 404 when a dynamic route that matches is added', async () => {
+    const browser = await next.browser('/docs/abc')
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    try {
+      await next.patchFile(
+        'app/docs/[slug]/page.tsx',
+        `export default async function Page(props: {
+          params: Promise<{ slug: string }>
+        }) {
+          const { slug } = await props.params
+          return <p id="added">{slug}</p>
+        }`
+      )
+      await retry(async () => {
+        expect((await next.fetch('/docs/abc')).status).toBe(200)
+      }, 15_000)
+      await next.patchFile(
+        'app/docs/[slug]/page.tsx',
+        `export default async function Page(props: {
+          params: Promise<{ slug: string }>
+        }) {
+          const { slug } = await props.params
+          return <p id="added" data-rev="2">{slug}</p>
+        }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('abc')
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/docs'))) {
+        await next.deleteFile('app/docs/[slug]/page.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/docs/abc')).status).toBe(404)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('updates a tab showing a 404 when a page in a route group is added', async () => {
+    const browser = await next.browser('/grouped')
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page could not be found'
+    )
+
+    try {
+      await next.patchFile(
+        'app/(group)/grouped/page.tsx',
+        `export default function Page() { return <p id="added">grouped</p> }`
+      )
+      await retry(async () => {
+        expect((await next.fetch('/grouped')).status).toBe(200)
+      }, 15_000)
+      await next.patchFile(
+        'app/(group)/grouped/page.tsx',
+        `export default function Page() { return <p id="added" data-rev="2">grouped</p> }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('grouped')
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/(group)'))) {
+        await next.deleteFile('app/(group)/grouped/page.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/grouped')).status).toBe(404)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('switches a tab between a dynamic route and a more specific page', async () => {
+    const browser = await next.browser('/posts/123')
+    expect(await browser.elementById('dynamic').text()).toBe('dynamic 123')
+
+    try {
+      // Adding a static page that takes precedence for the URL the tab is
+      // showing must switch the tab to it.
+      await next.patchFile(
+        'app/posts/123/page.tsx',
+        `export default function Page() { return <p id="static">static 123</p> }`
+      )
+      await retry(async () => {
+        expect(await (await next.fetch('/posts/123')).text()).toContain(
+          'id="static"'
+        )
+      }, 15_000)
+      await next.patchFile(
+        'app/posts/123/page.tsx',
+        `export default function Page() { return <p id="static" data-rev="2">static 123</p> }`
+      )
+      await retry(async () => {
+        expect(await browser.elementById('static').text()).toBe('static 123')
+      }, 15_000)
+
+      // Removing it must switch the tab back to the dynamic route.
+      await next.deleteFile('app/posts/123/page.tsx')
+      await retry(async () => {
+        expect(await browser.elementById('dynamic').text()).toBe('dynamic 123')
+      }, 15_000)
+    } finally {
+      if (nodeFs.existsSync(nodePath.join(next.testDir, 'app/posts/123'))) {
+        await next.deleteFile('app/posts/123/page.tsx')
+        await retry(async () => {
+          const html = await (await next.fetch('/posts/123')).text()
+          expect(html).toContain('id="dynamic"')
+          expect(html).not.toContain('id="static"')
+        }, 15_000)
+      }
+    }
+  })
+})
+
+describe('route-change-refetch - App Router refetch count', () => {
+  // Its own server: how often a change makes a tab refetch depends on what
+  // has been compiled so far, and on tabs other tests leave open.
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/app'),
+  })
+
+  // A refetch the dev server asked for carries the HMR refresh header, which
+  // tells it apart from a navigation or a prefetch.
+  async function startCountingRefetches(browser: Playwright) {
+    await browser.eval(() => {
+      const win = window as any
+      win.__refetches = 0
+      const originalFetch = win.fetch
+      win.fetch = (input: any, init: any) => {
+        if (new Headers(init?.headers).get('next-hmr-refresh') === '1') {
+          win.__refetches++
+        }
+        return originalFetch(input, init)
+      }
+    })
+  }
+
+  function countRefetches(browser: Playwright): Promise<number> {
+    return browser.eval(() => (window as any).__refetches)
+  }
+
+  it('refetches an open tab exactly twice when a page is added', async () => {
+    const browser = await next.browser('/counted')
+    expect(await browser.elementById('counted').text()).toBe('counted')
+    await startCountingRefetches(browser)
+
+    await next.patchFile(
+      'app/zz-added/page.tsx',
+      `export default function Page() { return <p id="added">/zz-added</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch('/zz-added')).status).toBe(200)
+    }, 15_000)
+    await retry(async () => {
+      // TODO: Stop counting a page add as an env change, then it'll be 1.
+      expect(await countRefetches(browser)).toBe(2)
+    }, 15_000)
+    // A later one would mean the change was announced more than once.
+    await waitFor(1000)
+    expect(await countRefetches(browser)).toBe(2)
+  })
+})
+
+describe('route-change-refetch - Pages Router', () => {
+  const { next } = nextTestSetup({
+    files: nodePath.join(__dirname, 'fixtures/pages'),
+  })
+
+  async function addPageAndWaitUntilServable(pathname: string) {
+    await next.patchFile(
+      `pages${pathname}.tsx`,
+      `export default function Page() { return <p id="added">${pathname}</p> }`
+    )
+    await retry(async () => {
+      expect((await next.fetch(pathname)).status).toBe(200)
+    }, 15_000)
+  }
+
+  async function cleanupAddedPage() {
+    if (nodeFs.existsSync(nodePath.join(next.testDir, 'pages/zz-added.tsx'))) {
+      await next.deleteFile('pages/zz-added.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/zz-added')).status).toBe(404)
+      }, 15_000)
+    }
+  }
+
+  it('reloads a tab showing a 404 when that page is added', async () => {
+    const browser = await next.browser('/zz-added')
+    expect(await browser.elementByCss('body').text()).toContain('404')
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      await retry(async () => {
+        expect(await browser.elementById('added').text()).toBe('/zz-added')
+      }, 15_000)
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
+
+  it('reloads a tab showing a page when that page is removed', async () => {
+    // The client only reloads when the removed page is the one it's showing,
+    // which it decides by comparing the route name in the message against
+    // its pathname. This also pins the naming.
+    const browser = await next.browser('/existing')
+    expect(await browser.elementById('existing').text()).toBe('existing')
+
+    try {
+      await next.renameFile('pages/existing.tsx', 'pages/existing.bak')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain('404')
+      }, 15_000)
+    } finally {
+      if (
+        nodeFs.existsSync(nodePath.join(next.testDir, 'pages/existing.bak'))
+      ) {
+        await next.renameFile('pages/existing.bak', 'pages/existing.tsx')
+        await retry(async () => {
+          expect((await next.fetch('/existing')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('reloads a tab showing a dynamic route when that route is removed', async () => {
+    // The client decides whether the removed page is the one it's showing by
+    // comparing the route name in the message against its pathname, which
+    // for dynamic routes is the pattern ("/posts/[id]"). This pins that the
+    // announced name is the pattern too.
+    const browser = await next.browser('/posts/123')
+    expect(await browser.elementById('dynamic').text()).toBe('dynamic 123')
+
+    try {
+      await next.renameFile('pages/posts/[id].tsx', 'pages/posts/id.bak')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain('404')
+      }, 15_000)
+    } finally {
+      if (
+        nodeFs.existsSync(nodePath.join(next.testDir, 'pages/posts/id.bak'))
+      ) {
+        await next.renameFile('pages/posts/id.bak', 'pages/posts/[id].tsx')
+        await retry(async () => {
+          expect((await next.fetch('/posts/123')).status).toBe(200)
+        }, 15_000)
+      }
+    }
+  })
+
+  it('refetches the route manifest exactly once when a page is added', async () => {
+    const manifestRequests: string[] = []
+    const browser = await next.browser('/existing', {
+      beforePageLoad(page: any) {
+        page.on('request', (request: any) => {
+          if (request.url().includes('_devPagesManifest')) {
+            manifestRequests.push(request.url())
+          }
+        })
+      },
+    })
+    expect(await browser.elementById('existing').text()).toBe('existing')
+    const baseline = manifestRequests.length
+
+    try {
+      await addPageAndWaitUntilServable('/zz-added')
+      await retry(async () => {
+        expect(manifestRequests.length).toBe(baseline + 1)
+      }, 15_000)
+    } finally {
+      await cleanupAddedPage()
+    }
+  })
+})


### PR DESCRIPTION
The dev server tells open tabs when a page is added or removed, so a tab showing a 404 picks up a page you just created, and a tab showing a page you just deleted falls back to the 404.

Both bundlers computed the list of changed pages wrong, in opposite directions.

**Turbopack announced pages that hadn't changed.** To find what changed, it compared the new route list against the entry maps in `currentEntrypoints`. Those maps key App Router entries by page name (`/blog/page`), but the route list is keyed by route (`/blog`), so no App Router route ever matched: every update announced every existing app route as added and every page name as removed, and starting the server announced every route once. Each announcement makes every connected tab refetch. Fixed by comparing the new route list to the previous route list, which uses the same naming. Starting the server now announces nothing on either bundler, since the first route list is not a change.

**webpack didn't announce pages that had changed.** It only announced when `prevSortedRoutes.every((val, idx) => val === sortedRoutes[idx])` was false. That is a prefix comparison: when a new route sorts after all existing ones, the old list is a prefix of the new one, and nothing is announced. In App Router this mostly went unnoticed, because adding a page was also (wrongly) treated as an env change, which refreshed tabs anyway; the next PR in this stack removes that. In Pages Router nothing hid it: the route manifest was never refetched, so client-side navigation to the new page kept returning 404 until a manual reload. Fixed by also comparing the lengths.

**What this PR does not fix:** on Turbopack there is a window right after a page is added where the dev server has already announced it to tabs, but can't serve it yet (the route isn't in the dev router's route table until the watcher pass in `setup-dev-bundler` runs). A tab that reacts inside that window gets the 404 again, and since each page is only announced once, it stays on the 404 until you reload it by hand. That bug predates this PR and is being fixed separately.

So that the new App Router tests don't hit this window, each one edits the added page again once it's confirmed servable. The edit makes the server announce again, and this time the tab can only get the page. The trade-off is that these tests don't prove the first announcement alone updates the tab — the refetch-count test covers how often changes are announced, and its tab never sits on the added page's 404, so it can't hit the window. A TODO in the tests says to drop the extra edits once the underlying bug is fixed. The Pages Router test needs no such edit: Turbopack updates the route matchers before it announces, and a Pages Router tab reloads the document instead of refetching.

## Test plan

New tests cover adds, removals, dynamic routes, route groups, and a dynamic route being shadowed by a more specific page and then unshadowed. One more counts how often an open tab refetches when a page is added: it wraps the tab's `fetch` and counts requests carrying the `next-hmr-refresh` header, which distinguishes a refetch the dev server asked for from a navigation or a prefetch. It runs on a dev server no other test shares, because the count depends on what has been compiled so far.

Before the fix, adding one page makes an open tab refetch:

```
Turbopack: 12 times   (every app route re-announced; grows with the number of routes)
webpack:    1 time    (the announcement is never sent; only the env-change refetch happens)
```

The correct count is currently 2: one refetch for the announcement, one for the env-change false alarm. The next PR removes the false alarm and tightens the expectation to 1.

Before the fix, webpack also fails the Pages Router manifest test (the manifest update is sent from the same skipped branch).

With the fix, both bundlers pass all ten tests.

