### PR TITLE
Add browserOnly for client-only rendering

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -985,9 +985,13 @@ async fn apply_vendored_react_aliases_server(
     if react_condition == "server" {
         // This is used in the server runtime to import React Server Components.
         alias.extend(
-            fxindexmap! {rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
+            fxindexmap! {// ESM projects may add a `.js` suffix, which must use the same RSC entrypoints.
+            rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
+            rcstr!("next/error.js") => rcstr!("next/dist/api/error.react-server"),
             rcstr!("next/navigation") => rcstr!("next/dist/api/navigation.react-server"),
-            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),},
+            rcstr!("next/navigation.js") => rcstr!("next/dist/api/navigation.react-server"),
+            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),
+            rcstr!("next/link.js") => rcstr!("next/dist/client/app-dir/link.react-server"),},
         );
     }
 
@@ -1016,9 +1020,13 @@ async fn rsc_aliases(
     if ty.should_use_react_server_condition() {
         // This is used in the server runtime to import React Server Components.
         alias.extend(
-            fxindexmap! {rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
+            fxindexmap! {// ESM projects may add a `.js` suffix, which must use the same RSC entrypoints.
+            rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
+            rcstr!("next/error.js") => rcstr!("next/dist/api/error.react-server"),
             rcstr!("next/navigation") => rcstr!("next/dist/api/navigation.react-server"),
-            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),},
+            rcstr!("next/navigation.js") => rcstr!("next/dist/api/navigation.react-server"),
+            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),
+            rcstr!("next/link.js") => rcstr!("next/dist/client/app-dir/link.react-server"),},
         );
     }
 

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -684,6 +684,7 @@ impl ReactServerComponentValidator {
                         "useServerInsertedHTML",
                         "ServerInsertedHTMLContext",
                         "unstable_isUnrecognizedActionError",
+                        "browserOnly",
                     ],
                 ),
                 (atom!("next/link").into(), vec!["useLinkStatus"]),

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -626,6 +626,21 @@ impl ReactServerComponentValidator {
         app_dir: Option<PathBuf>,
         page_extensions: Vec<String>,
     ) -> Self {
+        let invalid_error_apis = vec!["catchError"];
+        let invalid_navigation_apis = vec![
+            "useSearchParams",
+            "usePathname",
+            "useSelectedLayoutSegment",
+            "useSelectedLayoutSegments",
+            "useParams",
+            "useRouter",
+            "useServerInsertedHTML",
+            "ServerInsertedHTMLContext",
+            "unstable_isUnrecognizedActionError",
+            "browserOnly",
+        ];
+        let invalid_link_apis = vec!["useLinkStatus"];
+
         Self {
             is_react_server_layer,
             cache_components_enabled,
@@ -671,23 +686,15 @@ impl ReactServerComponentValidator {
                         "useFormState",
                     ],
                 ),
-                (atom!("next/error").into(), vec!["catchError"]),
+                (atom!("next/error").into(), invalid_error_apis.clone()),
+                (atom!("next/error.js").into(), invalid_error_apis),
                 (
                     atom!("next/navigation").into(),
-                    vec![
-                        "useSearchParams",
-                        "usePathname",
-                        "useSelectedLayoutSegment",
-                        "useSelectedLayoutSegments",
-                        "useParams",
-                        "useRouter",
-                        "useServerInsertedHTML",
-                        "ServerInsertedHTMLContext",
-                        "unstable_isUnrecognizedActionError",
-                        "browserOnly",
-                    ],
+                    invalid_navigation_apis.clone(),
                 ),
-                (atom!("next/link").into(), vec!["useLinkStatus"]),
+                (atom!("next/navigation.js").into(), invalid_navigation_apis),
+                (atom!("next/link").into(), invalid_link_apis.clone()),
+                (atom!("next/link.js").into(), invalid_link_apis),
             ]),
             deprecated_apis_mapping: FxHashMap::from_iter([(
                 atom!("next/server").into(),

--- a/docs/01-app/03-api-reference/04-functions/browserOnly.mdx
+++ b/docs/01-app/03-api-reference/04-functions/browserOnly.mdx
@@ -1,0 +1,156 @@
+---
+title: browserOnly
+description: API Reference for the browserOnly function.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+The `browserOnly` function marks a component subtree to render only in the browser. Pass the returned promise to React's [`use`](https://react.dev/reference/react/use) function and wrap the component in [`Suspense`](https://react.dev/reference/react/Suspense).
+
+<AppOnly>
+
+```tsx filename="app/browser-only-content.tsx" switcher highlight={7}
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>This content only renders in the browser.</p>
+}
+```
+
+```jsx filename="app/browser-only-content.js" switcher highlight={7}
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>This content only renders in the browser.</p>
+}
+```
+
+</AppOnly>
+
+<PagesOnly>
+
+```tsx filename="components/browser-only-content.tsx" switcher highlight={5}
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>This content only renders in the browser.</p>
+}
+```
+
+```jsx filename="components/browser-only-content.js" switcher highlight={5}
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>This content only renders in the browser.</p>
+}
+```
+
+</PagesOnly>
+
+Render the component inside a `Suspense` boundary:
+
+<AppOnly>
+
+```tsx filename="app/page.tsx" switcher highlight={6-8}
+import { Suspense } from 'react'
+import BrowserOnlyContent from './browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}
+```
+
+```jsx filename="app/page.js" switcher highlight={6-8}
+import { Suspense } from 'react'
+import BrowserOnlyContent from './browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}
+```
+
+</AppOnly>
+
+<PagesOnly>
+
+```tsx filename="pages/index.tsx" switcher highlight={6-8}
+import { Suspense } from 'react'
+import BrowserOnlyContent from '../components/browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}
+```
+
+```jsx filename="pages/index.js" switcher highlight={6-8}
+import { Suspense } from 'react'
+import BrowserOnlyContent from '../components/browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}
+```
+
+</PagesOnly>
+
+During server rendering, Next.js leaves the nearest `Suspense` fallback in the HTML. During hydration, the promise is already fulfilled, so React replaces the fallback with the browser-only subtree without waiting.
+
+## Reference
+
+### Parameters
+
+```tsx
+browserOnly()
+```
+
+`browserOnly` does not take any parameters.
+
+### Returns
+
+`browserOnly` returns a `Promise<void>`:
+
+| Environment | Behavior                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------- |
+| Server      | Causes React to render the fallback from the nearest `Suspense` boundary.                                     |
+| Browser     | Returns an already fulfilled promise, allowing the browser-only content to render without an additional wait. |
+
+> **Good to know**:
+>
+> - `browserOnly` requires React 19 or later.
+> - Wrap the smallest browser-only subtree in `Suspense`. If the bailout reaches the page root, production prerendering fails the build and request-time server rendering fails the request. See [Missing Suspense boundary with CSR bailout](/docs/messages/missing-suspense-with-csr-bailout).
+> - A `browserOnly` subtree does not opt the route into request-time dynamic rendering. Content outside the nearest `Suspense` boundary can remain prerendered.
+> - `browserOnly` is supported in both the App Router and Pages Router.
+
+<AppOnly>
+
+`browserOnly` can only be used in [Client Components](/docs/app/getting-started/server-and-client-components). Using it in a Server Component is unsupported and results in an error.
+
+</AppOnly>

--- a/docs/01-app/03-api-reference/04-functions/use-search-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-search-params.mdx
@@ -178,7 +178,7 @@ export default function Page() {
 > **Good to know**:
 >
 > - In development, routes are rendered on-demand, so `useSearchParams` doesn't suspend and things may appear to work without `Suspense`.
-> - During production builds, a static page that calls `useSearchParams` from a Client Component must be wrapped in a `Suspense` boundary, otherwise the build fails with the [Missing Suspense boundary with useSearchParams](/docs/messages/missing-suspense-with-csr-bailout) error.
+> - During production builds, a static page that calls `useSearchParams` from a Client Component must be wrapped in a `Suspense` boundary, otherwise the build fails with the [Missing Suspense boundary with CSR bailout](/docs/messages/missing-suspense-with-csr-bailout) error.
 > - If you intend the route to be dynamically rendered, prefer using the [`connection`](/docs/app/api-reference/functions/connection) function first in a Server Component to wait for an incoming request, this excludes everything below from prerendering. See what makes a route dynamic in the [Dynamic Rendering guide](/docs/app/glossary#dynamic-rendering).
 > - If you're already in a Server Component Page, consider using the [`searchParams` prop](/docs/app/api-reference/file-conventions/page#searchparams-optional) and passing the values to Client Components.
 > - You can also pass the Page [`searchParams` prop](/docs/app/api-reference/file-conventions/page#searchparams-optional) directly to a Client Component and unwrap it with React's `use()`. Although this will suspend, so the Client Component should be wrapped with a `Suspense` boundary.

--- a/docs/02-pages/04-api-reference/03-functions/browserOnly.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/browserOnly.mdx
@@ -1,0 +1,7 @@
+---
+title: browserOnly
+description: API Reference for the browserOnly function.
+source: app/api-reference/functions/browserOnly
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -1,14 +1,81 @@
 ---
-title: Missing Suspense boundary with useSearchParams
+title: Missing Suspense boundary with CSR bailout
 ---
 
 ## Why This Error Occurred
 
-Reading search parameters through `useSearchParams()` without a Suspense boundary will opt the entire page into client-side rendering. This could cause your page to be blank until the client-side JavaScript has loaded.
+During server rendering, a Client Component triggered a client-side rendering (CSR) bailout without a Suspense boundary. A CSR bailout tells Next.js that a subtree can only render in the browser. It must be contained by a Suspense boundary so Next.js can preserve the server-rendered shell. If the bailout reaches the page root, production prerendering fails the build and request-time server rendering fails the request.
+
+Common causes include:
+
+- Reading search parameters through `useSearchParams()` while statically rendering a route.
+- Calling `use(browserOnly())`, which explicitly marks a subtree as browser-only.
 
 ## Possible Ways to Fix It
 
-You have a few options depending on your intent:
+### Wrap the smallest subtree in Suspense
+
+Wrap the component that triggers the CSR bailout in a Suspense boundary. This preserves the static shell while the browser renders that subtree.
+
+When using [`browserOnly()`](/docs/app/api-reference/functions/browserOnly), read its promise with React's `use()` in a Client Component:
+
+```tsx filename="app/browser-only-content.tsx" switcher
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>This content only renders in the browser.</p>
+}
+```
+
+```jsx filename="app/browser-only-content.js" switcher
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>This content only renders in the browser.</p>
+}
+```
+
+Then render it inside a Suspense boundary:
+
+```tsx filename="app/page.tsx" switcher
+import { Suspense } from 'react'
+import BrowserOnlyContent from './browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { Suspense } from 'react'
+import BrowserOnlyContent from './browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}
+```
+
+`browserOnly()` requires React 19 or later. The same boundary requirement applies in the Pages Router.
+
+### Handle `useSearchParams()` based on your intent
+
+If `useSearchParams()` triggered the bailout, you have a few additional options:
 
 - To keep the route statically generated, wrap the smallest subtree that calls `useSearchParams()` in `Suspense`, for example you may move its usage into a child Client Component and render that component wrapped with `Suspense`. This preserves the static shell and avoids a full CSR bailout.
 - To make the route dynamically rendered, use the [`connection`](/docs/app/api-reference/functions/connection) function in a Server Component (e.g. the Page or a wrapping Layout). This waits for an incoming request and excludes everything below from prerendering.
@@ -159,7 +226,7 @@ export function Searchbar() {
 
 ## Disabling
 
-> **Note**: This is only available with Next.js version 14.x. If you're in versions above 14 please fix it with the approach above.
+> **Note**: This option only applies to the `useSearchParams()` check and is only available with Next.js version 14.x. If you're using a later version, fix the bailout with one of the approaches above.
 
 We don't recommend disabling this rule. However, if you need to, you can disable it by setting the `missingSuspenseWithCSRBailout` option to `false` in your `next.config.js`:
 
@@ -175,7 +242,7 @@ This configuration option will be removed in a future major version.
 
 ## Debugging
 
-If you're having trouble locating where `useSearchParams()` is being used without a Suspense boundary, you can get more detailed stack traces by running:
+If you're having trouble locating the component that triggered the CSR bailout, you can get more detailed stack traces by running:
 
 ```bash
 next build --debug-prerender
@@ -186,5 +253,7 @@ This provides unminified stack traces with source maps, making it easier to pinp
 ## Useful Links
 
 - [`useSearchParams`](/docs/app/api-reference/functions/use-search-params)
+- [`browserOnly`](/docs/app/api-reference/functions/browserOnly)
 - [`connection`](/docs/app/api-reference/functions/connection)
+- [React `Suspense`](https://react.dev/reference/react/Suspense)
 - [Debugging prerender errors](/docs/app/api-reference/cli/next#debugging-prerender-errors)

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1461,5 +1461,6 @@
   "1460": "[Server HMR] unreachable: unexpected update instruction type %s",
   "1461": "browserOnly()",
   "1462": "`browserOnly()` requires React 19 or later.",
-  "1463": "`browserOnly()` can only be used in Client Components."
+  "1463": "`browserOnly()` can only be used in Client Components.",
+  "1464": "browserOnly() should be wrapped in a Suspense boundary at page \"%s\". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1458,5 +1458,8 @@
   "1457": "Expected prerender classification data for PPR route \"%s\"",
   "1458": "Expected complete prerender classification for route \"%s\"",
   "1459": "[Server HMR] unreachable: unknown HMR instruction type %s",
-  "1460": "[Server HMR] unreachable: unexpected update instruction type %s"
+  "1460": "[Server HMR] unreachable: unexpected update instruction type %s",
+  "1461": "browserOnly()",
+  "1462": "`browserOnly()` requires React 19 or later.",
+  "1463": "`browserOnly()` can only be used in Client Components."
 }

--- a/packages/next/src/client/components/browser-only.ts
+++ b/packages/next/src/client/components/browser-only.ts
@@ -1,0 +1,48 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'client-only'
+
+import { use } from 'react'
+
+import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
+
+type FulfilledBrowserOnlyPromise = Promise<void> & {
+  status?: 'fulfilled'
+  value?: undefined
+}
+
+type RejectedBrowserOnlyPromise = Promise<void> & {
+  status?: 'rejected'
+  reason?: BailoutToCSRError
+}
+
+const fulfilledPromise: FulfilledBrowserOnlyPromise = Promise.resolve()
+fulfilledPromise.status = 'fulfilled'
+fulfilledPromise.value = undefined
+
+/**
+ * Returns a promise that causes the nearest Suspense boundary to bail out to
+ * client rendering on the server and resolves immediately in the browser.
+ *
+ * This is intended to be passed to React's `use()` inside a Suspense boundary.
+ * It requires React 19 or later and can only be used in Client Components.
+ */
+export function browserOnly(): Promise<void> {
+  if (typeof use !== 'function') {
+    throw new Error('`browserOnly()` requires React 19 or later.')
+  }
+
+  if (typeof window !== 'undefined') {
+    return fulfilledPromise
+  }
+
+  const error = new BailoutToCSRError('browserOnly()')
+  const rejectedPromise: RejectedBrowserOnlyPromise = Promise.reject(error)
+
+  // React reads the instrumented status synchronously. Attach a handler as well
+  // so the native rejected promise is never reported as unhandled.
+  rejectedPromise.catch(() => {})
+  rejectedPromise.status = 'rejected'
+  rejectedPromise.reason = error
+
+  return rejectedPromise
+}

--- a/packages/next/src/client/components/navigation.react-server.ts
+++ b/packages/next/src/client/components/navigation.react-server.ts
@@ -6,6 +6,10 @@ export function unstable_isUnrecognizedActionError(): boolean {
   )
 }
 
+export function browserOnly(): never {
+  throw new Error('`browserOnly()` can only be used in Client Components.')
+}
+
 export { redirect, permanentRedirect } from './redirect'
 export { notFound } from './not-found'
 export { forbidden } from './forbidden'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -351,6 +351,7 @@ export function useSelectedLayoutSegment(
 }
 
 export { unstable_isUnrecognizedActionError } from './unrecognized-action-error'
+export { browserOnly } from './browser-only'
 
 // Shared components APIs
 export {

--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -104,6 +104,14 @@ export async function exportPagesPage(
       )
     } catch (err) {
       if (!isBailoutToCSRError(err)) throw err
+      // Legacy Pages Router CSR bailouts may still opt the entire page into
+      // client rendering. browserOnly() requires a Suspense boundary so the
+      // export always preserves an HTML shell.
+      if (err.reason === 'browserOnly()') {
+        throw new Error(
+          `browserOnly() should be wrapped in a Suspense boundary at page "${page}". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout`
+        )
+      }
     }
   }
 

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -107,6 +107,7 @@ import { extractNextErrorCode } from '../lib/error-telemetry-utils'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import type { PagesDevOverlayBridgeType } from '../next-devtools/userspace/pages/pages-dev-overlay-setup'
 import { getScriptNonceFromHeader } from './app-render/get-script-nonce-from-header'
+import { isBailoutToCSRError } from '../shared/lib/lazy-dynamic/bailout-to-csr'
 
 let tryGetPreviewData: typeof import('./api-utils/node/try-get-preview-data').tryGetPreviewData
 let warn: typeof import('../build/output/log').warn
@@ -133,6 +134,15 @@ function noRouter() {
   const message =
     'No router instance found. you should only use "next/router" inside the client side of your app. https://nextjs.org/docs/messages/no-router-instance'
   throw new Error(message)
+}
+
+function onPagesRenderError(error: unknown): string | undefined {
+  if (isBailoutToCSRError(error)) {
+    return error.digest
+  }
+
+  // Keep React's default server error reporting for unexpected errors.
+  console.error(error)
 }
 
 async function renderToString(element: React.ReactElement) {
@@ -1379,6 +1389,9 @@ export async function renderToHTMLImpl(
       return await renderToInitialFizzStream({
         ReactDOMServer: ReactDOMServerPages,
         element: content,
+        streamOptions: {
+          onError: onPagesRenderError,
+        },
       })
     }
 

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -565,4 +565,34 @@ describe('Error Overlay for server components', () => {
       }
     )
   })
+
+  describe('fully specified Next.js client APIs called in Server Component', () => {
+    it.each([
+      ['catchError', 'next/error.js'],
+      ['useRouter', 'next/navigation.js'],
+      ['useLinkStatus', 'next/link.js'],
+    ])('should show error for %s from %s', async (api, module) => {
+      await using sandbox = await createSandbox(
+        next,
+        new Map([
+          [
+            'app/page.js',
+            outdent`
+              import { ${api} } from '${module}'
+              export default function Page() {
+                return "Hello world"
+              }
+            `,
+          ],
+        ])
+      )
+      const { session } = sandbox
+      await session.waitForRedbox()
+      const normalizedSource = await session.getRedboxSource()
+      expect(normalizedSource).toContain(
+        `You're importing a module that depends on \`${api}\` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
+      )
+      expect(normalizedSource).toContain(`import { ${api} } from '${module}'`)
+    })
+  })
 })

