### PR TITLE
fix: throw when generateStaticParams returns incomplete params with output: export

### DIFF
--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -1,0 +1,23 @@
+---
+title: 'Invalid `generateStaticParams` Value'
+---
+
+## Why This Error Occurred
+
+Your `generateStaticParams` function returned a value that is not an array. Next.js expects an array containing one params object for each route to generate.
+
+## Possible Ways to Fix It
+
+Return an array from `generateStaticParams`:
+
+```tsx filename="app/blog/[slug]/page.tsx"
+export function generateStaticParams() {
+  return [{ slug: 'first-post' }, { slug: 'second-post' }]
+}
+```
+
+See the [`generateStaticParams` return value documentation](/docs/app/api-reference/functions/generate-static-params#returns) for the expected shape.
+
+## Useful Links
+
+- [`generateStaticParams` documentation](/docs/app/api-reference/functions/generate-static-params)

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Invalid `generateStaticParams` Value'
+title: '`generateStaticParams` Error'
 ---
 
 ## Why This Error Occurred
@@ -23,6 +23,16 @@ export function generateStaticParams() {
 
 See the [`generateStaticParams` return value documentation](/docs/app/api-reference/functions/generate-static-params#returns) for the expected shape.
 
+## Using `output: 'export'`
+
+When your application uses `output: 'export'`, every [Dynamic Route](/docs/app/api-reference/file-conventions/dynamic-routes), such as `app/blog/[slug]/page.tsx`, must be rendered at build time.
+
+This error also occurs when a dynamic route does not export a `generateStaticParams` function.
+
+Export `generateStaticParams` from every dynamic route. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
+
 ## Useful Links
 
 - [`generateStaticParams` documentation](/docs/app/api-reference/functions/generate-static-params)
+- [Static Exports documentation](/docs/app/guides/static-exports)
+- [Dynamic Routes documentation](/docs/app/api-reference/file-conventions/dynamic-routes)

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -27,9 +27,12 @@ See the [`generateStaticParams` return value documentation](/docs/app/api-refere
 
 When your application uses `output: 'export'`, every [Dynamic Route](/docs/app/api-reference/file-conventions/dynamic-routes), such as `app/blog/[slug]/page.tsx`, must be rendered at build time.
 
-This error also occurs when a dynamic route does not export a `generateStaticParams` function.
+This error also occurs when a dynamic route:
 
-Export `generateStaticParams` from every dynamic route. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
+- does not export a `generateStaticParams` function, or
+- returns an empty array from `generateStaticParams`.
+
+Export `generateStaticParams` from every dynamic route and return at least one params object. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
 
 ## Useful Links
 

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -29,10 +29,13 @@ When your application uses `output: 'export'`, every [Dynamic Route](/docs/app/a
 
 This error also occurs when a dynamic route:
 
-- does not export a `generateStaticParams` function, or
-- returns an empty array from `generateStaticParams`.
+- does not export a `generateStaticParams` function,
+- returns an empty array from `generateStaticParams`, or
+- generates a route without every dynamic route parameter. For example, `{ slug: 'first' }` does not provide the `id` value for a route using an `[id]` segment.
 
-Export `generateStaticParams` from every dynamic route and return at least one params object. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
+When multiple route segments export `generateStaticParams`, Next.js combines the params returned by each parent and child function before generating routes.
+
+Export `generateStaticParams` from every dynamic route and make sure the combined params include all dynamic route parameters for every generated route. If the paths cannot be known at build time, remove `output: 'export'` from your Next.js configuration.
 
 ## Useful Links
 

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -4,11 +4,16 @@ title: 'Invalid `generateStaticParams` Value'
 
 ## Why This Error Occurred
 
-Your `generateStaticParams` function returned a value that is not an array. Next.js expects an array containing one params object for each route to generate.
+Next.js expects `generateStaticParams` to return an array containing one params object for each route to generate.
+
+This error occurs when:
+
+- `generateStaticParams` returns a value that is not an array, or
+- an item in the returned array is not an object. This includes `null`, arrays, primitive values, and `undefined`.
 
 ## Possible Ways to Fix It
 
-Return an array from `generateStaticParams`:
+Return an array of params objects from `generateStaticParams`:
 
 ```tsx filename="app/blog/[slug]/page.tsx"
 export function generateStaticParams() {

--- a/errors/generate-static-params.mdx
+++ b/errors/generate-static-params.mdx
@@ -9,7 +9,7 @@ Next.js expects `generateStaticParams` to return an array containing one params 
 This error occurs when:
 
 - `generateStaticParams` returns a value that is not an array, or
-- an item in the returned array is not an object. This includes `null`, arrays, primitive values, and `undefined`.
+- an item in the returned array is not a plain object. This includes `null`, arrays, primitive values, and `undefined`.
 
 ## Possible Ways to Fix It
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1451,5 +1451,6 @@
   "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1452,5 +1452,6 @@
   "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
   "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1454": "Page \"%s\" returned an empty array from \"generateStaticParams()\". With \"output: export\", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1455": "Page \"%s\" returned incomplete params from \"generateStaticParams()\". With \"output: export\", every params object must include all dynamic route parameters. Missing: %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1448,5 +1448,6 @@
   "1447": "Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.",
   "1448": "Error in the \"%s\" app-route HMR subscription",
   "1449": "Accessed `searchParams` during prerendering.",
-  "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1447,5 +1447,6 @@
   "1446": "Missing initURL",
   "1447": "Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.",
   "1448": "Error in the \"%s\" app-route HMR subscription",
-  "1449": "Accessed `searchParams` during prerendering."
+  "1449": "Accessed `searchParams` during prerendering.",
+  "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1449,5 +1449,7 @@
   "1448": "Error in the \"%s\" app-route HMR subscription",
   "1449": "Accessed `searchParams` during prerendering.",
   "1450": "Invalid value returned from generateStaticParams for \"%s\". Expected an array, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
-  "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params"
+  "1451": "Invalid value at index %s returned from generateStaticParams for \"%s\". Expected an object, but received type %s. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1452": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params",
+  "1453": "Page \"%s\" is missing exported function \"generateStaticParams()\", which is required with \"output: export\" config. See more info here: https://nextjs.org/docs/messages/generate-static-params"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2439,7 +2439,7 @@ export default async function build(
                               !hasGenerateStaticParams
                             ) {
                               throw new Error(
-                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                                `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params`
                               )
                             }
 

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -1299,6 +1299,59 @@ describe('generateRouteStaticParams', () => {
       ).rejects.toThrow('Async error')
     })
 
+    it('should reject a non-array object return value', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => ({ id: '1' }) as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject a null return value', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => null as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject an undefined return value', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => undefined as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject a non-array return value from a nested generateStaticParams', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ category: 'tech' }]),
+        createMockSegment(async () => undefined as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
     it('should handle partially failing generateStaticParams', async () => {
       const segments: TestAppSegment[] = [
         createMockSegment(async () => [{ category: 'tech' }]),

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -965,7 +965,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -981,7 +982,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -996,7 +998,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ id: '1' }, { id: '2' }])
     })
@@ -1018,7 +1021,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { category: 'tech', slug: 'tech-post-1' },
@@ -1043,7 +1047,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
@@ -1065,7 +1070,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en', slug: 'en-slug' }])
     })
@@ -1080,7 +1086,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -1096,7 +1103,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en' }])
     })
@@ -1114,7 +1122,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
@@ -1136,7 +1145,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(store.fetchCache).toBe('force-cache')
     })
@@ -1151,7 +1161,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(store.fetchCache).toBe('force-cache')
     })
@@ -1171,7 +1182,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       // Should have the last fetchCache value
       expect(store.fetchCache).toBe('default-cache')
@@ -1192,7 +1204,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ slug: ['a', 'b'] }, { slug: ['c', 'd', 'e'] }])
     })
@@ -1210,7 +1223,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en', slug: ['en', 'post'] }])
     })
@@ -1230,7 +1244,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ a: '1', b: '1-2', c: '1-2-3', d: '1-2-3-4' }])
     })
@@ -1247,7 +1262,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         { x: '1', y: 'a', z: 'i' },
@@ -1276,7 +1292,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           false,
-          []
+          [],
+          false
         )
       ).rejects.toThrow('Test error')
     })
@@ -1294,7 +1311,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           false,
-          []
+          [],
+          false
         )
       ).rejects.toThrow('Async error')
     })
@@ -1306,7 +1324,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1319,7 +1337,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1332,7 +1350,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1346,7 +1364,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value returned from generateStaticParams for "/test-page". Expected an array, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1359,7 +1377,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1372,7 +1390,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type string. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1385,7 +1403,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type array. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1398,7 +1416,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1412,7 +1430,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).rejects.toThrow(
         'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
       )
@@ -1423,7 +1441,7 @@ describe('generateRouteStaticParams', () => {
       const store = createMockWorkStore()
 
       await expect(
-        generateRouteStaticParams(segments, store, false, [])
+        generateRouteStaticParams(segments, store, false, [], false)
       ).resolves.toEqual([{}])
     })
 
@@ -1444,9 +1462,35 @@ describe('generateRouteStaticParams', () => {
           store,
 
           false,
-          []
+          [],
+          false
         )
       ).rejects.toThrow('Tech not allowed')
+    })
+
+    it('should reject an empty array in export mode', async () => {
+      const segments: TestAppSegment[] = [createMockSegment(async () => [])]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [], true)
+      ).rejects.toThrow(
+        'Page "/test-page" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject an empty array from a nested generateStaticParams in export mode', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(async () => []),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [], true)
+      ).rejects.toThrow(
+        'Page "/test-page" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
     })
 
     it('should throw error when generateStaticParams returns empty array with isRoutePPREnabled=true', async () => {
@@ -1461,7 +1505,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           true,
-          []
+          [],
+          false
         )
       ).rejects.toThrow(
         'When using Cache Components, all `generateStaticParams` functions must return at least one result'
@@ -1479,7 +1524,8 @@ describe('generateRouteStaticParams', () => {
           store,
 
           true,
-          []
+          [],
+          false
         )
       ).rejects.toThrow(
         'When using Cache Components, all `generateStaticParams` functions must return at least one result'
@@ -1497,7 +1543,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([{ lang: 'en' }])
     })
@@ -1512,7 +1559,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([])
     })
@@ -1541,7 +1589,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toHaveLength(12) // 3 langs × 2 categories × 2 slugs
       expect(result).toContainEqual({
@@ -1579,7 +1628,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toEqual([
         {
@@ -1620,7 +1670,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toHaveLength(8) // 2 years × 2 months × 2 slug variations
       expect(result).toContainEqual({
@@ -1646,7 +1697,8 @@ describe('generateRouteStaticParams', () => {
         store,
 
         false,
-        []
+        [],
+        false
       )
       expect(result).toHaveLength(1)
       expect(Object.keys(result[0])).toHaveLength(5000)

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -1352,6 +1352,81 @@ describe('generateRouteStaticParams', () => {
       )
     })
 
+    it('should reject a null array entry', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [null] as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject a string array entry', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [''] as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type string. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject an array entry', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [[]] as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type array. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject an undefined array entry', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [undefined] as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type undefined. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should reject an invalid array entry from a nested generateStaticParams', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ category: 'tech' }]),
+        createMockSegment(async () => [null] as unknown as Params[]),
+      ]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).rejects.toThrow(
+        'Invalid value at index 0 returned from generateStaticParams for "/test-page". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+      )
+    })
+
+    it('should allow an empty params object', async () => {
+      const segments: TestAppSegment[] = [createMockSegment(async () => [{}])]
+      const store = createMockWorkStore()
+
+      await expect(
+        generateRouteStaticParams(segments, store, false, [])
+      ).resolves.toEqual([{}])
+    })
+
     it('should handle partially failing generateStaticParams', async () => {
       const segments: TestAppSegment[] = [
         createMockSegment(async () => [{ category: 'tech' }]),

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -980,17 +980,29 @@ export async function buildAppStaticPaths({
     }
   }
 
+  const missingParamNames: string[] = []
+  if (routeParams.length > 0) {
+    for (const { paramName } of pathnameRouteParamSegments) {
+      if (routeParams.some((params) => !(paramName in params))) {
+        missingParamNames.push(paramName)
+      }
+    }
+  }
+
   // Determine if all the segments have had their parameters provided.
   const hadAllParamsGenerated =
     pathnameRouteParamSegments.length === 0 ||
-    (routeParams.length > 0 &&
-      routeParams.every((params) => {
-        for (const { paramName } of pathnameRouteParamSegments) {
-          if (paramName in params) continue
-          return false
-        }
-        return true
-      }))
+    (routeParams.length > 0 && missingParamNames.length === 0)
+
+  if (
+    nextConfigOutput === 'export' &&
+    routeParams.length > 0 &&
+    !hadAllParamsGenerated
+  ) {
+    throw new Error(
+      `Page "${page}" returned incomplete params from "generateStaticParams()". With "output: export", every params object must include all dynamic route parameters. Missing: ${missingParamNames.map((name) => `"${name}"`).join(', ')}. See more info here: https://nextjs.org/docs/messages/generate-static-params`
+    )
+  }
 
   // TODO: dynamic params should be allowed to be granular per segment but
   // we need additional information stored/leveraged in the prerender

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -641,6 +641,18 @@ async function callGenerateStaticParams(
     )
   }
 
+  for (const [index, params] of generatedParams.entries()) {
+    if (
+      params === null ||
+      typeof params !== 'object' ||
+      Array.isArray(params)
+    ) {
+      throw new Error(
+        `Invalid value at index ${index} returned from generateStaticParams for "${page}". Expected an object, but received type ${getValueType(params)}. See more info here: https://nextjs.org/docs/messages/generate-static-params`
+      )
+    }
+  }
+
   return generatedParams
 }
 

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -598,11 +598,18 @@ export function assignStaticShellMetadata(
   }
 }
 
