### PR TITLE
Fix Turbopack worker URL context lookup

### DIFF
--- a/test/e2e/app-dir/worker-module-url/app/layout.tsx
+++ b/test/e2e/app-dir/worker-module-url/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body style={{ margin: 0 }}>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/worker-module-url/app/page.tsx
+++ b/test/e2e/app-dir/worker-module-url/app/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Page() {
+  const [status, setStatus] = useState('idle')
+
+  function startWorker() {
+    try {
+      const worker = new Worker(
+        new URL('worker-package/worker.js', import.meta.url)
+      )
+      worker.onmessage = ({ data }) => {
+        setStatus(data)
+        worker.terminate()
+      }
+      worker.onerror = ({ message }) => {
+        setStatus(message)
+        worker.terminate()
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  return (
+    <main>
+      <button onClick={startWorker}>Start worker</button>
+      <p id="status">{status}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/worker-module-url/next.config.js
+++ b/test/e2e/app-dir/worker-module-url/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/worker-module-url/worker-module-url.test.ts
+++ b/test/e2e/app-dir/worker-module-url/worker-module-url.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('worker-module-url', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      // Mirrors the conditional wildcard exports used by worker packages.
+      'worker-package': 'file:./worker-package',
+    },
+  })
+
+  it('should create a worker from a bare module URL', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('button').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('status').text()).toBe('ready')
+    })
+  })
+})

--- a/test/e2e/app-dir/worker-module-url/worker-package/package.json
+++ b/test/e2e/app-dir/worker-module-url/worker-package/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "worker-package",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "./*": {
+      "import": "./*",
+      "require": "./*",
+      "default": "./*"
+    }
+  }
+}

--- a/test/e2e/app-dir/worker-module-url/worker-package/worker.js
+++ b/test/e2e/app-dir/worker-module-url/worker-package/worker.js
@@ -1,0 +1,1 @@
+self.postMessage('ready')

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -336,9 +336,9 @@ impl WorkerAssetReferenceCodeGen {
         let reference = self.reference.await?;
 
         // Build the request for PatternMapping
-        let request = match &reference.request {
-            WorkerRequest::Url(request) => **request,
-            WorkerRequest::Pattern { path, .. } => Request::parse(path.owned().await?),
+        let (request, request_key) = match &reference.request {
+            WorkerRequest::Url(request) => (**request, request.await?.request()),
+            WorkerRequest::Pattern { path, .. } => (Request::parse(path.owned().await?), None),
         };
 
         // Use PatternMapping to handle both single and multiple (dynamic) worker results
@@ -365,8 +365,14 @@ impl WorkerAssetReferenceCodeGen {
                             // Get the Worker constructor (callee)
                             let constructor = new_expr.callee.take();
 
-                            // Build the require call for the loader module
-                            let require_call = pm.create_require(*url_expr.take());
+                            // URL references are rewritten before their enclosing Worker
+                            // expression. Use the analyzed request string for the context lookup
+                            // instead of the rewritten URL object.
+                            let key_expr = match &request_key {
+                                Some(request) => Expr::Lit(Lit::Str(request.as_str().into())),
+                                None => *url_expr.take(),
+                            };
+                            let require_call = pm.create_require(key_expr);
 
                             // Build the arguments: (WorkerConstructor, ...rest_args)
                             let mut call_args = vec![ExprOrSpread {


### PR DESCRIPTION
## Summary

- Preserve the original static worker request when generating the Turbopack module-context lookup, instead of passing an already-rewritten URL object.
- Adds an e2e fixture for bare-module Worker URLs with conditional wildcard exports.

It looks like this might have regressed in #88602

Fixes #94015
Closes #94043 

## Verification

- `cargo check -p turbopack-ecmascript`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/worker-module-url/worker-module-url.test.ts`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/worker-module-url/worker-module-url.test.ts`