--- a/test/e2e/app-dir/app-esm-js/app/app/components-ext.js
+++ b/test/e2e/app-dir/app-esm-js/app/app/components-ext.js
@@ -1,14 +1,26 @@
 import NextImage, { getImageProps } from 'next/image.js'
 import Link from 'next/link.js'
+import * as NextError from 'next/error.js'
+import { redirect } from 'next/navigation.js'
 import Script from 'next/script.js'
 
 import src from '../../public/test.jpg'
+
+function getCatchErrorMessage() {
+  try {
+    NextError.catchError()
+  } catch (error) {
+    return error.message
+  }
+}
 
 export function Components() {
   return (
     <>
       <NextImage className="img" src={src} />
       <p className="typeof-getImageProps">{typeof getImageProps}</p>
+      <p className="catch-error-message">{getCatchErrorMessage()}</p>
+      <p className="typeof-redirect">{typeof redirect}</p>
       <Link className="link" href="/client">
         link
       </Link>

--- a/test/e2e/app-dir/app-esm-js/index.test.ts
+++ b/test/e2e/app-dir/app-esm-js/index.test.ts
@@ -19,6 +19,10 @@ describe('app-dir - esm js extension', () => {
     await validateDomNodes('#with-ext')
     await validateDomNodes('#without-ext')
 
+    expect(await $('#with-ext .catch-error-message').text()).toBe(
+      '`catchError` can only be used in Client Components.'
+    )
+    expect(await $('#with-ext .typeof-redirect').text()).toBe('function')
     expect($('head link[href="/test-ext.js"]').length).toBe(1)
     expect($('head link[href="/test.js"]').length).toBe(1)
   })

--- a/test/e2e/app-dir/browser-only-edge/app/browser-only-content.tsx
+++ b/test/e2e/app-dir/browser-only-edge/app/browser-only-content.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p id="edge-browser-content">edge browser content</p>
+}

--- a/test/e2e/app-dir/browser-only-edge/app/layout.tsx
+++ b/test/e2e/app-dir/browser-only-edge/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/browser-only-edge/app/page.tsx
+++ b/test/e2e/app-dir/browser-only-edge/app/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from './browser-only-content'
+
+export const runtime = 'edge'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="edge-fallback">edge fallback</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/browser-only-edge/browser-only-edge.test.ts
+++ b/test/e2e/app-dir/browser-only-edge/browser-only-edge.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 describe('browserOnly in the Edge Runtime', () => {
   if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
@@ -6,7 +6,7 @@ describe('browserOnly in the Edge Runtime', () => {
     return
   }
 
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -20,4 +20,28 @@ describe('browserOnly in the Edge Runtime', () => {
       'edge browser content'
     )
   })
+  if (!isReact18) {
+    it('renders a Pages Router fallback without reporting bailout errors', async () => {
+      const $ = await next.render$('/browser-only')
+      expect($('#pages-edge-fallback').text()).toBe('pages edge fallback')
+      expect($('#pages-edge-browser-content').length).toBe(0)
+
+      const browser = await next.browser('/browser-only', {
+        pushErrorAsConsoleLog: true,
+      })
+      expect(
+        await browser.elementByCss('#pages-edge-browser-content').text()
+      ).toBe('pages edge browser content')
+
+      const logs = await browser.log()
+      expect(logs.filter((entry) => entry.source === 'error')).toEqual([])
+      if (!isNextDeploy) {
+        expect(
+          next.cliOutput.includes(
+            'Bail out to client-side rendering: browserOnly()'
+          )
+        ).toBe(false)
+      }
+    })
+  }
 })

--- a/test/e2e/app-dir/browser-only-edge/browser-only-edge.test.ts
+++ b/test/e2e/app-dir/browser-only-edge/browser-only-edge.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('browserOnly in the Edge Runtime', () => {
+  if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
+    it.skip('requires the Edge Runtime, which Cache Components does not support', () => {})
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders a fallback on the server and content after hydration', async () => {
+    const $ = await next.render$('/')
+    expect($('#edge-fallback').text()).toBe('edge fallback')
+    expect($('#edge-browser-content').length).toBe(0)
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#edge-browser-content').text()).toBe(
+      'edge browser content'
+    )
+  })
+})