+function getValueType(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  return typeof value
+}
+
 /**
  * Calls a single generateStaticParams function within a WorkUnitStore context,
  * making root param getters available during static param generation.
  */
 async function callGenerateStaticParams(
+  page: string,
   generateStaticParams: NonNullable<AppSegment['generateStaticParams']>,
   parentParams: Params,
   rootParamKeys: readonly string[],
@@ -622,9 +629,19 @@ async function callGenerateStaticParams(
     rootParams,
   }
 
-  return workUnitAsyncStorage.run(workUnitStore, generateStaticParams, {
-    params: parentParams,
-  })
+  const generatedParams: unknown = await workUnitAsyncStorage.run(
+    workUnitStore,
+    generateStaticParams,
+    { params: parentParams }
+  )
+
+  if (!Array.isArray(generatedParams)) {
+    throw new Error(
+      `Invalid value returned from generateStaticParams for "${page}". Expected an array, but received type ${getValueType(generatedParams)}. See more info here: https://nextjs.org/docs/messages/generate-static-params`
+    )
+  }
+
+  return generatedParams
 }
 
 /**
@@ -695,6 +712,7 @@ export async function generateRouteStaticParams(
       // Process each parent parameter combination
       for (const parentParams of params) {
         const result = await callGenerateStaticParams(
+          store.page,
           current.generateStaticParams,
           parentParams,
           rootParamKeys,
@@ -716,6 +734,7 @@ export async function generateRouteStaticParams(
     } else {
       // No parent params, call generateStaticParams with empty object
       const result = await callGenerateStaticParams(
+        store.page,
         current.generateStaticParams,
         {},
         rootParamKeys,

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -613,7 +613,8 @@ async function callGenerateStaticParams(
   generateStaticParams: NonNullable<AppSegment['generateStaticParams']>,
   parentParams: Params,
   rootParamKeys: readonly string[],
-  implicitTags: ImplicitTags
+  implicitTags: ImplicitTags,
+  isStaticExport: boolean
 ): Promise<Params[]> {
   const rootParams: Params = {}
   for (const key of rootParamKeys) {
@@ -638,6 +639,12 @@ async function callGenerateStaticParams(
   if (!Array.isArray(generatedParams)) {
     throw new Error(
       `Invalid value returned from generateStaticParams for "${page}". Expected an array, but received type ${getValueType(generatedParams)}. See more info here: https://nextjs.org/docs/messages/generate-static-params`
+    )
+  }
+
+  if (isStaticExport && generatedParams.length === 0) {
+    throw new Error(
+      `Page "${page}" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params`
     )
   }
 
@@ -666,6 +673,7 @@ async function callGenerateStaticParams(
  * @param store - Work store for tracking fetch cache configuration
  * @param isRoutePPREnabled - Whether PPR is enabled for this route
  * @param rootParamKeys - The keys identifying which params are root params
+ * @param isStaticExport - Whether the route is built with output: export
  * @returns Promise that resolves to an array of all parameter combinations
  */
 export async function generateRouteStaticParams(
@@ -679,7 +687,8 @@ export async function generateRouteStaticParams(
   >,
   store: Pick<WorkStore, 'fetchCache' | 'page'>,
   isRoutePPREnabled: boolean,
-  rootParamKeys: readonly string[]
+  rootParamKeys: readonly string[],
+  isStaticExport: boolean
 ): Promise<Params[]> {
   // Early return if no segments to process
   if (segments.length === 0) return []
@@ -728,7 +737,8 @@ export async function generateRouteStaticParams(
           current.generateStaticParams,
           parentParams,
           rootParamKeys,
-          implicitTags
+          implicitTags,
+          isStaticExport
         )
 
         if (result.length > 0) {
@@ -750,7 +760,8 @@ export async function generateRouteStaticParams(
         current.generateStaticParams,
         {},
         rootParamKeys,
-        implicitTags
+        implicitTags,
+        isStaticExport
       )
       if (result.length === 0 && isRoutePPREnabled) {
         throwEmptyGenerateStaticParamsError(current.createEmptyParamsError)
@@ -918,7 +929,8 @@ export async function buildAppStaticPaths({
     segments,
     store,
     isRoutePPREnabled,
-    rootParamKeys
+    rootParamKeys,
+    nextConfigOutput === 'export'
   )
   const generatedParamNames = new Set<string>()
   for (const params of routeParams) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -857,7 +857,7 @@ export default class DevServer extends Server {
           if (this.nextConfig.output === 'export') {
             if (!prerenderedRoutes) {
               throw new Error(
-                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config.`
+                `Page "${page}" is missing exported function "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params`
               )
             }
 

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -39,6 +39,24 @@ describe('app dir - with output export - dynamic missing gsp', () => {
     })
   })
 
+  describe('should error when generateStaticParams returns incomplete params', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set wrong param',
+      expectedErrMsg:
+        'Page "/another/[slug]" returned incomplete params from "generateStaticParams()". With "output: export", every params object must include all dynamic route parameters. Missing: "slug". See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
+  describe('should error when one of the generated params is incomplete', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set mixed params',
+      expectedErrMsg:
+        'Page "/another/[slug]" returned incomplete params from "generateStaticParams()". With "output: export", every params object must include all dynamic route parameters. Missing: "slug". See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
   describe('should error when client component has generateStaticParams', () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? 'App pages cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -21,6 +21,15 @@ describe('app dir - with output export - dynamic missing gsp', () => {
     })
   })
 
+  describe('should error when generateStaticParams returns a non-object entry', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set invalid entry',
+      expectedErrMsg:
+        'Invalid value at index 0 returned from generateStaticParams for "/another/[slug]". Expected an object, but received type null. See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
   describe('should error when client component has generateStaticParams', () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? 'App pages cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -30,6 +30,15 @@ describe('app dir - with output export - dynamic missing gsp', () => {
     })
   })
 
+  describe('should error when generateStaticParams returns an empty array', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set empty',
+      expectedErrMsg:
+        'Page "/another/[slug]" returned an empty array from "generateStaticParams()". With "output: export", at least one route must be generated. See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
   describe('should error when client component has generateStaticParams', () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? 'App pages cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -7,8 +7,8 @@ describe('app dir - with output export - dynamic missing gsp', () => {
       dynamicPage: 'undefined',
       generateStaticParamsOpt: 'set noop',
       expectedErrMsg: isNextDev
-        ? 'Page "/another/[slug]/page" is missing exported function "generateStaticParams()", which is required with "output: export" config.'
-        : 'Page "/another/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.',
+        ? 'Page "/another/[slug]/page" is missing exported function "generateStaticParams()", which is required with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params'
+        : 'Page "/another/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config. See more info here: https://nextjs.org/docs/messages/generate-static-params',
     })
   })
 

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -12,6 +12,15 @@ describe('app dir - with output export - dynamic missing gsp', () => {
     })
   })
 
