### PR TITLE
Fix Turbopack polling watcher write-time invalidation

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -744,7 +744,12 @@ impl BatchedInvalidations {
             // invalidation, it's the way to reliably detect file content changes.
             // ref other implementation, i.e libuv does same thing to trigger `UV_CHANGES`
             // https://github.com/libuv/libuv/commit/73cf3600d75a5884b890a1a94048b8f3f9c66876
-            EventKind::Modify(ModifyKind::Data(_) | ModifyKind::Metadata(MetadataKind::Any)) => {
+            // The polling backend reports file changes as `MetadataKind::WriteTime` when the
+            // modification time changes, so it must be handled alongside `MetadataKind::Any`.
+            EventKind::Modify(
+                ModifyKind::Data(_)
+                | ModifyKind::Metadata(MetadataKind::Any | MetadataKind::WriteTime),
+            ) => {
                 for path in paths {
                     self.mark(path.into_boxed_path(), InvalidationFlags::PATH);
                 }
@@ -858,6 +863,36 @@ impl BatchedInvalidations {
             }
         }
         self.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use notify::{
+        Event, EventKind, RecursiveMode,
+        event::{MetadataKind, ModifyKind},
+    };
+
+    use super::{BatchedInvalidations, InvalidationFlags};
+
+    #[test]
+    fn write_time_metadata_change_is_invalidated() {
+        let path = PathBuf::from("/project/app/page.tsx");
+        let event = Event::new(EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::WriteTime,
+        )))
+        .add_path(path.clone());
+        let mut batch = BatchedInvalidations::new(RecursiveMode::NonRecursive);
+
+        assert!(batch.add_event(event));
+        assert!(
+            batch
+                .paths
+                .get(path.as_path())
+                .is_some_and(|flags| flags.contains(InvalidationFlags::PATH))
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #80665, where users reported that the watch function didn't work in Turbopack.

Polling mode represents ordinary file edits as `ModifyKind::Metadata(MetadataKind::WriteTime)`. The code previously only handled `MetadataKind::Any`, preventing affected paths from being invalidated.

I tested this issue locally on a VM with a Windows host and a Linux guest. It fixes the issue.

I've added a regression test as well.