--- a/test/e2e/app-dir/browser-only-edge/pages/browser-only.tsx
+++ b/test/e2e/app-dir/browser-only-edge/pages/browser-only.tsx
@@ -1,0 +1,19 @@
+import { Suspense, use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p id="pages-edge-browser-content">pages edge browser content</p>
+}
+
+export const config = {
+  runtime: 'experimental-edge',
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="pages-edge-fallback">pages edge fallback</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/browser-only-export/app/browser-only-content.tsx
+++ b/test/e2e/app-dir/browser-only-export/app/browser-only-content.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p id="browser-content">static browser content</p>
+}

--- a/test/e2e/app-dir/browser-only-export/app/layout.tsx
+++ b/test/e2e/app-dir/browser-only-export/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/browser-only-export/app/page.tsx
+++ b/test/e2e/app-dir/browser-only-export/app/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from './browser-only-content'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="server-sibling">static server sibling</p>
+      <Suspense fallback={<p id="fallback">static fallback</p>}>
+        <BrowserOnlyContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only-export/browser-only-export.test.ts
+++ b/test/e2e/app-dir/browser-only-export/browser-only-export.test.ts
@@ -1,0 +1,56 @@
+import { join } from 'path'
+import type { Server } from 'net'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { renderViaHTTP, startCleanStaticServer } from 'next-test-utils'
+
+describe('browserOnly with static export', () => {
+  if (isNextDev || process.env.__NEXT_CACHE_COMPONENTS === 'true') {
+    it.skip('requires an export-compatible production build', () => {})
+    return
+  }
+
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    nextConfig: {
+      output: 'export',
+    },
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let server: Server
+  let port: number
+
+  beforeAll(async () => {
+    const result = await next.build()
+    expect(result.exitCode).toBe(0)
+
+    server = await startCleanStaticServer(join(next.testDir, 'out'))
+    const address = server.address()
+    if (address === null || typeof address === 'string') {
+      throw new Error('Expected the static export server to listen on a port')
+    }
+    port = address.port
+  })
+
+  afterAll(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('exports the server fallback and hydrates browser-only content', async () => {
+    const html = await renderViaHTTP(port, '/')
+    expect(html).toContain('static fallback')
+    expect(html.includes('id="browser-content"')).toBe(false)
+
+    const browser = await next.browser('/', { baseUrl: port })
+    expect(await browser.elementByCss('#browser-content').text()).toBe(
+      'static browser content'
+    )
+  })
+})

--- a/test/e2e/app-dir/browser-only-in-server-component/app/layout.tsx
+++ b/test/e2e/app-dir/browser-only-in-server-component/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/browser-only-in-server-component/app/page.tsx
+++ b/test/e2e/app-dir/browser-only-in-server-component/app/page.tsx
@@ -1,0 +1,8 @@
+import { browserOnly } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  browserOnly()
+  return <p>dynamic Server Component import should fail during compilation</p>
+}

