### PR TITLE
Isolate local Request Insights spans from OpenTelemetry

### DIFF
--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -31,11 +31,16 @@ type LocalSpanOptions = {
   spanId?: string
   parentSpanId?: string
   delegateSpan?: Span
+  isolateOpenTelemetry?: boolean
 }
 
 type TraceLocalSpanOptions = Omit<
   LocalSpanOptions,
-  'traceId' | 'spanId' | 'parentSpanId' | 'delegateSpan'
+  | 'traceId'
+  | 'spanId'
+  | 'parentSpanId'
+  | 'delegateSpan'
+  | 'isolateOpenTelemetry'
 > & {
   parentSpan?: Span | null
 }
@@ -59,6 +64,7 @@ export function createLocalSpan({
   spanId,
   parentSpanId,
   delegateSpan,
+  isolateOpenTelemetry,
 }: LocalSpanOptions): Span {
   return new LocalRecordingSpan({
     name,
@@ -70,6 +76,7 @@ export function createLocalSpan({
     spanId: spanId ?? getLocalSpanId(),
     parentSpanId,
     requestIdentity: getCurrentRequestIdentity(),
+    isolateOpenTelemetry: isolateOpenTelemetry ?? false,
   })
 }
 
@@ -81,13 +88,17 @@ export function isLocalRecordingSpan(span: Span): boolean {
   return span instanceof LocalRecordingSpan
 }
 
+export function isOpenTelemetryIsolatedSpan(span: Span): boolean {
+  return span instanceof LocalRecordingSpan && span.isOpenTelemetryIsolated()
+}
+
 export function withLocalSpan<T>(span: Span, fn: () => T): T {
   return getLocalSpanAsyncStorage().run(span, fn)
 }
 
 /**
- * Records an async operation in the local Request Insights trace. Nested local
- * spans inherit the currently active local parent unless explicitly detached.
+ * Records an async operation without replacing or exporting through the active
+ * OpenTelemetry context. Nested Next.js spans remain in the local trace.
  */
 export async function traceLocalSpan<T>(
   { parentSpan, ...options }: TraceLocalSpanOptions,
@@ -100,6 +111,7 @@ export async function traceLocalSpan<T>(
     ...options,
     traceId: parentSpanContext?.traceId,
     parentSpanId: parentSpanContext?.spanId,
+    isolateOpenTelemetry: true,
   })
 
   return withLocalSpan(span, async () => {
@@ -119,6 +131,7 @@ export type LocalSpanRecorder = {
   createLocalSpan: typeof createLocalSpan
   getActiveLocalSpan: typeof getActiveLocalSpan
   isLocalRecordingSpan: typeof isLocalRecordingSpan
+  isOpenTelemetryIsolatedSpan: typeof isOpenTelemetryIsolatedSpan
   isLocalSpanRecordingEnabled: typeof isLocalSpanRecordingEnabled
   isRequestInsightsEnabled: typeof isRequestInsightsEnabled
   traceLocalSpan: typeof traceLocalSpan
@@ -135,6 +148,7 @@ export function registerLocalSpanRecorder(): void {
     createLocalSpan,
     getActiveLocalSpan,
     isLocalRecordingSpan,
+    isOpenTelemetryIsolatedSpan,
     isLocalSpanRecordingEnabled,
     isRequestInsightsEnabled,
     traceLocalSpan,
@@ -166,6 +180,7 @@ class LocalRecordingSpan implements Span {
   private attributes: SpanStoreAttributes
   private events: SpanStoreEvent[]
   private readonly spanContextValue: ReturnType<Span['spanContext']>
+  private readonly openTelemetryIsolated: boolean
   private delegateSpan?: Span
   private links?: SpanStoreLink[]
   private readonly parentSpanId?: string
@@ -191,6 +206,7 @@ class LocalRecordingSpan implements Span {
     spanId,
     parentSpanId,
     requestIdentity,
+    isolateOpenTelemetry,
   }: {
     name: string
     attributes?: LocalSpanAttributes
@@ -201,11 +217,13 @@ class LocalRecordingSpan implements Span {
     spanId: string
     parentSpanId?: string
     requestIdentity: RequestIdentity
+    isolateOpenTelemetry: boolean
   }) {
     this.name = name
     this.attributes = cleanSpanStoreAttributes(attributes)
     this.events = []
     this.delegateSpan = delegateSpan
+    this.openTelemetryIsolated = isolateOpenTelemetry
     this.spanContextValue = delegateSpan?.spanContext() ?? {
       traceId,
       spanId,
@@ -223,6 +241,10 @@ class LocalRecordingSpan implements Span {
 
   spanContext(): ReturnType<Span['spanContext']> {
     return this.spanContextValue
+  }
+
+  isOpenTelemetryIsolated(): boolean {
+    return this.openTelemetryIsolated
   }
 
   setAttribute(key: string, value: AttributeValue): this {

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -444,6 +444,7 @@ describe('local span recording', () => {
     })[0]
 
     expect(rootRecord.parentSpanId).toBeUndefined()
+    expect(rootRecord.traceId).not.toBe(foregroundSpan.spanContext().traceId)
     expect(childRecord).toEqual(
       expect.objectContaining({
         traceId: rootRecord.traceId,

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -19,11 +19,15 @@ import {
 } from '@opentelemetry/api'
 
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
-import { registerLocalSpanRecorder } from './local-span-recorder'
+import {
+  registerLocalSpanRecorder,
+  traceLocalSpan,
+} from './local-span-recorder'
 import {
   AppRenderSpan,
   BaseServerSpan,
   LoadComponentsSpan,
+  NextNodeServerSpan,
   NodeSpan,
 } from './constants'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
@@ -182,6 +186,7 @@ describe('local span recording', () => {
     } else {
       process.env.NEXT_OTEL_VERBOSE = originalOtelVerbose
     }
+    context.disable()
     trace.disable()
     setSpanRecorderForTest(undefined)
     spanRecords.length = 0
@@ -358,6 +363,105 @@ describe('local span recording', () => {
         }),
       }),
     ])
+  })
+
+  it('keeps OTel-isolated spans out of the active OTel context', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    process.env.NEXT_OTEL_VERBOSE = '1'
+    context.disable()
+    context.setGlobalContextManager(new TestContextManager())
+
+    const exportedSpans: string[] = []
+    const foregroundSpan = trace.wrapSpanContext({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    })
+    trace.setGlobalTracerProvider({
+      getTracer() {
+        return {
+          startSpan(name: string) {
+            exportedSpans.push(name)
+            return foregroundSpan
+          },
+          startActiveSpan(...args: unknown[]) {
+            exportedSpans.push(args[0] as string)
+            const callback = args.at(-1) as (
+              span: typeof foregroundSpan
+            ) => unknown
+            return callback(foregroundSpan)
+          },
+        }
+      },
+    })
+
+    const foregroundContext = trace.setSpan(ROOT_CONTEXT, foregroundSpan)
+    let activeSpanDuringLocalWork
+    let activeSpanDuringNestedLocalWork
+    let activeSpanDuringNextTrace
+    let activeSpanDuringDirectWithSpan
+
+    await context.with(foregroundContext, () =>
+      traceLocalSpan(
+        { name: 'Instant Insights', parentSpan: null },
+        async () => {
+          activeSpanDuringLocalWork = trace.getSpan(context.active())
+          await traceLocalSpan(
+            { name: 'Prepare validation inputs' },
+            async () => {
+              activeSpanDuringNestedLocalWork = trace.getSpan(context.active())
+              getTracer().trace(NextNodeServerSpan.createComponentTree, () => {
+                activeSpanDuringNextTrace = trace.getSpan(context.active())
+              })
+              const directSpan = getTracer().startSpan(
+                NextNodeServerSpan.getLayoutOrPageModule
+              )
+              getTracer().withSpan(directSpan, () => {
+                activeSpanDuringDirectWithSpan = trace.getSpan(context.active())
+              })
+              directSpan.end()
+            }
+          )
+        }
+      )
+    )
+
+    expect(activeSpanDuringLocalWork).toBe(foregroundSpan)
+    expect(activeSpanDuringNestedLocalWork).toBe(foregroundSpan)
+    expect(activeSpanDuringNextTrace).toBe(foregroundSpan)
+    expect(activeSpanDuringDirectWithSpan).toBe(foregroundSpan)
+    expect(exportedSpans).toEqual([])
+
+    const rootRecord = getSpanRecords({ name: 'Instant Insights' })[0]
+    const childRecord = getSpanRecords({
+      name: 'Prepare validation inputs',
+    })[0]
+    const nestedNextRecord = getSpanRecords({
+      name: NextNodeServerSpan.createComponentTree,
+    })[0]
+    const directNextRecord = getSpanRecords({
+      name: NextNodeServerSpan.getLayoutOrPageModule,
+    })[0]
+
+    expect(rootRecord.parentSpanId).toBeUndefined()
+    expect(childRecord).toEqual(
+      expect.objectContaining({
+        traceId: rootRecord.traceId,
+        parentSpanId: rootRecord.spanId,
+      })
+    )
+    expect(nestedNextRecord).toEqual(
+      expect.objectContaining({
+        traceId: rootRecord.traceId,
+        parentSpanId: childRecord.spanId,
+      })
+    )
+    expect(directNextRecord).toEqual(
+      expect.objectContaining({
+        traceId: rootRecord.traceId,
+        parentSpanId: childRecord.spanId,
+      })
+    )
   })
 
   it('mirrors span mutations made through the OTel span API', () => {

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -256,11 +256,20 @@ class NextTracerImpl implements NextTracer {
   }
 
   public getActiveScopeSpan(): Span | undefined {
+    const localSpanRecorder = getLocalSpanRecorder()
+    const activeLocalSpan = localSpanRecorder?.getActiveLocalSpan()
+    if (
+      activeLocalSpan &&
+      localSpanRecorder?.isOpenTelemetryIsolatedSpan(activeLocalSpan)
+    ) {
+      return activeLocalSpan
+    }
+
     const activeSpan = trace.getSpan(context.active())
     if (activeSpan || !process.env.__NEXT_DEV_SERVER) {
       return activeSpan
     }
-    return getLocalSpanRecorder()?.getActiveLocalSpan()
+    return activeLocalSpan
   }
 
   /**
@@ -366,9 +375,15 @@ class NextTracerImpl implements NextTracer {
 
     const spanName = options.spanName ?? type
 
+    const parentSpan = options.parentSpan ?? this.getActiveScopeSpan()
+    const isolatedParentSpan =
+      parentSpan && localSpanRecorder?.isOpenTelemetryIsolatedSpan(parentSpan)
+        ? parentSpan
+        : undefined
     const shouldDelegateSpan =
-      NextVanillaSpanAllowlist.has(type) ||
-      process.env.NEXT_OTEL_VERBOSE === '1'
+      !isolatedParentSpan &&
+      (NextVanillaSpanAllowlist.has(type) ||
+        process.env.NEXT_OTEL_VERBOSE === '1')
     const shouldTraceSpan =
       shouldDelegateSpan ||
       (localSpanRecorder?.isRequestInsightsEnabled() ?? false)
@@ -378,9 +393,9 @@ class NextTracerImpl implements NextTracer {
     }
 
     // Trying to get active scoped span to assign parent. If option specifies parent span manually, will try to use it.
-    let spanContext = this.getSpanContext(
-      options?.parentSpan ?? this.getActiveScopeSpan()
-    )
+    let spanContext = isolatedParentSpan
+      ? context.active()
+      : this.getSpanContext(parentSpan)
 
     if (!spanContext) {
       spanContext = context?.active() ?? ROOT_CONTEXT
@@ -410,6 +425,7 @@ class NextTracerImpl implements NextTracer {
         spanContext,
         tracingEnabled && shouldDelegateSpan,
         localSpanRecordingEnabled,
+        isolatedParentSpan,
         (span: Span) => {
           let startTime: number | undefined
           if (
@@ -510,6 +526,7 @@ class NextTracerImpl implements NextTracer {
     parentContext: Context,
     tracingEnabled: boolean,
     localSpanRecordingEnabled: boolean,
+    isolatedParentSpan: Span | undefined,
     fn: (span: Span) => T
   ): T {
     if (tracingEnabled) {
@@ -523,18 +540,31 @@ class NextTracerImpl implements NextTracer {
                   spanName,
                   options,
                   parentContext,
-                  span
+                  span,
+                  isolatedParentSpan
                 )
               : span
           )
       )
     }
 
-    const span = this.createLocalRecordingSpan(spanName, options, parentContext)
-    const activeContext = trace.setSpan(context.active(), span)
-
-    return getLocalSpanRecorder()!.withLocalSpan(span, () =>
-      context.with(activeContext, fn, undefined, span)
+    const span = this.createLocalRecordingSpan(
+      spanName,
+      options,
+      parentContext,
+      undefined,
+      isolatedParentSpan
+    )
+    const localSpanRecorder = getLocalSpanRecorder()!
+    return localSpanRecorder.withLocalSpan(span, () =>
+      localSpanRecorder.isOpenTelemetryIsolatedSpan(span)
+        ? fn(span)
+        : context.with(
+            trace.setSpan(context.active(), span),
+            fn,
+            undefined,
+            span
+          )
     )
   }
 
@@ -542,9 +572,11 @@ class NextTracerImpl implements NextTracer {
     name: string,
     options: TracerSpanOptions,
     parentContext: Context,
-    delegateSpan?: Span
+    delegateSpan?: Span,
+    isolatedParentSpan?: Span
   ): Span {
-    const parentSpanContext = trace.getSpanContext(parentContext)
+    const parentSpanContext =
+      isolatedParentSpan?.spanContext() ?? trace.getSpanContext(parentContext)
     const delegateSpanContext = delegateSpan?.spanContext()
 
     return getLocalSpanRecorder()!.createLocalSpan({
@@ -556,6 +588,7 @@ class NextTracerImpl implements NextTracer {
       traceId: delegateSpanContext?.traceId ?? parentSpanContext?.traceId,
       spanId: delegateSpanContext?.spanId,
       parentSpanId: parentSpanContext?.spanId,
+      isolateOpenTelemetry: isolatedParentSpan !== undefined,
     })
   }
 
@@ -623,25 +656,33 @@ class NextTracerImpl implements NextTracer {
         }
       : { attributes: { 'next.span_category': 'nextjs' } }
 
+    const localSpanRecorder = getLocalSpanRecorder()
+    const parentSpan = options.parentSpan ?? this.getActiveScopeSpan()
+    const isolatedParentSpan =
+      parentSpan && localSpanRecorder?.isOpenTelemetryIsolatedSpan(parentSpan)
+        ? parentSpan
+        : undefined
     const parentContext =
-      this.getSpanContext(options.parentSpan ?? this.getActiveScopeSpan()) ??
+      (isolatedParentSpan ? undefined : this.getSpanContext(parentSpan)) ??
       context.active()
     const localSpanRecordingEnabled =
-      getLocalSpanRecorder()?.isLocalSpanRecordingEnabled() ?? false
+      localSpanRecorder?.isLocalSpanRecordingEnabled() ?? false
 
     if (!localSpanRecordingEnabled) {
       return this.getTracerInstance().startSpan(type, options, parentContext)
     }
 
-    const delegateSpan = this.isOpenTelemetryEnabled()
-      ? this.getTracerInstance().startSpan(type, options, parentContext)
-      : undefined
+    const delegateSpan =
+      !isolatedParentSpan && this.isOpenTelemetryEnabled()
+        ? this.getTracerInstance().startSpan(type, options, parentContext)
+        : undefined
 
     return this.createLocalRecordingSpan(
       type,
       options,
       parentContext,
-      delegateSpan
+      delegateSpan,
+      isolatedParentSpan
     )
   }
 
@@ -674,12 +715,15 @@ class NextTracerImpl implements NextTracer {
   }
 
   public withSpan<T>(span: Span, fn: () => T): T {
-    const spanContext = trace.setSpan(context.active(), span)
     const recorder = getLocalSpanRecorder()
     if (recorder?.isLocalRecordingSpan(span)) {
-      return recorder.withLocalSpan(span, () => context.with(spanContext, fn))
+      return recorder.withLocalSpan(span, () =>
+        recorder.isOpenTelemetryIsolatedSpan(span)
+          ? fn()
+          : context.with(trace.setSpan(context.active(), span), fn)
+      )
     }
-    return context.with(spanContext, fn)
+    return context.with(trace.setSpan(context.active(), span), fn)
   }
 }
 


### PR DESCRIPTION
## Summary

- Keeps Request Insights diagnostic spans inside the local recorder.
- Nested generic Next.js spans retain the local parent hierarchy.
- The user’s active OpenTelemetry context remains active and unchanged.
- Diagnostic wrappers are not delegated to or exported through user OpenTelemetry.

## Verification

```bash
pnpm build-all
pnpm --filter=next types
pnpm --filter=next build
pnpm test-unit --runTestsByPath packages/next/src/server/lib/trace/local-span-recorder.test.ts packages/next/src/server/lib/trace/tracer.test.ts
```

<!-- NEXT_JS_LLM -->