+  describe('should error when generateStaticParams returns a non-array', () => {
+    runTests({
+      dynamicPage: 'undefined',
+      generateStaticParamsOpt: 'set non-array',
+      expectedErrMsg:
+        'Invalid value returned from generateStaticParams for "/another/[slug]". Expected an array, but received type object. See more info here: https://nextjs.org/docs/messages/generate-static-params',
+    })
+  })
+
   describe('should error when client component has generateStaticParams', () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? 'App pages cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -222,7 +222,9 @@ export function runTests({
     | 'set client'
     | 'set empty'
     | 'set invalid entry'
+    | 'set mixed params'
     | 'set non-array'
+    | 'set wrong param'
   expectedErrMsg?: string | RegExp
 }) {
   let { next, skipped, isNextDev } = nextTestSetup({
@@ -300,6 +302,20 @@ export function runTests({
         content.replace(
           `return [{ slug: 'first' }, { slug: 'second' }]`,
           'return []'
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set wrong param') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          `return [{ id: 'first' }]`
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set mixed params') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          `return [{ slug: 'first' }, { id: 'second' }]`
         )
       )
     }

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -217,7 +217,11 @@ export function runTests({
   dynamicPage?: string
   dynamicParams?: string
   dynamicApiRoute?: string
-  generateStaticParamsOpt?: 'set noop' | 'set client' | 'set non-array'
+  generateStaticParamsOpt?:
+    | 'set noop'
+    | 'set client'
+    | 'set invalid entry'
+    | 'set non-array'
   expectedErrMsg?: string | RegExp
 }) {
   let { next, skipped, isNextDev } = nextTestSetup({
@@ -281,6 +285,13 @@ export function runTests({
         content.replace(
           `return [{ slug: 'first' }, { slug: 'second' }]`,
           `return { slug: 'first' }`
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set invalid entry') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          `return [null]`
         )
       )
     }

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -220,6 +220,7 @@ export function runTests({
   generateStaticParamsOpt?:
     | 'set noop'
     | 'set client'
+    | 'set empty'
     | 'set invalid entry'
     | 'set non-array'
   expectedErrMsg?: string | RegExp
@@ -292,6 +293,13 @@ export function runTests({
         content.replace(
           `return [{ slug: 'first' }, { slug: 'second' }]`,
           `return [null]`
+        )
+      )
+    } else if (generateStaticParamsOpt === 'set empty') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          'return []'
         )
       )
     }

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -217,7 +217,7 @@ export function runTests({
   dynamicPage?: string
   dynamicParams?: string
   dynamicApiRoute?: string
-  generateStaticParamsOpt?: 'set noop' | 'set client'
+  generateStaticParamsOpt?: 'set noop' | 'set client' | 'set non-array'
   expectedErrMsg?: string | RegExp
 }) {
   let { next, skipped, isNextDev } = nextTestSetup({
@@ -275,6 +275,13 @@ export function runTests({
       await next.patchFile(
         'app/another/[slug]/page.js',
         (content) => '"use client"\n' + content
+      )
+    } else if (generateStaticParamsOpt === 'set non-array') {
+      await next.patchFile('app/another/[slug]/page.js', (content) =>
+        content.replace(
+          `return [{ slug: 'first' }, { slug: 'second' }]`,
+          `return { slug: 'first' }`
+        )
       )
     }
   })


### PR DESCRIPTION
Rebased version of #95969.

Throws when generateStaticParams returns an empty array or incomplete params when using output: export, and documents the new errors.