### PR TITLE
Bound Turbopack server HMR to active App routes

### DIFF
--- a/crates/next-api/src/aggregate_hmr.rs
+++ b/crates/next-api/src/aggregate_hmr.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TraitRef, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -70,12 +70,54 @@ impl AggregateHmrVersion {
     ) -> Result<Vc<Box<dyn Version>>> {
         // An empty `versions` map behaves the same as `NotFoundVersion` would in
         // `diff_chunks_against`, so no special case is needed here.
-        let chunks = map.hmr_chunks_in_path(root).await?;
-        Ok(Vc::upcast(Self::from_chunks(&chunks).await?))
+        let snapshot = map.hmr_chunks_in_path(root).await?;
+        Ok(Vc::upcast(Self::from_chunks(&snapshot.active).await?))
     }
 
     pub async fn from_chunks(chunks: &[HmrChunkWithContent]) -> Result<Vc<Self>> {
-        let versions = chunks
+        let versions = Self::versions_from_chunks(chunks)
+            .await?
+            .into_iter()
+            .collect();
+        Ok(Self { versions }.cell())
+    }
+
+    /// Builds the next aggregate version while retaining the last version of
+    /// chunks outside the current working set. Inactive entries therefore do
+    /// not need to be evaluated on every update, but can still be diffed against
+    /// their last active version when they re-enter the working set.
+    pub async fn from_chunks_with_previous(
+        chunks: &[HmrChunkWithContent],
+        inactive_paths: &FxHashSet<RcStr>,
+        previous: Vc<VersionState>,
+    ) -> Result<Vc<Self>> {
+        let mut versions = Self::versions_from_chunks(chunks).await?;
+
+        let previous = previous.get().to_resolved().await?;
+        if let Some(previous) = ResolvedVc::try_downcast_type::<AggregateHmrVersion>(previous) {
+            versions.extend(
+                previous
+                    .await?
+                    .versions
+                    .iter()
+                    .filter(|(path, _)| inactive_paths.contains(*path))
+                    .map(|(path, version)| (path.clone(), version.clone())),
+            );
+        }
+
+        // Aggregate version IDs depend on iteration order. Keep the union sorted
+        // so merely activating or deactivating an unchanged entry is a no-op.
+        versions.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(Self {
+            versions: versions.into_iter().collect(),
+        }
+        .cell())
+    }
+
+    async fn versions_from_chunks(
+        chunks: &[HmrChunkWithContent],
+    ) -> Result<Vec<(RcStr, TraitRef<Box<dyn Version>>)>> {
+        let mut versions = chunks
             .iter()
             .map(|HmrChunkWithContent { path, content }| {
                 let path = path.clone();
@@ -86,10 +128,9 @@ impl AggregateHmrVersion {
                 }
             })
             .try_join()
-            .await?
-            .into_iter()
-            .collect();
-        Ok(Self { versions }.cell())
+            .await?;
+        versions.sort_by(|(a, _), (b, _)| a.cmp(b));
+        Ok(versions)
     }
 }
 

