### PR TITLE
[turbopack] Add acknowledged edit transactions for agents

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -738,6 +738,86 @@ async fn benchmark_file_io(turbo_tasks: &NextTurboTasks, dir: &Path) -> Result<(
     Ok(())
 }
 
+#[turbo_tasks::function(operation, root)]
+fn project_fs_control_operation(container: ResolvedVc<ProjectContainer>) -> Vc<DiskFileSystem> {
+    container.project().project_fs()
+}
+
+/// Starts an explicitly acknowledged source-edit transaction. Filesystem invalidations are held
+/// until the matching token is ended or the watcher's safety timeout expires.
+#[napi]
+pub async fn project_begin_edit_transaction(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<u32> {
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+
+    ctx.turbo_tasks()
+        .run(async move {
+            project_fs_control_operation(container)
+                .read_strongly_consistent()
+                .await?
+                .begin_edit_transaction()
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
+/// Renews only the matching source-edit transaction's bounded lease.
+#[napi]
+pub async fn project_renew_edit_transaction(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    token: u32,
+) -> napi::Result<bool> {
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+
+    ctx.turbo_tasks()
+        .run(async move {
+            project_fs_control_operation(container)
+                .read_strongly_consistent()
+                .await?
+                .renew_edit_transaction(token)
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
+#[napi(object)]
+pub struct NapiEditTransactionEndResult {
+    pub accepted: bool,
+    pub flushed: bool,
+}
+
+/// Ends a source-edit transaction. The acknowledgement reports whether the token was accepted and
+/// whether this was the final active token whose invalidations were submitted before returning.
+#[napi]
+pub async fn project_end_edit_transaction(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    token: u32,
+    changed_paths: Vec<String>,
+) -> napi::Result<NapiEditTransactionEndResult> {
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+    let changed_paths = changed_paths.into_iter().map(PathBuf::from).collect();
+
+    let (accepted, flushed) = ctx
+        .turbo_tasks()
+        .run(async move {
+            project_fs_control_operation(container)
+                .read_strongly_consistent()
+                .await?
+                .end_edit_transaction(token, changed_paths)
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+
+    Ok(NapiEditTransactionEndResult { accepted, flushed })
+}
+
 #[tracing::instrument(level = "info", name = "update project", skip_all)]
 #[napi]
 pub async fn project_update(

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1463,5 +1463,13 @@
   "1462": "Unexpected chunk emitted in Before stage",
   "1463": "\\`experimental.turbopackGenerateComponentChunks\\` has been moved to \\`experimental.turbopackChunking.generateComponentChunks\\`. Please update your next.config.js file accordingly.",
   "1464": "\\`experimental.turbopackChunkingHeuristics\\` has been renamed to \\`experimental.turbopackChunking\\`. Please update your next.config.js file accordingly.",
-  "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s."
+  "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
+  "1466": "Turbopack project is not available. This tool requires the Turbopack bundler.",
+  "1467": "Changed path must be project-relative: %s",
+  "1468": "Changed path leaves the project root: %s",
+  "1469": "Too many active edit transactions (limit %s)",
+  "1470": "Changed path leaves the Turbopack filesystem root: %s",
+  "1471": "Edit transaction acknowledgement consumed its lease headroom; retry begin_edit_transaction",
+  "1472": "Changed path is watched outside the Turbopack source transaction: %s",
+  "1473": "Too much retained changed-path data (limit %s characters)"
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -330,6 +330,31 @@ export declare function projectNew(
   turboEngineOptions: NapiTurboEngineOptions,
   napiCallbacks: NapiNextTurbopackCallbacksJsObject
 ): Promise<{ __napiType: 'Project' }>
+/**
+ * Starts an explicitly acknowledged source-edit transaction. Filesystem invalidations are held
+ * until the matching token is ended or the watcher's safety timeout expires.
+ */
+export declare function projectBeginEditTransaction(project: {
+  __napiType: 'Project'
+}): Promise<number>
+/** Renews only the matching source-edit transaction's bounded lease. */
+export declare function projectRenewEditTransaction(
+  project: { __napiType: 'Project' },
+  token: number
+): Promise<boolean>
+export interface NapiEditTransactionEndResult {
+  accepted: boolean
+  flushed: boolean
+}
+/**
+ * Ends a source-edit transaction. The acknowledgement reports whether the token was accepted and
+ * whether this was the final active token whose invalidations were submitted before returning.
+ */
+export declare function projectEndEditTransaction(
+  project: { __napiType: 'Project' },
+  token: number,
+  changedPaths: Array<string>
+): Promise<NapiEditTransactionEndResult>
 export declare function projectUpdate(
   project: { __napiType: 'Project' },
   options: NapiPartialProjectOptions

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -26,6 +26,7 @@ import type {
   CompilationEvent,
   DefineEnv,
   Endpoint,
+  EditTransactionEndResult,
   HmrChunkNames,
   Lockfile,
   NodeJsHmrUpdate,
@@ -683,6 +684,7 @@ function bindingToApi(
 
   class ProjectImpl implements Project {
     private readonly _nativeProject: { __napiType: 'Project' }
+    private _editTransactionControl: Promise<void> = Promise.resolve()
 
     constructor(nativeProject: { __napiType: 'Project' }) {
       this._nativeProject = nativeProject
@@ -696,6 +698,42 @@ function bindingToApi(
       await binding.projectUpdate(
         this._nativeProject,
         await rustifyPartialProjectOptions(options)
+      )
+    }
+
+    private _serializeEditTransactionControl<T>(
+      operation: () => Promise<T>
+    ): Promise<T> {
+      const result = this._editTransactionControl.then(operation, operation)
+      this._editTransactionControl = result.then(
+        () => undefined,
+        () => undefined
+      )
+      return result
+    }
+
+    beginEditTransaction(): Promise<number> {
+      return this._serializeEditTransactionControl(() =>
+        binding.projectBeginEditTransaction(this._nativeProject)
+      )
+    }
+
+    renewEditTransaction(token: number): Promise<boolean> {
+      return this._serializeEditTransactionControl(() =>
+        binding.projectRenewEditTransaction(this._nativeProject, token)
+      )
+    }
+
+    endEditTransaction(
+      token: number,
+      changedPaths: string[]
+    ): Promise<EditTransactionEndResult> {
+      return this._serializeEditTransactionControl(() =>
+        binding.projectEndEditTransaction(
+          this._nativeProject,
+          token,
+          changedPaths
+        )
       )
     }
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -308,8 +308,32 @@ export interface UpdateInfo {
   tasks: number
 }
 
+export interface EditTransactionEndResult {
+  accepted: boolean
+  flushed: boolean
+}
+
 export interface Project {
   update(options: Partial<ProjectOptions>): Promise<void>
+
+  /**
+   * Begin a source-edit transaction and wait until the filesystem watcher has acknowledged it.
+   * The returned token must be passed to `endEditTransaction`.
+   */
+  beginEditTransaction(): Promise<number>
+
+  /** Renew only this source-edit transaction's bounded lease. */
+  renewEditTransaction(token: number): Promise<boolean>
+
+  /**
+   * End a source-edit transaction and explicitly invalidate the controller-confirmed paths.
+   * The result distinguishes a rejected token, a token still held by another transaction, and the
+   * final token whose invalidations have been submitted.
+   */
+  endEditTransaction(
+    token: number,
+    changedPaths: string[]
+  ): Promise<EditTransactionEndResult>
 
   writeAnalyzeData(appDirOnly: boolean): Promise<TurbopackResult<void>>
 

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -6,6 +6,7 @@ import { registerGetLogsTool } from './tools/get-logs'
 import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
+import { registerEditTransactionTools } from './tools/edit-transaction'
 import { registerCompileRouteTool } from './tools/compile-route'
 import { registerGetRequestInsightsTool } from './tools/get-request-insights'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
@@ -68,6 +69,23 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
 
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)
+    if (process.env.__NEXT_EXPERIMENTAL_EDIT_TRANSACTIONS === 'true') {
+      const turbopackRoot =
+        options.nextConfig.turbopack?.root ||
+        options.nextConfig.outputFileTracingRoot ||
+        options.projectPath
+      registerEditTransactionTools(
+        mcpServer,
+        options.projectPath,
+        turbopackRoot,
+        {
+          appDir: options.appDir,
+          pagesDir: options.pagesDir,
+          pageExtensions: options.nextConfig.pageExtensions,
+        },
+        options.getTurbopackProject
+      )
+    }
   }
 
   if (options.compileRoute) {

--- a/packages/next/src/server/mcp/tools/edit-transaction.test.ts
+++ b/packages/next/src/server/mcp/tools/edit-transaction.test.ts
@@ -1,0 +1,376 @@
+import { join } from 'node:path'
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import type { Project } from '../../../build/swc/types'
+import { registerEditTransactionTools } from './edit-transaction'
+
+type ToolResult = {
+  isError?: boolean
+  content: Array<{ type: 'text'; text: string }>
+}
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>
+
+function setup() {
+  const handlers = new Map<string, ToolHandler>()
+  const server = {
+    registerTool(name: string, _definition: unknown, handler: ToolHandler) {
+      handlers.set(name, handler)
+    },
+  } as unknown as McpServer
+  let nextNativeToken = 1
+  const project = {
+    beginEditTransaction: jest.fn(async () => nextNativeToken++),
+    renewEditTransaction: jest.fn(async () => true),
+    endEditTransaction: jest.fn(async () => ({
+      accepted: true,
+      flushed: true,
+    })),
+  } as unknown as Project
+
+  registerEditTransactionTools(
+    server,
+    '/repo/project',
+    '/repo',
+    {
+      appDir: '/repo/project/app',
+      pagesDir: '/repo/project/pages',
+      pageExtensions: ['js', 'jsx', 'ts', 'tsx'],
+    },
+    () => project
+  )
+
+  const call = async (name: string, args: Record<string, unknown> = {}) => {
+    const result = await handlers.get(name)!(args)
+    return {
+      isError: result.isError === true,
+      value: JSON.parse(result.content[0].text),
+    }
+  }
+
+  return { call, project }
+}
+
+describe('MCP edit transaction tools', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+  })
+
+  it('keeps leases independent of wall-clock adjustments', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const { call } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['app/component.tsx'],
+    })
+    expect(started.value.leaseMs).toBe(4_000)
+    expect(started.value.maximumDurationMs).toBe(60_000)
+
+    // System time can jump independently of the monotonic timer used by both lease cleanup and the
+    // native watcher. Neither direction may expire or extend this transaction.
+    jest.setSystemTime(1)
+    const afterBackwardJump = await call('renew_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(afterBackwardJump.value.status).toBe('renewed')
+    expect(afterBackwardJump.value.leaseMs).toBe(4_000)
+
+    jest.setSystemTime(10_000_000)
+    const afterForwardJump = await call('renew_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(afterForwardJump.value.status).toBe('renewed')
+    expect(afterForwardJump.value.leaseMs).toBe(4_000)
+    await call('end_edit_transaction', { token: started.value.token })
+  })
+
+  it('enforces the active-token limit without wall-clock timing', async () => {
+    const { call } = setup()
+    const accepted = []
+    for (let index = 0; index < 32; index++) {
+      const result = await call('begin_edit_transaction', {
+        changedPaths: ['app/component.tsx'],
+      })
+      expect(result.isError).toBe(false)
+      accepted.push(result.value.token as string)
+    }
+
+    const rejected = await call('begin_edit_transaction', {
+      changedPaths: ['app/component.tsx'],
+    })
+    expect(rejected.isError).toBe(true)
+    expect(rejected.value.error).toContain(
+      'Too many active edit transactions (limit 32)'
+    )
+
+    for (const token of accepted) {
+      await call('end_edit_transaction', { token })
+    }
+  })
+
+  it('submits abandoned changed paths without later tool traffic', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const { call, project } = setup()
+    const changedPaths = ['app/new-component', 'app/new-component/value.ts']
+    const abandoned = await call('begin_edit_transaction', { changedPaths })
+    expect(abandoned.isError).toBe(false)
+
+    // No intervening tool call drives cleanup. The conservative JavaScript lease timer settles the
+    // native token with its authoritative paths and retains only an opaque expired marker.
+    jest.advanceTimersByTime(4_000)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(project.endEditTransaction).toHaveBeenCalledWith(1, [
+      join('project', 'app', 'new-component'),
+      join('project', 'app', 'new-component', 'value.ts'),
+    ])
+
+    const lateEnd = await call('end_edit_transaction', {
+      token: abandoned.value.token,
+    })
+    expect(lateEnd.value.status).toBe('expired')
+    expect(project.endEditTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains the changed-path budget until the shared native batch flushes', async () => {
+    const { call, project } = setup()
+    const largeChangedPathSet = (prefix: string) =>
+      Array.from(
+        { length: 160 },
+        (_, index) => `${prefix}/${index}-${'x'.repeat(3_900)}`
+      )
+    const anchor = await call('begin_edit_transaction', { changedPaths: [] })
+    const first = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/first'),
+    })
+    ;(project.endEditTransaction as jest.Mock).mockResolvedValueOnce({
+      accepted: true,
+      flushed: false,
+    })
+    expect(
+      (await call('end_edit_transaction', { token: first.value.token })).value
+        .status
+    ).toBe('held_by_other_transaction')
+
+    const bounded = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/second'),
+    })
+    expect(bounded.isError).toBe(true)
+    expect(bounded.value.error).toContain(
+      'Too much retained changed-path data (limit 1048576 characters)'
+    )
+
+    expect(
+      (await call('end_edit_transaction', { token: anchor.value.token })).value
+        .status
+    ).toBe('flushed')
+    const afterFlush = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/second'),
+    })
+    expect(afterFlush.isError).toBe(false)
+    await call('end_edit_transaction', { token: afterFlush.value.token })
+  })
+
+  it('keeps batch accounting when a rejected end did not flush', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const monotonicNow = jest.spyOn(performance, 'now').mockReturnValue(0)
+    const { call, project } = setup()
+    const largeChangedPathSet = (prefix: string) =>
+      Array.from(
+        { length: 160 },
+        (_, index) => `${prefix}/${index}-${'x'.repeat(3_900)}`
+      )
+    const older = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/older'),
+    })
+    monotonicNow.mockReturnValue(1_000)
+    await call('begin_edit_transaction', { changedPaths: [] })
+    ;(project.endEditTransaction as jest.Mock)
+      .mockResolvedValueOnce({ accepted: false, flushed: false })
+      .mockRejectedValueOnce(new Error('newer native token still held'))
+
+    // Simulate an event-loop stall past both conservative JavaScript leases. Native time can still
+    // have the newer token active when the older rejected end is acknowledged.
+    monotonicNow.mockReturnValue(5_000)
+    const bounded = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/new'),
+    })
+    expect(bounded.isError).toBe(true)
+    expect(bounded.value.error).toContain(
+      'Too much retained changed-path data (limit 1048576 characters)'
+    )
+    expect(project.endEditTransaction).toHaveBeenCalledTimes(2)
+    expect(
+      (await call('end_edit_transaction', { token: older.value.token })).value
+        .status
+    ).toBe('expired')
+  })
+
+  it('releases batch accounting when a rejected final end still flushed', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const monotonicNow = jest.spyOn(performance, 'now').mockReturnValue(0)
+    const { call, project } = setup()
+    const largeChangedPathSet = (prefix: string) =>
+      Array.from(
+        { length: 160 },
+        (_, index) => `${prefix}/${index}-${'x'.repeat(3_900)}`
+      )
+    await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/expired'),
+    })
+    ;(project.endEditTransaction as jest.Mock).mockResolvedValueOnce({
+      accepted: false,
+      flushed: true,
+    })
+
+    // The token expired during an event-loop stall, but native settlement was still the final
+    // flush. That independent flush bit must release the shared changed-path budget immediately.
+    monotonicNow.mockReturnValue(5_000)
+    const afterFlush = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/after-flush'),
+    })
+    expect(afterFlush.isError).toBe(false)
+    expect(project.endEditTransaction).toHaveBeenCalledTimes(1)
+
+    await call('end_edit_transaction', { token: afterFlush.value.token })
+  })
+
+  it('reclaims stale batch accounting after failed settlement ages out', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const { call, project } = setup()
+    const largeChangedPathSet = (prefix: string) =>
+      Array.from(
+        { length: 160 },
+        (_, index) => `${prefix}/${index}-${'x'.repeat(3_900)}`
+      )
+    ;(project.endEditTransaction as jest.Mock).mockRejectedValueOnce(
+      new Error('native settlement failed')
+    )
+    const abandoned = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/abandoned'),
+    })
+
+    jest.advanceTimersByTime(4_000)
+    await Promise.resolve()
+    await Promise.resolve()
+    const bounded = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/bounded'),
+    })
+    expect(bounded.isError).toBe(true)
+
+    // The recovery payload remains available for a late end for 60 seconds. Once it ages out, the
+    // shared native maximum has also elapsed, so stale accounting must not wedge future begins.
+    jest.advanceTimersByTime(60_000)
+    const reclaimed = await call('begin_edit_transaction', {
+      changedPaths: largeChangedPathSet('app/reclaimed'),
+    })
+    expect(reclaimed.isError).toBe(false)
+    expect(
+      (await call('end_edit_transaction', { token: abandoned.value.token }))
+        .value.status
+    ).toBe('unknown')
+    await call('end_edit_transaction', { token: reclaimed.value.token })
+  })
+
+  it('serializes timer cleanup behind an in-flight native renewal', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const { call, project } = setup()
+    let finishRenewal: ((renewed: boolean) => void) | undefined
+    ;(project.renewEditTransaction as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishRenewal = resolve
+        })
+    )
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['app/component.tsx'],
+    })
+
+    jest.advanceTimersByTime(3_000)
+    const renewal = call('renew_edit_transaction', {
+      token: started.value.token,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    jest.advanceTimersByTime(1_000)
+    finishRenewal!(true)
+    expect((await renewal).value.status).toBe('renewed')
+
+    // Cleanup fired at the old four-second deadline while native renewal was pending. It must run
+    // after renewal and observe the extended lease, rather than moving the token to the expired map.
+    const stillActive = await call('renew_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(stillActive.value.status).toBe('renewed')
+    await call('end_edit_transaction', { token: started.value.token })
+  })
+
+  it('caps cumulative renewals at the advertised maximum duration', async () => {
+    jest.useFakeTimers({ now: 1_000_000 })
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['app/component.tsx'],
+    })
+    expect(started.value.maximumDurationMs).toBe(60_000)
+
+    for (let renewal = 0; renewal < 19; renewal++) {
+      jest.advanceTimersByTime(3_000)
+      const result = await call('renew_edit_transaction', {
+        token: started.value.token,
+      })
+      expect(result.value.status).toBe('renewed')
+    }
+
+    const rotated = await call('begin_edit_transaction', {
+      changedPaths: ['app/another.ts'],
+    })
+    expect(rotated.value.maximumDurationMs).toBe(3_000)
+
+    jest.advanceTimersByTime(3_000)
+    for (const token of [started.value.token, rotated.value.token]) {
+      const expired = await call('renew_edit_transaction', { token })
+      expect(expired.value.status).toBe('expired')
+    }
+    expect(project.renewEditTransaction).toHaveBeenCalledTimes(19)
+  })
+
+  it('rejects paths controlled by independent dev-server watchers before begin', async () => {
+    const { call, project } = setup()
+    for (const changedPath of [
+      '.env.local',
+      'tsconfig.json',
+      'jsconfig.json',
+      'next.config.js',
+      'app/page.tsx',
+      'app/api/route.ts',
+      'app/layout.tsx',
+      'app/icon.tsx',
+      'pages/index.tsx',
+      'middleware.ts',
+      'src/instrumentation.ts',
+    ]) {
+      const result = await call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(true)
+      expect(result.value.error).toContain(
+        'watched outside the Turbopack source transaction'
+      )
+    }
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('submits the changed paths declared before editing', async () => {
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['app/new-component', 'app/new-component/value.ts'],
+    })
+    const ended = await call('end_edit_transaction', {
+      token: started.value.token,
+    })
+
+    expect(ended.value.status).toBe('flushed')
+    expect(project.endEditTransaction).toHaveBeenCalledWith(1, [
+      join('project', 'app', 'new-component'),
+      join('project', 'app', 'new-component', 'value.ts'),
+    ])
+  })
+})

