### PR TITLE
Fallback to worker threads when loopback binding is denied

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,3 +1,5 @@
+#[cfg(any(all(feature = "process_pool", feature = "worker_pool"), test))]
+use std::future::Future;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -925,6 +927,45 @@ pub enum TurbopackPluginRuntimeStrategy {
     WorkerThreads,
     #[cfg(feature = "process_pool")]
     ChildProcesses,
+}
+
+#[cfg(any(all(feature = "process_pool", feature = "worker_pool"), test))]
+#[derive(Debug)]
+enum DefaultTurbopackPluginRuntimeStrategy {
+    ChildProcesses,
+    WorkerThreads,
+}
+
+#[cfg(any(all(feature = "process_pool", feature = "worker_pool"), test))]
+#[derive(Debug)]
+enum ResolvedTurbopackPluginRuntimeStrategy {
+    Configured(TurbopackPluginRuntimeStrategy),
+    Default(DefaultTurbopackPluginRuntimeStrategy),
+}
+
+#[cfg(any(all(feature = "process_pool", feature = "worker_pool"), test))]
+async fn resolve_turbopack_plugin_runtime_strategy<F, Fut>(
+    configured: Option<TurbopackPluginRuntimeStrategy>,
+    probe_loopback_listener: F,
+) -> ResolvedTurbopackPluginRuntimeStrategy
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = std::io::Result<()>>,
+{
+    if let Some(strategy) = configured {
+        return ResolvedTurbopackPluginRuntimeStrategy::Configured(strategy);
+    }
+
+    match probe_loopback_listener().await {
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            ResolvedTurbopackPluginRuntimeStrategy::Default(
+                DefaultTurbopackPluginRuntimeStrategy::WorkerThreads,
+            )
+        }
+        Ok(()) | Err(_) => ResolvedTurbopackPluginRuntimeStrategy::Default(
+            DefaultTurbopackPluginRuntimeStrategy::ChildProcesses,
+        ),
+    }
 }
 
 #[derive(
@@ -2474,17 +2515,31 @@ impl NextConfig {
         )
     }
 
