### PR TITLE
[cd] Send Slack notification if publish fails

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -660,6 +660,42 @@ jobs:
           path: pnpm-publish-summary.json
           if-no-files-found: ignore
 
+  reportPublishFailure:
+    name: report publish failure to slack
+    needs:
+      - deploy-target
+      - publishRelease
+    # Only alert for runs that would publish (production == v* tag push) where
+    # the publish did not succeed. In a production run publishRelease's own `if`
+    # is true, so it is only 'skipped' when a build dependency failed and
+    # 'failure' when it ran and failed -- both are caught by `!= 'success'`.
+    # `always()` is required so a skipped/failed publishRelease doesn't skip this
+    # job too (same pattern as the buildPassed job below).
+    if: >-
+      ${{
+        always() &&
+        needs.deploy-target.outputs.value == 'production' &&
+        needs.publishRelease.result != 'success'
+      }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_PUBLISH_SLACK_WEBHOOK_URL }}
+    steps:
+      - name: send webhook
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        with:
+          # The url is intentionally missing the protocol,
+          # allowing it to be transformed into an actual link in the Slack workflow
+          # (through slightly hacky means).
+          payload: |
+            {
+              "commit_title": ${{ toJSON(github.ref_name) }},
+              "workflow_run_url": "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']
     if: ${{ always() && needs.deploy-target.outputs.value != '' }}


### PR DESCRIPTION
Failing to publish (especially a partial publish) leaves Next.js in a corrupted state that needs to be addressed immediately. However, we only created alerts when deploy tests failed which requires a successful publish. 

Now we send special message to the same channel as broken canary and deploy tests go.

This won't catch a failing deploy-target job. We'll see if deploy-target also frequently fails/flakes.