### PR TITLE
fix(telemetry): don't let caller signal bypass request timeout

### DIFF
--- a/packages/next/src/telemetry/post-telemetry-payload.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.ts
@@ -16,8 +16,12 @@ interface Payload {
 }
 
 export function postNextTelemetryPayload(payload: Payload, signal?: any) {
-  if (!signal && 'timeout' in AbortSignal) {
-    signal = AbortSignal.timeout(5000)
+  if ('timeout' in AbortSignal) {
+    const timeoutSignal = AbortSignal.timeout(5000)
+    signal =
+      signal && 'any' in AbortSignal
+        ? AbortSignal.any([signal, timeoutSignal])
+        : signal || timeoutSignal
   }
   return (
     retry(


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/96291, reported by @cyhforlight.

## Problem
`postNextTelemetryPayload` only installs its built-in 5-second
`AbortSignal.timeout(5000)` when the caller passes no signal:

```js
if (!signal && 'timeout' in AbortSignal) {
  signal = AbortSignal.timeout(5000)
}
```

In the real `next build` path, `Telemetry.submitRecord` always
passes its own `postController.signal`, so this branch is skipped
and the request has no timeout at all. If the telemetry endpoint
stalls (proxy, firewalled network, TUN/fake-IP setups — see #96291
and the related #70758), the request falls through to the
underlying HTTP client's own default timeouts, which are far
longer, and `next build` hangs well past the intended 5s cutoff.

## Fix
Combine the caller-provided signal with the timeout using
`AbortSignal.any`, so either can independently abort the request:
caller-driven cancellation still works exactly as before, and a
stalled request is now also cut off at ~5s regardless of whether
a signal was passed in.

## Testing
- Reproduced the original issue using the repro project linked in
  #96291 (telemetry-enabled build ~20s+ slower than telemetry-disabled).
- Applied this fix, rebuilt `next` locally (`pnpm build`), packed
  and unpacked it into the repro project (`pnpm pack-next` /
  `pnpm unpack-next`), and re-ran the repro:
  - Before: telemetry enabled ~21–42s slower than disabled.
  - After: enabled/disabled builds within ~0.1s of each other;
    repro script reports `NOT REPRODUCED`.
- [Add: unit test in post-telemetry-payload.test.ts covering a
  never-resolving fetch with a non-firing caller signal, asserting
  the request still aborts around 5s.]

## Note
While investigating, I also found that `Telemetry.record()` in
`storage.ts` stores the *outer* chained promise
(`.then().catch().then()`) in `this.queue`, not the *inner* promise
returned by `submitRecord()` that actually has `_controller` set on
it — since `.then()` always returns a new Promise object rather than
inheriting custom properties, `item._controller` is always
`undefined` wherever it's read, so `flushDetached`'s
`item._controller?.abort()` silently no-ops. This is a separate bug
from the one above (it affects `next dev`'s detached flush, not the
build-time timeout), so I've left it out of this PR — happy to open
a separate PR for it if that's preferred, or fold it in here if
maintainers would rather see both together.