### PR TITLE
test: stabilize after() deploy revalidation checks

### DIFF
--- a/test/e2e/app-dir/next-after-app-deploy/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-deploy/index.test.ts
@@ -5,6 +5,10 @@ import { retry } from 'next-test-utils'
 const runtimes = ['nodejs', 'edge']
 
 const WAIT_BEFORE_REVALIDATING = 1000
+const REVALIDATION_SETTLE_TIMEOUT = 15_000
+const REVALIDATION_POLL_INTERVAL = 1000
+const REVALIDATION_RETRY_DURATION =
+  WAIT_BEFORE_REVALIDATING + REVALIDATION_SETTLE_TIMEOUT
 
 // If we want to verify that `after()` ran its callback,
 // we need it to perform some kind of side effect (because it can't affect the response).
@@ -21,7 +25,6 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
     files: __dirname,
     env: { WAIT_BEFORE_REVALIDATING: WAIT_BEFORE_REVALIDATING + '' },
   })
-  const retryDuration = WAIT_BEFORE_REVALIDATING * 2
 
   if (skipped) return
   const pathPrefix = '/' + runtimeValue
@@ -50,9 +53,19 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
       await getTimestampPageData(path)
     }
 
-    const data = await getTimestampPageData(path)
-    expect(data).toEqual(await getTimestampPageData(path)) // sanity check that it's static
-    return data
+    // A previous test attempt may leave an ISR revalidation in progress. Wait
+    // for two consecutive reads to agree before using the timestamp as the
+    // baseline for this attempt.
+    return retry(
+      async () => {
+        const data = await getTimestampPageData(path)
+        expect(data).toEqual(await getTimestampPageData(path))
+        return data
+      },
+      REVALIDATION_SETTLE_TIMEOUT,
+      REVALIDATION_POLL_INTERVAL,
+      'wait for timestamp page cache to settle'
+    )
   }
 
   it('triggers revalidate from a page', async () => {
@@ -66,8 +79,8 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
         const dataAfter = await getTimestampPageData(path)
         expect(dataAfter.timestamp).toBeGreaterThan(dataBefore.timestamp)
       },
-      retryDuration,
-      1000,
+      REVALIDATION_RETRY_DURATION,
+      REVALIDATION_POLL_INTERVAL,
       'check if timestamp page updated'
     )
   })
@@ -84,8 +97,8 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
         const dataAfter = await getTimestampPageData(path)
         expect(dataAfter.timestamp).toBeGreaterThan(dataBefore.timestamp)
       },
-      retryDuration,
-      1000,
+      REVALIDATION_RETRY_DURATION,
+      REVALIDATION_POLL_INTERVAL,
       'check if timestamp page updated'
     )
   })
@@ -101,8 +114,8 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
         const dataAfter = await getTimestampPageData(path)
         expect(dataAfter.timestamp).toBeGreaterThan(dataBefore.timestamp)
       },
-      retryDuration,
-      1000,
+      REVALIDATION_RETRY_DURATION,
+      REVALIDATION_POLL_INTERVAL,
       'check if timestamp page updated'
     )
   })
@@ -118,8 +131,8 @@ _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
         const dataAfter = await getTimestampPageData(path)
         expect(dataAfter.timestamp).toBeGreaterThan(dataBefore.timestamp)
       },
-      retryDuration,
-      1000,
+      REVALIDATION_RETRY_DURATION,
+      REVALIDATION_POLL_INTERVAL,
       'check if timestamp page updated'
     )
   })


### PR DESCRIPTION
## Summary

[PR #96354](https://github.com/vercel/next.js/pull/96354) changed `retry()` to enforce its duration as a wall-clock budget instead of effectively treating it as a retry count. This exposed the test’s previous two-second budget, which did not reliably cover the intentional one-second `after()` delay plus deployment and ISR latency.

Separates the callback delay from the ISR settling timeout and waits for timestamp reads to stabilize before establishing a baseline.

<!-- NEXT_JS_LLM -->