--- a/packages/next/src/server/mcp/tools/edit-transaction.ts
+++ b/packages/next/src/server/mcp/tools/edit-transaction.ts
@@ -1,0 +1,565 @@
+/**
+ * Experimental MCP tools for bracketing a bounded multi-file agent edit as one Turbopack
+ * invalidation transaction.
+ *
+ * begin_edit_transaction validates the complete changed-path set and does not return until the
+ * filesystem watcher has acknowledged the boundary. Controllers must call end_edit_transaction in
+ * a finally block and renew leases for edits longer than five seconds. The native watcher forces
+ * progress when a lease is abandoned and caps the continuously held batch's lifetime.
+ */
+import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import z from 'next/dist/compiled/zod'
+import type { PageExtensions } from '../../../build/page-extensions-type'
+import { createValidFileMatcher } from '../../lib/find-page-file'
+import {
+  getPossibleInstrumentationHookFilenames,
+  getPossibleMiddlewareFilenames,
+} from '../../../build/utils'
+import type { Project } from '../../../build/swc/types'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+
+const EDIT_TRANSACTION_LEASE_MS = 5_000
+const EDIT_TRANSACTION_LEASE_SAFETY_MS = 1_000
+const EDIT_TRANSACTION_MAX_DURATION_MS = 60_000
+const EXPIRED_TOKEN_RETENTION_MS = 60_000
+const MAX_ACTIVE_EDIT_TRANSACTIONS = 32
+const MAX_EXPIRED_EDIT_TRANSACTIONS = 64
+const MAX_CHANGED_PATHS = 2_048
+const MAX_RETAINED_CHANGED_PATH_CHARACTERS = 1_048_576
+
+type EditTransaction = {
+  project: Project
+  nativeToken: number
+  expiresAt: number
+  maximumExpiresAt: number
+  changedPaths: string[]
+}
+
+type ExpiredEditTransaction = {
+  retainUntil: number
+  transaction?: EditTransaction
+}
+
+function conservativeLease(
+  acknowledgmentStartedAt: number,
+  maximumExpiresAt: number
+) {
+  const expiresAt = Math.min(
+    acknowledgmentStartedAt +
+      EDIT_TRANSACTION_LEASE_MS -
+      EDIT_TRANSACTION_LEASE_SAFETY_MS,
+    maximumExpiresAt
+  )
+  return {
+    expiresAt,
+    leaseMs: Math.max(0, expiresAt - performance.now()),
+  }
+}
+
+const errorResult = (error: unknown) => ({
+  isError: true,
+  content: [
+    {
+      type: 'text' as const,
+      text: JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    },
+  ],
+})
+
+const successResult = (value: object) => ({
+  content: [
+    {
+      type: 'text' as const,
+      text: JSON.stringify(value),
+    },
+  ],
+})
+
+type RouteWatcherOptions = {
+  appDir: string | undefined
+  pagesDir: string | undefined
+  pageExtensions: PageExtensions
+}
+
+function pathIsInside(directory: string, candidate: string) {
+  const relative = path.relative(directory, candidate)
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  )
+}
+
+function createRouteWatcherPathMatcher(
+  projectPath: string,
+  { appDir, pagesDir, pageExtensions }: RouteWatcherOptions
+) {
+  const validFileMatcher = createValidFileMatcher(pageExtensions, appDir)
+  const routeRoot =
+    pagesDir || appDir ? path.dirname(pagesDir ?? appDir!) : projectPath
+  const rootConventionFiles = new Set(
+    [
+      ...getPossibleMiddlewareFilenames(routeRoot, pageExtensions),
+      ...getPossibleInstrumentationHookFilenames(routeRoot, pageExtensions),
+    ].map((file) => path.resolve(file))
+  )
+
+  return (absolute: string) => {
+    if (rootConventionFiles.has(absolute)) return true
+    if (
+      pagesDir &&
+      pathIsInside(pagesDir, absolute) &&
+      validFileMatcher.isPageFile(absolute)
+    ) {
+      return true
+    }
+    return Boolean(
+      appDir &&
+        pathIsInside(appDir, absolute) &&
+        (validFileMatcher.isAppRouterPage(absolute) ||
+          validFileMatcher.isAppLayoutPage(absolute) ||
+          validFileMatcher.isAppDefaultPage(absolute) ||
+          validFileMatcher.isRootNotFound(absolute))
+    )
+  }
+}
+
+function resolveChangedPaths(
+  projectPath: string,
+  turbopackRootPath: string,
+  routeWatcherOptions: RouteWatcherOptions,
+  changedPaths: string[]
+) {
+  const projectRoot = path.resolve(projectPath)
+  const turbopackRoot = path.resolve(turbopackRootPath)
+  const isRouteWatcherPath = createRouteWatcherPathMatcher(
+    projectRoot,
+    routeWatcherOptions
+  )
+  const resolved = new Set<string>()
+  for (const changedPath of changedPaths) {
+    if (path.isAbsolute(changedPath)) {
+      throw new Error(`Changed path must be project-relative: ${changedPath}`)
+    }
+    const absolute = path.resolve(projectRoot, changedPath)
+    const projectRelative = path.relative(projectRoot, absolute)
+    if (
+      projectRelative === '' ||
+      projectRelative === '..' ||
+      projectRelative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(projectRelative)
+    ) {
+      throw new Error(`Changed path leaves the project root: ${changedPath}`)
+    }
+
+    const normalizedProjectRelative = projectRelative.split(path.sep).join('/')
+    if (
+      /^\.env(?:\..+)?$/.test(normalizedProjectRelative) ||
+      normalizedProjectRelative === 'tsconfig.json' ||
+      normalizedProjectRelative === 'jsconfig.json' ||
+      /^next\.config\.(?:js|mjs|cjs|ts|mts|cts)$/.test(
+        normalizedProjectRelative
+      ) ||
+      isRouteWatcherPath(absolute)
+    ) {
+      throw new Error(
+        `Changed path is watched outside the Turbopack source transaction: ${changedPath}`
+      )
+    }
+
+    const turbopackRelative = path.relative(turbopackRoot, absolute)
+    if (
+      turbopackRelative === '' ||
+      turbopackRelative === '..' ||
+      turbopackRelative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(turbopackRelative)
+    ) {
+      throw new Error(
+        `Changed path leaves the Turbopack filesystem root: ${changedPath}`
+      )
+    }
+    resolved.add(turbopackRelative)
+  }
+  return [...resolved]
+}
+
+export function registerEditTransactionTools(
+  server: McpServer,
+  projectPath: string,
+  turbopackRootPath: string,
+  routeWatcherOptions: RouteWatcherOptions,
+  getProject: () => Project | undefined
+) {
+  const activeTransactions = new Map<string, EditTransaction>()
+  const expiredTransactions = new Map<string, ExpiredEditTransaction>()
+  let batchMaximumExpiresAt: number | undefined
+  // Count every declared path retained by the current native batch, including transactions that
+  // ended while another token still held the batch. Reset only after the native flush is observed.
+  let batchChangedPathCharacters = 0
+  let controlQueue: Promise<void> = Promise.resolve()
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined
+
+  const serializeControl = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = controlQueue.then(operation, operation)
+    controlQueue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  const hasRetainedTransactionPayload = () =>
+    [...expiredTransactions.values()].some(
+      (expired) => expired.transaction !== undefined
+    )
+
+  const resetBatchAccounting = () => {
+    batchMaximumExpiresAt = undefined
+    batchChangedPathCharacters = 0
+  }
+
+  const resetBatchAccountingIfFlushed = (result: {
+    accepted: boolean
+    flushed: boolean
+  }) => {
+    if (
+      activeTransactions.size === 0 &&
+      !hasRetainedTransactionPayload() &&
+      result.flushed
+    ) {
+      resetBatchAccounting()
+    }
+  }
+
+  const resetBatchAccountingIfMaximumElapsed = (now: number) => {
+    if (
+      batchMaximumExpiresAt !== undefined &&
+      batchMaximumExpiresAt <= now &&
+      activeTransactions.size === 0 &&
+      !hasRetainedTransactionPayload()
+    ) {
+      // Any native token that could not be explicitly settled is bounded by the same maximum. Once
+      // its recovery payload has aged out, the native watcher has necessarily forced the batch out.
+      resetBatchAccounting()
+    }
+  }
+
+  function scheduleCleanup() {
+    if (cleanupTimer !== undefined) clearTimeout(cleanupTimer)
+    let nextDeadline = Number.POSITIVE_INFINITY
+    for (const transaction of activeTransactions.values()) {
+      nextDeadline = Math.min(nextDeadline, transaction.expiresAt)
+    }
+    for (const expired of expiredTransactions.values()) {
+      nextDeadline = Math.min(nextDeadline, expired.retainUntil)
+    }
+    if (!Number.isFinite(nextDeadline)) {
+      cleanupTimer = undefined
+      return
+    }
+    cleanupTimer = setTimeout(
+      () => {
+        cleanupTimer = undefined
+        void serializeControl(async () => {
+          await pruneTransactions()
+        })
+      },
+      Math.max(0, nextDeadline - performance.now())
+    )
+    cleanupTimer.unref()
+  }
+
+  function rememberExpired(
+    token: string,
+    now: number,
+    transaction?: EditTransaction
+  ) {
+    // Refresh insertion order so the bounded map evicts the least recently touched token.
+    expiredTransactions.delete(token)
+    expiredTransactions.set(token, {
+      retainUntil: now + EXPIRED_TOKEN_RETENTION_MS,
+      transaction,
+    })
+    while (expiredTransactions.size > MAX_EXPIRED_EDIT_TRANSACTIONS) {
+      const oldestToken = expiredTransactions.keys().next().value
+      if (oldestToken === undefined) break
+      expiredTransactions.delete(oldestToken)
+    }
+    scheduleCleanup()
+  }
+
+  async function settleExpiredTransaction(
+    token: string,
+    transaction: EditTransaction,
+    now: number
+  ) {
+    try {
+      const result = await transaction.project.endEditTransaction(
+        transaction.nativeToken,
+        transaction.changedPaths
+      )
+      // The authoritative paths have reached the native batch. Retain only the opaque public token
+      // so a late end can report expiry without keeping Project or path payloads alive.
+      rememberExpired(token, performance.now())
+      resetBatchAccountingIfFlushed(result)
+    } catch {
+      // Preserve the payload for a late explicit end if native settlement itself failed.
+      rememberExpired(token, now, transaction)
+    }
+  }
+
+  async function pruneTransactions() {
+    const now = performance.now()
+    const expiredTransactionsToSettle: Array<[string, EditTransaction]> = []
+    for (const [token, transaction] of activeTransactions) {
+      if (transaction.expiresAt <= now) {
+        activeTransactions.delete(token)
+        expiredTransactionsToSettle.push([token, transaction])
+      }
+    }
+    for (const [token, transaction] of expiredTransactionsToSettle) {
+      await settleExpiredTransaction(token, transaction, now)
+    }
+    for (const [token, expired] of expiredTransactions) {
+      if (expired.retainUntil <= now) expiredTransactions.delete(token)
+    }
+    resetBatchAccountingIfMaximumElapsed(now)
+    scheduleCleanup()
+  }
+
+  server.registerTool(
+    'begin_edit_transaction',
+    {
+      description:
+        'Begin an acknowledged Turbopack source-edit transaction before changing multiple files. ' +
+        'Declare every project-relative file and every directory that will be created, removed, or renamed. ' +
+        'Environment/configuration files and routing convention files are rejected because independent dev-server watchers handle them. ' +
+        'The dev server withholds filesystem invalidations until the matching end_edit_transaction call, ' +
+        'so the browser receives one coherent final update instead of intermediate states. ' +
+        'Always end the returned opaque token in a finally block and renew it before leaseMs elapses.',
+      inputSchema: {
+        changedPaths: z
+          .array(z.string().min(1).max(4_096))
+          .max(MAX_CHANGED_PATHS)
+          .default([]),
+      },
+    },
+    async ({ changedPaths }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/begin_edit_transaction')
+      return serializeControl(async () => {
+        try {
+          await pruneTransactions()
+          if (activeTransactions.size >= MAX_ACTIVE_EDIT_TRANSACTIONS) {
+            throw new Error(
+              `Too many active edit transactions (limit ${MAX_ACTIVE_EDIT_TRANSACTIONS})`
+            )
+          }
+          const project = getProject()
+          if (!project) {
+            throw new Error(
+              'Turbopack project is not available. This tool requires the Turbopack bundler.'
+            )
+          }
+          const turbopackRelativeChangedPaths = resolveChangedPaths(
+            projectPath,
+            turbopackRootPath,
+            routeWatcherOptions,
+            changedPaths
+          )
+          const changedPathCharacters = turbopackRelativeChangedPaths.reduce(
+            (length, changedPath) => length + changedPath.length,
+            0
+          )
+          if (
+            batchChangedPathCharacters + changedPathCharacters >
+            MAX_RETAINED_CHANGED_PATH_CHARACTERS
+          ) {
+            throw new Error(
+              `Too much retained changed-path data (limit ${MAX_RETAINED_CHANGED_PATH_CHARACTERS} characters)`
+            )
+          }
+          const acknowledgmentStartedAt = performance.now()
+          const maximumExpiresAt =
+            batchMaximumExpiresAt ??
+            acknowledgmentStartedAt + EDIT_TRANSACTION_MAX_DURATION_MS
+          const nativeToken = await project.beginEditTransaction()
+          const lease = conservativeLease(
+            acknowledgmentStartedAt,
+            maximumExpiresAt
+          )
+          if (lease.leaseMs === 0) {
+            await project.endEditTransaction(nativeToken, [])
+            throw new Error(
+              'Edit transaction acknowledgement consumed its lease headroom; retry begin_edit_transaction'
+            )
+          }
+          batchMaximumExpiresAt = maximumExpiresAt
+          const token = randomUUID()
+          activeTransactions.set(token, {
+            project,
+            nativeToken,
+            expiresAt: lease.expiresAt,
+            maximumExpiresAt,
+            changedPaths: turbopackRelativeChangedPaths,
+          })
+          batchChangedPathCharacters += changedPathCharacters
+          scheduleCleanup()
+          return successResult({
+            token,
+            leaseMs: lease.leaseMs,
+            maximumDurationMs: Math.max(
+              0,
+              maximumExpiresAt - performance.now()
+            ),
+          })
+        } catch (error) {
+          return errorResult(error)
+        }
+      })
+    }
+  )
+
+  server.registerTool(
+    'renew_edit_transaction',
+    {
+      description:
+        'Renew one active Turbopack edit transaction lease while a bounded multi-file edit is still running. ' +
+        'Renew before leaseMs elapses; renewal never extends another controller token or the continuously held batch maximum duration.',
+      inputSchema: {
+        token: z.string().uuid(),
+      },
+    },
+    async ({ token }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/renew_edit_transaction')
+      return serializeControl(async () => {
+        try {
+          await pruneTransactions()
+          const transaction = activeTransactions.get(token)
+          if (!transaction) {
+            return successResult({
+              token,
+              status: expiredTransactions.has(token) ? 'expired' : 'unknown',
+            })
+          }
+          const acknowledgmentStartedAt = performance.now()
+          if (acknowledgmentStartedAt >= transaction.maximumExpiresAt) {
+            activeTransactions.delete(token)
+            await settleExpiredTransaction(
+              token,
+              transaction,
+              acknowledgmentStartedAt
+            )
+            return successResult({ token, status: 'expired' })
+          }
+          const renewed = await transaction.project.renewEditTransaction(
+            transaction.nativeToken
+          )
+          const lease = conservativeLease(
+            acknowledgmentStartedAt,
+            transaction.maximumExpiresAt
+          )
+          if (!renewed || lease.leaseMs === 0) {
+            activeTransactions.delete(token)
+            await settleExpiredTransaction(
+              token,
+              transaction,
+              performance.now()
+            )
+            return successResult({ token, status: 'expired' })
+          }
+          transaction.expiresAt = lease.expiresAt
+          scheduleCleanup()
+          return successResult({
+            token,
+            status: 'renewed',
+            leaseMs: lease.leaseMs,
+          })
+        } catch (error) {
+          return errorResult(error)
+        }
+      })
+    }
+  )
+
+  server.registerTool(
+    'end_edit_transaction',
+    {
+      description:
+        'End an acknowledged Turbopack source-edit transaction after every declared file write has completed. ' +
+        "A flushed result means the final token's invalidations were submitted before this call returned.",
+      inputSchema: {
+        token: z.string().uuid(),
+      },
+    },
+    async ({ token }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/end_edit_transaction')
+      return serializeControl(async () => {
+        try {
+          await pruneTransactions()
+          const activeTransaction = activeTransactions.get(token)
+          const expired = expiredTransactions.get(token)
+          const transaction = activeTransaction ?? expired?.transaction
+          if (!transaction) {
+            return successResult({
+              token,
+              status: expiredTransactions.has(token) ? 'expired' : 'unknown',
+            })
+          }
+          const wasActive = activeTransaction !== undefined
+          if (wasActive) {
+            activeTransactions.delete(token)
+          } else {
+            expiredTransactions.set(token, {
+              retainUntil: expired!.retainUntil,
+            })
+          }
+          let result
+          try {
+            result = await transaction.project.endEditTransaction(
+              transaction.nativeToken,
+              transaction.changedPaths
+            )
+          } catch (error) {
+            const now = performance.now()
+            if (wasActive) {
+              if (now < transaction.expiresAt) {
+                activeTransactions.set(token, transaction)
+              } else {
+                rememberExpired(token, now, transaction)
+              }
+            } else if (now < expired!.retainUntil) {
+              expiredTransactions.set(token, {
+                retainUntil: expired!.retainUntil,
+                transaction,
+              })
+            }
+            scheduleCleanup()
+            throw error
+          }
+          if (result.accepted) {
+            expiredTransactions.delete(token)
+          } else {
+            rememberExpired(token, performance.now())
+          }
+          resetBatchAccountingIfFlushed(result)
+          scheduleCleanup()
+          return successResult({
+            token,
+            status: !result.accepted
+              ? 'expired_or_rescanned'
+              : result.flushed
+                ? 'flushed'
+                : 'held_by_other_transaction',
+          })
+        } catch (error) {
+          return errorResult(error)
+        }
+      })
+    }
+  )
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -283,6 +283,9 @@ export type McpToolName =
   | 'mcp/get_server_action_by_id'
   | 'mcp/get_compilation_issues'
   | 'mcp/compile_route'
+  | 'mcp/begin_edit_transaction'
+  | 'mcp/renew_edit_transaction'
+  | 'mcp/end_edit_transaction'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/packages/next/src/telemetry/events/mcp-telemetry.test.ts
+++ b/packages/next/src/telemetry/events/mcp-telemetry.test.ts
@@ -82,6 +82,9 @@ describe('MCP Telemetry Events', () => {
       'mcp/get_server_action_by_id',
       'mcp/get_compilation_issues',
       'mcp/compile_route',
+      'mcp/begin_edit_transaction',
+      'mcp/renew_edit_transaction',
+      'mcp/end_edit_transaction',
     ]
 
     const usages = allTools.map((tool, index) => ({
@@ -91,7 +94,7 @@ describe('MCP Telemetry Events', () => {
 
     const events = eventMcpToolUsage(usages)
 
-    expect(events).toHaveLength(9)
+    expect(events).toHaveLength(12)
 
     events.forEach((event, index) => {
       expect(event.eventName).toBe(EVENT_MCP_TOOL_USAGE)

--- a/test/development/mcp-server/mcp-server-edit-transaction.test.ts
+++ b/test/development/mcp-server/mcp-server-edit-transaction.test.ts
@@ -1,0 +1,428 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'MCP edit transactions',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      subDir: 'project',
+      files: {
+        app: new FileRef(
+          path.join(__dirname, 'fixtures', 'default-template', 'app')
+        ),
+        'next.config.js': `
+          const path = require('path')
+          module.exports = {
+            // Exercise project-relative changed paths when Turbopack's filesystem root is the
+            // parent of the Next.js project, as it commonly is in a monorepo.
+            turbopack: { root: path.dirname(__dirname) },
+          }
+        `,
+      },
+      env: { __NEXT_EXPERIMENTAL_EDIT_TRANSACTIONS: 'true' },
+    })
+
+    if (skipped) return
+
+    beforeAll(async () => {
+      await next.patchFile(
+        'app/transaction-target.tsx',
+        'export function TransactionTarget() { return <h1>Home Page</h1> }\n'
+      )
+      await next.patchFile('app/page.tsx', (source) =>
+        source
+          .replace(
+            "import Link from 'next/link'",
+            "import Link from 'next/link'\nimport { TransactionTarget } from './transaction-target'"
+          )
+          .replace('<h1>Home Page</h1>', '<TransactionTarget />')
+      )
+    })
+
+    let requestId = 0
+    async function callMcpTool(
+      name: string,
+      args: Record<string, unknown> = {},
+      allowError = false
+    ) {
+      const response = await fetch(`${next.url}/_next/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `edit-transaction-${++requestId}`,
+          method: 'tools/call',
+          params: { name, arguments: args },
+        }),
+      })
+      const body = await response.text()
+      const match = body.match(/data: ({.*})/s)
+      expect(response.ok).toBe(true)
+      expect(match).toBeTruthy()
+      const envelope = JSON.parse(match![1])
+      expect(envelope.error).toBeUndefined()
+      if (!allowError) expect(envelope.result?.isError).not.toBe(true)
+      return {
+        isError: envelope.result?.isError === true,
+        value: JSON.parse(envelope.result?.content?.[0]?.text ?? '{}'),
+      }
+    }
+
+    const beginTransaction = async (changedPaths: string[] = []) =>
+      (await callMcpTool('begin_edit_transaction', { changedPaths })).value as {
+        token: string
+        leaseMs: number
+        maximumDurationMs: number
+      }
+
+    const endTransaction = async (
+      token: string,
+      _declaredChangedPaths: string[] = []
+    ) =>
+      (
+        await callMcpTool('end_edit_transaction', {
+          token,
+        })
+      ).value as {
+        token: string
+        status: string
+      }
+
+    it('holds invalidations until the last opaque nested token ends', async () => {
+      const browser = await next.browser('/')
+      const original = await next.readFile('app/transaction-target.tsx')
+      const first = await beginTransaction(['app/transaction-target.tsx'])
+      const second = await beginTransaction(['app/transaction-target.tsx'])
+      let firstOpen = true
+      let secondOpen = true
+      try {
+        expect(first.token).toMatch(/^[0-9a-f-]{36}$/)
+        expect(second.token).toMatch(/^[0-9a-f-]{36}$/)
+        expect(first.token).not.toBe(second.token)
+        expect(first.leaseMs).toBeGreaterThan(0)
+        expect(first.leaseMs).toBeLessThanOrEqual(4000)
+
+        await next.patchFile('app/transaction-target.tsx', (source) =>
+          source.replace('Home Page', 'Nested Transaction Complete')
+        )
+        await waitFor(750)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        expect(
+          await endTransaction(first.token, ['app/transaction-target.tsx'])
+        ).toMatchObject({
+          token: first.token,
+          status: 'held_by_other_transaction',
+        })
+        firstOpen = false
+        await waitFor(750)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        expect(
+          await endTransaction(second.token, ['app/transaction-target.tsx'])
+        ).toMatchObject({ token: second.token, status: 'flushed' })
+        secondOpen = false
+        await retry(async () => {
+          expect(
+            await browser.eval('document.querySelector("h1")?.textContent')
+          ).toBe('Nested Transaction Complete')
+        })
+      } finally {
+        if (firstOpen)
+          await endTransaction(first.token, ['app/transaction-target.tsx'])
+        if (secondOpen)
+          await endTransaction(second.token, ['app/transaction-target.tsx'])
+        await next.patchFile('app/transaction-target.tsx', original)
+        await browser.close()
+      }
+    })
+
+    it('hides an incomplete import until all changed paths are committed', async () => {
+      const browser = await next.browser('/')
+      const original = await next.readFile('app/transaction-target.tsx')
+      const { token } = await beginTransaction([
+        'app/transaction-target.tsx',
+        'app/transaction-value.ts',
+      ])
+      let transactionOpen = true
+      try {
+        await next.patchFile('app/transaction-target.tsx', (source) =>
+          source
+            .replace(
+              'export function TransactionTarget',
+              "import { transactionValue } from './transaction-value'\n\nexport function TransactionTarget"
+            )
+            .replace('<h1>Home Page</h1>', '<h1>{transactionValue}</h1>')
+        )
+        await waitFor(250)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        await next.patchFile(
+          'app/transaction-value.ts',
+          "export const transactionValue = 'Import Complete'\n"
+        )
+        await waitFor(250)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        expect(
+          await endTransaction(token, [
+            'app/transaction-target.tsx',
+            'app/transaction-value.ts',
+          ])
+        ).toMatchObject({ token, status: 'flushed' })
+        transactionOpen = false
+        await retry(async () => {
+          expect(
+            await browser.eval('document.querySelector("h1")?.textContent')
+          ).toBe('Import Complete')
+        })
+      } finally {
+        if (transactionOpen) {
+          await endTransaction(token, [
+            'app/transaction-target.tsx',
+            'app/transaction-value.ts',
+          ])
+        }
+        await next.patchFile('app/transaction-target.tsx', original)
+        await next.deleteFile('app/transaction-value.ts')
+        await browser.close()
+      }
+    })
+
+    it('discovers a source dependency created beneath declared new directories', async () => {
+      const browser = await next.browser('/')
+      const targetFile = 'app/transaction-target.tsx'
+      const original = await next.readFile(targetFile)
+      const relativeFile = 'app/edit-transaction-created/nested/value.ts'
+      const changedPaths = [
+        targetFile,
+        'app/edit-transaction-created',
+        'app/edit-transaction-created/nested',
+        relativeFile,
+      ]
+      const absoluteDirectory = path.join(
+        next.testDir,
+        'app/edit-transaction-created'
+      )
+      const absoluteFile = path.join(next.testDir, relativeFile)
+      const { token } = await beginTransaction(changedPaths)
+      let transactionOpen = true
+      try {
+        await next.patchFile(targetFile, (source) =>
+          source
+            .replace(
+              'export function TransactionTarget',
+              "import { nestedValue } from './edit-transaction-created/nested/value'\n\nexport function TransactionTarget"
+            )
+            .replace('<h1>Home Page</h1>', '<h1>{nestedValue}</h1>')
+        )
+        await waitFor(250)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        await fs.mkdir(path.dirname(absoluteFile), { recursive: true })
+        await fs.writeFile(
+          absoluteFile,
+          "export const nestedValue = 'Nested Dependency Complete'\n"
+        )
+        await waitFor(250)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        expect(await endTransaction(token, changedPaths)).toMatchObject({
+          token,
+          status: 'flushed',
+        })
+        transactionOpen = false
+        await retry(async () => {
+          expect(
+            await browser.eval('document.querySelector("h1")?.textContent')
+          ).toBe('Nested Dependency Complete')
+        })
+      } finally {
+        if (transactionOpen) await endTransaction(token, changedPaths)
+        await next.patchFile(targetFile, original)
+        await fs.rm(absoluteDirectory, { recursive: true, force: true })
+        await browser.close()
+        await waitFor(500)
+      }
+    })
+
+    it('renews only the matching lease for a long bounded edit', async () => {
+      const browser = await next.browser('/')
+      const original = await next.readFile('app/transaction-target.tsx')
+      const renewedTransaction = await beginTransaction([
+        'app/transaction-target.tsx',
+      ])
+      const expiringTransaction = await beginTransaction([
+        'app/transaction-target.tsx',
+      ])
+      let renewedOpen = true
+      let expiringOpen = true
+      try {
+        await next.patchFile('app/transaction-target.tsx', (source) =>
+          source.replace('Home Page', 'Renewed Transaction Complete')
+        )
+        const renew = async () => {
+          const renewal = (
+            await callMcpTool('renew_edit_transaction', {
+              token: renewedTransaction.token,
+            })
+          ).value as { token: string; status: string; leaseMs: number }
+          expect(renewal).toMatchObject({
+            token: renewedTransaction.token,
+            status: 'renewed',
+          })
+          expect(renewal.leaseMs).toBeGreaterThan(0)
+          expect(renewal.leaseMs).toBeLessThanOrEqual(4000)
+        }
+        await waitFor(1000)
+        await renew()
+        await waitFor(2500)
+        await renew()
+        await waitFor(1500)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        expect(
+          await endTransaction(expiringTransaction.token, [
+            'app/transaction-target.tsx',
+          ])
+        ).toMatchObject({
+          token: expiringTransaction.token,
+          status: 'expired',
+        })
+        expiringOpen = false
+        expect(
+          await endTransaction(renewedTransaction.token, [
+            'app/transaction-target.tsx',
+          ])
+        ).toMatchObject({
+          token: renewedTransaction.token,
+          status: 'flushed',
+        })
+        renewedOpen = false
+        await retry(async () => {
+          expect(
+            await browser.eval('document.querySelector("h1")?.textContent')
+          ).toBe('Renewed Transaction Complete')
+        })
+      } finally {
+        if (expiringOpen) {
+          await endTransaction(expiringTransaction.token, [
+            'app/transaction-target.tsx',
+          ])
+        }
+        if (renewedOpen) {
+          await endTransaction(renewedTransaction.token, [
+            'app/transaction-target.tsx',
+          ])
+        }
+        await next.patchFile('app/transaction-target.tsx', original)
+        await browser.close()
+      }
+    })
+
+    it('rejects unsupported paths before a transaction begins', async () => {
+      const outside = await callMcpTool(
+        'begin_edit_transaction',
+        { changedPaths: ['../outside.ts'] },
+        true
+      )
+      expect(outside.isError).toBe(true)
+      expect(outside.value.error).toContain('leaves the project root')
+
+      for (const changedPath of [
+        '.env.local',
+        'tsconfig.json',
+        'jsconfig.json',
+        'next.config.js',
+        'app/page.tsx',
+        'app/api/route.ts',
+        'app/layout.tsx',
+        'middleware.ts',
+        'src/instrumentation.ts',
+      ]) {
+        const unsupported = await callMcpTool(
+          'begin_edit_transaction',
+          { changedPaths: [changedPath] },
+          true
+        )
+        expect(unsupported.isError).toBe(true)
+        expect(unsupported.value.error).toContain(
+          'watched outside the Turbopack source transaction'
+        )
+      }
+
+      const { token } = await beginTransaction(['app/transaction-target.tsx'])
+      expect(await endTransaction(token)).toMatchObject({
+        token,
+        status: 'flushed',
+      })
+    })
+
+    it('acknowledges the final flush before a subsequent begin', async () => {
+      const first = await beginTransaction()
+      await expect(endTransaction(first.token, [])).resolves.toMatchObject({
+        token: first.token,
+        status: 'flushed',
+      })
+      const second = await beginTransaction()
+      await expect(endTransaction(second.token, [])).resolves.toMatchObject({
+        token: second.token,
+        status: 'flushed',
+      })
+    })
+
+    it('forces progress after an abandoned transaction', async () => {
+      const browser = await next.browser('/')
+      const original = await next.readFile('app/transaction-target.tsx')
+      const transactionStartedAt = Date.now()
+      const { token, leaseMs } = await beginTransaction([
+        'app/transaction-target.tsx',
+      ])
+      try {
+        await next.patchFile('app/transaction-target.tsx', (source) =>
+          source.replace('Home Page', 'Timeout Released')
+        )
+        await waitFor(250)
+        expect(
+          await browser.eval('document.querySelector("h1")?.textContent')
+        ).toBe('Home Page')
+
+        await retry(async () => {
+          expect(
+            await browser.eval('document.querySelector("h1")?.textContent')
+          ).toBe('Timeout Released')
+        }, 7000)
+        expect(Date.now() - transactionStartedAt).toBeGreaterThanOrEqual(
+          leaseMs
+        )
+        expect(
+          await endTransaction(token, ['app/transaction-target.tsx'])
+        ).toMatchObject({
+          token,
+          status: 'expired',
+        })
+      } finally {
+        await next.patchFile('app/transaction-target.tsx', original)
+        await browser.close()
+      }
+    })
+  }
+)

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -522,6 +522,46 @@ impl DiskFileSystem {
             .await
     }
 
+    pub async fn begin_edit_transaction(&self) -> Result<u32> {
+        self.inner.watcher.begin_edit_transaction().await
+    }
+
+    pub async fn renew_edit_transaction(&self, token: u32) -> Result<bool> {
+        self.inner.watcher.renew_edit_transaction(token).await
+    }
+
+    pub async fn end_edit_transaction(
+        &self,
+        token: u32,
+        changed_paths: Vec<PathBuf>,
+    ) -> Result<(bool, bool)> {
+        let root = self.inner.root_path();
+        let mut absolute_changed_paths = Vec::with_capacity(changed_paths.len());
+        for path in changed_paths {
+            if path.is_absolute()
+                || path.components().any(|component| {
+                    matches!(
+                        component,
+                        std::path::Component::Prefix(_)
+                            | std::path::Component::RootDir
+                            | std::path::Component::CurDir
+                            | std::path::Component::ParentDir
+                    )
+                })
+            {
+                bail!(
+                    "edit transaction changed path {} is not filesystem-root-relative",
+                    path.display()
+                );
+            }
+            absolute_changed_paths.push(root.join(path));
+        }
+        self.inner
+            .watcher
+            .end_edit_transaction(token, absolute_changed_paths)
+            .await
+    }
+
     pub async fn stop_watching(&self) {
         self.inner.watcher.stop_watching().await;
     }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -1,12 +1,13 @@
 use std::{
     any::Any,
-    collections::BTreeSet,
+    collections::{BTreeSet, VecDeque, hash_map::Entry},
     env, fmt,
     mem::take,
     path::{Path, PathBuf},
     sync::{
         Arc, LazyLock,
-        mpsc::{Receiver, RecvTimeoutError, channel},
+        atomic::{AtomicU32, Ordering},
+        mpsc::{Receiver, RecvTimeoutError, Sender, channel},
     },
     time::{Duration, Instant},
 };
@@ -19,7 +20,7 @@ use notify::{
     event::{MetadataKind, ModifyKind, RenameMode},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
-use tokio::sync::{RwLock, RwLockWriteGuard};
+use tokio::sync::{RwLock, RwLockWriteGuard, oneshot};
 use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -71,10 +72,144 @@ const BATCH_DELAY: Duration = Duration::from_millis(10);
 #[cfg(not(target_os = "linux"))]
 const BATCH_DELAY: Duration = Duration::from_millis(1);
 
+/// A transaction lease is deliberately short so a crashed controller cannot leave the preview
+/// stale. Long-running controllers can renew their own token without extending other controllers,
+/// but all overlapping tokens share an absolute batch lifetime so rotating tokens cannot withhold
+/// invalidation indefinitely.
+pub(crate) const EDIT_TRANSACTION_LEASE: Duration = Duration::from_secs(5);
+pub(crate) const EDIT_TRANSACTION_MAX_DURATION: Duration = Duration::from_secs(60);
+/// A long transaction must not turn unrelated checkout/install traffic into an unbounded in-memory
+/// path batch. Crossing either limit falls back to one deferred full invalidation.
+const EDIT_TRANSACTION_MAX_RETAINED_PATHS: usize = 16 * 1024;
+const EDIT_TRANSACTION_MAX_RETAINED_PATH_BYTES: usize = 4 * 1024 * 1024;
+
+fn initial_transaction_id() -> AtomicU32 {
+    AtomicU32::new(1)
+}
+
 #[derive(Encode, Decode)]
 pub(crate) struct DiskWatcher {
     #[bincode(skip)]
     state: State,
+    #[bincode(skip, default = "initial_transaction_id")]
+    next_transaction_id: AtomicU32,
+}
+
+#[derive(Clone, Copy)]
+struct EditTransactionLease {
+    expiration: Instant,
+    maximum_expiration: Instant,
+}
+
+impl EditTransactionLease {
+    fn new(now: Instant, maximum_expiration: Instant) -> Self {
+        Self {
+            expiration: (now + EDIT_TRANSACTION_LEASE).min(maximum_expiration),
+            maximum_expiration,
+        }
+    }
+
+    fn is_active_at(&self, requested_at: Instant) -> bool {
+        self.expiration > requested_at && self.maximum_expiration > requested_at
+    }
+
+    fn renew(&mut self, requested_at: Instant, now: Instant) -> bool {
+        if !self.is_active_at(requested_at) || self.maximum_expiration <= now {
+            return false;
+        }
+        self.expiration = (now + EDIT_TRANSACTION_LEASE).min(self.maximum_expiration);
+        true
+    }
+}
+
+#[derive(Default)]
+struct EditTransactionBatchState {
+    maximum_expiration: Option<Instant>,
+    forced_settle: bool,
+    pending_rescan: bool,
+}
+
+impl EditTransactionBatchState {
+    fn maximum_expiration(&mut self, now: Instant) -> Instant {
+        *self
+            .maximum_expiration
+            .get_or_insert(now + EDIT_TRANSACTION_MAX_DURATION)
+    }
+
+    fn force_settle(&mut self) {
+        self.forced_settle = true;
+    }
+
+    fn is_settling(&self, has_pending_end: bool) -> bool {
+        self.forced_settle || has_pending_end
+    }
+
+    fn is_forced_settle(&self) -> bool {
+        self.forced_settle
+    }
+
+    fn request_rescan(&mut self) {
+        self.pending_rescan = true;
+    }
+
+    fn has_pending_rescan(&self) -> bool {
+        self.pending_rescan
+    }
+
+    fn is_transaction_batch(&self) -> bool {
+        self.maximum_expiration.is_some()
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+enum WatchEventMessage {
+    Filesystem(notify::Result<notify::Event>),
+    /// Wakes the event receiver after a control message is queued. The control receiver is checked
+    /// first on every loop iteration, so it cannot sit behind a filesystem-event backlog.
+    ControlReady,
+}
+
+fn drain_rescan_event_backlog(event_rx: &Receiver<WatchEventMessage>) {
+    // A full rescan subsumes every filesystem message already queued. Control payloads use their
+    // own receiver and are polled directly before the next filesystem receive, so consuming their
+    // wake tokens here cannot lose or delay an edit-transaction control.
+    while event_rx.try_recv().is_ok() {}
+}
+
+enum EditTransactionMessage {
+    Begin {
+        token: u32,
+        acknowledged: oneshot::Sender<bool>,
+    },
+    Renew {
+        token: u32,
+        requested_at: Instant,
+        acknowledged: oneshot::Sender<bool>,
+    },
+    End {
+        token: u32,
+        requested_at: Instant,
+        changed_paths: Vec<PathBuf>,
+        acknowledged: oneshot::Sender<(bool, bool)>,
+    },
+}
+
+#[derive(Clone)]
+struct WatchSenders {
+    event_tx: Sender<WatchEventMessage>,
+    control_tx: Sender<EditTransactionMessage>,
+}
+
+impl WatchSenders {
+    fn send_control(&self, message: EditTransactionMessage) -> bool {
+        if self.control_tx.send(message).is_err() {
+            return false;
+        }
+        self.event_tx.send(WatchEventMessage::ControlReady).is_ok()
+    }
 }
 
 enum State {
@@ -112,6 +247,19 @@ impl State {
         }
     }
 
+    async fn message_senders(&self) -> Option<WatchSenders> {
+        match self {
+            Self::Recursive(state) => match &*state.read().await {
+                RecursiveState::Stopped => None,
+                RecursiveState::Watching { senders, .. } => Some(senders.clone()),
+            },
+            Self::NonRecursive(state) => match &*state.read().await {
+                NonRecursiveState::Stopped => None,
+                NonRecursiveState::Watching(state) => Some(state.senders.clone()),
+            },
+        }
+    }
+
     fn recursive_mode(&self) -> RecursiveMode {
         match self {
             Self::Recursive(_) => RecursiveMode::Recursive,
@@ -129,6 +277,7 @@ enum RecursiveState {
     Watching {
         /// Hold onto the watcher: When this is dropped, it will cause the channel to disconnect
         _notify_watcher: NotifyWatcher,
+        senders: WatchSenders,
     },
 }
 
@@ -143,6 +292,7 @@ enum NonRecursiveState {
 // split out from the `NonRecursiveState` enum because we want to pass this value around
 struct NonRecursiveWatchingState {
     notify_watcher: NotifyWatcher,
+    senders: WatchSenders,
     /// Keeps track of which directories are currently or were previously watched by
     /// [`Self::notify_watcher`].
     ///
@@ -357,6 +507,7 @@ impl DiskWatcher {
     pub fn new() -> Self {
         Self {
             state: State::new_stopped(),
+            next_transaction_id: AtomicU32::new(1),
         }
     }
 
@@ -394,8 +545,11 @@ impl DiskWatcher {
             return Ok(());
         }
 
-        // Create a channel to receive the events.
-        let (tx, rx) = channel();
+        // Keep filesystem events and transaction controls on separate channels. Controls wake the
+        // event receiver, but are always processed first, so a busy watcher cannot starve a timely
+        // renew or end behind an arbitrary filesystem backlog.
+        let (event_tx, event_rx) = channel();
+        let (control_tx, control_rx) = channel();
         // Create a watcher object, delivering debounced events.
         // The notification back-end is selected based on the platform.
         let config = Config::default();
@@ -405,9 +559,21 @@ impl DiskWatcher {
 
         let mut notify_watcher = if let Some(poll_interval) = poll_interval {
             let config = config.with_poll_interval(poll_interval);
-            NotifyWatcher::Polling(PollWatcher::new(tx, config)?)
+            let notify_tx = event_tx.clone();
+            NotifyWatcher::Polling(PollWatcher::new(
+                move |result| {
+                    let _ = notify_tx.send(WatchEventMessage::Filesystem(result));
+                },
+                config,
+            )?)
         } else {
-            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?)
+            let notify_tx = event_tx.clone();
+            NotifyWatcher::Recommended(RecommendedWatcher::new(
+                move |result| {
+                    let _ = notify_tx.send(WatchEventMessage::Filesystem(result));
+                },
+                config,
+            )?)
         };
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the
@@ -454,29 +620,110 @@ impl DiskWatcher {
         }
 
         spawn_thread(move || {
-            fs_inner
-                .clone()
-                .watcher
-                .watch_thread(rx, fs_inner, report_invalidation_reason)
+            fs_inner.clone().watcher.watch_thread(
+                event_rx,
+                control_rx,
+                fs_inner,
+                report_invalidation_reason,
+            )
         });
 
+        let senders = WatchSenders {
+            event_tx,
+            control_tx,
+        };
         // Updating `self.state` is done last. If we panic while setting up the watcher, it'll
         // stay in the `Stopped` state.
         match state_guard {
             StateWriteGuard::Recursive(mut recursive) => {
                 *recursive = RecursiveState::Watching {
                     _notify_watcher: notify_watcher,
+                    senders,
                 }
             }
             StateWriteGuard::NonRecursive(mut non_recursive) => {
                 *non_recursive = NonRecursiveState::Watching(NonRecursiveWatchingState {
                     notify_watcher,
+                    senders,
                     watched: BTreeSet::new(),
                 })
             }
         };
 
         Ok(())
+    }
+
+    /// Start an explicitly bounded source edit. The acknowledgement guarantees that the watcher is
+    /// retaining invalidations before this method returns.
+    pub async fn begin_edit_transaction(&self) -> Result<u32> {
+        let senders = self
+            .state
+            .message_senders()
+            .await
+            .context("filesystem watcher is not running")?;
+        let token = self.next_transaction_id.fetch_add(1, Ordering::Relaxed);
+        let (acknowledged, acknowledgment) = oneshot::channel();
+        if !senders.send_control(EditTransactionMessage::Begin {
+            token,
+            acknowledged,
+        }) {
+            anyhow::bail!("filesystem watcher stopped before transaction began");
+        }
+        if !acknowledgment
+            .await
+            .context("filesystem watcher stopped before acknowledging transaction")?
+        {
+            anyhow::bail!("filesystem watcher rejected edit transaction");
+        }
+        Ok(token)
+    }
+
+    /// Renew only the matching transaction's lease. A `false` result means the token was unknown
+    /// or its prior lease already expired.
+    pub async fn renew_edit_transaction(&self, token: u32) -> Result<bool> {
+        let senders = self
+            .state
+            .message_senders()
+            .await
+            .context("filesystem watcher is not running")?;
+        let (acknowledged, acknowledgment) = oneshot::channel();
+        if !senders.send_control(EditTransactionMessage::Renew {
+            token,
+            requested_at: Instant::now(),
+            acknowledged,
+        }) {
+            anyhow::bail!("filesystem watcher stopped before transaction renewed");
+        }
+        acknowledgment
+            .await
+            .context("filesystem watcher stopped before acknowledging transaction renewal")
+    }
+
+    /// Finish an explicitly bounded source edit. A successful acknowledgement is delayed until the
+    /// final token's invalidations have been submitted, so callers cannot mistake release for
+    /// flush.
+    pub async fn end_edit_transaction(
+        &self,
+        token: u32,
+        changed_paths: Vec<PathBuf>,
+    ) -> Result<(bool, bool)> {
+        let senders = self
+            .state
+            .message_senders()
+            .await
+            .context("filesystem watcher is not running")?;
+        let (acknowledged, acknowledgment) = oneshot::channel();
+        if !senders.send_control(EditTransactionMessage::End {
+            token,
+            requested_at: Instant::now(),
+            changed_paths,
+            acknowledged,
+        }) {
+            anyhow::bail!("filesystem watcher stopped before transaction ended");
+        }
+        acknowledgment
+            .await
+            .context("filesystem watcher stopped before acknowledging transaction end")
     }
 
     pub async fn stop_watching(&self) {
@@ -494,23 +741,189 @@ impl DiskWatcher {
     /// Should only be called once from `start_watching`.
     fn watch_thread(
         &self,
-        rx: Receiver<notify::Result<notify::Event>>,
+        event_rx: Receiver<WatchEventMessage>,
+        control_rx: Receiver<EditTransactionMessage>,
         fs_inner: Arc<DiskFileSystemInner>,
         report_invalidation_reason: bool,
     ) {
         let mut batch = BatchedInvalidations::new(self.state.recursive_mode());
+        let mut active_edit_transactions = FxHashMap::<u32, EditTransactionLease>::default();
+        // This is batch state, not token state. Keep it until the batch is actually executed so a
+        // begin racing an abandoned token's final settle cannot mint a fresh maximum or absorb the
+        // batch that is already being forced out.
+        let mut edit_transaction_batch = EditTransactionBatchState::default();
+        let mut pending_end_acknowledgements = Vec::new();
+        let mut deferred_controls = VecDeque::new();
+        let mut deferred_begins = Vec::new();
 
         'outer: loop {
-            let mut deadline: Option<Instant> = None;
+            let mut deadline = active_edit_transactions
+                .values()
+                .map(|lease| lease.expiration)
+                .min();
             loop {
+                // Transaction controls have their own channel and are checked before expiry and
+                // before every filesystem event. `requested_at` preserves whether a renew or end
+                // was timely even if this thread was busy processing an earlier event.
+                let control_message = deferred_controls
+                    .pop_front()
+                    .or_else(|| control_rx.try_recv().ok());
+                if let Some(message) = control_message {
+                    match message {
+                        EditTransactionMessage::Begin {
+                            token,
+                            acknowledged,
+                        } => {
+                            // A begin that races the final settle must wait for the previous flush.
+                            // It must not absorb that previous settling interval.
+                            if edit_transaction_batch
+                                .is_settling(!pending_end_acknowledgements.is_empty())
+                            {
+                                deferred_begins.push(EditTransactionMessage::Begin {
+                                    token,
+                                    acknowledged,
+                                });
+                            } else {
+                                let accepted = !active_edit_transactions.contains_key(&token);
+                                if accepted {
+                                    let now = Instant::now();
+                                    let maximum_expiration =
+                                        edit_transaction_batch.maximum_expiration(now);
+                                    active_edit_transactions.insert(
+                                        token,
+                                        EditTransactionLease::new(now, maximum_expiration),
+                                    );
+                                    if batch.exceeds_transaction_limits() {
+                                        eprintln!(
+                                            "edit transaction captured too many pre-existing \
+                                             filesystem paths; falling back to a full invalidation"
+                                        );
+                                        edit_transaction_batch.request_rescan();
+                                        batch.clear();
+                                    }
+                                    deadline = active_edit_transactions
+                                        .values()
+                                        .map(|lease| lease.expiration)
+                                        .min();
+                                }
+                                let _ = acknowledged.send(accepted);
+                            }
+                        }
+                        EditTransactionMessage::Renew {
+                            token,
+                            requested_at,
+                            acknowledged,
+                        } => {
+                            let now = Instant::now();
+                            let accepted = active_edit_transactions
+                                .get_mut(&token)
+                                .is_some_and(|lease| lease.renew(requested_at, now));
+                            let expired_active_lease =
+                                !accepted && active_edit_transactions.remove(&token).is_some();
+                            let _ = acknowledged.send(accepted);
+                            deadline = if !active_edit_transactions.is_empty() {
+                                active_edit_transactions
+                                    .values()
+                                    .map(|lease| lease.expiration)
+                                    .min()
+                            } else if pending_end_acknowledgements.is_empty()
+                                && expired_active_lease
+                            {
+                                edit_transaction_batch.force_settle();
+                                Some(now + BATCH_DELAY)
+                            } else {
+                                // A stale renewal must not extend another transaction's final
+                                // settle.
+                                deadline
+                            };
+                        }
+                        EditTransactionMessage::End {
+                            token,
+                            requested_at,
+                            changed_paths,
+                            acknowledged,
+                        } => {
+                            let accepted = active_edit_transactions
+                                .get(&token)
+                                .is_some_and(|lease| lease.is_active_at(requested_at));
+                            active_edit_transactions.remove(&token);
+                            if !edit_transaction_batch.has_pending_rescan() {
+                                batch.add_changed_paths(changed_paths);
+                                if batch.exceeds_transaction_limits() {
+                                    eprintln!(
+                                        "edit transaction end submitted too many paths; falling \
+                                         back to a full invalidation"
+                                    );
+                                    edit_transaction_batch.request_rescan();
+                                    batch.clear();
+                                }
+                            }
+                            if active_edit_transactions.is_empty() {
+                                // Controller-confirmed paths remain authoritative even if this end
+                                // was queued after the token expired. Report the final flush
+                                // independently from token acceptance so JavaScript can release its
+                                // retained path budget immediately after invalidation.
+                                pending_end_acknowledgements.push((acknowledged, (accepted, true)));
+                                if !edit_transaction_batch.is_forced_settle() {
+                                    deadline = Some(Instant::now() + BATCH_DELAY);
+                                }
+                            } else {
+                                let _ = acknowledged.send((accepted, false));
+                                deadline = active_edit_transactions
+                                    .values()
+                                    .map(|lease| lease.expiration)
+                                    .min();
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                // A busy filesystem queue must not starve transaction expiry or a final settle
+                // deadline. Check both before consuming each queued event.
+                let now = Instant::now();
+                let before = active_edit_transactions.len();
+                active_edit_transactions.retain(|_, lease| lease.expiration > now);
+                let expired = before - active_edit_transactions.len();
+                if expired > 0 {
+                    eprintln!("edit transaction lease expired for {expired} token(s)");
+                    deadline = if active_edit_transactions.is_empty() {
+                        // A controller may disappear in the middle of a physical write. Give the
+                        // filesystem the ordinary settling interval before forcing progress. This
+                        // deadline is fixed: neither filesystem traffic nor a racing begin may
+                        // extend or join the abandoned batch.
+                        edit_transaction_batch.force_settle();
+                        Some(now + BATCH_DELAY)
+                    } else {
+                        active_edit_transactions
+                            .values()
+                            .map(|lease| lease.expiration)
+                            .min()
+                    };
+                }
+                if active_edit_transactions.is_empty()
+                    && edit_transaction_batch.is_settling(!pending_end_acknowledgements.is_empty())
+                    && deadline.is_some_and(|deadline| deadline <= now)
+                {
+                    break;
+                }
+
                 let event_result = match deadline {
-                    None => rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
+                    None => event_rx.recv().map_err(|_| RecvTimeoutError::Disconnected),
                     Some(deadline) => {
-                        rx.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                        event_rx.recv_timeout(deadline.saturating_duration_since(Instant::now()))
                     }
                 };
                 match event_result {
-                    Ok(Ok(event)) => {
+                    Ok(WatchEventMessage::ControlReady) => continue,
+                    Ok(WatchEventMessage::Filesystem(Ok(event))) => {
+                        // A pending full invalidation already subsumes every later filesystem
+                        // event. Discard them so a deferred rescan cannot
+                        // rebuild an unbounded path batch.
+                        if edit_transaction_batch.has_pending_rescan() {
+                            continue;
+                        }
+
                         // TODO: We might benefit from some user-facing diagnostics if it rescans
                         // occur frequently (i.e. more than X times in Y minutes)
                         //
@@ -521,51 +934,63 @@ impl DiskWatcher {
                         // echo 3 | sudo tee /proc/sys/fs/inotify/max_queued_events
                         // ```
                         if event.need_rescan() {
-                            let _lock = fs_inner.invalidation_lock.blocking_write();
-
-                            // flush the whole mpsc queue, we're about to rescan, we don't need to
-                            // process any other update events that have already happened
-                            while rx.try_recv().is_ok() {}
-
-                            if let State::NonRecursive(non_recursive) = &self.state {
-                                // we can't narrow this down to a smaller set of paths: Rescan
-                                // events (at least when tested on
-                                // Linux) come with no `paths`, and we use
-                                // only one global `notify::Watcher` instance.
-                                //
-                                // TODO: Report diagnostics if an error happens
-                                fs_inner.tokio_handle.block_on(
-                                    non_recursive_helpers::restore_all_watched_ignore_errors(
-                                        non_recursive,
-                                        fs_inner.root_path(),
-                                    ),
-                                );
-                            }
-
-                            if report_invalidation_reason {
-                                fs_inner.invalidate_with_reason(|path| InvalidateRescan {
-                                    // this path is just used for display purposes
-                                    path: RcStr::from(path.to_string_lossy()),
-                                });
-                            } else {
-                                fs_inner.invalidate();
-                            }
-
-                            // no need to process the rest of the batch as we just
-                            // invalidated everything
+                            // A rescan means the platform watcher lost event history, but it must
+                            // not revoke an acknowledged semantic edit
+                            // and expose its partial state. Defer
+                            // the full invalidation until the active transaction settles or
+                            // expires. The eventual full invalidation
+                            // subsumes both the queued events and the
+                            // controller-confirmed changed paths.
+                            edit_transaction_batch.request_rescan();
                             batch.clear();
-                            break;
+                            if active_edit_transactions.is_empty()
+                                && !edit_transaction_batch
+                                    .is_settling(!pending_end_acknowledgements.is_empty())
+                            {
+                                break;
+                            }
+                            continue;
                         }
 
                         // Only an event that contributes to the batch keeps it open for another
                         // `BATCH_DELAY`.
                         if batch.add_event(event) {
-                            deadline = Some(Instant::now() + BATCH_DELAY);
+                            if edit_transaction_batch.is_transaction_batch()
+                                && batch.exceeds_transaction_limits()
+                            {
+                                eprintln!(
+                                    "edit transaction retained too many filesystem paths; falling \
+                                     back to a full invalidation"
+                                );
+                                edit_transaction_batch.request_rescan();
+                                batch.clear();
+                            }
+                            deadline = if !active_edit_transactions.is_empty() {
+                                active_edit_transactions
+                                    .values()
+                                    .map(|lease| lease.expiration)
+                                    .min()
+                            } else if !edit_transaction_batch
+                                .is_settling(!pending_end_acknowledgements.is_empty())
+                            {
+                                Some(Instant::now() + BATCH_DELAY)
+                            } else {
+                                // Controller-confirmed paths make the final settle deadline fixed.
+                                // Late watcher events are still included without extending the ack.
+                                deadline
+                            };
                         }
                     }
                     // Error raised by notify watcher itself
-                    Ok(Err(notify::Error { kind, paths })) => {
+                    Ok(WatchEventMessage::Filesystem(Err(notify::Error { kind, paths }))) => {
                         println!("watch error ({paths:?}): {kind:?} ");
+
+                        // The pending full invalidation also subsumes watcher-error paths.
+                        // Retaining them here would allow unbounded growth
+                        // while a transaction defers rescan.
+                        if edit_transaction_batch.has_pending_rescan() {
+                            continue;
+                        }
 
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
@@ -576,11 +1001,35 @@ impl DiskWatcher {
                                 batch.mark(path.into_boxed_path(), flags);
                             }
                         }
-                        deadline = Some(Instant::now() + BATCH_DELAY);
+                        if edit_transaction_batch.is_transaction_batch()
+                            && batch.exceeds_transaction_limits()
+                        {
+                            eprintln!(
+                                "edit transaction retained too many watcher-error paths; falling \
+                                 back to a full invalidation"
+                            );
+                            edit_transaction_batch.request_rescan();
+                            batch.clear();
+                        }
+                        deadline = if !active_edit_transactions.is_empty() {
+                            active_edit_transactions
+                                .values()
+                                .map(|lease| lease.expiration)
+                                .min()
+                        } else if !edit_transaction_batch
+                            .is_settling(!pending_end_acknowledgements.is_empty())
+                        {
+                            Some(Instant::now() + BATCH_DELAY)
+                        } else {
+                            // Match the ordinary event path: notification errors are included in
+                            // the final transaction flush without extending its acknowledgement.
+                            deadline
+                        };
                     }
                     Err(RecvTimeoutError::Timeout) => {
-                        // The batch is complete: break out to invalidate the collected paths.
-                        break;
+                        if active_edit_transactions.is_empty() {
+                            break;
+                        }
                     }
                     Err(RecvTimeoutError::Disconnected) => {
                         // Sender has been disconnected, which means DiskFileSystem has been dropped
@@ -590,42 +1039,71 @@ impl DiskWatcher {
                 }
             }
 
-            // We need to start watching first before invalidating the changed paths...
-            // This is only needed on platforms we don't do recursive watching on.
-            if let State::NonRecursive(non_recursive) = &self.state {
-                for path in batch.new_paths() {
-                    // TODO: Report diagnostics if this error happens
-                    let _ =
-                        fs_inner
-                            .tokio_handle
-                            .block_on(non_recursive_helpers::restore_if_watched(
+            if edit_transaction_batch.has_pending_rescan() {
+                let _lock = fs_inner.invalidation_lock.blocking_write();
+                drain_rescan_event_backlog(&event_rx);
+                if let State::NonRecursive(non_recursive) = &self.state {
+                    // Rescan events contain no usable paths for the one global non-recursive
+                    // watcher. Restore every previously tracked watch immediately before the full
+                    // invalidation becomes visible.
+                    fs_inner.tokio_handle.block_on(
+                        non_recursive_helpers::restore_all_watched_ignore_errors(
+                            non_recursive,
+                            fs_inner.root_path(),
+                        ),
+                    );
+                }
+                if report_invalidation_reason {
+                    fs_inner.invalidate_with_reason(|path| InvalidateRescan {
+                        // This path is used only for display purposes.
+                        path: RcStr::from(path.to_string_lossy()),
+                    });
+                } else {
+                    fs_inner.invalidate();
+                }
+                batch.clear();
+            } else {
+                // We need to start watching first before invalidating the changed paths. This is
+                // only needed on platforms where watching is non-recursive.
+                if let State::NonRecursive(non_recursive) = &self.state {
+                    for path in batch.new_paths() {
+                        // TODO: Report diagnostics if this error happens
+                        let _ = fs_inner.tokio_handle.block_on(
+                            non_recursive_helpers::restore_if_watched(
                                 non_recursive,
                                 path,
                                 fs_inner.root_path(),
-                            ));
+                            ),
+                        );
+                    }
                 }
+
+                let Some(turbo_tasks) = fs_inner.turbo_tasks.upgrade() else {
+                    // TurboTasks was dropped, stop watching
+                    break 'outer;
+                };
+                let _guard = fs_inner.tokio_handle.enter();
+
+                let _lock = fs_inner.invalidation_lock.blocking_write();
+                batch.execute(
+                    &fs_inner.invalidator_map,
+                    &fs_inner.dir_invalidator_map,
+                    |invalidation_reason_path, invalidator| {
+                        invalidate(
+                            &fs_inner,
+                            &*turbo_tasks,
+                            report_invalidation_reason,
+                            invalidation_reason_path,
+                            invalidator,
+                        )
+                    },
+                );
             }
-
-            let Some(turbo_tasks) = fs_inner.turbo_tasks.upgrade() else {
-                // TurboTasks was dropped, stop watching
-                break 'outer;
-            };
-            let _guard = fs_inner.tokio_handle.enter();
-
-            let _lock = fs_inner.invalidation_lock.blocking_write();
-            batch.execute(
-                &fs_inner.invalidator_map,
-                &fs_inner.dir_invalidator_map,
-                |invalidation_reason_path, invalidator| {
-                    invalidate(
-                        &fs_inner,
-                        &*turbo_tasks,
-                        report_invalidation_reason,
-                        invalidation_reason_path,
-                        invalidator,
-                    )
-                },
-            );
+            for (acknowledged, result) in take(&mut pending_end_acknowledgements) {
+                let _ = acknowledged.send(result);
+            }
+            edit_transaction_batch.reset();
+            deferred_controls.extend(take(&mut deferred_begins));
         }
     }
 
@@ -675,6 +1153,7 @@ bitflags! {
 /// `PathBuf` into multiple collections.
 struct BatchedInvalidations {
     paths: FxHashMap<Box<Path>, InvalidationFlags>,
+    path_bytes: usize,
     /// See [`Self::new_paths`]). Stored as [`None`] in non-recursive mode.
     new_paths: Option<FxHashSet<Box<Path>>>,
 }
@@ -683,6 +1162,7 @@ impl BatchedInvalidations {
     fn new(recursive_mode: RecursiveMode) -> Self {
         Self {
             paths: FxHashMap::default(),
+            path_bytes: 0,
             new_paths: match recursive_mode {
                 RecursiveMode::NonRecursive => Some(FxHashSet::default()),
                 RecursiveMode::Recursive => None,
@@ -692,6 +1172,7 @@ impl BatchedInvalidations {
 
     fn clear(&mut self) {
         self.paths.clear();
+        self.path_bytes = 0;
         if let Some(new_paths) = &mut self.new_paths {
             new_paths.clear();
         }
@@ -706,12 +1187,39 @@ impl BatchedInvalidations {
     }
 
     fn mark(&mut self, path: Box<Path>, flags: InvalidationFlags) {
-        *self.paths.entry(path).or_insert(InvalidationFlags::empty()) |= flags;
+        match self.paths.entry(path) {
+            Entry::Occupied(mut entry) => *entry.get_mut() |= flags,
+            Entry::Vacant(entry) => {
+                self.path_bytes += entry.key().as_os_str().as_encoded_bytes().len();
+                entry.insert(flags);
+            }
+        }
+    }
+
+    fn exceeds_transaction_limits(&self) -> bool {
+        self.paths.len() > EDIT_TRANSACTION_MAX_RETAINED_PATHS
+            || self.path_bytes > EDIT_TRANSACTION_MAX_RETAINED_PATH_BYTES
     }
 
     fn mark_parent_dir(&mut self, path: &Path) {
         if let Some(parent) = path.parent() {
             self.mark(Box::from(parent), InvalidationFlags::PATH_DIR);
+        }
+    }
+
+    /// Add controller-confirmed changed paths. The broad flags safely cover creates, removes,
+    /// renames, and modifications even when the platform watcher delivers its event after `end`.
+    /// Controllers include created, removed, and renamed directories as changed paths, so marking
+    /// each immediate parent is sufficient to discover a nested subtree without invalidating every
+    /// directory up to a monorepo root.
+    fn add_changed_paths(&mut self, paths: Vec<PathBuf>) {
+        for path in paths {
+            self.mark_parent_dir(&path);
+            self.mark_new_path(&path);
+            self.mark(
+                path.into_boxed_path(),
+                InvalidationFlags::PATH_AND_CHILDREN | InvalidationFlags::PATH_AND_CHILDREN_DIR,
+            );
         }
     }
 
@@ -926,5 +1434,188 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edit_transaction_renewal_has_an_absolute_deadline() {
+        let started_at = Instant::now();
+        let maximum_expiration = started_at + EDIT_TRANSACTION_MAX_DURATION;
+        let mut lease = EditTransactionLease::new(started_at, maximum_expiration);
+
+        assert!(lease.renew(
+            started_at + EDIT_TRANSACTION_LEASE / 2,
+            started_at + EDIT_TRANSACTION_LEASE / 2
+        ));
+        assert_eq!(
+            lease.expiration,
+            started_at + EDIT_TRANSACTION_LEASE + EDIT_TRANSACTION_LEASE / 2
+        );
+
+        let renewal_interval = EDIT_TRANSACTION_LEASE / 2;
+        let mut renewal_at = started_at + EDIT_TRANSACTION_LEASE;
+        while renewal_at < started_at + EDIT_TRANSACTION_MAX_DURATION {
+            assert!(lease.renew(renewal_at, renewal_at));
+            renewal_at += renewal_interval;
+        }
+
+        let just_before_maximum =
+            started_at + EDIT_TRANSACTION_MAX_DURATION - Duration::from_nanos(1);
+        let nested_lease = EditTransactionLease::new(just_before_maximum, maximum_expiration);
+        assert_eq!(nested_lease.expiration, maximum_expiration);
+        assert_eq!(nested_lease.maximum_expiration, maximum_expiration);
+
+        assert!(lease.renew(just_before_maximum, just_before_maximum));
+        assert_eq!(lease.expiration, lease.maximum_expiration);
+        assert!(!lease.renew(lease.maximum_expiration, lease.maximum_expiration));
+    }
+
+    #[test]
+    fn timely_queued_renewal_uses_request_time() {
+        let started_at = Instant::now();
+        let maximum_expiration = started_at + EDIT_TRANSACTION_MAX_DURATION;
+        let mut lease = EditTransactionLease::new(started_at, maximum_expiration);
+        let original_expiration = lease.expiration;
+        let requested_at = original_expiration - Duration::from_nanos(1);
+        let processed_at = original_expiration + Duration::from_secs(1);
+
+        assert!(lease.renew(requested_at, processed_at));
+        assert_eq!(lease.expiration, processed_at + EDIT_TRANSACTION_LEASE);
+
+        let late_request = lease.expiration;
+        assert!(!lease.renew(late_request, late_request));
+    }
+
+    #[test]
+    fn forced_settle_retains_batch_ceiling_and_defers_new_begin() {
+        let started_at = Instant::now();
+        let mut batch = EditTransactionBatchState::default();
+        let first_maximum = batch.maximum_expiration(started_at);
+
+        batch.force_settle();
+        batch.request_rescan();
+        assert!(batch.is_forced_settle());
+        assert!(batch.is_settling(false));
+        assert!(batch.has_pending_rescan());
+        assert_eq!(
+            batch.maximum_expiration(started_at + EDIT_TRANSACTION_LEASE),
+            first_maximum
+        );
+
+        batch.reset();
+        assert!(!batch.is_settling(false));
+        assert!(!batch.has_pending_rescan());
+        assert_eq!(
+            batch.maximum_expiration(started_at + EDIT_TRANSACTION_LEASE),
+            started_at + EDIT_TRANSACTION_LEASE + EDIT_TRANSACTION_MAX_DURATION
+        );
+    }
+
+    #[test]
+    fn controller_changed_directories_connect_nested_path_to_existing_parent() {
+        let root = Path::new("workspace");
+        let app = root.join("app");
+        let new_route = app.join("new-route");
+        let nested = new_route.join("nested");
+        let changed_file = nested.join("page.tsx");
+        let mut batch = BatchedInvalidations::new(RecursiveMode::Recursive);
+
+        batch.add_changed_paths(vec![
+            new_route.clone(),
+            nested.clone(),
+            changed_file.clone(),
+        ]);
+
+        for directory in [&app, &new_route, &nested] {
+            assert!(
+                batch
+                    .paths
+                    .get(directory.as_path())
+                    .is_some_and(|flags| flags.contains(InvalidationFlags::PATH_DIR)),
+                "directory listing was not invalidated: {}",
+                directory.display()
+            );
+        }
+        assert!(!batch.paths.contains_key(root));
+        assert!(
+            batch
+                .paths
+                .get(changed_file.as_path())
+                .is_some_and(|flags| {
+                    flags.contains(
+                        InvalidationFlags::PATH_AND_CHILDREN
+                            | InvalidationFlags::PATH_AND_CHILDREN_DIR,
+                    )
+                })
+        );
+    }
+
+    #[test]
+    fn transaction_batch_path_retention_is_bounded() {
+        let mut batch = BatchedInvalidations::new(RecursiveMode::Recursive);
+        for index in 0..=EDIT_TRANSACTION_MAX_RETAINED_PATHS {
+            batch.mark(
+                PathBuf::from(format!("/workspace/path-{index}")).into_boxed_path(),
+                InvalidationFlags::PATH,
+            );
+        }
+        assert!(batch.exceeds_transaction_limits());
+
+        batch.clear();
+        assert!(batch.paths.is_empty());
+        assert_eq!(batch.path_bytes, 0);
+        assert!(!batch.exceeds_transaction_limits());
+
+        batch.mark(
+            PathBuf::from("x".repeat(EDIT_TRANSACTION_MAX_RETAINED_PATH_BYTES + 1))
+                .into_boxed_path(),
+            InvalidationFlags::PATH,
+        );
+        assert!(batch.exceeds_transaction_limits());
+
+        batch.clear();
+        assert_eq!(batch.path_bytes, 0);
+        assert!(!batch.exceeds_transaction_limits());
+    }
+
+    #[test]
+    fn rescan_backlog_drain_preserves_control_messages() {
+        let (event_tx, event_rx) = channel();
+        let (control_tx, control_rx) = channel();
+        let senders = WatchSenders {
+            event_tx: event_tx.clone(),
+            control_tx,
+        };
+
+        event_tx
+            .send(WatchEventMessage::Filesystem(Ok(notify::Event::new(
+                EventKind::Any,
+            ))))
+            .unwrap();
+        let (acknowledged, _acknowledgment) = oneshot::channel();
+        assert!(senders.send_control(EditTransactionMessage::Begin {
+            token: 42,
+            acknowledged,
+        }));
+        event_tx
+            .send(WatchEventMessage::Filesystem(Ok(notify::Event::new(
+                EventKind::Any,
+            ))))
+            .unwrap();
+
+        drain_rescan_event_backlog(&event_rx);
+
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        assert!(matches!(
+            control_rx.try_recv(),
+            Ok(EditTransactionMessage::Begin { token: 42, .. })
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Add an experimental, acknowledged edit-transaction protocol for bounded
multi-file agent edits in Turbopack development mode.

When `__NEXT_EXPERIMENTAL_EDIT_TRANSACTIONS=true`, the Next development MCP
server exposes:

- `begin_edit_transaction`
- `renew_edit_transaction`
- `end_edit_transaction`

An agent controller declares the complete source-path set before writing. The
native watcher acknowledges that it has entered the hold, retains filesystem
invalidations while the semantic edit is incomplete, and submits one combined
invalidation batch after the final transaction ends.

This PR is deliberately opt-in. It does not change the default developer
workflow and is not intended as a general debounce.

## Why this matters for v0

v0 already knows which file operations belong to one agent action. Turbopack
currently sees only independently timed filesystem events:

1. the agent schedules a bounded set of file operations;
2. remote stat/write/stat and sandbox work make individual files finish at
   different times;
3. each completed file can start compilation, RSC rendering, HMR, and browser
   refetch work;
4. those intermediate revisions may already be obsolete or temporarily
   inconsistent;
5. the preview can render several times before reaching the revision the agent
   intended.

Filesystem timing cannot recover the missing semantic commit boundary. A short
debounce still splits slower edits, while a long debounce delays small edits
that already form one watcher wave.

## Protocol

```mermaid
sequenceDiagram
    participant Agent as v0 agent controller
    participant MCP as Next dev MCP
    participant Watcher as Turbopack watcher
    participant Graph as Turbopack graph

    Agent->>MCP: begin_edit_transaction(paths)
    MCP->>Watcher: begin(paths, token)
    Watcher-->>MCP: hold acknowledged
    MCP-->>Agent: opaque token + lease

    loop bounded file operations
        Agent->>Watcher: filesystem changes
        Watcher->>Watcher: retain invalidations
        Agent->>MCP: renew_edit_transaction(token)
    end

    Agent->>MCP: end_edit_transaction(token)
    MCP->>Watcher: end(token)
    Watcher->>Graph: one combined invalidation
    Watcher-->>MCP: flush acknowledged
    MCP-->>Agent: final status
```

The acknowledgement before the first write is essential. Without it, an edit
can race ahead of the watcher and recreate the partial-state problem.

## Real-v0 verdict

This is a large improvement for the specific multi-file agent-edit complaint:

- an ordinary 12-file edit generated approximately **half as much**
  compilation/render/refetch work and used **35.9% less sampled CPU**;
- a long 24-file edit collapsed from **12 RSC request waves to exactly 1**;
- for that long edit, the correct preview arrived **40.9% sooner after the
  final write**;
- ordinary edit latency was statistically neutral, so this is not presented as
  a universal latency optimization.

### Graph: ordinary 12-file edit

The bars show reduction relative to the same patched runtime operating without
an edit transaction. Larger is better.

```mermaid
xychart-beta
    title "Private v0 /projects: work reduction for a 12-file edit"
    x-axis ["RSC requests", "Server renders", "Encoded RSC", "CPU"]
    y-axis "Reduction (%)" 0 --> 60
    bar [48.8, 49.1, 47.7, 35.9]
```

### Graph: long staggered edit

```mermaid
xychart-beta
    title "RSC request waves for a 24-file edit"
    x-axis ["Unbounded", "Transaction"]
    y-axis "Requests per edit" 0 --> 12
    bar [12, 1]
```

## Benchmark design

The optimized native build was tested on private v0's real `/projects` route
in Vercel Internal Playground sandboxes.

Frozen inputs:

| Component | Version |
|---|---|
| Next.js base | `7e01f56f5b7b236dd8457f3248c28bec7ac5f84d` |
| Next.js version | `16.3.0-canary.103` |
| Private v0 revision | `d6b3fe8298f947cf65a2ef4573f5c980437f6008` |
| Node.js | 24.14.1 |
| Chromium | 148 |
| Resource shapes | 8 vCPU / 16 GB and 16 vCPU / 32 GB |

For every lane:

- a fresh dev-server process started with `.next` removed;
- `/projects` was compiled once before warmups;
- baseline and transaction lanes used the same patched runtime and native
  binary;
- A/B order was adjacent, interleaved, and balanced;
- each process ran two warmups and eight retained edits;
- the harness required the exact final 24-value revision, successful HTTP
  status, no page error, no unexpected full navigation, and fixture
  restoration;
- Chrome DevTools Protocol captured RSC requests and encoded transfer;
- server instrumentation counted render executions;
- the complete process tree was sampled for CPU and RSS.

### Sample ledger

| Panel | Workload | Measured edits | Warmups | Fresh-process pairs |
|---|---|---:|---:|---:|
| Primary A/B | 12 files × 50 ms | 128 | 32 | 8 |
| Identical-condition A/A | 12 files × 50 ms | 128 | 32 | 8 |
| Stress A/B | 24 files × 150 ms | 64 | 16 | 4 |
| **Inferential campaign** | | **320** | **80** | **20** |
| Artifact confirmations | same route, iterative frozen packages | 192 | 48 | — |
| **All retained evidence** | | **512** | **128** | — |

All 512 retained edits reached the exact final revision, restored the fixture,
and produced zero measured page errors. Artifact confirmations are kept
separate from the inferential panels rather than increasing the primary sample
size after seeing results.

## Primary result: ordinary agent edit

Workload: 12 source-dependency files, one physical write every 50 ms.

| Metric | Unbounded mean | Transaction mean | Paired change | Process-cluster 95% interval | Better pairs | Exact p |
|---|---:|---:|---:|---:|---:|---:|
| RSC requests/edit | 1.98 | 1.00 | **−48.8%** | **−54.5% to −41.9%** | 8/8 | 0.0078125 |
| Server renders/edit | 2.00 | 1.00 | **−49.1%** | **−55.2% to −41.9%** | 8/8 | 0.0078125 |
| Encoded RSC/edit | 132.6 KB | 68.3 KB | **−47.7%** | **−53.6% to −40.7%** | 8/8 | 0.0078125 |
| Sampled process-tree CPU | 7.90 CPU-s | 5.05 CPU-s | **−35.9%** | **−42.4% to −27.6%** | 8/8 | 0.0078125 |
| Operation start → correct preview | 1,210 ms | 1,219 ms | +0.4% | −3.3% to +4.3% | 4/8 | 0.859375 |
| Final write → correct preview | — | — | −0.3% | −7.1% to +6.9% | 4/8 | 0.9375 |
| Final write → quiescence | — | — | −0.3% | −3.9% to +3.4% | 5/8 | 0.8828125 |

Point estimates are geometric means of within-pair ratios. Confidence
intervals bootstrap complete paired fresh-process blocks, not individual edits.
Exact two-sided tests independently swap the A/B labels within each process
pair.

The result is intentionally worded as **less work**, not faster ordinary HMR:
the powered latency intervals include neutral.

## Noise floor: identical-condition A/A

The same harness and pair structure was run with identical unbounded behavior
under both labels:

| Metric | A/A label effect | Process-cluster 95% interval |
|---|---:|---:|
| RSC requests/renders | −1.8% | −10.6% to +8.4% |
| Encoded RSC | +0.5% | −8.0% to +10.9% |

Latency and CPU were also neutral with wider process-level variation. The
approximately 49% structural reduction is therefore well outside the observed
request-count label noise.

## Stress result: long staggered agent edit

Workload: 24 source-dependency files, one physical write every 150 ms over
3.45 seconds.

| Metric | Unbounded | Transaction | Paired change |
|---|---:|---:|---:|
| RSC requests/edit | **12** | **1** | **−91.7%** |
| Server renders/edit | — | — | **−92.4%** |
| Encoded RSC/edit | — | — | **−91.3%** |
| Operation start → correct preview | — | — | **−9.5%** |
| Final write → correct preview | 1,067 ms | 629 ms | **−40.9%** |
| Final write → quiescence | — | — | **−27.3%** |
| Sampled process-tree CPU | — | — | **−31.1%** |

Every one of the four fresh-process pairs produced exactly 12 unbounded
requests and exactly one transaction request. With only four pairs, the
smallest possible exact two-sided sign-flip p-value is 0.125, so this panel is
reported descriptively rather than overclaiming formal significance.

## Exact reviewed-artifact confirmation

After the final independent-review fix, the exact `final20` runtime/native
package ran one new A/B process pair on each resource shape:

- 32 measured edits plus 8 warmups;
- 32/32 measured edits and 8/8 warmups correct, restored, and page-error free;
- requests/renders: **−54.3%**;
- encoded RSC traffic: **−51.4%**;
- sampled process-tree CPU: **−40.5%**;
- operation-start latency: −6.0%;
- final-write latency: −11.0%.

Both confirmation pairs favored latency, but two pairs do not supersede the
powered primary panel's neutral ordinary-latency estimate.

## Operating envelope and negative controls

This protocol should be invoked only when a controller knows that several
source changes form one semantic operation.

| Case | Result | Recommendation |
|---|---|---|
| 12 files × 50 ms | About half the work | Use |
| 24 files × 150 ms | 12 waves → 1; final preview 40.9% faster | Strong use case |
| 2/4/12 files × 20 ms | Unbounded watcher already formed one wave; hold delayed completion by roughly 11%–16% | Skip |
| Single-file edit | No obsolete intermediate revision to suppress | Skip |
| Route/convention edit | Independent route-metadata watcher is outside this first protocol | Rejected by API |
| Config or environment edit | Independently watched outside this path | Rejected by API |

A separate six-pair experiment that physically submitted writes in groups of
four reduced operation-start latency by 53.5% and work by roughly 57%.
Grouped/bulk writes are complementary: they make the semantic edit finish
sooner, while this protocol guarantees one coherent invalidation after it is
finished. Those grouped-write gains are not attributed to this Next.js patch.

Primary RSS delta favored the transaction, but memory measurements were noisy
and the stress interval crossed neutral. This PR does not claim to fix OOMs.

One unbounded first warmup reproduced a turbo-tasks restore panic before any
retained sample. The exact slot was retried successfully and the failure was
preserved, but this PR does not claim crash prevention. Other setup failures
occurred before measurement and were likewise excluded and retained.

## Safety and progress guarantees

- begin is acknowledged by the native watcher before the first write;
- paths and created/removed/renamed directories are captured authoritatively
  at begin rather than trusted from a later end request;
- public tokens are opaque UUIDs bound to the captured Turbopack project;
- the controller advertises a conservative 4-second lease over the native
  watcher's 5-second lease;
- each token can renew only itself and expires independently;
- a continuous shared batch has a fixed 60-second maximum;
- abandoned tokens settle by timer even if no later MCP request arrives;
- nested transactions retain invalidations until the final valid token ends;
- racing begins, filesystem events, and late ends cannot extend or enter a
  forced settle;
- control messages use a separate channel and are checked before expiry and
  while processing filesystem traffic;
- request timestamps distinguish a timely queued renew/end from one issued
  after its deadline;
- a pending watcher rescan becomes one deferred full invalidation;
- the eventual rescan drains pre-rescan filesystem backlog under the
  invalidation lock, while transaction controls remain preserved on their
  separate channel;
- project-relative paths are validated in TypeScript and root-safe in Rust;
- broad create/remove/rename/modify invalidation handles paths declared before
  they exist;
- final `end` acknowledges only after invalidations have been submitted;
- JavaScript state is bounded to 32 active tokens, 64 retained expired records,
  2,048 paths, 4,096 characters per path, and 1 MiB of path text;
- native retention is independently bounded to 16,384 unique paths and 4 MiB
  of encoded path bytes, then degrades safely to one full invalidation;
- all lease and maximum-duration bookkeeping uses monotonic clocks.

Pages Router routes, App Router `page`/`layout`/`route`/`default` and
metadata conventions, root middleware/proxy/instrumentation, Next config,
TypeScript config, and `.env*` files are rejected because another watcher or
control plane owns part of their behavior.

Terminal-result replay is not part of this experimental version. A duplicate
`end` issued after a successful response does not recreate the flush result;
the first acknowledged response is authoritative. The edit is already safely
settled, and a bounded terminal-result replay protocol can be considered
separately if consumers need retry semantics.

## Correctness coverage

The Rust, MCP, and browser tests cover:

- nested opaque transactions and exact last-token release;
- an incomplete import followed by creation of its dependency;
- declared files that do not exist at begin;
- create, remove, rename, and directory changes;
- per-token renewal and independent expiry;
- cleanup serialized behind an in-flight native renewal;
- monotonic lease behavior across forward and backward wall-clock jumps;
- abandoned-controller cleanup without another MCP request;
- fixed maximum batch age and racing begins;
- project-root escape and independently watched path rejection;
- native path/byte overflow falling back to one full invalidation;
- rescan deferral, stale backlog draining, control preservation, and expiry
  status;
- default Linux non-recursive watching and forced recursive watching.

## Validation

The reviewed production source passed:

- `cargo test -p turbo-tasks-fs --lib` — **120 passed**
- focused MCP tool and telemetry Jest tests — **17 passed**
- real-browser MCP suite, default watcher — **7 passed**
- real-browser MCP suite, forced recursive watcher — **7 passed**
- `cargo fmt --all -- --check`
- Prettier and `git diff --check`
- `cargo clippy -p turbo-tasks-fs -p next-napi-bindings --lib -- -D warnings`
- `pnpm --filter next typescript`
- `pnpm --filter @next/swc build-native-release`
- `pnpm --filter next build`

The branch was then rebased directly onto current canary
`ccd47cfe53c7fef5e6b7ad472a3a020605a23608`. The only range-diff change was
regenerated `errors.json` IDs after an upstream error entry. On signed head
`f205bb42df3c69b16f196ce094a3dbe4a537bf46`, Rust passed 120/120, focused
Jest passed 17/17, the optimized native build and full Next build passed, and
the default and forced-recursive real-browser suites each passed 7/7 again.

GitHub's fresh all-target Rust check then identified one Clippy-only test
assertion idiom. Signed head `7bb199f9bff38518e56eaaa347a7d22cab05591e`
contained only that mechanical test rewrite on top. The exact CI command
`cargo clippy --workspace --all-targets -- -D warnings -A deprecated`,
`cargo fmt --all -- --check`, and the 120-test Rust suite all passed, and the
replacement ARM Rust job was green.

That broader run then found two POSIX-only expected path strings in the new
Jest test on Windows; production correctly supplied native Windows separators.
The final signed head `11ae7c5bdc3870b51c8065f070e65faf4213c786` uses
`node:path` for those expectations. Production source is unchanged. Prettier,
focused Jest 17/17, and the full Next TypeScript check pass on the final head.
The replacement GitHub matrix then completed with **113 passed**, **17
intentionally skipped**, zero pending, and zero failed checks.

## Independent review

GPT-5.6 Sol at xhigh effort and Claude Opus 5 at xhigh effort independently
found the same experiment-off P2 during final review: the rescan rewrite no
longer drained filesystem messages queued before a full invalidation, allowing
stale events to replay as a second rebuild.

The patch now restores that drain under the invalidation write lock and adds a
regression test proving transaction control payloads remain intact on their
separate channel. The full Rust suite and strict Clippy were rerun. The
post-fix GPT-5.6 Sol review and required same-model Claude Opus 5 retry both
returned zero actionable findings and `patch is correct`.

After rebasing onto canary.105, a fresh exact-branch Claude Opus 5 xhigh review
again returned no accepted/actionable findings and `patch is correct` at 0.83
confidence. It explicitly rechecked root/path trust, lease ordering and
liveness, memory bounds, experiment-off blast radius, and generated contracts.
The subsequent upstream error-ID regeneration, test-only Clippy idiom rewrite,
and platform-neutral Jest expectations had no semantic overlap with the
reviewed production code.

## Suggested v0 integration

```ts
const { token } = await beginEditTransaction(allChangedPaths)

try {
  await executeBoundedFileOperations()
  // Renew before the advertised controller lease when remote work is long.
} finally {
  await endEditTransaction(token)
}

await waitForExactFinalPreviewRevision()
```

Recommended rollout:

1. feature-flag the integration around the already-known multi-file file-tool
   queue;
2. declare every file and created/removed/renamed directory before the first
   write;
3. renew only while the same bounded semantic operation is active;
4. call `end` in `finally`;
5. keep the preview marked pending until the normal ready signal reports the
   intended final semantic revision;
6. skip the protocol for single-file, already-dense, route-convention, config,
   and environment edits;
7. compare request waves, render count, transferred RSC bytes, CPU, and
   final-write latency during the rollout.

## Patch scope

The PR changes 13 files:

- Next/Turbopack native bindings and generated TypeScript declarations;
- the `turbo-tasks-fs` disk watcher and transaction control channel;
- experimental Next development MCP tools;
- error definitions and MCP telemetry;
- Rust, Jest, telemetry, and real-browser integration tests.

Current diff: 2,387 additions and 88 deletions. Most additions are protocol
state-machine tests and end-to-end coverage.

## Evidence identity

| Artifact | SHA-256 |
|---|---|
| Exact reviewed runtime archive | `e646cc6378cb9f92c5a6ebe52ffad67de43b332940629f2be87627ecbe3a5867` |
| Exact reviewed native archive | `b081d6530591afd6714f7510e35d386b1b2fb022cb9801143a5def081ae7f9cf` |
| Exact optimized native binary | `d0a0dac8c83c1c95a9314291a93b74f96e63a49eb12491a836f3733493741908` |
| 8-vCPU final20 raw archive | `727030b4d60242cc7a20ef6199ed5ed7e4ce12a26aaf1f779f65368bed5e4eb7` |
| 16-vCPU final20 raw archive | `947a88bc494187e6b065649d158c9ea7eac4953dd7f39720fee9273fcf97149b` |
| Exact committed 13-file patch | `9feda7b27717c9e79ea34feaeb6719330253963bac26fe0c1eb8104208822027` |

The benchmarked canary.103 source commit is
`1171dc250404664950a801f2957f4198658def9b`. The current mergeable signed PR
head is `11ae7c5bdc3870b51c8065f070e65faf4213c786`, with source tree
`140a85bced8743f941dddf605ca1eebad1ccaa87`. The final landing-series patch is
SHA-256 `83d39deb1cf6870aa117e71264af1f22758ab891f42e45af5c24e7fbbe41e006`.
The production-source-equivalent native binary built immediately before the
two final test-only CI amendments is
`d4616822b8c551df47d5dd030620e5b5517203674745561da11b0768e413fa59`.

## Non-goals

- inferring transactions from arbitrary editor writes;
- changing default HMR behavior when the experiment is disabled;
- delaying single-file edits;
- coordinating the independent route-metadata watcher in this first version;
- claiming a general memory, OOM, or crash fix;
- replacing normal correctness/preview-ready checks in the agent controller.

