### PR TITLE
feat(turbopack): defer dynamic import chunks in development

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -52,7 +52,7 @@ use turbopack_core::{
     asset::AssetContent,
     chunk::{
         ChunkGroupResult, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssets,
-        availability_info::AvailabilityInfo,
+        HmrChunkListSource, availability_info::AvailabilityInfo,
     },
     file_source::FileSource,
     ident::{AssetIdent, Layer},
@@ -1427,7 +1427,11 @@ impl AppEndpoint {
             let client_reference_chunks =
                 get_client_references_chunks_for_hmr(*client_references_chunks);
             client_chunking_context
-                .hmr_chunk_list(client_components_chunks_ident, client_reference_chunks)
+                .hmr_chunk_list(
+                    client_components_chunks_ident,
+                    client_reference_chunks,
+                    HmrChunkListSource::Entry,
+                )
                 .await?
                 .iter()
                 .copied()

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -909,6 +909,34 @@ impl ProjectContainer {
             FileContent::NotFound.cell()
         }
     }
+
+    /// Materializes `client_path` when it is a lazy dynamic-import boundary, registering that
+    /// boundary's output operation so its chunks are emitted alongside the rest of the entry that
+    /// owns it. Paths that are not lazy boundaries are a no-op.
+    ///
+    /// Returns the paths the boundary contributed, relative to the client root, so the dev server
+    /// can attribute them to the entry that owns the boundary. Until it does, the chunks are
+    /// servable but not subscribable: HMR rejects a path it cannot trace back to an entrypoint.
+    #[turbo_tasks::function]
+    pub async fn materialize_lazy_chunk(
+        self: Vc<Self>,
+        client_path: FileSystemPath,
+    ) -> Result<Vc<Vec<RcStr>>> {
+        let Some(map) = self.await?.versioned_content_map else {
+            return Ok(Vc::cell(vec![]));
+        };
+        // The same roots the entry that owns the boundary was emitted with, so its chunks land
+        // alongside the rest of that entry's output.
+        let project = self.project();
+        let node_root = project.node_root().owned().await?;
+        let client_relative_path = project.client_relative_path().owned().await?;
+        Ok(map.materialize_lazy_boundary(
+            client_path,
+            node_root.clone(),
+            client_relative_path,
+            node_root,
+        ))
+    }
 }
 
 #[derive(Clone)]
