### PR TITLE
[ci] Run new/changed deploy tests asap

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -723,10 +723,9 @@ jobs:
 
   test-new-tests-deploy:
     name: Test new and changed tests when deployed
-    needs:
-      ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
+    needs: ['optimize-ci', 'changes']
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
     # test-new-tests-end-if
 
     strategy:


### PR DESCRIPTION
These are equally important if not more important (since they test build adapters) than next-start tests so we now run them immediately instead of waiting for test-prod.

They job is now skipped entirely for docs changes. Which saves a few seconds for docs-only changes.