### PR TITLE
Fix empty Fragment scroll ownership

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -172,6 +172,14 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
 
     if (hashFragment) {
       domNode = getHashFragmentDomNode(hashFragment)
+      if (domNode === null) {
+        // A missing hash target is still a handled scroll intent. Do not
+        // fall back to the route segment or leave the intent pending.
+        scrollRef.current = false
+        focusAndScrollRef.onlyHashChange = false
+        focusAndScrollRef.hashFragment = null
+        return
+      }
     }
 
     // `findDOMNode` is tricky because it returns just the first child if the component is a fragment.
@@ -288,14 +296,18 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
 
       let instance: FragmentInstance | HTMLElement | null = null
       const hashFragment = focusAndScrollRef.hashFragment
-      let isHashTarget = false
 
       if (hashFragment) {
         instance = getHashFragmentDomNode(hashFragment)
-        isHashTarget = instance !== null
-      }
-
-      if (!instance) {
+        if (instance === null) {
+          // A missing hash target is still a handled scroll intent. Do not
+          // fall back to the route Fragment or leave the intent pending.
+          scrollRef.current = false
+          focusAndScrollRef.onlyHashChange = false
+          focusAndScrollRef.hashFragment = null
+          return
+        }
+      } else {
         instance = childrenRef.current
       }
 
@@ -312,7 +324,7 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
           let viewportHeight: number | null = null
           let initialTargetState: ScrollTargetState | null = null
 
