### PR TITLE
fix: respect `htmlLimitedBots` in cache components without buffering the full response

### DIFF
--- a/docs/01-app/02-guides/streaming.mdx
+++ b/docs/01-app/02-guides/streaming.mdx
@@ -668,15 +668,15 @@ export default async function PostPage({ params }) {
 
 ### Bots and crawlers
 
-Bots and crawlers consume a complete, fully formed HTML document rather than rendering chunks as they arrive. Next.js detects them by their user agent and waits for the render to finish, then sends the whole document in a single response instead of streaming it progressively. [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) resolves before the response is sent for bots that only scrape static HTML (such as Twitterbot or Slackbot), so metadata is present in the `<head>` of that HTML. Full browsers and capable crawlers can instead receive [streaming metadata](/docs/app/api-reference/functions/generate-metadata#streaming-metadata) alongside the page content.
+HTML-limited bots and crawlers need metadata to be available in the `<head>` of the initial HTML. Next.js detects them by their user agent and waits for [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) to resolve before streaming the page content. Full browsers and DOM-capable crawlers can instead receive [streaming metadata](/docs/app/api-reference/functions/generate-metadata#streaming-metadata) alongside the page content.
 
 You can customize which bots receive blocking metadata with the [`htmlLimitedBots`](/docs/app/api-reference/config/next-config-js/htmlLimitedBots) configuration option. See the [`loading.js` SEO section](/docs/app/api-reference/file-conventions/loading#seo) for more details.
 
 #### Cache Components
 
-With [Cache Components](/docs/app/getting-started/caching), a visitor receives the prerendered shell immediately and dynamic content streams in as it resolves. A bot is served differently: because it needs a complete document, Next.js skips the prerendered shell and renders the entire page dynamically at request time, waiting for the full render to complete before sending the finished HTML.
+With [Cache Components](/docs/app/getting-started/caching), visitors and DOM-capable crawlers receive the prerendered shell immediately, and dynamic content streams in as it resolves. HTML-limited bots skip the prerendered shell and render the page dynamically so metadata can be placed in the `<head>`. Once the metadata resolves, the remaining page content can still stream.
 
-Keep this in mind when your prerendered shell depends on inputs that only exist while prerendering, such as build-time data or values that are not reachable in the request-time environment. A visitor receives the shell without re-running that code, but a bot re-renders it dynamically, so a page that loads for a person can fail to render for a crawler. Make sure any data the shell relies on is also available at request time.
+Keep this in mind when your prerendered shell depends on inputs that only exist while prerendering, such as build-time data or values that are not reachable in the request-time environment. Visitors and DOM-capable crawlers receive the shell without re-running that code, but an HTML-limited bot re-renders it dynamically, so a page that loads for a person can fail to render for a crawler. Make sure any data the shell relies on is also available at request time.
 
 ## What can affect streaming
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3312,8 +3312,10 @@ export default async function build(
                 ? true
                 : undefined
 
-            const htmlBotsRegexString =
-              // The htmlLimitedBots has been converted to a string during loadConfig
+            // htmlLimitedBots has been converted to a string during loadConfig.
+            // The configured pattern replaces the default HTML-limited bot
+            // pattern.
+            const htmlLimitedBotsRegexString =
               config.htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING
 
             // this flag is used to selectively bypass the static cache and invoke the lambda directly
@@ -3325,14 +3327,14 @@ export default async function build(
                 key: 'content-type',
                 value: 'multipart/form-data;.*',
               },
-              // If it's PPR rendered non-static page, bypass the PPR cache when streaming metadata is enabled.
-              // This will skip the postpone data for those bots requests and instead produce a dynamic render.
+              // For PPR routes, bypass the shell for user agents configured
+              // to receive blocking metadata and produce a dynamic render.
               ...(isRoutePPREnabled
                 ? [
                     {
                       type: 'header' as const,
                       key: 'user-agent',
-                      value: htmlBotsRegexString,
+                      value: htmlLimitedBotsRegexString,
                     },
                   ]
                 : []),

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -40,10 +40,7 @@ import {
   type OpaqueFallbackRouteParams,
 } from '../../server/request/fallback-params' with { 'turbopack-transition': 'next-server-utility' }
 import { setManifestsSingleton } from '../../server/app-render/manifests-singleton' with { 'turbopack-transition': 'next-server-utility' }
-import {
-  isHtmlBotRequest,
-  shouldServeStreamingMetadata,
-} from '../../server/lib/streaming-metadata' with { 'turbopack-transition': 'next-server-utility' }
+import { shouldServeStreamingMetadata } from '../../server/lib/streaming-metadata' with { 'turbopack-transition': 'next-server-utility' }
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths' with { 'turbopack-transition': 'next-server-utility' }
 import { getIsPossibleServerAction } from '../../server/lib/server-action-request-meta' with { 'turbopack-transition': 'next-server-utility' }
 import {
@@ -56,10 +53,7 @@ import {
   RSC_CONTENT_TYPE_HEADER,
   NEXT_HMR_REFRESH_HEADER,
 } from '../../client/components/app-router-headers' with { 'turbopack-transition': 'next-server-utility' }
-import {
-  getBotType,
-  isBot,
-} from '../../shared/lib/router/utils/is-bot' with { 'turbopack-transition': 'next-server-utility' }
+import { getBotType } from '../../shared/lib/router/utils/is-bot' with { 'turbopack-transition': 'next-server-utility' }
 import {
   CachedRouteKind,
   IncrementalCacheKind,
@@ -287,7 +281,6 @@ export function createAppPageEntrypoint({
 
     const userAgent = req.headers['user-agent'] || ''
     const botType = getBotType(userAgent)
-    const isHtmlBot = isHtmlBotRequest(req)
 
     /**
      * If true, this indicates that the request being made is for an app
@@ -539,12 +532,9 @@ export function createAppPageEntrypoint({
     // being true for a revalidate due to modifying the base-server this.renderOpts
     // when fixing this to correct logic it causes hydration issue since we set
     // serveStreamingMetadata to true during export
-    const serveStreamingMetadata =
-      botType && isRoutePPREnabled
-        ? false
-        : !userAgent
-          ? true
-          : shouldServeStreamingMetadata(userAgent, nextConfig.htmlLimitedBots)
+    const serveStreamingMetadata = !userAgent
+      ? true
+      : shouldServeStreamingMetadata(userAgent, nextConfig.htmlLimitedBots)
 
     // PPR shells are generated for streaming metadata. Requests that require
     // blocking metadata must bypass the shell so the prerender and dynamic
@@ -588,10 +578,6 @@ export function createAppPageEntrypoint({
         : // Otherwise, we can support dynamic responses if it's a dynamic RSC request.
           isDynamicRSCRequest)
 
-    // The fixed bot list historically waits for the entire PPR render. A bot
-    // configured only through htmlLimitedBots may stream after its metadata
-    // resolves.
-    const shouldWaitOnAllReady = Boolean(botType) && isRoutePPREnabled
     const remainingPrerenderableParams =
       prerenderInfo?.remainingPrerenderableParams ?? []
     // Concrete optional routes like `/optional-catchall` can still match their
@@ -884,7 +870,7 @@ export function createAppPageEntrypoint({
             page: srcPage,
             postponed,
             allowEmptyStaticShell,
-            shouldWaitOnAllReady,
+            shouldWaitOnAllReady: false,
             serveStreamingMetadata,
             supportsDynamicResponse:
               typeof postponed === 'string' || supportsDynamicResponse,
@@ -1140,13 +1126,14 @@ export function createAppPageEntrypoint({
             fallbackMode = FallbackMode.PRERENDER
           }
 
-          // When serving a HTML bot request, we want to serve a blocking render and
-          // not the prerendered page. This ensures that the correct content is served
-          // to the bot in the head.
-          if (fallbackMode === FallbackMode.PRERENDER && isBot(userAgent)) {
-            if (!isRoutePPREnabled || isHtmlBot) {
-              fallbackMode = FallbackMode.BLOCKING_STATIC_RENDER
-            }
+          // When serving a request that requires blocking metadata, we want to
+          // use a blocking render instead of the prerendered fallback. Without
+          // PPR, preserve the existing behavior for built-in bots.
+          if (
+            fallbackMode === FallbackMode.PRERENDER &&
+            (isRoutePPREnabled ? !serveStreamingMetadata : Boolean(botType))
+          ) {
+            fallbackMode = FallbackMode.BLOCKING_STATIC_RENDER
           }
 
           if (previousIncrementalCacheEntry?.isStale === -1) {

--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -1,8 +1,4 @@
-import {
-  getBotType,
-  HTML_LIMITED_BOT_UA_RE_STRING,
-} from '../../shared/lib/router/utils/is-bot'
-import type { BaseNextRequest } from '../base-http'
+import { HTML_LIMITED_BOT_UA_RE_STRING } from '../../shared/lib/router/utils/is-bot'
 
 let cachedPattern: string | undefined
 let cachedRegex: RegExp | undefined
@@ -21,15 +17,4 @@ export function shouldServeStreamingMetadata(
     return false
   }
   return true
-}
-
-// When the request UA is a html-limited bot, we should do a dynamic render.
-// In this case, postpone state is not sent.
-export function isHtmlBotRequest(req: {
-  headers: BaseNextRequest['headers']
-}): boolean {
-  const ua = req.headers['user-agent'] || ''
-  const botType = getBotType(ua)
-
-  return botType === 'html'
 }

--- a/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-custom-bots.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-custom-bots.test.ts
@@ -85,27 +85,98 @@ describeCacheComponents('metadata streaming with a custom bot list', () => {
     }
   })
 
-  // A custom htmlLimitedBots pattern currently replaces the built-in pattern
-  // in the deployment manifest, so only assert built-in classifications in
-  // start mode until the deployment proxy receives the union of both.
-  if (!isNextDeploy) {
-    it.each(['Discordbot', 'Googlebot'])(
-      'should preserve fully buffered rendering for the built-in %s classification',
-      async (userAgent) => {
-        const res = await next.fetch('/partial?stream=delay', {
+  it('should use the PPR shell for a default HTML-limited bot excluded by the custom pattern', async () => {
+    const res = await next.fetch('/partial?stream=delay', {
+      headers: {
+        'user-agent': 'Discordbot',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    if (!isNextDeploy) {
+      expect(res.headers.get('x-nextjs-postponed')).toBe('1')
+    }
+
+    const $ = cheerio.load(await res.text())
+    expect($('head title').length).toBe(0)
+    expect($('body title').text()).toBe('dynamic title')
+    expect($('#dynamic-content').text()).toBe('dynamic content')
+  })
+
+  it('should use the PPR shell with streamed metadata for a DOM-capable bot', async () => {
+    const res = await next.fetch('/partial?stream=delay', {
+      headers: {
+        'user-agent': 'Googlebot',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    if (!isNextDeploy) {
+      expect(res.headers.get('x-nextjs-postponed')).toBe('1')
+    }
+
+    const $ = cheerio.load(await res.text())
+    expect($('head title').length).toBe(0)
+    expect($('body title').text()).toBe('dynamic title')
+    expect($('#dynamic-content').text()).toBe('dynamic content')
+  })
+})
+;(isNextDev ? describe.skip : describe)(
+  'metadata streaming with Cache Components and a built-in bot in the custom pattern',
+  () => {
+    const { next, isNextDeploy } = nextTestSetup({
+      files: __dirname,
+      overrideFiles: {
+        'next.config.js': `
+          module.exports = {
+            cacheComponents: true,
+            htmlLimitedBots: /MyBot|Discordbot/i,
+          }
+        `,
+      },
+    })
+
+    it('should block metadata while continuing to stream the body for the included built-in HTML-limited bot', async () => {
+      const abortController = new AbortController()
+      let body:
+        | (AsyncIterable<Uint8Array> & {
+            destroy: () => void
+          })
+        | undefined
+
+      try {
+        const res = await next.fetch('/partial?stream=1', {
           headers: {
-            'user-agent': userAgent,
+            'user-agent': 'Discordbot',
           },
+          signal: abortController.signal,
         })
 
         expect(res.status).toBe(200)
-        expect(res.headers.get('x-nextjs-postponed')).toBeNull()
+        if (!isNextDeploy) {
+          expect(res.headers.get('x-nextjs-postponed')).toBeNull()
+        }
+        expect(res.body).not.toBeNull()
 
-        const $ = cheerio.load(await res.text())
-        expect($('head title').text()).toBe('dynamic title')
-        expect($('#dynamic-content').text()).toBe('dynamic content')
-        expect($('#dynamic-fallback').length).toBe(0)
+        body = res.body! as unknown as AsyncIterable<Uint8Array> & {
+          destroy: () => void
+        }
+        let initialHtml = ''
+
+        for await (const chunk of body) {
+          initialHtml += Buffer.from(chunk).toString()
+          if (initialHtml.includes('dynamic-fallback')) {
+            break
+          }
+        }
+
+        expect(initialHtml).toContain('<title>dynamic title</title>')
+        expect(initialHtml).toContain('dynamic-fallback')
+        expect(initialHtml).not.toContain('dynamic-content')
+      } finally {
+        abortController.abort()
+        body?.destroy()
       }
-    )
+    })
   }
-})
+)

--- a/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
@@ -33,23 +33,65 @@ function countSubstring(str: string, substr: string): number {
       expect($('#dynamic-content').text()).toBe('dynamic content')
     })
 
-    it('should serve a fully buffered dynamic render to a default HTML-limited bot', async () => {
+    it('should block metadata while continuing to stream the body for a default HTML-limited bot', async () => {
+      const abortController = new AbortController()
+      let body:
+        | (AsyncIterable<Uint8Array> & {
+            destroy: () => void
+          })
+        | undefined
+
+      try {
+        const res = await next.fetch('/partial?stream=1', {
+          headers: {
+            'user-agent': 'Discordbot',
+          },
+          signal: abortController.signal,
+        })
+
+        expect(res.status).toBe(200)
+        if (!isNextDeploy) {
+          expect(res.headers.get('x-nextjs-postponed')).toBeNull()
+        }
+        expect(res.body).not.toBeNull()
+
+        body = res.body! as unknown as AsyncIterable<Uint8Array> & {
+          destroy: () => void
+        }
+        let initialHtml = ''
+
+        for await (const chunk of body) {
+          initialHtml += Buffer.from(chunk).toString()
+          if (initialHtml.includes('dynamic-fallback')) {
+            break
+          }
+        }
+
+        expect(initialHtml).toContain('<title>dynamic title</title>')
+        expect(initialHtml).toContain('dynamic-fallback')
+        expect(initialHtml).not.toContain('dynamic-content')
+      } finally {
+        abortController.abort()
+        body?.destroy()
+      }
+    })
+
+    it('should use the PPR shell with streamed metadata for a DOM-capable bot', async () => {
       const res = await next.fetch('/partial?stream=delay', {
         headers: {
-          'user-agent': 'Discordbot',
+          'user-agent': 'Googlebot',
         },
       })
 
       expect(res.status).toBe(200)
       if (!isNextDeploy) {
-        expect(res.headers.get('x-nextjs-postponed')).toBeNull()
+        expect(res.headers.get('x-nextjs-postponed')).toBe('1')
       }
 
       const $ = cheerio.load(await res.text())
-      expect($('head title').text()).toBe('dynamic title')
-      expect($('body title').length).toBe(0)
+      expect($('head title').length).toBe(0)
+      expect($('body title').text()).toBe('dynamic title')
       expect($('#dynamic-content').text()).toBe('dynamic content')
-      expect($('#dynamic-fallback').length).toBe(0)
     })
 
     describe('Cache Components metadata streaming', () => {

--- a/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-wildcard-bots.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-wildcard-bots.test.ts
@@ -14,44 +14,50 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
       },
     })
 
-    it('should block metadata while continuing to stream the body', async () => {
-      const abortController = new AbortController()
-      let body:
-        | (AsyncIterable<Uint8Array> & {
-            destroy: () => void
+    it.each(['MyBrowser', 'Googlebot'])(
+      'should block metadata while continuing to stream the body for %s',
+      async (userAgent) => {
+        const abortController = new AbortController()
+        let body:
+          | (AsyncIterable<Uint8Array> & {
+              destroy: () => void
+            })
+          | undefined
+
+        try {
+          const res = await next.fetch('/partial?stream=1', {
+            headers: {
+              'user-agent': userAgent,
+            },
+            signal: abortController.signal,
           })
-        | undefined
 
-      try {
-        const res = await next.fetch('/partial?stream=1', {
-          signal: abortController.signal,
-        })
-
-        expect(res.status).toBe(200)
-        if (!isNextDeploy) {
-          expect(res.headers.get('x-nextjs-postponed')).toBeNull()
-        }
-        expect(res.body).not.toBeNull()
-
-        body = res.body! as unknown as AsyncIterable<Uint8Array> & {
-          destroy: () => void
-        }
-        let initialHtml = ''
-
-        for await (const chunk of body) {
-          initialHtml += Buffer.from(chunk).toString()
-          if (initialHtml.includes('dynamic-fallback')) {
-            break
+          expect(res.status).toBe(200)
+          if (!isNextDeploy) {
+            expect(res.headers.get('x-nextjs-postponed')).toBeNull()
           }
-        }
+          expect(res.body).not.toBeNull()
 
-        expect(initialHtml).toContain('<title>dynamic title</title>')
-        expect(initialHtml).toContain('dynamic-fallback')
-        expect(initialHtml).not.toContain('dynamic-content')
-      } finally {
-        abortController.abort()
-        body?.destroy()
+          body = res.body! as unknown as AsyncIterable<Uint8Array> & {
+            destroy: () => void
+          }
+          let initialHtml = ''
+
+          for await (const chunk of body) {
+            initialHtml += Buffer.from(chunk).toString()
+            if (initialHtml.includes('dynamic-fallback')) {
+              break
+            }
+          }
+
+          expect(initialHtml).toContain('<title>dynamic title</title>')
+          expect(initialHtml).toContain('dynamic-fallback')
+          expect(initialHtml).not.toContain('dynamic-content')
+        } finally {
+          abortController.abort()
+          body?.destroy()
+        }
       }
-    })
+    )
   }
 )

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
@@ -14,6 +14,11 @@ describe('app-dir - metadata-streaming-config-customized', () => {
   })
 
   it('should have the customized streaming metadata config output in routes-manifest.json', async () => {
+    const requiredServerFiles = JSON.parse(
+      await next.readFile('.next/required-server-files.json')
+    )
+    expect(requiredServerFiles.config.htmlLimitedBots).toBe('MyBot')
+
     const prerenderManifest = JSON.parse(
       await next.readFile('.next/prerender-manifest.json')
     )


### PR DESCRIPTION
## Summary

DOM-capable crawlers can consume streamed metadata, but with cacheComponents enabled, it treated them like HTML-limited bots and forced a full dynamic render. This meant capable crawlers could not use the prerendered shell even when they were not matched by `htmlLimitedBots`.

This change lets DOM-capable crawlers follow the normal PPR shell and streaming-metadata path. `htmlLimitedBots` remains the source of truth for requests that need blocking metadata, including when a custom pattern explicitly matches a DOM-capable crawler.

## Test Plan
Tests were added that contained a Suspense boundary that intentionally never resolves. The test reads the response stream until it receives the fallback, then verifies that blocking metadata has already been emitted while the unresolved page content has not. A fully buffered response would never return, so this avoids relying on timing or arbitrary delays.

This PR is stacked on #96366.