### PR TITLE
fix: recognize Meta's 2024 crawler UAs as HTML-limited bots

### DIFF
--- a/packages/next/src/shared/lib/router/utils/html-bots.ts
+++ b/packages/next/src/shared/lib/router/utils/html-bots.ts
@@ -2,5 +2,9 @@
 // due to how they parse the DOM. For example, they might explicitly check for metadata in the `head` tag, so we can't stream metadata tags after the `head` was sent.
 // Note: The pattern [\w-]+-Google captures all Google crawlers with "-Google" suffix (e.g., Mediapartners-Google, AdsBot-Google, Storebot-Google)
 // as well as crawlers starting with "Google-" (e.g., Google-PageRenderer, Google-InspectionTool)
+// Note: meta-externalagent and meta-externalfetcher are the crawler UAs Meta
+// introduced in 2024 alongside the legacy facebookexternalhit; none of them
+// execute JavaScript, so they only see metadata that is in the initial <head>.
+// x-ref: https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
 export const HTML_LIMITED_BOT_UA_RE =
-  /[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i
+  /[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|meta-externalagent|meta-externalfetcher|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -197,5 +197,29 @@ describe('app-dir - metadata-streaming', () => {
       expect($('title').length).toBe(1)
       expect($('head title').text()).toBe('partial static page')
     })
+
+    it("should still render blocking metadata for Meta's 2024 crawlers", async () => {
+      // Meta's current crawlers alongside the legacy facebookexternalhit.
+      // None of them execute JavaScript, so streamed metadata (tags after
+      // </head>) is invisible to them and link previews render blank.
+      // x-ref: https://developers.facebook.com/docs/sharing/webmasters/web-crawlers
+      const userAgents = [
+        'meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+        'meta-externalfetcher/1.1',
+      ]
+      for (const userAgent of userAgents) {
+        const $ = await next.render$(
+          '/static/partial',
+          {},
+          {
+            headers: {
+              'user-agent': userAgent,
+            },
+          }
+        )
+        expect($('title').length).toBe(1)
+        expect($('head title').text()).toBe('partial static page')
+      }
+    })
   })
 })


### PR DESCRIPTION
Rebased version of #96033.

Adds Meta's 2024 crawler user agents to the HTML-limited bot list.