### PR TITLE
fix(router): improve error message for non-string getStaticPaths params

### DIFF
--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -164,13 +164,20 @@ export async function buildPagesStaticPaths({
 
         if (
           (repeat && !Array.isArray(paramValue)) ||
+          (repeat &&
+            Array.isArray(paramValue) &&
+            paramValue.some((value) => typeof value !== 'string')) ||
           (!repeat && typeof paramValue !== 'string') ||
           typeof paramValue === 'undefined'
         ) {
           throw new Error(
             `A required parameter (${validParamKey}) was not provided as ${
-              repeat ? 'an array' : 'a string'
-            } received ${typeof paramValue} in getStaticPaths for ${page}`
+              repeat ? 'an array of strings' : 'a string'
+            } received ${
+              repeat && Array.isArray(paramValue)
+                ? 'an array with non-string values'
+                : typeof paramValue
+            } in getStaticPaths for ${page}`
           )
         }
 

--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -3,6 +3,11 @@ export default function escapePathDelimiters(
   segment: string,
   escapeEncoded?: boolean
 ): string {
+  if (typeof segment !== 'string') {
+    throw new Error(
+      `Expected segment to be a string, but received ${typeof segment}. This can happen if a non-string value is provided in getStaticPaths.`
+    )
+  }
   return segment.replace(
     new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
     (char: string) => encodeURIComponent(char)


### PR DESCRIPTION
Fixes #41281

**What**
Added explicit type validation for array elements returned from `getStaticPaths` when targeting catch-all routes in `pages.ts`, and added a fallback defensive check to `escapePathDelimiters.ts`.

**Why**
When returning `{ params: { page: [3] } }` for a catch-all route (`[...page].tsx`), the existing type check was bypassed because `Array.isArray([3])` was true, and the array elements were not verified as strings. As a result, the non-string value reached `escapePathDelimiters` which caused a cryptic `TypeError: segment.replace is not a function` crash. This gives users immediate, actionable feedback about which parameter was formatted incorrectly.

**How it was tested**
Tested locally with a `[...page].tsx` catch-all route returning `{ params: { page: [3] } }`. It now correctly throws `A required parameter (page) was not provided as an array of strings received an array with non-string values in getStaticPaths for /articles/[...page]` instead of a generic TypeError.