### PR TITLE
fix(with-docker): correct Node.js guide label

### DIFF
--- a/examples/with-docker/app/page.tsx
+++ b/examples/with-docker/app/page.tsx
@@ -192,13 +192,13 @@ export default function Home() {
               target="_blank"
               rel="noopener noreferrer"
               className="bg-white rounded-lg p-6 shadow-md border border-zinc-200 hover:shadow-lg transition-shadow group focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              aria-label="Read React.js Docker guide"
+              aria-label="Read Node.js Docker guide"
             >
               <h3 className="text-lg font-semibold mb-2 text-black group-hover:text-blue-600">
-                React.js Guide →
+                Node.js Guide →
               </h3>
               <p className="text-zinc-600 text-sm">
-                Official Docker guide for React.js applications following best
+                Official Docker guide for Node.js applications following best
                 practices for containerization.
               </p>
             </Link>


### PR DESCRIPTION
## Summary

Correct the title and accessible label for the Docker Node.js guide in the `with-docker` example.

The resource currently links to Docker's official Node.js guide, but the card is labeled as "React.js Guide", which is misleading.

## Changes

- Rename **React.js Guide** to **Node.js Guide**
- Update the `aria-label` from **"Read React.js Docker guide"** to **"Read Node.js Docker guide"**

## Before

- Card title: `React.js Guide`
- `aria-label`: `Read React.js Docker guide`

## After

- Card title: `Node.js Guide`
- `aria-label`: `Read Node.js Docker guide`