### PR TITLE
Force no-store on prerendered responses that carry a Set-Cookie header

### DIFF
--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -58,9 +58,9 @@ export async function sendRenderResult({
   // If cache control is already set on the response we don't
   // override it to allow users to customize it via next.config
   if (cacheControl && !res.getHeader('Cache-Control')) {
-    // A response carrying `Set-Cookie` holds user-specific data and must not be
-    // stored by shared caches (RFC 6265 §7.3), so never let a prerendered page's
-    // cacheable `s-maxage` header leak cookies across users on non-Vercel CDNs.
+    // `Set-Cookie` does not stop a shared cache from storing and reusing a
+    // response (RFC 9111 §7.3), so a prerendered page's cacheable `s-maxage`
+    // would otherwise leak one user's cookies to the next visitor.
     if (res.getHeader('Set-Cookie')) {
       res.setHeader(
         'Cache-Control',

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -58,7 +58,17 @@ export async function sendRenderResult({
   // If cache control is already set on the response we don't
   // override it to allow users to customize it via next.config
   if (cacheControl && !res.getHeader('Cache-Control')) {
-    res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
+    // A response carrying `Set-Cookie` holds user-specific data and must not be
+    // stored by shared caches (RFC 6265 §7.3), so never let a prerendered page's
+    // cacheable `s-maxage` header leak cookies across users on non-Vercel CDNs.
+    if (res.getHeader('Set-Cookie')) {
+      res.setHeader(
+        'Cache-Control',
+        'private, no-cache, no-store, max-age=0, must-revalidate'
+      )
+    } else {
+      res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
+    }
   }
 
   const payload = result.isDynamic ? null : result.toUnchunkedString()

--- a/test/production/app-dir/middleware-set-cookie-cache/app/layout.tsx
+++ b/test/production/app-dir/middleware-set-cookie-cache/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/middleware-set-cookie-cache/app/no-cookie/page.tsx
+++ b/test/production/app-dir/middleware-set-cookie-cache/app/no-cookie/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>no cookie</p>
+}

--- a/test/production/app-dir/middleware-set-cookie-cache/app/with-cookie/page.tsx
+++ b/test/production/app-dir/middleware-set-cookie-cache/app/with-cookie/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>with cookie</p>
+}

--- a/test/production/app-dir/middleware-set-cookie-cache/middleware-set-cookie-cache.test.ts
+++ b/test/production/app-dir/middleware-set-cookie-cache/middleware-set-cookie-cache.test.ts
@@ -3,14 +3,12 @@ import { nextTestSetup } from 'e2e-utils'
 describe('middleware-set-cookie-cache', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipStart: true,
+    // Cache-Control is applied outside of the Next.js server when deployed, so
+    // these assertions only hold for `next start`.
     skipDeployment: true,
   })
 
   if (skipped) return
-
-  beforeAll(() => next.start())
-  afterAll(() => next.stop())
 
   it('replaces a prerendered page cache-control with no-store when middleware sets a cookie', async () => {
     const res = await next.fetch('/with-cookie')

--- a/test/production/app-dir/middleware-set-cookie-cache/middleware-set-cookie-cache.test.ts
+++ b/test/production/app-dir/middleware-set-cookie-cache/middleware-set-cookie-cache.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('middleware-set-cookie-cache', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  beforeAll(() => next.start())
+  afterAll(() => next.stop())
+
+  it('replaces a prerendered page cache-control with no-store when middleware sets a cookie', async () => {
+    const res = await next.fetch('/with-cookie')
+    expect(res.headers.get('set-cookie')).toContain('token=secret-user-token')
+    expect(res.headers.get('cache-control')).toBe(
+      'private, no-cache, no-store, max-age=0, must-revalidate'
+    )
+  })
+
+  it('keeps the prerendered page cache-control when middleware sets no cookie', async () => {
+    const res = await next.fetch('/no-cookie')
+    expect(res.headers.get('set-cookie')).toBeNull()
+    expect(res.headers.get('cache-control')).toContain('s-maxage')
+  })
+})

--- a/test/production/app-dir/middleware-set-cookie-cache/middleware.ts
+++ b/test/production/app-dir/middleware-set-cookie-cache/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next()
+  if (request.nextUrl.pathname === '/with-cookie') {
+    response.cookies.set('token', 'secret-user-token')
+  }
+  return response
+}
+
+export const config = {
+  matcher: ['/with-cookie', '/no-cookie'],
+}

--- a/test/production/app-dir/middleware-set-cookie-cache/next.config.js
+++ b/test/production/app-dir/middleware-set-cookie-cache/next.config.js
@@ -1,0 +1,4 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {}


### PR DESCRIPTION
When middleware adds a `Set-Cookie` header to a `NextResponse.next()` response on a prerendered static page, Next.js leaves the page's `Cache-Control: s-maxage=31536000` untouched. The response then advertises itself as cacheable for a year while carrying user-specific cookies, so shared CDNs that honor `s-maxage` (CloudFront, Cloudflare, Netlify) can store one user's tokens and serve them to the next visitor.

`sendRenderResult` now swaps the cacheable header for `no-store` whenever the response already carries a `Set-Cookie`, in line with RFC 6265 §7.3. Responses without cookies keep their normal caching. Added a production test covering both the cookie and no-cookie cases.

Fixes #96266