### PR TITLE
[turbopack] Remove loader calls for dropped dynamic imports

### DIFF
--- a/test/production/app-dir/dynamic-import-evaluation-only/app/layout.tsx
+++ b/test/production/app-dir/dynamic-import-evaluation-only/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/dynamic-import-evaluation-only/app/page.tsx
+++ b/test/production/app-dir/dynamic-import-evaluation-only/app/page.tsx
@@ -1,0 +1,16 @@
+// Read through `globalThis` so the request stays a pattern the analyzer cannot fold to a single
+// target, without pulling in runtime request data that cache components would reject.
+async function loadLocale(locale: string) {
+  // eslint-disable-next-line no-empty-pattern
+  const {} = await import(`../locales/${locale}`)
+}
+
+export default async function Page() {
+  // Nothing is destructured out of either result, so both resolve to
+  // `ExportUsage::Evaluation`. The pattern import resolves to two targets of differing purity.
+  // eslint-disable-next-line no-empty-pattern
+  const {} = await import('../simple')
+  await loadLocale((globalThis as { __locale?: string }).__locale ?? 'pure')
+
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/dynamic-import-evaluation-only/dynamic-import-evaluation-only.test.ts
+++ b/test/production/app-dir/dynamic-import-evaluation-only/dynamic-import-evaluation-only.test.ts
@@ -1,0 +1,30 @@
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs'
+import path from 'path'
+
+describe('dynamic-import-evaluation-only', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+  if (skipped) return
+
+  it('should drop only the side-effect-free targets of evaluation-only dynamic imports', async () => {
+    const { exitCode, cliOutput } = await next.build()
+
+    expect(cliOutput).not.toContain('ModuleId not found for ident')
+    expect(exitCode).toBe(0)
+
+    const dir = path.join(next.testDir, '.next/server')
+    const output = fs
+      .readdirSync(dir, { recursive: true, encoding: 'utf8' })
+      .filter((file) => file.endsWith('.js'))
+      .map((file) => fs.readFileSync(path.join(dir, file), 'utf8'))
+      .join('\n')
+
+    expect(output).not.toContain('DROPPED_SIMPLE')
+    expect(output).not.toContain('DROPPED_PATTERN')
+    expect(output).toContain('__kept')
+  })
+})

--- a/test/production/app-dir/dynamic-import-evaluation-only/locales/effectful.js
+++ b/test/production/app-dir/dynamic-import-evaluation-only/locales/effectful.js
@@ -1,0 +1,1 @@
+globalThis.__kept = true

--- a/test/production/app-dir/dynamic-import-evaluation-only/locales/pure.js
+++ b/test/production/app-dir/dynamic-import-evaluation-only/locales/pure.js
@@ -1,0 +1,1 @@
+export const value = 'DROPPED_PATTERN'

--- a/test/production/app-dir/dynamic-import-evaluation-only/next.config.js
+++ b/test/production/app-dir/dynamic-import-evaluation-only/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/dynamic-import-evaluation-only/simple.js
+++ b/test/production/app-dir/dynamic-import-evaluation-only/simple.js
@@ -1,0 +1,1 @@
+export const value = 'DROPPED_SIMPLE'

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -303,7 +303,12 @@ pub enum SourceMapSourceType {
 }
 
 #[turbo_tasks::value(transparent, cell = "keyed")]
-pub struct UnusedReferences(FxHashSet<ResolvedVc<Box<dyn ModuleReference>>>);
+#[allow(clippy::type_complexity)]
+/// For each reference, the targets it resolves to that were dropped as unused. One reference can
+/// resolve to several targets, which are dropped independently.
+pub struct UnusedReferences(
+    FxHashMap<ResolvedVc<Box<dyn ModuleReference>>, FxHashSet<ResolvedVc<Box<dyn Module>>>>,
+);
 
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Default)]

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -115,7 +115,8 @@ pub async fn compute_binding_usage_info(
             ResolvedVc<Box<dyn Module>>,
         )>::default();
         let mut unused_references_edges = FxHashSet::default();
