### PR TITLE
Deliver client HMR events to a callback instead of an async iterator

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -27,6 +27,7 @@ import type {
   DefineEnv,
   Endpoint,
   HmrChunkNames,
+  HmrEvent,
   Lockfile,
   NodeJsHmrUpdate,
   PartialProjectOptions,
@@ -37,7 +38,6 @@ import type {
   TurboEngineOptions,
   TurbopackResult,
   TurbopackStackFrame,
-  Update,
   UpdateMessage,
   WrittenEndpoint,
 } from './types'
@@ -772,23 +772,30 @@ function bindingToApi(
       )
     }
 
-    hmrEvents(
+    hmrEvents<Target extends HmrTarget>(
       chunkName: string,
-      target: HmrTarget.Client
-    ): AsyncIterableIterator<TurbopackResult<Update>>
-    hmrEvents(
-      chunkName: string,
-      target: HmrTarget.Server
-    ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
-    hmrEvents(chunkName: string, target: HmrTarget.Client | HmrTarget.Server) {
-      return subscribe(true, async (callback) =>
-        binding.projectHmrEvents(
-          this._nativeProject,
-          chunkName,
-          target,
-          callback
-        )
+      target: Target,
+      callback: (...event: HmrEvent<Target>) => void
+    ): () => void {
+      let disposed = false
+      // `projectHmrEvents` hands back the task synchronously, so there is no
+      // window where an update can arrive before we can dispose it. An update
+      // already queued when it is disposed still arrives, so drop those here
+      // and callers can assume nothing happens after they unsubscribe.
+      const task = binding.projectHmrEvents(
+        this._nativeProject,
+        chunkName,
+        target,
+        (...event: HmrEvent<Target>) => {
+          if (disposed) return
+          callback(...event)
+        }
       )
+      return () => {
+        if (disposed) return
+        disposed = true
+        binding.rootTaskDispose(task)
+      }
     }
 
     /**

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -268,6 +268,15 @@ export type NodeJsHmrUpdate =
   | NodeJsPartialHmrUpdate
   | NodeJsRestartHmrUpdate
 
+/** The update shape an HMR subscription delivers, which depends on its target. */
+type HmrUpdate<Target extends import('./index').HmrTarget> =
+  Target extends import('./index').HmrTarget.Server ? NodeJsHmrUpdate : Update
+
+/** An HMR subscription delivers either an error or an update, never both. */
+export type HmrEvent<Target extends import('./index').HmrTarget> =
+  | [err: Error, update: undefined]
+  | [err: undefined, update: TurbopackResult<HmrUpdate<Target>>]
+
 export interface HmrChunkNames {
   /** Relative paths to output chunks that can receive HMR updates (e.g., "server/chunks/ssr/..._.js") */
   chunkNames: string[]
@@ -340,14 +349,16 @@ export interface Project {
     target: import('./index').HmrTarget.Server
   ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
 
-  hmrEvents(
+  /**
+   * Subscribe to HMR events for a single chunk. The subscription reports the
+   * current state once before any update. Returns a function that unsubscribes;
+   * the callback is not invoked after that returns.
+   */
+  hmrEvents<Target extends import('./index').HmrTarget>(
     identifier: string,
-    target: import('./index').HmrTarget.Client
-  ): AsyncIterableIterator<TurbopackResult<Update>>
-  hmrEvents(
-    identifier: string,
-    target: import('./index').HmrTarget.Server
-  ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
+    target: Target,
+    callback: (...event: HmrEvent<Target>) => void
+  ): () => void
 
   hmrChunkNamesSubscribe(
     target: import('./index').HmrTarget

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -965,7 +965,7 @@ export async function createHotReloaderTurbopack(
     currentEntryIssues.delete(key)
   }
 
-  async function subscribeToClientHmrEvents(client: ws, id: string) {
+  function subscribeToClientHmrEvents(client: ws, id: string) {
     const key = getEntryKey('assets', 'client', id)
     if (!hasEntrypointForKey(currentEntrypoints, key, assetMapper)) {
       // maybe throw an error / force the client to reload?
@@ -977,33 +977,43 @@ export async function createHotReloaderTurbopack(
       return
     }
 
-    const subscription = project!.hmrEvents(id, HmrTarget.Client)
-    state.subscriptions.set(id, subscription)
-
     // The subscription will always emit once, which is the initial
     // computation. This is not a change, so swallow it.
-    try {
-      await subscription.next()
+    let seenInitialState = false
 
-      for await (const data of subscription) {
-        processIssues(state.clientIssues, key, data, false, true)
-        if (data.type !== 'issues') {
-          sendTurbopackMessage(data as TurbopackUpdate)
+    const unsubscribe = project!.hmrEvents(
+      id,
+      HmrTarget.Client,
+      (err, data) => {
+        try {
+          if (err) {
+            throw err
+          }
+          if (!seenInitialState) {
+            seenInitialState = true
+            return
+          }
+
+          processIssues(state.clientIssues, key, data, false, true)
+          if (data.type !== 'issues') {
+            sendTurbopackMessage(data)
+          }
+        } catch (e) {
+          // The client might be using an HMR session from a previous server, tell them
+          // to fully reload the page to resolve the issue. We can't use
+          // `hotReloader.send` since that would force every connected client to
+          // reload, only this client is out of date.
+          unsubscribeFromClientHmrEvents(client, id)
+          const reloadMessage: ReloadPageMessage = {
+            type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
+            data: `error in HMR event subscription for ${id}: ${e}`,
+          }
+          sendToClient(client, reloadMessage)
+          client.close()
         }
       }
-    } catch (e) {
-      // The client might be using an HMR session from a previous server, tell them
-      // to fully reload the page to resolve the issue. We can't use
-      // `hotReloader.send` since that would force every connected client to
-      // reload, only this client is out of date.
-      const reloadMessage: ReloadPageMessage = {
-        type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
-        data: `error in HMR event subscription for ${id}: ${e}`,
-      }
-      sendToClient(client, reloadMessage)
-      client.close()
-      return
-    }
+    )
+    state.subscriptions.set(id, unsubscribe)
   }
 
   function unsubscribeFromClientHmrEvents(client: ws, id: string) {
@@ -1012,8 +1022,9 @@ export async function createHotReloaderTurbopack(
       return
     }
 
-    const subscription = state.subscriptions.get(id)
-    subscription?.return!()
+    const unsubscribe = state.subscriptions.get(id)
+    state.subscriptions.delete(id)
+    unsubscribe?.()
 
     const key = getEntryKey('assets', 'client', id)
     state.clientIssues.delete(key)
@@ -1377,7 +1388,7 @@ export async function createHotReloaderTurbopack(
     onHMR(req, socket: Socket, head, onUpgrade) {
       wsServer.handleUpgrade(req, socket, head, (client) => {
         const clientIssues: EntryIssuesMap = new Map()
-        const subscriptions: Map<string, AsyncIterator<any>> = new Map()
+        const subscriptions: Map<string, () => void> = new Map()
 
         const htmlRequestId = req.url
           ? new URL(req.url, 'http://n').searchParams.get('id')
@@ -1428,8 +1439,8 @@ export async function createHotReloaderTurbopack(
 
         client.on('close', () => {
           // Remove active subscriptions
-          for (const subscription of subscriptions.values()) {
-            subscription.return?.()
+          for (const unsubscribe of subscriptions.values()) {
+            unsubscribe()
           }
           clientStates.delete(client)
 

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -129,7 +129,7 @@ export type ClientState = {
   clientIssues: EntryIssuesMap
   messages: Map<string, HmrMessageSentToBrowser>
   turbopackUpdates: TurbopackUpdate[]
-  subscriptions: Map<string, AsyncIterator<any>>
+  subscriptions: Map<string, () => void>
 }
 
 export type ClientStateMap = WeakMap<ws, ClientState>

--- a/test/development/app-dir/hmr-resubscribe/app/layout.tsx
+++ b/test/development/app-dir/hmr-resubscribe/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-resubscribe/app/page.tsx
+++ b/test/development/app-dir/hmr-resubscribe/app/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return <p>version 0</p>
+}

--- a/test/development/app-dir/hmr-resubscribe/hmr-resubscribe.test.ts
+++ b/test/development/app-dir/hmr-resubscribe/hmr-resubscribe.test.ts
@@ -1,0 +1,89 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import WebSocket from 'ws'
+
+const pageSource = (version: number) =>
+  `'use client'\n\nexport default function Page() {\n  return <p>version ${version}</p>\n}\n`
+
+describe('hmr resubscribe', () => {
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (!isTurbopack || !isNextDev) {
+    it('skipped outside of Turbopack dev', () => {})
+    return
+  }
+
+  // Drives the HMR websocket directly, because the subscription state that
+  // governs this lives on the connection: unsubscribing and subscribing again
+  // has to happen without a reconnect for the resubscribe to matter.
+  it('keeps delivering updates to a chunk that was unsubscribed and subscribed again', async () => {
+    const html = await next.render('/')
+    // Every script the page loads is a candidate. Subscribing to all of them
+    // and seeing which ones report an update identifies the chunk lists without
+    // reimplementing how the browser runtime derives their paths.
+    const candidates = [
+      ...new Set(
+        [...html.matchAll(/src="\/_next\/([^"]+\.js[^"]*)"/g)].map((match) =>
+          decodeURIComponent(match[1].split('?')[0])
+        )
+      ),
+    ]
+    expect(candidates.length).toBeGreaterThan(0)
+
+    const ws = new WebSocket(`${next.url.replace(/^http/, 'ws')}/_next/hmr`)
+    let phase = 'setup'
+    const updates = new Set<string>()
+    ws.on('message', (raw: Buffer) => {
+      let message: any
+      try {
+        message = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+      if (message.type !== 'turbopack-message') return
+      for (const update of message.data) {
+        if (update.resource?.path) {
+          updates.add(`${phase} ${update.resource.path}`)
+        }
+      }
+    })
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ws.once('open', () => resolve())
+        ws.once('error', reject)
+      })
+      const send = (type: string, path: string) =>
+        ws.send(JSON.stringify({ type, path }))
+
+      for (const candidate of candidates) send('turbopack-subscribe', candidate)
+
+      phase = 'before'
+      await next.patchFile('app/page.tsx', pageSource(1))
+      let delivering: string[] = []
+      await retry(async () => {
+        delivering = candidates.filter((candidate) =>
+          updates.has(`before ${candidate}`)
+        )
+        expect(delivering.length).toBeGreaterThan(0)
+      })
+
+      for (const chunk of delivering) send('turbopack-unsubscribe', chunk)
+      for (const chunk of delivering) send('turbopack-subscribe', chunk)
+
+      phase = 'after'
+      await next.patchFile('app/page.tsx', pageSource(2))
+      await retry(async () => {
+        const stillDelivering = delivering.filter((chunk) =>
+          updates.has(`after ${chunk}`)
+        )
+        expect(stillDelivering).toEqual(delivering)
+      })
+    } finally {
+      ws.close()
+      await next.patchFile('app/page.tsx', pageSource(0))
+    }
+  })
+})

--- a/test/development/app-dir/hmr-resubscribe/next.config.js
+++ b/test/development/app-dir/hmr-resubscribe/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -8,11 +8,13 @@ import type {
   RawEntrypoints,
   StyledString,
   TurbopackResult,
+  Update,
   UpdateInfo,
 } from 'next/dist/build/swc/types'
 import loadConfig from 'next/dist/server/config'
 import path, { join } from 'path'
 import { spawnSync } from 'child_process'
+import { retry } from 'next-test-utils'
 
 function normalizePath(path: string) {
   return path
@@ -59,25 +61,6 @@ function normalizeIssues(issues: Issue[]) {
       if (a_ > b_) return 1
       return 0
     })
-}
-
-function raceIterators<T>(iterators: AsyncIterableIterator<T>[]) {
-  const nexts = iterators.map((iterator, i) =>
-    iterator.next().then((next) => ({ next, i }))
-  )
-  return (async function* () {
-    while (true) {
-      const remaining = nexts.filter((x) => x)
-      if (remaining.length === 0) return
-      const { next, i } = await Promise.race(remaining)
-      if (!next.done) {
-        yield next.value
-        nexts[i] = iterators[i].next().then((next) => ({ next, i }))
-      } else {
-        nexts[i] = undefined
-      }
-    }
-  })()
 }
 
 async function* filterMapAsyncIterator<T, U>(
@@ -625,18 +608,36 @@ describe('next.rs api', () => {
         const chunkNames = result.value.chunkNames
         expect(chunkNames).toHaveProperty('length', expect.toBePositive())
 
-        const subscriptions = chunkNames.map((chunkName) =>
-          project.hmrEvents(chunkName, HmrTarget.Client)
-        )
-        await Promise.all(
-          subscriptions.map(async (subscription) => {
-            const result = await subscription.next()
-            expect(result.done).toBe(false)
-            expect(result.value).toHaveProperty('resource', expect.toBeObject())
-            expect(result.value).toHaveProperty('type', 'issues')
-            expect(normalizeIssues(result.value.issues)).toEqual([])
-          })
-        )
+        const initialStates: TurbopackResult<Update>[] = []
+        const hmrUpdates: TurbopackResult<Update>[] = []
+        const subscriptionErrors: Error[] = []
+        const unsubscribes = chunkNames.map((chunkName) => {
+          let seenInitialState = false
+          return project.hmrEvents(
+            chunkName,
+            HmrTarget.Client,
+            (err, event) => {
+              if (err) {
+                subscriptionErrors.push(err)
+              } else if (!seenInitialState) {
+                seenInitialState = true
+                initialStates.push(event)
+              } else {
+                hmrUpdates.push(event)
+              }
+            }
+          )
+        })
+
+        await retry(async () => {
+          expect(initialStates).toHaveLength(chunkNames.length)
+        })
+        for (const initialState of initialStates) {
+          expect(initialState).toHaveProperty('resource', expect.toBeObject())
+          expect(initialState).toHaveProperty('type', 'issues')
+          expect(normalizeIssues(initialState.issues)).toEqual([])
+        }
+
         console.log('waiting for events')
         const { next: updateComplete } = await drainAndGetNext(
           projectUpdateSubscription
@@ -645,37 +646,10 @@ describe('next.rs api', () => {
         let ok = false
         try {
           await next.patchFile(file, content)
-          let foundUpdates: string[] | false = false
           let foundServerSideChange = false
           let done = false
           const result2 = await Promise.race(
             [
-              (async () => {
-                const merged = raceIterators(subscriptions)
-                for await (const item of merged) {
-                  if (done) return
-                  if (item.type === 'partial') {
-                    expect(item.instruction).toEqual({
-                      type: 'ChunkListUpdate',
-                      merged: [
-                        expect.objectContaining({
-                          chunks: expect.toBeObject(),
-                          entries: expect.toBeObject(),
-                        }),
-                      ],
-                    })
-                    const updates = Object.keys(
-                      item.instruction.merged[0].entries
-                    )
-                    expect(updates).not.toBeEmpty()
-
-                    foundUpdates = foundUpdates || []
-                    foundUpdates.push(
-                      ...Object.keys(item.instruction.merged[0].entries)
-                    )
-                  }
-                }
-              })(),
               serverSideSubscription &&
                 (async () => {
                   for await (const { issues } of serverSideSubscription) {
@@ -698,18 +672,39 @@ describe('next.rs api', () => {
               tasks: expect.toBePositive(),
             },
           })
+          expect(subscriptionErrors).toEqual([])
+
+          const partialUpdates = hmrUpdates.filter(
+            (update) => update.type === 'partial'
+          )
+          const updatedEntries: string[] = []
+          for (const update of partialUpdates) {
+            expect(update.instruction).toEqual({
+              type: 'ChunkListUpdate',
+              merged: [
+                expect.objectContaining({
+                  chunks: expect.toBeObject(),
+                  entries: expect.toBeObject(),
+                }),
+              ],
+            })
+            const entries = Object.keys(update.instruction.merged[0].entries)
+            expect(entries).not.toBeEmpty()
+            updatedEntries.push(...entries)
+          }
           if (typeof expectedUpdate === 'boolean') {
-            expect(foundUpdates).toBe(false)
+            expect(partialUpdates).toBeEmpty()
           } else {
-            expect(
-              typeof foundUpdates === 'boolean'
-                ? foundUpdates
-                : Array.from(new Set(foundUpdates))
-            ).toEqual([expect.stringContaining(expectedUpdate)])
+            expect(Array.from(new Set(updatedEntries))).toEqual([
+              expect.stringContaining(expectedUpdate),
+            ])
           }
           expect(foundServerSideChange).toBe(expectedServerSideChange)
           ok = true
         } finally {
+          for (const unsubscribe of unsubscribes) {
+            unsubscribe()
+          }
           try {
             const { next: updateComplete2 } = await drainAndGetNext(
               projectUpdateSubscription
@@ -744,37 +739,115 @@ describe('next.rs api', () => {
     expect(result.done).toBe(false)
     const chunkNames = result.value.chunkNames
 
-    const subscriptions = chunkNames.map((chunkName) =>
-      project.hmrEvents(chunkName, HmrTarget.Client)
-    )
-    await Promise.all(
-      subscriptions.map(async (subscription) => {
-        const result = await subscription.next()
-        expect(result.done).toBe(false)
-        expect(result.value).toHaveProperty('resource', expect.toBeObject())
-        expect(result.value).toHaveProperty('type', 'issues')
+    let partialUpdates = 0
+    const unsubscribes = chunkNames.map((chunkName) => {
+      let seenInitialState = false
+      return project.hmrEvents(chunkName, HmrTarget.Client, (err, event) => {
+        if (err) throw err
+        if (!seenInitialState) {
+          seenInitialState = true
+          expect(event).toHaveProperty('resource', expect.toBeObject())
+          expect(event).toHaveProperty('type', 'issues')
+          return
+        }
+        if (event.type === 'partial') {
+          partialUpdates++
+        }
       })
-    )
-    const merged = raceIterators(subscriptions)
+    })
+    const waitForPartialUpdates = (min: number) =>
+      retry(async () => {
+        expect(partialUpdates).toBeGreaterThanOrEqual(min)
+      })
 
     const file = 'pages/index.js'
     let currentContent = await next.readFile(file)
     let nextContent = pagesIndexCode('hello world2')
 
-    const count = process.env.NEXT_TEST_CI ? 300 : 1000
-    for (let i = 0; i < count; i++) {
-      await next.patchFile(file, nextContent)
-      const content = currentContent
-      currentContent = nextContent
-      nextContent = content
+    try {
+      const count = process.env.NEXT_TEST_CI ? 300 : 1000
+      for (let i = 0; i < count; i++) {
+        await next.patchFile(file, nextContent)
+        const content = currentContent
+        currentContent = nextContent
+        nextContent = content
 
-      while (true) {
-        const { value, done } = await merged.next()
-        expect(done).toBe(false)
-        if (value.type === 'partial') {
-          break
-        }
+        await waitForPartialUpdates(i + 1)
+      }
+    } finally {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe()
       }
     }
   }, 300000)
+
+  it('should stop delivering HMR events after unsubscribing', async () => {
+    const entrypointsSubscription = project.entrypointsSubscribe()
+    const entrypoints: TurbopackResult<RawEntrypoints | {}> = (
+      await entrypointsSubscription.next()
+    ).value
+    if (!('routes' in entrypoints)) {
+      throw new Error('Entrypoints not available due to compilation errors')
+    }
+    const route = entrypoints.routes.get('/')
+    entrypointsSubscription.return()
+
+    if (route.type !== 'page') throw new Error('unknown route type')
+    await route.htmlEndpoint.writeToDisk()
+
+    const result = await project.hmrChunkNamesSubscribe(HmrTarget.Client).next()
+    const chunkNames = result.value.chunkNames
+
+    let events = 0
+    let eventsWhenUnsubscribed: number | undefined
+    // Two subscriptions per chunk, so that an update always has a sibling
+    // event queued behind the one that unsubscribes.
+    const unsubscribes = [...chunkNames, ...chunkNames].map(
+      (chunkName: string) => {
+        let seenInitialState = false
+        return project.hmrEvents(chunkName, HmrTarget.Client, () => {
+          events++
+          if (!seenInitialState) {
+            seenInitialState = true
+            return
+          }
+          if (eventsWhenUnsubscribed !== undefined) {
+            return
+          }
+
+          // Unsubscribe from inside the first update, while the same update is
+          // still queued for the sibling subscriptions. Events are handed to
+          // the event loop from another thread, so block afterwards to give
+          // any sibling event that is not queued yet a chance to be.
+          for (const unsubscribe of unsubscribes) {
+            unsubscribe()
+          }
+          const blockUntil = Date.now() + 2000
+          while (Date.now() < blockUntil) {}
+          eventsWhenUnsubscribed = events
+        })
+      }
+    )
+
+    const file = 'pages/index.js'
+    const oldContent = await next.readFile(file)
+    try {
+      await retry(async () => {
+        expect(events).toBe(unsubscribes.length)
+      })
+
+      await next.patchFile(file, pagesIndexCode('hello world2'))
+      await retry(async () => {
+        expect(eventsWhenUnsubscribed).toBeDefined()
+      }, 30000)
+
+      await new Promise((r) => setTimeout(r, 3000))
+      expect(events).toBe(eventsWhenUnsubscribed)
+    } finally {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe()
+      }
+      await next.patchFile(file, oldContent)
+    }
+  }, 60000)
 })


### PR DESCRIPTION
The napi binding delivers HMR events to a callback. `project.hmrEvents()` wrapped that callback in an async generator — a buffer, a parked promise, a cancel sentinel — so the consumer could drive it with `for await`.

An async iterator is an awkward fit here. Every update pays for a promise and a generator step, every idle subscription holds a promise parked on the next event (one per connected browser per entrypoint), and unsubscribing isn't an operation you can call — it means breaking out of a loop elsewhere. Handing the callback through is cleaner and slightly cheaper:

```ts
const unsubscribe = project.hmrEvents(id, HmrTarget.Client, (err, update) => …)
```

`projectHmrEvents` returns the task handle synchronously, so one boolean makes unsubscribing idempotent and drops an event that was already queued at dispose. The target picks the update type, replacing two overloads and a cast at the call site.

It also fixes a latent one-way unsubscribe: `unsubscribeFromClientHmrEvents` left the entry in `state.subscriptions`, which is the map the subscribe path checks, so subscribing again to the same chunk on one connection did nothing. No app produces that sequence today.

Server side is unaffected — #95546 left `hmrEvents`' `HmrTarget.Server` overload with no callers. Supersedes #91704 and the client half of #96182.

<details>
<summary>Verification</summary>

`test/development/basic/next-rs-api.test.ts`, `test/development/basic/hmr/*` and `test/development/app-hmr/*` match the base commit. A new RS API test unsubscribes from inside the first update, while that rebuild's events are still queued for sibling subscriptions: 37 events with the guard, 78 without it.

Both consumers were also run against a simulated napi layer (synchronous task handle, events a tick late, an event queued before `rootTaskDispose` still landing) over 412 randomized subscribe / unsubscribe / update / error / close programs. Differences: the map entry above, plus the new consumer clearing a chunk's issue key on the error path just before it closes the client.

</details>
