### PR TITLE
docs: document the App Shell stale time threshold for cached content

### DIFF
--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -144,6 +144,8 @@ export default async function Page() {
 }
 ```
 
+> **Good to know**: The App Shell carries cached content whose [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time is at least 5 minutes, which holds for the `default` profile used above and every preset except `seconds`. Shorter-lived content streams in after the navigation instead. See [Prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior).
+
 ### Session content
 
 Content behind [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) varies per session, not per link, and [session data resolves in the App Shell](/docs/app/guides/runtime-prefetching#session-data-resolves-in-the-shell), so cached session content still gets included. Read the session value outside the cached function and pass it in, then remove `prefetch={true}` from the links:

--- a/docs/01-app/02-guides/instant-navigation.mdx
+++ b/docs/01-app/02-guides/instant-navigation.mdx
@@ -502,7 +502,7 @@ export const instant = false
 
 With `false` on `/dashboard/layout.tsx`, validation no longer flags navigations into `/dashboard` from outside; navigations between `/dashboard/a` and `/dashboard/b` are still checked.
 
-For opted-out segments, the navigation blocks on the server. If the content depends on cookies or headers but has a known cache lifetime, caching it with [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) lets the App Shell carry it ahead of the click instead of opting out.
+For opted-out segments, the navigation blocks on the server. If the content depends on cookies or headers but has a known cache lifetime, caching it with [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) lets the App Shell carry it ahead of the click instead of opting out, as long as its [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time is at least 5 minutes.
 
 ## Next steps
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -151,7 +151,7 @@ async function getRecommendations(productId) {
 }
 ```
 
-> **Good to know**: The `stale` time must be at least 30 seconds for runtime prefetching to work. See [`cacheLife` client cache behavior](/docs/app/api-reference/functions/cacheLife#client-cache-behavior) for details.
+> **Good to know**: The `stale` time must be at least 30 seconds for runtime prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
 
 ## Request APIs allowed in private caches
 

--- a/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
@@ -99,6 +99,7 @@ Cache profiles control caching behavior through three timing properties:
 During this time, the client-side router displays cached content immediately without any network request. After this period expires, the router must check with the server on the next navigation or request. This provides instant page loads from the client cache, but data may be outdated.
 
 - If omitted, defaults to the `default` profile's `stale` value (5 minutes, see [`staleTimes`](/docs/app/api-reference/config/next-config-js/staleTimes))
+- Also determines whether the content can be part of the route's [App Shell](/docs/app/glossary#app-shell). See [Prerendering behavior](#prerendering-behavior).
 
 ```tsx
 cacheLife({ stale: 300 }) // 5 minutes
@@ -260,7 +261,13 @@ When you call revalidation functions from a Server Action ([`revalidateTag`](/do
 
 ### Prerendering behavior
 
-Caches with very short lifetimes — zero `revalidate` or `expire` under 5 minutes — are automatically excluded from prerenders and become "dynamic holes" instead. This includes the `seconds` profile.
+A short cache lifetime changes where the cached content can be delivered from:
+
+- **`revalidate` of `0`, or `expire` under 5 minutes**: excluded from prerenders, becoming a "dynamic hole" resolved at request time.
+- **`stale` under 30 seconds**: excluded from prerenders, because a prefetch would expire before the user could click.
+- **`stale` from 30 seconds up to 5 minutes**: included in prerenders, but excluded from the route's [App Shell](/docs/app/glossary#app-shell).
+
+Of the presets, only `seconds` falls under any of these thresholds: its `expire` of 1 minute excludes it from prerenders.
 
 This behavior allows you to mix static and dynamic content within the same page. Static parts are prerendered, while short-lived caches create boundaries where data is fetched at request time rather than build time. Use a `<Suspense>` boundary around dynamic caches to provide a fallback while content loads.
 

--- a/docs/01-app/04-glossary.mdx
+++ b/docs/01-app/04-glossary.mdx
@@ -12,7 +12,7 @@ The Next.js router introduced in version 13, built on top of React Server Compon
 
 ## App Shell
 
-A per-route prerender containing the parts of a page that don't depend on URL data. Routes that read `cookies()` or `headers()` produce one that also includes session data, cached per session on the client. Used as the prefetch payload during client navigations, the loading state during [runtime prefetching](/docs/app/guides/runtime-prefetching), and the fallback for [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
+A per-route prerender containing the parts of a page that don't depend on URL data. Cached content is included when its [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time is at least 5 minutes, since the shell is reused for longer than shorter-lived content stays fresh. Routes that read `cookies()` or `headers()` produce one that also includes session data, cached per session on the client. Used as the prefetch payload during client navigations, the loading state during [runtime prefetching](/docs/app/guides/runtime-prefetching), and the fallback for [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 # B
 


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-6480/app-shells-exclude-stale-5-minutes-caches