--- a/test/e2e/app-dir/browser-only-in-server-component/browser-only-in-server-component.test.ts
+++ b/test/e2e/app-dir/browser-only-in-server-component/browser-only-in-server-component.test.ts
@@ -1,0 +1,42 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getRedboxSource, waitForRedbox } from 'next-test-utils'
+
+describe('browserOnly in a Server Component', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    it('shows a redbox for named imports in a Server Component', async () => {
+      await next.start()
+
+      const browser = await next.browser('/')
+      await waitForRedbox(browser)
+      const source = await getRedboxSource(browser)
+      expect(source).toContain(
+        "You're importing a module that depends on `browserOnly` into a React Server Component module."
+      )
+      expect(source).toContain(
+        'This API is only available in Client Components.'
+      )
+    })
+  } else {
+    it('fails the build for named imports in a Server Component', async () => {
+      const result = await next.build()
+
+      expect(result.exitCode).toBe(1)
+      expect(result.cliOutput).toContain(
+        "You're importing a module that depends on `browserOnly` into a React Server Component module."
+      )
+      expect(result.cliOutput).toContain(
+        'This API is only available in Client Components.'
+      )
+    })
+  }
+})

--- a/test/e2e/app-dir/browser-only-missing-suspense/app/layout.tsx
+++ b/test/e2e/app-dir/browser-only-missing-suspense/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/browser-only-missing-suspense/app/page.tsx
+++ b/test/e2e/app-dir/browser-only-missing-suspense/app/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function Page() {
+  use(browserOnly())
+  return <p>unreachable during prerender</p>
+}

