### PR TITLE
[Instant] Point to first blocking await in validation

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1458,5 +1458,7 @@
   "1457": "Expected prerender classification data for PPR route \"%s\"",
   "1458": "Expected complete prerender classification for route \"%s\"",
   "1459": "[Server HMR] unreachable: unknown HMR instruction type %s",
-  "1460": "[Server HMR] unreachable: unexpected update instruction type %s"
+  "1460": "[Server HMR] unreachable: unexpected update instruction type %s",
+  "1461": "Expected segment cache to have data for stage '%s'",
+  "1462": "Unexpected chunk emitted in Before stage"
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -323,7 +323,7 @@ import { ResponseCookies } from '../web/spec-extension/cookies'
 import { isInstantValidationError } from './instant-validation/instant-validation-error'
 import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
 import { RENDER_STAGES_BY_DATA_KIND } from '../dynamic-rendering-utils'
-import type { ValidationPrefetchKind } from './instant-validation/instant-validation'
+import type { StageEndTimes } from './instant-validation/instant-validation'
 import { hasNonRootStaticParams } from '../lib/params-utils'
 
 export type GetDynamicParamFromSegment = (
@@ -4382,8 +4382,7 @@ interface SyncInterruptedStagedDevRender {
 interface StagedDevRenderArtifacts {
   readonly accumulatedChunks: AccumulatedStreamChunks
   readonly startTime: number
-  readonly staticStageEndTime: number
-  readonly runtimeStageEndTime: number
+  readonly stageEndTimes: StageEndTimes
 }
 
 /**
@@ -4795,8 +4794,7 @@ async function prepareValidationInputs(
     inputsFromNavigation = {
       accumulatedChunks: result.outcome.accumulatedChunks,
       startTime: result.outcome.startTime,
-      staticStageEndTime: result.outcome.staticStageEndTime,
-      runtimeStageEndTime: result.outcome.runtimeStageEndTime,
+      stageEndTimes: result.outcome.stageEndTimes,
       requestStore,
       debugChannelClient: validationDebugChannel,
     }
@@ -5421,14 +5419,25 @@ async function streamStagedRenderInDev({
         ? { syncInterruptReason }
         : {
             startTime,
-            staticStageEndTime: stageController.getStaticStageEndTime(),
-            runtimeStageEndTime: stageController.getRuntimeStageEndTime(),
+            stageEndTimes: getStageEndTimes(stageController),
             accumulatedChunks,
           },
     }
   })
 
   return { stream, resultPromise }
+}
+
+function getStageEndTimes(
+  stageController: StagedRenderingController
+): StageEndTimes {
+  return {
+    [RenderStage.Static]: stageController.getStageEndTime(RenderStage.Static),
+    [RenderStage.ShellRuntime]: stageController.getStageEndTime(
+      RenderStage.ShellRuntime
+    ),
+    [RenderStage.Runtime]: stageController.getStageEndTime(RenderStage.Runtime),
+  }
 }
 
 async function renderWithWarmCachesForValidationInDev(
@@ -5517,8 +5526,7 @@ async function renderWithWarmCachesForValidationInDev(
   return {
     accumulatedChunks,
     startTime,
-    staticStageEndTime: stageController.getStaticStageEndTime(),
-    runtimeStageEndTime: stageController.getRuntimeStageEndTime(),
+    stageEndTimes: getStageEndTimes(stageController),
     requestStore,
     debugChannelClient: debugChannel?.clientSide.readable,
   }
@@ -5650,8 +5658,7 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
   return {
     accumulatedChunks: collectedChunksByStage,
     startTime,
-    staticStageEndTime: stageController.getStaticStageEndTime(),
-    runtimeStageEndTime: stageController.getRuntimeStageEndTime(),
+    stageEndTimes: getStageEndTimes(stageController),
     requestStore,
     debugChannelClient: debugChannel?.clientSide.readable,
   }
@@ -6352,8 +6359,7 @@ function toDevValidationInputs(
   return {
     accumulatedChunks: serialized.accumulatedChunks,
     startTime: serialized.startTime,
-    staticStageEndTime: serialized.staticStageEndTime,
-    runtimeStageEndTime: serialized.runtimeStageEndTime,
+    stageEndTimes: serialized.stageEndTimes,
     requestStore,
     debugChannelClient: serialized.debugChunks
       ? createNodeStreamFromChunks(serialized.debugChunks)
@@ -6592,6 +6598,7 @@ async function runValidationInDev(
       inputs.accumulatedChunks,
       debugChunks,
       inputs.startTime,
+      inputs.stageEndTimes,
       rootParams,
       fallbackRouteParams,
       ctx,
@@ -6641,7 +6648,7 @@ async function validateStaticShell(
 
   const loaderTree = ComponentMod.routeModule.userland.loaderTree
 
-  const { accumulatedChunks, staticStageEndTime, runtimeStageEndTime } = inputs
+  const { accumulatedChunks, stageEndTimes } = inputs
   const { staticChunks, runtimeChunks, dynamicChunks } = accumulatedChunks
 
   const allowEmptyStaticShell =
@@ -6652,7 +6659,7 @@ async function validateStaticShell(
     runtimeChunks,
     dynamicChunks,
     debugChunks,
-    runtimeStageEndTime,
+    stageEndTimes[RenderStage.Runtime],
     rootParams,
     fallbackRouteParams,
     allowEmptyStaticShell,
@@ -6677,7 +6684,7 @@ async function validateStaticShell(
     staticChunks,
     dynamicChunks,
     debugChunks,
-    staticStageEndTime,
+    stageEndTimes[RenderStage.Static],
     rootParams,
     fallbackRouteParams,
     allowEmptyStaticShell,
@@ -7054,6 +7061,7 @@ async function validateInstantConfigs(
   accumulatedChunks: AccumulatedStreamChunks,
   debugChunks: null | Array<Uint8Array>,
   startTime: number,
+  stageEndTimes: StageEndTimes,
   rootParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   ctx: ValidationRenderContext,
@@ -7078,6 +7086,11 @@ async function validateInstantConfigs(
 
   debug?.('\nStarting depth-based instant validation...')
 
+  const prefetchKind =
+    prefetchMode === PrefetchingMode.Partial
+      ? ValidationPrefetchKind.Shell
+      : ValidationPrefetchKind.LegacySpeculative
+
   const loaderTree = ctx.componentMod.routeModule.userland.loaderTree
 
   const clientReferenceManifest = getClientReferenceManifest()
@@ -7089,11 +7102,8 @@ async function validateInstantConfigs(
     ? createNodeDebugChannel
     : createWebDebugChannel
 
-  const {
-    cache,
-    payload: initialRscPayload,
-    stageEndTimes,
-  } = await collectStagedSegmentData(
+  const { cache, payload: initialRscPayload } = await collectStagedSegmentData(
+    prefetchKind,
     ctx.componentMod,
     renderFlightStream,
     {
@@ -7104,6 +7114,7 @@ async function validateInstantConfigs(
     },
     debugChunks,
     startTime,
+    stageEndTimes,
     clientReferenceManifest,
     createDebugChannel
   )
@@ -7111,20 +7122,13 @@ async function validateInstantConfigs(
   const { implicitTags, nonce, workStore, isDebugChannelEnabled } = ctx
 
   async function validateAtDepth(
-    prefetchKind: ValidationPrefetchKind,
     depth: number,
     groupDepthForValidation: number
   ): Promise<null | NavigationValidationResult> {
-    return validateAtDepthImpl(
-      prefetchKind,
-      depth,
-      groupDepthForValidation,
-      null
-    )
+    return validateAtDepthImpl(depth, groupDepthForValidation, null)
   }
 
   async function validateAtDepthImpl(
-    prefetchKind: ValidationPrefetchKind,
     depth: number,
     groupDepthForValidation: number,
     previousBoundaryState: null | ValidationBoundaryTracking
@@ -7161,7 +7165,6 @@ async function validateInstantConfigs(
       extraChunksSignal,
       boundaryState,
       clientReferenceManifest,
-      stageEndTimes,
       useRuntimeStageForPartialSegments
     )
 
@@ -7372,7 +7375,6 @@ async function validateInstantConfigs(
       }
 
       const dynamicOnlyResult = await validateAtDepthImpl(
-        prefetchKind,
         depth,
         groupDepthForValidation,
         boundaryState
@@ -7395,11 +7397,6 @@ async function validateInstantConfigs(
   const maxDepth = groupDepthsByUrlDepth.length
 
   let impairedValidation: null | Error | AggregateError = null
-
-  const prefetchKind =
-    prefetchMode === PrefetchingMode.Partial
-      ? ValidationPrefetchKind.Shell
-      : ValidationPrefetchKind.LegacySpeculative
 
   for (let depth = maxDepth - 1; depth >= 0; depth--) {
     const maxGroupDepth = groupDepthsByUrlDepth[depth]
@@ -7424,11 +7421,7 @@ async function validateInstantConfigs(
         return []
       }
 
-      const result = await validateAtDepth(
-        prefetchKind,
-        depth,
-        currentGroupDepth
-      )
+      const result = await validateAtDepth(depth, currentGroupDepth)
 
       if (Array.isArray(result)) {
         const errors: Array<Error> = result
@@ -8071,6 +8064,7 @@ async function validateInstantConfigInBuildWithSample(
     )
 
     const accumulatedChunks = await accumulatedChunksPromise
+    const endTimes = getStageEndTimes(stageController)
     const debugChunks = null // TODO(instant-validation-build): support debugChannel
 
     // Missing sample errors take priority over everything else,
@@ -8124,6 +8118,7 @@ async function validateInstantConfigInBuildWithSample(
       accumulatedChunks,
       debugChunks,
       startTime,
+      endTimes,
       sampleRootParams,
       fallbackRouteParams,
       validationRenderCtx,

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -4,6 +4,7 @@ import type { NextParsedUrlQuery } from '../request-meta'
 import type { PrefetchingMode } from './app-render'
 import type { NextConfigComplete, ValidationLevel } from '../config-shared'
 import type { ImageConfigComplete } from '../../shared/lib/image-config'
+import type { StageEndTimes } from './instant-validation/instant-validation'
 
 /**
  * Cross-module handoff for the dev validation worker (client-module warmup,
@@ -39,8 +40,7 @@ export interface SerializedValidationInputs {
   accumulatedChunks: SerializedAccumulatedChunks
   debugChunks: Uint8Array[] | null
   startTime: number
-  staticStageEndTime: number
-  runtimeStageEndTime: number
+  stageEndTimes: StageEndTimes
 }
 
 /**

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -55,8 +55,7 @@ export async function buildDevValidationSnapshot(
     accumulatedChunks: inputs.accumulatedChunks,
     debugChunks: await getDebugChunksOnce(inputs.debugChannelClient),
     startTime: inputs.startTime,
-    staticStageEndTime: inputs.staticStageEndTime,
-    runtimeStageEndTime: inputs.runtimeStageEndTime,
+    stageEndTimes: inputs.stageEndTimes,
   })
 
   return {

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -200,13 +200,6 @@ export type SegmentStage =
 /** The stages that a prefetched segment can be in. */
 type PrefetchedSegmentStage = Exclude<SegmentStage, RenderStage.Dynamic>
 
-const SEGMENT_STAGE_ORDER = [
-  RenderStage.Static,
-  RenderStage.ShellRuntime,
-  RenderStage.Runtime,
-  RenderStage.Dynamic,
-] as const satisfies readonly SegmentStage[]
-
 export type StageChunks = Record<SegmentStage, Uint8Array[]>
 
 export type StageEndTimes = Record<PrefetchedSegmentStage, number>
@@ -223,14 +216,72 @@ type RenderToFlightStream = (
  * into separate staged streams (also in arrays-of-chunks form), one for each segment.
  * */
 export async function collectStagedSegmentData(
+  prefetchKind: ValidationPrefetchKind,
   ComponentMod: FlightComponentMod,
   renderFlightStream: RenderToFlightStream,
   fullPageChunks: StageChunks,
   fullPageDebugChunks: Uint8Array[] | null,
   startTime: number,
+  stageEndTimes: StageEndTimes,
   clientReferenceManifest: ClientReferenceManifest,
   createDebugChannel: () => DebugChannelPair | undefined
-) {
+): Promise<{ cache: SegmentCache; payload: InitialRSCPayload }> {
+  const cache = createSegmentCache()
+
+  let partialStages: SegmentStage[]
+  switch (prefetchKind) {
+    case ValidationPrefetchKind.Shell: {
+      partialStages = [RenderStage.ShellRuntime, RenderStage.Runtime]
+      break
+    }
+    case ValidationPrefetchKind.LegacySpeculative: {
+      partialStages = [RenderStage.Static, RenderStage.Runtime]
+      break
+    }
+  }
+
+  const doStage = async (targetStage: SegmentStage) => {
+    const endTime =
+      targetStage !== RenderStage.Dynamic
+        ? stageEndTimes[targetStage]
+        : undefined
+    const firstStage = partialStages[0]
+    return await collectSegmentDataForStage(
+      ComponentMod,
+      renderFlightStream,
+      fullPageChunks,
+      fullPageDebugChunks,
+      clientReferenceManifest,
+      createDebugChannel,
+      cache,
+      firstStage,
+      targetStage,
+      startTime,
+      endTime
+    )
+  }
+
+  for (const targetStage of partialStages) {
+    await doStage(targetStage)
+  }
+  const payload = await doStage(RenderStage.Dynamic)
+
+  return { cache, payload }
+}
+
+async function collectSegmentDataForStage(
+  ComponentMod: FlightComponentMod,
+  renderFlightStream: RenderToFlightStream,
+  fullPageChunks: StageChunks,
+  fullPageDebugChunks: Uint8Array[] | null,
+  clientReferenceManifest: ClientReferenceManifest,
+  createDebugChannel: () => DebugChannelPair | undefined,
+  cache: SegmentCache,
+  firstStage: SegmentStage,
+  targetStage: SegmentStage,
+  startTime: number,
+  endTime: number | undefined
+): Promise<InitialRSCPayload> {
   const debugChannelAbortController = new AbortController()
   const debugStream = fullPageDebugChunks
     ? createNodeStreamFromChunks(
@@ -251,6 +302,7 @@ export async function collectStagedSegmentData(
   const environmentName = () => {
     const currentStage = controller.currentStage
     switch (currentStage) {
+      case RenderStage.Before:
       case RenderStage.Static:
         return 'Prerender'
       case RenderStage.ShellRuntime: // TODO(app-shells) - proper environmentName
@@ -264,26 +316,39 @@ export async function collectStagedSegmentData(
     }
   }
 
-  // Deserialize the payload.
-  // NOTE: the stream will initially be in the static stage, so that's as far as we get here.
-  // We still expect the outer structure of the payload to be readable in this state.
+  // Deserialize the payload partially so that we can traverse the structure.
+
   const serverConsumerManifest = {
     moduleLoading: null,
     moduleMap: clientReferenceManifest.rscModuleMapping,
     serverModuleMap: getServerModuleMap(),
   }
 
-  const payload = await createFromNodeStream<InitialRSCPayload>(
+  const payloadPromise = createFromNodeStream<InitialRSCPayload>(
     stream,
     serverConsumerManifest,
     {
       findSourceMapURL,
       debugChannel: debugStream ?? undefined,
-      // Do not pass start/end timings - we do not want to omit any debug info.
-      startTime: undefined,
-      endTime: undefined,
+      startTime,
+      // Each stage is decoded with an `endTime` corresponding to
+      // when it finished rendering, so that we can avoid pointing to
+      // IO that finished after the stage is done.
+      // This needs to happen during the first deserialization, because
+      // when we serialize the segments afterwards, React will clamp the
+      // timestamps of IO to the current time, and we will lose the ability
+      // to omit info about IO that hasn't resolved in this stage.
+      endTime,
     }
   )
+
+  // We expect the outer structure of the payload to be readable in any stage,
+  // even if the segments are incomplete.
+  // NOTE: This must be done after the `createFromNodeStream` call but *before*
+  // the result is awaited, otherwise we'll deadlock.
+  controller.advanceStage(firstStage)
+
+  const payload = await payloadPromise
 
   // Deconstruct the payload into separate streams per segment.
   // We have to preserve the stage information for each of them,
@@ -296,21 +361,13 @@ export async function collectStagedSegmentData(
     segments.set(segmentPath, createSegmentData(seedData))
   })
 
-  const cache = createSegmentCache()
   const pendingTasks: Promise<void>[] = []
 
-  /** Track when we advance stages so we can pass them as `endTime` later. */
-  const stageEndTimes: StageEndTimes = {
-    [RenderStage.Static]: Infinity,
-    [RenderStage.ShellRuntime]: Infinity,
-    [RenderStage.Runtime]: Infinity,
-  }
-
-  const renderIntoCacheItem = async (
+  const renderIntoStageEntry = async (
     data: HeadData | SegmentData,
-    cacheEntry: SegmentCacheItem
+    stageEntry: SegmentCacheItemStageEntry
   ): Promise<void> => {
-    const segmentDebugChannel = cacheEntry.debugChunks
+    const segmentDebugChannel = stageEntry.debugChunks
       ? createDebugChannel()
       : undefined
 
@@ -323,36 +380,7 @@ export async function collectStagedSegmentData(
         debugChannel: segmentDebugChannel?.serverSide,
         environmentName,
         startTime,
-        onError(error: unknown) {
-          const digest = getDigestForWellKnownError(error)
-          if (digest) {
-            return digest
-          }
-
-          // Forward existing digests
-          if (
-            error &&
-            typeof error === 'object' &&
-            'digest' in error &&
-            typeof error.digest === 'string'
-          ) {
-            return error.digest
-          }
-
-          // We don't need to log the errors because we would have already done that
-          // when generating the original Flight stream for the whole page.
-          if (
-            process.env.NEXT_DEBUG_BUILD ||
-            process.env.__NEXT_VERBOSE_LOGGING
-          ) {
-            const workStore = workAsyncStorage.getStore()
-            printDebugThrownValueForProspectiveRender(
-              error,
-              workStore?.route ?? 'unknown route',
-              Phase.InstantValidation
-            )
-          }
-        },
+        onError: onFlightRenderError,
       }
     )
 
@@ -360,50 +388,97 @@ export async function collectStagedSegmentData(
       // accumulate Flight chunks
       (async () => {
         for await (const chunk of itemStream) {
-          writeChunk(cacheEntry.chunks, controller.currentStage, chunk)
+          if (controller.currentStage === RenderStage.Before) {
+            throw new InvariantError('Unexpected chunk emitted in Before stage')
+          }
+          writeChunk(stageEntry, controller.currentStage, targetStage, chunk)
         }
       })(),
       // accumulate Debug chunks
       segmentDebugChannel &&
         (async () => {
           for await (const chunk of segmentDebugChannel.clientSide.readable) {
-            cacheEntry.debugChunks!.push(chunk)
+            stageEntry.debugChunks!.push(chunk)
           }
         })(),
     ])
   }
 
-  const advanceStage = (
-    targetStage: Exclude<SegmentStage, RenderStage.Static>
-  ) => {
-    const { currentStage } = controller
-    if (currentStage !== RenderStage.Dynamic) {
-      stageEndTimes[currentStage] = performance.now() + performance.timeOrigin
-    }
-    controller.advanceStage(targetStage)
-  }
-
+  // Each stage is rendered in a separate pass (passed in as targetStage),
+  // so we only need two stages:
+  // 1. the target stage
+  // 2. the dynamic stage (for late-release debug info)
   await runInSequentialTasks(
     () => {
+      if (targetStage !== RenderStage.Dynamic) {
+        controller.advanceStage(targetStage)
+      }
+
+      const withDebugChunks = !!fullPageDebugChunks
+
       {
-        const headCacheItem = createSegmentCacheItem(!!fullPageDebugChunks)
-        cache.head = headCacheItem
-        pendingTasks.push(renderIntoCacheItem(head, headCacheItem))
+        let headCacheItem = cache.head
+        if (!headCacheItem) {
+          headCacheItem = createSegmentCacheItem()
+          cache.head = headCacheItem
+        }
+        const stageEntry = getOrCreateStageEntry(
+          headCacheItem,
+          targetStage,
+          withDebugChunks
+        )
+        pendingTasks.push(renderIntoStageEntry(head, stageEntry))
       }
 
       for (const [segmentPath, segmentData] of segments) {
-        const segmentCacheItem = createSegmentCacheItem(!!fullPageDebugChunks)
-        cache.segments.set(segmentPath, segmentCacheItem)
-        pendingTasks.push(renderIntoCacheItem(segmentData, segmentCacheItem))
+        let segmentCacheItem = cache.segments.get(segmentPath)
+        if (!segmentCacheItem) {
+          segmentCacheItem = createSegmentCacheItem()
+          cache.segments.set(segmentPath, segmentCacheItem)
+        }
+        const stageEntry = getOrCreateStageEntry(
+          segmentCacheItem,
+          targetStage,
+          withDebugChunks
+        )
+        pendingTasks.push(renderIntoStageEntry(segmentData, stageEntry))
       }
     },
-    () => advanceStage(RenderStage.ShellRuntime),
-    () => advanceStage(RenderStage.Runtime),
-    () => advanceStage(RenderStage.Dynamic)
+    () => {
+      controller.advanceStage(RenderStage.Dynamic)
+    }
   )
   await Promise.all(pendingTasks)
 
-  return { cache, payload, stageEndTimes }
+  return payload
+}
+
+function onFlightRenderError(error: unknown): string | undefined {
+  const digest = getDigestForWellKnownError(error)
+  if (digest) {
+    return digest
+  }
+
+  // Forward existing digests
+  if (
+    error &&
+    typeof error === 'object' &&
+    'digest' in error &&
+    typeof error.digest === 'string'
+  ) {
+    return error.digest
+  }
+
+  // We don't need to log the errors because we would have already done that
+  // when generating the original Flight stream for the whole page.
+  if (process.env.NEXT_DEBUG_BUILD || process.env.__NEXT_VERBOSE_LOGGING) {
+    const workStore = workAsyncStorage.getStore()
+    printDebugThrownValueForProspectiveRender(
+      error,
+      workStore?.route ?? 'unknown route',
+      Phase.InstantValidation
+    )
+  }
 }
 
 /**
@@ -420,7 +495,7 @@ function createStagedStreamFromChunks(stageChunks: StageChunks) {
   const allChunks = stageChunks[RenderStage.Dynamic]
 
   let chunkIx = 0
-  let currentStage: SegmentStage = RenderStage.Static
+  let currentStage: SegmentStage | RenderStage.Before = RenderStage.Before
   let closed = false
 
   function emitNewChunks(chunks: Uint8Array[]) {
@@ -434,22 +509,9 @@ function createStagedStreamFromChunks(stageChunks: StageChunks) {
     stream.push(null)
   }
 
-  const stream = new Readable({
-    read() {
-      // Emit static chunks
-      emitNewChunks(stageChunks[RenderStage.Static])
+  const stream = new Readable({ read() {} })
 
-      // If there's no more chunks after this stage, finish the stream.
-      if (chunkIx >= allChunks.length) {
-        close()
-        return
-      }
-    },
-  })
-
-  function advanceStage(
-    stage: Exclude<SegmentStage, RenderStage.Static>
-  ): boolean {
+  function advanceStage(stage: SegmentStage): boolean {
     if (closed) return true
 
     // NOTE: we don't special handling for skipping stages,
@@ -478,24 +540,15 @@ function createStagedStreamFromChunks(stageChunks: StageChunks) {
 }
 
 function writeChunk(
-  stageChunks: StageChunks,
+  stageData: SegmentCacheItemStageEntry,
   currentStage: SegmentStage,
+  targetStage: SegmentStage,
   chunk: Uint8Array
 ) {
-  // Add the chunk to every stage that's greater or equal to the current stage.
-  // Iterate in reverse (descending order) so that we can easily skip the stages
-  // that are already completed.
-  for (let i = SEGMENT_STAGE_ORDER.length - 1; i >= 0; i--) {
-    const stage = SEGMENT_STAGE_ORDER[i]
-    if (stage >= currentStage) {
-      stageChunks[stage].push(chunk)
-    } else {
-      // Found the first stage that's less than the current stage
-      // (i.e. one that ended and shouldn't get this chunk).
-      // Skip it and the rest.
-      break
-    }
+  if (currentStage <= targetStage) {
+    stageData.chunks.push(chunk)
   }
+  stageData.allChunks.push(chunk)
 }
 
 //===============================================================
@@ -631,20 +684,22 @@ async function createValidationHead(
   cache: SegmentCache,
   releaseSignal: AbortSignal,
   clientReferenceManifest: ClientReferenceManifest,
-  stageEndTimes: StageEndTimes,
   stage: PrefetchedSegmentStage
 ): Promise<HeadData> {
   const segmentCacheItem = cache.head
   if (!segmentCacheItem) {
     throw new InvariantError(`Missing segment data: <head>`)
   }
+  const stageEntry = getStageEntry(segmentCacheItem, stage)
   return await deserializeFromChunks<HeadData>(
-    segmentCacheItem.chunks[stage],
-    segmentCacheItem.chunks[RenderStage.Dynamic],
-    segmentCacheItem.debugChunks,
+    stageEntry.chunks,
+    stageEntry.allChunks,
+    stageEntry.debugChunks,
     releaseSignal,
     clientReferenceManifest,
-    { startTime: undefined, endTime: stageEndTimes[stage] }
+    // NOTE: We're not passing an endTime, because the debug info has already been
+    // truncated to the appropriate `endTime` when the segment cache was filled.
+    { startTime: undefined, endTime: undefined }
   )
 }
 
@@ -740,16 +795,50 @@ function createSegmentCache(): SegmentCache {
   return { head: null, segments: new Map() }
 }
 
-function createSegmentCacheItem(withDebugChunks: boolean): SegmentCacheItem {
+function createSegmentCacheItem(): SegmentCacheItem {
   return {
-    chunks: {
-      [RenderStage.Static]: [],
-      [RenderStage.ShellRuntime]: [],
-      [RenderStage.Runtime]: [],
-      [RenderStage.Dynamic]: [],
-    },
+    [RenderStage.Static]: null,
+    [RenderStage.ShellRuntime]: null,
+    [RenderStage.Runtime]: null,
+    [RenderStage.Dynamic]: null,
+  }
+}
+
+function createSegmentCacheItemStageEntry(
+  withDebugChunks: boolean
+): SegmentCacheItemStageEntry {
+  return {
+    allChunks: [],
+    chunks: [],
     debugChunks: withDebugChunks ? [] : null,
   }
+}
+
+function getOrCreateStageEntry(
+  segmentCacheItem: SegmentCacheItem,
+  stage: SegmentStage,
+  withDebugChunks: boolean
+): SegmentCacheItemStageEntry {
+  let data = segmentCacheItem[stage]
+  if (!data) {
+    data = createSegmentCacheItemStageEntry(withDebugChunks)
+    segmentCacheItem[stage] = data
+  }
+  return data
+}
+
+function getStageEntry(
+  segmentCacheItem: SegmentCacheItem,
+  stage: SegmentStage
+): SegmentCacheItemStageEntry {
+  const data = segmentCacheItem[stage]
+  if (!data) {
+    // Indicates that we didn't fill the cache at this stage.
+    throw new InvariantError(
+      `Expected segment cache to have data for stage '${RenderStage[stage]}'`
+    )
+  }
+  return data
 }
 
 export type SegmentCache = {
@@ -757,8 +846,11 @@ export type SegmentCache = {
   segments: Map<SegmentPath, SegmentCacheItem>
 }
 
-type SegmentCacheItem = {
-  chunks: StageChunks
+type SegmentCacheItem = Record<SegmentStage, SegmentCacheItemStageEntry | null>
+
+type SegmentCacheItemStageEntry = {
+  chunks: Uint8Array[]
+  allChunks: Uint8Array[]
   debugChunks: Uint8Array[] | null
 }
 
@@ -932,7 +1024,6 @@ export async function createCombinedPayloadAtDepth(
   releaseSignal: AbortSignal,
   boundaryState: ValidationBoundaryTracking,
   clientReferenceManifest: ClientReferenceManifest,
-  stageEndTimes: StageEndTimes,
   useRuntimeStageForPartialSegments: boolean
 ): Promise<ValidationPayloadResult | null> {
   const workStore = workAsyncStorage.getStore()
@@ -1014,10 +1105,12 @@ export async function createCombinedPayloadAtDepth(
       throw new InvariantError(`Missing segment data: ${path}`)
     }
 
+    const stageEntry = getStageEntry(segmentCacheItem, RenderStage.Dynamic)
+    const dynamicChunks = stageEntry.chunks
     const segmentData = await deserializeFromChunks<SegmentData>(
-      segmentCacheItem.chunks[RenderStage.Dynamic],
-      segmentCacheItem.chunks[RenderStage.Dynamic],
-      segmentCacheItem.debugChunks,
+      dynamicChunks,
+      dynamicChunks,
+      stageEntry.debugChunks,
       releaseSignal,
       clientReferenceManifest,
       null
@@ -1254,13 +1347,16 @@ export async function createCombinedPayloadAtDepth(
 
     debug?.(`    ${path || '/'} - ${RenderStage[stage]}`)
 
+    const stageEntry = getStageEntry(segmentCacheItem, stage)
     const segmentData = await deserializeFromChunks<SegmentData>(
-      segmentCacheItem.chunks[stage],
-      segmentCacheItem.chunks[RenderStage.Dynamic],
-      segmentCacheItem.debugChunks,
+      stageEntry.chunks,
+      stageEntry.allChunks,
+      stageEntry.debugChunks,
       releaseSignal,
       clientReferenceManifest,
-      { startTime: undefined, endTime: stageEndTimes[stage] }
+      // NOTE: We're not passing an endTime, because the debug info has already been
+      // truncated to the appropriate `endTime` when the segment cache was filled.
+      { startTime: undefined, endTime: undefined }
     )
 
     // Build children first, then determine requiresInstantUI.
@@ -1392,7 +1488,6 @@ export async function createCombinedPayloadAtDepth(
     cache,
     releaseSignal,
     clientReferenceManifest,
-    stageEndTimes,
     headStage
   )
 

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -193,18 +193,8 @@ export class StagedRenderingController {
     return this.syncInterruptReason
   }
 
-  getStaticStageEndTime() {
-    // The Static stage ends when the stage after it began.
-    return (
-      this.triggers[getNextStage(RenderStage.Static)].triggeredAt ?? Infinity
-    )
-  }
-
-  getRuntimeStageEndTime() {
-    // The Runtime stage ended when the stage after it began.
-    return (
-      this.triggers[getNextStage(RenderStage.Runtime)].triggeredAt ?? Infinity
-    )
+  getStageEndTime(stage: Exclude<AdvanceableRenderStage, RenderStage.Dynamic>) {
+    return this.triggers[getNextStage(stage)].triggeredAt ?? Infinity
   }
 
   private abandonRender() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx
@@ -1,0 +1,23 @@
+export const instant = { level: 'experimental-error' }
+
+export default async function Page() {
+  await loadOuter()
+  return (
+    <main>
+      <p>
+        This page awaits a couple blocking (dynamic) things in sequence. We
+        should point to the first one as the cause.
+      </p>
+    </main>
+  )
+}
+
+async function loadOuter() {
+  await new Promise((resolve) => setTimeout(resolve)) // 1 (correct)
+  await loadInner()
+}
+
+async function loadInner() {
+  await new Promise((resolve) => setTimeout(resolve)) // 2 (incorrect)
+  await new Promise((resolve) => setTimeout(resolve)) // 3 (incorrect)
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx
@@ -1,0 +1,24 @@
+import { Instant } from 'next'
+
+export const instant: Instant = {
+  level: 'experimental-error',
+  unstable_samples: [{ searchParams: { foo: 'fooValue', bar: 'barValue' } }],
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[]>>
+}) {
+  await searchParams.then((sp) => sp.foo) // 1 (correct)
+  await searchParams.then((sp) => sp.bar) // 2 (incorrect)
+
+  return (
+    <main>
+      <p>
+        This page awaits a couple blocking (runtime) things in sequence. We
+        should point to the first one as the cause.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx
@@ -1,0 +1,26 @@
+import { Instant } from 'next'
+import { cookies } from 'next/headers'
+
+export const instant: Instant = { level: 'experimental-error' }
+
+export default async function Page() {
+  await loadOuter()
+  return (
+    <main>
+      <p>
+        This page awaits a couple blocking (runtime, then dynamic) things in
+        sequence. We should point to the first one as the cause.
+      </p>
+    </main>
+  )
+}
+
+async function loadOuter() {
+  await cookies() // 1 (correct)
+  await loadInner()
+}
+
+async function loadInner() {
+  await new Promise((resolve) => setTimeout(resolve)) // 2 (not correct, but expected)
+  await new Promise((resolve) => setTimeout(resolve)) // 3 (incorrect)
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -300,6 +300,19 @@ export default async function Page() {
           <DebugLinks href="/suspense-in-root/non-app-shell/valid-unguarded-static-params/123" />
         </li>
       </ul>
+
+      <h2>Blocking await attribution</h2>
+      <ul>
+        <li>
+          <DebugLinks href="/suspense-in-root/blocking-attribution/dynamic-then-dynamic" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/blocking-attribution/runtime-then-runtime" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/blocking-attribution/session-then-dynamic" />
+        </li>
+      </ul>
     </main>
   )
 }

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -927,4 +927,247 @@ export function registerHeadAndReportingTests(
       })
     })
   }
+
+  describe('validation failures point to the first blocking await', () => {
+    it('multiple dynamic awaits in sequence', async () => {
+      if (isNextDev) {
+        const browser = await navigateTo(
+          '/suspense-in-root/blocking-attribution/dynamic-then-dynamic'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx (1:24) @ instant
+         > 1 | export const instant = { level: 'experimental-error' }
+             |                        ^",
+               "stack": [
+                 "instant app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx (1:24)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1437",
+           "description": "Next.js encountered uncached data during a navigation.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx (16:9) @ loadOuter
+         > 16 |   await new Promise((resolve) => setTimeout(resolve)) // 1 (correct)
+              |         ^",
+           "stack": [
+             "loadOuter app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx (16:9)",
+             "Page app/suspense-in-root/blocking-attribution/dynamic-then-dynamic/page.tsx (4:9)",
+           ],
+         }
+        `)
+      } else {
+        const result = await prerender(
+          '/suspense-in-root/blocking-attribution/dynamic-then-dynamic'
+        )
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/suspense-in-root/blocking-attribution/dynamic-then-dynamic": Next.js encountered uncached data during prerendering or a navigation.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+         Ways to fix this:
+           - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+           - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+           - [block] Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+             at body (<anonymous>)
+             at html (<anonymous>)
+             at a (<anonymous>)
+         Build-time instant validation failed for route "/suspense-in-root/blocking-attribution/dynamic-then-dynamic".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/blocking-attribution/dynamic-then-dynamic" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).toBe(1)
+      }
+    })
+
+    it('multiple runtime awaits in sequence', async () => {
+      if (isNextDev) {
+        const browser = await navigateTo(
+          '/suspense-in-root/blocking-attribution/runtime-then-runtime'
+        )
+        if (partialPrefetching) {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (3:33) @ instant
+           > 3 | export const instant: Instant = {
+               |                                 ^",
+                 "stack": [
+                   "instant app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (3:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1439",
+             "description": "Next.js encountered URL data outside of Suspense.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (13:22) @ Page
+           > 13 |   await searchParams.then((sp) => sp.foo) // 1 (correct)
+                |                      ^",
+             "stack": [
+               "Promise.then <anonymous>",
+               "Page app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (13:22)",
+             ],
+           }
+          `)
+        } else {
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (3:33) @ instant
+           > 3 | export const instant: Instant = {
+               |                                 ^",
+                 "stack": [
+                   "instant app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (3:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1430",
+             "description": "Next.js encountered runtime data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (13:22) @ Page
+           > 13 |   await searchParams.then((sp) => sp.foo) // 1 (correct)
+                |                      ^",
+             "stack": [
+               "Promise.then <anonymous>",
+               "Page app/suspense-in-root/blocking-attribution/runtime-then-runtime/page.tsx (13:22)",
+             ],
+           }
+          `)
+        }
+      } else {
+        const result = await prerender(
+          '/suspense-in-root/blocking-attribution/runtime-then-runtime'
+        )
+        if (partialPrefetching) {
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/blocking-attribution/runtime-then-runtime": Next.js encountered URL data during prerendering or a navigation.
+
+           \`params\` or \`searchParams\` accessed outside of \`<Suspense>\` may prevent the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/instant-shell-url-data
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at a (<anonymous>)
+           Build-time instant validation failed for route "/suspense-in-root/blocking-attribution/runtime-then-runtime".
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/blocking-attribution/runtime-then-runtime" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        } else {
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/blocking-attribution/runtime-then-runtime": Next.js encountered runtime data during prerendering or a navigation.
+
+           \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-runtime
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at a (<anonymous>)
+           Build-time instant validation failed for route "/suspense-in-root/blocking-attribution/runtime-then-runtime".
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/blocking-attribution/runtime-then-runtime" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      }
+    })
+
+    it('session data then dynamic data', async () => {
+      // TODO(instant-validation): Arguably, we should point to `await cookies()` first,
+      // but due to our the discriminated error message strategy we favor holes that are still
+      // present in the runtime retry render. This can be confusing if we have runtime and then dynamic data
+      // in the same place. At least we can assert that we're pointing to the first await that was blocking in the runtime stage.
+      if (isNextDev) {
+        const browser = await navigateTo(
+          '/suspense-in-root/blocking-attribution/session-then-dynamic'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx (4:33) @ instant
+         > 4 | export const instant: Instant = { level: 'experimental-error' }
+             |                                 ^",
+               "stack": [
+                 "instant app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx (4:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1437",
+           "description": "Next.js encountered uncached data during a navigation.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx (24:9) @ loadInner
+         > 24 |   await new Promise((resolve) => setTimeout(resolve)) // 2 (not correct, but expected)
+              |         ^",
+           "stack": [
+             "loadInner app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx (24:9)",
+             "loadOuter app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx (20:9)",
+             "Page app/suspense-in-root/blocking-attribution/session-then-dynamic/page.tsx (7:3)",
+           ],
+         }
+        `)
+      } else {
+        const result = await prerender(
+          '/suspense-in-root/blocking-attribution/session-then-dynamic'
+        )
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/suspense-in-root/blocking-attribution/session-then-dynamic": Next.js encountered uncached data during prerendering or a navigation.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+         Ways to fix this:
+           - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+           - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+           - [block] Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+             at body (<anonymous>)
+             at html (<anonymous>)
+             at a (<anonymous>)
+         Build-time instant validation failed for route "/suspense-in-root/blocking-attribution/session-then-dynamic".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/blocking-attribution/session-then-dynamic" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).toBe(1)
+      }
+    })
+  })
 }


### PR DESCRIPTION
Closes NAR-854

### TLDR

New approach to #94949. We can work around the problem of debug info getting clamped when re-serializing by doing more work, which should be good enough unless we can figure out the correct way to adjust the clamping behavior in react.

### The problem

Before this PR, instant validation works like this:
1. deserialize the full page payload (in stages)
2. reserialize each segment (in stages)
3. reassemble the segments into a combined payload, varying the stage per segment as needed

Unfortunately, in step 2, we lose timing debug info that tells us when IO operations started/ended:
https://github.com/facebook/react/blob/c235eb40f1c3121798d233bf992fd8f8c8558d06/packages/react-server/src/ReactFlightServer.js#L5550-L5553

This means that even if we provide an appropriate `endTime` during step 3, no IO info will be omitted by `filterDebugInfo`, because it was all re-timed to when the render occurred. In practice, this means that when we report a blocking dynamic hole, it might point to a different await than the one that was actually blocking in the stage that we rendered the segment in.

### The solution

(h/t to @gnoff for coming up with this trick)

We can work around this problem with no changes in React. We just have to apply an `endTime` when deserializing the payload for the first time, before reserializing each segments. However, this means that we can no longer disassemble the payload into segments in one pass -- e.g. if we trim the debug info to what it'd be in the `Static` stage, we can't get good data for the `Runtime` stage anymore. So we have to run the segment disassembly separately for each stage we care about.

The debugInfo can now vary depending on the stage, we need to change the shape of `SegmentCacheItem`. Previously, it was like this:
```
'/foo':
  chunks:
    Static: [...]
    Runtime: [...]
    Dynamic: [...]
  debugChunks: [...]
```
But to account for the varying debug info, we now need to store the partial chunks, the complete chunks, and the debug chunks separately for each stage:
```
'/foo':
  Static:
    chunks: [...]
    allChunks: [...]
    debugChunks: [...]
  Runtime:
    chunks: [...]
    allChunks: [...]
    debugChunks: [...]
  Dynamic:
    ...
```
Most of the changes in the PR come from adjusting the code to
- create separate entries for each segmentPath + stage in the new way outlined above, using an `endTime` based on the stage
- consume the cache entry appropriately