--- a/crates/next-api/src/aggregate_hmr.rs
+++ b/crates/next-api/src/aggregate_hmr.rs
@@ -33,6 +33,8 @@ pub fn is_entry_chunk_list_content(content: ResolvedVc<Box<dyn VersionedContent>
 pub struct AggregateHmrVersion {
     #[turbo_tasks(trace_ignore)]
     pub versions: FxIndexMap<RcStr, TraitRef<Box<dyn Version>>>,
+    /// Monotonic token identifying the active-route aggregate transition.
+    pub reactivation_epoch: u32,
 }
 
 #[turbo_tasks::value_impl]
@@ -54,6 +56,7 @@ impl Version for AggregateHmrVersion {
             .await?;
 
         let mut hasher = Xxh3Hash64Hasher::new();
+        hasher.write_value(self.reactivation_epoch);
         hasher.write_value(entries.len());
         for (path, id) in entries {
             hasher.write_value(path.as_str());
@@ -71,15 +74,24 @@ impl AggregateHmrVersion {
         // An empty `versions` map behaves the same as `NotFoundVersion` would in
         // `diff_chunks_against`, so no special case is needed here.
         let snapshot = map.hmr_chunks_in_path(root).await?;
-        Ok(Vc::upcast(Self::from_chunks(&snapshot.active).await?))
+        Ok(Vc::upcast(
+            Self::from_chunks(&snapshot.active, snapshot.reactivation_epoch).await?,
+        ))
     }
 
-    pub async fn from_chunks(chunks: &[HmrChunkWithContent]) -> Result<Vc<Self>> {
+    pub async fn from_chunks(
+        chunks: &[HmrChunkWithContent],
+        reactivation_epoch: u32,
+    ) -> Result<Vc<Self>> {
         let versions = Self::versions_from_chunks(chunks)
             .await?
             .into_iter()
             .collect();
-        Ok(Self { versions }.cell())
+        Ok(Self {
+            versions,
+            reactivation_epoch,
+        }
+        .cell())
     }
 
     /// Builds the next aggregate version while retaining the last version of
@@ -89,6 +101,7 @@ impl AggregateHmrVersion {
     pub async fn from_chunks_with_previous(
         chunks: &[HmrChunkWithContent],
         inactive_paths: &FxHashSet<RcStr>,
+        reactivation_epoch: u32,
         previous: Vc<VersionState>,
     ) -> Result<Vc<Self>> {
         let mut versions = Self::versions_from_chunks(chunks).await?;
@@ -110,8 +123,27 @@ impl AggregateHmrVersion {
         versions.sort_by(|(a, _), (b, _)| a.cmp(b));
         Ok(Self {
             versions: versions.into_iter().collect(),
+            reactivation_epoch,
         }
         .cell())
+    }
+
+    pub async fn reactivation_epoch_from_state(state: Vc<VersionState>) -> Result<Option<u32>> {
+        let version = state.get().to_resolved().await?;
+        let Some(version) = ResolvedVc::try_downcast_type::<AggregateHmrVersion>(version) else {
+            return Ok(None);
+        };
+        Ok(Some(version.await?.reactivation_epoch))
+    }
+
+    pub async fn reactivation_epoch_from_version(
+        version: TraitRef<Box<dyn Version>>,
+    ) -> Result<Option<u32>> {
+        let version = TraitRef::cell(version).to_resolved().await?;
+        let Some(version) = ResolvedVc::try_downcast_type::<AggregateHmrVersion>(version) else {
+            return Ok(None);
+        };
+        Ok(Some(version.await?.reactivation_epoch))
     }
 
     async fn versions_from_chunks(

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -830,6 +830,9 @@ impl ProjectContainer {
         let root = project_hmr_root_path_operation(project, target)
             .read_strongly_consistent()
             .await?;
+        let project_fs = project_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
         let paths = chunk_names
             .into_iter()
             .map(|chunk_name| root.join(&chunk_name))
@@ -838,7 +841,7 @@ impl ProjectContainer {
         versioned_content_map_operation(map)
             .read_strongly_consistent()
             .await?
-            .set_hmr_chunks_active(paths, active)
+            .set_hmr_chunks_active(paths, active, &project_fs)
             .await?;
         Ok(())
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -505,6 +505,21 @@ fn output_fs_operation(project: ResolvedVc<Project>) -> Vc<DiskFileSystem> {
     project.project_fs()
 }
 
+#[turbo_tasks::function(operation, root)]
+fn project_hmr_root_path_operation(
+    project: ResolvedVc<Project>,
+    target: HmrTarget,
+) -> Vc<FileSystemPath> {
+    project.hmr_root_path(target)
+}
+
+#[turbo_tasks::function(operation, root)]
+fn versioned_content_map_operation(
+    map: ResolvedVc<VersionedContentMap>,
+) -> Vc<VersionedContentMap> {
+    *map
+}
+
 enum EnvDiffType {
     Added,
     Removed,
@@ -795,6 +810,37 @@ impl ProjectContainer {
         }
         .instrument(span_clone)
         .await
+    }
+
+    /// Adds or removes output entry chunks from the aggregate HMR working set.
+    /// This method is intentionally not a `turbo_tasks::function`: route activity
+    /// can toggle repeatedly with the same arguments during one dev session.
+    pub async fn set_hmr_chunks_active(
+        self: ResolvedVc<Self>,
+        chunk_names: Vec<RcStr>,
+        target: HmrTarget,
+        active: bool,
+    ) -> Result<()> {
+        let project_op = project_operation(self);
+        let project = project_op.resolve().strongly_consistent().await?;
+        let project_ref = project_op.read_strongly_consistent().await?;
+        let Some(map) = project_ref.versioned_content_map else {
+            bail!("must be in dev mode to configure hmr chunks")
+        };
+        let root = project_hmr_root_path_operation(project, target)
+            .read_strongly_consistent()
+            .await?;
+        let paths = chunk_names
+            .into_iter()
+            .map(|chunk_name| root.join(&chunk_name))
+            .collect::<Result<Vec<_>>>()?;
+
+        versioned_content_map_operation(map)
+            .read_strongly_consistent()
+            .await?
+            .set_hmr_chunks_active(paths, active)
+            .await?;
+        Ok(())
     }
 }
 
@@ -2640,15 +2686,20 @@ impl Project {
             bail!("must be in dev mode to hmr")
         };
         let root = self.aggregate_hmr_root_path(target).owned().await?;
-        let chunks_versioned_content = map.hmr_chunks_in_path(&root).await?;
+        let chunk_snapshot = map.hmr_chunks_in_path(&root).await?;
 
         // No chunks to diff yet (e.g. before any endpoints have been written).
-        if chunks_versioned_content.is_empty() {
+        if chunk_snapshot.active.is_empty() {
             return Ok(Update::None.cell());
         }
 
         // Build `to` up front so we can return it on every escape hatch below.
-        let to_aggregate = AggregateHmrVersion::from_chunks(&chunks_versioned_content).await?;
+        let to_aggregate = AggregateHmrVersion::from_chunks_with_previous(
+            &chunk_snapshot.active,
+            &chunk_snapshot.inactive_paths,
+            from,
+        )
+        .await?;
         let to_ref = Vc::upcast::<Box<dyn Version>>(to_aggregate)
             .into_trait_ref()
             .await?;
@@ -2656,7 +2707,7 @@ impl Project {
         let DiffResult {
             chunk_updates,
             has_new_chunks,
-        } = diff_chunks_against(&chunks_versioned_content, from).await?;
+        } = diff_chunks_against(&chunk_snapshot.active, from).await?;
 
         // Nothing to apply, but `from` still needs to advance to `to`. Reaching
         // here means `from` held a version we couldn't diff against (it wasn't an

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -845,6 +845,39 @@ impl ProjectContainer {
             .await?;
         Ok(())
     }
+
+    /// Permanently removes output entry chunks for routes deleted during a dev
+    /// session. This is distinct from temporary inactivity, which must retain
+    /// enough state for later reactivation.
+    pub async fn remove_hmr_chunks(
+        self: ResolvedVc<Self>,
+        chunk_names: Vec<RcStr>,
+        target: HmrTarget,
+    ) -> Result<()> {
+        let project_op = project_operation(self);
+        let project = project_op.resolve().strongly_consistent().await?;
+        let project_ref = project_op.read_strongly_consistent().await?;
+        let Some(map) = project_ref.versioned_content_map else {
+            bail!("must be in dev mode to remove hmr chunks")
+        };
+        let root = project_hmr_root_path_operation(project, target)
+            .read_strongly_consistent()
+            .await?;
+        let project_fs = project_fs_operation(project)
+            .read_strongly_consistent()
+            .await?;
+        let paths = chunk_names
+            .into_iter()
+            .map(|chunk_name| root.join(&chunk_name))
+            .collect::<Result<Vec<_>>>()?;
+
+        versioned_content_map_operation(map)
+            .read_strongly_consistent()
+            .await?
+            .remove_hmr_chunks(paths, &project_fs)
+            .await?;
+        Ok(())
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -863,9 +863,6 @@ impl ProjectContainer {
         let root = project_hmr_root_path_operation(project, target)
             .read_strongly_consistent()
             .await?;
-        let project_fs = project_fs_operation(project)
-            .read_strongly_consistent()
-            .await?;
         let paths = chunk_names
             .into_iter()
             .map(|chunk_name| root.join(&chunk_name))
@@ -874,7 +871,7 @@ impl ProjectContainer {
         versioned_content_map_operation(map)
             .read_strongly_consistent()
             .await?
-            .remove_hmr_chunks(paths, &project_fs)
+            .remove_hmr_chunks(paths)
             .await?;
         Ok(())
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -40,7 +40,7 @@ use tracing::{Instrument, field::Empty};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Completions, FxIndexMap, NonLocalValue, OperationValue, OperationVc, ReadRef,
-    ResolvedVc, State, TransientInstance, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    ResolvedVc, State, TraitRef, TransientInstance, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
@@ -209,6 +209,13 @@ impl std::str::FromStr for HmrTarget {
             )),
         }
     }
+}
+
+/// Extracts the route-reactivation acknowledgement carried by an aggregate HMR version.
+pub async fn aggregate_hmr_reactivation_epoch(
+    version: TraitRef<Box<dyn Version>>,
+) -> Result<Option<u32>> {
+    AggregateHmrVersion::reactivation_epoch_from_version(version).await
 }
 
 /// Pre-converted route keys from debug build paths for O(1) lookups.
@@ -820,7 +827,9 @@ impl ProjectContainer {
         chunk_names: Vec<RcStr>,
         target: HmrTarget,
         active: bool,
-    ) -> Result<()> {
+        reactivation_source_paths: Vec<RcStr>,
+        advance_reactivation_epoch: bool,
+    ) -> Result<u32> {
         let project_op = project_operation(self);
         let project = project_op.resolve().strongly_consistent().await?;
         let project_ref = project_op.read_strongly_consistent().await?;
@@ -830,20 +839,36 @@ impl ProjectContainer {
         let root = project_hmr_root_path_operation(project, target)
             .read_strongly_consistent()
             .await?;
-        let project_fs = project_fs_operation(project)
-            .read_strongly_consistent()
-            .await?;
+        let project_fs_op = project_fs_operation(project);
+        let project_fs_vc = project_fs_op.resolve().strongly_consistent().await?;
+        let project_fs = project_fs_op.read_strongly_consistent().await?;
         let paths = chunk_names
             .into_iter()
             .map(|chunk_name| root.join(&chunk_name))
+            .collect::<Result<Vec<_>>>()?;
+        let reactivation_source_paths = reactivation_source_paths
+            .into_iter()
+            .map(|path| {
+                project_fs
+                    .try_from_sys_path(project_fs_vc, Path::new(path.as_str()), None)
+                    .map(|path| project_fs.to_sys_path_raw(&path))
+                    .with_context(|| {
+                        format!("source path is outside the project filesystem: {path}")
+                    })
+            })
             .collect::<Result<Vec<_>>>()?;
 
         versioned_content_map_operation(map)
             .read_strongly_consistent()
             .await?
-            .set_hmr_chunks_active(paths, active, &project_fs)
-            .await?;
-        Ok(())
+            .set_hmr_chunks_active(
+                paths,
+                active,
+                &project_fs,
+                reactivation_source_paths,
+                advance_reactivation_epoch,
+            )
+            .await
     }
 
     /// Permanently removes output entry chunks for routes deleted during a dev
@@ -2721,15 +2746,16 @@ impl Project {
         let root = self.aggregate_hmr_root_path(target).owned().await?;
         let chunk_snapshot = map.hmr_chunks_in_path(&root).await?;
 
-        // No chunks to diff yet (e.g. before any endpoints have been written).
-        if chunk_snapshot.active.is_empty() {
-            return Ok(Update::None.cell());
-        }
-
-        // Build `to` up front so we can return it on every escape hatch below.
+        // Build `to` up front so even an empty active set can carry a route
+        // reactivation acknowledgement to the server runtime.
+        let from_reactivation_epoch =
+            AggregateHmrVersion::reactivation_epoch_from_state(from).await?;
+        let reactivation_epoch_changed =
+            from_reactivation_epoch != Some(chunk_snapshot.reactivation_epoch);
         let to_aggregate = AggregateHmrVersion::from_chunks_with_previous(
             &chunk_snapshot.active,
             &chunk_snapshot.inactive_paths,
+            chunk_snapshot.reactivation_epoch,
             from,
         )
         .await?;
@@ -2765,7 +2791,7 @@ impl Project {
             }
         }
 
-        if builder.is_empty() && !has_new_chunks {
+        if builder.is_empty() && !has_new_chunks && !reactivation_epoch_changed {
             return Ok(Update::None.cell());
         }
 

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -215,7 +215,7 @@ pub struct EndpointGroups(Vec<(EndpointGroupKey, EndpointGroup)>);
 #[turbo_tasks::value(transparent)]
 pub struct Endpoints(Vec<ResolvedVc<Box<dyn Endpoint>>>);
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 pub async fn endpoint_write_to_disk(
     endpoint: ResolvedVc<Box<dyn Endpoint>>,
 ) -> Result<Vc<EndpointOutputPaths>> {
@@ -251,10 +251,54 @@ pub async fn endpoint_write_to_disk_operation(
     endpoint: OperationVc<OptionEndpoint>,
 ) -> Result<Vc<EndpointOutputPaths>> {
     Ok(if let Some(endpoint) = *endpoint.connect().await? {
-        endpoint_write_to_disk(*endpoint)
+        endpoint_write_to_disk(endpoint).connect()
     } else {
         EndpointOutputPaths::NotFound.cell()
     })
+}
+
+#[turbo_tasks::value(cell = "new", eq = "manual")]
+struct EndpointInvalidationInfo {
+    endpoint: Option<ResolvedVc<Box<dyn Endpoint>>>,
+    output: Option<OperationVc<EndpointOutput>>,
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn endpoint_invalidation_info_operation(
+    endpoint: OperationVc<OptionEndpoint>,
+) -> Result<Vc<EndpointInvalidationInfo>> {
+    let Some(endpoint) = *endpoint.connect().await? else {
+        return Ok(EndpointInvalidationInfo {
+            endpoint: None,
+            output: None,
+        }
+        .cell());
+    };
+    let output = output_assets_operation(endpoint);
+    output.connect().await?;
+    Ok(EndpointInvalidationInfo {
+        endpoint: Some(endpoint),
+        output: Some(output),
+    }
+    .cell())
+}
+
+/// Invalidates the cached endpoint-output chain. This is used when an endpoint
+/// subscription was disconnected so the next write recomputes it from the
+/// current source tree.
+pub async fn invalidate_endpoint_output(endpoint: OperationVc<OptionEndpoint>) -> Result<()> {
+    let info = endpoint_invalidation_info_operation(endpoint)
+        .read_strongly_consistent()
+        .await?;
+    if let (Some(endpoint_value), Some(output)) = (info.endpoint, info.output) {
+        // Reconnecting under a strongly-consistent root makes watcher-invalidated
+        // dependencies current. Only the effectful output/write wrappers need an
+        // explicit rerun; the endpoint output operation itself may be immutable.
+        endpoint_output_assets_operation(output).invalidate();
+        endpoint_write_to_disk(endpoint_value).invalidate();
+    }
+    endpoint_write_to_disk_operation(endpoint).invalidate();
+    Ok(())
 }
 
 #[turbo_tasks::function(operation, root)]

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -64,9 +64,62 @@ struct ExpandedOutputAssetsOperationSet(
 // HACK: This is technically incorrect because the map's key contains a `ResolvedVc`...
 unsafe impl OperationValue for PathToOutputOperation {}
 
+#[derive(
+    Clone,
+    Default,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Debug,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+struct InactiveHmrPaths(FxHashSet<FileSystemPath>);
+
+// HACK: As above, the set's keys contain `ResolvedVc`s.
+unsafe impl OperationValue for InactiveHmrPaths {}
+
 // A precomputed map for quick access to output asset by filepath
 type OutputOperationToComputeEntry =
     FxHashMap<OperationVc<ExpandedOutputAssets>, OperationVc<OptionMapEntry>>;
+
+#[derive(
+    Clone, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Debug, NonLocalValue, Encode, Decode,
+)]
+struct InactiveOutputOperation {
+    compute_entry: OperationVc<OptionMapEntry>,
+    /// A materialized lookup snapshot keeps existing client-chunk subscriptions
+    /// and source maps valid without reconnecting the endpoint's output graph.
+    path_to_asset: FxHashMap<FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>>,
+}
+
+#[derive(
+    Clone,
+    Default,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Debug,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+struct InactiveOutputOperations(
+    #[turbo_tasks(trace_ignore)]
+    FxHashMap<OperationVc<ExpandedOutputAssets>, InactiveOutputOperation>,
+);
+
+// The ignored trace is intentional: these operation and asset handles must be
+// available for lookup/reactivation without keeping their task graphs connected.
+unsafe impl OperationValue for InactiveOutputOperations {}
+
+pub struct HmrChunkSnapshot {
+    pub active: Vec<HmrChunkWithContent>,
+    pub inactive_paths: FxHashSet<RcStr>,
+}
 
 // TODO: Ideally this structure is never persisted, so new sessions start from scratch and don't
 // accumulate entries or force rebuilds of all chunks when a new session is only interested in some
@@ -77,6 +130,12 @@ pub struct VersionedContentMap {
     // FxIndexSet<FileSystemPath>
     map_path_to_op: State<PathToOutputOperation>,
     map_op_to_compute_entry: State<OutputOperationToComputeEntry>,
+    inactive_output_operations: State<InactiveOutputOperations>,
+    /// Entry chunks that are not part of the aggregate HMR working set. Their
+    /// path index and operation handles remain available for reactivation, but
+    /// changes do not invalidate or rebuild the aggregate subscription until the
+    /// entry becomes active again.
+    inactive_hmr_paths: State<InactiveHmrPaths>,
 }
 
 impl VersionedContentMap {
@@ -86,6 +145,8 @@ impl VersionedContentMap {
         VersionedContentMap {
             map_path_to_op: State::new(PathToOutputOperation(FxHashMap::default())),
             map_op_to_compute_entry: State::new(FxHashMap::default()),
+            inactive_output_operations: State::new(InactiveOutputOperations::default()),
+            inactive_hmr_paths: State::new(InactiveHmrPaths::default()),
         }
         .resolved_cell()
     }
@@ -105,13 +166,25 @@ impl VersionedContentMap {
     pub async fn hmr_chunks_in_path(
         self: Vc<Self>,
         root: &FileSystemPath,
-    ) -> Result<Vec<HmrChunkWithContent>> {
+    ) -> Result<HmrChunkSnapshot> {
         let this = self.await?;
         // `State::get` returns a lock guard, which can't be held across the
-        // awaits below, so snapshot the keys and release it.
-        let paths: Vec<FileSystemPath> = {
+        // awaits below, so snapshot the keys and release it. Keep the inactive
+        // paths from the same snapshot: only those paths may retain their prior
+        // aggregate version when absent from the active chunks below.
+        let (paths, inactive_paths): (Vec<FileSystemPath>, FxHashSet<RcStr>) = {
             let map = &this.map_path_to_op.get().0;
-            map.keys().cloned().collect()
+            let inactive_hmr_paths = &this.inactive_hmr_paths.get().0;
+            (
+                map.keys()
+                    .filter(|path| !inactive_hmr_paths.contains(*path))
+                    .cloned()
+                    .collect(),
+                inactive_hmr_paths
+                    .iter()
+                    .filter_map(|path| root.get_path_to(path).map(RcStr::from))
+                    .collect(),
+            )
         };
 
         let mut chunks = paths
@@ -146,7 +219,155 @@ impl VersionedContentMap {
             .try_flat_join()
             .await?;
         chunks.sort_by(|a, b| a.path.cmp(&b.path));
-        Ok(chunks)
+        Ok(HmrChunkSnapshot {
+            active: chunks,
+            inactive_paths,
+        })
+    }
+
+    /// Adds or removes entry chunks from the aggregate HMR working set.
+    ///
+    /// Retiring an entry disconnects every output operation that owns that entry
+    /// path. The operation handles and path index are retained without tracing
+    /// them, so reactivation can reconnect the exact cached operation without a
+    /// new endpoint write.
+    ///
+    /// This is deliberately a direct state mutation rather than a cached
+    /// `turbo_tasks::function`: the same path can transition between active and
+    /// inactive multiple times during one dev session.
+    pub async fn set_hmr_chunks_active(
+        &self,
+        paths: impl IntoIterator<Item = FileSystemPath>,
+        active: bool,
+    ) -> Result<()> {
+        let paths = paths.into_iter().collect::<Vec<_>>();
+        let operations = {
+            let map = &self.map_path_to_op.get().0;
+            paths
+                .iter()
+                .filter_map(|path| map.get(path))
+                .flat_map(|operations| operations.0.iter().copied())
+                .collect::<FxHashSet<_>>()
+        };
+
+        if active {
+            let reactivated = {
+                let inactive = self.inactive_output_operations.get_untracked();
+                operations
+                    .iter()
+                    .filter_map(|operation| {
+                        inactive
+                            .0
+                            .get(operation)
+                            .map(|entry| (*operation, entry.compute_entry))
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            // Publish the live lookup before removing the inactive snapshot. A
+            // reader may briefly see both, but never sees the asset disappear.
+            self.map_op_to_compute_entry.update_conditionally(|map| {
+                let mut changed = false;
+                for &(operation, compute_entry) in &reactivated {
+                    changed |= map.insert(operation, compute_entry) != Some(compute_entry);
+                }
+                changed
+            });
+            // Retirement materializes each compute entry before disconnecting,
+            // so a strongly-consistent read is sufficient to catch up only the
+            // operations being reactivated.
+            for &(_, compute_entry) in &reactivated {
+                compute_entry.read_strongly_consistent().await?;
+            }
+            self.inactive_output_operations
+                .update_conditionally(|inactive| {
+                    let mut changed = false;
+                    for (operation, _) in &reactivated {
+                        changed |= inactive.0.remove(operation).is_some();
+                    }
+                    changed
+                });
+            // Reactivation reconnects operations before publishing their paths as
+            // active so a concurrent aggregate read never observes a missing entry.
+            self.inactive_hmr_paths
+                .update_conditionally(|inactive_hmr_paths| {
+                    let mut changed = false;
+                    for path in &paths {
+                        changed |= inactive_hmr_paths.0.remove(path);
+                    }
+                    changed
+                });
+        } else {
+            // Materialize the last asset lookup before disconnecting. Existing
+            // client chunk subscriptions and source-map requests can use this
+            // snapshot without reconnecting the endpoint's aggregate graph.
+            let compute_entries = {
+                let map = self.map_op_to_compute_entry.get();
+                operations
+                    .iter()
+                    .filter_map(|operation| {
+                        map.get(operation)
+                            .map(|compute_entry| (*operation, *compute_entry))
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let snapshots = compute_entries
+                .into_iter()
+                .map(|(operation, compute_entry)| async move {
+                    let map_entry = compute_entry.read_strongly_consistent().await?;
+                    let path_to_asset = if let Some(entry) = &*map_entry {
+                        entry.path_to_asset.clone()
+                    } else {
+                        FxHashMap::default()
+                    };
+                    Ok::<_, anyhow::Error>((
+                        operation,
+                        InactiveOutputOperation {
+                            compute_entry,
+                            path_to_asset,
+                        },
+                    ))
+                })
+                .try_join()
+                .await?
+                .into_iter()
+                .collect::<FxHashMap<_, _>>();
+
+            // Publish retirement before disconnecting its operations so a concurrent
+            // aggregate read preserves the previous versions.
+            self.inactive_hmr_paths
+                .update_conditionally(|inactive_hmr_paths| {
+                    let mut changed = false;
+                    for path in &paths {
+                        changed |= inactive_hmr_paths.0.insert(path.clone());
+                    }
+                    changed
+                });
+
+            let snapshot_operations = snapshots.keys().copied().collect::<Vec<_>>();
+            // Publish the inactive fallback before dropping the live lookup. A
+            // reader may briefly prefer the live entry, but never observes a gap.
+            self.inactive_output_operations
+                .update_conditionally(|inactive| {
+                    if snapshots.is_empty() {
+                        return false;
+                    }
+                    for (operation, inactive_operation) in snapshots {
+                        inactive.0.insert(operation, inactive_operation);
+                    }
+                    true
+                });
+            // Drop the traced roots only after their lookup snapshots are visible.
+            // No compute task depends on this project-wide state transition.
+            self.map_op_to_compute_entry.update_conditionally(|map| {
+                let mut changed = false;
+                for operation in snapshot_operations {
+                    changed |= map.remove(&operation).is_some();
+                }
+                changed
+            });
+        }
+        Ok(())
     }
 }
 
@@ -174,6 +395,8 @@ impl VersionedContentMap {
             client_relative_path,
             client_output_path,
         );
+        this.inactive_output_operations
+            .update_conditionally(|inactive| inactive.0.remove(&assets_operation).is_some());
         this.map_op_to_compute_entry.update_conditionally(|map| {
             map.insert(assets_operation, compute_entry) != Some(compute_entry)
         });
@@ -196,6 +419,9 @@ impl VersionedContentMap {
             // Any error should result in an empty list, which removes all assets from the map
             .ok();
 
+        // Retirement strongly reads this materialized entry before disconnecting
+        // it, so an in-flight computation can finish without observing global
+        // activity state or becoming a dependency of every route transition.
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
@@ -286,7 +512,24 @@ impl VersionedContentMap {
             return Ok(Vc::cell(Some(asset)));
         }
 
-        Ok(Vc::cell(None))
+        // A retired output operation is intentionally disconnected, but its
+        // last materialized assets remain valid lookup results. Returning only
+        // the requested asset avoids reconnecting the whole endpoint graph.
+        let inactive_asset = {
+            let this = self.await?;
+            let path_to_operations = &this.map_path_to_op.get().0;
+            let inactive_operations = this.inactive_output_operations.get();
+            path_to_operations.get(&path).and_then(|operations| {
+                operations.0.iter().find_map(|operation| {
+                    inactive_operations
+                        .0
+                        .get(operation)
+                        .and_then(|entry| entry.path_to_asset.get(&path))
+                        .copied()
+                })
+            })
+        };
+        Ok(Vc::cell(inactive_asset))
     }
 
     #[turbo_tasks::function]
@@ -308,23 +551,22 @@ impl VersionedContentMap {
 
     #[turbo_tasks::function]
     fn raw_get(&self, path: FileSystemPath) -> Vc<OptionMapEntry> {
-        let assets = {
-            let map = &self.map_path_to_op.get().0;
-            map.get(&path).and_then(|m| m.0.iter().next().copied())
+        let operation = {
+            let path_to_operations = &self.map_path_to_op.get().0;
+            let operation_to_compute_entry = self.map_op_to_compute_entry.get();
+            path_to_operations.get(&path).and_then(|operations| {
+                operations.0.iter().find_map(|operation| {
+                    operation_to_compute_entry
+                        .get(operation)
+                        .map(|compute_entry| (*operation, *compute_entry))
+                })
+            })
         };
-        let Some(assets) = assets else {
+        let Some((assets_operation, compute_entry)) = operation else {
             return Vc::cell(None);
         };
-        // Need to reconnect the operation to the map
-        let _ = assets.connect();
-
-        let compute_entry = {
-            let map = self.map_op_to_compute_entry.get();
-            map.get(&assets).copied()
-        };
-        let Some(compute_entry) = compute_entry else {
-            return Vc::cell(None);
-        };
+        // Need to reconnect both operations to the map.
+        let _ = assets_operation.connect();
         compute_entry.connect()
     }
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -90,6 +90,8 @@ type OutputOperationToComputeEntry =
 )]
 struct InactiveOutputOperation {
     compute_entry: OperationVc<OptionMapEntry>,
+    /// Project filesystem generation when this operation was disconnected.
+    filesystem_epoch: u64,
     /// A materialized lookup snapshot keeps existing client-chunk subscriptions
     /// and source maps valid without reconnecting the endpoint's output graph.
     path_to_asset: FxHashMap<FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>>,
@@ -131,6 +133,10 @@ pub struct VersionedContentMap {
     map_path_to_op: State<PathToOutputOperation>,
     map_op_to_compute_entry: State<OutputOperationToComputeEntry>,
     inactive_output_operations: State<InactiveOutputOperations>,
+    /// Deleted route entry paths retain only a disconnected operation handle so
+    /// re-adding a memoized route can reconnect it. Unlike inactive paths, these
+    /// are omitted from the aggregate version instead of preserving a frozen one.
+    removed_hmr_paths: State<InactiveHmrPaths>,
     /// Entry chunks that are not part of the aggregate HMR working set. Their
     /// path index and operation handles remain available for reactivation, but
     /// changes do not invalidate or rebuild the aggregate subscription until the
@@ -146,6 +152,7 @@ impl VersionedContentMap {
             map_path_to_op: State::new(PathToOutputOperation(FxHashMap::default())),
             map_op_to_compute_entry: State::new(FxHashMap::default()),
             inactive_output_operations: State::new(InactiveOutputOperations::default()),
+            removed_hmr_paths: State::new(InactiveHmrPaths::default()),
             inactive_hmr_paths: State::new(InactiveHmrPaths::default()),
         }
         .resolved_cell()
@@ -175,9 +182,12 @@ impl VersionedContentMap {
         let (paths, inactive_paths): (Vec<FileSystemPath>, FxHashSet<RcStr>) = {
             let map = &this.map_path_to_op.get().0;
             let inactive_hmr_paths = &this.inactive_hmr_paths.get().0;
+            let removed_hmr_paths = &this.removed_hmr_paths.get().0;
             (
                 map.keys()
-                    .filter(|path| !inactive_hmr_paths.contains(*path))
+                    .filter(|path| {
+                        !inactive_hmr_paths.contains(*path) && !removed_hmr_paths.contains(*path)
+                    })
                     .cloned()
                     .collect(),
                 inactive_hmr_paths
@@ -252,6 +262,14 @@ impl VersionedContentMap {
         };
 
         if active {
+            // Deletion and re-addition can be coalesced into one watcher batch,
+            // leaving the filesystem generation unchanged. Removed routes still
+            // need conservative catch-up before reconnecting their retained
+            // operation, even when the epoch comparison alone cannot see it.
+            let was_removed = {
+                let removed = self.removed_hmr_paths.get_untracked();
+                paths.iter().any(|path| removed.0.contains(path))
+            };
             let reactivated = {
                 let inactive = self.inactive_output_operations.get_untracked();
                 operations
@@ -260,7 +278,7 @@ impl VersionedContentMap {
                         inactive
                             .0
                             .get(operation)
-                            .map(|entry| (*operation, entry.compute_entry))
+                            .map(|entry| (*operation, entry.compute_entry, entry.filesystem_epoch))
                     })
                     .collect::<Vec<_>>()
             };
@@ -269,32 +287,44 @@ impl VersionedContentMap {
             // reader may briefly see both, but never sees the asset disappear.
             self.map_op_to_compute_entry.update_conditionally(|map| {
                 let mut changed = false;
-                for &(operation, compute_entry) in &reactivated {
+                for &(operation, compute_entry, _) in &reactivated {
                     changed |= map.insert(operation, compute_entry) != Some(compute_entry);
                 }
                 changed
             });
-            // A file may change while this operation is disconnected, when its
-            // filesystem invalidator is not live. Reconnect first, then
-            // invalidate the tracked project reads once so the strong read below
-            // cannot reuse a clean-but-stale graph. This cost is paid only when
-            // an inactive route is requested again, not by unrelated edits.
-            if !reactivated.is_empty() {
+            // Only routes that actually crossed a filesystem change need the
+            // conservative catch-up. Plain navigation after inactivity keeps the
+            // cached project graph warm.
+            let current_filesystem_epoch = project_fs.settled_change_epoch().await;
+            if was_removed
+                || reactivated
+                    .iter()
+                    .any(|(_, _, filesystem_epoch)| *filesystem_epoch < current_filesystem_epoch)
+            {
                 project_fs.invalidate_with_reason(|path| invalidation::Initialize {
                     path: RcStr::from(path.to_string_lossy()),
                 });
             }
-            for &(_, compute_entry) in &reactivated {
+            // Reconnect and strongly read these output graphs after the conditional
+            // catch-up. The caller then refreshes the endpoint's effectful wrappers.
+            for &(_, compute_entry, _) in &reactivated {
                 compute_entry.read_strongly_consistent().await?;
             }
             self.inactive_output_operations
                 .update_conditionally(|inactive| {
                     let mut changed = false;
-                    for (operation, _) in &reactivated {
+                    for (operation, _, _) in &reactivated {
                         changed |= inactive.0.remove(operation).is_some();
                     }
                     changed
                 });
+            self.removed_hmr_paths.update_conditionally(|removed| {
+                let mut changed = false;
+                for path in &paths {
+                    changed |= removed.0.remove(path);
+                }
+                changed
+            });
             // Reactivation reconnects operations before publishing their paths as
             // active so a concurrent aggregate read never observes a missing entry.
             self.inactive_hmr_paths
@@ -319,6 +349,7 @@ impl VersionedContentMap {
                     })
                     .collect::<Vec<_>>()
             };
+            let filesystem_epoch = project_fs.settled_change_epoch().await;
             let snapshots = compute_entries
                 .into_iter()
                 .map(|(operation, compute_entry)| async move {
@@ -332,6 +363,7 @@ impl VersionedContentMap {
                         operation,
                         InactiveOutputOperation {
                             compute_entry,
+                            filesystem_epoch,
                             path_to_asset,
                         },
                     ))
@@ -375,6 +407,106 @@ impl VersionedContentMap {
                 changed
             });
         }
+        Ok(())
+    }
+
+    /// Removes deleted routes from aggregate HMR versions and drops their
+    /// materialized output assets. Keep only the entry path plus disconnected
+    /// operation/compute handles: Turbopack may reuse that memoized graph when
+    /// the same route file is added again.
+    pub async fn remove_hmr_chunks(
+        &self,
+        paths: impl IntoIterator<Item = FileSystemPath>,
+        project_fs: &DiskFileSystem,
+    ) -> Result<()> {
+        let paths = paths.into_iter().collect::<Vec<_>>();
+        let operations = {
+            let map = &self.map_path_to_op.get().0;
+            paths
+                .iter()
+                .filter_map(|path| map.get(path))
+                .flat_map(|operations| operations.0.iter().copied())
+                .collect::<FxHashSet<_>>()
+        };
+        let current_filesystem_epoch = project_fs.settled_change_epoch().await;
+        let retained_operations = {
+            let active = self.map_op_to_compute_entry.get_untracked();
+            let inactive = self.inactive_output_operations.get_untracked();
+            operations
+                .iter()
+                .filter_map(|operation| {
+                    if let Some(entry) = inactive.0.get(operation) {
+                        Some((
+                            *operation,
+                            InactiveOutputOperation {
+                                compute_entry: entry.compute_entry,
+                                filesystem_epoch: entry.filesystem_epoch,
+                                path_to_asset: FxHashMap::default(),
+                            },
+                        ))
+                    } else {
+                        active.get(operation).map(|compute_entry| {
+                            (
+                                *operation,
+                                InactiveOutputOperation {
+                                    compute_entry: *compute_entry,
+                                    filesystem_epoch: current_filesystem_epoch,
+                                    path_to_asset: FxHashMap::default(),
+                                },
+                            )
+                        })
+                    }
+                })
+                .collect::<Vec<_>>()
+        };
+
+        self.inactive_output_operations
+            .update_conditionally(|inactive| {
+                if retained_operations.is_empty() {
+                    return false;
+                }
+                for (operation, retained) in &retained_operations {
+                    inactive.0.insert(*operation, retained.clone());
+                }
+                true
+            });
+        self.removed_hmr_paths.update_conditionally(|removed| {
+            let mut changed = false;
+            for path in &paths {
+                changed |= removed.0.insert(path.clone());
+            }
+            changed
+        });
+        self.inactive_hmr_paths
+            .update_conditionally(|inactive_hmr_paths| {
+                let mut changed = false;
+                for path in &paths {
+                    changed |= inactive_hmr_paths.0.remove(path);
+                }
+                changed
+            });
+        // Preserve only the entry-path lookup needed to find these operations on
+        // re-add; drop their ownership of every other emitted output path.
+        self.map_path_to_op.update_conditionally(|map| {
+            let mut changed = false;
+            map.0.retain(|path, owners| {
+                if paths.contains(path) {
+                    return true;
+                }
+                let old_len = owners.0.len();
+                owners.0.retain(|operation| !operations.contains(operation));
+                changed |= owners.0.len() != old_len;
+                !owners.0.is_empty()
+            });
+            changed
+        });
+        self.map_op_to_compute_entry.update_conditionally(|map| {
+            let mut changed = false;
+            for operation in &operations {
+                changed |= map.remove(operation).is_some();
+            }
+            changed
+        });
         Ok(())
     }
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
 use next_core::emit_assets;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -116,6 +118,8 @@ unsafe impl OperationValue for InactiveOutputOperations {}
 pub struct HmrChunkSnapshot {
     pub active: Vec<HmrChunkWithContent>,
     pub inactive_paths: FxHashSet<RcStr>,
+    /// Monotonic acknowledgement token for aggregate-HMR route reactivation.
+    pub reactivation_epoch: u32,
 }
 
 // TODO: Ideally this structure is never persisted, so new sessions start from scratch and don't
@@ -137,6 +141,9 @@ pub struct VersionedContentMap {
     /// changes do not invalidate or rebuild the aggregate subscription until the
     /// entry becomes active again.
     inactive_hmr_paths: State<InactiveHmrPaths>,
+    /// Advances after a route rejoins the aggregate HMR working set. The token is
+    /// carried by the aggregate version so JS can wait for that exact transition.
+    reactivation_epoch: State<u32>,
 }
 
 impl VersionedContentMap {
@@ -149,6 +156,7 @@ impl VersionedContentMap {
             inactive_output_operations: State::new(InactiveOutputOperations::default()),
             removed_hmr_paths: State::new(InactiveHmrPaths::default()),
             inactive_hmr_paths: State::new(InactiveHmrPaths::default()),
+            reactivation_epoch: State::new(0),
         }
         .resolved_cell()
     }
@@ -174,7 +182,11 @@ impl VersionedContentMap {
         // awaits below, so snapshot the keys and release it. Keep the inactive
         // paths from the same snapshot: only those paths may retain their prior
         // aggregate version when absent from the active chunks below.
-        let (paths, inactive_paths): (Vec<FileSystemPath>, FxHashSet<RcStr>) = {
+        let (paths, inactive_paths, reactivation_epoch): (
+            Vec<FileSystemPath>,
+            FxHashSet<RcStr>,
+            u32,
+        ) = {
             let map = &this.map_path_to_op.get().0;
             let inactive_hmr_paths = &this.inactive_hmr_paths.get().0;
             let removed_hmr_paths = &this.removed_hmr_paths.get().0;
@@ -189,6 +201,7 @@ impl VersionedContentMap {
                     .iter()
                     .filter_map(|path| root.get_path_to(path).map(RcStr::from))
                     .collect(),
+                *this.reactivation_epoch.get(),
             )
         };
 
@@ -227,6 +240,7 @@ impl VersionedContentMap {
         Ok(HmrChunkSnapshot {
             active: chunks,
             inactive_paths,
+            reactivation_epoch,
         })
     }
 
@@ -244,7 +258,12 @@ impl VersionedContentMap {
         paths: impl IntoIterator<Item = FileSystemPath>,
         active: bool,
         project_fs: &DiskFileSystem,
-    ) -> Result<()> {
+        reactivation_source_paths: Vec<PathBuf>,
+        advance_reactivation_epoch: bool,
+    ) -> Result<u32> {
+        if advance_reactivation_epoch && !active {
+            bail!("cannot acknowledge an inactive HMR chunk");
+        }
         let paths = paths.into_iter().collect::<Vec<_>>();
         let operations = {
             let map = &self.map_path_to_op.get().0;
@@ -263,6 +282,9 @@ impl VersionedContentMap {
                 let removed = self.removed_hmr_paths.get_untracked();
                 paths.iter().any(|path| removed.0.contains(path))
             };
+            if was_removed && reactivation_source_paths.is_empty() {
+                bail!("re-adding an HMR chunk requires its source path");
+            }
             let reactivated = {
                 let inactive = self.inactive_output_operations.get_untracked();
                 operations
@@ -287,10 +309,15 @@ impl VersionedContentMap {
             });
             // Deleted routes need conservative catch-up because Turbopack may
             // reuse the disconnected operation when the same file is added again.
+            // Invalidate only the re-added source file. Route discovery already
+            // observed the file before this call, so invalidating ancestor directory
+            // reads here would needlessly invalidate unrelated route graphs.
             // Ordinary inactive routes never disconnect their output graph.
             if was_removed {
-                project_fs.invalidate_with_reason(|path| invalidation::Initialize {
-                    path: RcStr::from(path.to_string_lossy()),
+                project_fs.invalidate_path_with_reason(reactivation_source_paths, |path| {
+                    invalidation::Initialize {
+                        path: RcStr::from(path.to_string_lossy()),
+                    }
                 });
             }
             // Reconnect and strongly read removed output graphs after catch-up.
@@ -323,6 +350,12 @@ impl VersionedContentMap {
                     }
                     changed
                 });
+            if advance_reactivation_epoch {
+                let mut epoch = self.reactivation_epoch.get_untracked();
+                *epoch = epoch
+                    .checked_add(1)
+                    .expect("HMR reactivation epoch overflow");
+            }
         } else {
             // Keep the endpoint output operations connected so source changes
             // continue to invalidate them while the route is inactive. Omitting
@@ -337,7 +370,7 @@ impl VersionedContentMap {
                     changed
                 });
         }
-        Ok(())
+        Ok(*self.reactivation_epoch.get_untracked())
     }
 
     /// Removes deleted routes from aggregate HMR versions and drops their

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
     TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
 };
-use turbo_tasks_fs::{FileContent, FileSystemPath};
+use turbo_tasks_fs::{DiskFileSystem, FileContent, FileSystemPath, invalidation};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::{ExpandedOutputAssets, OptionOutputAsset, OutputAsset},
@@ -239,6 +239,7 @@ impl VersionedContentMap {
         &self,
         paths: impl IntoIterator<Item = FileSystemPath>,
         active: bool,
+        project_fs: &DiskFileSystem,
     ) -> Result<()> {
         let paths = paths.into_iter().collect::<Vec<_>>();
         let operations = {
@@ -273,9 +274,16 @@ impl VersionedContentMap {
                 }
                 changed
             });
-            // Retirement materializes each compute entry before disconnecting,
-            // so a strongly-consistent read is sufficient to catch up only the
-            // operations being reactivated.
+            // A file may change while this operation is disconnected, when its
+            // filesystem invalidator is not live. Reconnect first, then
+            // invalidate the tracked project reads once so the strong read below
+            // cannot reuse a clean-but-stale graph. This cost is paid only when
+            // an inactive route is requested again, not by unrelated edits.
+            if !reactivated.is_empty() {
+                project_fs.invalidate_with_reason(|path| invalidation::Initialize {
+                    path: RcStr::from(path.to_string_lossy()),
+                });
+            }
             for &(_, compute_entry) in &reactivated {
                 compute_entry.read_strongly_consistent().await?;
             }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -90,11 +90,6 @@ type OutputOperationToComputeEntry =
 )]
 struct InactiveOutputOperation {
     compute_entry: OperationVc<OptionMapEntry>,
-    /// Project filesystem generation when this operation was disconnected.
-    filesystem_epoch: u64,
-    /// A materialized lookup snapshot keeps existing client-chunk subscriptions
-    /// and source maps valid without reconnecting the endpoint's output graph.
-    path_to_asset: FxHashMap<FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
 #[derive(
@@ -114,8 +109,8 @@ struct InactiveOutputOperations(
     FxHashMap<OperationVc<ExpandedOutputAssets>, InactiveOutputOperation>,
 );
 
-// The ignored trace is intentional: these operation and asset handles must be
-// available for lookup/reactivation without keeping their task graphs connected.
+// The ignored trace is intentional: these operation handles must remain
+// available for reactivation without keeping their task graphs connected.
 unsafe impl OperationValue for InactiveOutputOperations {}
 
 pub struct HmrChunkSnapshot {
@@ -237,10 +232,9 @@ impl VersionedContentMap {
 
     /// Adds or removes entry chunks from the aggregate HMR working set.
     ///
-    /// Retiring an entry disconnects every output operation that owns that entry
-    /// path. The operation handles and path index are retained without tracing
-    /// them, so reactivation can reconnect the exact cached operation without a
-    /// new endpoint write.
+    /// Retiring an entry keeps its output operations connected, but omits its
+    /// entry path from aggregate HMR versioning. Deleted entries use the separate
+    /// disconnected-operation path retained by [`Self::remove_hmr_chunks`].
     ///
     /// This is deliberately a direct state mutation rather than a cached
     /// `turbo_tasks::function`: the same path can transition between active and
@@ -262,10 +256,9 @@ impl VersionedContentMap {
         };
 
         if active {
-            // Deletion and re-addition can be coalesced into one watcher batch,
-            // leaving the filesystem generation unchanged. Removed routes still
-            // need conservative catch-up before reconnecting their retained
-            // operation, even when the epoch comparison alone cannot see it.
+            // A removed route may be re-added using its retained disconnected
+            // operation. Conservatively invalidate project filesystem reads before
+            // reconnecting that operation so it cannot reuse pre-deletion inputs.
             let was_removed = {
                 let removed = self.removed_hmr_paths.get_untracked();
                 paths.iter().any(|path| removed.0.contains(path))
@@ -278,7 +271,7 @@ impl VersionedContentMap {
                         inactive
                             .0
                             .get(operation)
-                            .map(|entry| (*operation, entry.compute_entry, entry.filesystem_epoch))
+                            .map(|entry| (*operation, entry.compute_entry))
                     })
                     .collect::<Vec<_>>()
             };
@@ -287,33 +280,28 @@ impl VersionedContentMap {
             // reader may briefly see both, but never sees the asset disappear.
             self.map_op_to_compute_entry.update_conditionally(|map| {
                 let mut changed = false;
-                for &(operation, compute_entry, _) in &reactivated {
+                for &(operation, compute_entry) in &reactivated {
                     changed |= map.insert(operation, compute_entry) != Some(compute_entry);
                 }
                 changed
             });
-            // Only routes that actually crossed a filesystem change need the
-            // conservative catch-up. Plain navigation after inactivity keeps the
-            // cached project graph warm.
-            let current_filesystem_epoch = project_fs.settled_change_epoch().await;
-            if was_removed
-                || reactivated
-                    .iter()
-                    .any(|(_, _, filesystem_epoch)| *filesystem_epoch < current_filesystem_epoch)
-            {
+            // Deleted routes need conservative catch-up because Turbopack may
+            // reuse the disconnected operation when the same file is added again.
+            // Ordinary inactive routes never disconnect their output graph.
+            if was_removed {
                 project_fs.invalidate_with_reason(|path| invalidation::Initialize {
                     path: RcStr::from(path.to_string_lossy()),
                 });
             }
-            // Reconnect and strongly read these output graphs after the conditional
-            // catch-up. The caller then refreshes the endpoint's effectful wrappers.
-            for &(_, compute_entry, _) in &reactivated {
+            // Reconnect and strongly read removed output graphs after catch-up.
+            // The caller then refreshes the endpoint's effectful wrappers.
+            for &(_, compute_entry) in &reactivated {
                 compute_entry.read_strongly_consistent().await?;
             }
             self.inactive_output_operations
                 .update_conditionally(|inactive| {
                     let mut changed = false;
-                    for (operation, _, _) in &reactivated {
+                    for (operation, _) in &reactivated {
                         changed |= inactive.0.remove(operation).is_some();
                     }
                     changed
@@ -336,45 +324,10 @@ impl VersionedContentMap {
                     changed
                 });
         } else {
-            // Materialize the last asset lookup before disconnecting. Existing
-            // client chunk subscriptions and source-map requests can use this
-            // snapshot without reconnecting the endpoint's aggregate graph.
-            let compute_entries = {
-                let map = self.map_op_to_compute_entry.get();
-                operations
-                    .iter()
-                    .filter_map(|operation| {
-                        map.get(operation)
-                            .map(|compute_entry| (*operation, *compute_entry))
-                    })
-                    .collect::<Vec<_>>()
-            };
-            let filesystem_epoch = project_fs.settled_change_epoch().await;
-            let snapshots = compute_entries
-                .into_iter()
-                .map(|(operation, compute_entry)| async move {
-                    let map_entry = compute_entry.read_strongly_consistent().await?;
-                    let path_to_asset = if let Some(entry) = &*map_entry {
-                        entry.path_to_asset.clone()
-                    } else {
-                        FxHashMap::default()
-                    };
-                    Ok::<_, anyhow::Error>((
-                        operation,
-                        InactiveOutputOperation {
-                            compute_entry,
-                            filesystem_epoch,
-                            path_to_asset,
-                        },
-                    ))
-                })
-                .try_join()
-                .await?
-                .into_iter()
-                .collect::<FxHashMap<_, _>>();
-
-            // Publish retirement before disconnecting its operations so a concurrent
-            // aggregate read preserves the previous versions.
+            // Keep the endpoint output operations connected so source changes
+            // continue to invalidate them while the route is inactive. Omitting
+            // the entry paths from aggregate HMR still avoids versioning every
+            // route on unrelated edits without risking a frozen output graph.
             self.inactive_hmr_paths
                 .update_conditionally(|inactive_hmr_paths| {
                     let mut changed = false;
@@ -383,29 +336,6 @@ impl VersionedContentMap {
                     }
                     changed
                 });
-
-            let snapshot_operations = snapshots.keys().copied().collect::<Vec<_>>();
-            // Publish the inactive fallback before dropping the live lookup. A
-            // reader may briefly prefer the live entry, but never observes a gap.
-            self.inactive_output_operations
-                .update_conditionally(|inactive| {
-                    if snapshots.is_empty() {
-                        return false;
-                    }
-                    for (operation, inactive_operation) in snapshots {
-                        inactive.0.insert(operation, inactive_operation);
-                    }
-                    true
-                });
-            // Drop the traced roots only after their lookup snapshots are visible.
-            // No compute task depends on this project-wide state transition.
-            self.map_op_to_compute_entry.update_conditionally(|map| {
-                let mut changed = false;
-                for operation in snapshot_operations {
-                    changed |= map.remove(&operation).is_some();
-                }
-                changed
-            });
         }
         Ok(())
     }
@@ -417,7 +347,6 @@ impl VersionedContentMap {
     pub async fn remove_hmr_chunks(
         &self,
         paths: impl IntoIterator<Item = FileSystemPath>,
-        project_fs: &DiskFileSystem,
     ) -> Result<()> {
         let paths = paths.into_iter().collect::<Vec<_>>();
         let operations = {
@@ -428,7 +357,6 @@ impl VersionedContentMap {
                 .flat_map(|operations| operations.0.iter().copied())
                 .collect::<FxHashSet<_>>()
         };
-        let current_filesystem_epoch = project_fs.settled_change_epoch().await;
         let retained_operations = {
             let active = self.map_op_to_compute_entry.get_untracked();
             let inactive = self.inactive_output_operations.get_untracked();
@@ -440,8 +368,6 @@ impl VersionedContentMap {
                             *operation,
                             InactiveOutputOperation {
                                 compute_entry: entry.compute_entry,
-                                filesystem_epoch: entry.filesystem_epoch,
-                                path_to_asset: FxHashMap::default(),
                             },
                         ))
                     } else {
@@ -450,8 +376,6 @@ impl VersionedContentMap {
                                 *operation,
                                 InactiveOutputOperation {
                                     compute_entry: *compute_entry,
-                                    filesystem_epoch: current_filesystem_epoch,
-                                    path_to_asset: FxHashMap::default(),
                                 },
                             )
                         })
@@ -559,9 +483,9 @@ impl VersionedContentMap {
             // Any error should result in an empty list, which removes all assets from the map
             .ok();
 
-        // Retirement strongly reads this materialized entry before disconnecting
-        // it, so an in-flight computation can finish without observing global
-        // activity state or becoming a dependency of every route transition.
+        // Ordinary inactive-route operations stay connected, so this publisher
+        // keeps their output-path ownership current across source changes. Deleted
+        // routes separately remove that ownership before disconnecting the graph.
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
@@ -652,24 +576,7 @@ impl VersionedContentMap {
             return Ok(Vc::cell(Some(asset)));
         }
 
-        // A retired output operation is intentionally disconnected, but its
-        // last materialized assets remain valid lookup results. Returning only
-        // the requested asset avoids reconnecting the whole endpoint graph.
-        let inactive_asset = {
-            let this = self.await?;
-            let path_to_operations = &this.map_path_to_op.get().0;
-            let inactive_operations = this.inactive_output_operations.get();
-            path_to_operations.get(&path).and_then(|operations| {
-                operations.0.iter().find_map(|operation| {
-                    inactive_operations
-                        .0
-                        .get(operation)
-                        .and_then(|entry| entry.path_to_asset.get(&path))
-                        .copied()
-                })
-            })
-        };
-        Ok(Vc::cell(inactive_asset))
+        Ok(Vc::cell(None))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -254,7 +254,7 @@ async fn endpoint_write_to_disk_with_apply(
     #[turbo_tasks::function(operation, root)]
     fn inner_operation(endpoint: ResolvedVc<Box<dyn Endpoint>>) -> Vc<EndpointOutputPaths> {
         // we must wrap this in an operation so we can get the Effects collectibles
-        endpoint_write_to_disk(*endpoint)
+        endpoint_write_to_disk(endpoint).connect()
     }
 
     #[turbo_tasks::value(serialization = "skip")]

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -10,6 +10,7 @@ use next_api::{
     route::{
         Endpoint, EndpointOutputPaths, endpoint_client_changed_operation,
         endpoint_server_changed_operation, endpoint_write_to_disk_operation,
+        invalidate_endpoint_output,
     },
 };
 use tracing::Instrument;
@@ -175,6 +176,25 @@ pub async fn endpoint_write_to_disk(
         result: NapiWrittenEndpoint::from(written.map(ReadRef::into_owned)),
         issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
     })
+}
+
+#[tracing::instrument(level = "info", name = "invalidate endpoint output", skip_all)]
+#[napi]
+pub async fn endpoint_invalidate_output(
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
+) -> napi::Result<()> {
+    let ctx = endpoint.turbopack_ctx();
+    let endpoint_op = ***endpoint;
+    endpoint
+        .turbopack_ctx()
+        .turbo_tasks()
+        .run(async move {
+            get_written_endpoint_with_issues_operation(endpoint_op).invalidate();
+            invalidate_endpoint_output(endpoint_op).await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+    Ok(())
 }
 
 #[tracing::instrument(level = "info", name = "get server-side endpoint changes", skip_all)]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -754,6 +754,35 @@ pub async fn project_update(
         .await
 }
 
+#[tracing::instrument(
+    level = "info",
+    name = "set aggregate HMR chunk activity",
+    skip_all,
+    fields(target = %target, active, chunk_count = chunk_names.len()),
+)]
+#[napi]
+pub async fn project_set_hmr_chunks_active(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    chunk_names: Vec<RcStr>,
+    target: String,
+    active: bool,
+) -> napi::Result<()> {
+    let hmr_target = target
+        .parse::<HmrTarget>()
+        .map_err(napi::Error::from_reason)?;
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+
+    ctx.turbo_tasks()
+        .run(async move {
+            container
+                .set_hmr_chunks_active(chunk_names, hmr_target, active)
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
 /// Invalidates the filesystem cache so that it will be deleted next time that a turbopack project
 /// is created with filesystem cache enabled.
 #[napi]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    collections::BTreeMap,
     fs::{canonicalize, create_dir_all},
     io::Write,
     path::{Path, PathBuf},
@@ -27,7 +28,7 @@ use next_api::{
     },
     project::{
         DebugBuildPaths, DefineEnv, DraftModeOptions, HmrTarget, PartialProjectOptions, Project,
-        ProjectContainer, ProjectOptions, WatchOptions,
+        ProjectContainer, ProjectOptions, WatchOptions, aggregate_hmr_reactivation_epoch,
     },
     project_asset_hashes_manifest::immutable_hashes_manifest_asset_if_enabled,
     route::{Endpoint, EndpointGroupKey, Route},
@@ -766,7 +767,9 @@ pub async fn project_set_hmr_chunks_active(
     chunk_names: Vec<RcStr>,
     target: String,
     active: bool,
-) -> napi::Result<()> {
+    reactivation_source_paths: Option<Vec<RcStr>>,
+    advance_reactivation_epoch: Option<bool>,
+) -> napi::Result<u32> {
     let hmr_target = target
         .parse::<HmrTarget>()
         .map_err(napi::Error::from_reason)?;
@@ -776,7 +779,13 @@ pub async fn project_set_hmr_chunks_active(
     ctx.turbo_tasks()
         .run(async move {
             container
-                .set_hmr_chunks_active(chunk_names, hmr_target, active)
+                .set_hmr_chunks_active(
+                    chunk_names,
+                    hmr_target,
+                    active,
+                    reactivation_source_paths.unwrap_or_default(),
+                    advance_reactivation_epoch.unwrap_or_default(),
+                )
                 .await
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
@@ -1979,19 +1988,23 @@ pub fn project_all_hmr_events(
             unmark_top_level_task_may_leak_eventually_consistent_state();
 
             let HmrUpdateWithIssues { update, issues, .. } = &*read;
-            match &**update {
-                Update::Missing | Update::None => {}
+            let reactivation_epoch = match &**update {
+                Update::Missing | Update::None => None,
                 Update::Total(TotalUpdate { to }) => {
+                    let epoch = aggregate_hmr_reactivation_epoch(to.clone()).await?;
                     state.set(to.clone()).await?;
+                    epoch
                 }
                 Update::Partial(PartialUpdate { to, .. }) => {
+                    let epoch = aggregate_hmr_reactivation_epoch(to.clone()).await?;
                     state.set(to.clone()).await?;
+                    epoch
                 }
-            }
-            Ok((Some(update.clone()), issues.clone()))
+            };
+            Ok((Some(update.clone()), issues.clone(), reactivation_epoch))
         },
         move |ctx| {
-            let (update, issues) = ctx.value;
+            let (update, issues, reactivation_epoch) = ctx.value;
 
             let napi_issues = issues
                 .iter()
@@ -2004,7 +2017,12 @@ pub fn project_all_hmr_events(
 
             let identifier = ResourceIdentifier {
                 path: identifier_path.clone(),
-                headers: None,
+                headers: reactivation_epoch.map(|epoch| {
+                    BTreeMap::from([(
+                        rcstr!("x-next-hmr-reactivation-epoch"),
+                        RcStr::from(epoch.to_string()),
+                    )])
+                }),
             };
             let update = match update.as_deref() {
                 None | Some(Update::Missing) | Some(Update::Total(_)) => {

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -783,6 +783,30 @@ pub async fn project_set_hmr_chunks_active(
         .await
 }
 
+#[tracing::instrument(
+    level = "info",
+    name = "remove aggregate HMR chunks",
+    skip_all,
+    fields(target = %target, chunk_count = chunk_names.len()),
+)]
+#[napi]
+pub async fn project_remove_hmr_chunks(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    chunk_names: Vec<RcStr>,
+    target: String,
+) -> napi::Result<()> {
+    let hmr_target = target
+        .parse::<HmrTarget>()
+        .map_err(napi::Error::from_reason)?;
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+
+    ctx.turbo_tasks()
+        .run(async move { container.remove_hmr_chunks(chunk_names, hmr_target).await })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
 /// Invalidates the filesystem cache so that it will be deleted next time that a turbopack project
 /// is created with filesystem cache enabled.
 #[napi]

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -171,6 +171,9 @@ export interface NapiWrittenEndpoint {
 export declare function endpointWriteToDisk(endpoint: {
   __napiType: 'Endpoint'
 }): Promise<TurbopackResult>
+export declare function endpointInvalidateOutput(endpoint: {
+  __napiType: 'Endpoint'
+}): Promise<void>
 export declare function endpointServerChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
   issues: boolean,
@@ -410,6 +413,12 @@ export declare function projectEntrypointsSubscribe(
   project: { __napiType: 'Project' },
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
+export declare function projectSetHmrChunksActive(
+  project: { __napiType: 'Project' },
+  chunkNames: Array<RcStr>,
+  target: string,
+  active: boolean
+): Promise<void>
 export declare function projectAllHmrEvents(
   project: { __napiType: 'Project' },
   target: string,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -337,6 +337,17 @@ export declare function projectUpdate(
   project: { __napiType: 'Project' },
   options: NapiPartialProjectOptions
 ): Promise<void>
+export declare function projectSetHmrChunksActive(
+  project: { __napiType: 'Project' },
+  chunkNames: Array<RcStr>,
+  target: string,
+  active: boolean
+): Promise<void>
+export declare function projectRemoveHmrChunks(
+  project: { __napiType: 'Project' },
+  chunkNames: Array<RcStr>,
+  target: string
+): Promise<void>
 /**
  * Invalidates the filesystem cache so that it will be deleted next time that a turbopack project
  * is created with filesystem cache enabled.
@@ -413,12 +424,6 @@ export declare function projectEntrypointsSubscribe(
   project: { __napiType: 'Project' },
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
-export declare function projectSetHmrChunksActive(
-  project: { __napiType: 'Project' },
-  chunkNames: Array<RcStr>,
-  target: string,
-  active: boolean
-): Promise<void>
 export declare function projectAllHmrEvents(
   project: { __napiType: 'Project' },
   target: string,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -341,8 +341,10 @@ export declare function projectSetHmrChunksActive(
   project: { __napiType: 'Project' },
   chunkNames: Array<RcStr>,
   target: string,
-  active: boolean
-): Promise<void>
+  active: boolean,
+  reactivationSourcePaths?: Array<RcStr> | undefined | null,
+  advanceReactivationEpoch?: boolean | undefined | null
+): Promise<number>
 export declare function projectRemoveHmrChunks(
   project: { __napiType: 'Project' },
   chunkNames: Array<RcStr>,

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -772,6 +772,19 @@ function bindingToApi(
       )
     }
 
+    setHmrChunksActive(
+      chunkNames: string[],
+      target: HmrTarget.Server,
+      active: boolean
+    ): Promise<void> {
+      return binding.projectSetHmrChunksActive(
+        this._nativeProject,
+        chunkNames,
+        target,
+        active
+      )
+    }
+
     hmrEvents(
       chunkName: string,
       target: HmrTarget.Client
@@ -878,6 +891,10 @@ function bindingToApi(
       return (await binding.endpointWriteToDisk(
         this._nativeEndpoint
       )) as TurbopackResult<WrittenEndpoint>
+    }
+
+    invalidateOutput(): Promise<void> {
+      return binding.endpointInvalidateOutput(this._nativeEndpoint)
     }
 
     async clientChanged(): Promise<AsyncIterableIterator<TurbopackResult>> {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -785,6 +785,17 @@ function bindingToApi(
       )
     }
 
+    removeHmrChunks(
+      chunkNames: string[],
+      target: HmrTarget.Server
+    ): Promise<void> {
+      return binding.projectRemoveHmrChunks(
+        this._nativeProject,
+        chunkNames,
+        target
+      )
+    }
+
     hmrEvents(
       chunkName: string,
       target: HmrTarget.Client

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -775,13 +775,17 @@ function bindingToApi(
     setHmrChunksActive(
       chunkNames: string[],
       target: HmrTarget.Server,
-      active: boolean
-    ): Promise<void> {
+      active: boolean,
+      reactivationSourcePaths?: string[],
+      advanceReactivationEpoch?: boolean
+    ): Promise<number> {
       return binding.projectSetHmrChunksActive(
         this._nativeProject,
         chunkNames,
         target,
-        active
+        active,
+        reactivationSourcePaths,
+        advanceReactivationEpoch
       )
     }
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -346,6 +346,11 @@ export interface Project {
     active: boolean
   ): Promise<void>
 
+  removeHmrChunks(
+    chunkNames: string[],
+    target: import('./index').HmrTarget.Server
+  ): Promise<void>
+
   hmrEvents(
     identifier: string,
     target: import('./index').HmrTarget.Client

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -343,8 +343,10 @@ export interface Project {
   setHmrChunksActive(
     chunkNames: string[],
     target: import('./index').HmrTarget.Server,
-    active: boolean
-  ): Promise<void>
+    active: boolean,
+    reactivationSourcePaths?: string[],
+    advanceReactivationEpoch?: boolean
+  ): Promise<number>
 
   removeHmrChunks(
     chunkNames: string[],

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -340,6 +340,12 @@ export interface Project {
     target: import('./index').HmrTarget.Server
   ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
 
+  setHmrChunksActive(
+    chunkNames: string[],
+    target: import('./index').HmrTarget.Server,
+    active: boolean
+  ): Promise<void>
+
   hmrEvents(
     identifier: string,
     target: import('./index').HmrTarget.Client
@@ -408,6 +414,9 @@ export type Route =
 export interface Endpoint {
   /** Write files for the endpoint to disk. */
   writeToDisk(): Promise<TurbopackResult<WrittenEndpoint>>
+
+  /** Invalidate cached endpoint output before writing it after inactivity. */
+  invalidateOutput(): Promise<void>
 
   /**
    * Listen to client-side changes to the endpoint.

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -215,14 +215,10 @@ export function useWebSocketPing(webSocket: WebSocket | undefined) {
       throw new InvariantError('Expected webSocket to be defined in dev mode.')
     }
 
-    // Never send pings when using Turbopack as it's not used.
-    // Pings were originally used to keep track of active routes in on-demand-entries with webpack.
-    if (process.env.TURBOPACK) {
-      return
-    }
-
-    // Taken from on-demand-entries-client.js
-    const interval = setInterval(() => {
+    // Taken from on-demand-entries-client.js. Send immediately after the socket
+    // opens as well: a short maxInactiveAge must not expire the route before the
+    // first interval tick records the connected router tree.
+    const sendPing = () => {
       if (webSocket.readyState === webSocket.OPEN) {
         webSocket.send(
           JSON.stringify({
@@ -232,8 +228,14 @@ export function useWebSocketPing(webSocket: WebSocket | undefined) {
           })
         )
       }
-    }, 2500)
-    return () => clearInterval(interval)
+    }
+    webSocket.addEventListener('open', sendPing, { once: true })
+    sendPing()
+    const interval = setInterval(sendPing, 2500)
+    return () => {
+      webSocket.removeEventListener('open', sendPing)
+      clearInterval(interval)
+    }
   }, [tree, webSocket])
 }
 

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -231,9 +231,14 @@ export function useWebSocketPing(webSocket: WebSocket | undefined) {
     }
     webSocket.addEventListener('open', sendPing, { once: true })
     sendPing()
+    // The upgrade callback installs the server's message listener after accepting
+    // the socket. Retry once after that synchronous setup so the initial route
+    // tree isn't lost if the browser's open event wins the race.
+    const initialRetry = setTimeout(sendPing, 100)
     const interval = setInterval(sendPing, 2500)
     return () => {
       webSocket.removeEventListener('open', sendPing)
+      clearTimeout(initialRetry)
       clearInterval(interval)
     }
   }, [tree, webSocket])

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -69,7 +69,10 @@ import {
   type SetupOpts,
 } from '../lib/router-utils/setup-dev-bundler'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
-import { findPagePathData } from './on-demand-entry-handler'
+import {
+  findPagePathData,
+  getEntrypointsFromTree,
+} from './on-demand-entry-handler'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import {
   type EntryKey,
@@ -157,6 +160,8 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
+/** Virtual output directory containing the App Router's server entry chunks. */
+const SERVER_HMR_APP_DIR = 'server/app'
 
 declare const __next__clear_chunk_cache__: (() => void) | null | undefined
 
@@ -546,6 +551,14 @@ export async function createHotReloaderTurbopack(
 
   // Dev specific
   const changeSubscriptions: ChangeSubscriptions = new Map()
+  // Route endpoint subscriptions keep Turbopack's dependency graph active. Bound
+  // App Router page subscriptions to routes that are still being viewed or were
+  // accessed recently, matching the lifetime used by webpack on-demand entries.
+  const routeChangeSubscriptionLastActive = new Map<EntryKey, number>()
+  const recentRouteChangeSubscriptions: EntryKey[] = []
+  const activeRouteSubscriptionsByClient = new Map<ws, Set<EntryKey>>()
+  const inactiveRouteChangeSubscriptions = new Set<EntryKey>()
+  const routeChangeSubscriptionsNeedingCatchUp = new Set<EntryKey>()
   const serverPathState = new Map<string, string>()
   const readyIds: ReadyIds = new Set()
   let currentEntriesHandlingResolve: ((value?: unknown) => void) | undefined
@@ -946,24 +959,187 @@ export async function createHotReloaderTurbopack(
         }
       }
     } catch (e) {
-      changeSubscriptions.delete(key)
+      if (changeSubscriptions.get(key) === changedPromise) {
+        changeSubscriptions.delete(key)
+      }
       const payload = await onError?.(e as Error)
       if (payload) {
         sendHmr(key, payload)
       }
       return
     }
-    changeSubscriptions.delete(key)
+    if (changeSubscriptions.get(key) === changedPromise) {
+      changeSubscriptions.delete(key)
+    }
   }
 
   async function unsubscribeFromClientChanges(key: EntryKey) {
-    const subscription = await changeSubscriptions.get(key)
-    if (subscription) {
-      await subscription.return?.()
+    const subscriptionPromise = changeSubscriptions.get(key)
+    if (subscriptionPromise) {
+      // Remove this before awaiting so a request that reactivates the route can
+      // install its replacement without racing the old iterator's shutdown.
       changeSubscriptions.delete(key)
+      const subscription = await subscriptionPromise
+      await subscription.return?.()
     }
     currentEntryIssues.delete(key)
   }
+
+  const maxInactiveAge = nextConfig.onDemandEntries?.maxInactiveAge ?? 60 * 1000
+  const pagesBufferLength = nextConfig.onDemandEntries?.pagesBufferLength ?? 5
+  const routeChangeSubscriptionDisposals = new Map<EntryKey, Promise<void>>()
+
+  function getServerHmrEntryChunkPath(key: EntryKey): string | undefined {
+    if (!serverFastRefresh || splitEntryKey(key).type !== 'app') {
+      return
+    }
+    const writtenEndpoint = currentWrittenEntrypoints.get(key)
+    if (!writtenEndpoint || writtenEndpoint.type !== 'nodejs') {
+      return
+    }
+
+    // entryPath comes from turbo-tasks' virtual filesystem and always uses
+    // forward slashes, including on Windows.
+    const appEntryPrefix = `${SERVER_HMR_APP_DIR}/`
+    return writtenEndpoint.entryPath.startsWith(appEntryPrefix) &&
+      writtenEndpoint.entryPath.endsWith('.js')
+      ? writtenEndpoint.entryPath
+      : undefined
+  }
+
+  async function setRouteHmrChunksActive(
+    keys: Iterable<EntryKey>,
+    active: boolean
+  ) {
+    const chunkPaths = Array.from(keys, getServerHmrEntryChunkPath).filter(
+      (path): path is string => path !== undefined
+    )
+    if (chunkPaths.length > 0) {
+      await project.setHmrChunksActive(chunkPaths, HmrTarget.Server, active)
+    }
+  }
+
+  async function markRouteChangeSubscriptionActive(key: EntryKey) {
+    routeChangeSubscriptionLastActive.set(key, Date.now())
+
+    const previousIndex = recentRouteChangeSubscriptions.indexOf(key)
+    if (previousIndex !== -1) {
+      recentRouteChangeSubscriptions.splice(previousIndex, 1)
+    }
+    recentRouteChangeSubscriptions.unshift(key)
+    if (recentRouteChangeSubscriptions.length > pagesBufferLength) {
+      recentRouteChangeSubscriptions.length = pagesBufferLength
+    }
+
+    // If cleanup raced with a request for this route, let the old iterator fully
+    // stop before handleRouteType installs its replacement.
+    await routeChangeSubscriptionDisposals.get(key)
+    const wasInactive = inactiveRouteChangeSubscriptions.has(key)
+    if (wasInactive) {
+      await setRouteHmrChunksActive([key], true)
+      inactiveRouteChangeSubscriptions.delete(key)
+      routeChangeSubscriptionsNeedingCatchUp.add(key)
+    }
+    return wasInactive
+  }
+
+  function getAppPageEntryKeysFromTree(
+    tree: Parameters<typeof getEntrypointsFromTree>[0]
+  ) {
+    const activePagePaths = new Set(
+      getEntrypointsFromTree(tree, true).map((page) =>
+        normalizeAppPath(`/${page}`)
+      )
+    )
+    const activeEntryKeys = new Set<EntryKey>()
+    // FlightRouterState contains URL segments, so route groups and parallel
+    // slots are absent. Map those public paths back to the original App entry
+    // names used by ensurePage and the endpoint subscription map.
+    for (const [name, route] of currentEntrypoints.app) {
+      if (
+        route.type === 'app-page' &&
+        activePagePaths.has(normalizeAppPath(name))
+      ) {
+        activeEntryKeys.add(getEntryKey('app', 'server', name))
+      }
+    }
+    return activeEntryKeys
+  }
+
+  async function disposeRouteChangeSubscriptions(keys: EntryKey[]) {
+    for (const key of keys) {
+      inactiveRouteChangeSubscriptions.add(key)
+    }
+
+    const disposal = (async () => {
+      // Removing the aggregate HMR dependency first prevents the endpoint
+      // iterator shutdown from waking a full all-routes scan. Keep the inactive
+      // marker if either step fails: the next request can safely retry an
+      // idempotent reactivation, while clearing it could leave a retired graph
+      // incorrectly recorded as active.
+      await setRouteHmrChunksActive(keys, false)
+      await Promise.all(keys.map(unsubscribeFromClientChanges))
+    })()
+    for (const key of keys) {
+      routeChangeSubscriptionDisposals.set(key, disposal)
+    }
+
+    try {
+      await disposal
+    } finally {
+      for (const key of keys) {
+        if (routeChangeSubscriptionDisposals.get(key) === disposal) {
+          routeChangeSubscriptionDisposals.delete(key)
+        }
+      }
+    }
+  }
+
+  const routeSubscriptionPingInterval = Math.max(
+    1000,
+    Math.min(5000, maxInactiveAge)
+  )
+  let disposingInactiveRouteSubscriptions = false
+  async function disposeInactiveRouteSubscriptions() {
+    if (disposingInactiveRouteSubscriptions) return
+    disposingInactiveRouteSubscriptions = true
+    try {
+      const activeRouteSubscriptions = new Set<EntryKey>()
+      for (const clientSubscriptions of activeRouteSubscriptionsByClient.values()) {
+        for (const key of clientSubscriptions) {
+          activeRouteSubscriptions.add(key)
+        }
+      }
+
+      const now = Date.now()
+      const keysToDispose: EntryKey[] = []
+      for (const [key, lastActiveTime] of routeChangeSubscriptionLastActive) {
+        if (
+          getServerHmrEntryChunkPath(key) === undefined ||
+          inactiveRouteChangeSubscriptions.has(key) ||
+          activeRouteSubscriptions.has(key) ||
+          recentRouteChangeSubscriptions.includes(key) ||
+          now - lastActiveTime <= maxInactiveAge
+        ) {
+          continue
+        }
+        keysToDispose.push(key)
+      }
+      if (keysToDispose.length > 0) {
+        await disposeRouteChangeSubscriptions(keysToDispose)
+      }
+    } finally {
+      disposingInactiveRouteSubscriptions = false
+    }
+  }
+
+  const disposeInactiveRouteSubscriptionsInterval = setInterval(() => {
+    void disposeInactiveRouteSubscriptions().catch(console.error)
+  }, routeSubscriptionPingInterval + 1000)
+  disposeInactiveRouteSubscriptionsInterval.unref()
+  opts.onDevServerCleanup?.(async () => {
+    clearInterval(disposeInactiveRouteSubscriptionsInterval)
+  })
 
   async function subscribeToClientHmrEvents(client: ws, id: string) {
     const key = getEntryKey('assets', 'client', id)
@@ -1432,6 +1608,7 @@ export async function createHotReloaderTurbopack(
             subscription.return?.()
           }
           clientStates.delete(client)
+          activeRouteSubscriptionsByClient.delete(client)
 
           if (htmlRequestId) {
             clientsByHtmlRequestId.delete(htmlRequestId)
@@ -1512,8 +1689,27 @@ export async function createHotReloaderTurbopack(
               break
             }
             case 'ping': {
-              // Handle ping events to keep WebSocket connections alive
-              // No-op - just acknowledge the ping
+              if (parsedData.appDirRoute && parsedData.tree) {
+                const activeEntryKeys = getAppPageEntryKeysFromTree(
+                  parsedData.tree
+                )
+                activeRouteSubscriptionsByClient.set(client, activeEntryKeys)
+                const reactivated = await Promise.all(
+                  Array.from(activeEntryKeys, (key) =>
+                    routeChangeSubscriptionLastActive.has(key)
+                      ? markRouteChangeSubscriptionActive(key)
+                      : undefined
+                  )
+                )
+                if (reactivated.some(Boolean)) {
+                  // A cached client navigation can update its router tree without
+                  // an RSC request. Refresh that client so ensurePage writes and
+                  // reconnects every output operation that was retired.
+                  sendToClient(client, {
+                    type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+                  })
+                }
+              }
               break
             }
 
@@ -1927,7 +2123,30 @@ export async function createHotReloaderTurbopack(
           }
 
           const finishBuilding = startBuilding(pathname, requestUrl, false)
+          let reactivatedRouteChangeSubscription = false
+          let routeChangeSubscriptionEntryKey: EntryKey | undefined
           try {
+            if (
+              serverFastRefresh &&
+              subscribeToChanges &&
+              route.type === 'app-page'
+            ) {
+              routeChangeSubscriptionEntryKey = getEntryKey(
+                'app',
+                'server',
+                page
+              )
+              await markRouteChangeSubscriptionActive(
+                routeChangeSubscriptionEntryKey
+              )
+              reactivatedRouteChangeSubscription =
+                routeChangeSubscriptionsNeedingCatchUp.has(
+                  routeChangeSubscriptionEntryKey
+                )
+              if (reactivatedRouteChangeSubscription) {
+                await route.htmlEndpoint.invalidateOutput()
+              }
+            }
             await handleRouteType({
               dev,
               page,
@@ -1951,13 +2170,35 @@ export async function createHotReloaderTurbopack(
                 handleWrittenEndpoint: (id, result, forceDeleteCache) => {
                   currentWrittenEntrypoints.set(id, result)
                   assetMapper.setPathsForKey(id, result.clientPaths)
-                  return clearRequireCache(id, result, {
+                  const didChange = clearRequireCache(id, result, {
                     force: forceDeleteCache,
                   })
+                  if (
+                    didChange &&
+                    reactivatedRouteChangeSubscription &&
+                    !forceDeleteCache
+                  ) {
+                    // This route missed in-place server HMR while its graph was
+                    // disconnected. Only reload its runtime module cache when
+                    // Turbopack reports that the server output actually changed.
+                    clearRequireCache(id, result, { force: true })
+                  }
+                  // While this route was inactive there was no subscription to
+                  // advance the dev cache version. Do it when the route is next
+                  // requested and Turbopack reports changed server output.
+                  if (didChange && reactivatedRouteChangeSubscription) {
+                    hmrHash++
+                  }
+                  return didChange
                 },
                 serverFastRefresh,
               },
             })
+            if (routeChangeSubscriptionEntryKey) {
+              routeChangeSubscriptionsNeedingCatchUp.delete(
+                routeChangeSubscriptionEntryKey
+              )
+            }
           } finally {
             finishBuilding()
             // Remove non-deferred entry from building set
@@ -1980,6 +2221,9 @@ export async function createHotReloaderTurbopack(
       }
       clientsWithoutHtmlRequestId.clear()
       clientsByHtmlRequestId.clear()
+      activeRouteSubscriptionsByClient.clear()
+      routeChangeSubscriptionsNeedingCatchUp.clear()
+      clearInterval(disposeInactiveRouteSubscriptionsInterval)
     },
   }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -160,8 +160,6 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
-/** Virtual output prefix; turbo-tasks paths always use forward slashes. */
-const SERVER_HMR_VIRTUAL_CHUNKS_PREFIX = 'server/chunks/'
 /** Virtual output directory containing the App Router's server entry chunks. */
 const SERVER_HMR_APP_DIR = 'server/app'
 const SERVER_HMR_REENTRY_WAIT_MS = 1000
@@ -210,18 +208,15 @@ function collectUpdatedChunkPaths(
   return Array.from(paths)
 }
 
+const SERVER_HMR_REACTIVATION_EPOCH_HEADER = 'x-next-hmr-reactivation-epoch'
+
 type ServerHmrUpdateWaiter = {
-  afterGeneration: number
-  chunkPaths: Set<string>
+  reactivationEpoch: number
   resolve: () => void
 }
 
 type ServerHmrUpdateTracker = {
-  captureGeneration: () => number
-  waitForChunkPathsAfter: (
-    afterGeneration: number,
-    chunkPaths: Iterable<string>
-  ) => Promise<void>
+  waitForReactivationEpoch: (reactivationEpoch: number) => Promise<void>
 }
 
 function setupServerHmr(
@@ -234,29 +229,28 @@ function setupServerHmr(
     onApplied: (chunkPaths: string[]) => void | Promise<void>
   }
 ): ServerHmrUpdateTracker {
-  let appliedGeneration = 0
-  let fullReEvaluationGeneration = 0
-  const chunkPathGenerations = new Map<string, number>()
+  let appliedReactivationEpoch = 0
   const updateWaiters = new Set<ServerHmrUpdateWaiter>()
 
-  function hasApplied(waiter: ServerHmrUpdateWaiter) {
-    return (
-      fullReEvaluationGeneration > waiter.afterGeneration ||
-      Array.from(waiter.chunkPaths).every(
-        (path) => (chunkPathGenerations.get(path) ?? 0) > waiter.afterGeneration
-      )
-    )
+  function getReactivationEpoch(update: NodeJsHmrUpdate) {
+    if (!('resource' in update)) return 0
+    const rawEpoch = (
+      update.resource.headers as Record<string, string> | undefined
+    )?.[SERVER_HMR_REACTIVATION_EPOCH_HEADER]
+    if (rawEpoch === undefined) return 0
+    const epoch = Number(rawEpoch)
+    return Number.isSafeInteger(epoch) && epoch > 0 ? epoch : 0
   }
 
-  function recordAppliedUpdate(chunkPaths?: string[]) {
-    const generation = ++appliedGeneration
-    if (chunkPaths === undefined) {
-      fullReEvaluationGeneration = generation
-    } else {
-      for (const path of chunkPaths) {
-        chunkPathGenerations.set(path, generation)
-      }
-    }
+  function hasApplied(waiter: ServerHmrUpdateWaiter) {
+    return appliedReactivationEpoch >= waiter.reactivationEpoch
+  }
+
+  function recordAppliedUpdate(reactivationEpoch: number) {
+    appliedReactivationEpoch = Math.max(
+      appliedReactivationEpoch,
+      reactivationEpoch
+    )
     for (const waiter of updateWaiters) {
       if (hasApplied(waiter)) {
         updateWaiters.delete(waiter)
@@ -272,7 +266,6 @@ function setupServerHmr(
     }
     const promise = Promise.resolve()
       .then(reEvaluateAllModulesExpensive)
-      .then(() => recordAppliedUpdate())
       .finally(() => {
         if (fullReEvaluationPromise === promise) {
           fullReEvaluationPromise = undefined
@@ -292,6 +285,7 @@ function setupServerHmr(
 
     for await (const result of subscription) {
       const update = result as NodeJsHmrUpdate
+      const reactivationEpoch = getReactivationEpoch(update)
 
       // A 'restart' from the wire protocol means the update can't be applied
       // incrementally, so we must fully re-evaluate all chunks from disk. This
@@ -299,6 +293,7 @@ function setupServerHmr(
       const requiresFullReEvaluation = update.type === 'restart'
       if (requiresFullReEvaluation) {
         await runFullReEvaluation()
+        recordAppliedUpdate(reactivationEpoch)
         continue
       }
 
@@ -322,12 +317,11 @@ function setupServerHmr(
       const updatedChunkPaths = collectUpdatedChunkPaths(instruction)
 
       // No handler registered yet (before first request, or right after
-      // reEvaluateAllModulesExpensive()) — nothing live to update. Recording the
-      // paths still releases a reentry waiter because there is no live cache that
-      // could serve stale modules.
+      // reEvaluateAllModulesExpensive()) — nothing live can serve stale modules.
+      // Acknowledge the aggregate transition directly.
       const handlers = globalThis.__turbopack_server_hmr_handlers__
       if (!handlers || handlers.size === 0) {
-        recordAppliedUpdate(updatedChunkPaths)
+        recordAppliedUpdate(reactivationEpoch)
         continue
       }
 
@@ -339,6 +333,7 @@ function setupServerHmr(
           // so the next request loads fresh, then skip onApplied. (A no-match
           // update is a no-op and does not throw.)
           await runFullReEvaluation()
+          recordAppliedUpdate(reactivationEpoch)
           continue
         }
 
@@ -348,9 +343,10 @@ function setupServerHmr(
         if (updatedChunkPaths.length > 0) {
           await onApplied(updatedChunkPaths)
         }
-        recordAppliedUpdate(updatedChunkPaths)
+        recordAppliedUpdate(reactivationEpoch)
       } else {
         await runFullReEvaluation()
+        recordAppliedUpdate(reactivationEpoch)
       }
     }
   }
@@ -373,14 +369,12 @@ function setupServerHmr(
   })()
 
   return {
-    captureGeneration: () => appliedGeneration,
-    waitForChunkPathsAfter(afterGeneration, chunkPaths) {
+    waitForReactivationEpoch(reactivationEpoch) {
       const waiter: ServerHmrUpdateWaiter = {
-        afterGeneration,
-        chunkPaths: new Set(chunkPaths),
+        reactivationEpoch,
         resolve: () => {},
       }
-      if (waiter.chunkPaths.size === 0 || hasApplied(waiter)) {
+      if (reactivationEpoch === 0 || hasApplied(waiter)) {
         return Promise.resolve()
       }
       let fallbackTimer: ReturnType<typeof setTimeout> | undefined
@@ -398,11 +392,12 @@ function setupServerHmr(
             resolve()
             return
           }
-          // Some endpoint output paths (notably client-component SSR chunks)
-          // are owned by a separate always-active aggregate entry and may have
-          // applied before this reentry began. Bound the route-specific wait and
-          // use the existing safe full-re-evaluation fallback rather than hanging.
-          runFullReEvaluation().then(resolve, reject)
+          // A subscription failure must not hang a request. A full evaluation
+          // installs the latest aggregate state and safely acknowledges this epoch.
+          runFullReEvaluation().then(() => {
+            recordAppliedUpdate(reactivationEpoch)
+            resolve()
+          }, reject)
         }, SERVER_HMR_REENTRY_WAIT_MS)
       })
       return Promise.race([updatePromise, fallbackPromise]).finally(() => {
@@ -753,11 +748,9 @@ export async function createHotReloaderTurbopack(
     writtenEndpoint: WrittenEndpoint,
     {
       force,
-      onServerHmrChunkChanged,
     }: {
       // Always clear the cache, don't check if files have changed
       force?: boolean
-      onServerHmrChunkChanged?: (path: string) => void
     } = {}
   ): boolean {
     if (force) {
@@ -784,9 +777,6 @@ export async function createHotReloaderTurbopack(
           (globalHash && globalHash !== contentHash)
         ) {
           hasChange = true
-          if (path.startsWith(SERVER_HMR_VIRTUAL_CHUNKS_PREFIX)) {
-            onServerHmrChunkChanged?.(path)
-          }
           serverPathState.set(localKey, contentHash)
           serverPathState.set(path, contentHash)
         } else {
@@ -1111,10 +1101,6 @@ export async function createHotReloaderTurbopack(
   const maxInactiveAge = nextConfig.onDemandEntries?.maxInactiveAge ?? 60 * 1000
   const pagesBufferLength = nextConfig.onDemandEntries?.pagesBufferLength ?? 5
   const routeChangeSubscriptionDisposals = new Map<EntryKey, Promise<void>>()
-  const routeChangeSubscriptionRetiredHmrGenerations = new Map<
-    EntryKey,
-    number
-  >()
   const routeChangeSubscriptionReactivations = new Map<
     EntryKey,
     { promise: Promise<void>; resolve: () => void }
@@ -1146,14 +1132,21 @@ export async function createHotReloaderTurbopack(
 
   async function setRouteHmrChunksActive(
     keys: Iterable<EntryKey>,
-    active: boolean
+    active: boolean,
+    reactivationSourcePaths?: string[],
+    advanceReactivationEpoch = false
   ) {
     const chunkPaths = Array.from(keys, getServerHmrEntryChunkPath).filter(
       (path): path is string => path !== undefined
     )
-    if (chunkPaths.length > 0) {
-      await project.setHmrChunksActive(chunkPaths, HmrTarget.Server, active)
-    }
+    if (chunkPaths.length === 0) return 0
+    return project.setHmrChunksActive(
+      chunkPaths,
+      HmrTarget.Server,
+      active,
+      reactivationSourcePaths,
+      advanceReactivationEpoch
+    )
   }
 
   async function removeRouteChangeSubscriptionState(keys: EntryKey[]) {
@@ -1193,7 +1186,6 @@ export async function createHotReloaderTurbopack(
       inactiveRouteChangeSubscriptions.delete(key)
       routeChangeSubscriptionsNeedingCatchUp.delete(key)
       routeChangeSubscriptionDisposals.delete(key)
-      routeChangeSubscriptionRetiredHmrGenerations.delete(key)
       const removedChunkPath = chunkPathsByKey.get(key)
       if (removedChunkPath) {
         removedRouteHmrChunkPaths.set(key, removedChunkPath)
@@ -1216,7 +1208,10 @@ export async function createHotReloaderTurbopack(
     }
   }
 
-  async function markRouteChangeSubscriptionActive(key: EntryKey) {
+  async function markRouteChangeSubscriptionActive(
+    key: EntryKey,
+    reactivationSourcePath: string
+  ) {
     markRouteChangeSubscriptionRecentlyActive(key)
 
     // If cleanup raced with a request for this route, let its native aggregate
@@ -1234,7 +1229,7 @@ export async function createHotReloaderTurbopack(
     const existingReactivation = routeChangeSubscriptionReactivations.get(key)
     if (existingReactivation) {
       await existingReactivation.promise
-      return { wasInactive: false, wasRemoved: false, ownsReactivation: false }
+      return { ownsReactivation: false }
     }
 
     const wasInactive = inactiveRouteChangeSubscriptions.has(key)
@@ -1258,7 +1253,12 @@ export async function createHotReloaderTurbopack(
         // be written. Ordinary inactive operations stay connected, so keep their
         // aggregate path inactive until the catch-up write is complete.
         if (wasRemoved) {
-          await setRouteHmrChunksActive([key], true)
+          await setRouteHmrChunksActive(
+            [key],
+            true,
+            [reactivationSourcePath],
+            false
+          )
           removedRouteHmrChunkPaths.delete(key)
         }
         // Stop suppressing endpoint issues before compiling. If catch-up fails,
@@ -1266,7 +1266,7 @@ export async function createHotReloaderTurbopack(
         inactiveRouteChangeSubscriptions.delete(key)
         routeChangeSubscriptionsNeedingCatchUp.add(key)
       }
-      return { wasInactive, wasRemoved, ownsReactivation }
+      return { ownsReactivation }
     } catch (error) {
       if (
         ownedReactivation &&
@@ -1312,13 +1312,7 @@ export async function createHotReloaderTurbopack(
       // output and change roots connected so edits cannot leave a stale graph.
       // The subscription loop suppresses refreshes and issues for inactive keys.
       await setRouteHmrChunksActive(keys, false)
-      const retiredHmrGeneration =
-        serverHmrUpdateTracker?.captureGeneration() ?? 0
       for (const key of keys) {
-        routeChangeSubscriptionRetiredHmrGenerations.set(
-          key,
-          retiredHmrGeneration
-        )
         currentEntryIssues.delete(key)
       }
     })()
@@ -2387,7 +2381,7 @@ export async function createHotReloaderTurbopack(
           let reactivatedRouteChangeSubscription = false
           let ownsRouteChangeSubscriptionReactivation = false
           let pendingNativeRouteHmrReactivation = false
-          const reactivatedServerHmrChunkPaths = new Set<string>()
+          let routeHmrReactivationEpoch = 0
           let routeChangeSubscriptionEntryKey: EntryKey | undefined
           try {
             if (
@@ -2407,15 +2401,17 @@ export async function createHotReloaderTurbopack(
                 ) ?? 0) + 1
               )
               const reactivation = await markRouteChangeSubscriptionActive(
-                routeChangeSubscriptionEntryKey
+                routeChangeSubscriptionEntryKey,
+                routeDef.filename
               )
               ownsRouteChangeSubscriptionReactivation =
                 reactivation.ownsReactivation
-              pendingNativeRouteHmrReactivation = reactivation.wasInactive
               reactivatedRouteChangeSubscription =
                 routeChangeSubscriptionsNeedingCatchUp.has(
                   routeChangeSubscriptionEntryKey
                 )
+              pendingNativeRouteHmrReactivation =
+                reactivatedRouteChangeSubscription
               if (reactivatedRouteChangeSubscription) {
                 await route.htmlEndpoint.invalidateOutput()
               }
@@ -2445,11 +2441,6 @@ export async function createHotReloaderTurbopack(
                   assetMapper.setPathsForKey(id, result.clientPaths)
                   const didChange = clearRequireCache(id, result, {
                     force: forceDeleteCache,
-                    onServerHmrChunkChanged: (path) => {
-                      if (reactivatedRouteChangeSubscription) {
-                        reactivatedServerHmrChunkPaths.add(path)
-                      }
-                    },
                   })
                   if (didChange && reactivatedRouteChangeSubscription) {
                     // Advance the cache version in the same synchronous step that
@@ -2467,29 +2458,22 @@ export async function createHotReloaderTurbopack(
               routeChangeSubscriptionEntryKey
             ) {
               // Publish the route back into aggregate HMR only after its output is
-              // current. Wait for the existing runtime to apply the changed chunks
-              // before the request can render; force-evicting shared runtime chunks
-              // here would orphan sibling routes' server-HMR handlers.
-              const generation =
-                routeChangeSubscriptionRetiredHmrGenerations.get(
-                  routeChangeSubscriptionEntryKey
-                ) ??
-                serverHmrUpdateTracker?.captureGeneration() ??
-                0
-              await setRouteHmrChunksActive(
+              // current. Native returns the exact aggregate transition that the
+              // runtime must apply before this request can render.
+              routeHmrReactivationEpoch = await setRouteHmrChunksActive(
                 [routeChangeSubscriptionEntryKey],
+                true,
+                undefined,
                 true
               )
               pendingNativeRouteHmrReactivation = false
-              await serverHmrUpdateTracker?.waitForChunkPathsAfter(
-                generation,
-                reactivatedServerHmrChunkPaths
+            }
+            if (routeHmrReactivationEpoch > 0) {
+              await serverHmrUpdateTracker?.waitForReactivationEpoch(
+                routeHmrReactivationEpoch
               )
             }
             if (routeChangeSubscriptionEntryKey) {
-              routeChangeSubscriptionRetiredHmrGenerations.delete(
-                routeChangeSubscriptionEntryKey
-              )
               routeChangeSubscriptionsNeedingCatchUp.delete(
                 routeChangeSubscriptionEntryKey
               )
@@ -2572,7 +2556,6 @@ export async function createHotReloaderTurbopack(
       removedRouteHmrChunkPaths.clear()
       routeChangeSubscriptionsNeedingCatchUp.clear()
       routeChangeSubscriptionDisposals.clear()
-      routeChangeSubscriptionRetiredHmrGenerations.clear()
       for (const reactivation of routeChangeSubscriptionReactivations.values()) {
         reactivation.resolve()
       }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -973,7 +973,10 @@ export async function createHotReloaderTurbopack(
     }
   }
 
-  async function unsubscribeFromClientChanges(key: EntryKey) {
+  async function unsubscribeFromClientChanges(
+    key: EntryKey,
+    preserveIssues = false
+  ) {
     const subscriptionPromise = changeSubscriptions.get(key)
     if (subscriptionPromise) {
       // Remove this before awaiting so a request that reactivates the route can
@@ -982,7 +985,9 @@ export async function createHotReloaderTurbopack(
       const subscription = await subscriptionPromise
       await subscription.return?.()
     }
-    currentEntryIssues.delete(key)
+    if (!preserveIssues) {
+      currentEntryIssues.delete(key)
+    }
   }
 
   const maxInactiveAge = nextConfig.onDemandEntries?.maxInactiveAge ?? 60 * 1000
@@ -1019,7 +1024,7 @@ export async function createHotReloaderTurbopack(
     }
   }
 
-  async function markRouteChangeSubscriptionActive(key: EntryKey) {
+  function markRouteChangeSubscriptionRecentlyActive(key: EntryKey) {
     routeChangeSubscriptionLastActive.set(key, Date.now())
 
     const previousIndex = recentRouteChangeSubscriptions.indexOf(key)
@@ -1030,10 +1035,20 @@ export async function createHotReloaderTurbopack(
     if (recentRouteChangeSubscriptions.length > pagesBufferLength) {
       recentRouteChangeSubscriptions.length = pagesBufferLength
     }
+  }
+
+  async function markRouteChangeSubscriptionActive(key: EntryKey) {
+    markRouteChangeSubscriptionRecentlyActive(key)
 
     // If cleanup raced with a request for this route, let the old iterator fully
-    // stop before handleRouteType installs its replacement.
-    await routeChangeSubscriptionDisposals.get(key)
+    // stop before handleRouteType installs its replacement. A failed iterator
+    // shutdown must not turn a later page request or ping into an unhandled
+    // rejection; reactivation is idempotent and can safely retry below.
+    try {
+      await routeChangeSubscriptionDisposals.get(key)
+    } catch (error) {
+      console.error('Failed to retire route HMR subscription:', error)
+    }
     const wasInactive = inactiveRouteChangeSubscriptions.has(key)
     if (wasInactive) {
       await setRouteHmrChunksActive([key], true)
@@ -1078,7 +1093,9 @@ export async function createHotReloaderTurbopack(
       // idempotent reactivation, while clearing it could leave a retired graph
       // incorrectly recorded as active.
       await setRouteHmrChunksActive(keys, false)
-      await Promise.all(keys.map(unsubscribeFromClientChanges))
+      await Promise.all(
+        keys.map((key) => unsubscribeFromClientChanges(key, true))
+      )
     })()
     for (const key of keys) {
       routeChangeSubscriptionDisposals.set(key, disposal)
@@ -1694,17 +1711,17 @@ export async function createHotReloaderTurbopack(
                   parsedData.tree
                 )
                 activeRouteSubscriptionsByClient.set(client, activeEntryKeys)
-                const reactivated = await Promise.all(
-                  Array.from(activeEntryKeys, (key) =>
-                    routeChangeSubscriptionLastActive.has(key)
-                      ? markRouteChangeSubscriptionActive(key)
-                      : undefined
-                  )
-                )
-                if (reactivated.some(Boolean)) {
+                let hasInactiveEntry = false
+                for (const key of activeEntryKeys) {
+                  if (!routeChangeSubscriptionLastActive.has(key)) continue
+                  markRouteChangeSubscriptionRecentlyActive(key)
+                  hasInactiveEntry ||= inactiveRouteChangeSubscriptions.has(key)
+                }
+                if (hasInactiveEntry) {
                   // A cached client navigation can update its router tree without
-                  // an RSC request. Refresh that client so ensurePage writes and
-                  // reconnects every output operation that was retired.
+                  // an RSC request. Keep the endpoint retired until that refresh
+                  // reaches ensurePage, so a failed or abandoned refresh cannot
+                  // leave a sticky catch-up marker behind.
                   sendToClient(client, {
                     type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
                   })
@@ -2173,16 +2190,6 @@ export async function createHotReloaderTurbopack(
                   const didChange = clearRequireCache(id, result, {
                     force: forceDeleteCache,
                   })
-                  if (
-                    didChange &&
-                    reactivatedRouteChangeSubscription &&
-                    !forceDeleteCache
-                  ) {
-                    // This route missed in-place server HMR while its graph was
-                    // disconnected. Only reload its runtime module cache when
-                    // Turbopack reports that the server output actually changed.
-                    clearRequireCache(id, result, { force: true })
-                  }
                   // While this route was inactive there was no subscription to
                   // advance the dev cache version. Do it when the route is next
                   // requested and Turbopack reports changed server output.

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -973,10 +973,7 @@ export async function createHotReloaderTurbopack(
     }
   }
 
-  async function unsubscribeFromClientChanges(
-    key: EntryKey,
-    preserveIssues = false
-  ) {
+  async function unsubscribeFromClientChanges(key: EntryKey) {
     const subscriptionPromise = changeSubscriptions.get(key)
     if (subscriptionPromise) {
       // Remove this before awaiting so a request that reactivates the route can
@@ -985,9 +982,7 @@ export async function createHotReloaderTurbopack(
       const subscription = await subscriptionPromise
       await subscription.return?.()
     }
-    if (!preserveIssues) {
-      currentEntryIssues.delete(key)
-    }
+    currentEntryIssues.delete(key)
   }
 
   const maxInactiveAge = nextConfig.onDemandEntries?.maxInactiveAge ?? 60 * 1000
@@ -1093,9 +1088,7 @@ export async function createHotReloaderTurbopack(
       // idempotent reactivation, while clearing it could leave a retired graph
       // incorrectly recorded as active.
       await setRouteHmrChunksActive(keys, false)
-      await Promise.all(
-        keys.map((key) => unsubscribeFromClientChanges(key, true))
-      )
+      await Promise.all(keys.map(unsubscribeFromClientChanges))
     })()
     for (const key of keys) {
       routeChangeSubscriptionDisposals.set(key, disposal)

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -558,6 +558,10 @@ export async function createHotReloaderTurbopack(
   const recentRouteChangeSubscriptions: EntryKey[] = []
   const activeRouteSubscriptionsByClient = new Map<ws, Set<EntryKey>>()
   const inactiveRouteChangeSubscriptions = new Set<EntryKey>()
+  // Deletion prunes native output snapshots and path indexes, but Turbopack may
+  // reuse the same memoized operation if the route file is added again. Retain
+  // only its entry-chunk path so that later ensure can resurrect that operation.
+  const removedRouteHmrChunkPaths = new Map<EntryKey, string>()
   const routeChangeSubscriptionsNeedingCatchUp = new Set<EntryKey>()
   const serverPathState = new Map<string, string>()
   const readyIds: ReadyIds = new Set()
@@ -994,7 +998,10 @@ export async function createHotReloaderTurbopack(
       return
     }
     const writtenEndpoint = currentWrittenEntrypoints.get(key)
-    if (!writtenEndpoint || writtenEndpoint.type !== 'nodejs') {
+    if (!writtenEndpoint) {
+      return removedRouteHmrChunkPaths.get(key)
+    }
+    if (writtenEndpoint.type !== 'nodejs') {
       return
     }
 
@@ -1016,6 +1023,52 @@ export async function createHotReloaderTurbopack(
     )
     if (chunkPaths.length > 0) {
       await project.setHmrChunksActive(chunkPaths, HmrTarget.Server, active)
+    }
+  }
+
+  async function removeRouteChangeSubscriptionState(keys: EntryKey[]) {
+    // Stop interval cleanup from selecting a deleted route while this function
+    // awaits an already-started disposal. Any disposal that yielded control has
+    // installed its promise in the map, so the snapshot below covers it.
+    for (const key of keys) {
+      routeChangeSubscriptionLastActive.delete(key)
+      for (const activeSubscriptions of activeRouteSubscriptionsByClient.values()) {
+        activeSubscriptions.delete(key)
+      }
+      const recentIndex = recentRouteChangeSubscriptions.indexOf(key)
+      if (recentIndex !== -1) {
+        recentRouteChangeSubscriptions.splice(recentIndex, 1)
+      }
+    }
+    await Promise.allSettled(
+      keys.map((key) => routeChangeSubscriptionDisposals.get(key))
+    )
+
+    const chunkPathsByKey = new Map<EntryKey, string>()
+    for (const key of keys) {
+      const chunkPath = getServerHmrEntryChunkPath(key)
+      if (chunkPath) {
+        chunkPathsByKey.set(key, chunkPath)
+      }
+    }
+    if (chunkPathsByKey.size > 0) {
+      await project.removeHmrChunks(
+        Array.from(chunkPathsByKey.values()),
+        HmrTarget.Server
+      )
+    }
+
+    for (const key of keys) {
+      currentWrittenEntrypoints.delete(key)
+      inactiveRouteChangeSubscriptions.delete(key)
+      routeChangeSubscriptionsNeedingCatchUp.delete(key)
+      routeChangeSubscriptionDisposals.delete(key)
+      const removedChunkPath = chunkPathsByKey.get(key)
+      if (removedChunkPath) {
+        removedRouteHmrChunkPaths.set(key, removedChunkPath)
+      } else {
+        removedRouteHmrChunkPaths.delete(key)
+      }
     }
   }
 
@@ -1045,12 +1098,14 @@ export async function createHotReloaderTurbopack(
       console.error('Failed to retire route HMR subscription:', error)
     }
     const wasInactive = inactiveRouteChangeSubscriptions.has(key)
-    if (wasInactive) {
+    const wasRemoved = removedRouteHmrChunkPaths.has(key)
+    if (wasInactive || wasRemoved) {
       await setRouteHmrChunksActive([key], true)
       inactiveRouteChangeSubscriptions.delete(key)
+      removedRouteHmrChunkPaths.delete(key)
       routeChangeSubscriptionsNeedingCatchUp.add(key)
     }
-    return wasInactive
+    return wasInactive || wasRemoved
   }
 
   function getAppPageEntryKeysFromTree(
@@ -1239,6 +1294,20 @@ export async function createHotReloaderTurbopack(
           !currentEntrypoints.page.has(route)
       )
       const removedRoutes = existingRoutes.filter((route) => !routes.has(route))
+      const nextAppPageNames = new Set<string>()
+      for (const route of routes.values()) {
+        if (route.type === 'app-page') {
+          for (const page of route.pages) {
+            nextAppPageNames.add(page.originalName)
+          }
+        }
+      }
+      const removedAppPageEntryKeys = Array.from(currentEntrypoints.app)
+        .filter(
+          ([name, route]) =>
+            route.type === 'app-page' && !nextAppPageNames.has(name)
+        )
+        .map(([name]) => getEntryKey('app', 'server', name))
 
       await handleEntrypoints({
         entrypoints: entrypoints as any,
@@ -1275,6 +1344,10 @@ export async function createHotReloaderTurbopack(
           },
         },
       })
+
+      if (removedAppPageEntryKeys.length > 0) {
+        await removeRouteChangeSubscriptionState(removedAppPageEntryKeys)
+      }
 
       // Reload matchers when the files have been compiled
       await propagateServerField(opts, 'reloadMatchers', undefined)
@@ -2222,7 +2295,12 @@ export async function createHotReloaderTurbopack(
       clientsWithoutHtmlRequestId.clear()
       clientsByHtmlRequestId.clear()
       activeRouteSubscriptionsByClient.clear()
+      routeChangeSubscriptionLastActive.clear()
+      recentRouteChangeSubscriptions.length = 0
+      inactiveRouteChangeSubscriptions.clear()
+      removedRouteHmrChunkPaths.clear()
       routeChangeSubscriptionsNeedingCatchUp.clear()
+      routeChangeSubscriptionDisposals.clear()
       clearInterval(disposeInactiveRouteSubscriptionsInterval)
     },
   }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -160,8 +160,11 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
+/** Virtual output prefix; turbo-tasks paths always use forward slashes. */
+const SERVER_HMR_VIRTUAL_CHUNKS_PREFIX = 'server/chunks/'
 /** Virtual output directory containing the App Router's server entry chunks. */
 const SERVER_HMR_APP_DIR = 'server/app'
+const SERVER_HMR_REENTRY_WAIT_MS = 1000
 
 declare const __next__clear_chunk_cache__: (() => void) | null | undefined
 
@@ -207,6 +210,20 @@ function collectUpdatedChunkPaths(
   return Array.from(paths)
 }
 
+type ServerHmrUpdateWaiter = {
+  afterGeneration: number
+  chunkPaths: Set<string>
+  resolve: () => void
+}
+
+type ServerHmrUpdateTracker = {
+  captureGeneration: () => number
+  waitForChunkPathsAfter: (
+    afterGeneration: number,
+    chunkPaths: Iterable<string>
+  ) => Promise<void>
+}
+
 function setupServerHmr(
   project: Project,
   {
@@ -216,7 +233,55 @@ function setupServerHmr(
     reEvaluateAllModulesExpensive: () => void | Promise<void>
     onApplied: (chunkPaths: string[]) => void | Promise<void>
   }
-) {
+): ServerHmrUpdateTracker {
+  let appliedGeneration = 0
+  let fullReEvaluationGeneration = 0
+  const chunkPathGenerations = new Map<string, number>()
+  const updateWaiters = new Set<ServerHmrUpdateWaiter>()
+
+  function hasApplied(waiter: ServerHmrUpdateWaiter) {
+    return (
+      fullReEvaluationGeneration > waiter.afterGeneration ||
+      Array.from(waiter.chunkPaths).every(
+        (path) => (chunkPathGenerations.get(path) ?? 0) > waiter.afterGeneration
+      )
+    )
+  }
+
+  function recordAppliedUpdate(chunkPaths?: string[]) {
+    const generation = ++appliedGeneration
+    if (chunkPaths === undefined) {
+      fullReEvaluationGeneration = generation
+    } else {
+      for (const path of chunkPaths) {
+        chunkPathGenerations.set(path, generation)
+      }
+    }
+    for (const waiter of updateWaiters) {
+      if (hasApplied(waiter)) {
+        updateWaiters.delete(waiter)
+        waiter.resolve()
+      }
+    }
+  }
+
+  let fullReEvaluationPromise: Promise<void> | undefined
+  function runFullReEvaluation() {
+    if (fullReEvaluationPromise) {
+      return fullReEvaluationPromise
+    }
+    const promise = Promise.resolve()
+      .then(reEvaluateAllModulesExpensive)
+      .then(() => recordAppliedUpdate())
+      .finally(() => {
+        if (fullReEvaluationPromise === promise) {
+          fullReEvaluationPromise = undefined
+        }
+      })
+    fullReEvaluationPromise = promise
+    return promise
+  }
+
   async function runSubscription() {
     const subscription = project.allHmrEvents(HmrTarget.Server)
 
@@ -233,7 +298,7 @@ function setupServerHmr(
       // clears the module cache and notifies browsers to refetch RSC.
       const requiresFullReEvaluation = update.type === 'restart'
       if (requiresFullReEvaluation) {
-        await reEvaluateAllModulesExpensive()
+        await runFullReEvaluation()
         continue
       }
 
@@ -254,12 +319,15 @@ function setupServerHmr(
           `[Server HMR] unreachable: unexpected update instruction type ${(instruction as { type: string }).type}`
         )
       }
+      const updatedChunkPaths = collectUpdatedChunkPaths(instruction)
 
       // No handler registered yet (before first request, or right after
-      // reEvaluateAllModulesExpensive()) — nothing live to update, so skip
-      // until the next request.
+      // reEvaluateAllModulesExpensive()) — nothing live to update. Recording the
+      // paths still releases a reentry waiter because there is no live cache that
+      // could serve stale modules.
       const handlers = globalThis.__turbopack_server_hmr_handlers__
       if (!handlers || handlers.size === 0) {
+        recordAppliedUpdate(updatedChunkPaths)
         continue
       }
 
@@ -270,19 +338,19 @@ function setupServerHmr(
           // A matching runtime tried the apply and threw. Evict require.cache
           // so the next request loads fresh, then skip onApplied. (A no-match
           // update is a no-op and does not throw.)
-          await reEvaluateAllModulesExpensive()
+          await runFullReEvaluation()
           continue
         }
 
-        const updatedChunkPaths = collectUpdatedChunkPaths(instruction)
         // An empty partial only advances the version state (e.g. the seed
         // transition or a new endpoint); nothing changed on disk, so don't
         // invalidate manifests or ping browsers to refetch RSC.
         if (updatedChunkPaths.length > 0) {
           await onApplied(updatedChunkPaths)
         }
+        recordAppliedUpdate(updatedChunkPaths)
       } else {
-        await reEvaluateAllModulesExpensive()
+        await runFullReEvaluation()
       }
     }
   }
@@ -298,11 +366,51 @@ function setupServerHmr(
         return
       } catch (err) {
         console.error('[Server HMR] Subscription error, resubscribing:', err)
-        await reEvaluateAllModulesExpensive()
+        await runFullReEvaluation()
         await new Promise((resolve) => setTimeout(resolve, 1000))
       }
     }
   })()
+
+  return {
+    captureGeneration: () => appliedGeneration,
+    waitForChunkPathsAfter(afterGeneration, chunkPaths) {
+      const waiter: ServerHmrUpdateWaiter = {
+        afterGeneration,
+        chunkPaths: new Set(chunkPaths),
+        resolve: () => {},
+      }
+      if (waiter.chunkPaths.size === 0 || hasApplied(waiter)) {
+        return Promise.resolve()
+      }
+      let fallbackTimer: ReturnType<typeof setTimeout> | undefined
+      const updatePromise = new Promise<void>((resolve) => {
+        waiter.resolve = resolve
+        updateWaiters.add(waiter)
+        if (hasApplied(waiter)) {
+          updateWaiters.delete(waiter)
+          resolve()
+        }
+      })
+      const fallbackPromise = new Promise<void>((resolve, reject) => {
+        fallbackTimer = setTimeout(() => {
+          if (hasApplied(waiter)) {
+            resolve()
+            return
+          }
+          // Some endpoint output paths (notably client-component SSR chunks)
+          // are owned by a separate always-active aggregate entry and may have
+          // applied before this reentry began. Bound the route-specific wait and
+          // use the existing safe full-re-evaluation fallback rather than hanging.
+          runFullReEvaluation().then(resolve, reject)
+        }, SERVER_HMR_REENTRY_WAIT_MS)
+      })
+      return Promise.race([updatePromise, fallbackPromise]).finally(() => {
+        if (fallbackTimer) clearTimeout(fallbackTimer)
+        updateWaiters.delete(waiter)
+      })
+    },
+  }
 }
 
 function getSourceMapFromTurbopack(
@@ -551,9 +659,10 @@ export async function createHotReloaderTurbopack(
 
   // Dev specific
   const changeSubscriptions: ChangeSubscriptions = new Map()
-  // Route endpoint subscriptions keep Turbopack's dependency graph active. Bound
-  // App Router page subscriptions to routes that are still being viewed or were
-  // accessed recently, matching the lifetime used by webpack on-demand entries.
+  // Bound aggregate server-HMR versioning to App Router pages that are still
+  // being viewed or were accessed recently, matching the lifetime used by
+  // webpack on-demand entries. Endpoint subscriptions remain connected so an
+  // inactive route's output graph still observes source changes.
   const routeChangeSubscriptionLastActive = new Map<EntryKey, number>()
   const recentRouteChangeSubscriptions: EntryKey[] = []
   const activeRouteSubscriptionsByClient = new Map<ws, Set<EntryKey>>()
@@ -644,9 +753,11 @@ export async function createHotReloaderTurbopack(
     writtenEndpoint: WrittenEndpoint,
     {
       force,
+      onServerHmrChunkChanged,
     }: {
       // Always clear the cache, don't check if files have changed
       force?: boolean
+      onServerHmrChunkChanged?: (path: string) => void
     } = {}
   ): boolean {
     if (force) {
@@ -673,6 +784,9 @@ export async function createHotReloaderTurbopack(
           (globalHash && globalHash !== contentHash)
         ) {
           hasChange = true
+          if (path.startsWith(SERVER_HMR_VIRTUAL_CHUNKS_PREFIX)) {
+            onServerHmrChunkChanged?.(path)
+          }
           serverPathState.set(localKey, contentHash)
           serverPathState.set(path, contentHash)
         } else {
@@ -806,6 +920,7 @@ export async function createHotReloaderTurbopack(
   // advancing there would both churn the hash without an edit and fail to
   // advance it at all when no client is connected.
   let hmrHash = 0
+  let serverHmrUpdateTracker: ServerHmrUpdateTracker | undefined
 
   // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every
   // foreground-job cycle, including empty no-op recompiles scheduled by
@@ -955,6 +1070,10 @@ export async function createHotReloaderTurbopack(
       const changed = await changedPromise
 
       for await (const change of changed) {
+        if (inactiveRouteChangeSubscriptions.has(key)) {
+          currentEntryIssues.delete(key)
+          continue
+        }
         processIssues(currentEntryIssues, key, change, false, true)
         // TODO: Get an actual content hash from Turbopack.
         const message = await createMessage(change, String(++hmrHash))
@@ -992,6 +1111,17 @@ export async function createHotReloaderTurbopack(
   const maxInactiveAge = nextConfig.onDemandEntries?.maxInactiveAge ?? 60 * 1000
   const pagesBufferLength = nextConfig.onDemandEntries?.pagesBufferLength ?? 5
   const routeChangeSubscriptionDisposals = new Map<EntryKey, Promise<void>>()
+  const routeChangeSubscriptionRetiredHmrGenerations = new Map<
+    EntryKey,
+    number
+  >()
+  const routeChangeSubscriptionReactivations = new Map<
+    EntryKey,
+    { promise: Promise<void>; resolve: () => void }
+  >()
+  // Multiple requests can concurrently ensure the same route (for example, an
+  // HTML request and an RSC prefetch), so this guard must be reference-counted.
+  const routeChangeSubscriptionsBeingHandled = new Map<EntryKey, number>()
 
   function getServerHmrEntryChunkPath(key: EntryKey): string | undefined {
     if (!serverFastRefresh || splitEntryKey(key).type !== 'app') {
@@ -1063,6 +1193,7 @@ export async function createHotReloaderTurbopack(
       inactiveRouteChangeSubscriptions.delete(key)
       routeChangeSubscriptionsNeedingCatchUp.delete(key)
       routeChangeSubscriptionDisposals.delete(key)
+      routeChangeSubscriptionRetiredHmrGenerations.delete(key)
       const removedChunkPath = chunkPathsByKey.get(key)
       if (removedChunkPath) {
         removedRouteHmrChunkPaths.set(key, removedChunkPath)
@@ -1088,24 +1219,64 @@ export async function createHotReloaderTurbopack(
   async function markRouteChangeSubscriptionActive(key: EntryKey) {
     markRouteChangeSubscriptionRecentlyActive(key)
 
-    // If cleanup raced with a request for this route, let the old iterator fully
-    // stop before handleRouteType installs its replacement. A failed iterator
-    // shutdown must not turn a later page request or ping into an unhandled
-    // rejection; reactivation is idempotent and can safely retry below.
+    // If cleanup raced with a request for this route, let its native aggregate
+    // transition finish before reactivation. A failed transition must not turn a
+    // later page request or ping into an unhandled rejection; reactivation is
+    // idempotent and can safely retry below.
     try {
       await routeChangeSubscriptionDisposals.get(key)
     } catch (error) {
       console.error('Failed to retire route HMR subscription:', error)
     }
+
+    // Serialize the catch-up write for overlapping HTML/RSC requests. The other
+    // callers keep the inactivity-cleanup refcount held while this promise waits.
+    const existingReactivation = routeChangeSubscriptionReactivations.get(key)
+    if (existingReactivation) {
+      await existingReactivation.promise
+      return { wasInactive: false, wasRemoved: false, ownsReactivation: false }
+    }
+
     const wasInactive = inactiveRouteChangeSubscriptions.has(key)
     const wasRemoved = removedRouteHmrChunkPaths.has(key)
-    if (wasInactive || wasRemoved) {
-      await setRouteHmrChunksActive([key], true)
-      inactiveRouteChangeSubscriptions.delete(key)
-      removedRouteHmrChunkPaths.delete(key)
-      routeChangeSubscriptionsNeedingCatchUp.add(key)
+    const ownsReactivation = wasInactive || wasRemoved
+    let ownedReactivation:
+      | { promise: Promise<void>; resolve: () => void }
+      | undefined
+    if (ownsReactivation) {
+      let resolve = () => {}
+      const promise = new Promise<void>((promiseResolve) => {
+        resolve = promiseResolve
+      })
+      ownedReactivation = { promise, resolve }
+      routeChangeSubscriptionReactivations.set(key, ownedReactivation)
     }
-    return wasInactive || wasRemoved
+
+    try {
+      if (ownsReactivation) {
+        // A deleted route's retained output operation must reconnect before it can
+        // be written. Ordinary inactive operations stay connected, so keep their
+        // aggregate path inactive until the catch-up write is complete.
+        if (wasRemoved) {
+          await setRouteHmrChunksActive([key], true)
+          removedRouteHmrChunkPaths.delete(key)
+        }
+        // Stop suppressing endpoint issues before compiling. If catch-up fails,
+        // its source-fix event must still clear the redbox without another request.
+        inactiveRouteChangeSubscriptions.delete(key)
+        routeChangeSubscriptionsNeedingCatchUp.add(key)
+      }
+      return { wasInactive, wasRemoved, ownsReactivation }
+    } catch (error) {
+      if (
+        ownedReactivation &&
+        routeChangeSubscriptionReactivations.get(key) === ownedReactivation
+      ) {
+        routeChangeSubscriptionReactivations.delete(key)
+        ownedReactivation.resolve()
+      }
+      throw error
+    }
   }
 
   function getAppPageEntryKeysFromTree(
@@ -1137,13 +1308,19 @@ export async function createHotReloaderTurbopack(
     }
 
     const disposal = (async () => {
-      // Removing the aggregate HMR dependency first prevents the endpoint
-      // iterator shutdown from waking a full all-routes scan. Keep the inactive
-      // marker if either step fails: the next request can safely retry an
-      // idempotent reactivation, while clearing it could leave a retired graph
-      // incorrectly recorded as active.
+      // Exclude inactive entry chunks from aggregate HMR while keeping their
+      // output and change roots connected so edits cannot leave a stale graph.
+      // The subscription loop suppresses refreshes and issues for inactive keys.
       await setRouteHmrChunksActive(keys, false)
-      await Promise.all(keys.map(unsubscribeFromClientChanges))
+      const retiredHmrGeneration =
+        serverHmrUpdateTracker?.captureGeneration() ?? 0
+      for (const key of keys) {
+        routeChangeSubscriptionRetiredHmrGenerations.set(
+          key,
+          retiredHmrGeneration
+        )
+        currentEntryIssues.delete(key)
+      }
     })()
     for (const key of keys) {
       routeChangeSubscriptionDisposals.set(key, disposal)
@@ -1182,6 +1359,7 @@ export async function createHotReloaderTurbopack(
         if (
           getServerHmrEntryChunkPath(key) === undefined ||
           inactiveRouteChangeSubscriptions.has(key) ||
+          routeChangeSubscriptionsBeingHandled.has(key) ||
           activeRouteSubscriptions.has(key) ||
           recentRouteChangeSubscriptions.includes(key) ||
           now - lastActiveTime <= maxInactiveAge
@@ -2207,6 +2385,9 @@ export async function createHotReloaderTurbopack(
 
           const finishBuilding = startBuilding(pathname, requestUrl, false)
           let reactivatedRouteChangeSubscription = false
+          let ownsRouteChangeSubscriptionReactivation = false
+          let pendingNativeRouteHmrReactivation = false
+          const reactivatedServerHmrChunkPaths = new Set<string>()
           let routeChangeSubscriptionEntryKey: EntryKey | undefined
           try {
             if (
@@ -2219,9 +2400,18 @@ export async function createHotReloaderTurbopack(
                 'server',
                 page
               )
-              await markRouteChangeSubscriptionActive(
+              routeChangeSubscriptionsBeingHandled.set(
+                routeChangeSubscriptionEntryKey,
+                (routeChangeSubscriptionsBeingHandled.get(
+                  routeChangeSubscriptionEntryKey
+                ) ?? 0) + 1
+              )
+              const reactivation = await markRouteChangeSubscriptionActive(
                 routeChangeSubscriptionEntryKey
               )
+              ownsRouteChangeSubscriptionReactivation =
+                reactivation.ownsReactivation
+              pendingNativeRouteHmrReactivation = reactivation.wasInactive
               reactivatedRouteChangeSubscription =
                 routeChangeSubscriptionsNeedingCatchUp.has(
                   routeChangeSubscriptionEntryKey
@@ -2255,11 +2445,16 @@ export async function createHotReloaderTurbopack(
                   assetMapper.setPathsForKey(id, result.clientPaths)
                   const didChange = clearRequireCache(id, result, {
                     force: forceDeleteCache,
+                    onServerHmrChunkChanged: (path) => {
+                      if (reactivatedRouteChangeSubscription) {
+                        reactivatedServerHmrChunkPaths.add(path)
+                      }
+                    },
                   })
-                  // While this route was inactive there was no subscription to
-                  // advance the dev cache version. Do it when the route is next
-                  // requested and Turbopack reports changed server output.
                   if (didChange && reactivatedRouteChangeSubscription) {
+                    // Advance the cache version in the same synchronous step that
+                    // consumes the changed output hashes. A later catch-up failure
+                    // must not permanently lose this edit's cache invalidation.
                     hmrHash++
                   }
                   return didChange
@@ -2267,16 +2462,92 @@ export async function createHotReloaderTurbopack(
                 serverFastRefresh,
               },
             })
+            if (
+              pendingNativeRouteHmrReactivation &&
+              routeChangeSubscriptionEntryKey
+            ) {
+              // Publish the route back into aggregate HMR only after its output is
+              // current. Wait for the existing runtime to apply the changed chunks
+              // before the request can render; force-evicting shared runtime chunks
+              // here would orphan sibling routes' server-HMR handlers.
+              const generation =
+                routeChangeSubscriptionRetiredHmrGenerations.get(
+                  routeChangeSubscriptionEntryKey
+                ) ??
+                serverHmrUpdateTracker?.captureGeneration() ??
+                0
+              await setRouteHmrChunksActive(
+                [routeChangeSubscriptionEntryKey],
+                true
+              )
+              pendingNativeRouteHmrReactivation = false
+              await serverHmrUpdateTracker?.waitForChunkPathsAfter(
+                generation,
+                reactivatedServerHmrChunkPaths
+              )
+            }
             if (routeChangeSubscriptionEntryKey) {
+              routeChangeSubscriptionRetiredHmrGenerations.delete(
+                routeChangeSubscriptionEntryKey
+              )
               routeChangeSubscriptionsNeedingCatchUp.delete(
                 routeChangeSubscriptionEntryKey
               )
             }
           } finally {
-            finishBuilding()
-            // Remove non-deferred entry from building set
-            if (hasDeferredEntriesConfig) {
-              nonDeferredBuildingEntries.delete(routeDef.page)
+            try {
+              // A failed catch-up compile still needs to rejoin aggregate HMR so
+              // the subsequent source fix can apply and clear the redbox.
+              if (
+                pendingNativeRouteHmrReactivation &&
+                routeChangeSubscriptionEntryKey
+              ) {
+                try {
+                  await setRouteHmrChunksActive(
+                    [routeChangeSubscriptionEntryKey],
+                    true
+                  )
+                  pendingNativeRouteHmrReactivation = false
+                } catch (error) {
+                  inactiveRouteChangeSubscriptions.add(
+                    routeChangeSubscriptionEntryKey
+                  )
+                  throw error
+                }
+              }
+            } finally {
+              if (
+                ownsRouteChangeSubscriptionReactivation &&
+                routeChangeSubscriptionEntryKey
+              ) {
+                const reactivation = routeChangeSubscriptionReactivations.get(
+                  routeChangeSubscriptionEntryKey
+                )
+                routeChangeSubscriptionReactivations.delete(
+                  routeChangeSubscriptionEntryKey
+                )
+                reactivation?.resolve()
+              }
+              if (routeChangeSubscriptionEntryKey) {
+                const handledCount = routeChangeSubscriptionsBeingHandled.get(
+                  routeChangeSubscriptionEntryKey
+                )
+                if (handledCount === 1) {
+                  routeChangeSubscriptionsBeingHandled.delete(
+                    routeChangeSubscriptionEntryKey
+                  )
+                } else if (handledCount !== undefined) {
+                  routeChangeSubscriptionsBeingHandled.set(
+                    routeChangeSubscriptionEntryKey,
+                    handledCount - 1
+                  )
+                }
+              }
+              finishBuilding()
+              // Remove non-deferred entry from building set
+              if (hasDeferredEntriesConfig) {
+                nonDeferredBuildingEntries.delete(routeDef.page)
+              }
             }
           }
         })
@@ -2301,6 +2572,12 @@ export async function createHotReloaderTurbopack(
       removedRouteHmrChunkPaths.clear()
       routeChangeSubscriptionsNeedingCatchUp.clear()
       routeChangeSubscriptionDisposals.clear()
+      routeChangeSubscriptionRetiredHmrGenerations.clear()
+      for (const reactivation of routeChangeSubscriptionReactivations.values()) {
+        reactivation.resolve()
+      }
+      routeChangeSubscriptionReactivations.clear()
+      routeChangeSubscriptionsBeingHandled.clear()
       clearInterval(disposeInactiveRouteSubscriptionsInterval)
     },
   }
@@ -2439,7 +2716,7 @@ export async function createHotReloaderTurbopack(
   }
 
   if (serverFastRefresh) {
-    setupServerHmr(project, {
+    serverHmrUpdateTracker = setupServerHmr(project, {
       reEvaluateAllModulesExpensive: async () => {
         // Evict every server-HMR-managed chunk from `require.cache`.
         // Trailing `sep` so e.g. `server/chunks-other/...` doesn't match.

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -135,7 +135,7 @@ function getPageBundleType(pageBundlePath: string): PAGE_TYPES {
       : PAGE_TYPES.ROOT
 }
 
-function getEntrypointsFromTree(
+export function getEntrypointsFromTree(
   tree: FlightRouterState,
   isFirst: boolean,
   parentPath: string[] = []

--- a/test/development/app-dir/server-hmr/app/(activity-group)/route-activity/client-marker.tsx
+++ b/test/development/app-dir/server-hmr/app/(activity-group)/route-activity/client-marker.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function ClientMarker() {
+  return <span id="route-activity-client-marker">client marker</span>
+}

--- a/test/development/app-dir/server-hmr/app/(activity-group)/route-activity/page.tsx
+++ b/test/development/app-dir/server-hmr/app/(activity-group)/route-activity/page.tsx
@@ -1,0 +1,13 @@
+import { routeActivityValue } from '../../../shared/route-activity-value'
+import { ClientMarker } from './client-marker'
+
+export default function Page() {
+  return (
+    <>
+      <p id="route-activity-greeting">
+        route activity page: {routeActivityValue}
+      </p>
+      <ClientMarker />
+    </>
+  )
+}

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -606,10 +606,86 @@ describe('server-hmr', () => {
   })
 })
 
+describe('server-hmr route activity', () => {
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
+    files: {
+      app: new FileRef(join(__dirname, 'app')),
+      shared: new FileRef(join(__dirname, 'shared')),
+    },
+    nextConfig: {
+      onDemandEntries: {
+        maxInactiveAge: 1000,
+        pagesBufferLength: 1,
+      },
+    },
+  })
+
+  const itTurbopackDev = isTurbopack && isNextDev ? it : it.skip
+
+  itTurbopackDev(
+    'keeps a connected route active and catches it up after inactivity',
+    async () => {
+      const routeFile = 'app/(activity-group)/route-activity/page.tsx'
+      const sharedFile = 'shared/route-activity-value.ts'
+      const browser = await next.browser('/route-activity')
+
+      // Exceed both maxInactiveAge and the cleanup interval. The route remains
+      // active because the connected App Router maps the public router tree back
+      // to its route-group-prefixed entry name.
+      await new Promise((resolve) => setTimeout(resolve, 5500))
+      await next.patchFile(routeFile, (content) =>
+        content.replace('route activity page', 'active route')
+      )
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#route-activity-greeting').text()
+        ).toBe('active route: route activity initial')
+      }, 10_000)
+
+      // Move the browser to another route, then let the original route leave
+      // both the connected router tree and the one-page recent buffer. Retiring
+      // its server graph must not make a still-subscribed client chunk disappear
+      // and hard-reload the page that is currently visible.
+      await browser.loadPage(`${next.url}/dynamic-import`)
+      await browser.eval(() => {
+        Reflect.set(window, '__routeActivityNoReload', true)
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5500))
+      expect(
+        await browser.eval(() => Reflect.get(window, '__routeActivityNoReload'))
+      ).toBe(true)
+
+      // The retired endpoint may depend on files outside app/. Editing one must
+      // be reflected when the route is reactivated.
+      await next.patchFile(sharedFile, (content) =>
+        content.replace('route activity initial', 'inactive route update')
+      )
+
+      // Re-entering the route must use its current output, and HMR must continue
+      // to work after its aggregate entry and endpoint subscription reactivate.
+      await browser.loadPage(`${next.url}/route-activity`)
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#route-activity-greeting').text()
+        ).toBe('active route: inactive route update')
+      }, 10_000)
+      await next.patchFile(routeFile, (content) =>
+        content.replace('active route', 'reactivated route')
+      )
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#route-activity-greeting').text()
+        ).toBe('reactivated route: inactive route update')
+      }, 10_000)
+    }
+  )
+})
+
 describe('server-hmr config opt-out', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
+      shared: new FileRef(join(__dirname, 'shared')),
     },
     nextConfig: {
       experimental: {
@@ -653,6 +729,7 @@ describe('server-hmr CLI/config conflict warning', () => {
   const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
+      shared: new FileRef(join(__dirname, 'shared')),
     },
     nextConfig: {
       experimental: {

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -627,6 +627,7 @@ describe('server-hmr route activity', () => {
     async () => {
       const routeFile = 'app/(activity-group)/route-activity/page.tsx'
       const sharedFile = 'shared/route-activity-value.ts'
+      const originalRouteSource = await next.readFile(routeFile)
       const browser = await next.browser('/route-activity')
 
       // Exceed both maxInactiveAge and the cleanup interval. The route remains
@@ -676,6 +677,51 @@ describe('server-hmr route activity', () => {
         expect(
           await browser.elementByCss('#route-activity-greeting').text()
         ).toBe('reactivated route: inactive route update')
+      }, 10_000)
+
+      // A second retirement without an intervening source edit must also
+      // reactivate cleanly. This takes the warm generation-matched path rather
+      // than conservatively invalidating every project filesystem read.
+      await browser.loadPage(`${next.url}/dynamic-import`)
+      const depEvalTimeBeforeWarmReactivation = await browser
+        .elementByCss('#dep-eval-time')
+        .text()
+      await new Promise((resolve) => setTimeout(resolve, 5500))
+      await browser.loadPage(`${next.url}/route-activity`)
+      expect(
+        await browser.elementByCss('#route-activity-greeting').text()
+      ).toBe('reactivated route: inactive route update')
+      await browser.loadPage(`${next.url}/dynamic-import`)
+      expect(await browser.elementByCss('#dep-eval-time').text()).toBe(
+        depEvalTimeBeforeWarmReactivation
+      )
+
+      // Deleting a retired route must prune its inactive operation snapshots and
+      // frozen aggregate version instead of retaining them for the session.
+      await new Promise((resolve) => setTimeout(resolve, 5500))
+      await next.deleteFile(routeFile)
+      await retry(async () => {
+        expect((await next.fetch('/route-activity')).status).toBe(404)
+      }, 10_000)
+
+      // Re-adding the same grouped route may reuse its memoized operation, but
+      // must rebuild from the current files and install a fresh HMR subscription
+      // rather than reviving the deleted output snapshot.
+      await next.patchFile(routeFile, originalRouteSource)
+      await retry(async () => {
+        expect((await next.fetch('/route-activity')).status).toBe(200)
+      }, 10_000)
+      await browser.loadPage(`${next.url}/route-activity`)
+      expect(
+        await browser.elementByCss('#route-activity-greeting').text()
+      ).toBe('route activity page: inactive route update')
+      await next.patchFile(routeFile, (content) =>
+        content.replace('route activity page', 're-added route')
+      )
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#route-activity-greeting').text()
+        ).toBe('re-added route: inactive route update')
       }, 10_000)
     }
   )

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -759,15 +759,24 @@ describe('server-hmr route activity', () => {
       await browser.loadPage(`${next.url}/route-activity`)
       await waitForRedbox(browser)
       await next.patchFile(routeFile, (content) =>
-        content.replace(
-          'export default function Page(',
-          'export default function Page()'
-        )
+        content
+          .replace(
+            'export default function Page(',
+            'export default function Page()'
+          )
+          .replace('inactive local update', 'recovered route')
       )
+      // The request retry owns the catch-up left behind by the failed compile.
+      // Its first response must wait for the recovery update to reach the runtime.
+      const firstRecoveryResponse = await next.fetch('/route-activity')
+      expect(firstRecoveryResponse.status).toBe(200)
+      const firstRecoveryHtml = await firstRecoveryResponse.text()
+      expect(firstRecoveryHtml).toContain('recovered route')
+      expect(firstRecoveryHtml).toContain('inactive route update')
       await retry(async () => {
         expect(
           await browser.elementByCss('#route-activity-greeting').text()
-        ).toBe('inactive local update: inactive route update')
+        ).toBe('recovered route: inactive route update')
       }, 10_000)
 
       // Deleting a retired route must prune its emitted output mappings and frozen
@@ -783,9 +792,16 @@ describe('server-hmr route activity', () => {
       // must rebuild from the current files and install a fresh HMR subscription
       // rather than reviving the deleted output snapshot.
       await next.patchFile(routeFile, originalRouteSource)
+      let firstReaddedRouteHtml: string | undefined
       await retry(async () => {
-        expect((await next.fetch('/route-activity')).status).toBe(200)
+        const response = await next.fetch('/route-activity')
+        expect(response.status).toBe(200)
+        firstReaddedRouteHtml = await response.text()
       }, 10_000)
+      // Assert outside retry so a stale first successful response cannot be hidden
+      // by a later request after the aggregate HMR update has caught up.
+      expect(firstReaddedRouteHtml).toContain('route activity page')
+      expect(firstReaddedRouteHtml).toContain('inactive route update')
       await browser.loadPage(`${next.url}/route-activity`)
       expect(
         await browser.elementByCss('#route-activity-greeting').text()

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -1,7 +1,7 @@
 import type { Response } from 'node-fetch'
 import { join } from 'path'
 import { nextTestSetup, FileRef } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { retry, waitForRedbox } from 'next-test-utils'
 
 describe('server-hmr', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
@@ -626,6 +626,8 @@ describe('server-hmr route activity', () => {
     'keeps a connected route active and catches it up after inactivity',
     async () => {
       const routeFile = 'app/(activity-group)/route-activity/page.tsx'
+      const clientMarkerFile =
+        'app/(activity-group)/route-activity/client-marker.tsx'
       const sharedFile = 'shared/route-activity-value.ts'
       const originalRouteSource = await next.readFile(routeFile)
       const browser = await next.browser('/route-activity')
@@ -679,9 +681,8 @@ describe('server-hmr route activity', () => {
         ).toBe('reactivated route: inactive route update')
       }, 10_000)
 
-      // A second retirement without an intervening source edit must also
-      // reactivate cleanly. This takes the warm generation-matched path rather
-      // than conservatively invalidating every project filesystem read.
+      // A second retirement without an intervening source edit must reactivate
+      // cleanly without invalidating unrelated project filesystem reads.
       await browser.loadPage(`${next.url}/dynamic-import`)
       const depEvalTimeBeforeWarmReactivation = await browser
         .elementByCss('#dep-eval-time')
@@ -696,8 +697,82 @@ describe('server-hmr route activity', () => {
         depEvalTimeBeforeWarmReactivation
       )
 
-      // Deleting a retired route must prune its inactive operation snapshots and
-      // frozen aggregate version instead of retaining them for the session.
+      // A multi-file server/client edit after a second retirement must be visible
+      // in the first uncached HTTP response. Retrying at the test level would hide
+      // a stale first preview or an ownership-mismatched HMR wait.
+      await new Promise((resolve) => setTimeout(resolve, 5500))
+      await browser.eval(() => {
+        Reflect.set(window, '__siblingRouteNoReload', true)
+      })
+      await next.patchFile(routeFile, (content) =>
+        content.replace('reactivated route', 'inactive local update')
+      )
+      await next.patchFile(clientMarkerFile, (content) =>
+        content.replace('client marker', 'inactive client marker')
+      )
+      // Let the retained inactive endpoint subscription observe the watcher event
+      // and finish its recompile. The single request below must then perform the
+      // route's synchronous catch-up instead of relying on an HMR retry.
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+      const firstReentryResponse = await next.fetch('/route-activity')
+      expect(firstReentryResponse.status).toBe(200)
+      const firstReentryHtml = await firstReentryResponse.text()
+      expect(firstReentryHtml).toContain('inactive local update: ')
+      expect(firstReentryHtml).toContain('inactive route update')
+      expect(firstReentryHtml).toContain('inactive client marker')
+
+      // Catch-up must preserve the currently rendered sibling route's runtime and
+      // HMR handler. Updating one of its server chunks should apply in place,
+      // without a reload, after the other route's first reentry response.
+      expect(
+        await browser.eval(() => Reflect.get(window, '__siblingRouteNoReload'))
+      ).toBe(true)
+      await next.patchFile('app/dynamic-import/lazy.ts', (content) =>
+        content.replace('lazy-v0', 'lazy-after-route-catch-up')
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#lazy-value').text()).toBe(
+          'lazy-after-route-catch-up'
+        )
+      }, 10_000)
+      expect(
+        await browser.eval(() => Reflect.get(window, '__siblingRouteNoReload'))
+      ).toBe(true)
+
+      // Synchronous catch-up must not re-evaluate unrelated server modules.
+      await browser.loadPage(`${next.url}/dynamic-import`)
+      expect(await browser.elementByCss('#dep-eval-time').text()).toBe(
+        depEvalTimeBeforeWarmReactivation
+      )
+
+      // A failed compile during reentry must not leave the retained endpoint
+      // subscription suppressed. Fixing the source should clear the redbox and
+      // recover through HMR without another navigation or manual reload.
+      await new Promise((resolve) => setTimeout(resolve, 5500))
+      await next.patchFile(routeFile, (content) =>
+        content.replace(
+          'export default function Page()',
+          'export default function Page('
+        )
+      )
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await browser.loadPage(`${next.url}/route-activity`)
+      await waitForRedbox(browser)
+      await next.patchFile(routeFile, (content) =>
+        content.replace(
+          'export default function Page(',
+          'export default function Page()'
+        )
+      )
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#route-activity-greeting').text()
+        ).toBe('inactive local update: inactive route update')
+      }, 10_000)
+
+      // Deleting a retired route must prune its emitted output mappings and frozen
+      // aggregate version instead of retaining them for the session.
+      await browser.loadPage(`${next.url}/dynamic-import`)
       await new Promise((resolve) => setTimeout(resolve, 5500))
       await next.deleteFile(routeFile)
       await retry(async () => {

--- a/test/development/app-dir/server-hmr/shared/route-activity-value.ts
+++ b/test/development/app-dir/server-hmr/shared/route-activity-value.ts
@@ -1,0 +1,1 @@
+export const routeActivityValue = 'route activity initial'

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -1,7 +1,6 @@
 //! The on-disk [`DiskFileSystem`] implementation and its supporting helpers.
 
 use std::{
-    collections::BTreeSet,
     env,
     ffi::OsString,
     fmt::{self, Debug, Formatter},
@@ -9,7 +8,7 @@ use std::{
     io::{self, ErrorKind, Write as _},
     mem::take,
     path::{MAIN_SEPARATOR, Path, PathBuf},
-    sync::{Arc, LazyLock, Mutex, Weak},
+    sync::{Arc, LazyLock, Weak},
     time::Duration,
 };
 
@@ -22,7 +21,7 @@ use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use tokio::{
     runtime::Handle,
-    sync::{RwLock, RwLockReadGuard, watch},
+    sync::{RwLock, RwLockReadGuard},
 };
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
@@ -189,66 +188,6 @@ fn create_read_semaphore() -> tokio::sync::Semaphore {
     tokio::sync::Semaphore::new(*TURBO_ENGINE_READ_CONCURRENCY)
 }
 
-#[derive(Default)]
-struct ChangeEpochState {
-    observed: u64,
-    settled: u64,
-    completed: BTreeSet<u64>,
-}
-
-impl ChangeEpochState {
-    fn record(&mut self) -> u64 {
-        self.observed = self
-            .observed
-            .checked_add(1)
-            .expect("filesystem change generation overflowed");
-        self.observed
-    }
-
-    fn settle(&mut self, epoch: u64) -> Option<u64> {
-        if epoch == 0 || epoch > self.observed {
-            debug_assert!(false, "settled an unrecorded filesystem generation");
-            return None;
-        }
-        if epoch <= self.settled || !self.completed.insert(epoch) {
-            // Duplicate completion is harmless. In particular, never let a
-            // bookkeeping bug wrap a counter and wedge future waiters.
-            return None;
-        }
-        let previous_settled = self.settled;
-        loop {
-            let next = self.settled + 1;
-            if !self.completed.remove(&next) {
-                break;
-            }
-            self.settled = next;
-        }
-        (self.settled != previous_settled).then_some(self.settled)
-    }
-}
-
-fn is_relative_path_denied(denied_paths: &[RcStr], path: &str) -> bool {
-    denied_paths.iter().any(|denied_path| {
-        path.starts_with(denied_path.as_str())
-            && (path.len() == denied_path.len()
-                || path.as_bytes().get(denied_path.len()) == Some(&b'/'))
-    })
-}
-
-fn is_watched_path_denied(root_path: &Path, denied_paths: &[RcStr], path: &Path) -> bool {
-    let Ok(relative_path) = path.strip_prefix(root_path) else {
-        return false;
-    };
-    let Some(relative_path) = relative_path.to_str() else {
-        return false;
-    };
-    is_relative_path_denied(denied_paths, &sys_to_unix(relative_path))
-}
-
-fn create_settled_change_epoch() -> watch::Sender<u64> {
-    watch::channel(0).0
-}
-
 fn create_write_semaphore() -> tokio::sync::Semaphore {
     // the semaphore isn't serialized, and we assume the environment variable doesn't change during
     // runtime, so it's okay to access it in this untracked way.
@@ -287,16 +226,6 @@ pub(crate) struct DiskFileSystemInner {
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[bincode(skip)]
     pub(crate) invalidation_lock: RwLock<()>,
-    /// Observed and completed filesystem generations. Keeping both under one
-    /// lock lets waiters snapshot a target and lets out-of-order completions
-    /// advance only the contiguous settled prefix.
-    #[turbo_tasks(debug_ignore, trace_ignore)]
-    #[bincode(skip)]
-    change_epochs: Mutex<ChangeEpochState>,
-    /// Latest contiguous generation whose debounced invalidations have completed.
-    #[turbo_tasks(debug_ignore, trace_ignore)]
-    #[bincode(skip, default = "create_settled_change_epoch")]
-    settled_change_epoch: watch::Sender<u64>,
     /// Semaphore to limit the maximum number of concurrent file operations.
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[bincode(skip, default = "create_read_semaphore")]
@@ -330,24 +259,6 @@ impl DiskFileSystemInner {
         Path::new(&*self.root)
     }
 
-    pub(crate) fn record_change(&self) -> u64 {
-        self.change_epochs.lock().unwrap().record()
-    }
-
-    pub(crate) fn settle_change(&self, epoch: u64) {
-        let Some(settled) = self.change_epochs.lock().unwrap().settle(epoch) else {
-            return;
-        };
-
-        self.settled_change_epoch.send_if_modified(|published| {
-            if *published >= settled {
-                return false;
-            }
-            *published = settled;
-            true
-        });
-    }
-
     /// Checks if a path is within the denied path
     /// Returns true if the path should be treated as non-existent
     ///
@@ -357,20 +268,13 @@ impl DiskFileSystemInner {
     /// - relative to the fs root
     ///
     /// We can efficiently check using string operations
-    fn is_relative_path_denied(&self, path: &str) -> bool {
-        is_relative_path_denied(&self.denied_paths, path)
-    }
-
     fn is_path_denied(&self, path: &FileSystemPath) -> bool {
-        self.is_relative_path_denied(&path.path)
-    }
-
-    /// Returns whether an absolute path reported by the OS watcher belongs to a
-    /// denied subtree such as Next.js' output directory. Recursive watchers see
-    /// those writes even though project reads cannot access them, so they must
-    /// not advance the project-source generation used for route catch-up.
-    pub(crate) fn is_watched_path_denied(&self, path: &Path) -> bool {
-        is_watched_path_denied(self.root_path(), &self.denied_paths, path)
+        let path = &path.path;
+        self.denied_paths.iter().any(|denied_path| {
+            path.starts_with(denied_path.as_str())
+                && (path.len() == denied_path.len()
+                    || path.as_bytes().get(denied_path.len()) == Some(&b'/'))
+        })
     }
 
     /// registers the path as an invalidator for the current task,
@@ -389,11 +293,11 @@ impl DiskFileSystemInner {
     /// re-read the updated content. This is necessary because the file watcher may not be active
     /// (e.g., in tests or build-only scenarios).
     fn invalidate_from_write(&self, full_path: &Path) {
-        let change_epoch = self.record_change();
         let mut invalidator_map = self.invalidator_map.lock().unwrap();
-        if let Some(invalidators) = invalidator_map.remove(full_path)
-            && let Some(turbo_tasks) = self.turbo_tasks.upgrade()
-        {
+        if let Some(invalidators) = invalidator_map.remove(full_path) {
+            let Some(turbo_tasks) = self.turbo_tasks.upgrade() else {
+                return;
+            };
             let _guard = self.tokio_handle.enter();
             let reason = Write {
                 path: full_path.to_string_lossy().into_owned(),
@@ -402,7 +306,6 @@ impl DiskFileSystemInner {
                 invalidator.invalidate_with_reason(&*turbo_tasks, reason.clone());
             }
         }
-        self.settle_change(change_epoch);
     }
 
     /// registers the path as an invalidator for the current task,
@@ -582,22 +485,6 @@ impl DiskFileSystem {
 
     pub fn root(&self) -> &RcStr {
         &self.inner.root
-    }
-
-    /// Waits for filesystem changes already observed when this method starts to
-    /// finish their debounced invalidation batches, then returns the settled
-    /// generation. Later watcher traffic cannot extend this wait.
-    pub async fn settled_change_epoch(&self) -> u64 {
-        let mut settled_change_epoch = self.inner.settled_change_epoch.subscribe();
-        let target = self.inner.change_epochs.lock().unwrap().observed;
-        loop {
-            let settled = *settled_change_epoch.borrow_and_update();
-            if settled >= target {
-                return settled;
-            }
-            // The sender lives with `self.inner`, so this cannot close while we wait.
-            let _ = settled_change_epoch.changed().await;
-        }
     }
 
     pub fn invalidate(&self) {
@@ -878,8 +765,6 @@ impl DiskFileSystem {
                 root,
                 mutex_map: Default::default(),
                 invalidation_lock: Default::default(),
-                change_epochs: Default::default(),
-                settled_change_epoch: create_settled_change_epoch(),
                 invalidator_map: InvalidatorMap::new(),
                 dir_invalidator_map: InvalidatorMap::new(),
                 read_semaphore: create_read_semaphore(),
@@ -1649,45 +1534,6 @@ mod tests {
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
     use super::*;
-
-    #[test]
-    fn change_epochs_settle_only_contiguous_generations() {
-        let mut state = ChangeEpochState::default();
-        let first = state.record();
-        let second = state.record();
-        assert_eq!(state.settle(second), None);
-        assert_eq!(state.settle(second), None);
-        assert_eq!(state.settle(first), Some(second));
-        assert_eq!(state.settle(first), None);
-    }
-
-    #[test]
-    fn denied_path_matching_stays_within_the_subtree() {
-        let denied = [rcstr!("project/.next")];
-        assert!(is_relative_path_denied(&denied, "project/.next"));
-        assert!(is_relative_path_denied(
-            &denied,
-            "project/.next/server/app/page.js"
-        ));
-        assert!(!is_relative_path_denied(&denied, "project/.next-cache"));
-        assert!(!is_relative_path_denied(&denied, "project/app/page.tsx"));
-
-        let root = PathBuf::from(if cfg!(windows) {
-            r"C:\workspace"
-        } else {
-            "/workspace"
-        });
-        assert!(is_watched_path_denied(
-            &root,
-            &denied,
-            &root.join("project/.next/server/app/page.js")
-        ));
-        assert!(!is_watched_path_denied(
-            &root,
-            &denied,
-            &root.join("project/app/page.tsx")
-        ));
-    }
 
     #[turbo_tasks::function(operation, root)]
     async fn extract_effects_operation(op: OperationVc<()>) -> anyhow::Result<Vc<Effects>> {

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -376,11 +376,12 @@ impl DiskFileSystemInner {
     }
 
     /// Invalidates tracked files/directories for `paths` and their children.
-    /// Also invalidates tracked directory reads for all parent directories to
-    /// account for file creations/deletions under the deferred subtree.
+    /// Optionally invalidates tracked directory reads for all parent directories
+    /// to account for file creations/deletions under a subtree.
     fn invalidate_path_and_children_with_reason<R: InvalidationReason + Clone>(
         &self,
         paths: impl IntoIterator<Item = PathBuf>,
+        invalidate_parent_dirs: bool,
         reason: impl Fn(&Path) -> R + Sync,
     ) {
         let _span =
@@ -396,10 +397,12 @@ impl DiskFileSystemInner {
         let mut parent_dirs_to_invalidate = FxHashSet::default();
 
         for path in paths {
-            let mut current_parent = path.parent();
-            while let Some(parent) = current_parent {
-                parent_dirs_to_invalidate.insert(parent.to_path_buf());
-                current_parent = parent.parent();
+            if invalidate_parent_dirs {
+                let mut current_parent = path.parent();
+                while let Some(parent) = current_parent {
+                    parent_dirs_to_invalidate.insert(parent.to_path_buf());
+                    current_parent = parent.parent();
+                }
             }
 
             for (invalidated_path, path_invalidators) in
@@ -504,7 +507,18 @@ impl DiskFileSystem {
         reason: impl Fn(&Path) -> R + Sync,
     ) {
         self.inner
-            .invalidate_path_and_children_with_reason(paths, reason);
+            .invalidate_path_and_children_with_reason(paths, true, reason);
+    }
+
+    /// Invalidates tracked reads at `paths` without invalidating directory reads
+    /// for their ancestors. Use this when discovery has already observed the path.
+    pub fn invalidate_path_with_reason<R: InvalidationReason + Clone>(
+        &self,
+        paths: impl IntoIterator<Item = PathBuf>,
+        reason: impl Fn(&Path) -> R + Sync,
+    ) {
+        self.inner
+            .invalidate_path_and_children_with_reason(paths, false, reason);
     }
 
     pub async fn start_watching(&self, poll_interval: Option<Duration>) -> Result<()> {

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -1,6 +1,7 @@
 //! The on-disk [`DiskFileSystem`] implementation and its supporting helpers.
 
 use std::{
+    collections::BTreeSet,
     env,
     ffi::OsString,
     fmt::{self, Debug, Formatter},
@@ -8,7 +9,7 @@ use std::{
     io::{self, ErrorKind, Write as _},
     mem::take,
     path::{MAIN_SEPARATOR, Path, PathBuf},
-    sync::{Arc, LazyLock, Weak},
+    sync::{Arc, LazyLock, Mutex, Weak},
     time::Duration,
 };
 
@@ -21,7 +22,7 @@ use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use tokio::{
     runtime::Handle,
-    sync::{RwLock, RwLockReadGuard},
+    sync::{RwLock, RwLockReadGuard, watch},
 };
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
@@ -188,6 +189,66 @@ fn create_read_semaphore() -> tokio::sync::Semaphore {
     tokio::sync::Semaphore::new(*TURBO_ENGINE_READ_CONCURRENCY)
 }
 
+#[derive(Default)]
+struct ChangeEpochState {
+    observed: u64,
+    settled: u64,
+    completed: BTreeSet<u64>,
+}
+
+impl ChangeEpochState {
+    fn record(&mut self) -> u64 {
+        self.observed = self
+            .observed
+            .checked_add(1)
+            .expect("filesystem change generation overflowed");
+        self.observed
+    }
+
+    fn settle(&mut self, epoch: u64) -> Option<u64> {
+        if epoch == 0 || epoch > self.observed {
+            debug_assert!(false, "settled an unrecorded filesystem generation");
+            return None;
+        }
+        if epoch <= self.settled || !self.completed.insert(epoch) {
+            // Duplicate completion is harmless. In particular, never let a
+            // bookkeeping bug wrap a counter and wedge future waiters.
+            return None;
+        }
+        let previous_settled = self.settled;
+        loop {
+            let next = self.settled + 1;
+            if !self.completed.remove(&next) {
+                break;
+            }
+            self.settled = next;
+        }
+        (self.settled != previous_settled).then_some(self.settled)
+    }
+}
+
+fn is_relative_path_denied(denied_paths: &[RcStr], path: &str) -> bool {
+    denied_paths.iter().any(|denied_path| {
+        path.starts_with(denied_path.as_str())
+            && (path.len() == denied_path.len()
+                || path.as_bytes().get(denied_path.len()) == Some(&b'/'))
+    })
+}
+
+fn is_watched_path_denied(root_path: &Path, denied_paths: &[RcStr], path: &Path) -> bool {
+    let Ok(relative_path) = path.strip_prefix(root_path) else {
+        return false;
+    };
+    let Some(relative_path) = relative_path.to_str() else {
+        return false;
+    };
+    is_relative_path_denied(denied_paths, &sys_to_unix(relative_path))
+}
+
+fn create_settled_change_epoch() -> watch::Sender<u64> {
+    watch::channel(0).0
+}
+
 fn create_write_semaphore() -> tokio::sync::Semaphore {
     // the semaphore isn't serialized, and we assume the environment variable doesn't change during
     // runtime, so it's okay to access it in this untracked way.
@@ -226,6 +287,16 @@ pub(crate) struct DiskFileSystemInner {
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[bincode(skip)]
     pub(crate) invalidation_lock: RwLock<()>,
+    /// Observed and completed filesystem generations. Keeping both under one
+    /// lock lets waiters snapshot a target and lets out-of-order completions
+    /// advance only the contiguous settled prefix.
+    #[turbo_tasks(debug_ignore, trace_ignore)]
+    #[bincode(skip)]
+    change_epochs: Mutex<ChangeEpochState>,
+    /// Latest contiguous generation whose debounced invalidations have completed.
+    #[turbo_tasks(debug_ignore, trace_ignore)]
+    #[bincode(skip, default = "create_settled_change_epoch")]
+    settled_change_epoch: watch::Sender<u64>,
     /// Semaphore to limit the maximum number of concurrent file operations.
     #[turbo_tasks(debug_ignore, trace_ignore)]
     #[bincode(skip, default = "create_read_semaphore")]
@@ -259,6 +330,24 @@ impl DiskFileSystemInner {
         Path::new(&*self.root)
     }
 
+    pub(crate) fn record_change(&self) -> u64 {
+        self.change_epochs.lock().unwrap().record()
+    }
+
+    pub(crate) fn settle_change(&self, epoch: u64) {
+        let Some(settled) = self.change_epochs.lock().unwrap().settle(epoch) else {
+            return;
+        };
+
+        self.settled_change_epoch.send_if_modified(|published| {
+            if *published >= settled {
+                return false;
+            }
+            *published = settled;
+            true
+        });
+    }
+
     /// Checks if a path is within the denied path
     /// Returns true if the path should be treated as non-existent
     ///
@@ -268,13 +357,20 @@ impl DiskFileSystemInner {
     /// - relative to the fs root
     ///
     /// We can efficiently check using string operations
+    fn is_relative_path_denied(&self, path: &str) -> bool {
+        is_relative_path_denied(&self.denied_paths, path)
+    }
+
     fn is_path_denied(&self, path: &FileSystemPath) -> bool {
-        let path = &path.path;
-        self.denied_paths.iter().any(|denied_path| {
-            path.starts_with(denied_path.as_str())
-                && (path.len() == denied_path.len()
-                    || path.as_bytes().get(denied_path.len()) == Some(&b'/'))
-        })
+        self.is_relative_path_denied(&path.path)
+    }
+
+    /// Returns whether an absolute path reported by the OS watcher belongs to a
+    /// denied subtree such as Next.js' output directory. Recursive watchers see
+    /// those writes even though project reads cannot access them, so they must
+    /// not advance the project-source generation used for route catch-up.
+    pub(crate) fn is_watched_path_denied(&self, path: &Path) -> bool {
+        is_watched_path_denied(self.root_path(), &self.denied_paths, path)
     }
 
     /// registers the path as an invalidator for the current task,
@@ -293,11 +389,11 @@ impl DiskFileSystemInner {
     /// re-read the updated content. This is necessary because the file watcher may not be active
     /// (e.g., in tests or build-only scenarios).
     fn invalidate_from_write(&self, full_path: &Path) {
+        let change_epoch = self.record_change();
         let mut invalidator_map = self.invalidator_map.lock().unwrap();
-        if let Some(invalidators) = invalidator_map.remove(full_path) {
-            let Some(turbo_tasks) = self.turbo_tasks.upgrade() else {
-                return;
-            };
+        if let Some(invalidators) = invalidator_map.remove(full_path)
+            && let Some(turbo_tasks) = self.turbo_tasks.upgrade()
+        {
             let _guard = self.tokio_handle.enter();
             let reason = Write {
                 path: full_path.to_string_lossy().into_owned(),
@@ -306,6 +402,7 @@ impl DiskFileSystemInner {
                 invalidator.invalidate_with_reason(&*turbo_tasks, reason.clone());
             }
         }
+        self.settle_change(change_epoch);
     }
 
     /// registers the path as an invalidator for the current task,
@@ -485,6 +582,22 @@ impl DiskFileSystem {
 
     pub fn root(&self) -> &RcStr {
         &self.inner.root
+    }
+
+    /// Waits for filesystem changes already observed when this method starts to
+    /// finish their debounced invalidation batches, then returns the settled
+    /// generation. Later watcher traffic cannot extend this wait.
+    pub async fn settled_change_epoch(&self) -> u64 {
+        let mut settled_change_epoch = self.inner.settled_change_epoch.subscribe();
+        let target = self.inner.change_epochs.lock().unwrap().observed;
+        loop {
+            let settled = *settled_change_epoch.borrow_and_update();
+            if settled >= target {
+                return settled;
+            }
+            // The sender lives with `self.inner`, so this cannot close while we wait.
+            let _ = settled_change_epoch.changed().await;
+        }
     }
 
     pub fn invalidate(&self) {
@@ -765,6 +878,8 @@ impl DiskFileSystem {
                 root,
                 mutex_map: Default::default(),
                 invalidation_lock: Default::default(),
+                change_epochs: Default::default(),
+                settled_change_epoch: create_settled_change_epoch(),
                 invalidator_map: InvalidatorMap::new(),
                 dir_invalidator_map: InvalidatorMap::new(),
                 read_semaphore: create_read_semaphore(),
@@ -1534,6 +1649,45 @@ mod tests {
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
     use super::*;
+
+    #[test]
+    fn change_epochs_settle_only_contiguous_generations() {
+        let mut state = ChangeEpochState::default();
+        let first = state.record();
+        let second = state.record();
+        assert_eq!(state.settle(second), None);
+        assert_eq!(state.settle(second), None);
+        assert_eq!(state.settle(first), Some(second));
+        assert_eq!(state.settle(first), None);
+    }
+
+    #[test]
+    fn denied_path_matching_stays_within_the_subtree() {
+        let denied = [rcstr!("project/.next")];
+        assert!(is_relative_path_denied(&denied, "project/.next"));
+        assert!(is_relative_path_denied(
+            &denied,
+            "project/.next/server/app/page.js"
+        ));
+        assert!(!is_relative_path_denied(&denied, "project/.next-cache"));
+        assert!(!is_relative_path_denied(&denied, "project/app/page.tsx"));
+
+        let root = PathBuf::from(if cfg!(windows) {
+            r"C:\workspace"
+        } else {
+            "/workspace"
+        });
+        assert!(is_watched_path_denied(
+            &root,
+            &denied,
+            &root.join("project/.next/server/app/page.js")
+        ));
+        assert!(!is_watched_path_denied(
+            &root,
+            &denied,
+            &root.join("project/app/page.tsx")
+        ));
+    }
 
     #[turbo_tasks::function(operation, root)]
     async fn extract_effects_operation(op: OperationVc<()>) -> anyhow::Result<Vc<Effects>> {

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -77,6 +77,22 @@ pub(crate) struct DiskWatcher {
     state: State,
 }
 
+/// Settles a watcher generation even if invalidation panics and unwinds the
+/// watcher thread. Without this guard, a recorded-but-unsettled generation
+/// would leave every later `settled_change_epoch` caller waiting forever.
+struct ChangeEpochGuard<'a> {
+    fs_inner: &'a DiskFileSystemInner,
+    epoch: Option<u64>,
+}
+
+impl Drop for ChangeEpochGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(epoch) = self.epoch.take() {
+            self.fs_inner.settle_change(epoch);
+        }
+    }
+}
+
 enum State {
     // Note: Information about if we're a recursive or non-recursive watcher must live outside the
     // `RwLock` to allow us to quickly bail out on calls to `ensure_watched`.
@@ -502,6 +518,7 @@ impl DiskWatcher {
 
         'outer: loop {
             let mut deadline: Option<Instant> = None;
+            let mut batch_change_epoch = None;
             loop {
                 let event_result = match deadline {
                     None => rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
@@ -510,7 +527,7 @@ impl DiskWatcher {
                     }
                 };
                 match event_result {
-                    Ok(Ok(event)) => {
+                    Ok(Ok(mut event)) => {
                         // TODO: We might benefit from some user-facing diagnostics if it rescans
                         // occur frequently (i.e. more than X times in Y minutes)
                         //
@@ -542,6 +559,9 @@ impl DiskWatcher {
                                 );
                             }
 
+                            let change_epoch = batch_change_epoch
+                                .take()
+                                .unwrap_or_else(|| fs_inner.record_change());
                             if report_invalidation_reason {
                                 fs_inner.invalidate_with_reason(|path| InvalidateRescan {
                                     // this path is just used for display purposes
@@ -550,6 +570,7 @@ impl DiskWatcher {
                             } else {
                                 fs_inner.invalidate();
                             }
+                            fs_inner.settle_change(change_epoch);
 
                             // no need to process the rest of the batch as we just
                             // invalidated everything
@@ -557,15 +578,30 @@ impl DiskWatcher {
                             break;
                         }
 
+                        // Recursive watchers also report writes under denied output
+                        // directories. Those paths cannot participate in project reads, so
+                        // ignore them both for invalidation and for the project-source
+                        // generation used by inactive route catch-up.
+                        event
+                            .paths
+                            .retain(|path| !fs_inner.is_watched_path_denied(path));
+
                         // Only an event that contributes to the batch keeps it open for another
                         // `BATCH_DELAY`.
                         if batch.add_event(event) {
+                            batch_change_epoch.get_or_insert_with(|| fs_inner.record_change());
                             deadline = Some(Instant::now() + BATCH_DELAY);
                         }
                     }
                     // Error raised by notify watcher itself
-                    Ok(Err(notify::Error { kind, paths })) => {
+                    Ok(Err(notify::Error { kind, mut paths })) => {
                         println!("watch error ({paths:?}): {kind:?} ");
+
+                        let had_paths = !paths.is_empty();
+                        paths.retain(|path| !fs_inner.is_watched_path_denied(path));
+                        if had_paths && paths.is_empty() {
+                            continue;
+                        }
 
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
@@ -576,6 +612,7 @@ impl DiskWatcher {
                                 batch.mark(path.into_boxed_path(), flags);
                             }
                         }
+                        batch_change_epoch.get_or_insert_with(|| fs_inner.record_change());
                         deadline = Some(Instant::now() + BATCH_DELAY);
                     }
                     Err(RecvTimeoutError::Timeout) => {
@@ -585,10 +622,21 @@ impl DiskWatcher {
                     Err(RecvTimeoutError::Disconnected) => {
                         // Sender has been disconnected, which means DiskFileSystem has been dropped
                         // exit thread
+                        if let Some(change_epoch) = batch_change_epoch.take() {
+                            fs_inner.settle_change(change_epoch);
+                        }
                         break 'outer;
                     }
                 }
             }
+
+            // Install the settlement guard before any fallible or blocking work
+            // below. It settles normally at the end of the loop iteration and on
+            // panic unwind from watcher restoration or invalidation.
+            let _change_epoch_guard = ChangeEpochGuard {
+                fs_inner: &fs_inner,
+                epoch: batch_change_epoch.take(),
+            };
 
             // We need to start watching first before invalidating the changed paths...
             // This is only needed on platforms we don't do recursive watching on.
@@ -605,9 +653,8 @@ impl DiskWatcher {
                             ));
                 }
             }
-
             let Some(turbo_tasks) = fs_inner.turbo_tasks.upgrade() else {
-                // TurboTasks was dropped, stop watching
+                // TurboTasks was dropped, stop watching.
                 break 'outer;
             };
             let _guard = fs_inner.tokio_handle.enter();
@@ -775,19 +822,37 @@ impl BatchedInvalidations {
             }
             // A single event emitted with both the `From` and `To` paths.
             EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
-                let [source, destination] = <[PathBuf; 2]>::try_from(paths)
-                    .expect("RenameMode::Both event must contain exactly two paths");
-                self.mark_parent_dir(&source);
-                self.mark(
-                    source.into_boxed_path(),
-                    InvalidationFlags::PATH_AND_CHILDREN,
-                );
-                self.mark_parent_dir(&destination);
-                self.mark_new_path(&destination);
-                self.mark(
-                    destination.into_boxed_path(),
-                    InvalidationFlags::PATH_AND_CHILDREN,
-                );
+                match <[PathBuf; 2]>::try_from(paths) {
+                    Ok([source, destination]) => {
+                        self.mark_parent_dir(&source);
+                        self.mark(
+                            source.into_boxed_path(),
+                            InvalidationFlags::PATH_AND_CHILDREN,
+                        );
+                        self.mark_parent_dir(&destination);
+                        self.mark_new_path(&destination);
+                        self.mark(
+                            destination.into_boxed_path(),
+                            InvalidationFlags::PATH_AND_CHILDREN,
+                        );
+                    }
+                    Err(paths) => {
+                        // Denied-path filtering can remove one side of a rename that
+                        // crosses the project/output boundary. We no longer know if
+                        // each remaining path is the source or destination, so treat
+                        // it conservatively as both: invalidate it and its directory,
+                        // and restore its watch if it exists.
+                        for path in paths {
+                            self.mark_parent_dir(&path);
+                            self.mark_new_path(&path);
+                            self.mark(
+                                path.into_boxed_path(),
+                                InvalidationFlags::PATH_AND_CHILDREN
+                                    | InvalidationFlags::PATH_AND_CHILDREN_DIR,
+                            );
+                        }
+                    }
+                }
                 true
             }
             // We expect `RenameMode::Both` to cover most of the cases we need to invalidate,
@@ -926,5 +991,32 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_both_rename_is_conservatively_invalidated() {
+        let source = PathBuf::from("/project/source.ts");
+        let parent = source.parent().unwrap().to_path_buf();
+        let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+            .add_path(source.clone());
+        let mut batch = BatchedInvalidations::new(RecursiveMode::NonRecursive);
+
+        assert!(batch.add_event(event));
+        assert_eq!(
+            batch.paths.get(source.as_path()),
+            Some(
+                &(InvalidationFlags::PATH_AND_CHILDREN | InvalidationFlags::PATH_AND_CHILDREN_DIR)
+            )
+        );
+        assert_eq!(
+            batch.paths.get(parent.as_path()),
+            Some(&InvalidationFlags::PATH_DIR)
+        );
+        assert!(batch.new_paths.as_ref().unwrap().contains(source.as_path()));
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -77,22 +77,6 @@ pub(crate) struct DiskWatcher {
     state: State,
 }
 
-/// Settles a watcher generation even if invalidation panics and unwinds the
-/// watcher thread. Without this guard, a recorded-but-unsettled generation
-/// would leave every later `settled_change_epoch` caller waiting forever.
-struct ChangeEpochGuard<'a> {
-    fs_inner: &'a DiskFileSystemInner,
-    epoch: Option<u64>,
-}
-
-impl Drop for ChangeEpochGuard<'_> {
-    fn drop(&mut self) {
-        if let Some(epoch) = self.epoch.take() {
-            self.fs_inner.settle_change(epoch);
-        }
-    }
-}
-
 enum State {
     // Note: Information about if we're a recursive or non-recursive watcher must live outside the
     // `RwLock` to allow us to quickly bail out on calls to `ensure_watched`.
@@ -518,7 +502,6 @@ impl DiskWatcher {
 
         'outer: loop {
             let mut deadline: Option<Instant> = None;
-            let mut batch_change_epoch = None;
             loop {
                 let event_result = match deadline {
                     None => rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
@@ -527,7 +510,7 @@ impl DiskWatcher {
                     }
                 };
                 match event_result {
-                    Ok(Ok(mut event)) => {
+                    Ok(Ok(event)) => {
                         // TODO: We might benefit from some user-facing diagnostics if it rescans
                         // occur frequently (i.e. more than X times in Y minutes)
                         //
@@ -559,9 +542,6 @@ impl DiskWatcher {
                                 );
                             }
 
-                            let change_epoch = batch_change_epoch
-                                .take()
-                                .unwrap_or_else(|| fs_inner.record_change());
                             if report_invalidation_reason {
                                 fs_inner.invalidate_with_reason(|path| InvalidateRescan {
                                     // this path is just used for display purposes
@@ -570,7 +550,6 @@ impl DiskWatcher {
                             } else {
                                 fs_inner.invalidate();
                             }
-                            fs_inner.settle_change(change_epoch);
 
                             // no need to process the rest of the batch as we just
                             // invalidated everything
@@ -578,30 +557,15 @@ impl DiskWatcher {
                             break;
                         }
 
-                        // Recursive watchers also report writes under denied output
-                        // directories. Those paths cannot participate in project reads, so
-                        // ignore them both for invalidation and for the project-source
-                        // generation used by inactive route catch-up.
-                        event
-                            .paths
-                            .retain(|path| !fs_inner.is_watched_path_denied(path));
-
                         // Only an event that contributes to the batch keeps it open for another
                         // `BATCH_DELAY`.
                         if batch.add_event(event) {
-                            batch_change_epoch.get_or_insert_with(|| fs_inner.record_change());
                             deadline = Some(Instant::now() + BATCH_DELAY);
                         }
                     }
                     // Error raised by notify watcher itself
-                    Ok(Err(notify::Error { kind, mut paths })) => {
+                    Ok(Err(notify::Error { kind, paths })) => {
                         println!("watch error ({paths:?}): {kind:?} ");
-
-                        let had_paths = !paths.is_empty();
-                        paths.retain(|path| !fs_inner.is_watched_path_denied(path));
-                        if had_paths && paths.is_empty() {
-                            continue;
-                        }
 
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
@@ -612,7 +576,6 @@ impl DiskWatcher {
                                 batch.mark(path.into_boxed_path(), flags);
                             }
                         }
-                        batch_change_epoch.get_or_insert_with(|| fs_inner.record_change());
                         deadline = Some(Instant::now() + BATCH_DELAY);
                     }
                     Err(RecvTimeoutError::Timeout) => {
@@ -622,21 +585,10 @@ impl DiskWatcher {
                     Err(RecvTimeoutError::Disconnected) => {
                         // Sender has been disconnected, which means DiskFileSystem has been dropped
                         // exit thread
-                        if let Some(change_epoch) = batch_change_epoch.take() {
-                            fs_inner.settle_change(change_epoch);
-                        }
                         break 'outer;
                     }
                 }
             }
-
-            // Install the settlement guard before any fallible or blocking work
-            // below. It settles normally at the end of the loop iteration and on
-            // panic unwind from watcher restoration or invalidation.
-            let _change_epoch_guard = ChangeEpochGuard {
-                fs_inner: &fs_inner,
-                epoch: batch_change_epoch.take(),
-            };
 
             // We need to start watching first before invalidating the changed paths...
             // This is only needed on platforms we don't do recursive watching on.
@@ -653,8 +605,9 @@ impl DiskWatcher {
                             ));
                 }
             }
+
             let Some(turbo_tasks) = fs_inner.turbo_tasks.upgrade() else {
-                // TurboTasks was dropped, stop watching.
+                // TurboTasks was dropped, stop watching
                 break 'outer;
             };
             let _guard = fs_inner.tokio_handle.enter();
@@ -822,37 +775,19 @@ impl BatchedInvalidations {
             }
             // A single event emitted with both the `From` and `To` paths.
             EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
-                match <[PathBuf; 2]>::try_from(paths) {
-                    Ok([source, destination]) => {
-                        self.mark_parent_dir(&source);
-                        self.mark(
-                            source.into_boxed_path(),
-                            InvalidationFlags::PATH_AND_CHILDREN,
-                        );
-                        self.mark_parent_dir(&destination);
-                        self.mark_new_path(&destination);
-                        self.mark(
-                            destination.into_boxed_path(),
-                            InvalidationFlags::PATH_AND_CHILDREN,
-                        );
-                    }
-                    Err(paths) => {
-                        // Denied-path filtering can remove one side of a rename that
-                        // crosses the project/output boundary. We no longer know if
-                        // each remaining path is the source or destination, so treat
-                        // it conservatively as both: invalidate it and its directory,
-                        // and restore its watch if it exists.
-                        for path in paths {
-                            self.mark_parent_dir(&path);
-                            self.mark_new_path(&path);
-                            self.mark(
-                                path.into_boxed_path(),
-                                InvalidationFlags::PATH_AND_CHILDREN
-                                    | InvalidationFlags::PATH_AND_CHILDREN_DIR,
-                            );
-                        }
-                    }
-                }
+                let [source, destination] = <[PathBuf; 2]>::try_from(paths)
+                    .expect("RenameMode::Both event must contain exactly two paths");
+                self.mark_parent_dir(&source);
+                self.mark(
+                    source.into_boxed_path(),
+                    InvalidationFlags::PATH_AND_CHILDREN,
+                );
+                self.mark_parent_dir(&destination);
+                self.mark_new_path(&destination);
+                self.mark(
+                    destination.into_boxed_path(),
+                    InvalidationFlags::PATH_AND_CHILDREN,
+                );
                 true
             }
             // We expect `RenameMode::Both` to cover most of the cases we need to invalidate,
@@ -991,32 +926,5 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn partial_both_rename_is_conservatively_invalidated() {
-        let source = PathBuf::from("/project/source.ts");
-        let parent = source.parent().unwrap().to_path_buf();
-        let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
-            .add_path(source.clone());
-        let mut batch = BatchedInvalidations::new(RecursiveMode::NonRecursive);
-
-        assert!(batch.add_event(event));
-        assert_eq!(
-            batch.paths.get(source.as_path()),
-            Some(
-                &(InvalidationFlags::PATH_AND_CHILDREN | InvalidationFlags::PATH_AND_CHILDREN_DIR)
-            )
-        );
-        assert_eq!(
-            batch.paths.get(parent.as_path()),
-            Some(&InvalidationFlags::PATH_DIR)
-        );
-        assert!(batch.new_paths.as_ref().unwrap().contains(source.as_path()));
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -134,6 +134,14 @@ impl<T: ?Sized> OperationVc<T> {
         Self::into_raw(self).into()
     }
 
+    /// Invalidates this operation so its next connected read re-executes it.
+    ///
+    /// This is intended for operations that were deliberately disconnected from
+    /// external invalidations and need to catch up before being reactivated.
+    pub fn invalidate(self) {
+        turbo_tasks().invalidate(self.task);
+    }
+
     /// Returns the `RawVc` corresponding to this `OperationVc`.
     /// inverse of [`RawVc::as_task_output`]
     fn into_raw(vc: Self) -> RawVc {


### PR DESCRIPTION
## What

Bound Turbopack's global server Fast Refresh working set to App Router pages
that are active under the existing `onDemandEntries` policy.

Today, every App page visited during a dev-server process continues to
participate in `Project::all_hmr_update`. As a session navigates through more
routes, later shared-module edits enumerate and version an ever-growing set of
unrelated entries.

This change:

- sends the existing App Router tree over the dev WebSocket on connection,
  tree changes, and a 2.5-second heartbeat;
- keeps connected, recently active, and buffered pages in the aggregate-HMR
  working set;
- retires older page chunks from the global aggregate;
- keeps their endpoint output graph and change iterator connected so inactive
  source edits are not lost;
- drains inactive endpoint events without refreshing the browser;
- transactionally writes and applies current changed chunks to the existing
  server runtime before the first reentry response;
- advances an explicit native reactivation epoch only after that catch-up write
  and waits for the exact epoch before rendering;
- bounds that catch-up wait and falls back to the existing safe full
  re-evaluation path after one second;
- handles concurrent HTML/RSC requests, syntax-error recovery, route
  deletion/re-addition, failed-catch-up retries, and empty aggregate working
  sets.

This is intentionally an App Router / Node dev-server change. It does not
change production builds, Pages Router, Edge routes, or route handlers.

## Why

The existing global server-HMR subscription accumulates every written App page
for the process lifetime. The source already called out the missing lifecycle.
Large, long-running sessions—especially agent workflows that navigate across
many previews—therefore pay for old routes on every later edit.

The patch separates two requirements:

1. an inactive endpoint's output must stay current; and
2. that endpoint does not need to participate in every global HMR version scan.

Rejected faster prototypes disconnected one of the source-observing roots and
returned stale first responses. The final design leaves those roots live,
removes only aggregate membership, and publishes reentry transactionally.

## Performance

Exact reviewed candidate, Node 24.14.1, 16 vCPU / 32 GB Internal Playground
DevBox, fresh `.next` and process per run, eight edits, alternating A/B order.
The primary estimate is the geometric mean of six within-block ratios; intervals
are deterministic block-bootstrap 95% intervals.

### 100 previously visited routes

| Metric | Baseline | Candidate | Paired effect |
| --- | ---: | ---: | ---: |
| Mean edit completion | 204.96 ms | 169.38 ms | **-17.37%** [-21.09, -14.13] |
| Warm edits 2–8 | 165.97 ms | 135.51 ms | **-18.34%** [-21.76, -15.17] |
| First edit | 477.87 ms | 406.49 ms | **-14.97%** [-20.13, -9.53] |
| Route-warming navigation | 18.95 s | 18.90 s | -0.22% [-3.38, +3.21] |
| RSS after eight edits | 1.78 GiB | 1.91 GiB | **+6.80%** [+5.60, +8.00] |

All six latency pairs favored the candidate and all 12 processes reached every
exact revision. Exact-baseline A/A was +3.18% [-1.23, +7.79].

### Route-count boundary

| Visited pages | Paired mean-edit effect |
| ---: | ---: |
| 1 | +1.01% |
| 10 | -1.64% |
| 25 | -5.27% |
| 50 | **-18.47%** |
| 100 | **-17.37%** (six-block primary panel) |

The benefit is for long sessions around 50+ visited pages, not startup or small
apps.

### Reentry cost

Four alternating blocks, 100 visited routes, four inactive edits per process:

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| No-edit retired-route request | 51.03 ms | 106.03 ms |
| First request after inactive edit | 42.10 ms | 121.60 ms |
| Following warm request | 31.57 ms | 31.51 ms |

All first responses contained the current revision. The one-time ~80 ms dirty
reentry cost is the transactional catch-up that prevents stale previews.

That powered panel used the canary.102 performance runtime. The final
canary.104 landing build adds the explicit post-write epoch required by review.
Two fresh 100-route correctness smokes measured:

| Final landing smoke | Process 1 | Process 2 |
| --- | ---: | ---: |
| No-edit retired-route request | 294.33 ms | 308.58 ms |
| Mean first request after inactive edit | 108.03 ms | 112.18 ms |
| Mean following warm request | 26.04 ms | 25.89 ms |

All eight dirty reentries returned the exact marker. The two-process smoke is
not a powered estimate, but it makes the final tradeoff explicit: a no-edit
return to a retired route can cost roughly 250 ms more than the original
baseline.

The memory regression is real and is not claimed as an OOM improvement.

### Real-v0 negative control

Private v0 `/projects`, 22 warmed production routes, 12 files written 50 ms
apart, cancellation enabled, six A/B process pairs, 72 measured edits:

| Metric | Baseline | Candidate | Paired effect |
| --- | ---: | ---: | ---: |
| Final visible from first write | 1,432.20 ms | 1,491.60 ms | +3.88% [-1.99, +10.11] |
| RSC requests / server renders | 1.00 / 1.00 | 1.00 / 1.00 | 0.00% / 0.00% |
| Target-route navigation | 16.97 s | 18.13 s | **+6.93%** [+3.63, +10.45] |
| Mean of 22 warm navigations | 11.21 s | 11.60 s | **+3.42%** [+1.59, +5.53] |
| Peak RSS | 14.68 GiB | 15.25 GiB | +3.59% [-7.58, +17.03] |

All 72 revisions were exact; all 12 processes restored their source/config and
had zero non-OK responses or page errors. This result deliberately narrows the
claim: the patch is not a v0 edit-latency improvement at 22 warmed routes. Its
measured benefit starts around the 50–100-route accumulated-session regime.

## Correctness

The new regression uses a one-second inactive age and exercises:

- connected-route retention;
- a shared server edit while the route is retired;
- no-edit reentry without unrelated module re-evaluation;
- a retired two-file server + client-component edit whose single first response
  contains both changes;
- a visible sibling dynamic-import route and later in-place lazy-chunk HMR;
- unrelated server state preservation;
- retired-route syntax error, redbox, first-response recovery after source fix,
  and automatic browser recovery;
- route delete, a fresh first successful re-add response, and later HMR.

The route remains excluded from aggregate HMR while its endpoint is written.
After the write, native code advances a monotonic reactivation epoch and
includes it in both the aggregate version identity and the update resource
header. The request waits for that exact epoch before rendering. Pure epoch
updates survive an empty aggregate, and retries left by a failed catch-up own
the same post-write acknowledgement.

The normal path never globally force-evicts the shared runtime. A one-second
timeout deduplicates through the existing full re-evaluation promise so a route
cannot wedge.

## Validation

- `pnpm test-dev-turbo test/development/app-dir/server-hmr/server-hmr.test.ts`
  with the exact native binary: **17/17 pass** on canary.102; after rebasing
  onto canary.104, the strict-route-types + filesystem-cache run also passed
  **17/17** in 101.57 s
- `pnpm --filter next build`: pass
- `cargo check -p next-api -p next-napi-bindings`: pass
- repository lint-staged hook: pass
- Prettier / ESLint / Rustfmt / `git diff --check`: pass
- Claude Opus 5 xhigh final review: clean on exact `c49038b32b`, no
  accepted/actionable findings, `patch is correct` (0.72)

The bundled Codex reviewer could not authenticate in the clean review
environment, so the final review is explicitly a one-reviewer panel.

Runtime fingerprints:

```text
hot-reloader-turbopack.js
395178d6e5a1eb4f32690e4810796bd61ca46d1382152bec3d4f9609b4c34462

next-swc.linux-x64-gnu.node
e9f634bfd4621b528b7e24b3895a9c7315486f09a5e507849aa693cd0c471c17
```

## Follow-ups / tradeoffs

- Exact-final RSS is 6%–8% higher in the 100-route fixture.
- The route-tree heartbeat is a small message every 2.5 seconds.
- Reentry moves work from every unrelated edit to the first later use.
- Route activity/inactive-path entries that never regain an emitted chunk can
  remain for the dev-server lifetime.
- This does not make multi-file filesystem edits atomic; it composes with a
  future acknowledged edit transaction.
- The real-v0 22-route control did not reproduce the synthetic edit-latency
  win and made route warming 3%–7% slower.