--- a/test/e2e/app-dir/browser-only-missing-suspense/browser-only-missing-suspense.test.ts
+++ b/test/e2e/app-dir/browser-only-missing-suspense/browser-only-missing-suspense.test.ts
@@ -1,0 +1,40 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getRedboxDescription, retry, waitForRedbox } from 'next-test-utils'
+
+describe('browserOnly without Suspense', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    it('shows a redbox', async () => {
+      await next.start()
+
+      const browser = await next.browser('/')
+      await waitForRedbox(browser)
+      expect(await getRedboxDescription(browser)).toContain(
+        'Bail out to client-side rendering: browserOnly()'
+      )
+      await retry(() => {
+        expect(next.cliOutput).toContain(
+          'browserOnly() should be wrapped in a suspense boundary'
+        )
+      })
+    })
+  } else {
+    it('fails the build', async () => {
+      const result = await next.build()
+
+      expect(result.exitCode).toBe(1)
+      expect(result.cliOutput).toContain(
+        'browserOnly() should be wrapped in a suspense boundary'
+      )
+    })
+  }
+})

--- a/test/e2e/app-dir/browser-only/app/browser-only-content.tsx
+++ b/test/e2e/app-dir/browser-only/app/browser-only-content.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { use, type ReactNode } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export function BrowserOnlyContent({
+  children,
+  id,
+}: {
+  children: ReactNode
+  id: string
+}) {
+  use(browserOnly())
+  return <p id={id}>{children}</p>
+}

--- a/test/e2e/app-dir/browser-only/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/browser-only/app/dynamic/page.tsx
@@ -1,0 +1,28 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from '../browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense
+      fallback={<p id="dynamic-shell-fallback">dynamic shell fallback</p>}
+    >
+      <DynamicContent />
+    </Suspense>
+  )
+}
+
+async function DynamicContent() {
+  await connection()
+
+  return (
+    <main>
+      <p id="dynamic-server-sibling">dynamic server sibling</p>
+      <Suspense fallback={<p id="dynamic-fallback">dynamic fallback</p>}>
+        <BrowserOnlyContent id="dynamic-browser-content">
+          dynamic browser content
+        </BrowserOnlyContent>
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/layout.tsx
+++ b/test/e2e/app-dir/browser-only/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/navigation/page.tsx
+++ b/test/e2e/app-dir/browser-only/app/navigation/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <p>navigation source</p>
+      <Link id="to-target" href="/target" prefetch={false}>
+        target
+      </Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/nested/page.tsx
+++ b/test/e2e/app-dir/browser-only/app/nested/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from '../browser-only-content'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="outer-server-sibling">outer server sibling</p>
+      <Suspense fallback={<p id="outer-fallback">outer fallback</p>}>
+        <p id="inner-server-sibling">inner server sibling</p>
+        <Suspense fallback={<p id="inner-fallback">inner fallback</p>}>
+          <BrowserOnlyContent id="nested-browser-content">
+            nested browser content
+          </BrowserOnlyContent>
+        </Suspense>
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/page.tsx
+++ b/test/e2e/app-dir/browser-only/app/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from './browser-only-content'
+import { BrowserOnlyErrorBoundary } from '../browser-only-error-boundary'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="server-sibling">static server sibling</p>
+      <Suspense fallback={<p id="fallback">static fallback</p>}>
+        <BrowserOnlyErrorBoundary fallbackId="app-error-fallback">
+          <BrowserOnlyContent id="browser-content">
+            static browser content
+          </BrowserOnlyContent>
+        </BrowserOnlyErrorBoundary>
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/rerender/page.tsx
+++ b/test/e2e/app-dir/browser-only/app/rerender/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import { Rerender } from './rerender'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="rerender-fallback">rerender fallback</p>}>
+      <Rerender />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/rerender/rerender.tsx
+++ b/test/e2e/app-dir/browser-only/app/rerender/rerender.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { use, useState } from 'react'
+import { browserOnly } from 'next/navigation'
+
+function BrowserOnlyValue({ id }: { id: string }) {
+  use(browserOnly())
+  return <span id={id}>ready</span>
+}
+
+export function Rerender() {
+  use(browserOnly())
+  const [count, setCount] = useState(0)
+
+  return (
+    <>
+      <p id="render-count">{count}</p>
+      <BrowserOnlyValue id="first-value" />
+      <BrowserOnlyValue id="second-value" />
+      <button id="rerender" onClick={() => setCount((value) => value + 1)}>
+        rerender
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/browser-only/app/target/page.tsx
+++ b/test/e2e/app-dir/browser-only/app/target/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from '../browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="target-fallback">target fallback</p>}>
+      <BrowserOnlyContent id="target-browser-content">
+        target browser content
+      </BrowserOnlyContent>
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/browser-only/browser-only-error-boundary.tsx
+++ b/test/e2e/app-dir/browser-only/browser-only-error-boundary.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { catchError, type ErrorInfo } from 'next/error'
+
+type BrowserOnlyErrorBoundaryProps = {
+  fallbackId: string
+}
+
+function BrowserOnlyErrorFallback(
+  { fallbackId }: BrowserOnlyErrorBoundaryProps,
+  errorInfo: ErrorInfo
+) {
+  return <p id={fallbackId}>{String(errorInfo.error)}</p>
+}
+
+export const BrowserOnlyErrorBoundary = catchError(BrowserOnlyErrorFallback)

--- a/test/e2e/app-dir/browser-only/browser-only.test.ts
+++ b/test/e2e/app-dir/browser-only/browser-only.test.ts
@@ -1,0 +1,84 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('browser-only', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders a static fallback on the server and content after hydration', async () => {
+    const $ = await next.render$('/')
+    expect($('#server-sibling').text()).toBe('static server sibling')
+    expect($('#fallback').text()).toBe('static fallback')
+    expect($('#browser-content').length).toBe(0)
+    expect($('#app-error-fallback').length).toBe(0)
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#browser-content').text()).toBe(
+      'static browser content'
+    )
+    expect(await browser.hasElementByCssSelector('#app-error-fallback')).toBe(
+      false
+    )
+  })
+
+  it('renders a dynamic SSR fallback on the server and content after hydration', async () => {
+    const $ = await next.render$('/dynamic')
+    expect($('#dynamic-server-sibling').text()).toBe('dynamic server sibling')
+    expect($('#dynamic-fallback').text()).toBe('dynamic fallback')
+    expect($('#dynamic-browser-content').length).toBe(0)
+
+    const browser = await next.browser('/dynamic')
+    expect(await browser.elementByCss('#dynamic-browser-content').text()).toBe(
+      'dynamic browser content'
+    )
+  })
+
+  it('keeps server siblings while a nested boundary bails out', async () => {
+    const $ = await next.render$('/nested')
+    expect($('#outer-server-sibling').text()).toBe('outer server sibling')
+    expect($('#inner-server-sibling').text()).toBe('inner server sibling')
+    expect($('#inner-fallback').text()).toBe('inner fallback')
+    expect($('#outer-fallback').length).toBe(0)
+    expect($('#nested-browser-content').length).toBe(0)
+
+    const browser = await next.browser('/nested')
+    expect(await browser.elementByCss('#nested-browser-content').text()).toBe(
+      'nested browser content'
+    )
+  })
+
+  it('supports repeated calls and rerenders without uncached promise warnings', async () => {
+    const browser = await next.browser('/rerender', {
+      pushErrorAsConsoleLog: true,
+    })
+
+    expect(await browser.elementByCss('#render-count').text()).toBe('0')
+    expect(await browser.elementByCss('#first-value').text()).toBe('ready')
+    expect(await browser.elementByCss('#second-value').text()).toBe('ready')
+
+    await browser.elementByCss('#rerender').click()
+    expect(await browser.elementByCss('#render-count').text()).toBe('1')
+
+    const logs = await browser.log()
+    expect(
+      logs.filter(
+        (entry) =>
+          entry.source === 'error' || entry.message.includes('uncached promise')
+      ).length
+    ).toBe(0)
+  })
+
+  it('works during a client navigation without a hard reload', async () => {
+    const browser = await next.browser('/navigation')
+    await browser.eval('window.__browserOnlyNavigationMarker = true')
+
+    await browser.elementByCss('#to-target').click()
+
+    expect(await browser.elementByCss('#target-browser-content').text()).toBe(
+      'target browser content'
+    )
+    expect(
+      await browser.eval('window.__browserOnlyNavigationMarker === true')
+    ).toBe(true)
+  })
+})