-        let mut unused_references = FxHashSet::default();
+        let mut unused_references =
+            FxHashMap::<_, FxHashSet<ResolvedVc<Box<dyn Module>>>>::default();
 
         let graph = graph.connect();
         let graph_ref = graph.await?;
@@ -173,7 +174,10 @@ pub async fn compute_binding_usage_info(
                             target,
                         ));
                         unused_references_edges.insert(edge);
-                        unused_references.insert(ref_data.reference);
+                        unused_references
+                            .entry(ref_data.reference)
+                            .or_default()
+                            .insert(target);
                         return Ok(GraphTraversalAction::Skip);
                     }
                     // If the current edge is an unused import, skip it
@@ -194,7 +198,10 @@ pub async fn compute_binding_usage_info(
                                     target,
                                 ));
                                 unused_references_edges.insert(edge);
-                                unused_references.insert(ref_data.reference);
+                                unused_references
+                                    .entry(ref_data.reference)
+                                    .or_default()
+                                    .insert(target);
 
                                 return Ok(GraphTraversalAction::Skip);
                             } else {
@@ -205,7 +212,14 @@ pub async fn compute_binding_usage_info(
                                     target,
                                 ));
                                 unused_references_edges.remove(&edge);
-                                unused_references.remove(&ref_data.reference);
+                                if let Entry::Occupied(mut e) =
+                                    unused_references.entry(ref_data.reference)
+                                {
+                                    e.get_mut().remove(&target);
+                                    if e.get().is_empty() {
+                                        e.remove();
+                                    }
+                                }
                                 // Continue, add export
                             }
                         }
@@ -217,7 +231,14 @@ pub async fn compute_binding_usage_info(
                                 target,
                             ));
                             unused_references_edges.remove(&edge);
-                            unused_references.remove(&ref_data.reference);
+                            if let Entry::Occupied(mut e) =
+                                unused_references.entry(ref_data.reference)
+                            {
+                                e.get_mut().remove(&target);
+                                if e.get().is_empty() {
+                                    e.remove();
+                                }
+                            }
                             // Continue, has to always be included
                         }
                     }
