### PR TITLE
fix: serialize prerender manifest updates in dev to prevent corruption

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -27,6 +27,7 @@ import fs from 'fs'
 import { Worker } from 'next/dist/compiled/jest-worker'
 import { installUseCacheProbe } from './use-cache-probe-pool'
 import { installDevValidationWorker } from './dev-validation-worker-pool'
+import { PrerenderManifestUpdater } from './prerender-manifest-updater'
 import { join as pathJoin } from 'path'
 import { PUBLIC_DIR_MIDDLEWARE_CONFLICT } from '../../lib/constants'
 import { findPagesDir } from '../../lib/find-pages-dir'
@@ -86,7 +87,6 @@ import {
   ensureInstrumentationRegistered,
   getInstrumentationModule,
 } from '../lib/router-utils/instrumentation-globals.external'
-import type { PrerenderManifest } from '../../build'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
@@ -143,6 +143,7 @@ export default class DevServer extends Server {
   private staticPathsCache: LRUCache<
     UnwrapPromise<ReturnType<DevServer['getStaticPaths']>>
   >
+  private readonly prerenderManifestUpdater: PrerenderManifestUpdater
   private startServerSpan: Span
   private readonly serverComponentsHmrCache:
     | ServerComponentsHmrCache
@@ -221,6 +222,10 @@ export default class DevServer extends Server {
         }
       )
     }