-    #[turbo_tasks::function]
-    pub fn turbopack_plugin_runtime_strategy(&self) -> Vc<TurbopackPluginRuntimeStrategy> {
-        #[cfg(feature = "process_pool")]
-        let default = TurbopackPluginRuntimeStrategy::ChildProcesses;
-        #[cfg(all(feature = "worker_pool", not(feature = "process_pool")))]
-        let default = TurbopackPluginRuntimeStrategy::WorkerThreads;
+    #[turbo_tasks::function(network, session_dependent)]
+    pub async fn turbopack_plugin_runtime_strategy(&self) -> Vc<TurbopackPluginRuntimeStrategy> {
+        let configured = self.experimental.turbopack_plugin_runtime_strategy;
 
-        self.experimental
-            .turbopack_plugin_runtime_strategy
-            .unwrap_or(default)
-            .cell()
+        #[cfg(all(feature = "process_pool", feature = "worker_pool"))]
+        let strategy = match resolve_turbopack_plugin_runtime_strategy(
+            configured,
+            turbopack_node::process_pool::probe_loopback_listener,
+        )
+        .await
+        {
+            ResolvedTurbopackPluginRuntimeStrategy::Configured(strategy) => strategy,
+            ResolvedTurbopackPluginRuntimeStrategy::Default(
+                DefaultTurbopackPluginRuntimeStrategy::ChildProcesses,
+            ) => TurbopackPluginRuntimeStrategy::ChildProcesses,
+            ResolvedTurbopackPluginRuntimeStrategy::Default(
+                DefaultTurbopackPluginRuntimeStrategy::WorkerThreads,
+            ) => TurbopackPluginRuntimeStrategy::WorkerThreads,
+        };
+        #[cfg(all(feature = "process_pool", not(feature = "worker_pool")))]
+        let strategy = configured.unwrap_or(TurbopackPluginRuntimeStrategy::ChildProcesses);
+        #[cfg(all(feature = "worker_pool", not(feature = "process_pool")))]
+        let strategy = configured.unwrap_or(TurbopackPluginRuntimeStrategy::WorkerThreads);
+
+        strategy.cell()
     }
 
     #[turbo_tasks::function]
@@ -2860,7 +2915,72 @@ pub fn lightningcss_feature_names_to_mask(
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
+
+    #[tokio::test]
+    async fn defaults_to_child_processes_when_loopback_binding_is_allowed() {
+        let strategy = resolve_turbopack_plugin_runtime_strategy(None, || async { Ok(()) }).await;
+
+        assert!(matches!(
+            strategy,
+            ResolvedTurbopackPluginRuntimeStrategy::Default(
+                DefaultTurbopackPluginRuntimeStrategy::ChildProcesses
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn defaults_to_worker_threads_when_loopback_binding_is_denied() {
+        let strategy = resolve_turbopack_plugin_runtime_strategy(None, || async {
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        })
+        .await;
+
+        assert!(matches!(
+            strategy,
+            ResolvedTurbopackPluginRuntimeStrategy::Default(
+                DefaultTurbopackPluginRuntimeStrategy::WorkerThreads
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn explicit_plugin_runtime_strategy_skips_the_loopback_probe() {
+        let probed = Cell::new(false);
+        let strategy = resolve_turbopack_plugin_runtime_strategy(
+            Some(TurbopackPluginRuntimeStrategy::ChildProcesses),
+            || {
+                probed.set(true);
+                async { Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)) }
+            },
+        )
+        .await;
+
+        assert!(!probed.get());
+        assert!(matches!(
+            strategy,
+            ResolvedTurbopackPluginRuntimeStrategy::Configured(
+                TurbopackPluginRuntimeStrategy::ChildProcesses
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn keeps_the_child_process_default_for_unexpected_probe_errors() {
+        let strategy = resolve_turbopack_plugin_runtime_strategy(None, || async {
+            Err(std::io::Error::from(std::io::ErrorKind::AddrNotAvailable))
+        })
+        .await;
+
+        assert!(matches!(
+            strategy,
+            ResolvedTurbopackPluginRuntimeStrategy::Default(
+                DefaultTurbopackPluginRuntimeStrategy::ChildProcesses
+            )
+        ));
+    }
 
     #[test]
     fn test_serde_rule_config_item_options() {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -739,8 +739,9 @@ export interface ExperimentalConfig {
    * Selects the backend used by Turbopack for Node.js evaluation, e.g. webpack
    * loaders, Babel, or PostCSS.
    *
-   * This defaults to `'childProcesses'`, which creates a pool of child node.js
-   * processes and communciates with them over sockets.
+   * By default, Next.js creates a pool of child Node.js processes and
+   * communicates with them over loopback sockets. If the environment denies
+   * local socket binding, Next.js falls back to worker threads.
    *
    * `'workerThreads'` runs the same work in worker threads instead, which should
    * use less memory and CPU. It may become the default in a future version of
@@ -2234,7 +2235,7 @@ export const defaultConfig = Object.freeze({
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: turbopackFileSystemCacheForBuildDefault(),
     turbopackInferModuleSideEffects: true,
-    turbopackPluginRuntimeStrategy: 'childProcesses',
+    turbopackPluginRuntimeStrategy: undefined,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -73,6 +73,30 @@ describe('loadConfig', () => {
     })
   })
 
+  describe('turbopack plugin runtime strategy', () => {
+    it('leaves the default strategy unresolved', async () => {
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {},
+      })
+
+      expect(result.experimental.turbopackPluginRuntimeStrategy).toBeUndefined()
+    })
+
+    it('preserves an explicitly configured strategy', async () => {
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {
+          experimental: {
+            turbopackPluginRuntimeStrategy: 'childProcesses',
+          },
+        },
+      })
+
+      expect(result.experimental.turbopackPluginRuntimeStrategy).toBe(
+        'childProcesses'
+      )
+    })
+  })
+
   describe('canary-only features', () => {
     beforeAll(() => {
       process.env.__NEXT_VERSION = '14.2.0'

--- a/turbopack/crates/turbopack-node/src/process_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/process_pool/mod.rs
@@ -85,6 +85,20 @@ impl PartialEq for NodeJsPoolProcess {
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
+async fn bind_loopback_listener() -> std::io::Result<TcpListener> {
+    TcpListener::bind("127.0.0.1:0").await
+}
+
+/// Checks whether the child-process pool can create its loopback IPC listener.
+///
+/// The listener is closed immediately. This uses the same bind operation as
+/// child-process startup so callers can select another backend before emitting
+/// backend-specific runtime code.
+pub async fn probe_loopback_listener() -> std::io::Result<()> {
+    drop(bind_loopback_listener().await?);
+    Ok(())
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct OutputEntry {
     data: Arc<[u8]>,
@@ -312,7 +326,7 @@ impl NodeJsPoolProcess {
         debug: bool,
     ) -> Result<Self> {
         let guard = duration_span!("Node.js process startup");
-        let listener = TcpListener::bind("127.0.0.1:0")
+        let listener = bind_loopback_listener()
             .await
             .context("binding to a port")?;
         let port = listener.local_addr().context("getting port")?.port();


### PR DESCRIPTION
## What?

When the default Turbopack Node.js plugin runtime cannot bind its
`127.0.0.1:0` IPC listener because a sandbox returns `PermissionDenied`, select
worker threads before backend-specific runtime code is emitted.

Explicit `turbopackPluginRuntimeStrategy` choices remain strict. Other probe
errors preserve the child-process default and its existing lazy startup
behavior. The capability probe is session-dependent so a persistent Turbo
Tasks cache cannot carry a backend decision into a differently sandboxed
session.

## Why?

The default Codex CLI macOS Seatbelt profile denies local socket binding.
Production builds that exercise PostCSS or webpack loaders therefore fail
after child-process startup retries with `binding to a port` / `EPERM`, while
webpack and Turbopack's worker-thread backend succeed.

This is the underlying compatibility issue reported in
https://github.com/openai/codex/issues/18895.

## Verification

- `cargo test -p next-core --lib loopback`
- `cargo test -p next-core --lib keeps_the_child_process_default_for_unexpected_probe_errors`
- `cargo check -p next-core`
- `cargo check -p next-core --features worker_pool`
- `cargo check -p next-core --no-default-features --features worker_pool`
- `pnpm exec jest packages/next/src/server/config.test.ts --runInBand`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/turbopack-node-backend/turbopack-node-backend.test.ts`
- `CI=1 pnpm build-all`
- Direct Codex Seatbelt control: a fresh local-canary Turbopack production
  build completed, and the loader PID matched the build PID, confirming the
  automatic worker-thread fallback.
- Warm-cache control: an unsandboxed build populated the filesystem cache with
  different build/loader PIDs (child process); restoring that same cache under
  Codex Seatbelt completed with matching PIDs (worker thread), confirming the
  capability probe re-ran for the new session.

<!-- NEXT_JS_LLM -->
