### PR TITLE
fix: apply built-in telemetry timeout when a caller signal is provided

### DIFF
--- a/packages/next/src/telemetry/post-telemetry-payload.test.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.test.ts
@@ -86,4 +86,91 @@ describe('postNextTelemetryPayload', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(2) // Initial try + 1 retry
   })
+
+  it('applies the built-in timeout even when a caller signal is provided', async () => {
+    const timeoutController = new AbortController()
+    const timeoutSpy = jest
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(timeoutController.signal)
+
+    let fetchSignal: AbortSignal | undefined
+    const mockFetch = jest.fn().mockImplementation((_url, opts) => {
+      fetchSignal = opts.signal
+      if (opts.signal.aborted) {
+        return Promise.reject(opts.signal.reason)
+      }
+      return new Promise((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => reject(opts.signal.reason))
+      })
+    })
+    global.fetch = mockFetch
+
+    const payload = {
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    }
+
+    // Caller signal that never aborts (e.g. `next build` waiting on flush)
+    const callerController = new AbortController()
+    const resPromise = postNextTelemetryPayload(
+      payload,
+      callerController.signal
+    )
+
+    // The built-in timeout must still be installed
+    expect(timeoutSpy).toHaveBeenCalledWith(5000)
+    expect(fetchSignal!.aborted).toBe(false)
+
+    // Simulate the built-in timeout firing while the caller never aborts
+    timeoutController.abort()
+    expect(fetchSignal!.aborted).toBe(true)
+
+    // Errors from the aborted request are swallowed
+    await resPromise
+
+    timeoutSpy.mockRestore()
+  })
+
+  it('still aborts the request when the caller signal aborts', async () => {
+    let fetchSignal: AbortSignal | undefined
+    const mockFetch = jest.fn().mockImplementation((_url, opts) => {
+      fetchSignal = opts.signal
+      if (opts.signal.aborted) {
+        return Promise.reject(opts.signal.reason)
+      }
+      return new Promise((_resolve, reject) => {
+        opts.signal.addEventListener('abort', () => reject(opts.signal.reason))
+      })
+    })
+    global.fetch = mockFetch
+
+    const payload = {
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    }
+
+    const callerController = new AbortController()
+    const resPromise = postNextTelemetryPayload(
+      payload,
+      callerController.signal
+    )
+
+    expect(fetchSignal!.aborted).toBe(false)
+
+    callerController.abort()
+    expect(fetchSignal!.aborted).toBe(true)
+
+    // Errors from the aborted request are swallowed
+    await resPromise
+  })
 })

--- a/packages/next/src/telemetry/post-telemetry-payload.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.ts
@@ -16,8 +16,16 @@ interface Payload {
 }
 
 export function postNextTelemetryPayload(payload: Payload, signal?: any) {
-  if (!signal && 'timeout' in AbortSignal) {
-    signal = AbortSignal.timeout(5000)
+  // The built-in timeout must always bound the wait, even when the caller
+  // provides its own cancellation signal (e.g. `next build`). Otherwise a
+  // stalled telemetry endpoint can delay the process far beyond the timeout.
+  if ('timeout' in AbortSignal) {
+    const timeoutSignal = AbortSignal.timeout(5000)
+    if (signal && 'any' in AbortSignal) {
+      signal = AbortSignal.any([signal, timeoutSignal])
+    } else if (!signal) {
+      signal = timeoutSignal
+    }
   }
   return (
     retry(


### PR DESCRIPTION
Fixes #96291, reported by @cyhforlight.

`postNextTelemetryPayload` only applied its built-in timeout when the caller did not pass an AbortSignal. When a caller signal was provided it replaced the timeout signal entirely, so `next build` could wait far beyond the intended telemetry timeout if the telemetry endpoint hung and the caller signal never fired.

Fix: combine the caller signal with the built-in timeout via `AbortSignal.any`, so whichever fires first aborts the request. Caller-initiated aborts still work exactly as before.

All 15 telemetry tests pass locally (3 suites). The new timeout test fails without the fix; the caller-abort test guards the existing behavior.
