### PR TITLE
fix: Route group layout leaks into root not-found page

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1088,8 +1088,8 @@ async fn directory_tree_to_loader_tree(
 ///   set.
 /// * `file_path` - The file path to the default page if neither the current module nor the parent
 ///   module is set.
-/// * `is_first_layer_group_route` - If true, the module will be overridden with the parent module
-///   if it is not set.
+/// * `is_first_layer_group_route` - If true and the module is not set, the module will be
+///   overridden with the parent module, but only when the parent module is the built-in default.
 async fn check_and_update_module_references(
     app_dir: FileSystemPath,
     module: &mut Option<FileSystemPath>,
@@ -1100,10 +1100,18 @@ async fn check_and_update_module_references(
     match (module.as_mut(), parent_module.as_mut()) {
         // If the module is set, update the parent module to the same value
         (Some(module), _) => *parent_module = Some(module.clone()),
-        // If we are in a first layer group route and we have a parent module, we want to override
-        // a nonexistent module with the parent module
+        // If we are in a first layer group route and we have a parent module, we only want to
+        // override a nonexistent module with the built-in default module. When the parent
+        // (i.e. the root) defines its own convention file, e.g. `app/not-found.js`, we must not
+        // duplicate that boundary inside the group route, otherwise `notFound()` thrown below the
+        // group route would render the root boundary nested in the group route's layout instead of
+        // bubbling up to the root layout. This mirrors the webpack implementation in
+        // `next-app-loader`.
         (None, Some(parent_module)) if is_first_layer_group_route => {
-            *module = Some(parent_module.clone())
+            let default_page = get_next_package(app_dir).await?.join(file_path)?;
+            if *parent_module == default_page {
+                *module = Some(default_page);
+            }
         }
         // If we are not in a first layer group route, and the module is not set, and the parent
         // module is set, we do nothing

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1078,7 +1078,8 @@ async fn directory_tree_to_loader_tree(
 
 /// Checks the current module if it needs to be updated with the default page.
 /// If the module is already set, update the parent module to the same value.
-/// If the parent module is set and module is not set, set the module to the parent module.
+/// If the module is not set and the parent module is set, only first layer group routes are
+/// updated, and only when the parent module is the built-in default page.
 /// If the module and the parent module are not set, set them to the default value.
 ///
 /// # Arguments

--- a/test/e2e/app-dir/forbidden/basic/app/(group)/group-dynamic/[id]/page.js
+++ b/test/e2e/app-dir/forbidden/basic/app/(group)/group-dynamic/[id]/page.js
@@ -1,0 +1,16 @@
+import { forbidden } from 'next/navigation'
+
+// avoid static generation to fill the dynamic params
+export const dynamic = 'force-dynamic'
+
+export default async function Page(props) {
+  const params = await props.params
+
+  const { id } = params
+
+  if (id === '403') {
+    forbidden()
+  }
+
+  return <p id="page">{`group-dynamic [id]`}</p>
+}

--- a/test/e2e/app-dir/forbidden/basic/app/(group)/layout.js
+++ b/test/e2e/app-dir/forbidden/basic/app/(group)/layout.js
@@ -1,0 +1,3 @@
+export default function GroupLayout({ children }) {
+  return <div id="group-layout">{children}</div>
+}

--- a/test/e2e/app-dir/forbidden/basic/forbidden-basic.test.ts
+++ b/test/e2e/app-dir/forbidden/basic/forbidden-basic.test.ts
@@ -38,4 +38,24 @@ describe('app dir - forbidden with customized boundary', () => {
       'Root Forbidden'
     )
   })
+
+  it('should escalate forbidden past a group route layout to render root forbidden', async () => {
+    const browserDynamicId = await next.browser('/group-dynamic/123')
+    expect(await browserDynamicId.elementByCss('#page').text()).toBe(
+      'group-dynamic [id]'
+    )
+    expect(
+      await browserDynamicId.hasElementByCssSelector('#group-layout')
+    ).toBe(true)
+
+    // no forbidden boundary in the group route, escalate to the root boundary
+    // instead of rendering it inside the group route's layout
+    const browserForbidden = await next.browser('/group-dynamic/403')
+    expect(
+      await browserForbidden.hasElementByCssSelector('#group-layout')
+    ).toBe(false)
+    expect(await browserForbidden.elementByCss('h1').text()).toBe(
+      'Root Forbidden'
+    )
+  })
 })

--- a/test/e2e/app-dir/forbidden/basic/forbidden-basic.test.ts
+++ b/test/e2e/app-dir/forbidden/basic/forbidden-basic.test.ts
@@ -51,11 +51,11 @@ describe('app dir - forbidden with customized boundary', () => {
     // no forbidden boundary in the group route, escalate to the root boundary
     // instead of rendering it inside the group route's layout
     const browserForbidden = await next.browser('/group-dynamic/403')
-    expect(
-      await browserForbidden.hasElementByCssSelector('#group-layout')
-    ).toBe(false)
     expect(await browserForbidden.elementByCss('h1').text()).toBe(
       'Root Forbidden'
     )
+    expect(
+      await browserForbidden.hasElementByCssSelector('#group-layout')
+    ).toBe(false)
   })
 })

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/group-dynamic/[id]/page.js
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/group-dynamic/[id]/page.js
@@ -11,7 +11,7 @@ export default async function Page(props) {
 
   return (
     <>
-      <p>{`group-dynamic [id]`}</p>
+      <p id="page">{`group-dynamic [id]`}</p>
       <Link href="/group-dynamic/404" id="to-404">
         to 404
       </Link>

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/group-dynamic/[id]/page.js
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/group-dynamic/[id]/page.js
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
@@ -8,5 +9,12 @@ export default async function Page(props) {
     notFound()
   }
 
-  return <p>{`group-dynamic [id]`}</p>
+  return (
+    <>
+      <p>{`group-dynamic [id]`}</p>
+      <Link href="/group-dynamic/404" id="to-404">
+        to 404
+      </Link>
+    </>
+  )
 }

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/layout.js
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/layout.js
@@ -1,0 +1,8 @@
+export default function GroupLayout({ children }) {
+  return (
+    <div id="group-layout">
+      <p>Group layout</p>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/layout.js
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/app/(group)/layout.js
@@ -1,8 +1,3 @@
 export default function GroupLayout({ children }) {
-  return (
-    <div id="group-layout">
-      <p>Group layout</p>
-      {children}
-    </div>
-  )
+  return <div id="group-layout">{children}</div>
 }

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('app dir - group routes with root not-found', () => {
   const { next, skipped } = nextTestSetup({
@@ -18,10 +19,28 @@ describe('app dir - group routes with root not-found', () => {
 
   it('should render root not found for group routes if hit 404', async () => {
     const browser = await next.browser('/group-dynamic/123')
-    expect(await browser.elementByCss('p').text()).toBe('group-dynamic [id]')
+    expect(await browser.elementByCss('p').text()).toBe('Group layout')
+    expect(await browser.elementByCss('#group-layout > p + p').text()).toBe(
+      'group-dynamic [id]'
+    )
 
     await browser.loadPage(next.url + '/group-dynamic/404')
+    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(false)
     expect(await browser.elementByCss('p').text()).toBe('Not found placeholder')
+    expect(await browser.elementByCss('h1').text()).toBe('Root layout')
+  })
+
+  it('should render root not found for group routes when soft navigating to a 404', async () => {
+    const browser = await next.browser('/group-dynamic/123')
+    await browser.elementByCss('#to-404').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe(
+        'Not found placeholder'
+      )
+    })
+
+    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(false)
     expect(await browser.elementByCss('h1').text()).toBe('Root layout')
   })
 })

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
@@ -19,19 +19,21 @@ describe('app dir - group routes with root not-found', () => {
 
   it('should render root not found for group routes if hit 404', async () => {
     const browser = await next.browser('/group-dynamic/123')
-    expect(await browser.elementByCss('p').text()).toBe('Group layout')
-    expect(await browser.elementByCss('#group-layout > p + p').text()).toBe(
+    expect(await browser.elementByCss('#page').text()).toBe(
       'group-dynamic [id]'
     )
+    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(true)
 
     await browser.loadPage(next.url + '/group-dynamic/404')
-    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(false)
     expect(await browser.elementByCss('p').text()).toBe('Not found placeholder')
     expect(await browser.elementByCss('h1').text()).toBe('Root layout')
+    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(false)
   })
 
   it('should render root not found for group routes when soft navigating to a 404', async () => {
     const browser = await next.browser('/group-dynamic/123')
+    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(true)
+
     await browser.elementByCss('#to-404').click()
 
     await retry(async () => {
@@ -40,7 +42,7 @@ describe('app dir - group routes with root not-found', () => {
       )
     })
 
-    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(false)
     expect(await browser.elementByCss('h1').text()).toBe('Root layout')
+    expect(await browser.hasElementByCssSelector('#group-layout')).toBe(false)
   })
 })

--- a/test/e2e/app-dir/unauthorized/basic/app/(group)/group-dynamic/[id]/page.js
+++ b/test/e2e/app-dir/unauthorized/basic/app/(group)/group-dynamic/[id]/page.js
@@ -1,0 +1,16 @@
+import { unauthorized } from 'next/navigation'
+
+// avoid static generation to fill the dynamic params
+export const dynamic = 'force-dynamic'
+
+export default async function Page(props) {
+  const params = await props.params
+
+  const { id } = params
+
+  if (id === '401') {
+    unauthorized()
+  }
+
+  return <p id="page">{`group-dynamic [id]`}</p>
+}

--- a/test/e2e/app-dir/unauthorized/basic/app/(group)/layout.js
+++ b/test/e2e/app-dir/unauthorized/basic/app/(group)/layout.js
@@ -1,0 +1,3 @@
+export default function GroupLayout({ children }) {
+  return <div id="group-layout">{children}</div>
+}

--- a/test/e2e/app-dir/unauthorized/basic/unauthorized-basic.test.ts
+++ b/test/e2e/app-dir/unauthorized/basic/unauthorized-basic.test.ts
@@ -51,11 +51,11 @@ describe('app dir - unauthorized - basic', () => {
     // no unauthorized boundary in the group route, escalate to the root boundary
     // instead of rendering it inside the group route's layout
     const browserUnauthorized = await next.browser('/group-dynamic/401')
-    expect(
-      await browserUnauthorized.hasElementByCssSelector('#group-layout')
-    ).toBe(false)
     expect(await browserUnauthorized.elementByCss('h1').text()).toBe(
       'Root Unauthorized'
     )
+    expect(
+      await browserUnauthorized.hasElementByCssSelector('#group-layout')
+    ).toBe(false)
   })
 })

--- a/test/e2e/app-dir/unauthorized/basic/unauthorized-basic.test.ts
+++ b/test/e2e/app-dir/unauthorized/basic/unauthorized-basic.test.ts
@@ -38,4 +38,24 @@ describe('app dir - unauthorized - basic', () => {
       'Root Unauthorized'
     )
   })
+
+  it('should escalate unauthorized past a group route layout to render root unauthorized', async () => {
+    const browserDynamicId = await next.browser('/group-dynamic/123')
+    expect(await browserDynamicId.elementByCss('#page').text()).toBe(
+      'group-dynamic [id]'
+    )
+    expect(
+      await browserDynamicId.hasElementByCssSelector('#group-layout')
+    ).toBe(true)
+
+    // no unauthorized boundary in the group route, escalate to the root boundary
+    // instead of rendering it inside the group route's layout
+    const browserUnauthorized = await next.browser('/group-dynamic/401')
+    expect(
+      await browserUnauthorized.hasElementByCssSelector('#group-layout')
+    ).toBe(false)
+    expect(await browserUnauthorized.elementByCss('h1').text()).toBe(
+      'Root Unauthorized'
+    )
+  })
 })


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/96361

Turbopack copied the root's `not-found.js` / `forbidden.js` / `unauthorized.js` into first-layer group routes, so an interrupt thrown below `app/(group)/` rendered the root boundary nested inside the group layout instead of bubbling up to the root layout. The parent module is now only propagated when it is the built-in default, matching `next-app-loader`. Webpack was already correct.