+
+    this.prerenderManifestUpdater = new PrerenderManifestUpdater(
+      pathJoin(this.distDir, PRERENDER_MANIFEST)
+    )
 
     installUseCacheProbe({
       distDir: this.distDir,
@@ -927,51 +932,46 @@ export default class DevServer extends Server {
         ) {
           // we write the static paths to partial manifest for
           // fallback handling inside of entry handler's
-          const rawExistingManifest = await fs.promises.readFile(
-            pathJoin(this.distDir, PRERENDER_MANIFEST),
-            'utf8'
-          )
-          const existingManifest: PrerenderManifest =
-            JSON.parse(rawExistingManifest)
-          for (const staticPath of value.staticPaths || []) {
-            existingManifest.routes[staticPath] = {} as any
-          }
+          //
+          // Several pages can resolve their static paths at the same time, and
+          // each one reads the whole manifest and writes it back. Those cycles
+          // go through the updater so they cannot interleave and corrupt the
+          // file.
+          const fallbackMode = res.value.fallbackMode
 
-          // Find the fallback route from the prerendered routes. This is
-          // the route whose pathname matches the page pattern (e.g.
-          // /dynamic-params/[slug]) and has fallback route params describing
-          // which params are unknown at build time.
-          const fallbackPrerenderedRoute = prerenderedRoutes?.find(
-            (route) => route.pathname === pathname
-          )
+          await this.prerenderManifestUpdater.update((existingManifest) => {
+            for (const staticPath of value.staticPaths || []) {
+              existingManifest.routes[staticPath] = {} as any
+            }
 
-          existingManifest.dynamicRoutes[pathname] = {
-            dataRoute: null,
-            dataRouteRegex: null,
-            fallback: fallbackModeToFallbackField(res.value.fallbackMode, page),
-            fallbackRevalidate: false,
-            fallbackExpire: undefined,
-            fallbackHeaders: undefined,
-            fallbackStatus: undefined,
-            fallbackRootParams: fallbackPrerenderedRoute?.fallbackRootParams,
-            fallbackRouteParams: fallbackPrerenderedRoute?.fallbackRouteParams,
-            fallbackSourceRoute: pathname,
-            prefetchDataRoute: undefined,
-            prefetchDataRouteRegex: undefined,
-            routeRegex: getRouteRegex(pathname).re.source,
-            experimentalPPR: undefined,
-            renderingMode: undefined,
-            allowHeader: [],
-          }
-
-          const updatedManifest = JSON.stringify(existingManifest)
-
-          if (updatedManifest !== rawExistingManifest) {
-            await fs.promises.writeFile(
-              pathJoin(this.distDir, PRERENDER_MANIFEST),
-              updatedManifest
+            // Find the fallback route from the prerendered routes. This is
+            // the route whose pathname matches the page pattern (e.g.
+            // /dynamic-params/[slug]) and has fallback route params describing
+            // which params are unknown at build time.
+            const fallbackPrerenderedRoute = prerenderedRoutes?.find(
+              (route) => route.pathname === pathname
             )
-          }
+
+            existingManifest.dynamicRoutes[pathname] = {
+              dataRoute: null,
+              dataRouteRegex: null,
+              fallback: fallbackModeToFallbackField(fallbackMode, page),
+              fallbackRevalidate: false,
+              fallbackExpire: undefined,
+              fallbackHeaders: undefined,
+              fallbackStatus: undefined,
+              fallbackRootParams: fallbackPrerenderedRoute?.fallbackRootParams,
+              fallbackRouteParams:
+                fallbackPrerenderedRoute?.fallbackRouteParams,
+              fallbackSourceRoute: pathname,
+              prefetchDataRoute: undefined,
+              prefetchDataRouteRegex: undefined,
+              routeRegex: getRouteRegex(pathname).re.source,
+              experimentalPPR: undefined,
+              renderingMode: undefined,
+              allowHeader: [],
+            }
+          })
         }
         this.staticPathsCache.set(pathname, value)
 

--- a/packages/next/src/server/dev/prerender-manifest-updater.test.ts
+++ b/packages/next/src/server/dev/prerender-manifest-updater.test.ts
@@ -1,0 +1,151 @@
+import type { PrerenderManifest, PrerenderManifestRoute } from '../../build'
+
+import fs from 'fs'
+import os from 'os'
+import { join } from 'path'
+
+import { PrerenderManifestUpdater } from './prerender-manifest-updater'
+
+const createManifest = (): PrerenderManifest => ({
+  version: 4,
+  routes: {},
+  dynamicRoutes: {},
+  notFoundRoutes: [],
+  preview: {
+    previewModeId: 'preview-mode-id',
+    previewModeEncryptionKey: 'a'.repeat(64),
+    previewModeSigningKey: 'b'.repeat(64),
+  },
+})
+
+// Matches what the dev server writes for a statically known path.
+const emptyRoute = () => ({}) as PrerenderManifestRoute
+
+describe('PrerenderManifestUpdater', () => {
+  let distDir: string
+  let manifestPath: string
+  let updater: PrerenderManifestUpdater
+
+  beforeEach(() => {
+    distDir = fs.mkdtempSync(join(os.tmpdir(), 'prerender-manifest-updater-'))
+    manifestPath = join(distDir, 'prerender-manifest.json')
+    fs.writeFileSync(manifestPath, JSON.stringify(createManifest()))
+    updater = new PrerenderManifestUpdater(manifestPath)
+  })
+
+  afterEach(() => {
+    fs.rmSync(distDir, { recursive: true, force: true })
+  })
+
+  const readManifest = (): PrerenderManifest =>
+    JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+  it('runs concurrent cycles one at a time, in call order', async () => {
+    const cycles = 25
+    const observed: number[] = []
+
+    await Promise.all(
+      Array.from({ length: cycles }, (_, i) =>
+        updater.update((manifest) => {
+          // Each cycle reads what the previous one wrote, so the number of
+          // routes it observes is its own position in the queue.
+          observed.push(Object.keys(manifest.routes).length)
+          manifest.routes[`/route-${i}`] = emptyRoute()
+        })
+      )
+    )
+
+    expect(observed).toEqual(Array.from({ length: cycles }, (_, i) => i))
+
+    // No update is lost: every cycle's route survives.
+    expect(Object.keys(readManifest().routes)).toHaveLength(cycles)
+  })
+
+  it('never exposes a partially written manifest to a reader', async () => {
+    // In dev this manifest is re-read on route module loads rather than cached,
+    // so a non-atomic write lets a reader land mid-write and parse truncated
+    // JSON. A large payload widens that window.
+    const routesPerCycle = 500
+    const readErrors: unknown[] = []
+    const observedRouteCounts: number[] = []
+
+    let reading = true
+    const reader = (async () => {
+      while (reading) {
+        try {
+          const manifest: PrerenderManifest = JSON.parse(
+            fs.readFileSync(manifestPath, 'utf8')
+          )
+          observedRouteCounts.push(Object.keys(manifest.routes).length)
+        } catch (err) {
+          readErrors.push(err)
+        }
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+    })()
+
+    await Promise.all(
+      Array.from({ length: 10 }, (_, cycle) =>
+        updater.update((manifest) => {
+          for (let i = 0; i < routesPerCycle; i++) {
+            manifest.routes[`/cycle-${cycle}/route-${i}`] = emptyRoute()
+          }
+        })
+      )
+    )
+
+    reading = false
+    await reader
+
+    expect(readErrors).toEqual([])
+
+    // A reader also never observes a manifest that went backwards, which is
+    // what a lost update would look like from the outside.
+    expect(observedRouteCounts).toEqual(
+      [...observedRouteCounts].sort((a, b) => a - b)
+    )
+  })
+
+  it('surfaces a failed cycle without poisoning the queue', async () => {
+    const failure = new Error('mutate failed')
+
+    await expect(
+      updater.update(() => {
+        throw failure
+      })
+    ).rejects.toBe(failure)
+
+    await updater.update((manifest) => {
+      manifest.routes['/after-failure'] = emptyRoute()
+    })
+
+    expect(Object.keys(readManifest().routes)).toEqual(['/after-failure'])
+  })
+
+  it('skips the write when the manifest is unchanged', async () => {
+    const writeFile = jest.spyOn(fs.promises, 'writeFile')
+
+    await updater.update(() => {})
+
+    expect(writeFile).not.toHaveBeenCalled()
+
+    writeFile.mockRestore()
+  })
+
+  it('removes the temporary file when the write fails', async () => {
+    const failure = new Error('rename failed')
+    const rename = jest
+      .spyOn(fs.promises, 'rename')
+      .mockRejectedValue(failure as never)
+
+    await expect(
+      updater.update((manifest) => {
+        manifest.routes['/route'] = emptyRoute()
+      })
+    ).rejects.toBe(failure)
+
+    rename.mockRestore()
+
+    expect(fs.readdirSync(distDir)).toEqual(['prerender-manifest.json'])
+  })
+})

--- a/packages/next/src/server/dev/prerender-manifest-updater.ts
+++ b/packages/next/src/server/dev/prerender-manifest-updater.ts
@@ -1,0 +1,66 @@
+import type { PrerenderManifest } from '../../build'
+
+import fs from 'fs'
+
+/**
+ * Serializes read-modify-write cycles against the dev prerender manifest.
+ *
+ * `getStaticPaths` can resolve for several pages at the same time, and every
+ * resolution reads the whole manifest, adds its own routes and writes the whole
+ * file back. Left unsynchronized, those cycles interleave and corrupt the file:
+ * both writes open it with `'w'` and write from offset 0, so a shorter payload
+ * finishing last only overwrites a prefix of a longer one and leaves its tail
+ * behind, leaving valid JSON followed by garbage. Interleaving also loses
+ * updates, because the later cycle read the file before the earlier one wrote
+ * it.
+ *
+ * Writes go through a temporary file and `rename` so a reader can never observe
+ * a partially written manifest. That matters in dev specifically:
+ * `route-modules/route-module.ts` loads this manifest with
+ * `shouldCache: !this.isDev`, so it is re-read and re-parsed on route module
+ * loads rather than cached.
+ */
+export class PrerenderManifestUpdater {
+  private queue: Promise<void> = Promise.resolve()
+
+  constructor(private readonly manifestPath: string) {}
+
+  /**
+   * Applies `mutate` to the current on-disk manifest and persists the result.
+   *
+   * Cycles run one at a time in call order. The returned promise rejects if
+   * this cycle failed, and a failed cycle does not prevent later ones from
+   * running.
+   */
+  public update(mutate: (manifest: PrerenderManifest) => void): Promise<void> {
+    const cycle = this.queue.then(() => this.readModifyWrite(mutate))
+
+    // Keep the queue usable when a cycle fails, while still surfacing the
+    // failure to the caller.
+    this.queue = cycle.catch(() => {})
+
+    return cycle
+  }
+
+  private async readModifyWrite(
+    mutate: (manifest: PrerenderManifest) => void
+  ): Promise<void> {
+    const raw = await fs.promises.readFile(this.manifestPath, 'utf8')
+    const manifest: PrerenderManifest = JSON.parse(raw)
+
+    mutate(manifest)
+
+    const updated = JSON.stringify(manifest)
+    if (updated === raw) return
+
+    const tmpPath = `${this.manifestPath}.${process.pid}.tmp`
+
+    try {
+      await fs.promises.writeFile(tmpPath, updated)
+      await fs.promises.rename(tmpPath, this.manifestPath)
+    } catch (err) {
+      await fs.promises.unlink(tmpPath).catch(() => {})
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
### What

`getStaticPaths` in the dev server performs an unsynchronized read-modify-write on `.next/dev/prerender-manifest.json`:

```ts
const rawExistingManifest = await fs.promises.readFile(manifestPath, 'utf8')
const existingManifest: PrerenderManifest = JSON.parse(rawExistingManifest)
// ...mutate routes / dynamicRoutes...
if (updatedManifest !== rawExistingManifest) {
  await fs.promises.writeFile(manifestPath, updatedManifest)
}
```

When two pages under the same dynamic segment resolve their static paths at the same time, the cycles interleave. Both `writeFile` calls open with `'w'` and write from offset 0, so a shorter payload finishing last only overwrites a prefix of a longer one and leaves its tail behind — the file becomes valid JSON followed by garbage. A reader landing mid-write sees a truncated document instead. Interleaving also loses updates, since the later cycle read the file before the earlier one wrote it.

A `generateStaticParams` on a root layout (the standard i18n `app/[locale]` setup) amplifies it: every page under the segment runs its own cycle on first compile, so collision probability grows with page count.

**Why one corrupt file takes down the whole dev server.** The two read paths behave differently, and the correction here is [@zoujimmy82-boop's](https://github.com/vercel/next.js/issues/96259#issuecomment-5128644737) — the original issue text attributed this to `base-server.ts` reading the manifest per request, which is not accurate:

- `next-server.ts` memoizes into `_cachedPreviewManifest`, and the dev server does not override it — so normally this reads from disk once per process. But the assignment happens *after* `loadManifest` returns, so while the file is corrupt the cache never gets populated and every request re-reads the bad file and re-throws. That is why the symptom is "every subsequent request 500s" rather than one bad request, and why a later, longer write silently heals it.
- `route-modules/route-module.ts` loads the same manifest with `shouldCache: !this.isDev`, so in dev it is re-read and re-parsed on route module loads rather than cached. That is what keeps the read window wide enough to collide with the unsynchronized write in the first place.

Either way the `SyntaxError` surfaces on routes unrelated to the pages that raced, which makes it very hard to trace back.

### How

- Add `PrerenderManifestUpdater`, which routes the read-modify-write through a promise queue so cycles cannot interleave. A failed cycle is surfaced to the caller but does not poison the queue.
- Write via a temporary file and `rename`, so a concurrent reader can never observe a partially written manifest.

The queue also removes lost updates, which the atomic write alone would not fix.

### Tests

`prerender-manifest-updater.test.ts` covers this without depending on `next dev` compile timing, so it is not flaky:

- **`runs concurrent cycles one at a time, in call order`** — 25 concurrent cycles each record how many routes they observed. Serialized, that sequence is exactly `[0, 1, ..., 24]`, and all 25 routes survive. Against the current implementation this fails deterministically: every cycle observes `0` and only one route survives.
- **`never exposes a partially written manifest to a reader`** — a reader parses the file in a loop while ten large cycles run. Against the current implementation this reproduces the exact reported failure, `SyntaxError: Unexpected end of JSON input`. It also asserts the observed route count never goes backwards, which is what a lost update looks like from the outside.
- Three smaller cases: a failed cycle rejects without poisoning the queue, an unchanged manifest is not rewritten, and the temporary file is cleaned up when the write fails.

### Reproduction

https://github.com/LouisTsang-jk/nextjs-prerender-manifest-race

`./repro.sh` starts the dev server and requests 10 `[locale]` pages concurrently:

```
==> .next/dev/prerender-manifest.json
    CORRUPT: Unexpected end of JSON input
==> GET /api/ping
    HTTP 500
⨯ SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>) { page: '/en/page-9' }
```

Independently confirmed on `16.2.10` in [this comment](https://github.com/vercel/next.js/issues/96259#issuecomment-5128644737), where it presented as a Playwright suite failing roughly 1 run in 3 on a test unrelated to the pages that raced.

### Notes

This replaces #96260, which I closed myself shortly after opening because the branch was based wrong — the diff showed 30k files. The change itself was never reviewed. This one is based on `canary` and touches three files.

Fixes #96259

<!-- NEXT_JS_LLM -->
