### PR TITLE
Remove obsolete shouldWaitOnAllReady render option

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -870,7 +870,6 @@ export function createAppPageEntrypoint({
             page: srcPage,
             postponed,
             allowEmptyStaticShell,
-            shouldWaitOnAllReady: false,
             serveStreamingMetadata,
             supportsDynamicResponse:
               typeof postponed === 'string' || supportsDynamicResponse,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -130,7 +130,6 @@ async function requestHandler(
       params,
       page: srcPage,
       postponed: undefined,
-      shouldWaitOnAllReady: false,
       serveStreamingMetadata: true,
       supportsDynamicResponse: true,
       buildManifest,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3290,7 +3290,6 @@ async function renderToStream(
     page,
     reactMaxHeadersLength,
     setReactDebugChannel,
-    shouldWaitOnAllReady,
     subresourceIntegrityManifest,
     supportsDynamicResponse,
     cacheComponents,
@@ -3887,8 +3886,7 @@ async function renderToStream(
           tracingMetadata: tracingMetadata,
         })
 
-        const generateStaticHTML =
-          supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+        const generateStaticHTML = supportsDynamicResponse !== true
 
         const appElement = (
           <App
@@ -4031,8 +4029,7 @@ async function renderToStream(
           tracingMetadata: tracingMetadata,
         })
 
-        const generateStaticHTML =
-          supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+        const generateStaticHTML = supportsDynamicResponse !== true
 
         const appElement = (
           <App
@@ -4209,8 +4206,7 @@ async function renderToStream(
         }
 
         try {
-          const generateStaticHTML =
-            supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+          const generateStaticHTML = supportsDynamicResponse !== true
 
           const { stream: errorHtmlStream, allReady: errorAllReady } =
             await workUnitAsyncStorage.run(
@@ -4308,8 +4304,7 @@ async function renderToStream(
         }
 
         try {
-          const generateStaticHTML =
-            supportsDynamicResponse !== true || !!shouldWaitOnAllReady
+          const generateStaticHTML = supportsDynamicResponse !== true
 
           const { stream: errorHtmlStream, allReady: errorAllReady } =
             await workUnitAsyncStorage.run(

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -188,12 +188,6 @@ export interface RenderOptsPartial {
   postponed?: string
 
   /**
-   * Should wait for react stream allReady to resolve all suspense boundaries,
-   * in order to perform a full page render.
-   */
-  shouldWaitOnAllReady?: boolean
-
-  /**
    * A prefilled resume data cache. This was either generated for this page
    * during dev warmup, or when a page with defined params was previously
    * prerendered, and now its matching optional fallback shell is prerendered.

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -65,7 +65,6 @@ export type WorkStoreContext = {
     RenderOpts,
     | 'assetPrefix'
     | 'supportsDynamicResponse'
-    | 'shouldWaitOnAllReady'
     | 'isBuildTimePrerendering'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
@@ -115,7 +114,6 @@ export function createWorkStore({
    * coalescing, and ISR continue working as intended.
    */
   const isStaticGeneration =
-    !renderOpts.shouldWaitOnAllReady &&
     !renderOpts.supportsDynamicResponse &&
     !renderOpts.isDraftMode &&
     !renderOpts.isPossibleServerAction


### PR DESCRIPTION
## Summary

`shouldWaitOnAllReady` previously allowed an otherwise dynamic App Router render to wait for every Suspense boundary before sending the response. After [#96367](https://github.com/vercel/next.js/pull/96367), no caller enables this behavior anymore.

This removes the unused option and makes `supportsDynamicResponse` the sole signal for whether App Router generates static HTML. Static generation still waits for `allReady`, while dynamic responses continue streaming.

<!-- NEXT_JS_LLM -->