### PR TITLE
Turbopack: Allow DiskWatcher to use a mocked DiskFileSystem, add a small unit test

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -458,8 +458,7 @@ impl DiskFileSystemInner {
             .concurrency_limited(&self.write_semaphore)
             .await?;
 
-        self.watcher
-            .start_watching(self.clone(), report_invalidation_reason, poll_interval)
+        DiskWatcher::start_watching(self.clone(), report_invalidation_reason, poll_interval)
             .await?;
 
         Ok(())

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/fs_api.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/fs_api.rs
@@ -1,0 +1,77 @@
+use std::{path::Path, sync::Arc};
+
+use tokio::{runtime::Handle, sync::RwLock};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{InvalidationReason, TurboTasksApi};
+
+use crate::{DiskFileSystemInner, invalidator_map::InvalidatorMap, watcher::DiskWatcher};
+
+/// The subset of [`DiskFileSystemInner`] that [`DiskWatcher`] needs in order to invalidate tasks
+/// when the filesystem changes.
+///
+/// The watcher goes through this trait rather than through [`DiskFileSystemInner`] directly so that
+/// it can be exercised in unit tests without building a whole
+/// [`DiskFileSystem`][crate::DiskFileSystem], which can only be constructed from inside a
+/// turbo-tasks task.
+pub(crate) trait DiskFileSystemWatcherApi: Send + Sync + 'static {
+    fn name(&self) -> &RcStr;
+    fn root_path(&self) -> &Path;
+    fn watcher(&self) -> &DiskWatcher
+    where
+        Self: Sized;
+    fn turbo_tasks(&self) -> Option<Arc<dyn TurboTasksApi>>;
+    fn tokio_handle(&self) -> &Handle;
+    fn invalidator_map(&self) -> &InvalidatorMap;
+    fn dir_invalidator_map(&self) -> &InvalidatorMap;
+    fn invalidation_lock(&self) -> &RwLock<()>;
+    fn invalidate_all(&self);
+    fn invalidate_all_with_reason<R: InvalidationReason + Clone>(
+        &self,
+        reason: impl Fn(&Path) -> R + Sync,
+    );
+}
+
+impl DiskFileSystemWatcherApi for DiskFileSystemInner {
+    fn name(&self) -> &RcStr {
+        &self.name
+    }
+
+    fn root_path(&self) -> &Path {
+        self.root_path()
+    }
+
+    fn watcher(&self) -> &DiskWatcher {
+        &self.watcher
+    }
+
+    fn turbo_tasks(&self) -> Option<Arc<dyn TurboTasksApi>> {
+        self.turbo_tasks.upgrade()
+    }
+
+    fn tokio_handle(&self) -> &Handle {
+        &self.tokio_handle
+    }
+
+    fn invalidator_map(&self) -> &InvalidatorMap {
+        &self.invalidator_map
+    }
+
+    fn dir_invalidator_map(&self) -> &InvalidatorMap {
+        &self.dir_invalidator_map
+    }
+
+    fn invalidation_lock(&self) -> &RwLock<()> {
+        &self.invalidation_lock
+    }
+
+    fn invalidate_all(&self) {
+        self.invalidate();
+    }
+
+    fn invalidate_all_with_reason<R: InvalidationReason + Clone>(
+        &self,
+        reason: impl Fn(&Path) -> R + Sync,
+    ) {
+        self.invalidate_with_reason(reason);
+    }
+}

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mock_fs_api.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mock_fs_api.rs
@@ -1,0 +1,145 @@
+use std::{
+    fs::{canonicalize, metadata},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, Weak},
+};
+
+use rustc_hash::FxHashMap;
+use tempfile::TempDir;
+use tokio::{runtime::Handle, sync::RwLock};
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{
+    InvalidationReason, NonLocalValue, TransientInstance, TurboTasksApi,
+    trace::{TraceRawVcs, TraceRawVcsContext},
+};
+
+use crate::{
+    invalidator_map::InvalidatorMap,
+    watcher::{DiskFileSystemWatcherApi, DiskWatcher},
+};
+
+/// A stand-in for [`DiskFileSystemInner`], carrying only the state [`DiskWatcher`] touches.
+pub struct MockFileSystem {
+    pub name: RcStr,
+    pub root_path: PathBuf,
+    pub watcher: DiskWatcher,
+    pub turbo_tasks: Weak<dyn TurboTasksApi>,
+    pub tokio_handle: Handle,
+    pub invalidator_map: InvalidatorMap,
+    pub dir_invalidator_map: InvalidatorMap,
+    pub invalidation_lock: RwLock<()>,
+    pub run_counts: Mutex<FxHashMap<Arc<PathBuf>, u64>>,
+    transient_handle: TransientInstance<MockFsHandle>,
+    _temp_dir: TempDir,
+}
+
+struct MockFsHandle(Weak<MockFileSystem>);
+
+unsafe impl NonLocalValue for MockFsHandle {}
+impl TraceRawVcs for MockFsHandle {
+    fn trace_raw_vcs(&self, _trace_context: &mut TraceRawVcsContext) {}
+}
+
+impl MockFileSystem {
+    pub fn new() -> Arc<MockFileSystem> {
+        let temp_dir = TempDir::new().unwrap();
+        let root_path = canonicalize(temp_dir.path()).unwrap();
+        Arc::new_cyclic(|weak| MockFileSystem {
+            name: rcstr!("mock"),
+            root_path,
+            watcher: DiskWatcher::new(),
+            turbo_tasks: turbo_tasks::turbo_tasks_weak(),
+            tokio_handle: Handle::current(),
+            invalidator_map: InvalidatorMap::new(),
+            dir_invalidator_map: InvalidatorMap::new(),
+            invalidation_lock: RwLock::new(()),
+            run_counts: Mutex::new(FxHashMap::default()),
+            transient_handle: TransientInstance::new(MockFsHandle(weak.clone())),
+            _temp_dir: temp_dir,
+        })
+    }
+
+    pub async fn tracked_read_strongly_consistent(self: &Arc<Self>, path: &Path) -> u64 {
+        #[turbo_tasks::function(operation, root)]
+        async fn tracked_read_operation(fs: TransientInstance<MockFsHandle>, path: RcStr) {
+            let fs = fs.0.upgrade().unwrap();
+            let path = Arc::new(PathBuf::from(&*path));
+
+            if metadata(&*path).unwrap().is_dir() {
+                fs.dir_invalidator_map
+                    .insert(path.clone(), turbo_tasks::get_invalidator().unwrap());
+                fs.watcher
+                    .ensure_watched_dir(&path, &fs.root_path)
+                    .await
+                    .unwrap();
+            } else {
+                fs.invalidator_map
+                    .insert(path.clone(), turbo_tasks::get_invalidator().unwrap());
+                fs.watcher
+                    .ensure_watched_file(&path, &fs.root_path)
+                    .await
+                    .unwrap();
+            };
+
+            let mut run_counts = fs.run_counts.lock().unwrap();
+            let count = run_counts.entry(path).or_default();
+            *count += 1;
+        }
+
+        tracked_read_operation(
+            self.transient_handle.clone(),
+            RcStr::from(path.to_str().unwrap()),
+        )
+        .read_strongly_consistent()
+        .await
+        .unwrap();
+        *self
+            .run_counts
+            .lock()
+            .unwrap()
+            .get(&Arc::new(path.to_owned()))
+            .unwrap()
+    }
+}
+
+impl DiskFileSystemWatcherApi for MockFileSystem {
+    fn name(&self) -> &RcStr {
+        &self.name
+    }
+
+    fn root_path(&self) -> &Path {
+        &self.root_path
+    }
+
+    fn watcher(&self) -> &DiskWatcher {
+        &self.watcher
+    }
+
+    fn turbo_tasks(&self) -> Option<Arc<dyn TurboTasksApi>> {
+        self.turbo_tasks.upgrade()
+    }
+
+    fn tokio_handle(&self) -> &Handle {
+        &self.tokio_handle
+    }
+
+    fn invalidator_map(&self) -> &InvalidatorMap {
+        &self.invalidator_map
+    }
+
+    fn dir_invalidator_map(&self) -> &InvalidatorMap {
+        &self.dir_invalidator_map
+    }
+
+    fn invalidation_lock(&self) -> &RwLock<()> {
+        &self.invalidation_lock
+    }
+
+    fn invalidate_all(&self) {}
+
+    fn invalidate_all_with_reason<R: InvalidationReason + Clone>(
+        &self,
+        _reason: impl Fn(&Path) -> R + Sync,
+    ) {
+    }
+}

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
@@ -1,8 +1,11 @@
+mod fs_api;
+#[cfg(test)]
+mod mock_fs_api;
+
 use std::{
     any::Any,
     collections::BTreeSet,
     env, fmt,
-    mem::take,
     path::{Path, PathBuf},
     sync::{
         Arc, LazyLock,
@@ -23,15 +26,16 @@ use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, InvalidationReason, InvalidationReasonKind, Invalidator, TurboTasksApi, parallel,
+    FxIndexSet, InvalidationReason, InvalidationReasonKind, Invalidator, TurboTasksApi,
     spawn_thread, util::StaticOrArc,
 };
 
 use crate::{
-    DiskFileSystemInner, format_absolute_fs_path,
+    format_absolute_fs_path,
     invalidation::{WatchChange, WatchStart},
     invalidator_map::InvalidatorMap,
     path_map::OrderedPathMapExt,
+    watcher::fs_api::DiskFileSystemWatcherApi,
 };
 
 static WATCH_RECURSIVE_MODE: LazyLock<RecursiveMode> = LazyLock::new(|| {
@@ -360,28 +364,13 @@ impl DiskWatcher {
         }
     }
 
-    /// Create a watcher and start watching by creating `debounced` watcher
-    /// via `full debouncer`
-    ///
-    /// `notify` provides 2 different debouncer implementations, `-full`
-    /// provides below differences for the easy of use:
-    ///
-    /// - Only emits a single Rename event if the rename From and To events can be matched
-    /// - Merges multiple Rename events
-    /// - Takes Rename events into account and updates paths for events that occurred before the
-    ///   rename event, but which haven't been emitted, yet
-    /// - Optionally keeps track of the file system IDs all files and stitches rename events
-    ///   together (FSevents, Windows)
-    /// - Emits only one Remove event when deleting a directory (inotify)
-    /// - Doesn't emit duplicate create events
-    /// - Doesn't emit Modify events after a Create event
-    pub async fn start_watching(
-        &self,
-        fs_inner: Arc<DiskFileSystemInner>,
+    pub async fn start_watching<FsApi: DiskFileSystemWatcherApi>(
+        fs: Arc<FsApi>,
         report_invalidation_reason: bool,
         poll_interval: Option<Duration>,
     ) -> Result<()> {
-        let state_guard = self.state.write().await;
+        let watcher: &Self = fs.watcher();
+        let state_guard = watcher.state.write().await;
 
         // bail out if we're already watching
         if let StateWriteGuard::Recursive(guard) = &state_guard
@@ -412,7 +401,7 @@ impl DiskWatcher {
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the
         // watchers in their associated functions
-        let root_path = fs_inner.root_path();
+        let root_path = fs.root_path();
         let recursive_mode = match state_guard {
             StateWriteGuard::Recursive(_) => RecursiveMode::Recursive,
             StateWriteGuard::NonRecursive(_) => RecursiveMode::NonRecursive,
@@ -423,41 +412,20 @@ impl DiskWatcher {
         // side-effect, this will call `ensure_watched` again, setting up any watchers needed.
         //
         // Best is to start_watching before starting to read
-        if let Some(turbo_tasks) = fs_inner.turbo_tasks.upgrade() {
-            let _span = tracing::info_span!("invalidate filesystem").entered();
-            let _guard = fs_inner.tokio_handle.enter();
-            let invalidator_map = take(&mut *fs_inner.invalidator_map.lock().unwrap());
-            let dir_invalidator_map = take(&mut *fs_inner.dir_invalidator_map.lock().unwrap());
-            let iter = invalidator_map.into_iter().chain(dir_invalidator_map);
-            if report_invalidation_reason {
-                let invalidators = iter
-                    .flat_map(|(path, invalidators)| {
-                        let reason = WatchStart {
-                            name: fs_inner.name.clone(),
-                            // this path is just used for display purposes
-                            path: RcStr::from(path.to_string_lossy()),
-                        };
-                        invalidators.into_iter().map(move |i| (reason.clone(), i))
-                    })
-                    .collect::<Vec<_>>();
-                parallel::for_each_owned(invalidators, |(reason, invalidator)| {
-                    invalidator.invalidate_with_reason(&*turbo_tasks, reason);
-                });
-            } else {
-                let invalidators = iter
-                    .flat_map(|(_, invalidators)| invalidators.into_iter())
-                    .collect::<Vec<_>>();
-                parallel::for_each_owned(invalidators, |invalidator| {
-                    invalidator.invalidate(&*turbo_tasks);
-                });
-            }
+        if report_invalidation_reason {
+            let name = fs.name().clone();
+            fs.invalidate_all_with_reason(|path| WatchStart {
+                name: name.clone(),
+                // this path is just used for display purposes
+                path: RcStr::from(path.to_string_lossy()),
+            });
+        } else {
+            fs.invalidate_all();
         }
 
-        spawn_thread(move || {
-            fs_inner
-                .clone()
-                .watcher
-                .watch_thread(rx, fs_inner, report_invalidation_reason)
+        spawn_thread({
+            let fs = fs.clone();
+            move || Self::watch_thread(fs, rx, report_invalidation_reason)
         });
 
         // Updating `self.state` is done last. If we panic while setting up the watcher, it'll
@@ -492,13 +460,13 @@ impl DiskWatcher {
     /// and invalidates the cache.
     ///
     /// Should only be called once from `start_watching`.
-    fn watch_thread(
-        &self,
+    fn watch_thread<FsApi: DiskFileSystemWatcherApi>(
+        fs: Arc<FsApi>,
         rx: Receiver<notify::Result<notify::Event>>,
-        fs_inner: Arc<DiskFileSystemInner>,
         report_invalidation_reason: bool,
     ) {
-        let mut batch = BatchedInvalidations::new(self.state.recursive_mode());
+        let watcher: &Self = fs.watcher();
+        let mut batch = BatchedInvalidations::new(watcher.state.recursive_mode());
 
         'outer: loop {
             let mut deadline: Option<Instant> = None;
@@ -521,34 +489,34 @@ impl DiskWatcher {
                         // echo 3 | sudo tee /proc/sys/fs/inotify/max_queued_events
                         // ```
                         if event.need_rescan() {
-                            let _lock = fs_inner.invalidation_lock.blocking_write();
+                            let _lock = fs.invalidation_lock().blocking_write();
 
                             // flush the whole mpsc queue, we're about to rescan, we don't need to
                             // process any other update events that have already happened
                             while rx.try_recv().is_ok() {}
 
-                            if let State::NonRecursive(non_recursive) = &self.state {
+                            if let State::NonRecursive(non_recursive) = &watcher.state {
                                 // we can't narrow this down to a smaller set of paths: Rescan
                                 // events (at least when tested on
                                 // Linux) come with no `paths`, and we use
                                 // only one global `notify::Watcher` instance.
                                 //
                                 // TODO: Report diagnostics if an error happens
-                                fs_inner.tokio_handle.block_on(
+                                fs.tokio_handle().block_on(
                                     non_recursive_helpers::restore_all_watched_ignore_errors(
                                         non_recursive,
-                                        fs_inner.root_path(),
+                                        fs.root_path(),
                                     ),
                                 );
                             }
 
                             if report_invalidation_reason {
-                                fs_inner.invalidate_with_reason(|path| InvalidateRescan {
+                                fs.invalidate_all_with_reason(|path| InvalidateRescan {
                                     // this path is just used for display purposes
                                     path: RcStr::from(path.to_string_lossy()),
                                 });
                             } else {
-                                fs_inner.invalidate();
+                                fs.invalidate_all();
                             }
 
                             // no need to process the rest of the batch as we just
@@ -570,7 +538,7 @@ impl DiskWatcher {
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
                         if paths.is_empty() {
-                            batch.mark(fs_inner.root_path().into(), flags);
+                            batch.mark(fs.root_path().into(), flags);
                         } else {
                             for path in paths {
                                 batch.mark(path.into_boxed_path(), flags);
@@ -592,33 +560,32 @@ impl DiskWatcher {
 
             // We need to start watching first before invalidating the changed paths...
             // This is only needed on platforms we don't do recursive watching on.
-            if let State::NonRecursive(non_recursive) = &self.state {
+            if let State::NonRecursive(non_recursive) = &watcher.state {
                 for path in batch.new_paths() {
                     // TODO: Report diagnostics if this error happens
-                    let _ =
-                        fs_inner
-                            .tokio_handle
-                            .block_on(non_recursive_helpers::restore_if_watched(
-                                non_recursive,
-                                path,
-                                fs_inner.root_path(),
-                            ));
+                    let _ = fs
+                        .tokio_handle()
+                        .block_on(non_recursive_helpers::restore_if_watched(
+                            non_recursive,
+                            path,
+                            fs.root_path(),
+                        ));
                 }
             }
 
-            let Some(turbo_tasks) = fs_inner.turbo_tasks.upgrade() else {
+            let Some(turbo_tasks) = fs.turbo_tasks() else {
                 // TurboTasks was dropped, stop watching
                 break 'outer;
             };
-            let _guard = fs_inner.tokio_handle.enter();
+            let _guard = fs.tokio_handle().enter();
 
-            let _lock = fs_inner.invalidation_lock.blocking_write();
+            let _lock = fs.invalidation_lock().blocking_write();
             batch.execute(
-                &fs_inner.invalidator_map,
-                &fs_inner.dir_invalidator_map,
+                fs.invalidator_map(),
+                fs.dir_invalidator_map(),
                 |invalidation_reason_path, invalidator| {
                     invalidate(
-                        &fs_inner,
+                        &*fs,
                         &*turbo_tasks,
                         report_invalidation_reason,
                         invalidation_reason_path,
@@ -869,7 +836,7 @@ impl BatchedInvalidations {
     fields(name = %invalidation_reason_path.display())
 )]
 fn invalidate(
-    inner: &DiskFileSystemInner,
+    inner: &impl DiskFileSystemWatcherApi,
     turbo_tasks: &dyn TurboTasksApi,
     report_invalidation_reason: bool,
     invalidation_reason_path: &Path,
@@ -877,7 +844,7 @@ fn invalidate(
 ) {
     if report_invalidation_reason
         && let Some(path) =
-            format_absolute_fs_path(invalidation_reason_path, &inner.name, inner.root_path())
+            format_absolute_fs_path(invalidation_reason_path, inner.name(), inner.root_path())
     {
         invalidator.invalidate_with_reason(turbo_tasks, WatchChange { path });
         return;
@@ -926,5 +893,77 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use turbo_tasks::TurboTasks;
+    use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
+
+    use super::*;
+    use crate::watcher::mock_fs_api::MockFileSystem;
+
+    /// Polls [`tracked_read`] until it has executed more than `previous_runs` times, i.e. until the
+    /// watcher has invalidated it.
+    async fn wait_for_rerun(fs: &Arc<MockFileSystem>, path: &Path, previous_runs: u64) {
+        const WATCH_TIMEOUT: Duration = Duration::from_secs(5);
+        let deadline = Instant::now() + WATCH_TIMEOUT;
+        loop {
+            if fs.tracked_read_strongly_consistent(path).await > previous_runs {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the watcher did not invalidate {path:?} within {WATCH_TIMEOUT:?}",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watches_file_and_directory_changes() {
+        let tt = TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        tt.run_once(async move {
+            let fs = MockFileSystem::new();
+            let sub_dir = fs.root_path.join("sub");
+            let file_path = sub_dir.join("file.txt");
+            fs::create_dir(&sub_dir).unwrap();
+            fs::write(&file_path, "initial").unwrap();
+
+            DiskWatcher::start_watching(
+                fs.clone(),
+                /* report_invalidation_reason */ true,
+                None,
+            )
+            .await?;
+
+            // the initial reads register the invalidators that the watcher will later fire
+            assert_eq!(fs.tracked_read_strongly_consistent(&file_path).await, 1);
+            assert_eq!(fs.tracked_read_strongly_consistent(&sub_dir).await, 1);
+
+            // reading again without touching the filesystem must not re-run anything
+            assert_eq!(fs.tracked_read_strongly_consistent(&file_path).await, 1);
+            assert_eq!(fs.tracked_read_strongly_consistent(&sub_dir).await, 1);
+
+            // modifying a file invalidates the task that read that file
+            fs::write(&file_path, "updated")?;
+            wait_for_rerun(&fs, &file_path, 1).await;
+
+            // creating a file invalidates the task that listed the containing directory
+            let dir_runs = fs.tracked_read_strongly_consistent(&sub_dir).await;
+            fs::write(sub_dir.join("new.txt"), "new")?;
+            wait_for_rerun(&fs, &sub_dir, dir_runs).await;
+
+            fs.watcher.stop_watching().await;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
Attempting to clean up our testing story here so that we have a way to test the watcher in isolation, ahead of trying to tackle https://github.com/vercel/next.js/pull/96288