@@ -252,7 +273,7 @@ pub async fn compute_binding_usage_info(
 
         graph_ref.traverse_cycles(
             // No need to traverse edges that are unused.
-            |e| e.chunking_type.is_parallel() && !unused_references.contains(&e.reference),
+            |e| e.chunking_type.is_parallel() && !unused_references.contains_key(&e.reference),
             |cycle| {
                 // We could compute this based on the module graph via a DFS from each entry point
                 // to the cycle.  Whatever node is hit first is an entry point to the cycle.

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -176,6 +176,7 @@ impl AmdDefineWithDependenciesCodeGen {
                                 self.error_mode,
                             ),
                             ResolveType::ChunkItem,
+                            None,
                         )
                         .await?,
                         request_str: request_str.to_string(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -204,28 +204,13 @@ impl CjsRequireAssetReferenceCodeGen {
     ) -> Result<CodeGeneration> {
         let reference = self.reference.await?;
 
-        // This `require()` is in `unused_references`: its result is unused and
-        // the target is side-effect free. Replace the call with a placeholder
-        // at the expression level.
-        if reference.cjs_tree_shaking
-            && chunking_context
-                .unused_references()
-                .contains_key(&ResolvedVc::upcast(self.reference))
-                .await?
-        {
-            let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
-                // `const {a,b} = 0;` is a clever way to assign undefined to all the variables
-                *expr = quote!("0" as Expr);
-            });
-            return Ok(CodeGeneration::visitors(vec![visitor]));
-        }
-
         let pm = PatternMapping::resolve_request(
             *reference.request,
             *reference.origin,
             chunking_context,
             self.reference.resolve_reference(),
             ResolveType::ChunkItem,
+            Some(Vc::upcast(*self.reference)),
         )
         .await?;
         let mut visitors = Vec::new();
@@ -366,6 +351,7 @@ impl CjsRequireResolveAssetReferenceCodeGen {
             chunking_context,
             self.reference.resolve_reference(),
             ResolveType::ChunkItem,
+            Some(Vc::upcast(*self.reference)),
         )
         .await?;
         let mut visitors = Vec::new();

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -158,6 +158,7 @@ impl EsmAsyncAssetReferenceCodeGen {
             } else {
                 ResolveType::ChunkItem
             },
+            Some(Vc::upcast(*self.reference)),
         )
         .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/hot_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/hot_module.rs
@@ -144,6 +144,7 @@ impl ModuleHotReferenceCodeGen {
                     chunking_context,
                     resolve_result,
                     ResolveType::ChunkItem,
+                    None,
                 )
                 .await
             })

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -789,6 +789,7 @@ impl EcmascriptChunkPlaceable for ImportMetaGlobAsset {
                 chunking_context,
                 *entry.result,
                 ResolveType::ChunkItem,
+                None,
             )
             .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, collections::HashSet};
 
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use rustc_hash::FxHashSet;
 use swc_core::{
     common::DUMMY_SP,
     ecma::ast::{
@@ -21,6 +22,8 @@ use turbopack_core::{
         IssueExt, IssueSeverity, StyledString, code_gen::CodeGenerationIssue,
         module::emit_unknown_module_type_error,
     },
+    module::Module,
+    reference::ModuleReference,
     resolve::{
         ExternalType, ModuleResolveResult, ModuleResolveResultItem, origin::ResolveOrigin,
         parse::Request,
@@ -65,6 +68,8 @@ pub(crate) enum SinglePatternMapping {
     ModuleLoader(ModuleId),
     /// External reference with request and type
     External(RcStr, ExternalType),
+    /// The target was unused and dropped from the module graph, so nothing is loaded for it.
+    Dropped,
 }
 
 /// A mapping from a request pattern (e.g. "./module", `./images/${name}.png`)
@@ -105,7 +110,7 @@ impl SinglePatternMapping {
                 )
             }
             Self::Unresolvable(request) => throw_module_not_found_expr(request),
-            Self::Ignored => {
+            Self::Ignored | Self::Dropped => {
                 quote!("undefined" as Expr)
             }
             Self::Module(module_id) | Self::ModuleLoader(module_id) => module_id_to_lit(module_id),
@@ -118,6 +123,7 @@ impl SinglePatternMapping {
             Self::Invalid => self.create_id(key_expr),
             Self::Unresolvable(request) => throw_module_not_found_expr(request),
             Self::Ignored => quote!("{}" as Expr),
+            Self::Dropped => quote!("0" as Expr),
             Self::Module(_) | Self::ModuleLoader(_) => quote!(
                 "$turbopack_require($arg)" as Expr,
                 turbopack_require: Expr = TURBOPACK_REQUIRE.into(),
@@ -204,7 +210,7 @@ impl SinglePatternMapping {
                     id: Expr = module_id_to_lit(module_id)
                 )
             }
-            Self::Ignored => {
+            Self::Ignored | Self::Dropped => {
                 quote!("Promise.resolve({})" as Expr)
             }
             Self::Module(_) => Expr::Call(CallExpr {
@@ -305,6 +311,7 @@ async fn to_single_pattern_mapping(
     resolve_item: &ModuleResolveResultItem,
     primary: &[(turbopack_core::resolve::RequestKey, ModuleResolveResultItem)],
     resolve_type: ResolveType,
+    dropped_targets: Option<&FxHashSet<ResolvedVc<Box<dyn Module>>>>,
 ) -> Result<SinglePatternMapping> {
     let module = match resolve_item {
         ModuleResolveResultItem::Module(module) => *module,
@@ -335,6 +342,7 @@ async fn to_single_pattern_mapping(
                 &primary[*first].1,
                 primary,
                 resolve_type,
+                dropped_targets,
             ))
             .await;
         }
@@ -362,6 +370,10 @@ async fn to_single_pattern_mapping(
             return Ok(SinglePatternMapping::Invalid);
         }
     };
+    // The module graph dropped the edge to this target, so it has no chunk item to point at.
+    if dropped_targets.is_some_and(|dropped| dropped.contains(&module)) {
+        return Ok(SinglePatternMapping::Dropped);
+    }
     if let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) {
         match resolve_type {
             ResolveType::AsyncChunkLoader => {
@@ -406,8 +418,18 @@ impl PatternMapping {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         resolve_result: Vc<ModuleResolveResult>,
         resolve_type: ResolveType,
+        reference: Option<ResolvedVc<Box<dyn ModuleReference>>>,
     ) -> Result<Vc<PatternMapping>> {
         let result = resolve_result.await?;
+        // Targets of this reference that were dropped from the module graph as unused.
+        let unused_references;
+        let dropped_targets = match reference {
+            Some(reference) => {
+                unused_references = chunking_context.unused_references().await?;
+                unused_references.get(&reference)
+            }
+            None => None,
+        };
         match result.primary.len() {
             0 => Ok(PatternMapping::Single(SinglePatternMapping::Unresolvable(
                 request_to_string(request).await?.to_string(),
@@ -421,6 +443,7 @@ impl PatternMapping {
                     resolve_item,
                     &result.primary,
                     resolve_type,
+                    dropped_targets,
                 )
                 .await?;
                 Ok(PatternMapping::Single(single_pattern_mapping).cell())
@@ -444,6 +467,7 @@ impl PatternMapping {
                             v,
                             primary,
                             resolve_type,
+                            dropped_targets,
                         )
                         .await?;
                         Ok((k, single_pattern_mapping))

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -488,6 +488,7 @@ impl EcmascriptChunkPlaceable for RequireContextAsset {
                 chunking_context,
                 *entry.result,
                 ResolveType::ChunkItem,
+                None,
             )
             .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -348,6 +348,7 @@ impl WorkerAssetReferenceCodeGen {
             chunking_context,
             self.reference.resolve_reference(),
             ResolveType::ChunkItem,
+            None,
         )
         .await?;
 


### PR DESCRIPTION
For modules that we were not using, that we're asynchronously loading, we would still generate the loader but the file would not exist. This meant building a Next.js app with:

```javascript
// pure.js — side-effect free: nothing observable happens on evaluation
export const version = '1.0.0'

// app/page.tsx
export default async function Page() {
  const {} = await import('../pure')   // ← nothing destructured out
  return <p>hello world</p>
}
```

Would error with:

```
▲ Next.js 16.3.0-canary.87 (Turbopack)
  Creating an optimized production build ...

FATAL: An unexpected Turbopack error occurred.

> Build error occurred
Error [TurbopackInternalError]: Failed to write app endpoint /page

Caused by:
- ModuleId not found for ident: [project]/pure.js [app-rsc] (ecmascript, async loader)

Debug info:
...
- Execution of PatternMapping::resolve_request failed
- ModuleId not found for ident: [project]/pure.js [app-rsc] (ecmascript, async loader)
```  

Now, we re-write those loaders to empty promises:

```diff
 async function evaluationOnly() {
-    const {} = await __turbopack_context__.A("…/pure.js [test] (ecmascript, async loader)");
+    const {} = await Promise.resolve({});
 }
 async function named() {
     const { used } = await __turbopack_context__.A("…/named.js [test] (ecmascript, async loader)");
     console.log(used);
 }
 async function pattern(locale) {
     const {} = await __turbopack_context__.f({
         "./locales/effectful.js": {
             id: ()=>"…/locales/effectful.js [test] (ecmascript, async loader)",
             module: ()=>__turbopack_context__.A("…/locales/effectful.js …")
         },
         "./locales/pure.js": {
-            id: ()=>"…/locales/pure.js [test] (ecmascript, async loader)",
-            module: ()=>__turbopack_context__.A("…/locales/pure.js …")
+            id: ()=>undefined,
+            module: ()=>Promise.resolve({})
         }
     }).import(`./locales/${locale}.js`);
 }
```

It turns `UnusedReferences` into a map between references and target that can be dropped, where the target IDs are the unused targets. It then passes the reference through to `pattern_mapping.rs` so it can determine the `dropped_targets`. It needs to be target-specific as you can have a situation (like above) where some targets are pure and some aren't.