### PR TITLE
test: reproduce empty parallel route scroll regression

### DIFF
--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body style={{ margin: 0 }}>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/(.)open/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/(.)open/page.tsx
@@ -1,0 +1,3 @@
+export default function InterceptedModal() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function ModalCatchAll() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/[...catchAll]/page.tsx
@@ -1,3 +1,0 @@
-export default function ModalCatchAll() {
-  return null
-}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/layout.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+export default function ModalLayout({
+  children,
+  modal,
+}: {
+  children: ReactNode
+  modal: ReactNode
+}) {
+  return (
+    <>
+      <header style={{ height: 100, background: '#ddd' }}>
+        Persistent header
+      </header>
+      <main>{children}</main>
+      <footer
+        id="modal-page-footer"
+        style={{ height: 300, background: '#ddd' }}
+      >
+        Persistent footer
+      </footer>
+      {modal}
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/open/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/open/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Canonical modal page</p>
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div id="modal-page" style={{ minHeight: 2400 }}>
+      <h1>Modal page</h1>
+      <Link
+        id="open-empty-modal"
+        href="/modal/open"
+        style={{
+          position: 'fixed',
+          top: 20,
+          right: 20,
+          padding: 12,
+          background: 'white',
+        }}
+      >
+        Open empty modal
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>parallel route empty fragment scroll fixture</p>
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
@@ -1,0 +1,38 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe.each([false, true])(
+  'parallel-routes-empty-fragment-scroll (appNewScrollHandler: %s)',
+  (appNewScrollHandler) => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      nextConfig: {
+        experimental: {
+          appNewScrollHandler,
+        },
+      },
+    })
+
+    /* eslint-disable jest/no-standalone-expect */
+    ;(appNewScrollHandler ? it.failing : it)(
+      'preserves scroll when an empty modal catch-all is the only changed slot',
+      async () => {
+        const browser = await next.browser('/modal')
+
+        await browser.eval('window.scrollTo(0, 1200)')
+        const initialScroll = await browser.eval('window.scrollY')
+        expect(initialScroll).toBeGreaterThan(0)
+
+        await browser.elementByCss('#open-empty-modal').click()
+        await retry(async () => {
+          expect(await browser.url()).toBe(`${next.url}/modal/open`)
+        })
+
+        await retry(async () => {
+          expect(await browser.eval('window.scrollY')).toBe(initialScroll)
+        })
+      }
+    )
+    /* eslint-enable jest/no-standalone-expect */
+  }
+)

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
@@ -15,7 +15,7 @@ describe.each([false, true])(
 
     /* eslint-disable jest/no-standalone-expect */
     ;(appNewScrollHandler ? it.failing : it)(
-      'preserves scroll when an empty modal catch-all is the only changed slot',
+      'preserves scroll when an empty intercepted modal is the only changed slot',
       async () => {
         const browser = await next.browser('/modal')
 


### PR DESCRIPTION
## Summary

Adds a minimal App Router regression test for a soft navigation where an empty parallel route is rendered after persistent page content.

The test runs with `appNewScrollHandler` both disabled and enabled. The legacy-handler case passes normally, while the new-handler case uses `it.failing` to highlight the regression.