### PR TITLE
fix(next/form): include the submitter's name and value when navigating

### DIFF
--- a/packages/next/src/client/app-dir/form.tsx
+++ b/packages/next/src/client/app-dir/form.tsx
@@ -213,7 +213,11 @@ function onFormSubmit(
     }
   }
 
-  const targetUrl = createFormSubmitDestinationUrl(action, formElement)
+  const targetUrl = createFormSubmitDestinationUrl(
+    action,
+    formElement,
+    submitter
+  )
 
   // Finally, no more reasons for bailing out.
   event.preventDefault()

--- a/packages/next/src/client/form-shared.tsx
+++ b/packages/next/src/client/form-shared.tsx
@@ -50,7 +50,8 @@ export type FormProps<RouteInferType = any> = InternalFormProps
 
 export function createFormSubmitDestinationUrl(
   action: string,
-  formElement: HTMLFormElement
+  formElement: HTMLFormElement,
+  submitter: HTMLElement | null
 ) {
   let targetUrl: URL
   try {
@@ -77,7 +78,14 @@ export function createFormSubmitDestinationUrl(
     targetUrl.search = ''
   }
 
-  const formData = new FormData(formElement)
+  // Passing the submitter matches the native behavior of including its
+  // name/value pair, positioned where the submitter appears in the form:
+  //
+  //  "If the field element is a submitter button, [...] append an entry to the
+  //   entry list with the field element's name and value"
+  //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-entry-list
+  //
+  const formData = new FormData(formElement, submitter)
 
   for (let [name, value] of formData) {
     if (typeof value !== 'string') {

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -149,7 +149,11 @@ function onFormSubmit(
     }
   }
 
-  const targetUrl = createFormSubmitDestinationUrl(action, formElement)
+  const targetUrl = createFormSubmitDestinationUrl(
+    action,
+    formElement,
+    submitter
+  )
 
   // Finally, no more reasons for bailing out.
   event.preventDefault()

--- a/test/e2e/next-form/default/app/forms/button-with-value/page.tsx
+++ b/test/e2e/next-form/default/app/forms/button-with-value/page.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default function Home() {
+  return (
+    <Form action="/search" id="search-form">
+      <input name="query" />
+      <button type="submit" name="sort" value="relevance">
+        Submit
+      </button>
+      {/* comes after the submitter, to verify that the entries stay in tree order */}
+      <input name="page" defaultValue="1" />
+    </Form>
+  )
+}

--- a/test/e2e/next-form/default/pages/pages-dir/forms/button-with-value/index.tsx
+++ b/test/e2e/next-form/default/pages/pages-dir/forms/button-with-value/index.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default function Home() {
+  return (
+    <Form action="/pages-dir/search" id="search-form">
+      <input name="query" />
+      <button type="submit" name="sort" value="relevance">
+        Submit
+      </button>
+      {/* comes after the submitter, to verify that the entries stay in tree order */}
+      <input name="page" defaultValue="1" />
+    </Form>
+  )
+}

--- a/test/e2e/next-form/default/shared-tests.util.ts
+++ b/test/e2e/next-form/default/shared-tests.util.ts
@@ -65,6 +65,38 @@ export function runSharedTests(type: 'app' | 'pages') {
       expect(await navigationTracker.didMpaNavigate()).toBe(false)
     })
 
+    it("should include the submitter's name and value in tree order", async () => {
+      const session = await next.browser(
+        pathPrefix + '/forms/button-with-value'
+      )
+      const navigationTracker = await trackMpaNavs(session)
+
+      const searchInput = await session.elementByCss('input[name="query"]')
+      await searchInput.fill('my search')
+
+      const submitButton = await session.elementByCss('[type="submit"]')
+      await submitButton.click()
+
+      const result = await session.waitForElementByCss('#search-results').text()
+      expect(result).toMatch(/query: "my search"/)
+
+      // A submit button with a `name` contributes its `value` to the form data,
+      // at the position where the button appears in the form:
+      //
+      //   "If the field element is a submitter button, [...] append an entry to
+      //    the entry list with the field element's name and value"
+      //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set
+      //
+      const url = new URL(await session.url())
+      expect([...url.searchParams.entries()]).toEqual([
+        ['query', 'my search'],
+        ['sort', 'relevance'],
+        ['page', '1'],
+      ])
+
+      expect(await navigationTracker.didMpaNavigate()).toBe(false)
+    })
+
     // `<form action={someFunction}>` is only supported in React 19.x
     ;(isReact18 ? describe.skip : describe)(
       'functions passed to action',


### PR DESCRIPTION
**What? **

`<Form action="/search">` with `<button type="submit" name="sort" value="relevance">` — the sort=relevance pair is missing from the resulting URL.
A native <form> includes it, positioned where the submitter appears in the form (tree order).
Affects App Router and Pages Router, both next dev and next start.


**Why?**

`createFormSubmitDestinationUrl` in `packages/next/src/client/form-shared.tsx` built the entry list with new `FormData(formElement)`.
The FormData constructor takes an optional second submitter argument; that argument is what contributes the submitter's name/value pair.
Spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-entry-list

**How?**

Thread the already-available submitter (from event.nativeEvent.submitter) through to createFormSubmitDestinationUrl and pass it to FormData.
Both call sites already had the variable in scope; no new plumbing.

**Browser support (the point a reviewer will raise)**

Second argument: Chrome/Edge 112, Firefox 111, Safari 16.4.
Next.js' documented floor: Chrome 111, Edge 111, Firefox 111, Safari 16.4 — so the gap is Chrome/Edge 111 only.
Extra constructor arguments are ignored per WebIDL, so on Chrome 111 this degrades to the current behaviour — no exception, no regression.
React, as vendored in this repo, already calls new FormData(nativeEventTarget, submitter) with no fallback, so <Form action={someFunction}> already depends on 112+ for this pair.

**Why React's internals can't leak into the query string**

Server-action submitters are encoded with formMethod="post"; hasUnsupportedSubmitterAttributes bails out because isSupportedFormMethod only allows get. They never reach this code, so $ACTION_ID_* fields cannot end up in the URL.

**Tests**

New fixture forms/button-with-value for both routers.
Asserts the full searchParams.entries() list including order, so an implementation that appended the pair at the end would fail.
Verified failing before the change and passing after; ran dev+Turbopack, start+Turbopack and dev+webpack.
Credit

Releted issue https://github.com/vercel/next.js/issues/84857