### PR TITLE
[turbopack] Respect `sideEffects` in a `package.json` file with `optimizePackageImports`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -228,12 +228,6 @@ pub async fn get_side_effect_free_declaration(
     path: FileSystemPath,
     side_effect_free_packages: Option<Vc<Glob>>,
 ) -> Result<Vc<SideEffectsDeclaration>> {
-    if let Some(side_effect_free_packages) = side_effect_free_packages
-        && side_effect_free_packages.await?.matches(&path.path)
-    {
-        return Ok(SideEffectsDeclaration::SideEffectFree.cell());
-    }
-
     let find_package_json = find_context_file(path.parent(), package_json(), false).await?;
 
     if let FindContextFileResult::Found(package_json, _) = &*find_package_json {
@@ -259,6 +253,12 @@ pub async fn get_side_effect_free_declaration(
                 }
             }
         }
+    }
+
+    if let Some(side_effect_free_packages) = side_effect_free_packages
+        && side_effect_free_packages.await?.matches(&path.path)
+    {
+        return Ok(SideEffectsDeclaration::SideEffectFree.cell());
     }
 
     Ok(SideEffectsDeclaration::None.cell())

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -229,7 +229,8 @@ pub async fn get_side_effect_free_declaration(
     side_effect_free_packages: Option<Vc<Glob>>,
 ) -> Result<Vc<SideEffectsDeclaration>> {
     let find_package_json = find_context_file(path.parent(), package_json(), false).await?;
-
+    // Always respect the package.json over the global side_effect_free_packages by checking it
+    // first See #96333
     if let FindContextFileResult::Found(package_json, _) = &*find_package_json {
         match *side_effects_from_package_json(package_json.clone()).await? {
             SideEffectsValue::None => {}

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -26,7 +26,10 @@ use turbo_tasks_fs::{
 use turbo_unix_path::sys_to_unix;
 use turbopack::{
     ModuleAssetContext,
-    module_options::{EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions},
+    module_options::{
+        EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions,
+        side_effect_free_packages_glob,
+    },
 };
 use turbopack_core::{
     chunk::{ChunkingConfig, MangleType, MinifyType},
@@ -279,6 +282,10 @@ struct TestOptions {
     minify: bool,
     #[serde(default)]
     production_chunking: bool,
+    /// Packages that are assumed to be side effect free, unless they declare otherwise in their
+    /// package.json.
+    #[serde(default)]
+    side_effect_free_packages: Vec<RcStr>,
 }
 
 fn default_true() -> bool {
@@ -296,6 +303,7 @@ impl Default for TestOptions {
             cjs_tree_shaking: false,
             minify: false,
             production_chunking: false,
+            side_effect_free_packages: Vec::new(),
         }
     }
 }
@@ -423,6 +431,16 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
             .resolved_cell(),
     );
 
+    let side_effect_free_packages = if options.side_effect_free_packages.is_empty() {
+        None
+    } else {
+        Some(
+            side_effect_free_packages_glob(Vc::cell(options.side_effect_free_packages.clone()))
+                .to_resolved()
+                .await?,
+        )
+    };
+
     let mut fallback_import_map = ImportMap::empty();
     fallback_import_map.insert_exact_alias(
         rcstr!("fallback"),
@@ -452,11 +470,13 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
             environment: Some(env),
             follow_reexports: options.follow_reexports,
             module_fragments_enabled: options.module_fragments_enabled,
+            side_effect_free_packages,
             rules: vec![(
                 ContextCondition::InNodeModules,
                 ModuleOptionsContext {
                     follow_reexports: options.follow_reexports,
                     module_fragments_enabled: options.module_fragments_enabled,
+                    side_effect_free_packages,
                     ..Default::default()
                 }
                 .resolved_cell(),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/effect.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/effect.js
@@ -1,0 +1,1 @@
+export const effects = []

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/esm/other.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/esm/other.js
@@ -1,0 +1,3 @@
+import { effects } from '../effect.js'
+
+effects.push('other.js')

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/esm/sidecar.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/esm/sidecar.js
@@ -1,0 +1,3 @@
+import { effects } from '../effect.js'
+
+effects.push('sidecar.js')

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-glob/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": [
+    "**/sidecar.js"
+  ]
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-side-effectful/effect.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-side-effectful/effect.js
@@ -1,0 +1,1 @@
+export const effects = []

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-side-effectful/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-side-effectful/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-side-effectful/register.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-declared-side-effectful/register.js
@@ -1,0 +1,3 @@
+import { effects } from './effect.js'
+
+effects.push('register.js')

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-undeclared/effect.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-undeclared/effect.js
@@ -1,0 +1,1 @@
+export const effects = []

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-undeclared/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-undeclared/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "package-undeclared"
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-undeclared/register.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/node_modules/package-undeclared/register.js
@@ -1,0 +1,3 @@
+import { effects } from './effect.js'
+
+effects.push('register.js')

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/side-effect-free-packages/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/side-effect-free-packages/input/index.js
@@ -1,0 +1,22 @@
+// The packages are imported by relative path so that the module paths still land in
+// `node_modules`, which is what the `sideEffectFreePackages` glob matches on.
+import '../../node_modules/package-declared-glob/esm/sidecar.js'
+import '../../node_modules/package-declared-glob/esm/other.js'
+import '../../node_modules/package-declared-side-effectful/register.js'
+import '../../node_modules/package-undeclared/register.js'
+
+import { effects as declaredGlobEffects } from '../../node_modules/package-declared-glob/effect.js'
+import { effects as declaredSideEffectfulEffects } from '../../node_modules/package-declared-side-effectful/effect.js'
+import { effects as undeclaredEffects } from '../../node_modules/package-undeclared/effect.js'
+
+it('should keep modules matching the sideEffects glob of a package assumed to be side effect free', () => {
+  expect(declaredGlobEffects).toEqual(['sidecar.js'])
+})
+
+it('should keep modules of a package declaring sideEffects: true even when it is assumed to be side effect free', () => {
+  expect(declaredSideEffectfulEffects).toEqual(['register.js'])
+})
+
+it('should drop side effects of a package that declares no sideEffects', () => {
+  expect(undeclaredEffects).toEqual([])
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/side-effect-free-packages/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/side-effect-free-packages/options.json
@@ -1,0 +1,7 @@
+{
+  "sideEffectFreePackages": [
+    "package-declared-glob",
+    "package-declared-side-effectful",
+    "package-undeclared"
+  ]
+}


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/96333 by re-ordering the statements in `get_side_effect_free_declaration`. The rest of this PR is then a test + adding to a test fixture. This seems like a reasonable change to me as we'd match Webpack's behaviour.