--- a/test/e2e/app-dir/browser-only/browser-only.test.ts
+++ b/test/e2e/app-dir/browser-only/browser-only.test.ts
@@ -1,7 +1,7 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 describe('browser-only', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -81,4 +81,83 @@ describe('browser-only', () => {
       await browser.eval('window.__browserOnlyNavigationMarker === true')
     ).toBe(true)
   })
+  if (!isReact18) {
+    it('renders static Pages Router boundaries without reporting bailout errors', async () => {
+      const $ = await next.render$('/browser-only')
+      expect($('#pages-server-sibling').text()).toBe('pages server sibling')
+      expect($('#pages-fallback').text()).toBe('pages fallback')
+      expect($('#pages-second-fallback').text()).toBe('pages second fallback')
+      expect($('#pages-browser-content').length).toBe(0)
+      expect($('#pages-second-browser-content').length).toBe(0)
+      expect($('#pages-error-fallback').length).toBe(0)
+
+      const browser = await next.browser('/browser-only', {
+        pushErrorAsConsoleLog: true,
+      })
+      expect(await browser.elementByCss('#pages-browser-content').text()).toBe(
+        'pages browser content'
+      )
+      expect(
+        await browser.elementByCss('#pages-second-browser-content').text()
+      ).toBe('pages second browser content')
+      expect(
+        await browser.hasElementByCssSelector('#pages-error-fallback')
+      ).toBe(false)
+
+      const logs = await browser.log()
+      expect(logs.filter((entry) => entry.source === 'error')).toEqual([])
+      expect(
+        next.cliOutput.includes(
+          'Bail out to client-side rendering: browserOnly()'
+        )
+      ).toBe(false)
+    })
+
+    it('renders a request-time Pages Router boundary without reporting bailout errors', async () => {
+      const $ = await next.render$('/browser-only-ssr')
+      expect($('#pages-ssr-server-sibling').text()).toBe(
+        'pages SSR server sibling'
+      )
+      expect($('#pages-ssr-fallback').text()).toBe('pages SSR fallback')
+      expect($('#pages-ssr-browser-content').length).toBe(0)
+
+      const browser = await next.browser('/browser-only-ssr', {
+        pushErrorAsConsoleLog: true,
+      })
+      expect(
+        await browser.elementByCss('#pages-ssr-browser-content').text()
+      ).toBe('pages SSR browser content')
+
+      const logs = await browser.log()
+      expect(logs.filter((entry) => entry.source === 'error')).toEqual([])
+      if (!isNextDeploy) {
+        expect(
+          next.cliOutput.includes(
+            'Bail out to client-side rendering: browserOnly()'
+          )
+        ).toBe(false)
+      }
+    })
+  } else {
+    it('reports that Pages Router usage requires React 19', async () => {
+      await next.render$('/browser-only')
+
+      expect(next.cliOutput).toContain(
+        '`browserOnly()` requires React 19 or later.'
+      )
+    })
+  }
+
+  // Skip in deploy because `next.cliOutput` only contains build logs there,
+  // not runtime logs from the request below.
+  if (!isNextDeploy) {
+    it('continues reporting non-bailout Pages Router render errors', async () => {
+      const outputIndex = next.cliOutput.length
+      const $ = await next.render$('/server-render-error')
+      expect($('#server-error-fallback').text()).toBe('error fallback')
+      expect(next.cliOutput.slice(outputIndex)).toContain(
+        'expected Pages Router server render error'
+      )
+    })
+  }
 })

--- a/test/e2e/app-dir/browser-only/pages/_document.tsx
+++ b/test/e2e/app-dir/browser-only/pages/_document.tsx
@@ -1,0 +1,10 @@
+import Document, { type DocumentContext } from 'next/document'
+
+class CustomDocument extends Document {
+  // Exercise browserOnly() through the legacy custom Document renderPage path.
+  static async getInitialProps(ctx: DocumentContext) {
+    return Document.getInitialProps(ctx)
+  }
+}
+
+export default CustomDocument

