### PR TITLE
[Cache Components] Only consider rendered parallel slots for instant insights validation

### DIFF
--- a/packages/next/src/client/components/instant-validation/boundary.tsx
+++ b/packages/next/src/client/components/instant-validation/boundary.tsx
@@ -6,4 +6,5 @@ export {
   PlaceValidationBoundaryBelowThisLevel,
   RenderValidationBoundaryAtThisLevel,
   SlotMarker,
+  recordMountedForkSlot,
 } from './impl'

--- a/packages/next/src/client/components/instant-validation/impl.browser.tsx
+++ b/packages/next/src/client/components/instant-validation/impl.browser.tsx
@@ -2,3 +2,5 @@ export const InstantValidationBoundaryContext = null
 export const PlaceValidationBoundaryBelowThisLevel = null
 export const RenderValidationBoundaryAtThisLevel = null
 export const SlotMarker = null
+// Fork-slot mounts are only observed server-side.
+export const recordMountedForkSlot = null

--- a/packages/next/src/client/components/instant-validation/impl.tsx
+++ b/packages/next/src/client/components/instant-validation/impl.tsx
@@ -3,4 +3,5 @@ export {
   PlaceValidationBoundaryBelowThisLevel,
   RenderValidationBoundaryAtThisLevel,
   SlotMarker,
+  recordMountedForkSlot,
 } from '../../../server/app-render/instant-validation/boundary-impl'

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -36,6 +36,7 @@ import { HTTPAccessFallbackBoundary } from './http-access-fallback/error-boundar
 import {
   InstantValidationBoundaryContext,
   RenderValidationBoundaryAtThisLevel,
+  recordMountedForkSlot,
 } from './instant-validation/boundary'
 import { createRouterCacheKey } from './router-reducer/create-router-cache-key'
 import {
@@ -612,6 +613,7 @@ export default function OuterLayoutRouter({
   forbidden,
   unauthorized,
   segmentViewBoundaries,
+  validationSlotPath,
 }: {
   parallelRouterKey: string
   error: ErrorComponent | undefined
@@ -624,7 +626,18 @@ export default function OuterLayoutRouter({
   forbidden: React.ReactNode | undefined
   unauthorized: React.ReactNode | undefined
   segmentViewBoundaries?: React.ReactNode
+  /** Present only on fork slots of dev renders that record for instant
+   * validation (see `RequestStore.serializedForkSlots`): this router
+   * rendering means the fork slot mounted in the client tree. */
+  validationSlotPath?: string
 }) {
+  if (validationSlotPath !== undefined && recordMountedForkSlot !== null) {
+    // Observe the mount for instant validation's rendered-slot semantics.
+    // Only records during a document SSR whose request store is armed;
+    // no-ops in the browser and in validation renders.
+    recordMountedForkSlot(validationSlotPath)
+  }
+
   const context = useContext(LayoutRouterContext)
   if (!context) {
     throw new Error('invariant expected layout router to be mounted')

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -320,6 +320,7 @@ import {
   getValidationSegment,
   stringifySegment,
 } from './instant-validation/segment-path'
+import { createMountObservationTimeoutError } from '../../shared/lib/instant-messages'
 import {
   createValidationBoundaryTracking,
   type ValidationBoundaryTracking,
@@ -4775,6 +4776,26 @@ type LazyDevValidationInputs = MemoizedThunk<
 >
 
 const VALIDATION_BAILOUT = Symbol('VALIDATION_BAILOUT')
+
+const MOUNT_OBSERVATION_TIMED_OUT = Symbol('MOUNT_OBSERVATION_TIMED_OUT')
+
+const MOUNT_OBSERVATION_TIMEOUT_MS = 5_000
+
+/**
+ * How long instant validation waits for a fork-slot mount observation —
+ * either the document SSR settling (`mountedForkSlotsSettled`) or the
+ * dedicated observation render — before reporting that validation could
+ * not discover which fork slots render.
+ */
+function getMountObservationTimeoutMs(): number {
+  if (process.env.__NEXT_TEST_MODE) {
+    const override = Number(process.env.NEXT_TEST_MOUNT_OBSERVATION_TIMEOUT_MS)
+    if (Number.isFinite(override) && override >= 0) {
+      return override
+    }
+  }
+  return MOUNT_OBSERVATION_TIMEOUT_MS
+}
 type ValidationBailout = typeof VALIDATION_BAILOUT
 
 function createLazyDevValidationInputs(
@@ -6640,7 +6661,29 @@ async function runValidationInDev(
       validatedRequestStore.mountedForkSlots !== undefined &&
       validatedRequestStore.mountedForkSlotsSettled !== undefined
     ) {
-      await validatedRequestStore.mountedForkSlotsSettled
+      // Validation normally starts after the response has finished, so the
+      // settle promise is usually already resolved. When it isn't —
+      // something in a Client Component is preventing the document SSR
+      // from completing — don't wait forever: report that discovery
+      // couldn't complete instead.
+      let timeoutId: NodeJS.Timeout | undefined
+      const timedOut = new Promise<boolean>((resolve) => {
+        timeoutId = setTimeout(
+          () => resolve(true),
+          getMountObservationTimeoutMs()
+        )
+      })
+      const settled = validatedRequestStore.mountedForkSlotsSettled.then(
+        () => false
+      )
+      const observationTimedOut = await Promise.race([settled, timedOut])
+      clearTimeout(timeoutId)
+      if (validationAbortSignal.aborted) {
+        return
+      }
+      if (observationTimedOut) {
+        return [createMountObservationTimeoutError(ctx.workStore.route)]
+      }
       mountedForkSlots = validatedRequestStore.mountedForkSlots
     }
 
@@ -7191,7 +7234,9 @@ async function validateInstantConfigs(
    * unmounted at that point isn't part of the instant window, so it is
    * dead for validation purposes.
    */
-  async function observeMountedForkSlotsInSSR(): Promise<ReadonlySet<string>> {
+  async function observeMountedForkSlotsInSSR(): Promise<
+    ReadonlySet<string> | typeof MOUNT_OBSERVATION_TIMED_OUT
+  > {
     const extraChunksController = new AbortController()
     const extraChunksSignal =
       validationAbortSignal === undefined
@@ -7260,6 +7305,17 @@ async function validateInstantConfigs(
       mountedForkSlots: observedMountedForkSlots,
     }
 
+    // The observation render should settle almost immediately: server data
+    // is fully resolved in the recorded chunks and the render is aborted
+    // once synchronously-settleable work settles. If a Client Component
+    // keeps it from settling, give up after a bound and report instead of
+    // consuming a partial (under-reporting) mounted set.
+    let observationTimedOut = false
+    const observationTimeout = setTimeout(() => {
+      observationTimedOut = true
+      reactController.abort()
+    }, getMountObservationTimeoutMs())
+
     try {
       await runInSequentialTasks(
         () => {
@@ -7311,6 +7367,13 @@ async function validateInstantConfigs(
       )
     } catch (thrownValue) {
       // Same reasoning as onError: whatever failed to render didn't mount.
+    } finally {
+      clearTimeout(observationTimeout)
+    }
+
+    if (observationTimedOut) {
+      debug?.('Mount observation render timed out')
+      return MOUNT_OBSERVATION_TIMED_OUT
     }
 
     debug?.(
@@ -7329,7 +7392,14 @@ async function validateInstantConfigs(
     serializedForkSlots !== undefined &&
     serializedForkSlots.size > 0
   ) {
-    observedMountedForkSlots = await observeMountedForkSlotsInSSR()
+    const observation = await observeMountedForkSlotsInSSR()
+    if (observation === MOUNT_OBSERVATION_TIMED_OUT) {
+      if (validationAbortSignal?.aborted) {
+        return []
+      }
+      return [createMountObservationTimeoutError(workStore.route)]
+    }
+    observedMountedForkSlots = observation
   }
   const liveForkSlots =
     observedMountedForkSlots !== undefined

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -316,6 +316,11 @@ import {
 } from './instant-validation/stream-utils'
 
 import {
+  getSerializedForkSlotsRecorder,
+  getValidationSegment,
+  stringifySegment,
+} from './instant-validation/segment-path'
+import {
   createValidationBoundaryTracking,
   type ValidationBoundaryTracking,
 } from './instant-validation/boundary-tracking'
@@ -2130,6 +2135,12 @@ async function getRSCPayload(
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
     MetadataOutlet,
+    validationSegmentPath:
+      getSerializedForkSlotsRecorder() !== undefined
+        ? stringifySegment(
+            getValidationSegment(tree, ctx.getDynamicParamFromSegment, query)
+          )
+        : null,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -5434,6 +5445,9 @@ async function renderWithWarmCachesForValidationInDev(
     requestStore.mutableCookies,
     requestStore.headers
   )
+  // This render exists to feed instant validation, so always arm
+  // serialized-fork-slot recording for it (see `RecordSerializedForkSlot`).
+  requestStore.serializedForkSlots = new Set()
 
   const debugChannel = setReactDebugChannel && createNodeDebugChannel()
   const environmentName = () =>
@@ -5695,6 +5709,14 @@ async function stagedRenderWithCachesInDev({
   const validationGeneration = shouldValidate
     ? beginDevValidation(ctx.htmlRequestId)
     : undefined
+
+  if (shouldValidate) {
+    // Arm serialized-fork-slot recording for this render: the flight render
+    // records which parallel fork slots its output references (see
+    // `RecordSerializedForkSlot`), and validation treats configs inside
+    // fork slots that were never serialized as vacuous.
+    requestStore.serializedForkSlots = new Set()
+  }
 
   try {
     const { setReactDebugChannel } = ctx.renderOpts
@@ -6407,6 +6429,11 @@ export async function runValidationInDevFromSnapshot(
     serverComponentsHmrCache: undefined,
     fallbackParams: requestFallbackRouteParams,
   })
+  if (message.serializedForkSlots !== null) {
+    // Reattach the serialized-fork-slot set recorded by the render that
+    // instant validation consumes (see `RequestStore.serializedForkSlots`).
+    requestStore.serializedForkSlots = new Set(message.serializedForkSlots)
+  }
 
   const staticInputs = toDevValidationInputs(message.staticInputs, requestStore)
 
@@ -6568,6 +6595,9 @@ async function runValidationInDev(
       hmrRefreshHash,
       validationSamples,
       devRenderDidError,
+      // The request store of the render being validated carries the
+      // serialized-fork-slot set that render recorded.
+      inputs.requestStore.serializedForkSlots,
       validationAbortSignal
     )
 
@@ -7030,6 +7060,10 @@ async function validateInstantConfigs(
   hmrRefreshHash: string | undefined,
   validationSamples: ValidationStoreClient['validationSamples'] | null,
   devRenderDidError: boolean,
+  /** The serialized-fork-slot set recorded by the render being validated
+   * (see `RequestStore.serializedForkSlots`), or undefined when recording
+   * wasn't armed (e.g. build validation). */
+  serializedForkSlots: ReadonlySet<string> | undefined,
   validationAbortSignal?: AbortSignal
 ): Promise<Array<unknown>> {
   const debug =
@@ -7132,7 +7166,8 @@ async function validateInstantConfigs(
       boundaryState,
       clientReferenceManifest,
       stageEndTimes,
-      useRuntimeStageForPartialSegments
+      useRuntimeStageForPartialSegments,
+      serializedForkSlots
     )
 
     if (payloadResult === null) {
@@ -8099,7 +8134,10 @@ async function validateInstantConfigInBuildWithSample(
       validationRenderCtx,
       undefined, // hmrRefreshHash,
       validationSamples,
-      false // build has no shared dev render that would surface errors
+      false, // build has no shared dev render that would surface errors
+      // Build renders don't record serialized fork slots (yet), so every
+      // config is considered.
+      undefined
     )
   })
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7133,17 +7133,10 @@ async function validateInstantConfigs(
   const debug =
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
 
-  // Fork slots that can appear in the validated render's client tree: the
-  // SSR-observed mounted set when the render had a document SSR, otherwise
-  // the serialized set. The serialized set is conservative — client
-  // components may still drop slots they were handed — so renders without
-  // a document SSR over-approximate until they get their own observation.
-  const liveForkSlots =
-    mountedForkSlots !== undefined ? mountedForkSlots : serializedForkSlots
-
   const {
     createCombinedPayloadAtDepth,
     createCombinedPayloadStream,
+    createMountObservationPayload,
     collectStagedSegmentData,
     discoverValidationDepths,
     ValidationPrefetchKind,
@@ -7185,6 +7178,163 @@ async function validateInstantConfigs(
   )
 
   const { implicitTags, nonce, workStore, isDebugChannelEnabled } = ctx
+
+  /**
+   * Observes which serialized fork slots mount in the client tree by
+   * SSR-rendering the validated render's recorded chunks once, with
+   * nothing withheld. Used when the validated render had no document SSR
+   * (RSC navigations, the warm-cache validation render). Server-side fork
+   * decisions are baked into the recorded Flight data; only client
+   * components re-execute, and the fork-slot routers they render report
+   * their mounts (see `recordMountedForkSlot`). The render is aborted
+   * once synchronously-settleable work settles: a serialized fork slot
+   * unmounted at that point isn't part of the instant window, so it is
+   * dead for validation purposes.
+   */
+  async function observeMountedForkSlotsInSSR(): Promise<ReadonlySet<string>> {
+    const extraChunksController = new AbortController()
+    const extraChunksSignal =
+      validationAbortSignal === undefined
+        ? extraChunksController.signal
+        : AbortSignal.any([extraChunksController.signal, validationAbortSignal])
+
+    const payload = await createMountObservationPayload(
+      initialRscPayload,
+      cache,
+      loaderTree,
+      ctx.getDynamicParamFromSegment,
+      ctx.query,
+      extraChunksSignal,
+      clientReferenceManifest
+    )
+
+    const reactController = new AbortController()
+    const renderController = new AbortController()
+    const reactSignal =
+      validationAbortSignal === undefined
+        ? reactController.signal
+        : AbortSignal.any([reactController.signal, validationAbortSignal])
+    const preinitScripts = () => {}
+    const { ServerInsertedHTMLProvider } = createServerInsertedHTML()
+
+    const { stream: serverStream, debugStream } =
+      await createCombinedPayloadStream(
+        ctx.componentMod,
+        renderFlightStream,
+        payload,
+        extraChunksController,
+        reactSignal,
+        clientReferenceManifest,
+        startTime,
+        isDebugChannelEnabled,
+        createDebugChannel
+      )
+
+    const clientDynamicTracking = createDynamicTrackingState(false)
+    const validationSampleTracking =
+      validationSamples !== null ? createValidationSampleTracking() : null
+
+    const observedMountedForkSlots = new Set<string>()
+
+    const prerenderStore: PrerenderStore = {
+      type: 'validation-client',
+      phase: 'render',
+      rootParams,
+      implicitTags,
+      renderSignal: renderController.signal,
+      controller: reactController,
+      cacheSignal: null,
+      dynamicTracking: clientDynamicTracking,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+      stale: INFINITE_CACHE,
+      tags: [...implicitTags.tags],
+      resumeDataCache: null,
+      hmrRefreshHash,
+      varyParamsAccumulator: null,
+      // Nothing places validation boundaries in the observation payload.
+      boundaryState: null,
+      fallbackRouteParams,
+      validationSamples,
+      validationSampleTracking,
+      mountedForkSlots: observedMountedForkSlots,
+    }
+
+    try {
+      await runInSequentialTasks(
+        () => {
+          const pendingResult = workUnitAsyncStorage.run(
+            prerenderStore,
+            getClientPrerender,
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx -- React Client
+            <App
+              reactServerStream={serverStream}
+              reactDebugStream={debugStream ?? undefined}
+              debugEndTime={undefined}
+              preinitScripts={preinitScripts}
+              ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+              nonce={nonce}
+              images={ctx.renderOpts.images}
+            />,
+            {
+              signal: reactSignal,
+              onError: (err: unknown) => {
+                // The observation isn't judging errors — the validation
+                // passes will surface them. A component that errored or was
+                // interrupted didn't mount its subtree within the instant
+                // window, which the absence of mounts already expresses.
+                if (isReactLargeShellError(err)) {
+                  console.error(err)
+                  return undefined
+                }
+                return getDigestForWellKnownError(err)
+              },
+            }
+          )
+
+          reactSignal.addEventListener(
+            'abort',
+            () => {
+              renderController.abort()
+            },
+            { once: true }
+          )
+
+          return pendingResult
+        },
+        () => {
+          workUnitAsyncStorage.run(
+            prerenderStore,
+            reactController.abort.bind(reactController)
+          )
+        }
+      )
+    } catch (thrownValue) {
+      // Same reasoning as onError: whatever failed to render didn't mount.
+    }
+
+    debug?.(
+      `Mount observation render settled; ${observedMountedForkSlots.size} fork slots mounted`
+    )
+    return observedMountedForkSlots
+  }
+
+  // Fork slots that can appear in the validated render's client tree: the
+  // observed mounted set (from the document SSR when the render had one,
+  // otherwise from a dedicated observation render), falling back to the
+  // serialized set when there is nothing to observe.
+  let observedMountedForkSlots = mountedForkSlots
+  if (
+    observedMountedForkSlots === undefined &&
+    serializedForkSlots !== undefined &&
+    serializedForkSlots.size > 0
+  ) {
+    observedMountedForkSlots = await observeMountedForkSlotsInSSR()
+  }
+  const liveForkSlots =
+    observedMountedForkSlots !== undefined
+      ? observedMountedForkSlots
+      : serializedForkSlots
 
   async function validateAtDepth(
     prefetchKind: ValidationPrefetchKind,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3930,6 +3930,17 @@ async function renderToStream(
           formState,
         }
 
+        let mountedForkSlotsSettled: PromiseWithResolvers<void> | null = null
+        if (requestStore.serializedForkSlots !== undefined) {
+          // The document SSR observes which serialized fork slots actually
+          // mount in the client tree (see `RequestStore.mountedForkSlots`).
+          // The set and its settle promise are assigned together so
+          // consumers never observe one without the other.
+          requestStore.mountedForkSlots = new Set()
+          mountedForkSlotsSettled = createPromiseWithResolvers<void>()
+          requestStore.mountedForkSlotsSettled = mountedForkSlotsSettled.promise
+        }
+
         const { stream: htmlStream, allReady } = await getTracer().trace(
           AppRenderSpan.renderToNodeFizzStream,
           () =>
@@ -3941,6 +3952,15 @@ async function renderToStream(
               { waitForAllReady: generateStaticHTML }
             )
         )
+
+        if (mountedForkSlotsSettled !== null) {
+          // The mounted set is complete once the SSR settles, whether it
+          // finished cleanly or errored.
+          allReady.then(
+            mountedForkSlotsSettled.resolve,
+            mountedForkSlotsSettled.resolve
+          )
+        }
 
         // End the render span only after React completed rendering (including anything inside Suspense boundaries)
         allReady.finally(() => {
@@ -4073,12 +4093,32 @@ async function renderToStream(
           formState,
         }
 
+        let mountedForkSlotsSettled: PromiseWithResolvers<void> | null = null
+        if (requestStore.serializedForkSlots !== undefined) {
+          // The document SSR observes which serialized fork slots actually
+          // mount in the client tree (see `RequestStore.mountedForkSlots`).
+          // The set and its settle promise are assigned together so
+          // consumers never observe one without the other.
+          requestStore.mountedForkSlots = new Set()
+          mountedForkSlotsSettled = createPromiseWithResolvers<void>()
+          requestStore.mountedForkSlotsSettled = mountedForkSlotsSettled.promise
+        }
+
         const { stream: htmlStream, allReady } = await workUnitAsyncStorage.run(
           requestStore,
           renderToWebFizzStream,
           appElement,
           fizzOptions
         )
+
+        if (mountedForkSlotsSettled !== null) {
+          // The mounted set is complete once the SSR settles, whether it
+          // finished cleanly or errored.
+          allReady.then(
+            mountedForkSlotsSettled.resolve,
+            mountedForkSlotsSettled.resolve
+          )
+        }
 
         // End the render span only after React completed rendering (including anything inside Suspense boundaries)
         allReady.finally(() => {
@@ -6434,6 +6474,12 @@ export async function runValidationInDevFromSnapshot(
     // instant validation consumes (see `RequestStore.serializedForkSlots`).
     requestStore.serializedForkSlots = new Set(message.serializedForkSlots)
   }
+  if (message.mountedForkSlots !== null) {
+    // The transported mounted set was serialized after the document SSR
+    // settled, so it is already complete.
+    requestStore.mountedForkSlots = new Set(message.mountedForkSlots)
+    requestStore.mountedForkSlotsSettled = Promise.resolve()
+  }
 
   const staticInputs = toDevValidationInputs(message.staticInputs, requestStore)
 
@@ -6584,6 +6630,20 @@ async function runValidationInDev(
       : null
     const hmrRefreshHash = getHmrRefreshHash(inputs.requestStore)
 
+    // The request store of the render being validated carries the
+    // serialized-fork-slot set that render recorded, and — when that render
+    // had a document SSR — the observed mounted set, complete once the SSR
+    // has settled.
+    const validatedRequestStore = inputs.requestStore
+    let mountedForkSlots: ReadonlySet<string> | undefined = undefined
+    if (
+      validatedRequestStore.mountedForkSlots !== undefined &&
+      validatedRequestStore.mountedForkSlotsSettled !== undefined
+    ) {
+      await validatedRequestStore.mountedForkSlotsSettled
+      mountedForkSlots = validatedRequestStore.mountedForkSlots
+    }
+
     const result = await validateInstantConfigs(
       prefetchMode,
       inputs.accumulatedChunks,
@@ -6595,9 +6655,8 @@ async function runValidationInDev(
       hmrRefreshHash,
       validationSamples,
       devRenderDidError,
-      // The request store of the render being validated carries the
-      // serialized-fork-slot set that render recorded.
-      inputs.requestStore.serializedForkSlots,
+      validatedRequestStore.serializedForkSlots,
+      mountedForkSlots,
       validationAbortSignal
     )
 
@@ -7064,10 +7123,23 @@ async function validateInstantConfigs(
    * (see `RequestStore.serializedForkSlots`), or undefined when recording
    * wasn't armed (e.g. build validation). */
   serializedForkSlots: ReadonlySet<string> | undefined,
+  /** The fork slots observed mounting during the validated render's
+   * document SSR (see `RequestStore.mountedForkSlots`), settled and
+   * complete. Undefined when that render had no document SSR (e.g. RSC
+   * navigations, the warm-cache validation render). */
+  mountedForkSlots: ReadonlySet<string> | undefined,
   validationAbortSignal?: AbortSignal
 ): Promise<Array<unknown>> {
   const debug =
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
+
+  // Fork slots that can appear in the validated render's client tree: the
+  // SSR-observed mounted set when the render had a document SSR, otherwise
+  // the serialized set. The serialized set is conservative — client
+  // components may still drop slots they were handed — so renders without
+  // a document SSR over-approximate until they get their own observation.
+  const liveForkSlots =
+    mountedForkSlots !== undefined ? mountedForkSlots : serializedForkSlots
 
   const {
     createCombinedPayloadAtDepth,
@@ -7167,7 +7239,7 @@ async function validateInstantConfigs(
       clientReferenceManifest,
       stageEndTimes,
       useRuntimeStageForPartialSegments,
-      serializedForkSlots
+      liveForkSlots
     )
 
     if (payloadResult === null) {
@@ -8137,6 +8209,8 @@ async function validateInstantConfigInBuildWithSample(
       false, // build has no shared dev render that would surface errors
       // Build renders don't record serialized fork slots (yet), so every
       // config is considered.
+      undefined,
+      // Build renders have no document SSR to observe mounts from.
       undefined
     )
   })

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -752,6 +752,13 @@ async function createComponentTreeInternal(
           ...(isSegmentViewEnabled && {
             segmentViewBoundaries,
           }),
+          // On recording-armed renders, fork-slot routers report their
+          // mounts for instant validation (see `recordMountedForkSlot`).
+          ...(childrenAreForkSlots &&
+            childValidationSegmentPath !== null &&
+            serializedForkSlots !== undefined && {
+              validationSlotPath: childValidationSegmentPath,
+            }),
         })
 
         if (

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -40,6 +40,12 @@ import {
   getConventionPathByType,
   isNextjsBuiltinFilePath,
 } from './segment-explorer-path'
+import {
+  createChildSegmentPath,
+  getSerializedForkSlotsRecorder,
+  getValidationSegment,
+  type SegmentPath,
+} from './instant-validation/segment-path'
 
 /**
  * Use the provided loader tree to create the React Component tree.
@@ -59,6 +65,15 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   MetadataOutlet: ComponentType
+  /**
+   * The validation SegmentPath of `loaderTree`, used to record serialized
+   * fork slots for instant validation (see `RecordSerializedForkSlot`).
+   * Callers that render from the route root compute it with
+   * `getValidationSegment` when `workStore.serializedForkSlots` is armed;
+   * callers that render an interior subtree pass null (those renders are
+   * never validated, so nothing is recorded).
+   */
+  validationSegmentPath: SegmentPath | null
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -67,6 +82,28 @@ export function createComponentTree(props: {
     },
     () => createComponentTreeInternal(props, true)
   )
+}
+
+/**
+ * Records that a parallel fork slot's router element was serialized into
+ * the flight payload. Flight executes server components exactly when
+ * they're reachable from the serialized output — including inside a client
+ * component's props, which serialize deeply — so this component executing
+ * is precisely the "this slot was handed to the client" signal. Server
+ * components leave no trace in the payload, so wrapping the slot element
+ * does not change what the client receives.
+ */
+function RecordSerializedForkSlot({
+  slotPath,
+  serializedForkSlots,
+  children,
+}: {
+  slotPath: SegmentPath
+  serializedForkSlots: Set<string>
+  children?: React.ReactNode
+}) {
+  serializedForkSlots.add(slotPath)
+  return children
 }
 
 function errorMissingDefaultExport(
@@ -95,6 +132,7 @@ async function createComponentTreeInternal(
     preloadCallbacks,
     authInterrupts,
     MetadataOutlet,
+    validationSegmentPath,
   }: {
     loaderTree: LoaderTree
     parentParams: Params
@@ -108,6 +146,7 @@ async function createComponentTreeInternal(
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
+    validationSegmentPath: SegmentPath | null
   },
   isRoot: boolean
 ): Promise<CacheNodeSeedData> {
@@ -505,15 +544,38 @@ async function createComponentTreeInternal(
     tree,
   })
 
+  const serializedForkSlots = getSerializedForkSlotsRecorder()
+  const parallelRouteKeys = Object.keys(parallelRoutes)
+  // Fork slots (sibling parallel routes) are the unit of instant
+  // validation's rendered-slot semantics; single-child segments are never
+  // recorded.
+  const childrenAreForkSlots = parallelRouteKeys.length > 1
+
   // TODO: Combine this `map` traversal with the loop below that turns the array
   // into an object.
   const parallelRouteMap = await Promise.all(
-    Object.keys(parallelRoutes).map(
+    parallelRouteKeys.map(
       async (
         parallelRouteKey
       ): Promise<[string, React.ReactNode, CacheNodeSeedData | null]> => {
         const isChildrenRouteKey = parallelRouteKey === 'children'
         const parallelRoute = parallelRoutes[parallelRouteKey]
+
+        // The validation SegmentPath for this slot's subtree. Only
+        // computed while the flight render is recording serialized fork
+        // slots for instant validation.
+        const childValidationSegmentPath =
+          validationSegmentPath !== null && serializedForkSlots !== undefined
+            ? createChildSegmentPath(
+                validationSegmentPath,
+                parallelRouteKey,
+                getValidationSegment(
+                  parallelRoute,
+                  ctx.getDynamicParamFromSegment,
+                  ctx.query
+                )
+              )
+            : null
 
         const notFoundComponent = isChildrenRouteKey
           ? notFoundElement
@@ -599,6 +661,7 @@ async function createComponentTreeInternal(
                 // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
                 // but we only want to throw on the first one.
                 MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
+                validationSegmentPath: childValidationSegmentPath,
               },
               false
             )
@@ -665,35 +728,52 @@ async function createComponentTreeInternal(
             )
           : null
 
-        return [
-          parallelRouteKey,
-          createElement(LayoutRouter, {
-            parallelRouterKey: parallelRouteKey,
-            error: ErrorComponent,
-            errorStyles: wrappedErrorStyles,
-            errorScripts: errorScripts,
-            template:
-              isSegmentViewEnabled && templateFilePath
-                ? createElement(
-                    SegmentViewNode,
-                    {
-                      type: 'template',
-                      pagePath: templateFilePath,
-                    },
-                    templateNode
-                  )
-                : templateNode,
-            templateStyles: templateStyles,
-            templateScripts: templateScripts,
-            notFound: notFoundComponent,
-            forbidden: forbiddenComponent,
-            unauthorized: unauthorizedComponent,
-            ...(isSegmentViewEnabled && {
-              segmentViewBoundaries,
-            }),
+        let slotElement: React.ReactNode = createElement(LayoutRouter, {
+          parallelRouterKey: parallelRouteKey,
+          error: ErrorComponent,
+          errorStyles: wrappedErrorStyles,
+          errorScripts: errorScripts,
+          template:
+            isSegmentViewEnabled && templateFilePath
+              ? createElement(
+                  SegmentViewNode,
+                  {
+                    type: 'template',
+                    pagePath: templateFilePath,
+                  },
+                  templateNode
+                )
+              : templateNode,
+          templateStyles: templateStyles,
+          templateScripts: templateScripts,
+          notFound: notFoundComponent,
+          forbidden: forbiddenComponent,
+          unauthorized: unauthorizedComponent,
+          ...(isSegmentViewEnabled && {
+            segmentViewBoundaries,
           }),
-          childCacheNodeSeedData,
-        ]
+        })
+
+        if (
+          childrenAreForkSlots &&
+          childValidationSegmentPath !== null &&
+          serializedForkSlots !== undefined
+        ) {
+          // Instant validation's rendered-slot semantics need to know
+          // which fork slots the parent's output actually referenced for
+          // this request. The recorder executes exactly when flight
+          // serializes this element and vanishes from the payload.
+          slotElement = createElement(
+            RecordSerializedForkSlot,
+            {
+              slotPath: childValidationSegmentPath,
+              serializedForkSlots,
+            },
+            slotElement
+          )
+        }
+
+        return [parallelRouteKey, slotElement, childCacheNodeSeedData]
       }
     )
   )

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -90,6 +90,12 @@ export interface DevValidationSnapshot {
   optimisticRouting: boolean
   forceStatic: boolean | undefined
   validationLevel: ValidationLevel
+  /**
+   * The parallel fork slots the validated render's flight output
+   * serialized, as validation SegmentPaths (see
+   * `WorkStore.serializedForkSlots`). Null when recording wasn't armed.
+   */
+  serializedForkSlots: string[] | null
   implicitTags: string[]
   /**
    * Pages whose client reference manifests supplied client references to the

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -93,9 +93,16 @@ export interface DevValidationSnapshot {
   /**
    * The parallel fork slots the validated render's flight output
    * serialized, as validation SegmentPaths (see
-   * `WorkStore.serializedForkSlots`). Null when recording wasn't armed.
+   * `RequestStore.serializedForkSlots`). Null when recording wasn't armed.
    */
   serializedForkSlots: string[] | null
+  /**
+   * The fork slots observed mounting during the validated render's
+   * document SSR, settled and complete (see
+   * `RequestStore.mountedForkSlots`). Null when that render had no
+   * document SSR.
+   */
+  mountedForkSlots: string[] | null
   implicitTags: string[]
   /**
    * Pages whose client reference manifests supplied client references to the

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -17,6 +17,22 @@ import { isNodeNextResponse } from '../base-http/helpers'
  * `getDynamicParamFromSegment`) are reconstructed on the worker from this seed.
  * Draining the debug channels is async, so this returns a promise.
  */
+async function serializeMountedForkSlots(
+  instantInputs: ResolvedValidationInputs | null
+): Promise<string[] | null> {
+  if (instantInputs === null) {
+    return null
+  }
+  const { mountedForkSlots, mountedForkSlotsSettled } =
+    instantInputs.requestStore
+  if (mountedForkSlots === undefined || mountedForkSlotsSettled === undefined) {
+    return null
+  }
+  // The mounted set is only complete once the document SSR has settled.
+  await mountedForkSlotsSettled
+  return [...mountedForkSlots]
+}
+
 export async function buildDevValidationSnapshot(
   ctx: AppRenderContext,
   instantInputs: ResolvedValidationInputs | null,
@@ -83,13 +99,14 @@ export async function buildDevValidationSnapshot(
     optimisticRouting: ctx.renderOpts.experimental.optimisticRouting,
     forceStatic: ctx.workStore.forceStatic,
     validationLevel: ctx.workStore.validationLevel,
-    // The recorded set travels with the render that instant validation
-    // consumes; static validation never reads it.
+    // The recorded sets travel with the render that instant validation
+    // consumes; static validation never reads them.
     serializedForkSlots:
       instantInputs !== null &&
       instantInputs.requestStore.serializedForkSlots !== undefined
         ? [...instantInputs.requestStore.serializedForkSlots]
         : null,
+    mountedForkSlots: await serializeMountedForkSlots(instantInputs),
     implicitTags: ctx.implicitTags.tags,
     additionalClientReferenceManifestPages: ctx.workStore
       .additionalClientReferenceManifestPages

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -83,6 +83,13 @@ export async function buildDevValidationSnapshot(
     optimisticRouting: ctx.renderOpts.experimental.optimisticRouting,
     forceStatic: ctx.workStore.forceStatic,
     validationLevel: ctx.workStore.validationLevel,
+    // The recorded set travels with the render that instant validation
+    // consumes; static validation never reads it.
+    serializedForkSlots:
+      instantInputs !== null &&
+      instantInputs.requestStore.serializedForkSlots !== undefined
+        ? [...instantInputs.requestStore.serializedForkSlots]
+        : null,
     implicitTags: ctx.implicitTags.tags,
     additionalClientReferenceManifestPages: ctx.workStore
       .additionalClientReferenceManifestPages

--- a/packages/next/src/server/app-render/instant-validation/boundary-impl.tsx
+++ b/packages/next/src/server/app-render/instant-validation/boundary-impl.tsx
@@ -108,6 +108,43 @@ const InstantValidationBoundary =
     ) as typeof INSTANT_VALIDATION_BOUNDARY_NAME
   ]
 
+// Records that a fork slot's router mounted in the client tree during the
+// document SSR (see `RequestStore.mountedForkSlots`). Called by
+// `OuterLayoutRouter` when its element carries a `validationSlotPath` —
+// which `create-component-tree` only attaches while serialized-fork-slot
+// recording is armed. Typed nullable because the browser variant of this
+// module exports null: mounts are only observed server-side.
+export const recordMountedForkSlot: ((slotPath: string) => void) | null =
+  function recordMountedForkSlot(slotPath: string): void {
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    if (workUnitStore === undefined) {
+      return
+    }
+    switch (workUnitStore.type) {
+      case 'request': {
+        const mountedForkSlots = workUnitStore.mountedForkSlots
+        if (mountedForkSlots !== undefined) {
+          mountedForkSlots.add(slotPath)
+        }
+        return
+      }
+      case 'validation-client':
+      case 'prerender':
+      case 'prerender-client':
+      case 'prerender-ppr':
+      case 'prerender-legacy':
+      case 'prerender-runtime':
+      case 'cache':
+      case 'private-cache':
+      case 'unstable-cache':
+      case 'generate-static-params':
+        return
+      default:
+        workUnitStore satisfies never
+        return
+    }
+  }
+
 // Slot marker component for attributing validation errors to the
 // correct config when a boundary spans multiple parallel slots.
 // Renders a dynamically-named inner component so the slot index

--- a/packages/next/src/server/app-render/instant-validation/boundary-impl.tsx
+++ b/packages/next/src/server/app-render/instant-validation/boundary-impl.tsx
@@ -121,14 +121,14 @@ export const recordMountedForkSlot: ((slotPath: string) => void) | null =
       return
     }
     switch (workUnitStore.type) {
-      case 'request': {
+      case 'request':
+      case 'validation-client': {
         const mountedForkSlots = workUnitStore.mountedForkSlots
         if (mountedForkSlots !== undefined) {
           mountedForkSlots.add(slotPath)
         }
         return
       }
-      case 'validation-client':
       case 'prerender':
       case 'prerender-client':
       case 'prerender-ppr':

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -47,7 +47,6 @@ import type { FlightComponentMod } from '../stream-ops'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createFromNodeStream } from 'react-server-dom-webpack/client'
 import {
-  addSearchParamsIfPageSegment,
   isGroupSegment,
   PAGE_SEGMENT_KEY,
   DEFAULT_SEGMENT_KEY,
@@ -85,8 +84,13 @@ const debug =
 // 1. Validation planning
 //===============================================================
 
-/** Used to identify a segment. Conceptually similar to request keys in the Client Segment Cache. */
-export type SegmentPath = string & { _tag: 'SegmentPath' }
+export type { SegmentPath } from './segment-path'
+import {
+  createChildSegmentPath,
+  getValidationSegment,
+  stringifySegment,
+  type SegmentPath,
+} from './segment-path'
 
 /**
  * Isomorphic to a FlightRouterState, but with extra data attached.
@@ -165,26 +169,6 @@ function traverseCacheNodeSegments(
       processSegment
     )
   }
-}
-
-function createChildSegmentPath(
-  parentPath: SegmentPath,
-  parallelRouteKey: string,
-  segment: Segment
-): SegmentPath {
-  const parallelRoutePrefix =
-    parallelRouteKey === 'children'
-      ? ''
-      : `@${encodeURIComponent(parallelRouteKey)}/`
-  return `${parentPath}/${parallelRoutePrefix}${stringifySegment(segment)}` as SegmentPath
-}
-
-function stringifySegment(segment: Segment): SegmentPath {
-  return (
-    typeof segment === 'string'
-      ? encodeURIComponent(segment)
-      : encodeURIComponent(segment[0]) + '|' + segment[1] + '|' + segment[2]
-  ) as SegmentPath
 }
 
 //===============================================================
@@ -933,7 +917,15 @@ export async function createCombinedPayloadAtDepth(
   boundaryState: ValidationBoundaryTracking,
   clientReferenceManifest: ClientReferenceManifest,
   stageEndTimes: StageEndTimes,
-  useRuntimeStageForPartialSegments: boolean
+  useRuntimeStageForPartialSegments: boolean,
+  /** Fork slots the validated render's flight output serialized (see
+   * `RecordSerializedForkSlot` in `create-component-tree.tsx`). A fork
+   * slot absent from this set is dead for the validated render: nothing
+   * client-side was ever handed its element, so nothing can mount it.
+   * Configs inside dead fork slots are vacuous. Undefined when recording
+   * wasn't armed (e.g. build validation), in which case every config is
+   * considered. */
+  serializedForkSlots: ReadonlySet<string> | undefined
 ): Promise<ValidationPayloadResult | null> {
   const workStore = workAsyncStorage.getStore()
   if (!workStore) {
@@ -985,12 +977,7 @@ export async function createCombinedPayloadAtDepth(
   }
 
   function getSegment(loaderTree: LoaderTree): Segment {
-    const dynamicParam = getDynamicParamFromSegment(loaderTree)
-    if (dynamicParam) {
-      return dynamicParam.treeSegment
-    }
-    const segment = loaderTree[0]
-    return query ? addSearchParamsIfPageSegment(segment, query) : segment
+    return getValidationSegment(loaderTree, getDynamicParamFromSegment, query)
   }
 
   async function buildSharedTreeSeedData(
@@ -998,7 +985,9 @@ export async function createCombinedPayloadAtDepth(
     parentPath: SegmentPath | null,
     key: string | null,
     urlDepthConsumed: number,
-    groupDepthConsumed: number
+    groupDepthConsumed: number,
+    isForkSlot: boolean,
+    parentWithinDeadForkSlot: boolean
   ): Promise<TreeResult> {
     const { parallelRoutes } = parseLoaderTree(loaderTree)
 
@@ -1007,6 +996,13 @@ export async function createCombinedPayloadAtDepth(
       parentPath === null
         ? stringifySegment(segment)
         : createChildSegmentPath(parentPath, key!, segment)
+
+    const isDeadForkSlot =
+      isForkSlot &&
+      serializedForkSlots !== undefined &&
+      !serializedForkSlots.has(path)
+    const withinDeadForkSlot = parentWithinDeadForkSlot || isDeadForkSlot
+    const childrenAreForkSlots = Object.keys(parallelRoutes).length > 1
 
     debug?.(`    ${path || '/'} - Dynamic`)
     const segmentCacheItem = cache.segments.get(path)
@@ -1078,7 +1074,9 @@ export async function createCombinedPayloadAtDepth(
           path,
           parallelRouteKey,
           false /* isInsideRuntimePrefetch */,
-          0 /* segmentDepth */
+          0 /* segmentDepth */,
+          childrenAreForkSlots,
+          withinDeadForkSlot
         )
         slotResults.set(parallelRouteKey, result)
         slots[parallelRouteKey] = result.seedData
@@ -1132,7 +1130,9 @@ export async function createCombinedPayloadAtDepth(
         path,
         parallelRouteKey,
         nextUrlDepth,
-        currentGroupDepth
+        currentGroupDepth,
+        childrenAreForkSlots,
+        withinDeadForkSlot
       )
       slotResults.set(parallelRouteKey, result)
       slots[parallelRouteKey] = result.seedData
@@ -1168,7 +1168,9 @@ export async function createCombinedPayloadAtDepth(
     parentPath: SegmentPath | null,
     key: string | null,
     isInsideRuntimePrefetch: boolean,
-    segmentDepth: number
+    segmentDepth: number,
+    isForkSlot: boolean,
+    parentWithinDeadForkSlot: boolean
   ): Promise<TreeResult> {
     const { parallelRoutes } = parseLoaderTree(lt)
     const { mod: layoutOrPageMod, filePath: layoutOrPageFilePath } =
@@ -1180,6 +1182,13 @@ export async function createCombinedPayloadAtDepth(
       parentPath === null
         ? stringifySegment(segment)
         : createChildSegmentPath(parentPath, key!, segment)
+
+    const isDeadForkSlot =
+      isForkSlot &&
+      serializedForkSlots !== undefined &&
+      !serializedForkSlots.has(path)
+    const withinDeadForkSlot = parentWithinDeadForkSlot || isDeadForkSlot
+    const childrenAreForkSlots = Object.keys(parallelRoutes).length > 1
 
     let instantConfig: Instant | null = null
     let prefetchConfig: AppSegmentConfig['prefetch'] | null = null
@@ -1298,7 +1307,9 @@ export async function createCombinedPayloadAtDepth(
         path,
         parallelRouteKey,
         childIsInsideRuntimePrefetch,
-        childSegmentDepth
+        childSegmentDepth,
+        childrenAreForkSlots,
+        withinDeadForkSlot
       )
       slotResults.set(parallelRouteKey, result)
       slots[parallelRouteKey] = result.seedData
@@ -1341,6 +1352,16 @@ export async function createCombinedPayloadAtDepth(
       configDepth = bestChildConfigDepth
     }
 
+    // A dead fork slot was never serialized into the validated render's
+    // payload, so nothing client-side can mount it or anything below it.
+    // Configs inside it (explicit or implicit) are vacuous: they demand
+    // nothing and cannot block.
+    if (withinDeadForkSlot) {
+      requiresInstantUI = false
+      createInstantStack = null
+      configDepth = -1
+    }
+
     // First mod we find in DFS order: this segment's own layout/page if
     // any, otherwise the first non-null we got from a child.
     const firstModFilePath = localModFilePath ?? childFirstModFilePath
@@ -1360,7 +1381,9 @@ export async function createCombinedPayloadAtDepth(
       null /* parentPath */,
       null /* key */,
       0 /* urlDepthConsumed */,
-      0 /* groupDepthConsumed */
+      0 /* groupDepthConsumed */,
+      false /* isForkSlot */,
+      false /* parentWithinDeadForkSlot */
     )
 
   if (!requiresInstantUI) {

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -918,14 +918,15 @@ export async function createCombinedPayloadAtDepth(
   clientReferenceManifest: ClientReferenceManifest,
   stageEndTimes: StageEndTimes,
   useRuntimeStageForPartialSegments: boolean,
-  /** Fork slots the validated render's flight output serialized (see
-   * `RecordSerializedForkSlot` in `create-component-tree.tsx`). A fork
-   * slot absent from this set is dead for the validated render: nothing
-   * client-side was ever handed its element, so nothing can mount it.
-   * Configs inside dead fork slots are vacuous. Undefined when recording
+  /** Fork slots that can appear in the validated render's client tree:
+   * the document SSR's observed mounted set when one is available,
+   * otherwise the flight render's serialized set (see
+   * `RequestStore.serializedForkSlots` / `mountedForkSlots`). A fork slot
+   * absent from this set is dead for the validated render — nothing can
+   * mount it — so configs inside it are vacuous. Undefined when recording
    * wasn't armed (e.g. build validation), in which case every config is
    * considered. */
-  serializedForkSlots: ReadonlySet<string> | undefined
+  liveForkSlots: ReadonlySet<string> | undefined
 ): Promise<ValidationPayloadResult | null> {
   const workStore = workAsyncStorage.getStore()
   if (!workStore) {
@@ -998,9 +999,7 @@ export async function createCombinedPayloadAtDepth(
         : createChildSegmentPath(parentPath, key!, segment)
 
     const isDeadForkSlot =
-      isForkSlot &&
-      serializedForkSlots !== undefined &&
-      !serializedForkSlots.has(path)
+      isForkSlot && liveForkSlots !== undefined && !liveForkSlots.has(path)
     const withinDeadForkSlot = parentWithinDeadForkSlot || isDeadForkSlot
     const childrenAreForkSlots = Object.keys(parallelRoutes).length > 1
 
@@ -1184,9 +1183,7 @@ export async function createCombinedPayloadAtDepth(
         : createChildSegmentPath(parentPath, key!, segment)
 
     const isDeadForkSlot =
-      isForkSlot &&
-      serializedForkSlots !== undefined &&
-      !serializedForkSlots.has(path)
+      isForkSlot && liveForkSlots !== undefined && !liveForkSlots.has(path)
     const withinDeadForkSlot = parentWithinDeadForkSlot || isDeadForkSlot
     const childrenAreForkSlots = Object.keys(parallelRoutes).length > 1
 

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1447,3 +1447,95 @@ export async function createCombinedPayloadAtDepth(
     slotStacks,
   }
 }
+
+/**
+ * Builds an RSC payload for the fork-slot mount-observation render, used
+ * when the validated render had no document SSR to observe (RSC
+ * navigations, the warm-cache validation render).
+ *
+ * Every segment uses the Dynamic stage — the fully-resolved data from the
+ * validated render — so no server-side data is withheld: server-side fork
+ * decisions are already baked into the recorded Flight data, and only
+ * client components re-execute during the SSR pass. Fork-slot routers in
+ * the recorded data already carry their `validationSlotPath` (attached at
+ * flight time, see `create-component-tree.tsx`), so replaying the chunks
+ * replays the mount reporters; no additional instrumentation is added.
+ */
+export async function createMountObservationPayload(
+  initialRSCPayload: InitialRSCPayload,
+  cache: SegmentCache,
+  initialLoaderTree: LoaderTree,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  query: NextParsedUrlQuery | null,
+  releaseSignal: AbortSignal,
+  clientReferenceManifest: ClientReferenceManifest
+): Promise<InitialRSCPayload> {
+  async function buildObservationTreeSeedData(
+    loaderTree: LoaderTree,
+    parentPath: SegmentPath | null,
+    key: string | null
+  ): Promise<CacheNodeSeedData> {
+    const { parallelRoutes } = parseLoaderTree(loaderTree)
+
+    const segment = getValidationSegment(
+      loaderTree,
+      getDynamicParamFromSegment,
+      query
+    )
+    const path: SegmentPath =
+      parentPath === null
+        ? stringifySegment(segment)
+        : createChildSegmentPath(parentPath, key!, segment)
+
+    const segmentCacheItem = cache.segments.get(path)
+    if (!segmentCacheItem) {
+      throw new InvariantError(`Missing segment data: ${path}`)
+    }
+
+    const segmentData = await deserializeFromChunks<SegmentData>(
+      segmentCacheItem.chunks[RenderStage.Dynamic],
+      segmentCacheItem.chunks[RenderStage.Dynamic],
+      segmentCacheItem.debugChunks,
+      releaseSignal,
+      clientReferenceManifest,
+      null
+    )
+
+    const slots: CacheNodeSeedDataSlots = {}
+    for (const parallelRouteKey in parallelRoutes) {
+      slots[parallelRouteKey] = await buildObservationTreeSeedData(
+        parallelRoutes[parallelRouteKey],
+        path,
+        parallelRouteKey
+      )
+    }
+
+    return getCacheNodeSeedDataFromSegment(segmentData, slots)
+  }
+
+  const seedData = await buildObservationTreeSeedData(
+    initialLoaderTree,
+    null /* parentPath */,
+    null /* key */
+  )
+
+  const { flightRouterState } = getRootDataFromPayload(initialRSCPayload)
+
+  const headCacheItem = cache.head
+  if (!headCacheItem) {
+    throw new InvariantError(`Missing segment data: <head>`)
+  }
+  const head = await deserializeFromChunks<HeadData>(
+    headCacheItem.chunks[RenderStage.Dynamic],
+    headCacheItem.chunks[RenderStage.Dynamic],
+    headCacheItem.debugChunks,
+    releaseSignal,
+    clientReferenceManifest,
+    null
+  )
+
+  return {
+    ...initialRSCPayload,
+    f: [[flightRouterState, seedData, head]],
+  }
+}

--- a/packages/next/src/server/app-render/instant-validation/segment-path.ts
+++ b/packages/next/src/server/app-render/instant-validation/segment-path.ts
@@ -1,0 +1,87 @@
+import type { Segment } from '../../../shared/lib/app-router-types'
+import type { LoaderTree } from '../../lib/app-dir-module'
+import type { GetDynamicParamFromSegment } from '../app-render'
+import type { NextParsedUrlQuery } from '../../request-meta'
+import { addSearchParamsIfPageSegment } from '../../../shared/lib/segment'
+import { workUnitAsyncStorage } from '../work-unit-async-storage.external'
+
+/**
+ * Used to identify a segment during instant validation. Conceptually similar
+ * to request keys in the Client Segment Cache.
+ *
+ * These paths are produced in two places that must agree exactly: the flight
+ * render records serialized fork slots by path (see
+ * `RecordSerializedForkSlot` in `create-component-tree.tsx`), and the
+ * validation payload builders look segments up by path. Always build paths
+ * with the helpers in this module.
+ */
+export type SegmentPath = string & { _tag: 'SegmentPath' }
+
+export function stringifySegment(segment: Segment): SegmentPath {
+  return (
+    typeof segment === 'string'
+      ? encodeURIComponent(segment)
+      : encodeURIComponent(segment[0]) + '|' + segment[1] + '|' + segment[2]
+  ) as SegmentPath
+}
+
+export function createChildSegmentPath(
+  parentPath: SegmentPath,
+  parallelRouteKey: string,
+  segment: Segment
+): SegmentPath {
+  const parallelRoutePrefix =
+    parallelRouteKey === 'children'
+      ? ''
+      : `@${encodeURIComponent(parallelRouteKey)}/`
+  return `${parentPath}/${parallelRoutePrefix}${stringifySegment(segment)}` as SegmentPath
+}
+
+/**
+ * Resolves the Segment used for a LoaderTree node's SegmentPath: the dynamic
+ * param's tree segment when the node is dynamic, otherwise the raw segment
+ * (with search params attached for page segments).
+ */
+export function getValidationSegment(
+  loaderTree: LoaderTree,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  query: NextParsedUrlQuery | null
+): Segment {
+  const dynamicParam = getDynamicParamFromSegment(loaderTree)
+  if (dynamicParam) {
+    return dynamicParam.treeSegment
+  }
+  const segment = loaderTree[0]
+  return query ? addSearchParamsIfPageSegment(segment, query) : segment
+}
+
+/**
+ * The serialized-fork-slot recorder of the render in progress, or undefined
+ * when the current work unit isn't a recording-armed request render. Only
+ * dev renders that will be validated arm recording (see
+ * `RequestStore.serializedForkSlots`).
+ */
+export function getSerializedForkSlotsRecorder(): Set<string> | undefined {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workUnitStore === undefined) {
+    return undefined
+  }
+  switch (workUnitStore.type) {
+    case 'request':
+      return workUnitStore.serializedForkSlots
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'prerender-runtime':
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      return undefined
+    default:
+      workUnitStore satisfies never
+      return undefined
+  }
+}

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -19,6 +19,11 @@ import type { AppRenderContext } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
+import {
+  getSerializedForkSlotsRecorder,
+  getValidationSegment,
+  stringifySegment,
+} from './instant-validation/segment-path'
 import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param'
 
 /**
@@ -277,6 +282,11 @@ export async function walkTreeWithFlightRouterState({
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
         MetadataOutlet,
+        // This render starts at an interior subtree, so its position from
+        // the route root is unknown here. Renders that are validated go
+        // through `createFullTreeFlightDataForNavigation` instead, so no
+        // serialized fork slots need to be recorded on this path.
+        validationSegmentPath: null,
       }
     )
 
@@ -407,6 +417,12 @@ export async function createFullTreeFlightDataForNavigation({
     preloadCallbacks,
     authInterrupts: experimental.authInterrupts,
     MetadataOutlet,
+    validationSegmentPath:
+      getSerializedForkSlotsRecorder() !== undefined
+        ? stringifySegment(
+            getValidationSegment(loaderTree, getDynamicParamFromSegment, query)
+          )
+        : null,
   })
 
   return [

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -107,6 +107,26 @@ export interface RequestStore extends CommonWorkUnitStore {
    * dev renders that will be validated.
    */
   serializedForkSlots?: Set<string>
+
+  /**
+   * DEV-only. When set, the document SSR performed under this store
+   * records here the validation SegmentPath of every serialized fork slot
+   * whose router actually mounted in the client tree (see
+   * `OuterLayoutRouter`). Consumers must await `mountedForkSlotsSettled`
+   * before reading — the set is only complete once the SSR has settled. A
+   * serialized fork slot absent from the settled set did not render
+   * within the instant window (late, effect-mounted UI is not instant
+   * UI), so instant validation treats it as dead too. Undefined when this
+   * render has no document SSR (e.g. RSC navigations) or recording isn't
+   * armed.
+   */
+  mountedForkSlots?: Set<string>
+
+  /**
+   * Resolves once the document SSR has settled and `mountedForkSlots` is
+   * complete. Present exactly when `mountedForkSlots` is.
+   */
+  mountedForkSlotsSettled?: Promise<void>
 }
 
 export type InstantValidationSamples = {

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -178,6 +178,16 @@ export interface ValidationStoreClient extends PrerenderStoreModernCommon {
   validationSamples: InstantValidationSamples | null
   validationSampleTracking: InstantValidationSampleTracking | null
   fallbackRouteParams: OpaqueFallbackRouteParams | null
+  /**
+   * DEV-only. Set only for the fork-slot mount-observation render that
+   * instant validation performs when the validated render had no document
+   * SSR (see `RequestStore.mountedForkSlots` for the document-SSR
+   * variant). Fork-slot routers report their mounts here via
+   * `recordMountedForkSlot`; a serialized fork slot absent from the set
+   * when the observation render settles did not mount within the instant
+   * window and is treated as dead.
+   */
+  mountedForkSlots?: Set<string>
 }
 
 export interface PrerenderStoreModernServer

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -93,6 +93,20 @@ export interface RequestStore extends CommonWorkUnitStore {
 
   // DEV-only
   usedDynamic?: boolean
+
+  /**
+   * DEV-only. When set, the flight render performed under this store
+   * records here the validation SegmentPath of every parallel fork slot
+   * whose router element was serialized into the payload — referenced by
+   * a parent's rendered output, including via a client component's props
+   * (see `RecordSerializedForkSlot` in `create-component-tree.tsx`). A
+   * fork slot absent from this set is dead for this render: no
+   * client-side code was ever handed its element, so nothing can mount
+   * it. Instant validation treats configs inside dead fork slots as
+   * vacuous. Undefined when recording isn't armed; it is armed only for
+   * dev renders that will be validated.
+   */
+  serializedForkSlots?: Set<string>
 }
 
 export type InstantValidationSamples = {

--- a/packages/next/src/shared/lib/instant-messages.ts
+++ b/packages/next/src/shared/lib/instant-messages.ts
@@ -1,3 +1,13 @@
+export function createMountObservationTimeoutError(route: string): Error {
+  return new Error(
+    `Route "${route}": Could not validate that this route has instant navigation.\n\n` +
+      `Next.js could not discover which parallel route slots render because client-side rendering did not settle in time. Something in a Client Component may be preventing rendering from completing.\n\n` +
+      `Ways to fix this:\n` +
+      `  - [retry] Reload the page with a hard refresh to validate against the full document render\n` +
+      `  - [ignore] Set \`export const instant = false\` to opt the route out of instant-navigation validation`
+  )
+}
+
 export function createUnrenderedSegmentError(
   route: string,
   missingFiles: readonly string[]

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -202,6 +202,9 @@ export default async function Page() {
         <li>
           <DebugLinks href="/suspense-in-root/parallel/client-auth-fork" />
         </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/slow-client-auth-fork" />
+        </li>
       </ul>
 
       <h2>Head</h2>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -196,6 +196,12 @@ export default async function Page() {
         <li>
           <DebugLinks href="/suspense-in-root/parallel/auth-fork" />
         </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/auth-fork-with-client-io" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/client-auth-fork" />
+        </li>
       </ul>
 
       <h2>Head</h2>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -193,6 +193,9 @@ export default async function Page() {
         <li>
           <DebugLinks href="/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked" />
         </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/auth-fork" />
+        </li>
       </ul>
 
       <h2>Head</h2>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/@login/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/@login/page.tsx
@@ -1,0 +1,11 @@
+// Renders only when the `logged-in` cookie is absent (see layout).
+// Explicitly allowed to block: when this branch renders, the layout's
+// blocking cookies() read is acknowledged and must not be reported.
+// The sibling children page's error-level config must not apply here
+// because that slot never renders — including when unrelated client IO
+// is pending elsewhere on the page.
+export const instant = false
+
+export default function LoginPage() {
+  return <p>auth-fork-with-client-io — logged-out login page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/client.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/client.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { use } from 'react'
+import { useDataCache } from '../../../../client-data-fetching-lib/client'
+
+// Suspends on client IO during every SSR pass (the per-render data cache
+// starts empty each time). The layout isolates this in a Suspense
+// boundary, so the pending IO is allowed by validation.
+export function FetchesClientData() {
+  const dataCache = useDataCache()
+  const promise = dataCache.getOrLoad('my-key', async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10))
+    return 'My client data result'
+  })
+  const data = use(promise)
+  return <div>Got client data: "{data}"</div>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/layout.tsx
@@ -1,0 +1,40 @@
+import { ReactNode, Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { FetchesClientData } from './client'
+import { DataCacheProvider } from '../../../../client-data-fetching-lib/server'
+
+// Same request-state fork as auth-fork — when the `logged-in` cookie is
+// present only `children` renders, otherwise only `@login` — plus a
+// Suspense-isolated client component that suspends on client IO during
+// every SSR pass. The isolated client IO is allowed by validation and
+// must not affect which fork slot configs are considered: the fork is
+// decided by this server layout, so its outcome is knowable from the
+// serialized payload alone regardless of any pending client IO.
+export default async function AuthForkWithClientIOLayout({
+  children,
+  login,
+}: {
+  children: ReactNode
+  login: ReactNode
+}) {
+  const cookieStore = await cookies()
+  let branchName: string
+  let branch: ReactNode
+  if (cookieStore.has('logged-in')) {
+    branchName = 'children'
+    branch = children
+  } else {
+    branchName = 'login'
+    branch = login
+  }
+  return (
+    <section data-branch={branchName}>
+      <DataCacheProvider>
+        <Suspense fallback={<p>loading client data...</p>}>
+          <FetchesClientData />
+        </Suspense>
+      </DataCacheProvider>
+      {branch}
+    </section>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork-with-client-io/page.tsx
@@ -1,13 +1,12 @@
 // Renders only when the `logged-in` cookie is present (see layout).
 // Requires instant navigation: when this branch renders, the layout's
 // blocking cookies() read must be reported against this config.
-// The build sample simulates a logged-out request, so at build only
-// the @login branch renders and this config is vacuous there too.
+// The build sample simulates a logged-out request.
 export const instant = {
   level: 'experimental-error',
   unstable_samples: [{ cookies: [{ name: 'logged-in', value: null }] }],
 }
 
 export default function LoggedInPage() {
-  return <p>auth-fork — logged-in children page</p>
+  return <p>auth-fork-with-client-io — logged-in children page</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork/@login/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork/@login/page.tsx
@@ -1,0 +1,10 @@
+// Renders only when the `logged-in` cookie is absent (see layout).
+// Explicitly allowed to block: when this branch renders, the layout's
+// blocking cookies() read is acknowledged and must not be reported.
+// The sibling children page's error-level config must not apply here
+// because that slot never renders.
+export const instant = false
+
+export default function LoginPage() {
+  return <p>auth-fork — logged-out login page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork/layout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react'
+import { cookies } from 'next/headers'
+
+// Forks on request state: when the `logged-in` cookie is present only
+// `children` renders; when it is absent only the `@login` slot renders.
+// The unsuspended cookies() read makes this layout itself a blocking
+// hole — whether that hole is a violation depends on the config of the
+// slot that actually rendered in this request.
+export default async function AuthForkLayout({
+  children,
+  login,
+}: {
+  children: ReactNode
+  login: ReactNode
+}) {
+  const cookieStore = await cookies()
+  if (cookieStore.has('logged-in')) {
+    return <section data-branch="children">{children}</section>
+  }
+  return <section data-branch="login">{login}</section>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/auth-fork/page.tsx
@@ -1,0 +1,8 @@
+// Renders only when the `logged-in` cookie is present (see layout).
+// Requires instant navigation: when this branch renders, the layout's
+// blocking cookies() read must be reported against this config.
+export const instant = { level: 'experimental-error' }
+
+export default function LoggedInPage() {
+  return <p>auth-fork — logged-in children page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/@login/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/@login/page.tsx
@@ -1,0 +1,11 @@
+// Renders only when the `logged-in` cookie is absent (see layout and
+// client-fork). Explicitly allowed to block: when this branch renders,
+// the layout's blocking cookies() read is acknowledged and must not be
+// reported. The sibling children page's error-level config must not
+// apply here because that slot never renders — even though it IS
+// serialized into the client component's props.
+export const instant = false
+
+export default function LoginPage() {
+  return <p>client-auth-fork — logged-out login page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/client-fork.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/client-fork.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+// Renders exactly one of the two slots it was handed. Both slots are
+// serialized into this component's props, so which one actually renders
+// is only observable by executing this component during an SSR pass —
+// the server payload alone cannot reveal the outcome.
+export function ClientAuthFork({
+  isLoggedIn,
+  loggedInUI,
+  loggedOutUI,
+}: {
+  isLoggedIn: boolean
+  loggedInUI: ReactNode
+  loggedOutUI: ReactNode
+}) {
+  if (isLoggedIn) {
+    return <section data-branch="children">{loggedInUI}</section>
+  }
+  return <section data-branch="login">{loggedOutUI}</section>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/layout.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react'
+import { cookies } from 'next/headers'
+import { ClientAuthFork } from './client-fork'
+
+// Forks on request state like auth-fork, but the fork decision is made
+// by a CLIENT component: this layout serializes BOTH slots into the
+// client component's props along with the cookie-derived flag. Which
+// branch actually renders is only observable by executing the client
+// component during an SSR pass.
+export default async function ClientAuthForkLayout({
+  children,
+  login,
+}: {
+  children: ReactNode
+  login: ReactNode
+}) {
+  const cookieStore = await cookies()
+  const isLoggedIn = cookieStore.has('logged-in')
+  return (
+    <ClientAuthFork
+      isLoggedIn={isLoggedIn}
+      loggedInUI={children}
+      loggedOutUI={login}
+    />
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/client-auth-fork/page.tsx
@@ -1,0 +1,12 @@
+// Renders only when the `logged-in` cookie is present (see layout and
+// client-fork). Requires instant navigation: when this branch renders,
+// the layout's blocking cookies() read must be reported against this
+// config. The build sample simulates a logged-out request.
+export const instant = {
+  level: 'experimental-error',
+  unstable_samples: [{ cookies: [{ name: 'logged-in', value: null }] }],
+}
+
+export default function LoggedInPage() {
+  return <p>client-auth-fork — logged-in children page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/@login/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/@login/page.tsx
@@ -1,0 +1,7 @@
+// Renders only when the `logged-in` cookie is absent (see layout and
+// slow-client-fork). Explicitly allowed to block.
+export const instant = false
+
+export default function LoginPage() {
+  return <p>slow-client-auth-fork — logged-out login page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/layout.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react'
+import { cookies } from 'next/headers'
+import { SlowClientAuthFork } from './slow-client-fork'
+
+// Like client-auth-fork — a client component decides the fork, so both
+// slots are serialized and validation must observe which branch renders —
+// but the client component burns CPU before rendering. With the
+// observation timeout lowered (see the mount-observation-timeout test),
+// the observation render for client navigations cannot settle in time and
+// validation must report that discovery couldn't complete instead of
+// consuming a partial mounted set.
+export default async function SlowClientAuthForkLayout({
+  children,
+  login,
+}: {
+  children: ReactNode
+  login: ReactNode
+}) {
+  const cookieStore = await cookies()
+  const isLoggedIn = cookieStore.has('logged-in')
+  return (
+    <SlowClientAuthFork
+      isLoggedIn={isLoggedIn}
+      loggedInUI={children}
+      loggedOutUI={login}
+    />
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/page.tsx
@@ -1,0 +1,11 @@
+// Renders only when the `logged-in` cookie is present (see layout and
+// slow-client-fork). Requires instant navigation. The build sample
+// simulates a logged-out request.
+export const instant = {
+  level: 'experimental-error',
+  unstable_samples: [{ cookies: [{ name: 'logged-in', value: null }] }],
+}
+
+export default function LoggedInPage() {
+  return <p>slow-client-auth-fork — logged-in children page</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/slow-client-fork.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slow-client-auth-fork/slow-client-fork.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+// Burns CPU synchronously before rendering its branch, so any SSR pass of
+// this component takes well over a millisecond. Used by the
+// mount-observation timeout test, which lowers the observation timeout via
+// NEXT_TEST_MOUNT_OBSERVATION_TIMEOUT_MS so the observation render is
+// guaranteed to exceed it. Fixed iterations rather than a clock so no
+// sync-IO API (Date.now etc.) is involved.
+function burnCpu() {
+  let acc = 0
+  for (let i = 0; i < 50_000_000; i++) {
+    acc = (acc + i) % 1_000_000_007
+  }
+  return acc
+}
+
+export function SlowClientAuthFork({
+  isLoggedIn,
+  loggedInUI,
+  loggedOutUI,
+}: {
+  isLoggedIn: boolean
+  loggedInUI: ReactNode
+  loggedOutUI: ReactNode
+}) {
+  const burned = burnCpu()
+  if (isLoggedIn) {
+    return (
+      <section data-branch="children" data-burned={burned}>
+        {loggedInUI}
+      </section>
+    )
+  }
+  return (
+    <section data-branch="login" data-burned={burned}>
+      {loggedOutUI}
+    </section>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/layout.tsx
@@ -1,7 +1,7 @@
 // Inner layout intentionally drops `{children}` so the inner page
-// boundary (configured for instant validation) cannot render. This
-// produces a missing-boundary fallback at the inner depth's iteration
-// of the validation loop.
+// (configured for instant validation) never renders. An unrendered
+// segment is vacuous: its config demands nothing and it cannot block
+// anything, so this route must validate cleanly.
 export default function Layout() {
-  return <p>Children intentionally hidden to test multi-depth deferral.</p>
+  return <p>Children intentionally hidden to test unrendered segments.</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/layout.tsx
@@ -1,7 +1,8 @@
-// Inner layout intentionally drops `{children}` so the inner page
-// (configured for instant validation) never renders. An unrendered
-// segment is vacuous: its config demands nothing and it cannot block
-// anything, so this route must validate cleanly.
+// Inner layout intentionally drops its plain `{children}` so the inner
+// page (configured for instant validation) never renders. This is not a
+// fork — there is no sibling slot to render instead — so the configured
+// page below is still considered for validation and the route reports
+// "could not validate".
 export default function Layout() {
   return <p>Children intentionally hidden to test unrendered segments.</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/page.tsx
@@ -1,9 +1,7 @@
 // Inner page configured for instant validation. The parent layout
-// hides `{children}`, so this page never renders — its boundary will
-// never appear in `boundaryState.renderedIds`, producing a missing-
-// boundary fallback at the inner depth's iteration of the validation
-// loop. The outer layout above is also configured but validates
-// cleanly, so the deferred fallback surfaces only at the end.
+// hides `{children}`, so this page never renders — its config is
+// vacuous and must not produce any validation error. The outer layout
+// above is also configured and validates cleanly.
 export const instant = { level: 'experimental-error' }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/inner/page.tsx
@@ -1,7 +1,8 @@
-// Inner page configured for instant validation. The parent layout
-// hides `{children}`, so this page never renders — its config is
-// vacuous and must not produce any validation error. The outer layout
-// above is also configured and validates cleanly.
+// Inner page configured for instant validation. The parent layout hides
+// its plain `{children}` — a non-fork drop, so this segment is still
+// considered for validation and the route must deterministically report
+// "could not validate". The outer layout above is also configured and
+// validates cleanly, exercising the deferred missing-boundary fallback.
 export const instant = { level: 'experimental-error' }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/multi-depth-deferred-fallback/layout.tsx
@@ -1,12 +1,10 @@
 import { ReactNode } from 'react'
 
 // Outer layout: configured for instant validation, no errors. Renders
-// children cleanly so this depth's iteration of the validation loop
-// validates without producing errors or fallback. Used together with
-// the deeper inner page config to exercise the multi-depth deferral
-// path: the inner depth defers a missing-boundary fallback, this
-// (shallower) depth has nothing to report, and the deferred fallback
-// surfaces only after the loop has exhausted every depth.
+// children cleanly so its own validation passes. Used together with
+// the deeper inner page config (whose segment is dropped from
+// rendering by the inner layout) to check that a rendered, clean
+// config validates while the unrendered deeper config stays vacuous.
 export const instant = { level: 'experimental-error' }
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/inter/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/inter/inner/page.tsx
@@ -1,6 +1,7 @@
 // Config lives here, but test-firstmod/layout.tsx (two levels above)
-// drops {children}, so this page never renders. Its config is vacuous
-// and must not produce any validation error.
+// drops its plain {children}, so this page never renders. That drop is
+// not a fork, so this config is still considered for validation and the
+// route reports "could not validate".
 export const instant = { level: 'experimental-error' }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/inter/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/inter/inner/page.tsx
@@ -1,8 +1,6 @@
-// Config lives here (inside __PAGE__ child of inner). The boundary
-// lands at `inner` because of depth iteration, and inner/layout.tsx
-// is the boundary segment's local mod. If firstModFilePath correctly
-// prefers the boundary segment's own layout, the error should point
-// at inner/layout.tsx — not this file.
+// Config lives here, but test-firstmod/layout.tsx (two levels above)
+// drops {children}, so this page never renders. Its config is vacuous
+// and must not produce any validation error.
 export const instant = { level: 'experimental-error' }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/layout.tsx
@@ -1,6 +1,8 @@
-// No config. Hides {children}, so everything below (including the
-// configured inter/inner page) never renders and is vacuous for
-// validation. The route must validate cleanly.
+// No config. Hides its plain {children}, so everything below (including
+// the configured inter/inner page) never renders. This is not a fork —
+// there is no sibling slot to render instead — so the configured page is
+// still considered for validation and the route reports "could not
+// validate" pointing at the shallowest unrendered file.
 import { ReactNode } from 'react'
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-firstmod/layout.tsx
@@ -1,6 +1,6 @@
-// No config. Hides {children} to trigger the missing-boundary fallback.
-// The config lives deeper (inner/leaf/page.tsx), but this layout is
-// what prevents it from rendering.
+// No config. Hides {children}, so everything below (including the
+// configured inter/inner page) never renders and is vacuous for
+// validation. The route must validate cleanly.
 import { ReactNode } from 'react'
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-multi-unrendered/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/test-multi-unrendered/layout.tsx
@@ -1,6 +1,6 @@
 // Drops both {children} and {sidebar}. Both slots have configured
-// pages, so both boundaries will be missing — the error should list
-// both files.
+// pages, but neither renders — both configs are vacuous and the route
+// must validate cleanly.
 import { ReactNode } from 'react'
 
 export default function Layout({

--- a/test/e2e/app-dir/instant-validation/harness.util.ts
+++ b/test/e2e/app-dir/instant-validation/harness.util.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup, type NextInstance, type Playwright } from 'e2e-utils'
-import { waitForValidation } from 'e2e-utils/instant-validation'
+import {
+  getDevCliValidationOutput,
+  waitForValidation,
+} from 'e2e-utils/instant-validation'
 import { retry, waitForNoErrorToast } from '../../../lib/next-test-utils'
 
 export interface InstantValidationCaseContext {
@@ -102,6 +105,15 @@ export function runInstantValidationTests(
       if (start.responseFinished !== undefined) {
         expect(start.responseFinished).toBe(true)
       }
+      // Delivered validation errors are printed between the validation
+      // start/end markers, so asserting on the extracted CLI output is
+      // race-free — unlike the error toast, which the browser may render
+      // after the wait below times out.
+      const validationOutput = await getDevCliValidationOutput(
+        url,
+        getCliOutputSinceMark
+      )
+      expect(validationOutput).not.toContain('Error:')
       await waitForNoErrorToast(browser, NO_VALIDATION_ERRORS_WAIT)
     }
 

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -269,62 +269,149 @@ export function registerHeadAndReportingTests(
     })
   })
 
-  describe('unrendered configured segments are vacuous', () => {
-    // A segment that never appears in the client tree cannot block
-    // anything, so its instant config demands nothing. Validation
-    // determines the set of rendered segments from a full dynamic
-    // render, and only the configs of segments in that set are
-    // considered. A configured segment that a layout drops from
-    // rendering therefore produces no "could not validate" error —
-    // and no warning of any kind.
+  describe('unrendered fork slots are vacuous', () => {
+    // A fork slot that never appears in the client tree cannot block
+    // anything, so its instant config demands nothing. Parallel slots
+    // are the convention for conditionally rendered route UI, and
+    // validation determines which fork slots actually render for the
+    // current request; configs on the unrendered branches are vacuous —
+    // no "could not validate" error, and no warning of any kind.
 
-    it('valid - configured page dropped by its parent layout', async () => {
+    it('valid - multiple configured fork slots dropped by the same layout', async () => {
+      // Layout drops both {children} and {sidebar}. Both slots of the
+      // fork have configured pages; both are vacuous because neither
+      // renders.
+      if (isNextDev) {
+        const browser = await navigateTo(
+          '/suspense-in-root/static/test-multi-unrendered'
+        )
+        await expectNoDevValidationErrors(browser, await browser.url())
+      } else {
+        const result = await prerender(
+          '/suspense-in-root/static/test-multi-unrendered'
+        )
+        expectNoBuildValidationErrors(result)
+      }
+    })
+  })
+
+  describe('unrendered non-fork segments report could-not-validate', () => {
+    // Non-fork segments are always considered for validation. A layout
+    // that drops a plain {children} — with no sibling slot to render
+    // instead — is not expressing a conditional route branch (parallel
+    // slots are the convention for that), so a configured segment below
+    // the drop deterministically reports "could not validate" instead of
+    // being silently skipped.
+
+    it('errors - configured page dropped by its parent layout', async () => {
       // Outer layout has instant and validates cleanly. Inner page has
       // instant but its parent layout drops {children}, so the inner
-      // page never renders and its config is vacuous.
+      // boundary can't render. The deepest iteration's missing-boundary
+      // fallback is deferred while shallower depths run; with no real
+      // error anywhere it surfaces at the end.
       if (isNextDev) {
         const browser = await navigateTo(
           '/suspense-in-root/static/multi-depth-deferred-fallback/inner'
         )
-        await expectNoDevValidationErrors(browser, await browser.url())
+        await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "code": "E1286",
+             "description": "Next.js could not validate that a segment in your UI has instant navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "/suspense-in-root/static/multi-depth-deferred-fallback/inner
+           │
+           │ ├─ suspense-in-root/
+           │ │  ├─ static/
+           │ │  │  ├─ multi-depth-deferred-fallback/
+           │ │  │  │  ├─ inner/
+           │             └─ page.tsx ← dropped from rendering
+           │",
+             "stack": [],
+           }
+          `)
       } else {
         const result = await prerender(
           '/suspense-in-root/static/multi-depth-deferred-fallback/inner'
         )
-        expectNoBuildValidationErrors(result)
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/suspense-in-root/static/multi-depth-deferred-fallback/inner": Could not validate that a segment in your UI has instant navigation.
+
+         This segment was dropped from rendering. Issues that would prevent instant navigation will go undetected.
+
+         Dropped segment:
+           app/suspense-in-root/static/multi-depth-deferred-fallback/inner/page.tsx
+
+         Ways to fix this:
+           - [render] Render the dropped segment
+           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
+
+         Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
+             at ignore-listed frames
+         Build-time instant validation failed for route "/suspense-in-root/static/multi-depth-deferred-fallback/inner".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/multi-depth-deferred-fallback/inner" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).toBe(1)
       }
     })
 
-    it('valid - configured page dropped further up the tree', async () => {
-      // Config is on inter/inner/page.tsx, but test-firstmod/layout.tsx
-      // (two levels above) drops {children}. Nothing below the drop
-      // point renders, so the config is vacuous.
+    it('errors - reports the shallowest unrendered file, not the configured file', async () => {
+      // Config is on inter/inner/page.tsx. The shallowest boundary
+      // iteration lands at test-firstmod, and inter/layout.tsx is the
+      // first child mod that didn't render — not the configured page,
+      // and not test-firstmod/layout.tsx (which DID render but dropped
+      // its children).
       if (isNextDev) {
         const browser = await navigateTo(
           '/suspense-in-root/static/test-firstmod/inter/inner'
         )
-        await expectNoDevValidationErrors(browser, await browser.url())
+        await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "code": "E1286",
+             "description": "Next.js could not validate that a segment in your UI has instant navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "/suspense-in-root/static/test-firstmod/inter/inner
+           │
+           │ ├─ suspense-in-root/
+           │ │  ├─ static/
+           │ │  │  ├─ test-firstmod/
+           │ │  │  │  ├─ inter/
+           │             └─ layout.tsx ← dropped from rendering
+           │",
+             "stack": [],
+           }
+          `)
       } else {
         const result = await prerender(
           '/suspense-in-root/static/test-firstmod/inter/inner'
         )
-        expectNoBuildValidationErrors(result)
-      }
-    })
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/suspense-in-root/static/test-firstmod/inter/inner": Could not validate that a segment in your UI has instant navigation.
 
-    it('valid - multiple configured slots dropped by the same layout', async () => {
-      // Layout drops both {children} and {sidebar}. Both slots have
-      // configured pages; both are vacuous because neither renders.
-      if (isNextDev) {
-        const browser = await navigateTo(
-          '/suspense-in-root/static/test-multi-unrendered'
-        )
-        await expectNoDevValidationErrors(browser, await browser.url())
-      } else {
-        const result = await prerender(
-          '/suspense-in-root/static/test-multi-unrendered'
-        )
-        expectNoBuildValidationErrors(result)
+         This segment was dropped from rendering. Issues that would prevent instant navigation will go undetected.
+
+         Dropped segment:
+           app/suspense-in-root/static/test-firstmod/inter/layout.tsx
+
+         Ways to fix this:
+           - [render] Render the dropped segment
+           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
+
+         Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
+             at ignore-listed frames
+         Build-time instant validation failed for route "/suspense-in-root/static/test-firstmod/inter/inner".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/test-firstmod/inter/inner" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).toBe(1)
       }
     })
   })

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -269,184 +269,62 @@ export function registerHeadAndReportingTests(
     })
   })
 
-  describe('multi-depth fallback deferral', () => {
-    // The validation outer loop iterates from deepest configured depth
-    // to shallowest. When the deepest iteration only produces a missing-
-    // boundary fallback (i.e., the configured boundary didn't render and
-    // there were no thrown errors), that fallback should be deferred so
-    // a real error from a shallower depth can win. If no shallower depth
-    // surfaces a real error, the deferred fallback eventually surfaces
-    // so the user is still made aware that validation didn't complete.
+  describe('unrendered configured segments are vacuous', () => {
+    // A segment that never appears in the client tree cannot block
+    // anything, so its instant config demands nothing. Validation
+    // determines the set of rendered segments from a full dynamic
+    // render, and only the configs of segments in that set are
+    // considered. A configured segment that a layout drops from
+    // rendering therefore produces no "could not validate" error —
+    // and no warning of any kind.
 
-    it('surfaces deferred fallback when no shallower depth has a real error', async () => {
-      // Outer layout has instant and validates cleanly. Inner
-      // page has instant but its parent layout drops {children},
-      // so the inner boundary can't render. Without the deferral, we'd
-      // bail out after the deepest iteration; with deferral, the outer
-      // iteration runs cleanly and the deferred fallback then surfaces.
+    it('valid - configured page dropped by its parent layout', async () => {
+      // Outer layout has instant and validates cleanly. Inner page has
+      // instant but its parent layout drops {children}, so the inner
+      // page never renders and its config is vacuous.
       if (isNextDev) {
         const browser = await navigateTo(
           '/suspense-in-root/static/multi-depth-deferred-fallback/inner'
         )
-        await expect(browser).toDisplayCollapsedRedbox(`
-           {
-             "code": "E1286",
-             "description": "Next.js could not validate that a segment in your UI has instant navigation.",
-             "environmentLabel": "Server",
-             "label": "Instant",
-             "source": "/suspense-in-root/static/multi-depth-deferred-fallback/inner
-           │
-           │ ├─ suspense-in-root/
-           │ │  ├─ static/
-           │ │  │  ├─ multi-depth-deferred-fallback/
-           │ │  │  │  ├─ inner/
-           │             └─ page.tsx ← dropped from rendering
-           │",
-             "stack": [],
-           }
-          `)
+        await expectNoDevValidationErrors(browser, await browser.url())
       } else {
         const result = await prerender(
           '/suspense-in-root/static/multi-depth-deferred-fallback/inner'
         )
-        expect(extractBuildValidationError(result.cliOutput))
-          .toMatchInlineSnapshot(`
-         "Error: Route "/suspense-in-root/static/multi-depth-deferred-fallback/inner": Could not validate that a segment in your UI has instant navigation.
-
-         This segment was dropped from rendering. Issues that would prevent instant navigation will go undetected.
-
-         Dropped segment:
-           app/suspense-in-root/static/multi-depth-deferred-fallback/inner/page.tsx
-
-         Ways to fix this:
-           - [render] Render the dropped segment
-           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
-
-         Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
-             at ignore-listed frames
-         Build-time instant validation failed for route "/suspense-in-root/static/multi-depth-deferred-fallback/inner".
-         To get a more detailed stack trace and pinpoint the issue, try one of the following:
-           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/multi-depth-deferred-fallback/inner" in your browser to investigate the error.
-           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-         Stopping prerender due to instant validation errors."
-        `)
-        expect(result.exitCode).toBe(1)
+        expectNoBuildValidationErrors(result)
       }
     })
-  })
 
-  describe('unrendered segment file reporting', () => {
-    it('reports the shallowest unrendered file, not the configured file', async () => {
-      // Config is on inter/inner/page.tsx. The shallowest boundary
-      // iteration lands at test-firstmod, and inter/layout.tsx is the
-      // first child mod that didn't render — not the configured page,
-      // and not test-firstmod/layout.tsx (which DID render but dropped
-      // its children).
+    it('valid - configured page dropped further up the tree', async () => {
+      // Config is on inter/inner/page.tsx, but test-firstmod/layout.tsx
+      // (two levels above) drops {children}. Nothing below the drop
+      // point renders, so the config is vacuous.
       if (isNextDev) {
         const browser = await navigateTo(
           '/suspense-in-root/static/test-firstmod/inter/inner'
         )
-        await expect(browser).toDisplayCollapsedRedbox(`
-           {
-             "code": "E1286",
-             "description": "Next.js could not validate that a segment in your UI has instant navigation.",
-             "environmentLabel": "Server",
-             "label": "Instant",
-             "source": "/suspense-in-root/static/test-firstmod/inter/inner
-           │
-           │ ├─ suspense-in-root/
-           │ │  ├─ static/
-           │ │  │  ├─ test-firstmod/
-           │ │  │  │  ├─ inter/
-           │             └─ layout.tsx ← dropped from rendering
-           │",
-             "stack": [],
-           }
-          `)
+        await expectNoDevValidationErrors(browser, await browser.url())
       } else {
         const result = await prerender(
           '/suspense-in-root/static/test-firstmod/inter/inner'
         )
-        expect(extractBuildValidationError(result.cliOutput))
-          .toMatchInlineSnapshot(`
-         "Error: Route "/suspense-in-root/static/test-firstmod/inter/inner": Could not validate that a segment in your UI has instant navigation.
-
-         This segment was dropped from rendering. Issues that would prevent instant navigation will go undetected.
-
-         Dropped segment:
-           app/suspense-in-root/static/test-firstmod/inter/layout.tsx
-
-         Ways to fix this:
-           - [render] Render the dropped segment
-           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
-
-         Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
-             at ignore-listed frames
-         Build-time instant validation failed for route "/suspense-in-root/static/test-firstmod/inter/inner".
-         To get a more detailed stack trace and pinpoint the issue, try one of the following:
-           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/test-firstmod/inter/inner" in your browser to investigate the error.
-           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-         Stopping prerender due to instant validation errors."
-        `)
-        expect(result.exitCode).toBe(1)
+        expectNoBuildValidationErrors(result)
       }
     })
 
-    it('reports the boundary segment layout when multiple slots are dropped', async () => {
-      // Layout drops both {children} and {sidebar}. Both have
-      // configured pages, but only one boundary id is created (at
-      // the segment level, covering all slots). The reported file is
-      // the boundary segment's own layout — the nearest mod to the
-      // boundary placement.
+    it('valid - multiple configured slots dropped by the same layout', async () => {
+      // Layout drops both {children} and {sidebar}. Both slots have
+      // configured pages; both are vacuous because neither renders.
       if (isNextDev) {
         const browser = await navigateTo(
           '/suspense-in-root/static/test-multi-unrendered'
         )
-        await expect(browser).toDisplayCollapsedRedbox(`
-           {
-             "code": "E1286",
-             "description": "Next.js could not validate that a segment in your UI has instant navigation.",
-             "environmentLabel": "Server",
-             "label": "Instant",
-             "source": "/suspense-in-root/static/test-multi-unrendered
-           │
-           │ ├─ suspense-in-root/
-           │ │  ├─ static/
-           │ │  │  ├─ test-multi-unrendered/
-           │ │  │  │  ├─ @sidebar/
-           │ │  │  │  │  └─ page.tsx ← dropped from rendering
-           │          └─ page.tsx ← dropped from rendering
-           │",
-             "stack": [],
-           }
-          `)
+        await expectNoDevValidationErrors(browser, await browser.url())
       } else {
         const result = await prerender(
           '/suspense-in-root/static/test-multi-unrendered'
         )
-        expect(extractBuildValidationError(result.cliOutput))
-          .toMatchInlineSnapshot(`
-         "Error: Route "/suspense-in-root/static/test-multi-unrendered": Could not validate that a segment in your UI has instant navigation.
-
-         This segment was dropped from rendering. Issues that would prevent instant navigation will go undetected.
-
-         Dropped segments:
-           app/suspense-in-root/static/test-multi-unrendered/@sidebar/page.tsx
-           app/suspense-in-root/static/test-multi-unrendered/page.tsx
-
-         Ways to fix this:
-           - [render] Render the dropped segment
-           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
-
-         Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
-             at ignore-listed frames
-         Build-time instant validation failed for route "/suspense-in-root/static/test-multi-unrendered".
-         To get a more detailed stack trace and pinpoint the issue, try one of the following:
-           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/static/test-multi-unrendered" in your browser to investigate the error.
-           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-         Stopping prerender due to instant validation errors."
-        `)
-        expect(result.exitCode).toBe(1)
+        expectNoBuildValidationErrors(result)
       }
     })
   })

--- a/test/e2e/app-dir/instant-validation/mount-observation-timeout.test.ts
+++ b/test/e2e/app-dir/instant-validation/mount-observation-timeout.test.ts
@@ -1,0 +1,107 @@
+import { nextTestSetup, type Playwright } from 'e2e-utils'
+import {
+  getDevCliValidationOutput,
+  waitForValidation,
+} from 'e2e-utils/instant-validation'
+import { retry, waitForNoErrorToast } from '../../../lib/next-test-utils'
+
+// Validation observes which fork slots mount by SSR-rendering the
+// validated render's recorded chunks when that render had no document SSR
+// (client navigations). If a Client Component keeps the observation render
+// from settling, validation must give up after a bound and say so rather
+// than consume a partial (under-reporting) mounted set. This suite lowers
+// the bound to a millisecond and navigates to a fixture whose client fork
+// burns CPU, so the observation render is guaranteed to exceed it.
+describe('instant validation - mount observation timeout', () => {
+  const { next, skipped, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+      NEXT_TEST_MOUNT_OBSERVATION_TIMEOUT_MS: '1',
+    },
+  })
+  if (skipped) return
+
+  if (!isNextDev) {
+    // Mount observation only runs in dev; build validation doesn't record
+    // fork slots yet.
+    it.skip('dev-only suite', () => {})
+    return
+  }
+
+  beforeAll(async () => {
+    await next.start()
+  })
+
+  let currentCliOutputIndex = 0
+  beforeEach(() => {
+    currentCliOutputIndex = next.cliOutput.length
+  })
+
+  function getCliOutputSinceMark(): string {
+    if (next.cliOutput.length < currentCliOutputIndex) {
+      currentCliOutputIndex = 0
+    }
+    return next.cliOutput.slice(currentCliOutputIndex)
+  }
+
+  async function expectNoDevValidationErrors(
+    browser: Playwright,
+    url: string
+  ): Promise<void> {
+    await waitForValidation(url, getCliOutputSinceMark)
+    const validationOutput = await getDevCliValidationOutput(
+      url,
+      getCliOutputSinceMark
+    )
+    expect(validationOutput).not.toContain('Error:')
+    await waitForNoErrorToast(browser, { waitInMs: 500 })
+  }
+
+  const href = '/suspense-in-root/parallel/slow-client-auth-fork'
+
+  it('initial load - the document SSR observation is not subject to the observation timeout', async () => {
+    // The document SSR observes mounts as a side effect of the render the
+    // user is already waiting on, and validation starts only after it has
+    // settled — so even a 1ms bound cannot fire. The logged-out branch
+    // renders, the children config is vacuous, and validation passes.
+    const browser = await next.browser(href)
+    const branch = await browser
+      .elementByCss('section[data-branch]')
+      .getAttribute('data-branch')
+    expect(branch).toBe('login')
+    await expectNoDevValidationErrors(browser, await browser.url())
+  })
+
+  it('client navigation - reports when the observation render cannot settle in time', async () => {
+    const browser = await next.browser('/suspense-in-root')
+    await browser
+      .elementByCss(`[data-link-type="soft"][href="${href}"]`)
+      .click()
+    await retry(
+      async () => {
+        expect(await browser.url()).toContain(href)
+      },
+      undefined,
+      100,
+      'wait for url to change'
+    )
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "description": "Route "/suspense-in-root/parallel/slow-client-auth-fork": Could not validate that this route has instant navigation.
+
+     Next.js could not discover which parallel route slots render because client-side rendering did not settle in time. Something in a Client Component may be preventing rendering from completing.
+
+     Ways to fix this:
+       - [retry] Reload the page with a hard refresh to validate against the full document render
+       - [ignore] Set \`export const instant = false\` to opt the route out of instant-navigation validation",
+       "environmentLabel": "Server",
+       "label": "Console Error",
+       "source": null,
+       "stack": [],
+     }
+    `)
+  })
+})

--- a/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
@@ -3,6 +3,7 @@ import {
   expectBuildValidationSkipped,
   expectNoBuildValidationErrors,
   extractBuildValidationError,
+  getDevCliValidationOutput,
   waitForValidation,
 } from 'e2e-utils/instant-validation'
 import { retry, waitForNoErrorToast } from '../../../lib/next-test-utils'
@@ -68,6 +69,15 @@ describe('instant validation - parallel slot configs', () => {
     url: string
   ): Promise<void> {
     await waitForValidation(url, getCliOutputSinceMark)
+    // Delivered validation errors are printed between the validation
+    // start/end markers, so asserting on the extracted CLI output is
+    // race-free — unlike the error toast, which the browser may render
+    // after the wait below times out.
+    const validationOutput = await getDevCliValidationOutput(
+      url,
+      getCliOutputSinceMark
+    )
+    expect(validationOutput).not.toContain('Error:')
     await waitForNoErrorToast(browser, NO_VALIDATION_ERRORS_WAIT)
   }
 
@@ -620,9 +630,11 @@ describe('instant validation - parallel slot configs', () => {
           const browser = await navigateWithCookieState(false)
           await expectNoDevValidationErrors(browser, await browser.url())
         } else {
-          // A build has no request state, so the dynamic discovery render
-          // takes the logged-out branch: @login renders and is allowed to
-          // block while the children config is vacuous.
+          // A build has no request state; the children page declares a
+          // logged-out `unstable_samples` entry (`logged-in` cookie
+          // absent), so the build's discovery render takes the @login
+          // branch: it is allowed to block while the children config is
+          // vacuous.
           const result = await prerender(href)
           expectNoBuildValidationErrors(result)
         }
@@ -638,11 +650,11 @@ describe('instant validation - parallel slot configs', () => {
              "cause": [
                {
                  "label": "Caused by: Instant Validation",
-                 "source": "app/suspense-in-root/parallel/auth-fork/page.tsx (4:24) @ instant
-           > 4 | export const instant = { level: 'experimental-error' }
+                 "source": "app/suspense-in-root/parallel/auth-fork/page.tsx (6:24) @ instant
+           > 6 | export const instant = {
                |                        ^",
                  "stack": [
-                   "instant app/suspense-in-root/parallel/auth-fork/page.tsx (4:24)",
+                   "instant app/suspense-in-root/parallel/auth-fork/page.tsx (6:24)",
                    "Set.forEach <anonymous>",
                  ],
                },
@@ -656,6 +668,185 @@ describe('instant validation - parallel slot configs', () => {
                 |                                    ^",
              "stack": [
                "AuthForkLayout app/suspense-in-root/parallel/auth-fork/layout.tsx (16:36)",
+             ],
+           }
+          `)
+        })
+      }
+    })
+
+    describe('rendered-slot config selection (server fork with unrelated client IO)', () => {
+      // Same request-state fork as auth-fork, plus a Suspense-isolated
+      // client component elsewhere in the layout that suspends on client
+      // IO during every SSR pass. The fork is decided by the server
+      // layout, so which slot renders is knowable from the serialized
+      // payload alone — pending client IO in an unrelated subtree must
+      // not change which fork slot configs are considered. (This is the
+      // determinism case: rendered-slot semantics may not degrade based
+      // on incidental client IO or cache state.)
+      const href = '/suspense-in-root/parallel/auth-fork-with-client-io'
+
+      async function navigateWithCookieState(loggedIn: boolean) {
+        const browser = await next.browser('/suspense-in-root')
+        // The browser context is shared between tests, so clear any
+        // `logged-in` cookie left behind by a previous test.
+        await browser.deleteCookies()
+        if (loggedIn) {
+          await browser.addCookie({ name: 'logged-in', value: '1' })
+        }
+        if (isClientNav) {
+          await browser
+            .elementByCss(`[data-link-type="soft"][href="${href}"]`)
+            .click()
+          await retry(
+            async () => {
+              expect(await browser.url()).toContain(href)
+            },
+            undefined,
+            100,
+            'wait for url to change'
+          )
+        } else {
+          await browser.get(new URL(href, next.url).href)
+        }
+        const branch = await browser
+          .elementByCss('section[data-branch]')
+          .getAttribute('data-branch')
+        expect(branch).toBe(loggedIn ? 'children' : 'login')
+        return browser
+      }
+
+      it('valid - logged out: unrendered children config is vacuous despite pending client IO', async () => {
+        if (isNextDev) {
+          const browser = await navigateWithCookieState(false)
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          // A build has no request state; the children page declares a
+          // logged-out `unstable_samples` entry (`logged-in` cookie
+          // absent), so the build takes the @login branch: it is allowed
+          // to block while the children config is vacuous.
+          const result = await prerender(href)
+          expectNoBuildValidationErrors(result)
+        }
+      })
+
+      if (isNextDev) {
+        // Only the dev server can observe a logged-in request; a build
+        // always renders the cookie-less (logged-out) branch.
+        it('errors - logged in: rendered children config applies despite pending client IO', async () => {
+          const browser = await navigateWithCookieState(true)
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/parallel/auth-fork-with-client-io/page.tsx (5:24) @ instant
+           > 5 | export const instant = {
+               |                        ^",
+                 "stack": [
+                   "instant app/suspense-in-root/parallel/auth-fork-with-client-io/page.tsx (5:24)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1430",
+             "description": "Next.js encountered runtime data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/parallel/auth-fork-with-client-io/layout.tsx (20:36) @ AuthForkWithClientIOLayout
+           > 20 |   const cookieStore = await cookies()
+                |                                    ^",
+             "stack": [
+               "AuthForkWithClientIOLayout app/suspense-in-root/parallel/auth-fork-with-client-io/layout.tsx (20:36)",
+             ],
+           }
+          `)
+        })
+      }
+    })
+
+    describe('rendered-slot config selection (client-component fork)', () => {
+      // Forks on request state like auth-fork, but the fork decision is
+      // made by a CLIENT component: the layout serializes BOTH slots into
+      // the client component's props along with a cookie-derived flag.
+      // The serialized payload alone cannot reveal which branch renders —
+      // only executing the client component during an SSR pass can — so
+      // validation must observe the rendered outcome rather than infer it
+      // from serialization.
+      const href = '/suspense-in-root/parallel/client-auth-fork'
+
+      async function navigateWithCookieState(loggedIn: boolean) {
+        const browser = await next.browser('/suspense-in-root')
+        // The browser context is shared between tests, so clear any
+        // `logged-in` cookie left behind by a previous test.
+        await browser.deleteCookies()
+        if (loggedIn) {
+          await browser.addCookie({ name: 'logged-in', value: '1' })
+        }
+        if (isClientNav) {
+          await browser
+            .elementByCss(`[data-link-type="soft"][href="${href}"]`)
+            .click()
+          await retry(
+            async () => {
+              expect(await browser.url()).toContain(href)
+            },
+            undefined,
+            100,
+            'wait for url to change'
+          )
+        } else {
+          await browser.get(new URL(href, next.url).href)
+        }
+        const branch = await browser
+          .elementByCss('section[data-branch]')
+          .getAttribute('data-branch')
+        expect(branch).toBe(loggedIn ? 'children' : 'login')
+        return browser
+      }
+
+      it('valid - logged out: client-dropped children config is vacuous, rendered @login allows blocking', async () => {
+        if (isNextDev) {
+          const browser = await navigateWithCookieState(false)
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          // A build has no request state; the children page declares a
+          // logged-out `unstable_samples` entry (`logged-in` cookie
+          // absent), so the build observes the @login branch: it is
+          // allowed to block while the children config is vacuous.
+          const result = await prerender(href)
+          expectNoBuildValidationErrors(result)
+        }
+      })
+
+      if (isNextDev) {
+        // Only the dev server can observe a logged-in request; a build
+        // always renders the cookie-less (logged-out) branch.
+        it('errors - logged in: client-rendered children config applies, unrendered @login opt-out is vacuous', async () => {
+          const browser = await navigateWithCookieState(true)
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/parallel/client-auth-fork/page.tsx (5:24) @ instant
+           > 5 | export const instant = {
+               |                        ^",
+                 "stack": [
+                   "instant app/suspense-in-root/parallel/client-auth-fork/page.tsx (5:24)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1430",
+             "description": "Next.js encountered runtime data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/parallel/client-auth-fork/layout.tsx (17:36) @ ClientAuthForkLayout
+           > 17 |   const cookieStore = await cookies()
+                |                                    ^",
+             "stack": [
+               "ClientAuthForkLayout app/suspense-in-root/parallel/client-auth-fork/layout.tsx (17:36)",
              ],
            }
           `)

--- a/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
@@ -529,30 +529,17 @@ describe('instant validation - parallel slot configs', () => {
         }
       })
 
-      it('errors when configured children slot is hidden, no cookies', async () => {
+      it('valid - configured children slot is hidden, no cookies', async () => {
+        // The children page is configured for instant validation but the
+        // layout never renders {children}. A slot that never renders is
+        // vacuous: it cannot block anything and its config demands
+        // nothing, so this must not produce a "could not validate"
+        // error (or any other warning).
         const href =
           '/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked'
         if (isNextDev) {
           const browser = await navigateTo(href)
-          await expect(browser).toDisplayCollapsedRedbox(`
-           {
-             "code": "E1286",
-             "description": "Next.js could not validate that a segment in your UI has instant navigation.",
-             "environmentLabel": "Server",
-             "label": "Instant",
-             "source": "/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked
-           │
-           │ ├─ suspense-in-root/
-           │ │  ├─ parallel/
-           │ │  │  ├─ conditional-breadcrumbs/
-           │ │  │  │  ├─ show-only-breadcrumbs/
-           │ │  │  │  │  ├─ (group)/
-           │ │  │  │  │  │  ├─ unblocked/
-           │                   └─ page.tsx ← dropped from rendering
-           │",
-             "stack": [],
-           }
-          `)
+          await expectNoDevValidationErrors(browser, await browser.url())
         } else {
           // The route group workaround only fires in dev mode; build-time
           // pattern matching doesn't resolve through (group)/ so the
@@ -562,37 +549,17 @@ describe('instant validation - parallel slot configs', () => {
         }
       })
 
-      it('errors when configured children slot is hidden, breadcrumbs blocked', async () => {
+      it('valid - configured children slot is hidden, breadcrumbs blocked', async () => {
+        // The configured children page never renders, so its error-level
+        // config is vacuous and must not be applied to the sibling
+        // breadcrumbs slot. Breadcrumbs itself is unconfigured (the suite
+        // runs with `validationLevel: 'manual-warning'`), so its blocking
+        // cookies() read is acknowledged and no error is reported.
         const href =
           '/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked'
         if (isNextDev) {
           const browser = await navigateTo(href)
-          await expect(browser).toDisplayCollapsedRedbox(`
-           {
-             "cause": [
-               {
-                 "label": "Caused by: Instant Validation",
-                 "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/(group)/blocked/page.tsx (1:24) @ instant
-           > 1 | export const instant = { level: 'experimental-error' }
-               |                        ^",
-                 "stack": [
-                   "instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/(group)/blocked/page.tsx (1:24)",
-                   "Set.forEach <anonymous>",
-                 ],
-               },
-             ],
-             "code": "E1430",
-             "description": "Next.js encountered runtime data during a navigation.",
-             "environmentLabel": "Server",
-             "label": "Instant",
-             "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/@breadcrumbs/blocked/page.tsx (3:16) @ BreadcrumbsPage
-           > 3 |   await cookies()
-               |                ^",
-             "stack": [
-               "BreadcrumbsPage app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/@breadcrumbs/blocked/page.tsx (3:16)",
-             ],
-           }
-          `)
+          await expectNoDevValidationErrors(browser, await browser.url())
         } else {
           // The route group workaround only fires in dev mode; build-time
           // pattern matching doesn't resolve through (group)/ so the
@@ -601,6 +568,99 @@ describe('instant validation - parallel slot configs', () => {
           expectBuildValidationSkipped(result)
         }
       })
+    })
+
+    describe('rendered-slot config selection (request-state fork)', () => {
+      // The auth-fork layout renders exactly one of its two slots based
+      // on the `logged-in` cookie. Validation must determine the set of
+      // rendered slots from a full dynamic render of the actual request
+      // (the fork sits behind a blocking cookies() read, so aborting
+      // validation passes cannot discover it) and only consider the
+      // configs of slots that actually rendered:
+      // - logged out: only @login renders; its `instant = false`
+      //   acknowledges the layout's blocking cookies() read, and the
+      //   children page's error-level config is vacuous.
+      // - logged in: only children renders; its error-level config makes
+      //   the layout's cookies() read a violation, and @login's
+      //   `instant = false` is vacuous.
+      const href = '/suspense-in-root/parallel/auth-fork'
+
+      async function navigateWithCookieState(loggedIn: boolean) {
+        const browser = await next.browser('/suspense-in-root')
+        // The browser context is shared between tests, so clear any
+        // `logged-in` cookie left behind by a previous test.
+        await browser.deleteCookies()
+        if (loggedIn) {
+          await browser.addCookie({ name: 'logged-in', value: '1' })
+        }
+        if (isClientNav) {
+          await browser
+            .elementByCss(`[data-link-type="soft"][href="${href}"]`)
+            .click()
+          await retry(
+            async () => {
+              expect(await browser.url()).toContain(href)
+            },
+            undefined,
+            100,
+            'wait for url to change'
+          )
+        } else {
+          await browser.get(new URL(href, next.url).href)
+        }
+        const branch = await browser
+          .elementByCss('section[data-branch]')
+          .getAttribute('data-branch')
+        expect(branch).toBe(loggedIn ? 'children' : 'login')
+        return browser
+      }
+
+      it('valid - logged out: unrendered children config is vacuous, rendered @login allows blocking', async () => {
+        if (isNextDev) {
+          const browser = await navigateWithCookieState(false)
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          // A build has no request state, so the dynamic discovery render
+          // takes the logged-out branch: @login renders and is allowed to
+          // block while the children config is vacuous.
+          const result = await prerender(href)
+          expectNoBuildValidationErrors(result)
+        }
+      })
+
+      if (isNextDev) {
+        // Only the dev server can observe a logged-in request; a build
+        // always renders the cookie-less (logged-out) branch.
+        it('errors - logged in: rendered children config applies, unrendered @login opt-out is vacuous', async () => {
+          const browser = await navigateWithCookieState(true)
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/parallel/auth-fork/page.tsx (4:24) @ instant
+           > 4 | export const instant = { level: 'experimental-error' }
+               |                        ^",
+                 "stack": [
+                   "instant app/suspense-in-root/parallel/auth-fork/page.tsx (4:24)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1430",
+             "description": "Next.js encountered runtime data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/parallel/auth-fork/layout.tsx (16:36) @ AuthForkLayout
+           > 16 |   const cookieStore = await cookies()
+                |                                    ^",
+             "stack": [
+               "AuthForkLayout app/suspense-in-root/parallel/auth-fork/layout.tsx (16:36)",
+             ],
+           }
+          `)
+        })
+      }
     })
   })
 })


### PR DESCRIPTION
There can be complex App Router setups with parallel routes that lead to surprising insights where you might opt out of instant in one slot but another slot is matched for the URL and because that slot doesn't opt out we report blocking UI. Sometimes this is useful because you might not have realized that, for example, your breadcrumbs slot is blocking your main content.

However sometimes some slots are not even rendered, for example, you might have a login slot that is only conditionally rendered if you are logged out.

To limit confusion instant insights will now use the rendered slots for the actual dev request to determine which slots contribute to the page. It will ignore validation configuration for un-rendered slots.

For simple cases (no parallel slots) we still assume the entire tree is rendered
To avoid doing extra work we use the actual dev SSR render pass to determine which slots rendered. If we are doing a client navigation we kick off a discovery SSR render that aborts as soon as we've discovered all slots.