### PR TITLE
fix(telemetry): preserve AbortController reference through record()'s promise chain

### DIFF
--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -175,33 +175,16 @@ export class Telemetry {
     _events: TelemetryEvent | TelemetryEvent[],
     deferred?: boolean
   ): Promise<RecordObject> => {
-    const prom = (
-      deferred
-        ? // if we know we are going to immediately call
-          // flushDetached we can skip starting the initial
-          // submitRecord which will then be cancelled
-          new Promise((resolve) =>
-            resolve({
-              isFulfilled: true,
-              isRejected: false,
-              value: _events,
-            })
-          )
-        : this.submitRecord(_events)
-    )
-      .then((value) => ({
-        isFulfilled: true,
-        isRejected: false,
-        value,
-      }))
-      .catch((reason) => ({
-        isFulfilled: false,
-        isRejected: true,
-        reason,
-      }))
-      // Acts as `Promise#finally` because `catch` transforms the error
+    const submitted = deferred
+      ? new Promise((resolve) =>
+          resolve({ isFulfilled: true, isRejected: false, value: _events })
+        )
+      : this.submitRecord(_events)
+
+    const prom = submitted
+      .then((value) => ({ isFulfilled: true, isRejected: false, value }))
+      .catch((reason) => ({ isFulfilled: false, isRejected: true, reason }))
       .then((res) => {
-        // Clean up the event to prevent unbounded `Set` growth
         if (!deferred) {
           this.queue.delete(prom)
         }
@@ -209,8 +192,7 @@ export class Telemetry {
       })
 
     ;(prom as any)._events = Array.isArray(_events) ? _events : [_events]
-    ;(prom as any)._controller = (prom as any)._controller
-    // Track this `Promise` so we can flush pending events
+    ;(prom as any)._controller = (submitted as any)._controller // ← read from submitted, not prom
     this.queue.add(prom)
 
     return prom


### PR DESCRIPTION
Fixes #96317 

## Problem

`Telemetry.record()` chains `.then().catch().then()` onto the Promise
returned by `submitRecord()`, and stores the *final chained* Promise in
`this.queue`:

```js
const prom = this.submitRecord(_events)
  .then((value) => ({ isFulfilled: true, isRejected: false, value }))
  .catch((reason) => ({ isFulfilled: false, isRejected: true, reason }))
  .then((res) => { /* ... */ return res })

;(prom as any)._controller = (prom as any)._controller
this.queue.add(prom)
```

`.then()` or `.catch()` always return a brand-new Promise object and never
copy custom properties forward from the Promise they're called on. So
`prom` is never the same object as the Promise `submitRecord()` returned
— the one that actually has `_controller` set on it inside
`submitRecord`:

```js
const postController = new AbortController()
const res = postNextTelemetryPayload(payload, postController.signal)
res._controller = postController
return res
```

As a result, `(prom as any)._controller = (prom as any)._controller` is
a no-op, it reads `undefined` and writes `undefined` back to itself.
Every item in `this.queue` has `_controller === undefined`.

This silently breaks `flushDetached()`'s cancellation logic:

```js
this.queue.forEach((item) => {
  try {
    item._controller?.abort()   // always a no-op, item._controller is always undefined
    allEvents.push(...item._events)
  } catch (_) {}
})
```

The `?.` swallows this without any error or warning, so there's no
visible symptom, it just means in-flight telemetry requests are never
actually aborted before `next dev` writes pending events to disk and
spawns the detached flush process.

Minimal standalone reproduction of the underlying Promise-identity
mechanism (no Next.js required): https://github.com/ash2228/next-promise-identity-repro

## Fix

Keep a named reference to the Promise `submitRecord()` actually returns
(`submitted`), and read `_controller` off that instead of off the final
chained Promise:

```js
const submitted = deferred ? /* ... */ : this.submitRecord(_events)
const prom = submitted.then(...).catch(...).then(...)

;(prom as any)._controller = (submitted as any)._controller
```