--- a/test/e2e/app-dir/browser-only/pages/browser-only-ssr.tsx
+++ b/test/e2e/app-dir/browser-only/pages/browser-only-ssr.tsx
@@ -1,0 +1,22 @@
+import { Suspense, use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+function BrowserContent() {
+  use(browserOnly())
+  return <p id="pages-ssr-browser-content">pages SSR browser content</p>
+}
+
+export function getServerSideProps() {
+  return { props: {} }
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="pages-ssr-server-sibling">pages SSR server sibling</p>
+      <Suspense fallback={<p id="pages-ssr-fallback">pages SSR fallback</p>}>
+        <BrowserContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only/pages/browser-only.tsx
+++ b/test/e2e/app-dir/browser-only/pages/browser-only.tsx
@@ -1,0 +1,30 @@
+import { Suspense, use, type ReactNode } from 'react'
+import { browserOnly } from 'next/navigation'
+import { BrowserOnlyErrorBoundary } from '../browser-only-error-boundary'
+
+function BrowserContent({ children, id }: { children: ReactNode; id: string }) {
+  use(browserOnly())
+  return <p id={id}>{children}</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="pages-server-sibling">pages server sibling</p>
+      <Suspense fallback={<p id="pages-fallback">pages fallback</p>}>
+        <BrowserOnlyErrorBoundary fallbackId="pages-error-fallback">
+          <BrowserContent id="pages-browser-content">
+            pages browser content
+          </BrowserContent>
+        </BrowserOnlyErrorBoundary>
+      </Suspense>
+      <Suspense
+        fallback={<p id="pages-second-fallback">pages second fallback</p>}
+      >
+        <BrowserContent id="pages-second-browser-content">
+          pages second browser content
+        </BrowserContent>
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/browser-only/pages/server-render-error.tsx
+++ b/test/e2e/app-dir/browser-only/pages/server-render-error.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+
+function ServerErrorContent() {
+  if (typeof window === 'undefined') {
+    throw new Error('expected Pages Router server render error')
+  }
+
+  return <p>client content</p>
+}
+
+export function getServerSideProps() {
+  return { props: {} }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="server-error-fallback">error fallback</p>}>
+      <ServerErrorContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/browser-only/browser-only-content.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/browser-only/browser-only-content.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p data-testid="browser-only-content">browser-only content</p>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/browser-only/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/browser-only/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from './browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <p data-testid="browser-only-fallback">browser-only fallback</p>
+      }
+    >
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/page.tsx
@@ -11,6 +11,11 @@ export default function HomePage() {
           </Link>
         </li>
         <li>
+          <Link href="/browser-only" id="link-to-browser-only">
+            Go to browser-only page
+          </Link>
+        </li>
+        <li>
           <Link
             href="/runtime-prefetch-target?myParam=testValue"
             id="link-to-runtime-prefetch"

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/app/browser-only/browser-only-content.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/app/browser-only/browser-only-content.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p data-testid="browser-only-content">browser-only content</p>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/app/browser-only/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/app/browser-only/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from './browser-only-content'
+
+export default function Page() {
+  return (
+    <Suspense
+      fallback={
+        <p data-testid="browser-only-fallback">browser-only fallback</p>
+      }
+    >
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/partial-prefetch/app/page.tsx
@@ -13,6 +13,9 @@ export default function HomePage() {
       <Link href="/dynamic-params/hello" prefetch={true} id="full-link">
         Full prefetch link
       </Link>
+      <Link href="/browser-only" id="browser-only-link">
+        Browser-only page
+      </Link>
     </div>
   )
 }

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -87,6 +87,31 @@ async function openPage(
   return page
 }
 
+async function assertBrowserOnlyInstantNavigation(
+  next: NextInstance,
+  linkSelector: string
+) {
+  const page = await openPage(next, '/')
+  const navigationsBeforeClick = navigationRequests.length
+
+  await instant(page, async () => {
+    await page.click(linkSelector)
+
+    const content = page.locator('[data-testid="browser-only-content"]')
+    await content.waitFor({ state: 'visible' })
+    expect(await content.textContent()).toBe('browser-only content')
+    expect(
+      await page.locator('[data-testid="browser-only-fallback"]').count()
+    ).toBe(0)
+    expect(navigationRequests.length).toBe(navigationsBeforeClick)
+  })
+
+  expect(
+    await page.locator('[data-testid="browser-only-content"]').textContent()
+  ).toBe('browser-only content')
+  expect(navigationRequests.length).toBe(navigationsBeforeClick)
+}
+
 afterEach(async () => {
   if (activeBrowser) {
     // Console-error checking targets production minified React errors (e.g. a
@@ -103,6 +128,10 @@ afterEach(async () => {
 describe('instant-navigation-testing-api', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'default'),
+  })
+
+  it('renders browserOnly content immediately without a hard navigation', async () => {
+    await assertBrowserOnlyInstantNavigation(next, '#link-to-browser-only')
   })
 
   it('renders prefetched loading shell instantly during navigation', async () => {
@@ -1226,6 +1255,10 @@ describe('instant-navigation-testing-api - partial prefetching (App Shells)', ()
     // shell-restriction behavior under test. Disable it so the suite exercises
     // only the navigation-lock behavior.
     disableAutoSkewProtection: true,
+  })
+
+  it('renders browserOnly content immediately from a partial prefetch', async () => {
+    await assertBrowserOnlyInstantNavigation(next, '#browser-only-link')
   })
 
   // Under Partial Prefetching with App Shells, an auto (partial) prefetch only

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -146,6 +146,9 @@ export default async function Page() {
           <DebugLinks href="/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation" />
         </li>
         <li>
+          <DebugLinks href="/suspense-in-root/static/valid-browser-only-does-not-block-validation" />
+        </li>
+        <li>
           <DebugLinks href="/suspense-in-root/static/server-error-blocks-children" />
         </li>
         <li>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-browser-only-does-not-block-validation/client.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-browser-only-does-not-block-validation/client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>browser-only content</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-browser-only-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-browser-only-does-not-block-validation/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { BrowserOnlyContent } from './client'
+
+export const instant = { level: 'experimental-error' }
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>browser-only fallback</p>}>
+        <BrowserOnlyContent />
+      </Suspense>
+      <p>This static sibling should remain available for instant validation</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/client.util.ts
+++ b/test/e2e/app-dir/instant-validation/client.util.ts
@@ -150,6 +150,19 @@ export function registerClientTests(ctx: InstantValidationCaseContext) {
       }
     })
 
+    it('valid - browserOnly inside Suspense does not block validation', async () => {
+      const pathname =
+        '/suspense-in-root/static/valid-browser-only-does-not-block-validation'
+
+      if (isNextDev) {
+        const browser = await navigateTo(pathname)
+        await expectNoDevValidationErrors(browser, await browser.url())
+      } else {
+        const result = await prerender(pathname)
+        expectNoBuildValidationErrors(result)
+      }
+    })
+
     it('valid - unguarded params in client page', async () => {
       if (isNextDev) {
         const browser = await navigateTo(

--- a/test/e2e/browser-only-pages-export/browser-only-pages-export.test.ts
+++ b/test/e2e/browser-only-pages-export/browser-only-pages-export.test.ts
@@ -1,0 +1,73 @@
+import { join } from 'node:path'
+import type { Server } from 'node:net'
+import { isNextDev, isReact18, nextTestSetup } from 'e2e-utils'
+import { renderViaHTTP, startCleanStaticServer } from 'next-test-utils'
+
+describe('browserOnly in a Pages Router static export', () => {
+  if (isReact18) {
+    it.skip('requires React 19 or later', () => {})
+    return
+  }
+
+  if (isNextDev || process.env.__NEXT_CACHE_COMPONENTS === 'true') {
+    it.skip('requires an export-compatible production build', () => {})
+    return
+  }
+
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    nextConfig: {
+      output: 'export',
+    },
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let server: Server
+  let port: number
+
+  beforeAll(async () => {
+    const result = await next.build()
+    expect(result.exitCode).toBe(0)
+
+    server = await startCleanStaticServer(join(next.testDir, 'out'))
+    const address = server.address()
+    if (address === null || typeof address === 'string') {
+      throw new Error('Expected the static export server to listen on a port')
+    }
+    port = address.port
+  })
+
+  afterAll(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('exports the fallback and hydrates browser-only content', async () => {
+    const html = await renderViaHTTP(port, '/')
+    expect(html).toContain('pages server sibling')
+    expect(html).toContain('pages fallback')
+    expect(html.includes('id="pages-browser-content"')).toBe(false)
+
+    const browser = await next.browser('/', {
+      baseUrl: port,
+      pushErrorAsConsoleLog: true,
+    })
+    expect(await browser.elementByCss('#pages-browser-content').text()).toBe(
+      'pages browser content'
+    )
+
+    const logs = await browser.log()
+    expect(logs.filter((entry) => entry.source === 'error')).toEqual([])
+    expect(
+      next.cliOutput.includes(
+        'Bail out to client-side rendering: browserOnly()'
+      )
+    ).toBe(false)
+  })
+})

--- a/test/e2e/browser-only-pages-export/pages/index.tsx
+++ b/test/e2e/browser-only-pages-export/pages/index.tsx
@@ -1,0 +1,18 @@
+import { Suspense, use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p id="pages-browser-content">pages browser content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p id="pages-server-sibling">pages server sibling</p>
+      <Suspense fallback={<p id="pages-fallback">pages fallback</p>}>
+        <BrowserOnlyContent />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/browser-only-pages-missing-suspense/browser-only-pages-missing-suspense.test.ts
+++ b/test/e2e/browser-only-pages-missing-suspense/browser-only-pages-missing-suspense.test.ts
@@ -1,0 +1,40 @@
+import { isReact18, nextTestSetup } from 'e2e-utils'
+import { getRedboxDescription, waitForRedbox } from 'next-test-utils'
+
+describe('browserOnly without Suspense in the Pages Router', () => {
+  if (isReact18) {
+    it.skip('requires React 19 or later', () => {})
+    return
+  }
+
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    it('shows a redbox', async () => {
+      await next.start()
+
+      const browser = await next.browser('/')
+      await waitForRedbox(browser)
+      expect(await getRedboxDescription(browser)).toContain(
+        'Bail out to client-side rendering: browserOnly()'
+      )
+    })
+  } else {
+    it('fails the build', async () => {
+      const result = await next.build()
+
+      expect(result.exitCode).toBe(1)
+      expect(result.cliOutput).toContain(
+        'browserOnly() should be wrapped in a Suspense boundary'
+      )
+    })
+  }
+})

--- a/test/e2e/browser-only-pages-missing-suspense/pages/index.tsx
+++ b/test/e2e/browser-only-pages-missing-suspense/pages/index.tsx
@@ -1,0 +1,7 @@
+import { use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+export default function Page() {
+  use(browserOnly())
+  return <p>unreachable during prerender</p>
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/browser-only/browser-only-content.tsx
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/browser-only/browser-only-content.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Suspense, use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+function Content() {
+  use(browserOnly())
+  return <p>browser content</p>
+}
+
+export function BrowserOnlyContent() {
+  return (
+    <Suspense fallback={<p>browser fallback</p>}>
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/browser-only/page.tsx
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/browser-only/page.tsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+import { BrowserOnlyContent } from './browser-only-content'
+
+export default async function Page() {
+  await connection()
+  return <BrowserOnlyContent />
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/pages/browser-only.tsx
+++ b/test/e2e/on-request-error/skip-next-internal-error/pages/browser-only.tsx
@@ -1,0 +1,19 @@
+import { Suspense, use } from 'react'
+import { browserOnly } from 'next/navigation'
+
+function BrowserOnlyContent() {
+  use(browserOnly())
+  return <p>browser content</p>
+}
+
+export function getServerSideProps() {
+  return { props: {} }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>browser fallback</p>}>
+      <BrowserOnlyContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -12,6 +12,7 @@ describe('on-request-error - skip-next-internal-error', () => {
 
   async function assertNoNextjsInternalErrors() {
     const output = next.cliOutput
+    expect(output.includes('[instrumentation]:error')).toBe(false)
     // No navigation errors
     expect(output).not.toContain('NEXT_REDIRECT')
     expect(output).not.toContain('NEXT_NOT_FOUND')
@@ -60,6 +61,14 @@ describe('on-request-error - skip-next-internal-error', () => {
     // No SSR
     it('should not catch next dynamic no-ssr errors', async () => {
       await next.fetch('/client/no-ssr')
+      await assertNoNextjsInternalErrors()
+    })
+
+    it('should not catch browserOnly CSR bailout errors', async () => {
+      const response = await next.fetch('/client/browser-only')
+
+      expect(response.status).toBe(200)
+      expect((await response.text()).includes('browser fallback')).toBe(true)
       await assertNoNextjsInternalErrors()
     })
 

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isReact18, nextTestSetup } from 'e2e-utils'
 
 describe('on-request-error - skip-next-internal-error', () => {
   const { next, skipped } = nextTestSetup({
@@ -96,4 +96,13 @@ describe('on-request-error - skip-next-internal-error', () => {
       await assertNoNextjsInternalErrors()
     })
   })
+  if (!isReact18) {
+    it('should not catch Pages Router browserOnly CSR bailout errors', async () => {
+      const response = await next.fetch('/browser-only')
+
+      expect(response.status).toBe(200)
+      expect((await response.text()).includes('browser fallback')).toBe(true)
+      await assertNoNextjsInternalErrors()
+    })
+  }
 })


### PR DESCRIPTION
### Why?

Client Components sometimes need to opt a Suspense subtree out of server rendering while preserving the surrounding server-rendered shell. Existing APIs do not expose a promise-shaped primitive that can be consumed with `use()` and reused safely during client renders.

The Pages Router also did not pass a custom Fizz `onError` handler for page-shell renders. As a result, an expected `BailoutToCSRError` lost its digest, was logged on the server, and surfaced as a recoverable hydration error.

### How?

- Add `browserOnly()` to `next/navigation`. It is client-only, returns a shared fulfilled promise in the browser, and an immediately rejected CSR-bailout promise during server rendering.
- Cover Suspense boundaries, missing boundaries, RSC import restrictions, repeated renders, static export, Edge runtime, instant navigation, and instant validation.
- Preserve CSR bailout digests in Pages Router page-shell rendering while retaining React's default reporting for unexpected errors.
- Keep `_document` and other internal string renders unchanged by scoping the handler to the user page shell.

The first commit introduces the API and App Router behavior. The second adds Pages Router support independently.

### Test plan

- Dev and production with Turbopack and Webpack.
- Static export and Edge runtime with Turbopack and Webpack.
- Pages static optimization, GSSP, multiple Suspense boundaries, and a custom `_document`.
- Verify expected bailouts do not reach `onRequestError`, while real SSR errors remain reported.
- Verify existing Pages `next/dynamic({ ssr: false })` behavior remains unchanged.
- Verify instant navigation and instant validation behavior.

<!-- NEXT_JS_LLM -->
