### PR TITLE
Add local Request Insights span tracing

### DIFF
--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -5,7 +5,7 @@
 import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
-import { createLocalSpan } from './local-span-recorder'
+import { createLocalSpan, traceLocalSpan } from './local-span-recorder'
 import { runWithRequestInsightsIdentity } from './request-insights-identity'
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 import {
@@ -122,6 +122,59 @@ describe('local recording span', () => {
         ],
       }),
     ])
+  })
+
+  it('ends traced local spans and records thrown errors', async () => {
+    const error = new TypeError('boom')
+
+    await expect(
+      traceLocalSpan({ name: 'test.local-span.trace-error' }, async () => {
+        throw error
+      })
+    ).rejects.toBe(error)
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'test.local-span.trace-error',
+        status: 'error',
+        error: {
+          type: 'TypeError',
+          message: 'boom',
+        },
+      }),
+    ])
+  })
+
+  it('can start a detached trace inside an active local span', async () => {
+    await traceLocalSpan({ name: 'foreground' }, async () => {
+      await traceLocalSpan(
+        { name: 'detached root', parentSpan: null },
+        async () => {
+          await traceLocalSpan({ name: 'detached child' }, async () => {})
+        }
+      )
+    })
+
+    const foreground = spanRecords.find((span) => span.name === 'foreground')!
+    const detachedRoot = spanRecords.find(
+      (span) => span.name === 'detached root'
+    )!
+    const detachedChild = spanRecords.find(
+      (span) => span.name === 'detached child'
+    )!
+
+    expect(detachedRoot).toEqual(
+      expect.objectContaining({
+        parentSpanId: undefined,
+      })
+    )
+    expect(detachedRoot.traceId).not.toBe(foreground.traceId)
+    expect(detachedChild).toEqual(
+      expect.objectContaining({
+        traceId: detachedRoot.traceId,
+        parentSpanId: detachedRoot.spanId,
+      })
+    )
   })
 
   it('uses the request insights identity before the work store exists', () => {

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -22,6 +22,24 @@ const SPAN_ID_HEX_LENGTH = 16
 
 type LocalSpanAttributes = Partial<Record<string, AttributeValue | undefined>>
 
+type LocalSpanOptions = {
+  name: string
+  attributes?: LocalSpanAttributes
+  links?: SpanOptions['links']
+  startTime?: SpanOptions['startTime']
+  traceId?: string
+  spanId?: string
+  parentSpanId?: string
+  delegateSpan?: Span
+}
+
+type TraceLocalSpanOptions = Omit<
+  LocalSpanOptions,
+  'traceId' | 'spanId' | 'parentSpanId' | 'delegateSpan'
+> & {
+  parentSpan?: Span | null
+}
+
 let lastLocalTraceId = 0
 let lastLocalSpanId = 0
 let localSpanAsyncStorage: AsyncLocalStorage<Span> | undefined
@@ -41,16 +59,7 @@ export function createLocalSpan({
   spanId,
   parentSpanId,
   delegateSpan,
-}: {
-  name: string
-  attributes?: LocalSpanAttributes
-  links?: SpanOptions['links']
-  startTime?: SpanOptions['startTime']
-  traceId?: string
-  spanId?: string
-  parentSpanId?: string
-  delegateSpan?: Span
-}): Span {
+}: LocalSpanOptions): Span {
   return new LocalRecordingSpan({
     name,
     attributes,
@@ -76,12 +85,43 @@ export function withLocalSpan<T>(span: Span, fn: () => T): T {
   return getLocalSpanAsyncStorage().run(span, fn)
 }
 
+/**
+ * Records an async operation in the local Request Insights trace. Nested local
+ * spans inherit the currently active local parent unless explicitly detached.
+ */
+export async function traceLocalSpan<T>(
+  { parentSpan, ...options }: TraceLocalSpanOptions,
+  fn: () => Promise<T>
+): Promise<T> {
+  const resolvedParentSpan =
+    parentSpan === undefined ? getActiveLocalSpan() : parentSpan
+  const parentSpanContext = resolvedParentSpan?.spanContext()
+  const span = createLocalSpan({
+    ...options,
+    traceId: parentSpanContext?.traceId,
+    parentSpanId: parentSpanContext?.spanId,
+  })
+
+  return withLocalSpan(span, async () => {
+    try {
+      return await fn()
+    } catch (err) {
+      span.recordException(err as Error)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+      throw err
+    } finally {
+      span.end()
+    }
+  })
+}
+
 export type LocalSpanRecorder = {
   createLocalSpan: typeof createLocalSpan
   getActiveLocalSpan: typeof getActiveLocalSpan
   isLocalRecordingSpan: typeof isLocalRecordingSpan
   isLocalSpanRecordingEnabled: typeof isLocalSpanRecordingEnabled
   isRequestInsightsEnabled: typeof isRequestInsightsEnabled
+  traceLocalSpan: typeof traceLocalSpan
   withLocalSpan: typeof withLocalSpan
 }
 
@@ -97,6 +137,7 @@ export function registerLocalSpanRecorder(): void {
     isLocalRecordingSpan,
     isLocalSpanRecordingEnabled,
     isRequestInsightsEnabled,
+    traceLocalSpan,
     withLocalSpan,
   }
 }


### PR DESCRIPTION
## Summary

- Adds a local `traceLocalSpan` primitive for Request Insights diagnostics.
- Supports detached roots and nested local parentage.
- Records thrown errors, marks span status, rethrows, and always ends the span.
- Keeps this foundational behavior separate from tracer/OTel integration.

## Verification

```bash
pnpm build-all
pnpm --filter=next types
pnpm --filter=next build
pnpm test-unit --runTestsByPath packages/next/src/server/lib/trace/local-span-recorder.test.ts
```

<!-- NEXT_JS_LLM -->
