### PR TITLE
Restore comments dropped during a refactor

### DIFF
--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -231,7 +231,9 @@ fn uri_encode_path(path: &str) -> String {
 }
 
 /// Applies the standard `turbopack:///[fs]/` source-URL transform to a structured map,
-/// sharing every other field (notably `sourcesContent`) with the input.
+/// sharing every other field (notably `sourcesContent`) with the input. `transform` is given
+/// the source string as found in the map (i.e. a URI) with the `turbopack:///[fs]/` prefix
+/// stripped.
 async fn transform_relative_files<F>(
     map: &StructuredSourceMap,
     context_path: &FileSystemPath,
@@ -257,6 +259,7 @@ where
 }
 
 /// Turns `turbopack:///[project]` references in the map's sources into absolute `file://` uris.
+/// This is useful for debugging environments.
 pub async fn absolute_fileify_source_map(
     map: &StructuredSourceMap,
     context_path: FileSystemPath,
@@ -277,6 +280,7 @@ pub async fn absolute_fileify_source_map(
 }
 
 /// Turns `turbopack:///[project]` references in the map's sources into `./`-relative uris.
+/// This is useful in server environments and especially build environments.
 pub async fn relative_fileify_source_map(
     map: &StructuredSourceMap,
     context_path: FileSystemPath,
@@ -288,6 +292,12 @@ pub async fn relative_fileify_source_map(
         .collect::<Vec<_>>()
         .join("/");
     transform_relative_files(map, &context_path, |_context_fs, src_rest| {
+        // NOTE: we just include the relative path prefix here instead of using `sourceRoot`
+        // since the spec on sourceRoot is broken.
+
+        // TODO(bgw): this shouldn't be necessary to uri encode since the strings we get out of the
+        // source map should already be uri encoded, however in the case of the turbopack scheme in
+        // particular we are inconsistent so be defensive here.
         let src_rest = uri_encode_path(src_rest);
         if relative_path_to_output_root.is_empty() {
             Ok(src_rest.to_string())

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -216,6 +216,8 @@ pub fn generate_js_source_map<'a>(
     );
 
     if original_source_maps.is_empty() {
+        // We don't convert sourcemap::SourceMap into raw_sourcemap::SourceMap because we don't
+        // need to adjust mappings
         add_default_ignore_list(&mut new_mappings);
         StructuredSourceMap::from_swc_map(new_mappings)
     } else if fast_path_single_original_source_map {


### PR DESCRIPTION
Restores a handful of comments and TODOs in `turbopack-core/src/source_map/utils.rs` and `turbopack-ecmascript/src/parse.rs` that got silently dropped during the LLM-assisted refactor in #95934, while their surrounding code stayed the same.

Thanks @eps1lon for the tip to keep an eye on this.