@@ -1623,6 +1651,7 @@ impl Project {
                 .next_config()
                 .turbo_nested_async_chunking(self.next_mode(), true),
             shared_runtime: self.next_config().turbo_shared_runtime(self.next_mode()),
+            lazy_dynamic_imports: self.next_config().turbopack_lazy_dynamic_imports(),
             debug_ids: self.next_config().turbopack_debug_ids(),
             worker_asset_prefix: self.next_config().turbopack_worker_asset_prefix(),
             should_use_absolute_url_references: self.next_config().inline_css(),

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -10,7 +10,8 @@ use turbo_tasks::{
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    output::{ExpandedOutputAssets, OptionOutputAsset, OutputAsset},
+    lazy_output_asset::LazyOutputAsset,
+    output::{ExpandedOutputAssets, OptionOutputAsset, OutputAsset, OutputAssetsReference},
     source_map::GenerateSourceMap,
     version::OptionVersionedContent,
 };
@@ -289,6 +290,59 @@ impl VersionedContentMap {
         Ok(Vc::cell(None))
     }
 
+    /// Materializes the lazy boundary registered at `path`, emitting its chunks to the given output
+    /// roots, and returns every path the boundary contributed, relative to `client_relative_path`.
+    ///
+    /// Empty when `path` is unknown or is not a lazy boundary. The contributed paths are ordinary
+    /// assets in the new map entry, so a later lookup of any of them resolves without materializing
+    /// again.
+    #[turbo_tasks::function]
+    pub async fn materialize_lazy_boundary(
+        self: Vc<Self>,
+        path: FileSystemPath,
+        node_root: FileSystemPath,
+        client_relative_path: FileSystemPath,
+        client_output_path: FileSystemPath,
+    ) -> Result<Vc<Vec<RcStr>>> {
+        let result = self.raw_get(path.clone()).await?;
+        let Some(entry) = &*result else {
+            return Ok(Vc::cell(vec![]));
+        };
+        let Some(&asset) = entry.path_to_asset.get(&path) else {
+            return Ok(Vc::cell(vec![]));
+        };
+        if !LazyOutputAsset::is_lazy(asset) {
+            return Ok(Vc::cell(vec![]));
+        }
+
+        let assets_operation = lazy_asset_references_operation(asset);
+        let compute_entry = compute_entry_operation(
+            self.to_resolved().await?,
+            assets_operation,
+            node_root,
+            client_relative_path.clone(),
+            client_output_path,
+        );
+        // The operation stays connected to the map, so later edits recompute and re-emit it through
+        // the same path as any eagerly emitted asset, which is what keeps HMR working for a
+        // materialized chunk.
+        self.await?
+            .map_op_to_compute_entry
+            .update_conditionally(|map| {
+                map.insert(assets_operation, compute_entry) != Some(compute_entry)
+            });
+        let Some(materialized) = &*compute_entry.connect().await? else {
+            return Ok(Vc::cell(vec![]));
+        };
+        Ok(Vc::cell(
+            materialized
+                .path_to_asset
+                .keys()
+                .filter_map(|path| client_relative_path.get_path_to(path).map(RcStr::from))
+                .collect(),
+        ))
+    }
+
     #[turbo_tasks::function]
     pub async fn keys_in_path(&self, root: FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
@@ -333,6 +387,15 @@ type GetEntriesResultT = Vec<(FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>)>
 
 #[turbo_tasks::value(transparent)]
 struct GetEntriesResult(GetEntriesResultT);
+
+/// Everything a lazy boundary contributes once materialized: the wrapped asset itself plus every
+/// asset reachable from it. See [`LazyOutputAsset`].
+#[turbo_tasks::function(operation, root)]
+fn lazy_asset_references_operation(
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
+) -> Vc<ExpandedOutputAssets> {
+    asset.references().expand_all_assets()
+}
 
 #[turbo_tasks::function(operation, root)]
 async fn get_entries(assets: OperationVc<ExpandedOutputAssets>) -> Result<Vc<GetEntriesResult>> {

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -12,6 +12,7 @@ use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
+    lazy_output_asset::LazyOutputAsset,
     output::{ExpandedOutputAssets, OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
 };
@@ -60,6 +61,11 @@ pub async fn emit_assets(
         .iter()
         .copied()
         .map(async |asset| {
+            // A lazy boundary is registered by path but materialized on request, so there is
+            // nothing to write for it here. Writing it would resolve the chunk group it defers.
+            if LazyOutputAsset::is_lazy(asset) {
+                return Ok(None);
+            }
             let path = asset.path().owned().await?;
             let location = if path.is_inside_ref(&node_root) {
                 Location::Node

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -488,6 +488,7 @@ pub struct ClientChunkingContextOptions {
     pub scope_hoisting: Vc<bool>,
     pub nested_async_chunking: Vc<bool>,
     pub shared_runtime: Vc<bool>,
+    pub lazy_dynamic_imports: Vc<bool>,
     pub debug_ids: Vc<bool>,
     pub worker_asset_prefix: Vc<Option<RcStr>>,
     pub should_use_absolute_url_references: Vc<bool>,
@@ -532,6 +533,7 @@ pub async fn get_client_chunking_context(
         scope_hoisting,
         nested_async_chunking,
         shared_runtime,
+        lazy_dynamic_imports,
         debug_ids,
         worker_asset_prefix,
         should_use_absolute_url_references,
@@ -599,6 +601,7 @@ pub async fn get_client_chunking_context(
 
     if next_mode.is_development() {
         builder = builder
+            .manifest_chunks(*lazy_dynamic_imports.await?)
             .hot_module_replacement()
             .source_map_source_type(SourceMapSourceType::AbsoluteFileUri)
             .dynamic_chunk_content_loading(true);

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1385,6 +1385,10 @@ pub struct ExperimentalConfig {
     turbopack_worker_asset_prefix: Option<RcStr>,
     turbopack_client_side_nested_async_chunking: Option<bool>,
     turbopack_server_side_nested_async_chunking: Option<bool>,
+    /// Defer the chunk-group computation for a dynamic `import()` behind its manifest chunk, so it
+    /// runs when the browser first requests the chunk instead of while compiling the route.
+    /// Development only.
+    turbopack_lazy_dynamic_imports: Option<bool>,
     turbopack_import_type_bytes: Option<bool>,
     /// Disable automatic configuration of the sass loader.
     #[serde(default)]
@@ -2557,6 +2561,17 @@ impl NextConfig {
                 NextMode::Build => client_side,
             }
         }))
+    }
+
+    /// Whether the chunk group behind a dynamic `import()` is computed lazily. Only ever enabled in
+    /// development, where the caller applies it.
+    #[turbo_tasks::function]
+    pub fn turbopack_lazy_dynamic_imports(&self) -> Vc<bool> {
+        Vc::cell(
+            self.experimental
+                .turbopack_lazy_dynamic_imports
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2676,6 +2676,98 @@ pub fn project_get_source_map_sync(
     })
 }
 
+#[napi(object)]
+pub struct NapiMaterializedLazyChunk {
+    /// Paths the boundary contributed, relative to the client root. Empty when the requested path
+    /// is not a lazy boundary.
+    pub client_paths: Vec<String>,
+}
+
+#[turbo_tasks::value(serialization = "skip")]
+struct MaterializedLazyChunk {
+    client_paths: Option<ReadRef<Vec<RcStr>>>,
+    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    effects: Arc<Effects>,
+}
+
+/// Materializes a lazy chunk, collecting the paths it contributed along with the issues emitted
+/// while doing so and the emit effects it declared, so the caller can apply them and write the
+/// chunks like any other output asset.
+#[turbo_tasks::function(operation, root)]
+async fn materialize_lazy_chunk_operation(
+    container: ResolvedVc<ProjectContainer>,
+    chunk_url_path: RcStr,
+) -> Result<Vc<MaterializedLazyChunk>> {
+    let inner_op = materialize_lazy_chunk_inner_operation(container, chunk_url_path);
+    let filter = container.project().issue_filter().await?;
+    let (client_paths, issues, effects) =
+        strongly_consistent_catch_collectables(inner_op, &filter).await?;
+    Ok(MaterializedLazyChunk {
+        client_paths,
+        issues,
+        effects,
+    }
+    .cell())
+}
+
+/// Materializes a lazy dynamic-import boundary in the project's content map, registering its
+/// complete output operation. A path that is not a lazy boundary is a no-op.
+#[turbo_tasks::function(operation, root)]
+async fn materialize_lazy_chunk_inner_operation(
+    container: ResolvedVc<ProjectContainer>,
+    chunk_url_path: RcStr,
+) -> Result<Vc<Vec<RcStr>>> {
+    let project = container.project();
+    // Strip the `/_next/` URL prefix and any query string, then URL-decode to recover the on-disk
+    // client output path used as the VersionedContentMap key (URLs encode e.g. `+` as `%2B`).
+    let path = chunk_url_path
+        .split_once('?')
+        .map_or(&*chunk_url_path, |(path, _)| path);
+    let rel = path.strip_prefix("/_next/").unwrap_or(path);
+    let rel = urlencoding::decode(rel)
+        .map(|s| s.into_owned())
+        .unwrap_or_else(|_| rel.to_string());
+    let client_path = project.client_relative_path().await?.join(&rel)?;
+    Ok(container.materialize_lazy_chunk(client_path))
+}
+
+#[tracing::instrument(level = "info", name = "materialize lazy chunk", skip_all)]
+#[napi]
+pub async fn project_materialize_lazy_chunk(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    chunk_url_path: RcStr,
+) -> napi::Result<TurbopackResult<NapiMaterializedLazyChunk>> {
+    let container = project.container;
+    let (client_paths, issues) = project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run(async move {
+            // Applying the effects emits the materialized chunks to disk, where the normal static
+            // path serves them.
+            let op = materialize_lazy_chunk_operation(container, chunk_url_path);
+            let read = read_strongly_consistent_and_apply_effects(op, |v| &v.effects).await?;
+            let MaterializedLazyChunk {
+                client_paths,
+                issues,
+                ..
+            } = &*read;
+            Ok((
+                client_paths
+                    .iter()
+                    .flat_map(|paths| paths.iter().map(|path| path.to_string()))
+                    .collect::<Vec<_>>(),
+                issues.clone(),
+            ))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: NapiMaterializedLazyChunk { client_paths },
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+    })
+}
+
 #[napi]
 pub async fn project_write_analyze_data(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -489,6 +489,17 @@ export declare function projectGetSourceMapSync(
   project: { __napiType: 'Project' },
   filePath: RcStr
 ): string | null
+export interface NapiMaterializedLazyChunk {
+  /**
+   * Paths the boundary contributed, relative to the client root. Empty when the requested path
+   * is not a lazy boundary.
+   */
+  clientPaths: Array<string>
+}
+export declare function projectMaterializeLazyChunk(
+  project: { __napiType: 'Project' },
+  chunkUrlPath: RcStr
+): Promise<TurbopackResult>
 export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -831,6 +831,16 @@ function bindingToApi(
       return binding.projectGetSourceMapSync(this._nativeProject, filePath)
     }
 
+    async materializeLazyChunk(
+      chunkUrlPath: string
+    ): Promise<TurbopackResult<{ clientPaths: string[] }>> {
+      const napiResult = (await binding.projectMaterializeLazyChunk(
+        this._nativeProject,
+        chunkUrlPath
+      )) as TurbopackResult<{ clientPaths: string[] }>
+      return napiResult
+    }
+
     updateInfoSubscribe(aggregationMs: number) {
       return subscribe<TurbopackResult<UpdateMessage>>(true, async (callback) =>
         binding.projectUpdateInfoSubscribe(

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -357,6 +357,18 @@ export interface Project {
   getSourceMap(filePath: string): Promise<string | null>
   getSourceMapSync(filePath: string): string | null
 
+  /**
+   * Materialize a lazy dynamic-import boundary, emitting its chunks to disk so
+   * they can be served like any other output asset. A path that is not a lazy
+   * boundary is a no-op.
+   *
+   * Resolves with the paths the boundary contributed, relative to the client
+   * root, so the caller can attribute them to the entry that owns the boundary.
+   */
+  materializeLazyChunk(
+    chunkUrlPath: string
+  ): Promise<TurbopackResult<{ clientPaths: string[] }>>
+
   traceSource(
     stackFrame: TurbopackStackFrame,
     currentDirectoryFileUrl: string

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -395,6 +395,7 @@ export const experimentalSchema = {
   turbopackWorkerAssetPrefix: z.string().optional(),
   turbopackClientSideNestedAsyncChunking: z.boolean().optional(),
   turbopackServerSideNestedAsyncChunking: z.boolean().optional(),
+  turbopackLazyDynamicImports: z.boolean().optional(),
   turbopackImportTypeBytes: z.boolean().optional(),
   turbopackUseBuiltinBabel: z.boolean().optional(),
   turbopackUseBuiltinSass: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -854,6 +854,14 @@ export interface ExperimentalConfig {
   turbopackServerSideNestedAsyncChunking?: boolean
 
   /**
+   * Defer the chunk-group computation for a dynamic `import()` until the browser first requests it,
+   * instead of performing it while compiling the route. Development only.
+   *
+   * Defaults to `false`.
+   */
+  turbopackLazyDynamicImports?: boolean
+
+  /**
    * Enable filesystem cache for the turbopack dev server.
    *
    * Defaults to `true`.

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1348,6 +1348,56 @@ export async function createHotReloaderTurbopack(
         }
       }
 
+      if (req.url?.startsWith('/_next/static/chunks/')) {
+        // Materialize lazy dynamic-import boundaries, which emits the requested chunk and all its
+        // siblings. Serving is left to the static path so a lazy chunk is indistinguishable from an
+        // eagerly emitted one. Paths that are not lazy boundaries are a no-op.
+        //
+        // This runs on every request rather than only when the file is missing: dev chunk names are
+        // stable across edits, so an existing file is not necessarily a current one. Re-emitting an
+        // unchanged chunk is already a no-op in the write effect.
+        try {
+          const { clientPaths, issues } = await project.materializeLazyChunk(
+            req.url
+          )
+
+          // Materializing compiles, so it can surface issues of its own. There is no entry to
+          // attach them to, so log them rather than let them disappear.
+          for (const issue of issues) {
+            if (issue.severity === 'warning') {
+              printNonFatalIssue(issue)
+            } else if (
+              issue.severity === 'error' ||
+              issue.severity === 'fatal'
+            ) {
+              Log.error(formatIssue(issue))
+            }
+          }
+
+          if (clientPaths.length > 0) {
+            // Attribute the materialized chunks to whichever entries own the boundary. Their
+            // paths are not in any entrypoint's written output — that is the point of the
+            // boundary — and `subscribeToClientHmrEvents` drops a subscription for a path it
+            // cannot trace back to a live entrypoint, so without this their HMR chunk list is
+            // subscribed to by the browser and then silently ignored.
+            // `assetMapper` keys assets by their path relative to the dist dir, which is what
+            // the `/_next/` prefix maps to.
+            const boundaryPath = decodeURIComponent(
+              req.url.split('?')[0].replace(/^\/_next\//, '')
+            )
+            for (const key of assetMapper.getKeysByAsset(boundaryPath)) {
+              assetMapper.setPathsForKey(key, [
+                ...assetMapper.getAssetPathsByKey(key),
+                ...clientPaths,
+              ])
+            }
+          }
+        } catch (err) {
+          // Serving falls through to the static path, which 404s if the chunk was never emitted.
+          console.error(err)
+        }
+      }
+
       for (const middleware of middlewares) {
         let calledNext = false
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1348,7 +1348,10 @@ export async function createHotReloaderTurbopack(
         }
       }
 
-      if (req.url?.startsWith('/_next/static/chunks/')) {
+      if (
+        nextConfig.experimental.turbopackLazyDynamicImports &&
+        req.url?.startsWith('/_next/static/chunks/')
+      ) {
         // Materialize lazy dynamic-import boundaries, which emits the requested chunk and all its
         // siblings. Serving is left to the static path so a lazy chunk is indistinguishable from an
         // eagerly emitted one. Paths that are not lazy boundaries are a no-op.

--- a/test/development/app-dir/lazy-dynamic-chunks/app/demo.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/demo.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+import { EAGER_MARKER } from './eager-dep'
+
+// `ssr: false` keeps the target out of the server graph, and gating the render behind a click
+// keeps the browser from requesting the chunk until the test asks for it.
+const LazyTarget = dynamic(
+  () => import('./lazy-target').then((mod) => mod.LazyTarget),
+  {
+    ssr: false,
+    loading: () => <p id="loading">loading</p>,
+  }
+)
+
+export function Demo() {
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      <p id="eager">{EAGER_MARKER}</p>
+      <button id="render-target" onClick={() => setShow(true)}>
+        render target
+      </button>
+      {show ? <LazyTarget /> : <p id="idle">idle</p>}
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/eager-dep.ts
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/eager-dep.ts
@@ -1,0 +1,4 @@
+// Statically imported by the client component below, so it is part of the route's eager client
+// chunk. The test uses it as a positive anchor: once this marker is on disk, the route's client
+// emit pass has finished, which makes the absence of the lazy marker meaningful.
+export const EAGER_MARKER = 'eager-chunk-marker-4c1d'

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/demo.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/demo.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+import { EAGER_MARKER } from '../eager-dep'
+
+const InteractiveTarget = dynamic(
+  () => import('./target').then((mod) => mod.InteractiveTarget),
+  {
+    ssr: false,
+    loading: () => <p id="loading">loading</p>,
+  }
+)
+
+export function InteractiveDemo() {
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      <p id="eager">{EAGER_MARKER}</p>
+      <button id="render-target" onClick={() => setShow(true)}>
+        render target
+      </button>
+      {show ? <InteractiveTarget /> : <p id="idle">idle</p>}
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/page.tsx
@@ -1,0 +1,11 @@
+import { InteractiveDemo } from './demo'
+
+// This route owns the click-driven materialization case, on its own target module so it cannot
+// disturb the compile-only assertions on `/`.
+export default function InteractivePage() {
+  return (
+    <main>
+      <InteractiveDemo />
+    </main>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.module.css
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.module.css
@@ -1,0 +1,5 @@
+.target {
+  /* Unique marker so the test can find this file regardless of the hashed chunk name. */
+  --interactive-css-marker-5d1c: 1;
+  color: rgb(0, 128, 0);
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.tsx
@@ -1,0 +1,11 @@
+import styles from './target.module.css'
+
+export const INTERACTIVE_MARKER = 'interactive-chunk-marker-2e8b'
+
+export function InteractiveTarget() {
+  return (
+    <p id="target" className={styles.target}>
+      {INTERACTIVE_MARKER}
+    </p>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/layout.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.module.css
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.module.css
@@ -1,0 +1,5 @@
+.target {
+  /* Unique marker so the test can find this file regardless of the hashed chunk name. */
+  --lazy-css-marker-7b2e: 1;
+  color: rgb(0, 128, 0);
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.tsx
@@ -1,0 +1,11 @@
+import styles from './lazy-target.module.css'
+
+export const LAZY_MARKER = 'lazy-chunk-marker-9f3a'
+
+export function LazyTarget() {
+  return (
+    <p id="target" className={styles.target}>
+      {LAZY_MARKER}
+    </p>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/page.tsx
@@ -1,0 +1,11 @@
+import { Demo } from './demo'
+
+// This route is only ever compiled, never interacted with, so its lazy chunk stays
+// unmaterialized for the whole run.
+export default function Page() {
+  return (
+    <main>
+      <Demo />
+    </main>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/lazy-dynamic-chunks.test.ts
+++ b/test/development/app-dir/lazy-dynamic-chunks/lazy-dynamic-chunks.test.ts
@@ -1,0 +1,253 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// Markers live inside module bodies rather than in filenames, so these assertions survive chunk
+// hashing and any change to how chunks are named or split.
+const EAGER_MARKER = 'eager-chunk-marker-4c1d'
+const LAZY_MARKER = 'lazy-chunk-marker-9f3a'
+const LAZY_CSS_MARKER = 'lazy-css-marker-7b2e'
+const INTERACTIVE_MARKER = 'interactive-chunk-marker-2e8b'
+const INTERACTIVE_CSS_MARKER = 'interactive-css-marker-5d1c'
+
+// Lazy dynamic-import chunk groups are Turbopack-only, and only wired up in the dev client
+// chunking context, behind `experimental.turbopackLazyDynamicImports` in this fixture's config.
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'lazy-dynamic-chunks',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      patchFileDelay: 500,
+    })
+
+    /** Every file the client emit pass has written so far. */
+    async function clientAssets(): Promise<string[]> {
+      const root = path.join(next.testDir, next.distDir, 'static')
+      const found: string[] = []
+
+      async function walk(dir: string) {
+        let entries
+        try {
+          entries = await fs.readdir(dir, { withFileTypes: true })
+        } catch {
+          // The directory does not exist until the first client asset is emitted.
+          return
+        }
+        for (const entry of entries) {
+          const entryPath = path.join(dir, entry.name)
+          if (entry.isDirectory()) {
+            await walk(entryPath)
+          } else {
+            found.push(entryPath)
+          }
+        }
+      }
+
+      await walk(root)
+      return found
+    }
+
+    /** Client assets whose contents contain `marker`. */
+    async function assetsContaining(marker: string): Promise<string[]> {
+      const assets = await clientAssets()
+      const matches = await Promise.all(
+        assets.map(async (asset) => {
+          const contents = await fs.readFile(asset, 'utf8').catch(() => '')
+          return contents.includes(marker) ? asset : null
+        })
+      )
+      return matches.filter((asset): asset is string => asset !== null)
+    }
+
+    /** Every file the react-loadable manifest lists for `route`, across all dynamic imports. */
+    async function loadableManifestFiles(route: string): Promise<string[]> {
+      const manifestPath = path.join(
+        next.testDir,
+        next.distDir,
+        'server/app',
+        route,
+        'react-loadable-manifest.json'
+      )
+      const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+      return Object.values(manifest).flatMap(
+        (entry: { files: string[] }) => entry.files
+      )
+    }
+
+    it('does not emit the dynamic import chunk while compiling the route', async () => {
+      // Drive the compile over HTTP rather than a browser so nothing can speculatively request
+      // the lazy chunk and materialize it behind the assertion.
+      const res = await next.fetch('/')
+      expect(res.status).toBe(200)
+
+      // `emit_assets` skips lazy assets, so "was it built eagerly?" is just "is it on disk?".
+      // Anchor on the eager marker first: once it lands, this route's client emit pass has run,
+      // which is what makes the absence checks below meaningful rather than merely early.
+      await retry(async () => {
+        expect(await assetsContaining(EAGER_MARKER)).not.toHaveLength(0)
+      })
+
+      expect(await assetsContaining(LAZY_MARKER)).toHaveLength(0)
+      expect(await assetsContaining(LAZY_CSS_MARKER)).toHaveLength(0)
+    })
+
+    it('resolves the dynamic import to a boundary chunk rather than its target group', async () => {
+      // The chunks being absent from disk only shows they were not *written*. The loadable manifest
+      // is built from whatever the async loader resolved to, so it is where an eagerly resolved
+      // target chunk group would show up. The target imports a CSS module, so its group contains a
+      // CSS chunk; the boundary that stands in for it is JS only.
+      expect(await next.fetch('/').then((res) => res.status)).toBe(200)
+
+      let files: string[]
+      await retry(async () => {
+        files = await loadableManifestFiles('page')
+        expect(files).not.toHaveLength(0)
+      })
+
+      expect(files.filter((file) => file.endsWith('.css'))).toHaveLength(0)
+      expect(files.every((file) => file.endsWith('.js'))).toBe(true)
+    })
+
+    it('emits and serves the dynamic import chunk when the browser requests it', async () => {
+      const browser = await next.browser('/interactive')
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#eager').text()).toBe(EAGER_MARKER)
+      })
+
+      /** URLs the page has requested so far. */
+      const requestedUrls = async (): Promise<string[]> =>
+        (await browser.eval(
+          `performance.getEntriesByType('resource').map((entry) => entry.name)`
+        )) as string[]
+
+      const requestedBefore = new Set(await requestedUrls())
+      const emittedBefore = new Set(await clientAssets())
+
+      await browser.elementByCss('#render-target').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#target').text()).toBe(
+          INTERACTIVE_MARKER
+        )
+      })
+
+      // The CSS sibling has to come from the same materialized snapshot as the JS chunk. Reading
+      // the computed style proves it was served and applied, not merely produced somewhere.
+      expect(
+        await browser.eval(
+          `getComputedStyle(document.querySelector('#target')).color`
+        )
+      ).toBe('rgb(0, 128, 0)')
+
+      // Materializing a boundary applies the emit effects it declared, so the chunks land on disk
+      // like any other output asset and the normal static path can serve them from here on.
+      await retry(async () => {
+        expect(await assetsContaining(INTERACTIVE_MARKER)).not.toHaveLength(0)
+        expect(await assetsContaining(INTERACTIVE_CSS_MARKER)).not.toHaveLength(
+          0
+        )
+      })
+
+      // New chunks rather than rewrites of the route's existing ones, which also catches siblings
+      // being dropped from the materialized snapshot.
+      const newAssets = (await clientAssets()).filter(
+        (asset) => !emittedBefore.has(asset)
+      )
+      expect(newAssets).not.toHaveLength(0)
+
+      // Also assert over the wire, since the first request is served from the content map before
+      // anything reaches disk. Re-requesting covers the second-hit path.
+      const newChunkUrls = (await requestedUrls())
+        .filter((url) => !requestedBefore.has(url))
+        .filter((url) => url.includes('/_next/static/chunks/'))
+      expect(newChunkUrls).not.toHaveLength(0)
+
+      const bodies = await Promise.all(
+        newChunkUrls.map(async (url) => {
+          const { pathname, search } = new URL(url)
+          const res = await next.fetch(pathname + search)
+          expect(res.status).toBe(200)
+          return { url, body: await res.text() }
+        })
+      )
+
+      expect(
+        bodies.filter(({ body }) => body.includes(INTERACTIVE_MARKER))
+      ).not.toHaveLength(0)
+      expect(
+        bodies.filter(({ body }) => body.includes(INTERACTIVE_CSS_MARKER))
+      ).not.toHaveLength(0)
+    })
+
+    it('resolves a source map for the boundary chunk', async () => {
+      // This is the path the dev overlay takes to map a stack frame, and it reaches the boundary
+      // through the content map, which hands back the lazy wrapper rather than the chunk it wraps.
+      // The wrapper has to forward `GenerateSourceMap` for the lookup to resolve; when it does not,
+      // the lookup raises and this endpoint answers 500.
+      const boundaryChunk = (await loadableManifestFiles('interactive/page'))[0]
+      expect(boundaryChunk).toMatch(/\.js$/)
+
+      const filename = path.join(next.testDir, next.distDir, boundaryChunk)
+      const res = await next.fetch(
+        `/__nextjs_source-map?filename=${encodeURIComponent(filename)}`
+      )
+      expect(res.status).toBe(200)
+      expect(await res.json()).toHaveProperty('version', 3)
+    })
+
+    it('applies an edit to a mounted dynamic component over HMR', async () => {
+      // HMR is driven by chunk lists, and the page's own list cannot name the chunks behind a
+      // boundary — knowing them is the work being deferred. They get a list of their own,
+      // generated behind the same boundary, and the dev server has to attribute the materialized
+      // paths to the entry that owns the boundary; the subscription is dropped for a path it
+      // cannot trace back to an entrypoint. Without either, this edit never arrives.
+      const targetPath = path.join('app', 'interactive', 'target.tsx')
+      const originalContent = await next.readFile(targetPath)
+      try {
+        const browser = await next.browser('/interactive')
+        await browser.elementByCss('#render-target').click()
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#target').text()).toBe(
+            INTERACTIVE_MARKER
+          )
+        })
+
+        const timeOrigin = await browser.eval('performance.timeOrigin')
+
+        await next.patchFile(
+          targetPath,
+          originalContent.replace(INTERACTIVE_MARKER, 'updated-marker')
+        )
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#target').text()).toBe(
+            'updated-marker'
+          )
+        }, 10000)
+
+        // Applied as an update rather than a reload, so a component that is already mounted keeps
+        // its state.
+        expect(await browser.eval('performance.timeOrigin')).toEqual(timeOrigin)
+      } finally {
+        await next.patchFile(targetPath, originalContent)
+      }
+    })
+
+    it('keeps the lazy chunk of an untouched route unmaterialized', async () => {
+      // `/` is compiled but never interacted with, so materializing `/interactive` in the
+      // previous test must not have dragged this route's boundary along with it.
+      const res = await next.fetch('/')
+      expect(res.status).toBe(200)
+
+      await retry(async () => {
+        expect(await assetsContaining(EAGER_MARKER)).not.toHaveLength(0)
+      })
+
+      expect(await assetsContaining(LAZY_MARKER)).toHaveLength(0)
+      expect(await assetsContaining(LAZY_CSS_MARKER)).toHaveLength(0)
+    })
+  }
+)

--- a/test/development/app-dir/lazy-dynamic-chunks/next.config.js
+++ b/test/development/app-dir/lazy-dynamic-chunks/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbopackLazyDynamicImports: true,
+  },
+}
+
+module.exports = nextConfig

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -12,9 +12,9 @@ use turbopack_core::{
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkLoadRetry, ChunkType,
         ChunkableModule, ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing,
-        CrossOrigin, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets, MinifyType,
-        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
-        WorkerConfigurationOptions,
+        CrossOrigin, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
+        HmrChunkListSource, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences,
+        UrlBehavior, WorkerConfigurationOptions,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         chunk_id_strategy::ModuleIdStrategy,
@@ -835,6 +835,11 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
+    fn is_hot_module_replacement_enabled(&self) -> Vc<bool> {
+        Vc::cell(self.enable_hot_module_replacement)
+    }
+
+    #[turbo_tasks::function]
     pub fn minify_type(&self) -> Vc<MinifyType> {
         self.minify_type.cell()
     }
@@ -1048,6 +1053,7 @@ impl ChunkingContext for BrowserChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         chunks: Vc<OutputAssets>,
+        source: HmrChunkListSource,
     ) -> Result<Vc<OutputAssets>> {
         let this = self.await?;
         if !this.enable_hot_module_replacement {
@@ -1061,7 +1067,10 @@ impl ChunkingContext for BrowserChunkingContext {
                 ident,
                 EvaluatableAssets::empty(),
                 chunks,
-                EcmascriptDevChunkListSource::Entry,
+                match source {
+                    HmrChunkListSource::Entry => EcmascriptDevChunkListSource::Entry,
+                    HmrChunkListSource::Dynamic => EcmascriptDevChunkListSource::Dynamic,
+                },
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -293,6 +293,20 @@ pub struct ChunkingConfig {
 #[turbo_tasks::value(transparent)]
 pub struct ChunkingConfigs(FxHashMap<ResolvedVc<Box<dyn ChunkType>>, ChunkingConfig>);
 
+/// What a standalone HMR chunk list stands for, which decides how the client reacts when the list
+/// stops existing: a runtime entry has to restart the application, while a dynamic import can just
+/// discard the modules it owned.
+#[turbo_tasks::task_input]
+#[derive(
+    Eq, PartialEq, Debug, Clone, Copy, Hash, TraceRawVcs, Serialize, Deserialize, Encode, Decode,
+)]
+pub enum HmrChunkListSource {
+    /// The chunk list belongs to a runtime entry, e.g. a page.
+    Entry,
+    /// The chunk list belongs to a dynamic import.
+    Dynamic,
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Copy, Hash, Default, Deserialize)]
 pub enum SourceMapSourceType {
@@ -442,6 +456,13 @@ pub trait ChunkingContext {
         Vc::cell(false)
     }
 
+    /// Whether chunks are generated for hot module replacement, and so [`Self::hmr_chunk_list`] may
+    /// be called.
+    #[turbo_tasks::function]
+    fn is_hot_module_replacement_enabled(self: Vc<Self>) -> Vc<bool> {
+        Vc::cell(false)
+    }
+
     #[turbo_tasks::function]
     fn minify_type(self: Vc<Self>) -> Vc<MinifyType> {
         MinifyType::NoMinify.cell()
@@ -492,14 +513,20 @@ pub trait ChunkingContext {
 
     /// In development, produces a standalone HMR chunk-list register chunk
     /// that tracks `chunks` for hot-module-replacement without producing an
-    /// evaluate chunk. Returns `None` (empty vec) outside dev or when HMR is
-    /// disabled. Used to register a page-specific chunk list that covers
-    /// client-reference chunks built outside the shared module graph.
+    /// evaluate chunk.
+    ///
+    /// Used for chunks that no evaluated chunk group's list already covers:
+    /// client-reference chunks built outside the shared module graph, and the
+    /// chunks behind a lazily materialized dynamic-import boundary.
+    ///
+    /// Only valid to call when [`Self::is_hot_module_replacement_enabled`] is
+    /// true.
     #[turbo_tasks::function]
     fn hmr_chunk_list(
         self: Vc<Self>,
         _ident: Vc<AssetIdent>,
         _chunks: Vc<OutputAssets>,
+        _source: HmrChunkListSource,
     ) -> Vc<OutputAssets> {
         OutputAssets::empty()
     }

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -28,8 +28,8 @@ pub use crate::chunk::{
     },
     chunking_context::{
         AssetSuffix, ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs,
-        ChunkingContext, ChunkingContextExt, EntryChunkGroupResult, MangleType, MinifyType,
-        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        ChunkingContext, ChunkingContextExt, EntryChunkGroupResult, HmrChunkListSource, MangleType,
+        MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
         WorkerConfigurationOptions,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},

--- a/turbopack/crates/turbopack-core/src/lazy_output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/lazy_output_asset.rs
@@ -1,0 +1,109 @@
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{FileContent, FileSystemPath};
+
+use crate::{
+    asset::{Asset, AssetContent},
+    chunk::{OutputChunk, OutputChunkRuntimeInfo},
+    output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
+    source_map::GenerateSourceMap,
+    version::VersionedContent,
+};
+
+/// An [`OutputAsset`] that is registered by path, but whose content and references are not
+/// generated while the owning endpoint is emitted.
+///
+/// Emitting skips lazy assets, and output asset expansion stops at them instead of walking their
+/// references. Serving the path materializes the boundary: [`Self::references`] yields the wrapped
+/// asset *and* everything it references, so a single expansion registers both the requested path
+/// and every sibling it pulls in.
+///
+/// Everything else is forwarded, so a materialized lazy asset behaves exactly like the asset it
+/// wraps.
+#[turbo_tasks::value]
+pub struct LazyOutputAsset {
+    inner: ResolvedVc<Box<dyn OutputAsset>>,
+}
+
+#[turbo_tasks::value_impl]
+impl LazyOutputAsset {
+    #[turbo_tasks::function]
+    pub fn new(inner: ResolvedVc<Box<dyn OutputAsset>>) -> Vc<Self> {
+        LazyOutputAsset { inner }.cell()
+    }
+}
+
+impl LazyOutputAsset {
+    /// Whether `asset` is a lazy output boundary.
+    ///
+    /// A local type check rather than a method on [`OutputAsset`], so that the callers that ask
+    /// this of every asset they walk — expansion and emitting — don't pay a turbo-tasks call
+    /// per asset.
+    pub fn is_lazy(asset: ResolvedVc<Box<dyn OutputAsset>>) -> bool {
+        ResolvedVc::try_downcast_type::<LazyOutputAsset>(asset).is_some()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.inner.content()
+    }
+
+    #[turbo_tasks::function]
+    fn versioned_content(&self) -> Vc<Box<dyn VersionedContent>> {
+        self.inner.versioned_content()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsReference for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn references(&self) -> Vc<OutputAssetsWithReferenced> {
+        self.inner.references().concatenate_asset(*self.inner)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAsset for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.inner.path()
+    }
+}
+
+// The wrapped asset is typically a chunk, and callers reach for these two traits by sidecasting the
+// asset they were handed. Without forwarding, the sidecasts fail on the wrapper and degrade
+// silently: source map lookups for the path stop resolving, and `ChunkData` loses the chunk's
+// `included` module ids.
+
+#[turbo_tasks::value_impl]
+impl GenerateSourceMap for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn generate_source_map(&self) -> Vc<FileContent> {
+        match ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.inner) {
+            Some(inner) => inner.generate_source_map(),
+            None => FileContent::NotFound.cell(),
+        }
+    }
+
+    #[turbo_tasks::function]
+    fn by_section(&self, section: RcStr) -> Vc<FileContent> {
+        match ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.inner) {
+            Some(inner) => inner.by_section(section),
+            None => FileContent::NotFound.cell(),
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputChunk for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn runtime_info(&self) -> Vc<OutputChunkRuntimeInfo> {
+        match ResolvedVc::try_sidecast::<Box<dyn OutputChunk>>(self.inner) {
+            Some(inner) => inner.runtime_info(),
+            None => OutputChunkRuntimeInfo::empty(),
+        }
+    }
+}

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod generated_code_source;
 pub mod ident;
 pub mod introspect;
 pub mod issue;
+pub mod lazy_output_asset;
 pub mod loader;
 pub mod module;
 pub mod module_graph;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -817,6 +817,21 @@ impl ModuleGraph {
         .cell())
     }
 
+    /// A graph containing nothing but `entry` and whatever it references, as an async chunk group
+    /// entry.
+    #[turbo_tasks::function]
+    pub fn isolated_async_entry(entry: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
+        Self::from_graphs(
+            vec![SingleModuleGraph::new_with_entry(
+                ChunkGroupEntry::Async(entry),
+                false,
+                false,
+            )],
+            None,
+        )
+        .connect()
+    }
+
     #[turbo_tasks::function]
     pub async fn chunk_group_info(self: Vc<Self>) -> Result<Vc<ChunkGroupInfo>> {
         compute_chunk_group_info(&*self.await?).await

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 
-use crate::asset::Asset;
+use crate::{asset::Asset, lazy_output_asset::LazyOutputAsset};
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionOutputAsset(Option<ResolvedVc<Box<dyn OutputAsset>>>);
@@ -245,7 +245,7 @@ async fn get_referenced_assets(
 ) -> Result<impl Iterator<Item = ExpandOutputAssetsInput>> {
     let refs = match input {
         ExpandOutputAssetsInput::Asset(output_asset) => {
-            if !inner_output_assets {
+            if !inner_output_assets || LazyOutputAsset::is_lazy(output_asset) {
                 return Ok(Either::Left(std::iter::empty()));
             }
             output_asset.references().await?

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -5,14 +5,15 @@ use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkData, ChunkableModule, ChunkingContext, ChunkingContextExt,
-        ChunksData, availability_info::AvailabilityInfo,
+        ChunksData, HmrChunkListSource, availability_info::AvailabilityInfo,
     },
     ident::AssetIdent,
+    lazy_output_asset::LazyOutputAsset,
     module::{Module, ModuleSideEffects},
     module_graph::{
         ModuleGraph, chunk_group_info::ChunkGroup, module_batch::ChunkableModuleOrBatch,
     },
-    output::OutputAssetsWithReferenced,
+    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
 };
 
 use crate::{
@@ -70,6 +71,33 @@ impl ManifestAsyncModule {
         )
     }
 
+    /// A chunk list tracking the dynamic import's chunks for HMR, empty when HMR is disabled.
+    ///
+    /// Nothing else covers those chunks. An evaluated chunk group builds one chunk list for
+    /// everything it can reach, but it reaches this dynamic import through the manifest chunk,
+    /// which is a lazy boundary, so the traversal stops before the chunks behind it. Without a
+    /// list of their own, an edit to the dynamically imported module has no subscription to
+    /// arrive through and never reaches a component that is already mounted.
+    ///
+    /// This is generated behind the same boundary as the chunks it tracks, so it costs nothing
+    /// until the dynamic import is actually reached.
+    #[turbo_tasks::function]
+    async fn hmr_chunk_list(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
+        let this = self.await?;
+        if !*this
+            .chunking_context
+            .is_hot_module_replacement_enabled()
+            .await?
+        {
+            return Ok(OutputAssets::empty());
+        }
+        Ok(this.chunking_context.hmr_chunk_list(
+            self.ident(),
+            *self.chunk_group().await?.assets,
+            HmrChunkListSource::Dynamic,
+        ))
+    }
+
     #[turbo_tasks::function]
     pub async fn manifest_chunk_group(
         self: ResolvedVc<Self>,
@@ -94,12 +122,46 @@ impl ManifestAsyncModule {
                 .cell());
             }
         }
-        Ok(this.chunking_context.chunk_group_assets(
-            self.ident(),
-            ChunkGroup::Async(ResolvedVc::upcast(self)),
-            *this.module_graph,
-            this.availability_info,
-        ))
+        let module_graph = ModuleGraph::isolated_async_entry(*ResolvedVc::upcast(self));
+        let manifest_group = this
+            .chunking_context
+            .chunk_group_assets(
+                self.ident(),
+                ChunkGroup::Async(ResolvedVc::upcast(self)),
+                module_graph,
+                this.availability_info,
+            )
+            .await?;
+
+        // Only the group's own assets become lazy boundaries. `referenced_assets` and `references`
+        // are group-level and get expanded eagerly, so anything reachable through them would drag
+        // the dynamic import's real chunk group back onto the eager path. They are empty for an
+        // async group today; assert it rather than let a future change defeat the deferral in
+        // silence.
+        debug_assert!(
+            manifest_group.referenced_assets.await?.is_empty()
+                && manifest_group.references.await?.is_empty(),
+            "a manifest chunk group must not have group-level references, or they would be \
+             emitted eagerly"
+        );
+
+        let assets = manifest_group
+            .assets
+            .await?
+            .iter()
+            .map(async |asset| {
+                Ok(ResolvedVc::upcast::<Box<dyn OutputAsset>>(
+                    LazyOutputAsset::new(**asset).to_resolved().await?,
+                ))
+            })
+            .try_join()
+            .await?;
+        Ok(OutputAssetsWithReferenced {
+            assets: ResolvedVc::cell(assets),
+            referenced_assets: manifest_group.referenced_assets,
+            references: manifest_group.references,
+        }
+        .cell())
     }
 
     #[turbo_tasks::function]
@@ -126,9 +188,14 @@ impl ManifestAsyncModule {
     #[turbo_tasks::function]
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
+        // The chunk list is loaded alongside the chunks it tracks, because loading it is what
+        // registers the HMR subscription on the client.
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root().owned().await?,
-            *self.chunk_group().await?.assets,
+            self.chunk_group()
+                .await?
+                .assets
+                .concatenate(self.hmr_chunk_list()),
         ))
     }
 }
@@ -224,6 +291,11 @@ impl EcmascriptChunkPlaceable for ManifestAsyncModule {
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
         _module_graph: Vc<ModuleGraph>,
     ) -> Vc<OutputAssetsWithReferenced> {
+        // Making the chunk list an output asset of this module is what gets it emitted, alongside
+        // the target chunks, when the boundary is materialized.
         self.chunk_group()
+            .concatenate(OutputAssetsWithReferenced::from_assets(
+                self.hmr_chunk_list(),
+            ))
     }
 }


### PR DESCRIPTION
## Summary

feat(turbopack): defer dynamic import chunks in development

## Verification

- Pre-commit formatting and lint checks passed for all changed files.
- Focused behavior is covered by `test/development/app-dir/lazy-dynamic-chunks/lazy-dynamic-chunks.test.ts`.
- CI pending.

<!-- NEXT_JS_LLM -->