-          if (!isHashTarget) {
+          if (!hashFragment) {
             // Store the current viewport height because reading `clientHeight` causes a reflow,
             // and it won't change during this function.
             viewportHeight = htmlElement.clientHeight

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -101,17 +101,22 @@ function shouldSkipElement(element: HTMLElement) {
   return rectProperties.every((item) => rect[item] === 0)
 }
 
+const enum ScrollTargetState {
+  NoClientRects,
+  InViewport,
+  OutOfViewport,
+}
+
 /**
- * Check if the top corner of the HTMLElement is in the viewport.
+ * Check where the top corner of the HTMLElement is relative to the viewport.
  */
-function topOfElementInViewport(
+function getScrollTargetState(
   instance: HTMLElement | FragmentInstance,
   viewportHeight: number
-): boolean {
+): ScrollTargetState {
   const rects = instance.getClientRects()
   if (rects.length === 0) {
-    // Just to be explicit.
-    return false
+    return ScrollTargetState.NoClientRects
   }
   let elementTop = Number.POSITIVE_INFINITY
   for (let i = 0; i < rects.length; i++) {
@@ -121,6 +126,8 @@ function topOfElementInViewport(
     }
   }
   return elementTop >= 0 && elementTop <= viewportHeight
+    ? ScrollTargetState.InViewport
+    : ScrollTargetState.OutOfViewport
 }
 
 /**
@@ -212,7 +219,10 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
         const viewportHeight = htmlElement.clientHeight
 
         // If the element's top edge is already in the viewport, exit early.
-        if (topOfElementInViewport(domNode, viewportHeight)) {
+        if (
+          getScrollTargetState(domNode, viewportHeight) ===
+          ScrollTargetState.InViewport
+        ) {
           return
         }
 
@@ -223,7 +233,10 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
         htmlElement.scrollTop = 0
 
         // Scroll to domNode if domNode is not in viewport when scrolled to top of document
-        if (!topOfElementInViewport(domNode, viewportHeight)) {
+        if (
+          getScrollTargetState(domNode, viewportHeight) !==
+          ScrollTargetState.InViewport
+        ) {
           // Scroll into view doesn't scroll horizontally by default when not needed
           domNode.scrollIntoView()
         }
@@ -274,9 +287,11 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
 
       let instance: FragmentInstance | HTMLElement | null = null
       const hashFragment = focusAndScrollRef.hashFragment
+      let isHashTarget = false
 
       if (hashFragment) {
         instance = getHashFragmentDomNode(hashFragment)
+        isHashTarget = instance !== null
       }
 
       if (!instance) {
@@ -288,27 +303,45 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
         return
       }
 
-      // Mark as scrolled so no other segment scrolls for this navigation.
-      scrollRef.current = false
-
-      // This handler intentionally leaves focus untouched; resetting focus on
-      // navigation is deferred.
+      let didHandleScroll = false
 
       disableSmoothScrollDuringRouteTransition(
         () => {
+          const htmlElement = document.documentElement
+          let viewportHeight: number | null = null
+          let initialTargetState: ScrollTargetState | null = null
+
+          if (!isHashTarget) {
+            // Store the current viewport height because reading `clientHeight` causes a reflow,
+            // and it won't change during this function.
+            viewportHeight = htmlElement.clientHeight
+            initialTargetState = getScrollTargetState(instance, viewportHeight)
+
+            // An empty Fragment is not a scroll target. In particular, avoid
+            // React's sibling fallback and leave the scroll signal available
+            // for another changed segment.
+            if (initialTargetState === ScrollTargetState.NoClientRects) {
+              return
+            }
+          }
+
+          didHandleScroll = true
+
+          // Mark as scrolled so no other segment scrolls for this navigation.
+          scrollRef.current = false
+
+          // This handler intentionally leaves focus untouched; resetting focus on
+          // navigation is deferred.
+
           // In case of hash scroll, we only need to scroll the element into view
           if (hashFragment) {
             instance.scrollIntoView()
 
             return
           }
-          // Store the current viewport height because reading `clientHeight` causes a reflow,
-          // and it won't change during this function.
-          const htmlElement = document.documentElement
-          const viewportHeight = htmlElement.clientHeight
 
           // If the element's top edge is already in the viewport, exit early.
-          if (topOfElementInViewport(instance, viewportHeight)) {
+          if (initialTargetState === ScrollTargetState.InViewport) {
             return
           }
 
@@ -319,7 +352,10 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
           htmlElement.scrollTop = 0
 
           // Scroll to domNode if domNode is not in viewport when scrolled to top of document
-          if (!topOfElementInViewport(instance, viewportHeight)) {
+          if (
+            getScrollTargetState(instance, viewportHeight!) ===
+            ScrollTargetState.OutOfViewport
+          ) {
             // Scroll into view doesn't scroll horizontally by default when not needed
             instance.scrollIntoView()
           }
@@ -330,6 +366,10 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
           onlyHashChange: focusAndScrollRef.onlyHashChange,
         }
       )
+
+      if (!didHandleScroll) {
+        return
+      }
 
       // Mutate after scrolling so that it can be read by `disableSmoothScrollDuringRouteTransition`
       focusAndScrollRef.onlyHashChange = false

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -146,7 +146,8 @@ function getHashFragmentDomNode(hashFragment: string) {
   return (
     document.getElementById(hashFragment) ??
     // If the hash fragment is a name, the page has to scroll to the first element with that name.
-    document.getElementsByName(hashFragment)[0]
+    document.getElementsByName(hashFragment)[0] ??
+    null
   )
 }
 interface ScrollAndMaybeFocusHandlerProps {

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/(.)visible/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/@modal/(.)visible/page.tsx
@@ -1,0 +1,3 @@
+export default function InterceptedModal() {
+  return <div id="visible-modal">Visible modal</div>
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
@@ -4,6 +4,7 @@ export default function Page() {
   return (
     <div id="modal-page" style={{ minHeight: 2400 }}>
       <h1>Modal page</h1>
+      <input id="focus-target" aria-label="Focus target" />
       <Link
         id="open-empty-modal"
         href="/modal/open"

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function Page() {
   return (
-    <div id="modal-page" style={{ minHeight: 2400 }}>
+    <div id="modal-page" style={{ minHeight: 3200 }}>
       <h1>Modal page</h1>
       <input id="focus-target" aria-label="Focus target" />
       <Link
@@ -18,6 +18,35 @@ export default function Page() {
       >
         Open empty modal
       </Link>
+      <Link
+        id="open-empty-modal-missing-hash"
+        href="/modal/open#missing-target"
+        style={{
+          position: 'fixed',
+          top: 80,
+          right: 20,
+          padding: 12,
+          background: 'white',
+        }}
+      >
+        Open empty modal with missing hash
+      </Link>
+      <Link
+        id="open-empty-modal-real-hash"
+        href="/modal/open#hash-target"
+        style={{
+          position: 'fixed',
+          top: 140,
+          right: 20,
+          padding: 12,
+          background: 'white',
+        }}
+      >
+        Open empty modal with real hash
+      </Link>
+      <div id="hash-target" style={{ marginTop: 1800 }}>
+        Hash target
+      </div>
     </div>
   )
 }

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/page.tsx
@@ -19,8 +19,8 @@ export default function Page() {
         Open empty modal
       </Link>
       <Link
-        id="open-empty-modal-missing-hash"
-        href="/modal/open#missing-target"
+        id="open-modal-missing-hash"
+        href="/modal/visible#missing-target"
         style={{
           position: 'fixed',
           top: 80,
@@ -29,7 +29,7 @@ export default function Page() {
           background: 'white',
         }}
       >
-        Open empty modal with missing hash
+        Open visible modal with missing hash
       </Link>
       <Link
         id="open-empty-modal-real-hash"

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/visible/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/app/modal/visible/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Canonical visible modal page</p>
+}

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
@@ -51,18 +51,23 @@ describe.each([false, true])(
       )
     })
 
-    it('preserves scroll and focus when the hash target is missing', async () => {
+    it('consumes a missing hash without scrolling or blurring', async () => {
       const browser = await next.browser('/modal')
 
       const initialScroll = await browser.eval(`
           window.scrollTo(0, 1200)
           document.getElementById('focus-target').focus({ preventScroll: true })
-          document.getElementById('open-empty-modal-missing-hash').click()
+          document.getElementById('open-modal-missing-hash').click()
           window.scrollY
         `)
       await retry(async () => {
         expect(await browser.url()).toBe(
-          `${next.url}/modal/open#missing-target`
+          `${next.url}/modal/visible#missing-target`
+        )
+      })
+      await retry(async () => {
+        expect(await browser.elementByCss('#visible-modal').text()).toBe(
+          'Visible modal'
         )
       })
 

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
@@ -43,9 +43,52 @@ describe.each([false, true])(
         expect(await browser.url()).toBe(`${next.url}/modal/open`)
       })
 
+      await browser.eval(
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+      )
       expect(await browser.eval('document.activeElement.id')).toBe(
         'focus-target'
       )
+    })
+
+    it('preserves scroll and focus when the hash target is missing', async () => {
+      const browser = await next.browser('/modal')
+
+      const initialScroll = await browser.eval(`
+          window.scrollTo(0, 1200)
+          document.getElementById('focus-target').focus({ preventScroll: true })
+          document.getElementById('open-empty-modal-missing-hash').click()
+          window.scrollY
+        `)
+      await retry(async () => {
+        expect(await browser.url()).toBe(
+          `${next.url}/modal/open#missing-target`
+        )
+      })
+
+      await browser.eval(
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+      )
+      expect(await browser.eval('window.scrollY')).toBe(initialScroll)
+      expect(await browser.eval('document.activeElement.id')).toBe(
+        'focus-target'
+      )
+    })
+
+    it('scrolls to a real hash target', async () => {
+      const browser = await next.browser('/modal')
+
+      await browser.elementByCss('#open-empty-modal-real-hash').click()
+      await retry(async () => {
+        expect(await browser.url()).toBe(`${next.url}/modal/open#hash-target`)
+      })
+
+      await retry(async () => {
+        const targetTop = await browser.eval(
+          "document.getElementById('hash-target').getBoundingClientRect().top"
+        )
+        expect(Math.abs(targetTop)).toBeLessThan(1)
+      })
     })
   }
 )

--- a/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
+++ b/test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts
@@ -13,26 +13,39 @@ describe.each([false, true])(
       },
     })
 
-    /* eslint-disable jest/no-standalone-expect */
-    ;(appNewScrollHandler ? it.failing : it)(
-      'preserves scroll when an empty intercepted modal is the only changed slot',
-      async () => {
-        const browser = await next.browser('/modal')
+    it('preserves scroll when an empty intercepted modal is the only changed slot', async () => {
+      const browser = await next.browser('/modal')
 
-        await browser.eval('window.scrollTo(0, 1200)')
-        const initialScroll = await browser.eval('window.scrollY')
-        expect(initialScroll).toBeGreaterThan(0)
+      await browser.eval('window.scrollTo(0, 1200)')
+      const initialScroll = await browser.eval('window.scrollY')
+      expect(initialScroll).toBeGreaterThan(0)
 
-        await browser.elementByCss('#open-empty-modal').click()
-        await retry(async () => {
-          expect(await browser.url()).toBe(`${next.url}/modal/open`)
-        })
+      await browser.elementByCss('#open-empty-modal').click()
+      await retry(async () => {
+        expect(await browser.url()).toBe(`${next.url}/modal/open`)
+      })
 
-        await retry(async () => {
-          expect(await browser.eval('window.scrollY')).toBe(initialScroll)
-        })
-      }
-    )
-    /* eslint-enable jest/no-standalone-expect */
+      await browser.eval(
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+      )
+      expect(await browser.eval('window.scrollY')).toBe(initialScroll)
+    })
+
+    it('does not blur focus when the empty slot cannot handle scroll', async () => {
+      const browser = await next.browser('/modal')
+
+      await browser.eval(`
+          window.scrollTo(0, 1200)
+          document.getElementById('focus-target').focus({ preventScroll: true })
+          document.getElementById('open-empty-modal').click()
+        `)
+      await retry(async () => {
+        expect(await browser.url()).toBe(`${next.url}/modal/open`)
+      })
+
+      expect(await browser.eval('document.activeElement.id')).toBe(
+        'focus-target'
+      )
+    })
   }
 )


### PR DESCRIPTION
## Summary

- treat Fragment instances without client rects as unavailable route scroll targets
- leave the shared scroll signal unconsumed so another changed segment can handle an empty route Fragment
- avoid focus and scroll side effects when an empty segment cannot claim ownership
- consume and clear an explicit hash intent when no matching target exists, without falling back to route content
- cover empty and visible intercepted routes across both scroll handlers, including focus preservation and real hash scrolling

This PR is stacked on #96323, which provides the minimal reproduction.

## Verification

- `HEADLESS=true pnpm test-dev-turbo test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts` (8/8)
- `HEADLESS=true pnpm test-dev-webpack test/e2e/app-dir/parallel-routes-scroll-owner/parallel-routes-scroll-owner.test.ts` (8/8)
- `HEADLESS=true pnpm test-dev-turbo test/e2e/app-dir/navigation-focus/navigation-focus.test.ts` (5/5)

<!-- NEXT_JS_LLM -->