### PR TITLE
Unify full/partial navigation response types

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -4,15 +4,15 @@ import { createHrefFromUrl } from './create-href-from-url'
 import { extractPathFromFlightRouterState } from './compute-changed-path'
 
 import type { AppRouterState } from './router-reducer-types'
-import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
+import { transportNodeToFlightRouterState } from '../../../shared/lib/rsc-transport'
 import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import {
-  convertRootFlightRouterStateToRouteTree,
   resolveStaleAt,
   processRuntimePrefetchStream,
   writeDynamicRenderResponseIntoCache,
   writePrerenderResponseIntoCache,
 } from '../segment-cache/cache'
+import { decodeTransportTreeIntoRouteTree } from '../segment-cache/decode-server-response'
 import { FetchStrategy } from '../segment-cache/types'
 import {
   UnknownDynamicStaleTime,
@@ -37,13 +37,12 @@ export function createInitialRouterState({
 }: InitialRouterStateParameters): AppRouterState {
   const {
     c: initialCanonicalUrlParts,
-    f: initialFlightData,
+    t: initialTransportData,
     q: initialRenderedSearch,
     i: initialCouldBeIntercepted,
     S: initialSupportsPerSegmentPrefetching,
     s: initialStaleTime,
     l: initialStaticStageByteLength,
-    h: initialHeadVaryParams,
     r: initialRootVaryParams,
     p: initialRuntimePrefetchStream,
     d: initialDynamicStaleTimeSeconds,
@@ -54,14 +53,12 @@ export function createInitialRouterState({
   // as a URL that should be crawled.
   const initialCanonicalUrl = initialCanonicalUrlParts.join('/')
 
-  const normalizedFlightData = getFlightDataPartsFromPath(initialFlightData[0])
-  const {
-    tree: initialTree,
-    seedData: initialSeedData,
-    head: initialHead,
-  } = normalizedFlightData
-  // For the SSR render, seed data should always be available (we only send back a `null` response
-  // in the case of a `loading` segment, pre-PPR.)
+  const initialHead = initialTransportData.h.r
+
+  // The initial router state tree, derived from the transport tree. Page
+  // segments keep their search params, which travel inside the segment
+  // string.
+  const initialTree = transportNodeToFlightRouterState(initialTransportData.t)
 
   const canonicalUrl =
     // location.href is read as the initial value for canonicalUrl in the browser
@@ -71,24 +68,26 @@ export function createInitialRouterState({
         createHrefFromUrl(location)
       : initialCanonicalUrl
 
-  // Convert the initial FlightRouterState into the RouteTree type.
+  // Decode the initial transport tree into the RouteTree type, with the
+  // payload's render output embedded on each node. (discoverKnownRoute below
+  // stores this tree in the route cache, which strips the data on write —
+  // see stripDataFromRouteTree.)
   // NOTE: The metadataVaryPath isn't used for anything currently because the
   // head is embedded into the CacheNode tree, but eventually we'll lift it out
   // and store it on the top-level state object.
   //
-  // For statically-generated-at-build-time HTML pages, the FlightRouterState
-  // baked into the initial RSC payload won't have the correct segment inlining
-  // hints because those are computed after the pre-render. The server marks
-  // these trees with InliningHintsStale, which causes the route cache entry
-  // to be immediately expired. The next prefetch will re-fetch the tree with
+  // For statically-generated-at-build-time HTML pages, the tree baked into
+  // the initial RSC payload won't have the correct segment inlining hints
+  // because those are computed after the pre-render. The server marks these
+  // trees with InliningHintsStale, which causes the route cache entry to be
+  // immediately expired. The next prefetch will re-fetch the tree with
   // correct hints from the /_tree response.
   const acc = { metadataVaryPath: null }
-  const initialRouteTree = convertRootFlightRouterStateToRouteTree(
-    initialTree,
-    // Embed the initial payload's seed data directly into the RouteTree.
-    // (discoverKnownRoute below stores this tree in the route cache, which
-    // strips the data on write — see stripDataFromRouteTree.)
-    initialSeedData,
+  const initialRouteTree = decodeTransportTreeIntoRouteTree(
+    initialTransportData.t,
+    // There's no base tree to overlay onto; the initial payload is a full
+    // render from the root.
+    null,
     initialRenderedSearch as NormalizedSearch,
     acc
   )
@@ -127,7 +126,7 @@ export function createInitialRouterState({
 
     // Write the initial seed data into the segment cache so subsequent
     // navigations to the initial page can serve cached segments instantly.
-    if (initialSeedData !== null && initialStaleTime !== undefined) {
+    if (initialStaleTime !== undefined) {
       if (
         initialStaticStageByteLength !== undefined &&
         initialFlightStreamForCache != null
@@ -150,9 +149,8 @@ export function createInitialRouterState({
             writePrerenderResponseIntoCache(
               now,
               FetchStrategy.PPR,
-              staticStageResponse.f,
+              staticStageResponse.t,
               undefined, // no build ID mismatch check for initial HTML
-              staticStageResponse.h,
               staticStageResponse.r ?? null,
               staleAt,
               initialTree,
@@ -177,9 +175,8 @@ export function createInitialRouterState({
             writePrerenderResponseIntoCache(
               now,
               FetchStrategy.PPR,
-              initialFlightData,
+              initialTransportData,
               undefined, // buildId — not applicable for initial HTML
-              initialHeadVaryParams,
               initialRootVaryParams ?? null,
               staleAt,
               initialTree,
@@ -216,7 +213,6 @@ export function createInitialRouterState({
             writeDynamicRenderResponseIntoCache(
               Date.now(),
               FetchStrategy.PPRRuntime,
-              processed.flightDatas,
               processed.buildId,
               processed.isResponsePartial,
               processed.headVaryParams,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -30,11 +30,8 @@ import {
 } from '../app-router-headers'
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
-import {
-  normalizeFlightData,
-  prepareFlightRouterStateForRequest,
-  type NormalizedFlightData,
-} from '../../flight-data-helpers'
+import { prepareFlightRouterStateForRequest } from '../../flight-data-helpers'
+import type { PartialTransportData } from '../../../shared/lib/rsc-transport'
 import { setCacheBustingSearchParam } from './set-cache-busting-search-param'
 import { urlToUrlWithoutFlightMarker } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
@@ -79,7 +76,7 @@ export type StaticStageData<
 }
 
 type SpaFetchServerResponseResult = {
-  flightData: NormalizedFlightData[]
+  transportData: PartialTransportData | null
   canonicalUrl: URL
   renderedSearch: NormalizedSearch
   couldBeIntercepted: boolean
@@ -279,9 +276,10 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
-    const normalizedFlightData = normalizeFlightData(flightResponse.f)
-    if (typeof normalizedFlightData === 'string') {
-      return doMpaNavigation(normalizedFlightData)
+    if (flightResponse.n !== undefined) {
+      // The server responded with an MPA navigation URL instead of a
+      // SPA payload.
+      return doMpaNavigation(flightResponse.n)
     }
 
     const staticStageData =
@@ -290,7 +288,7 @@ export async function fetchServerResponse(
         : null
 
     return {
-      flightData: normalizedFlightData,
+      transportData: flightResponse.t ?? null,
       canonicalUrl: canonicalUrl,
       // TODO: We should be able to read this from the rewrite header, not the
       // Flight response. Theoretically they should always agree, but there are

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -23,7 +23,7 @@ import { getLastCommittedTree } from './reducers/committed-state'
 import {
   convertServerPatchToFullTree,
   type NavigationSeed,
-} from '../segment-cache/navigation'
+} from '../segment-cache/decode-server-response'
 import {
   type RouteTree,
   type RSCSegmentData,
@@ -1800,7 +1800,7 @@ async function fetchMissingDynamicData(
     const seed = convertServerPatchToFullTree(
       now,
       task.route,
-      result.flightData,
+      result.transportData,
       result.renderedSearch,
       result.dynamicStaleTime
     )
@@ -1828,9 +1828,8 @@ async function fetchMissingDynamicData(
           writePrerenderResponseIntoCache(
             now,
             FetchStrategy.PPR,
-            staticStageResponse.f,
+            staticStageResponse.t ?? null,
             buildId,
-            staticStageResponse.h,
             staticStageResponse.r ?? null,
             staleAt,
             dynamicRequestTree,
@@ -1856,7 +1855,6 @@ async function fetchMissingDynamicData(
             writeDynamicRenderResponseIntoCache(
               now,
               FetchStrategy.PPRRuntime,
-              processed.flightDatas,
               processed.buildId,
               processed.isResponsePartial,
               processed.headVaryParams,

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -4,10 +4,8 @@ import type {
   RefreshAction,
 } from '../router-reducer-types'
 import { ScrollBehavior } from '../router-reducer-types'
-import {
-  convertServerPatchToFullTree,
-  navigateToKnownRoute,
-} from '../../segment-cache/navigation'
+import { navigateToKnownRoute } from '../../segment-cache/navigation'
+import { convertServerPatchToFullTree } from '../../segment-cache/decode-server-response'
 import { invalidateSegmentCacheEntries } from '../../segment-cache/cache'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 import { FreshnessPolicy, getCurrentNavigationLock } from '../ppr-navigations'

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -15,8 +15,8 @@ import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
 import {
   completeHardNavigation,
   completeTraverseNavigation,
-  convertServerPatchToFullTree,
 } from '../../segment-cache/navigation'
+import { convertServerPatchToFullTree } from '../../segment-cache/decode-server-response'
 import { UnknownDynamicStaleTime } from '../../segment-cache/bfcache'
 
 export function restoreReducer(

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -33,12 +33,9 @@ import type {
 import { ScrollBehavior } from '../router-reducer-types'
 import { assignLocation } from '../../../assign-location'
 import { createHrefFromUrl } from '../create-href-from-url'
+import type { PartialTransportData } from '../../../../shared/lib/rsc-transport'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
-import {
-  normalizeFlightData,
-  prepareFlightRouterStateForRequest,
-  type NormalizedFlightData,
-} from '../../../flight-data-helpers'
+import { prepareFlightRouterStateForRequest } from '../../../flight-data-helpers'
 import { getRedirectError } from '../../redirect'
 import type { RedirectType } from '../../redirect-error'
 import { removeBasePath } from '../../../remove-base-path'
@@ -54,10 +51,10 @@ import { getNavigationBuildId } from '../../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../../lib/constants'
 import {
   completeHardNavigation,
-  convertServerPatchToFullTree,
   navigateToKnownRoute,
   navigate,
 } from '../../segment-cache/navigation'
+import { convertServerPatchToFullTree } from '../../segment-cache/decode-server-response'
 import { discoverKnownRoute } from '../../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../../segment-cache/cache-key'
 import {
@@ -95,7 +92,11 @@ type FetchServerActionResult = {
   redirectType: RedirectType | undefined
   revalidationKind: ActionRevalidationKind
   actionResult: ActionResult | undefined
-  actionFlightData: NormalizedFlightData[] | string | undefined
+  /**
+   * The transport data from the action response, or a URL string when the
+   * response handling triggered an external (MPA) redirect.
+   */
+  actionFlightData: PartialTransportData | string | undefined
   actionFlightDataRenderedSearch: NormalizedSearch | undefined
   isPrerender: boolean
   couldBeIntercepted: boolean
@@ -279,10 +280,12 @@ async function fetchServerAction(
       // still be processed, and the absence of flight data will cause an
       // MPA navigation via completeHardNavigation().
     } else {
-      const maybeFlightData = normalizeFlightData(response.f)
-      if (maybeFlightData !== '') {
-        actionFlightData = maybeFlightData
+      if (response.t !== undefined) {
+        actionFlightData = response.t
         actionFlightDataRenderedSearch = response.q as NormalizedSearch
+      } else if (response.n !== undefined) {
+        // The server responded with an MPA navigation URL.
+        actionFlightData = response.n
       }
     }
   } else {

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -1,6 +1,6 @@
 import type { CacheNode, ScrollRef } from '../../../shared/lib/app-router-types'
 import type { FlightRouterState } from '../../../shared/lib/app-router-types'
-import type { NavigationSeed } from '../segment-cache/navigation'
+import type { NavigationSeed } from '../segment-cache/decode-server-response'
 import type { FetchServerResponseResult } from './fetch-server-response'
 import type { FreshnessPolicy } from './ppr-navigations'
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -4,12 +4,9 @@ import type {
   RootTreePrefetch,
   SegmentPrefetchResponse,
 } from '../../../server/app-render/collect-segment-data'
-import type {
-  CacheNodeSeedData,
-  FlightData,
-  Segment as FlightRouterStateSegment,
-} from '../../../shared/lib/app-router-types'
+import type { Segment as FlightRouterStateSegment } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
+import type { PartialTransportData } from '../../../shared/lib/rsc-transport'
 import {
   readVaryParams,
   type VaryParams,
@@ -101,19 +98,24 @@ import type {
   FlightRouterState,
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
-import {
-  type NormalizedFlightData,
-  normalizeFlightData,
-  prepareFlightRouterStateForRequest,
-} from '../../flight-data-helpers'
+import { prepareFlightRouterStateForRequest } from '../../flight-data-helpers'
 import { STATIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer'
 import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
-import { readFromBFCache, UnknownDynamicStaleTime } from './bfcache'
+import {
+  readFromBFCache,
+  UnknownDynamicStaleTime,
+  computeDynamicStaleAt,
+} from './bfcache'
 import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
-import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
+import {
+  convertServerPatchToFullTree,
+  decodeTransportTreeIntoRouteTree,
+  createRouteTreeNode,
+  type NavigationSeed,
+} from './decode-server-response'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 
@@ -1694,7 +1696,7 @@ function rejectSegmentCacheEntry(
   pingBlockedTasks(entry)
 }
 
-type RouteTreeAccumulator = {
+export type RouteTreeAccumulator = {
   metadataVaryPath: PageVaryPath | null
 }
 
@@ -1883,16 +1885,11 @@ function convertTreePrefetchToRouteTree(
 
 export function convertRootFlightRouterStateToRouteTree(
   flightRouterState: FlightRouterState,
-  // Seed data from the same server response as the FlightRouterState, walked
-  // in parallel so each RouteTree node carries its own render output. Pass
-  // null when converting a structure-only tree (e.g. client-local state).
-  seedData: CacheNodeSeedData | null,
   renderedSearch: NormalizedSearch,
   acc: RouteTreeAccumulator
-): RouteTree<RSCSegmentData | null> {
+): RouteTree<null> {
   return convertFlightRouterStateToRouteTree(
     flightRouterState,
-    seedData,
     ROOT_SEGMENT_REQUEST_KEY,
     null,
     renderedSearch,
@@ -1927,9 +1924,6 @@ export function convertReusedFlightRouterStateToRouteTree(
   )
   return convertFlightRouterStateToRouteTree(
     flightRouterState,
-    // Reused slots come from client-local state; there's no server response
-    // data associated with them.
-    null,
     requestKey,
     parentPartialVaryPath,
     renderedSearch,
@@ -1937,14 +1931,13 @@ export function convertReusedFlightRouterStateToRouteTree(
   )
 }
 
-function convertFlightRouterStateToRouteTree(
+export function convertFlightRouterStateToRouteTree(
   flightRouterState: FlightRouterState,
-  seedData: CacheNodeSeedData | null,
   requestKey: SegmentRequestKey,
   parentPartialVaryPath: PartialSegmentVaryPath | null,
   parentRenderedSearch: NormalizedSearch,
   acc: RouteTreeAccumulator
-): RouteTree<RSCSegmentData | null> {
+): RouteTree<null> {
   const originalSegment = flightRouterState[0]
 
   // This segment's param (if any) is a root param iff the segment is at or
@@ -1967,77 +1960,25 @@ function convertFlightRouterStateToRouteTree(
   const renderedSearch =
     refreshState !== null ? refreshState.renderedSearch : parentRenderedSearch
 
-  let segment: FlightRouterStateSegment
-  let partialVaryPath: PartialSegmentVaryPath | null
-  let isPage: boolean
-  let varyPath: SegmentVaryPath
-  if (Array.isArray(originalSegment)) {
-    isPage = false
-    const paramCacheKey = originalSegment[1]
-    const paramName = originalSegment[0]
-    partialVaryPath = appendLayoutVaryPath(
-      parentPartialVaryPath,
-      paramCacheKey,
-      paramName,
-      isRootParam
-    )
-    varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
-    segment = originalSegment
-  } else {
-    // This segment does not have a param. Inherit the partial vary path of
-    // the parent.
-    partialVaryPath = parentPartialVaryPath
-    if (requestKey.endsWith(PAGE_SEGMENT_KEY)) {
-      // This is a page segment.
-      isPage = true
+  const tree = createRouteTreeNode<null>(
+    originalSegment,
+    isRootParam,
+    requestKey,
+    parentPartialVaryPath,
+    renderedSearch,
+    acc
+  )
+  tree.refreshState = refreshState
+  const partialVaryPath = tree.isPage
+    ? getPartialPageVaryPath(tree.varyPath)
+    : getPartialLayoutVaryPath(tree.varyPath)
 
-      // The navigation implementation expects the search params to be included
-      // in the segment. However, in the case of a static response, the search
-      // params are omitted. So the client needs to add them back in when reading
-      // from the Segment Cache.
-      //
-      // For consistency, we'll do this for dynamic responses, too.
-      //
-      // TODO: We should move search params out of FlightRouterState and handle
-      // them entirely on the client, similar to our plan for dynamic params.
-      segment = PAGE_SEGMENT_KEY
-      varyPath = finalizePageVaryPath(
-        requestKey,
-        renderedSearch,
-        partialVaryPath
-      )
-      // The metadata "segment" is not part the route tree, but it has the same
-      // conceptual params as a page segment. Write the vary path into the
-      // accumulator object. If there are multiple parallel pages, we use the
-      // first one. Which page we choose is arbitrary as long as it's
-      // consistently the same one every time every time. See
-      // finalizeMetadataVaryPath for more details.
-      if (acc.metadataVaryPath === null) {
-        acc.metadataVaryPath = finalizeMetadataVaryPath(
-          requestKey,
-          renderedSearch,
-          partialVaryPath
-        )
-      }
-    } else {
-      // This is a layout segment.
-      isPage = false
-      segment = originalSegment
-      varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
-    }
-  }
-
-  let slots: Map<string, RouteTree<RSCSegmentData | null>> | null = null
+  let slots: Map<string, RouteTree<null>> | null = null
 
   const parallelRoutes = flightRouterState[1]
-  const seedDataChildren = seedData !== null ? seedData[1] : null
   for (let parallelRouteKey in parallelRoutes) {
     const childRouterState = parallelRoutes[parallelRouteKey]
     const childSegment = childRouterState[0]
-    const childSeedData =
-      seedDataChildren !== null
-        ? (seedDataChildren[parallelRouteKey] ?? null)
-        : null
     // TODO: Eventually, the param values will not be included in the response
     // from the server. We'll instead fill them in on the client by parsing
     // the URL. This is where we'll do that.
@@ -2049,7 +1990,6 @@ function convertFlightRouterStateToRouteTree(
     )
     const childTree = convertFlightRouterStateToRouteTree(
       childRouterState,
-      childSeedData,
       childRequestKey,
       partialVaryPath,
       renderedSearch,
@@ -2061,39 +2001,9 @@ function convertFlightRouterStateToRouteTree(
     slots.set(parallelRouteKey, childTree)
   }
 
-  // `data: null` means the response carried no information for this segment
-  // at all, while a data object with `rsc: null` means the response covered
-  // this position without rendering it (e.g. the intermediate nodes on the
-  // path to a patched subtree, synthesized in convertServerPatchToFullTreeImpl).
-  // Consumers use the former to decide whether a segment was accounted for
-  // by the response, and the latter to decide whether there's output
-  // to write.
-  const data: RSCSegmentData | null =
-    seedData !== null
-      ? {
-          rsc: seedData[0],
-          isPartial: seedData[3],
-          varyParams: seedData[4],
-        }
-      : null
-
-  return {
-    requestKey,
-    segment,
-    shellVaryPath: getShellSegmentVaryPath(varyPath),
-    refreshState,
-    data,
-    // TODO: Cheating the type system here a bit because TypeScript can't tell
-    // that the type of isPage and varyPath are consistent. The fix would be to
-    // create separate constructors and call the appropriate one from each of
-    // the branches above. Just seems a bit overkill only for one field so I'll
-    // leave it as-is for now. If isPage were wrong it would break the behavior
-    // and we'd catch it quickly, anyway.
-    varyPath: varyPath as any,
-    isPage: isPage as boolean as any,
-    slots,
-    prefetchHints: flightRouterState[4] ?? 0,
-  }
+  tree.slots = slots
+  tree.prefetchHints = flightRouterState[4] ?? 0
+  return tree
 }
 
 export function convertRouteTreeToFlightRouterState(
@@ -2349,7 +2259,6 @@ export async function fetchRouteOnCacheMiss(
       // root params). Individual segments carry their own iterables in
       // CacheNodeSeedData; the root iterable is threaded down so each segment
       // unions it too.
-      const headVaryParams = readVaryParams(serverData.h, serverData.r)
       writeDynamicTreeResponseIntoCache(
         Date.now(),
         // The non-PPR response format is what we'd get if we prefetched these segments
@@ -2361,7 +2270,6 @@ export async function fetchRouteOnCacheMiss(
         couldBeIntercepted,
         canonicalUrl,
         routeIsPPREnabled,
-        headVaryParams,
         serverData.r ?? null,
         pathname,
         search,
@@ -3395,9 +3303,8 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           writePrerenderResponseIntoCache(
             now,
             FetchStrategy.PPR,
-            serverData.f,
+            serverData.t ?? null,
             buildId,
-            serverData.h,
             serverData.r ?? null,
             staleAt,
             dynamicRequestTree,
@@ -3421,9 +3328,8 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           writePrerenderResponseIntoCache(
             now,
             FetchStrategy.RuntimeShell,
-            shellStageData.f,
+            shellStageData.t ?? null,
             buildId,
-            shellStageData.h,
             shellStageData.r ?? null,
             shellStaleAt,
             dynamicRequestTree,
@@ -3434,16 +3340,10 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       }
     }
 
-    // Read head vary params synchronously (unioning in the response-level root
-    // params). Individual segments carry their own iterables in
-    // CacheNodeSeedData; the root iterable is threaded down so each segment
-    // unions it too.
+    // Root params are emitted once at the response level; the iterable is
+    // threaded down so each segment unions it too.
     const rootVaryParamsIterable =
       serverDataThatSatisfiesSpawnedEntries.r ?? null
-    const headVaryParams = readVaryParams(
-      serverDataThatSatisfiesSpawnedEntries.h,
-      rootVaryParamsIterable
-    )
 
     // PPRRuntime and RuntimeShell prefetches are partial when the server
     // marks the response as '~' (Partial). RuntimeShell additionally omits
@@ -3455,20 +3355,24 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       (fetchStrategy === FetchStrategy.PPRRuntime &&
         (cacheData?.isResponsePartial ?? false))
 
-    const flightDatas = normalizeFlightData(
-      serverDataThatSatisfiesSpawnedEntries.f
-    )
-    if (typeof flightDatas === 'string') {
+    const transportData = serverDataThatSatisfiesSpawnedEntries.t
+    if (transportData === undefined) {
       rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
       return null
     }
     const navigationSeed = convertServerPatchToFullTree(
       now,
       dynamicRequestTree,
-      flightDatas,
+      transportData,
       renderedSearch,
       // Not needed for prefetch responses; pass unknown to use the default.
       UnknownDynamicStaleTime
+    )
+    // Read head vary params synchronously, unioning in the response-level
+    // root params.
+    const headVaryParams = readVaryParams(
+      navigationSeed.headVaryParams,
+      rootVaryParamsIterable
     )
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -3476,7 +3380,6 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     fulfilledEntries = writeDynamicRenderResponseIntoCache(
       now,
       fetchStrategy,
-      flightDatas,
       buildId,
       isResponsePartial,
       headVaryParams,
@@ -3532,7 +3435,6 @@ function writeDynamicTreeResponseIntoCache(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   routeIsPPREnabled: boolean,
-  headVaryParams: VaryParams | null,
   rootVaryParamsIterable: VaryParamsIterable | null,
   originalPathname: string,
   originalSearch: NormalizedSearch,
@@ -3540,41 +3442,36 @@ function writeDynamicTreeResponseIntoCache(
 ): void {
   const renderedSearch = getRenderedSearch(response)
 
-  const normalizedFlightDataResult = normalizeFlightData(serverData.f)
+  const transportData = serverData.t
   if (
-    // A string result means navigating to this route will result in an
-    // MPA navigation.
-    typeof normalizedFlightDataResult === 'string' ||
-    normalizedFlightDataResult.length !== 1
+    transportData === undefined ||
+    serverData.n !== undefined ||
+    // A covered root (data present without output) means the response's
+    // rendered content starts below the root — an unexpected format for this
+    // flow, which always requests a full render from the root.
+    (transportData.t.d !== undefined && transportData.t.d.r === null)
   ) {
-    rejectRouteCacheEntry(entry, now + 10 * 1000)
-    return
-  }
-  const flightData = normalizedFlightDataResult[0]
-  if (!flightData.isRootRender) {
-    // Unexpected response format.
+    // The response carries no root render (e.g. it's an MPA navigation), so
+    // there's nothing to cache.
     rejectRouteCacheEntry(entry, now + 10 * 1000)
     return
   }
 
-  const flightRouterState = flightData.tree
   // If the response was postponed, segments may contain dynamic holes.
-  // The head has its own partiality flag (flightDataEntry.isHeadPartial)
-  // which is handled separately in writeDynamicRenderResponseIntoCache.
+  // The head has its own partiality flag, handled separately in
+  // writeDynamicRenderResponseIntoCache.
   const isResponsePartial =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
 
-  // Convert the server-sent data into the RouteTree format used by the
-  // client cache.
+  // Decode the server-sent tree into the RouteTree format used by the
+  // client cache. There's no base to overlay onto: this response is always a
+  // full render from the root.
   //
   // During this traversal, we accumulate additional data into this
   // "accumulator" object.
   const acc: RouteTreeAccumulator = { metadataVaryPath: null }
-  const routeTree = convertRootFlightRouterStateToRouteTree(
-    flightRouterState,
-    // This tree is stored in the route cache, which must not retain seed
-    // data. The response's segment data is written into the segment cache
-    // separately, below.
+  const routeTree = decodeTransportTreeIntoRouteTree(
+    transportData.t,
     null,
     renderedSearch,
     acc
@@ -3604,19 +3501,27 @@ function writeDynamicTreeResponseIntoCache(
   // TODO: This is a leftover branch from before Client Segment Cache was
   // enabled everywhere. Tree prefetches should never include segment data.  We
   // can delete it. Leaving for a subsequent PR.
-  const navigationSeed = convertServerPatchToFullTree(
-    now,
-    flightRouterState,
-    normalizedFlightDataResult,
-    renderedSearch,
-    UnknownDynamicStaleTime
+  const transportHead = transportData.h
+  // Read head vary params synchronously, unioning in the response-level
+  // root params.
+  const headVaryParams = readVaryParams(
+    transportHead !== undefined ? transportHead.v : null,
+    rootVaryParamsIterable
   )
+  const navigationSeed: NavigationSeed = {
+    routeTree,
+    metadataVaryPath,
+    renderedSearch,
+    head: transportHead !== undefined ? transportHead.r : null,
+    isHeadPartial: transportHead !== undefined ? transportHead.p : true,
+    headVaryParams: transportHead !== undefined ? transportHead.v : null,
+    dynamicStaleAt: computeDynamicStaleAt(now, UnknownDynamicStaleTime),
+  }
   const buildId =
     response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
-    normalizedFlightDataResult,
     buildId,
     isResponsePartial,
     headVaryParams,
@@ -3650,7 +3555,6 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.PPRRuntime
     | FetchStrategy.RuntimeShell
     | FetchStrategy.Full,
-  flightDatas: NormalizedFlightData[],
   buildId: string | undefined,
   isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
@@ -3675,9 +3579,8 @@ export function writeDynamicRenderResponseIntoCache(
       : null
 
   // The route tree carries the render output of every segment the response
-  // included (the per-path patches were folded into a single tree when the
-  // response was converted to a NavigationSeed), so a single traversal from
-  // the root writes all of it into the cache.
+  // included, so a single traversal from the root writes all of it into
+  // the cache.
   writeSeedDataIntoCache(
     now,
     fetchStrategy,
@@ -3688,38 +3591,36 @@ export function writeDynamicRenderResponseIntoCache(
     spawnedEntries
   )
 
-  for (const flightDataEntry of flightDatas) {
-    const head = flightDataEntry.head
-    if (head !== null && metadataTree !== null) {
-      // When Cache Components is enabled, the server's `isHeadPartial` flag
-      // (isPossiblyPartialHead in app-render.tsx) is unreliable: it's computed
-      // before the head is serialized, so it's conservatively `true` for every
-      // statically-generated PPR page — even pages whose head is actually
-      // complete — and it's `false` for runtime/dynamic responses whose head is
-      // actually partial (e.g. a route with an async `generateMetadata`). So we
-      // ignore it and derive the head's partiality from whether the response
-      // itself was partial, exactly as we do for segments (see
-      // `writeSeedDataIntoCache`). A non-partial response carries a complete
-      // head; a partial (postponed) one does not.
-      //
-      // Without Cache Components, the server sends the correct isHeadPartial.
-      const isHeadPartial = process.env.__NEXT_CACHE_COMPONENTS
-        ? isResponsePartial
-        : flightDataEntry.isHeadPartial
+  const head = navigationSeed.head
+  if (head !== null && metadataTree !== null) {
+    // When Cache Components is enabled, the server's `isHeadPartial` flag
+    // (isPossiblyPartialHead in app-render.tsx) is unreliable: it's computed
+    // before the head is serialized, so it's conservatively `true` for every
+    // statically-generated PPR page — even pages whose head is actually
+    // complete — and it's `false` for runtime/dynamic responses whose head is
+    // actually partial (e.g. a route with an async `generateMetadata`). So we
+    // ignore it and derive the head's partiality from whether the response
+    // itself was partial, exactly as we do for segments (see
+    // `writeSeedDataIntoCache`). A non-partial response carries a complete
+    // head; a partial (postponed) one does not.
+    //
+    // Without Cache Components, the server sends the correct isHeadPartial.
+    const isHeadPartial = process.env.__NEXT_CACHE_COMPONENTS
+      ? isResponsePartial
+      : navigationSeed.isHeadPartial
 
-      fulfillEntrySpawnedByRuntimePrefetch(
-        now,
-        fetchStrategy,
-        head,
-        isHeadPartial,
-        staleAt,
-        // For head entries, use the head-specific vary params passed as
-        // parameter.
-        headVaryParams,
-        metadataTree,
-        spawnedEntries
-      )
-    }
+    fulfillEntrySpawnedByRuntimePrefetch(
+      now,
+      fetchStrategy,
+      head,
+      isHeadPartial,
+      staleAt,
+      // For head entries, use the head-specific vary params passed as
+      // parameter.
+      headVaryParams,
+      metadataTree,
+      spawnedEntries
+    )
   }
   // Any entry that's still pending was intentionally not rendered by the
   // server, because it was inside the loading boundary. Mark them as rejected
@@ -3762,6 +3663,8 @@ function writeSeedDataIntoCache(
   if (data === null) {
     // The response carried no information for this segment or anything
     // below it.
+    // TODO: This is where "skip a middle segment but render below it" would
+    // need to keep descending. No producer emits that shape yet.
     return
   }
   const rsc = data.rsc
@@ -4244,37 +4147,33 @@ export async function resolveStaleAt(
 export function writePrerenderResponseIntoCache(
   now: number,
   fetchStrategy: FetchStrategy.PPR | FetchStrategy.RuntimeShell,
-  flightData: FlightData,
+  transportData: PartialTransportData | null,
   buildId: string | undefined,
-  headVaryParamsIterable: VaryParamsIterable | null,
   rootVaryParamsIterable: VaryParamsIterable | null,
   staleAt: number,
   baseTree: FlightRouterState,
   renderedSearch: string,
   isResponsePartial: boolean
 ): void {
-  // Root params are emitted once at the top level; readVaryParams unions them
-  // into the head, and they're threaded down to each segment below.
-  const headVaryParams = readVaryParams(
-    headVaryParamsIterable,
-    rootVaryParamsIterable
-  )
-
-  const flightDatas = normalizeFlightData(flightData)
-  if (typeof flightDatas === 'string') {
+  if (transportData === null) {
     return
   }
   const navigationSeed = convertServerPatchToFullTree(
     now,
     baseTree,
-    flightDatas,
+    transportData,
     renderedSearch,
     UnknownDynamicStaleTime
+  )
+  // Root params are emitted once at the top level; readVaryParams unions them
+  // into the head, and they're threaded down to each segment below.
+  const headVaryParams = readVaryParams(
+    navigationSeed.headVaryParams,
+    rootVaryParamsIterable
   )
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
-    flightDatas,
     buildId,
     isResponsePartial,
     headVaryParams,
@@ -4297,7 +4196,6 @@ export async function processRuntimePrefetchStream(
   baseTree: FlightRouterState,
   renderedSearch: string
 ): Promise<{
-  flightDatas: NormalizedFlightData[]
   navigationSeed: NavigationSeed
   buildId: string | undefined
   isResponsePartial: boolean
@@ -4314,28 +4212,31 @@ export async function processRuntimePrefetchStream(
       { allowPartialStream: true }
     )
 
-  // Root params are emitted once at the top level; readVaryParams unions them
-  // into the head, and we return the iterable so the caller can union it into
-  // each segment too.
   const rootVaryParamsIterable = serverData.r ?? null
-  const headVaryParams = readVaryParams(serverData.h, rootVaryParamsIterable)
 
   const staleAt = await resolveStaleAt(now, serverData.s)
 
-  const flightDatas = normalizeFlightData(serverData.f)
-  if (typeof flightDatas === 'string') {
+  const transportData = serverData.t
+  if (transportData === undefined) {
     return null
   }
   const navigationSeed = convertServerPatchToFullTree(
     now,
     baseTree,
-    flightDatas,
+    transportData,
     renderedSearch,
     UnknownDynamicStaleTime
   )
 
+  // Root params are emitted once at the top level; readVaryParams unions them
+  // into the head, and we return the iterable so the caller can union it into
+  // each segment too.
+  const headVaryParams = readVaryParams(
+    navigationSeed.headVaryParams,
+    rootVaryParamsIterable
+  )
+
   return {
-    flightDatas,
     navigationSeed,
     buildId: serverData.b,
     isResponsePartial: isPartial,

--- a/packages/next/src/client/components/segment-cache/decode-server-response.ts
+++ b/packages/next/src/client/components/segment-cache/decode-server-response.ts
@@ -1,0 +1,387 @@
+/**
+ * Decoding of RSC server responses (the transport format defined in
+ * shared/lib/rsc-transport) into the client's own representations. This is
+ * the only place on the client that consumes transport types; everything
+ * downstream operates on RouteTree / NavigationSeed / CacheNode.
+ */
+
+import type {
+  FlightRouterState,
+  HeadData,
+  Segment as FlightRouterStateSegment,
+} from '../../../shared/lib/app-router-types'
+import {
+  PrefetchHint,
+  SubtreePrefetchHints,
+  propagateSubtreeBits,
+} from '../../../shared/lib/app-router-types'
+import type {
+  PartialTransportData,
+  PartialTransportNode,
+} from '../../../shared/lib/rsc-transport'
+import { transportSegmentToSegment } from '../../../shared/lib/rsc-transport'
+import type { VaryParamsIterable } from '../../../shared/lib/segment-cache/vary-params-decoding'
+import {
+  type SegmentRequestKey,
+  ROOT_SEGMENT_REQUEST_KEY,
+  appendSegmentRequestKeyPart,
+  createSegmentRequestKeyPart,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
+import type { NormalizedSearch } from './cache-key'
+import type {
+  PageVaryPath,
+  PartialSegmentVaryPath,
+  SegmentVaryPath,
+} from './vary-path'
+import {
+  appendLayoutVaryPath,
+  finalizeLayoutVaryPath,
+  finalizeMetadataVaryPath,
+  finalizePageVaryPath,
+  getPartialLayoutVaryPath,
+  getPartialPageVaryPath,
+  getShellSegmentVaryPath,
+} from './vary-path'
+import {
+  type RouteTree,
+  type RSCSegmentData,
+  type RefreshState,
+  type RouteTreeAccumulator,
+  convertFlightRouterStateToRouteTree,
+  convertRootFlightRouterStateToRouteTree,
+} from './cache'
+import { computeDynamicStaleAt } from './bfcache'
+
+export type NavigationSeed = {
+  renderedSearch: string
+  routeTree: RouteTree<RSCSegmentData | null>
+  metadataVaryPath: PageVaryPath | null
+  head: HeadData | null
+  isHeadPartial: boolean
+  headVaryParams: VaryParamsIterable | null
+  dynamicStaleAt: number
+}
+
+export function convertServerPatchToFullTree(
+  now: number,
+  currentTree: FlightRouterState,
+  transportData: PartialTransportData | null,
+  renderedSearch: string,
+  dynamicStaleTimeSeconds: number
+): NavigationSeed {
+  // During a client navigation or prefetch, the server responds with a
+  // transport tree that covers only the parts of the route that have changed.
+  // Decode it into a full RouteTree, overlaying it on the base tree so that
+  // the slots the response carries no information about are reused from the
+  // client's current state.
+  //
+  // The returned RouteTree carries the response's render output on each node
+  // (RSCSegmentData). Pass a null transportData to convert the base tree
+  // alone (e.g. for refreshes and history restores, before a response
+  // is received).
+  const acc: { metadataVaryPath: PageVaryPath | null } = {
+    metadataVaryPath: null,
+  }
+  let routeTree: RouteTree<RSCSegmentData | null>
+  let head: HeadData | null = null
+  let isHeadPartial = true
+  let headVaryParams: VaryParamsIterable | null = null
+  if (transportData !== null) {
+    routeTree = decodeTransportTreeIntoRouteTree(
+      transportData.t,
+      currentTree,
+      renderedSearch as NormalizedSearch,
+      acc
+    )
+    const transportHead = transportData.h
+    if (transportHead !== undefined) {
+      head = transportHead.r
+      isHeadPartial = transportHead.p
+      headVaryParams = transportHead.v
+    }
+  } else {
+    routeTree = convertRootFlightRouterStateToRouteTree(
+      currentTree,
+      renderedSearch as NormalizedSearch,
+      acc
+    )
+  }
+
+  return {
+    routeTree,
+    metadataVaryPath: acc.metadataVaryPath,
+    renderedSearch,
+    head,
+    isHeadPartial,
+    headVaryParams,
+    dynamicStaleAt: computeDynamicStaleAt(now, dynamicStaleTimeSeconds),
+  }
+}
+
+/**
+ * Creates a RouteTree node for a segment, with its identity and cache-key
+ * information (vary paths, page-ness, the normalized segment value)
+ * initialized, and the remaining fields set to their defaults. The caller
+ * finishes initializing those in place after recursing into the children.
+ * Shared by the FlightRouterState converter and the transport decoder so the
+ * two cannot drift, and so every node they produce has the same property
+ * order (one hidden class).
+ */
+export function createRouteTreeNode<TData>(
+  originalSegment: FlightRouterStateSegment,
+  isRootParam: boolean,
+  requestKey: SegmentRequestKey,
+  parentPartialVaryPath: PartialSegmentVaryPath | null,
+  renderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
+): RouteTree<TData | null> {
+  let segment: FlightRouterStateSegment
+  let partialVaryPath: PartialSegmentVaryPath | null
+  let isPage: boolean
+  let varyPath: SegmentVaryPath
+  if (Array.isArray(originalSegment)) {
+    isPage = false
+    const paramCacheKey = originalSegment[1]
+    const paramName = originalSegment[0]
+    partialVaryPath = appendLayoutVaryPath(
+      parentPartialVaryPath,
+      paramCacheKey,
+      paramName,
+      isRootParam
+    )
+    varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
+    segment = originalSegment
+  } else {
+    // This segment does not have a param. Inherit the partial vary path of
+    // the parent.
+    partialVaryPath = parentPartialVaryPath
+    if (requestKey.endsWith(PAGE_SEGMENT_KEY)) {
+      // This is a page segment.
+      isPage = true
+
+      // The navigation implementation expects the search params to be included
+      // in the segment. However, in the case of a static response, the search
+      // params are omitted. So the client needs to add them back in when reading
+      // from the Segment Cache.
+      //
+      // For consistency, we'll do this for dynamic responses, too.
+      //
+      // TODO: We should move search params out of FlightRouterState and handle
+      // them entirely on the client, similar to our plan for dynamic params.
+      segment = PAGE_SEGMENT_KEY
+      varyPath = finalizePageVaryPath(
+        requestKey,
+        renderedSearch,
+        partialVaryPath
+      )
+      // The metadata "segment" is not part the route tree, but it has the same
+      // conceptual params as a page segment. Write the vary path into the
+      // accumulator object. If there are multiple parallel pages, we use the
+      // first one. Which page we choose is arbitrary as long as it's
+      // consistently the same one every time every time. See
+      // finalizeMetadataVaryPath for more details.
+      if (acc.metadataVaryPath === null) {
+        acc.metadataVaryPath = finalizeMetadataVaryPath(
+          requestKey,
+          renderedSearch,
+          partialVaryPath
+        )
+      }
+    } else {
+      // This is a layout segment.
+      isPage = false
+      segment = originalSegment
+      varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
+    }
+  }
+  return {
+    requestKey,
+    segment,
+    shellVaryPath: getShellSegmentVaryPath(varyPath),
+    refreshState: null,
+    data: null,
+    // TODO: Cheating the type system here a bit because TypeScript can't tell
+    // that the type of isPage and varyPath are consistent. If isPage were
+    // wrong it would break the behavior and we'd catch it quickly.
+    varyPath: varyPath as any,
+    isPage: isPage as boolean as any,
+    slots: null,
+    prefetchHints: 0,
+  }
+}
+
+/**
+ * Decodes a response's transport tree into a RouteTree, using the client's
+ * current router state as the base for the parts of the route the response
+ * carries no information about.
+ *
+ * The response is an overlay over the base:
+ *
+ * - Nodes with rendered output — and nodes with no data at all, which are
+ *   server-sent structure whose output the client fetches lazily — are
+ *   authoritative: their identity, hints, and subtree come entirely from
+ *   the response.
+ * - Covered-but-not-rendered nodes (data with a null rsc) sit on the path
+ *   from the root down to the rendered subtrees. The client is expected to
+ *   already have them, so their refresh state and hints are inherited from
+ *   the base tree, and any slot the response doesn't mention is reused from
+ *   the base as-is.
+ *
+ * TODO: The base is a FlightRouterState only because that's the
+ * representation the client router currently renders from (the router
+ * reducer's `state.tree`, which the CacheNode tree and layout-router are
+ * keyed against). Once the rendering path is updated to use RouteTree as its
+ * source of truth, the base tree here can be a RouteTree, and the base-only
+ * conversion path (convertFlightRouterStateToRouteTree) goes away with it.
+ */
+export function decodeTransportTreeIntoRouteTree(
+  transportNode: PartialTransportNode,
+  baseRouterState: FlightRouterState | null,
+  renderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
+): RouteTree<RSCSegmentData | null> {
+  return decodeTransportNode(
+    transportNode,
+    baseRouterState ?? undefined,
+    ROOT_SEGMENT_REQUEST_KEY,
+    null,
+    renderedSearch,
+    acc
+  )
+}
+
+function decodeTransportNode(
+  node: PartialTransportNode,
+  base: FlightRouterState | undefined,
+  requestKey: SegmentRequestKey,
+  parentPartialVaryPath: PartialSegmentVaryPath | null,
+  parentRenderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
+): RouteTree<RSCSegmentData | null> {
+  const nodeData = node.d
+  const inheritsFromBase = nodeData !== undefined && nodeData.r === null
+  // The base node this position inherits from, when it does.
+  const inheritedBase = inheritsFromBase ? base : undefined
+
+  const originalSegment = transportSegmentToSegment(node.s)
+
+  const baseHints = inheritedBase !== undefined ? (inheritedBase[4] ?? 0) : 0
+  let prefetchHints = node.h ?? baseHints
+
+  // This segment's param (if any) is a root param iff the segment is at or
+  // above the root layout, which the server marks directly.
+  const isRootParam = (prefetchHints & PrefetchHint.IsRootLayoutOrAbove) !== 0
+
+  // Inherited positions keep the base tree's refresh state. Its rendered
+  // search is updated to this response's, since all pages within the same
+  // response share the same search value. (The refresh state acts like a
+  // "context provider" for inactive parallel routes.)
+  const baseCompressedRefreshState =
+    inheritedBase !== undefined ? (inheritedBase[2] ?? null) : null
+  const refreshState: RefreshState | null =
+    baseCompressedRefreshState !== null
+      ? {
+          canonicalUrl: baseCompressedRefreshState[0] as string,
+          renderedSearch: parentRenderedSearch,
+        }
+      : null
+  const renderedSearch =
+    refreshState !== null ? refreshState.renderedSearch : parentRenderedSearch
+
+  const tree = createRouteTreeNode<RSCSegmentData>(
+    originalSegment,
+    isRootParam,
+    requestKey,
+    parentPartialVaryPath,
+    renderedSearch,
+    acc
+  )
+  tree.refreshState = refreshState
+  const partialVaryPath = tree.isPage
+    ? getPartialPageVaryPath(tree.varyPath)
+    : getPartialLayoutVaryPath(tree.varyPath)
+
+  let slots: Map<string, RouteTree<RSCSegmentData | null>> | null = null
+  const transportChildren = node.c
+  const baseChildren =
+    inheritedBase !== undefined ? inheritedBase[1] : undefined
+  if (transportChildren !== undefined) {
+    for (const [parallelRouteKey, childNode] of transportChildren) {
+      const childBase =
+        baseChildren !== undefined ? baseChildren[parallelRouteKey] : undefined
+      const childSegment = transportSegmentToSegment(childNode.s)
+      const childRequestKey = appendSegmentRequestKeyPart(
+        requestKey,
+        parallelRouteKey,
+        createSegmentRequestKeyPart(childSegment)
+      )
+      const childTree = decodeTransportNode(
+        childNode,
+        childBase,
+        childRequestKey,
+        partialVaryPath,
+        renderedSearch,
+        acc
+      )
+      if (slots === null) {
+        slots = new Map()
+      }
+      slots.set(parallelRouteKey, childTree)
+    }
+  }
+  if (baseChildren !== undefined) {
+    // Slots the response carries no information about are reused from the
+    // base tree, structure-only.
+    for (const parallelRouteKey in baseChildren) {
+      if (
+        transportChildren !== undefined &&
+        transportChildren.has(parallelRouteKey)
+      ) {
+        continue
+      }
+      const childBase = baseChildren[parallelRouteKey]
+      const childRequestKey = appendSegmentRequestKeyPart(
+        requestKey,
+        parallelRouteKey,
+        createSegmentRequestKeyPart(childBase[0])
+      )
+      const childTree = convertFlightRouterStateToRouteTree(
+        childBase,
+        childRequestKey,
+        partialVaryPath,
+        renderedSearch,
+        acc
+      )
+      if (slots === null) {
+        slots = new Map()
+      }
+      slots.set(parallelRouteKey, childTree)
+    }
+  }
+
+  if (inheritsFromBase) {
+    // Recompute the propagated "subtree" prefetch hints for this segment,
+    // since its children may combine response and base subtrees. Mirrors the
+    // propagation done on the server in createFlightRouterStateFromLoaderTree.
+    let propagated = prefetchHints & ~SubtreePrefetchHints
+    if (slots !== null) {
+      for (const childTree of slots.values()) {
+        propagated = propagateSubtreeBits(propagated, childTree.prefetchHints)
+      }
+    }
+    prefetchHints = propagated
+  }
+
+  if (nodeData !== undefined) {
+    tree.data = {
+      rsc: nodeData.r,
+      isPartial: nodeData.p,
+      varyParams: nodeData.v,
+    }
+  }
+
+  tree.slots = slots
+  tree.prefetchHints = prefetchHints
+  return tree
+}

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -1,17 +1,9 @@
 import type {
-  CacheNodeSeedData,
   FlightRouterState,
-  FlightSegmentPath,
   ScrollRef,
 } from '../../../shared/lib/app-router-types'
 import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { HeadData } from '../../../shared/lib/app-router-types'
-import {
-  PrefetchHint,
-  SubtreePrefetchHints,
-  propagateSubtreeBits,
-} from '../../../shared/lib/app-router-types'
-import type { NormalizedFlightData } from '../../flight-data-helpers'
+import { PrefetchHint } from '../../../shared/lib/app-router-types'
 import { fetchServerResponse } from '../router-reducer/fetch-server-response'
 import {
   startPPRNavigation,
@@ -27,13 +19,10 @@ import {
   EntryStatus,
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
-  convertRootFlightRouterStateToRouteTree,
   resolveStaleAt,
   writePrerenderResponseIntoCache,
   processRuntimePrefetchStream,
   writeDynamicRenderResponseIntoCache,
-  type RouteTree,
-  type RSCSegmentData,
   type FulfilledRouteCacheEntry,
 } from './cache'
 import { discoverKnownRoute } from './optimistic-routes'
@@ -41,13 +30,16 @@ import { createCacheKey, type NormalizedSearch } from './cache-key'
 import { schedulePrefetchTask } from './scheduler'
 import { PrefetchPriority, FetchStrategy } from './types'
 import { getLinkForCurrentNavigation } from '../links'
-import type { PageVaryPath } from './vary-path'
 import type { AppRouterState } from '../router-reducer/router-reducer-types'
 import { ScrollBehavior } from '../router-reducer/router-reducer-types'
 import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
 import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
 import { createLinkPrefetchPartialError } from '../../../shared/lib/instant-messages'
+import {
+  convertServerPatchToFullTree,
+  type NavigationSeed,
+} from './decode-server-response'
 
 /**
  * Navigate to a new URL, using the Segment Cache to construct a response.
@@ -402,6 +394,8 @@ function navigateUsingPrefetchedRouteTree(
     routeTree,
     metadataVaryPath: route.metadata.varyPath as any,
     head: null,
+    isHeadPartial: true,
+    headVaryParams: null,
     dynamicStaleAt: computeDynamicStaleAt(now, UnknownDynamicStaleTime),
   }
   return navigateToKnownRoute(
@@ -494,7 +488,7 @@ async function navigateToUnknownRoute(
   }
 
   const {
-    flightData,
+    transportData,
     canonicalUrl,
     renderedSearch,
     couldBeIntercepted,
@@ -512,7 +506,7 @@ async function navigateToUnknownRoute(
   const navigationSeed = convertServerPatchToFullTree(
     now,
     currentFlightRouterState,
-    flightData,
+    transportData,
     renderedSearch,
     dynamicStaleTime
   )
@@ -559,9 +553,8 @@ async function navigateToUnknownRoute(
           writePrerenderResponseIntoCache(
             now,
             FetchStrategy.PPR,
-            staticStageResponse.f,
+            staticStageResponse.t ?? null,
             buildId,
-            staticStageResponse.h,
             staticStageResponse.r ?? null,
             staleAt,
             currentFlightRouterState,
@@ -587,7 +580,6 @@ async function navigateToUnknownRoute(
             writeDynamicRenderResponseIntoCache(
               now,
               FetchStrategy.PPRRuntime,
-              processed.flightDatas,
               processed.buildId,
               processed.isResponsePartial,
               processed.headVaryParams,
@@ -847,212 +839,6 @@ export function completeTraverseNavigation(
     // canonical URL, there should be a corresponding Next-Url.
     previousNextUrl: null,
     debugInfo: null,
-  }
-}
-
-// TODO: The rest of this file is related to converting the server response into
-// the data structures used by the client. Probably should move to a
-// separate module.
-
-export type NavigationSeed = {
-  renderedSearch: string
-  routeTree: RouteTree<RSCSegmentData | null>
-  metadataVaryPath: PageVaryPath | null
-  head: HeadData | null
-  dynamicStaleAt: number
-}
-
-export function convertServerPatchToFullTree(
-  now: number,
-  currentTree: FlightRouterState,
-  flightData: Array<NormalizedFlightData> | null,
-  renderedSearch: string,
-  dynamicStaleTimeSeconds: number
-): NavigationSeed {
-  // During a client navigation or prefetch, the server sends back only a patch
-  // for the parts of the tree that have changed.
-  //
-  // This applies the patch to the base tree to create a full representation of
-  // the resulting tree.
-  //
-  // The returned RouteTree carries the response's render output on each
-  // node (RSCSegmentData); this is the only place on the client where the
-  // wire format's separate CacheNodeSeedData tree is consumed.
-  //
-  // TODO: This similar to what apply-router-state-patch-to-tree does. It
-  // will eventually fully replace it. We should get rid of all the remaining
-  // places where we iterate over the server patch format. This should also
-  // eventually replace normalizeFlightData.
-
-  let baseTree: FlightRouterState = currentTree
-  let baseData: CacheNodeSeedData | null = null
-  let head: HeadData | null = null
-  if (flightData !== null) {
-    for (const {
-      segmentPath,
-      tree: treePatch,
-      seedData: dataPatch,
-      head: headPatch,
-    } of flightData) {
-      const result = convertServerPatchToFullTreeImpl(
-        baseTree,
-        baseData,
-        treePatch,
-        dataPatch,
-        segmentPath,
-        renderedSearch,
-        0
-      )
-      baseTree = result.tree
-      baseData = result.data
-      // This is the same for all patches per response, so just pick an
-      // arbitrary one
-      head = headPatch
-    }
-  }
-
-  const finalFlightRouterState = baseTree
-
-  // Convert the final FlightRouterState into a RouteTree type.
-  //
-  // TODO: Eventually, FlightRouterState will evolve to being a transport format
-  // only. The RouteTree type will become the main type used for dealing with
-  // routes on the client, and we'll store it in the state directly.
-  const acc = { metadataVaryPath: null }
-  const routeTree = convertRootFlightRouterStateToRouteTree(
-    finalFlightRouterState,
-    // Embed the response's seed data directly into the RouteTree, so each
-    // node carries its own render output.
-    baseData,
-    renderedSearch as NormalizedSearch,
-    acc
-  )
-
-  return {
-    routeTree,
-    metadataVaryPath: acc.metadataVaryPath,
-    renderedSearch,
-    head,
-    dynamicStaleAt: computeDynamicStaleAt(now, dynamicStaleTimeSeconds),
-  }
-}
-
-function convertServerPatchToFullTreeImpl(
-  baseRouterState: FlightRouterState,
-  baseData: CacheNodeSeedData | null,
-  treePatch: FlightRouterState,
-  dataPatch: CacheNodeSeedData | null,
-  segmentPath: FlightSegmentPath,
-  renderedSearch: string,
-  index: number
-): { tree: FlightRouterState; data: CacheNodeSeedData | null } {
-  if (index === segmentPath.length) {
-    // We reached the part of the tree that we need to patch.
-    return {
-      tree: treePatch,
-      data: dataPatch,
-    }
-  }
-
-  // segmentPath represents the parent path of subtree. It's a repeating
-  // pattern of parallel route key and segment:
-  //
-  //   [string, Segment, string, Segment, string, Segment, ...]
-  //
-  // This path tells us which part of the base tree to apply the tree patch.
-  //
-  // NOTE: We receive the FlightRouterState patch in the same request as the
-  // seed data patch. Therefore we don't need to worry about diffing the segment
-  // values; we can assume the server sent us a correct result.
-  const updatedParallelRouteKey: string = segmentPath[index]
-  // const segment: Segment = segmentPath[index + 1] <-- Not used, see note above
-
-  const baseTreeChildren = baseRouterState[1]
-  const baseSeedDataChildren = baseData !== null ? baseData[1] : null
-  const newTreeChildren: Record<string, FlightRouterState> = {}
-  const newSeedDataChildren: Record<string, CacheNodeSeedData | null> = {}
-  for (const parallelRouteKey in baseTreeChildren) {
-    const childBaseRouterState = baseTreeChildren[parallelRouteKey]
-    const childBaseSeedData =
-      baseSeedDataChildren !== null
-        ? (baseSeedDataChildren[parallelRouteKey] ?? null)
-        : null
-    if (parallelRouteKey === updatedParallelRouteKey) {
-      const result = convertServerPatchToFullTreeImpl(
-        childBaseRouterState,
-        childBaseSeedData,
-        treePatch,
-        dataPatch,
-        segmentPath,
-        renderedSearch,
-        // Advance the index by two and keep cloning until we reach
-        // the end of the segment path.
-        index + 2
-      )
-
-      newTreeChildren[parallelRouteKey] = result.tree
-      newSeedDataChildren[parallelRouteKey] = result.data
-    } else {
-      // This child is not being patched. Copy it over as-is.
-      newTreeChildren[parallelRouteKey] = childBaseRouterState
-      newSeedDataChildren[parallelRouteKey] = childBaseSeedData
-    }
-  }
-
-  let clonedTree: FlightRouterState
-  let clonedSeedData: CacheNodeSeedData
-  // Clone all the fields except the children.
-
-  // Clone the FlightRouterState tree. Based on equivalent logic in
-  // apply-router-state-patch-to-tree, but should confirm whether we need to
-  // copy all of these fields. Not sure the server ever sends, e.g. the
-  // refetch marker.
-  clonedTree = [baseRouterState[0], newTreeChildren]
-  if (2 in baseRouterState) {
-    const compressedRefreshState = baseRouterState[2]
-    if (
-      compressedRefreshState !== undefined &&
-      compressedRefreshState !== null
-    ) {
-      // Since this part of the tree was patched with new data, any parent
-      // refresh states should be updated to reflect the new rendered search
-      // value. (The refresh state acts like a "context provider".) All pages
-      // within the same server response share the same renderedSearch value,
-      // but the same RouteTree could be composed from multiple different
-      // routes, and multiple responses.
-      clonedTree[2] = [compressedRefreshState[0], renderedSearch]
-    }
-  }
-  if (3 in baseRouterState) {
-    clonedTree[3] = baseRouterState[3]
-  }
-  // Recompute the propagated "subtree" prefetch hints for this segment. Mirrors
-  // the propagation done on the server in
-  // createFlightRouterStateFromLoaderTree.
-  let prefetchHints = (baseRouterState[4] ?? 0) & ~SubtreePrefetchHints
-  for (const parallelRouteKey in newTreeChildren) {
-    const childHints = newTreeChildren[parallelRouteKey][4]
-    if (childHints !== undefined) {
-      prefetchHints = propagateSubtreeBits(prefetchHints, childHints)
-    }
-  }
-  if (prefetchHints !== 0) {
-    clonedTree[4] = prefetchHints
-  }
-
-  // Clone the CacheNodeSeedData tree.
-  const isEmptySeedDataPartial = true
-  clonedSeedData = [
-    null,
-    newSeedDataChildren,
-    null,
-    isEmptySeedDataPartial,
-    null,
-  ]
-
-  return {
-    tree: clonedTree,
-    data: clonedSeedData,
   }
 }
 

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -1,13 +1,13 @@
 import type {
-  CacheNodeSeedData,
-  FlightData,
-  FlightDataPath,
   FlightRouterState,
   FlightSegmentPath,
   Segment,
-  HeadData,
   InitialRSCPayload,
 } from '../shared/lib/app-router-types'
+import type {
+  FullTransportNode,
+  TransportSegment,
+} from '../shared/lib/rsc-transport'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 import type { NormalizedSearch } from './components/segment-cache/cache-key'
 import {
@@ -18,55 +18,6 @@ import {
   getRenderedSearch,
 } from './route-params'
 import { createHrefFromUrl } from './components/router-reducer/create-href-from-url'
-
-export type NormalizedFlightData = {
-  /**
-   * The full `FlightSegmentPath` inclusive of the final `Segment`
-   */
-  segmentPath: FlightSegmentPath
-  /**
-   * The `FlightSegmentPath` exclusive of the final `Segment`
-   */
-  pathToSegment: FlightSegmentPath
-  segment: Segment
-  tree: FlightRouterState
-  seedData: CacheNodeSeedData | null
-  head: HeadData
-  isHeadPartial: boolean
-  isRootRender: boolean
-}
-
-// TODO: We should only have to export `normalizeFlightData`, however because the initial flight data
-// that gets passed to `createInitialRouterState` doesn't conform to the `FlightDataPath` type (it's missing the root segment)
-// we're currently exporting it so we can use it directly. This should be fixed as part of the unification of
-// the different ways we express `FlightSegmentPath`.
-export function getFlightDataPartsFromPath(
-  flightDataPath: FlightDataPath
-): NormalizedFlightData {
-  // Pick the last 4 items from the `FlightDataPath` to get the [tree, seedData, viewport, isHeadPartial].
-  const flightDataPathLength = 4
-  // tree, seedData, and head are *always* the last three items in the `FlightDataPath`.
-  const [tree, seedData, head, isHeadPartial] =
-    flightDataPath.slice(-flightDataPathLength)
-  // The `FlightSegmentPath` is everything except the last three items. For a root render, it won't be present.
-  const segmentPath = flightDataPath.slice(0, -flightDataPathLength)
-
-  return {
-    // TODO: Unify these two segment path helpers. We are inconsistently pushing an empty segment ("")
-    // to the start of the segment path in some places which makes it hard to use solely the segment path.
-    // Look for "// TODO-APP: remove ''" in the codebase.
-    pathToSegment: segmentPath.slice(0, -1),
-    segmentPath,
-    // if the `FlightDataPath` corresponds with the root, there'll be no segment path,
-    // in which case we default to ''.
-    segment: segmentPath[segmentPath.length - 1] ?? '',
-    tree,
-    seedData,
-    head,
-    isHeadPartial,
-    isRootRender: flightDataPath.length === flightDataPathLength,
-  }
-}
 
 export function createInitialRSCPayloadFromFallbackPrerender(
   response: Response,
@@ -92,36 +43,28 @@ export function createInitialRSCPayloadFromFallbackPrerender(
   // "export" mode, where we currently don't assume that custom response
   // headers are present.
 
-  // Patch the Flight data sent by the server with the correct params parsed
-  // from the URL + response object.
+  // Patch the transport tree sent by the server with the correct params
+  // parsed from the URL + response object.
   const renderedPathname = getRenderedPathname(response)
   const renderedSearch = getRenderedSearch(response)
   const canonicalUrl = createHrefFromUrl(new URL(location.href))
-  const originalFlightDataPath = fallbackInitialRSCPayload.f[0]
-  const originalFlightRouterState = originalFlightDataPath[0]
+  const fallbackTransportData = fallbackInitialRSCPayload.t
   const payload: InitialRSCPayload = {
     c: canonicalUrl.split('/'),
     q: renderedSearch,
     i: fallbackInitialRSCPayload.i,
-    f: [
-      [
-        fillInFallbackFlightRouterState(
-          originalFlightRouterState,
-          renderedPathname,
-          renderedSearch as NormalizedSearch
-        ),
-        originalFlightDataPath[1],
-        originalFlightDataPath[2],
-        // isHeadPartial. Previously this incorrectly passed the head itself
-        // (index 2), which is truthy, so the head was always treated
-        // as partial.
-        originalFlightDataPath[3],
-      ],
-    ],
+    t: {
+      t: fillInFallbackTransportTree(
+        fallbackTransportData.t,
+        renderedPathname.split('/').filter((part) => part !== ''),
+        0,
+        renderedSearch as NormalizedSearch
+      ),
+      h: fallbackTransportData.h,
+    },
     m: fallbackInitialRSCPayload.m,
     G: fallbackInitialRSCPayload.G,
     S: fallbackInitialRSCPayload.S,
-    h: fallbackInitialRSCPayload.h,
   }
   if (fallbackInitialRSCPayload.b) {
     payload.b = fallbackInitialRSCPayload.b
@@ -129,44 +72,35 @@ export function createInitialRSCPayloadFromFallbackPrerender(
   return payload
 }
 
-function fillInFallbackFlightRouterState(
-  flightRouterState: FlightRouterState,
-  renderedPathname: string,
-  renderedSearch: NormalizedSearch
-): FlightRouterState {
-  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
-  const index = 0
-  return fillInFallbackFlightRouterStateImpl(
-    flightRouterState,
-    renderedSearch,
-    pathnameParts,
-    index
-  )
-}
-
-function fillInFallbackFlightRouterStateImpl(
-  flightRouterState: FlightRouterState,
-  renderedSearch: NormalizedSearch,
+/**
+ * A fallback prerender is rendered without concrete param values. Fill them
+ * in by parsing the rendered pathname, so the hydrated tree has the same
+ * identity a direct render of this URL would have.
+ */
+function fillInFallbackTransportTree(
+  node: FullTransportNode,
   pathnameParts: Array<string>,
-  pathnamePartsIndex: number
-): FlightRouterState {
-  const originalSegment = flightRouterState[0]
-  let newSegment: Segment
+  pathnamePartsIndex: number,
+  renderedSearch: NormalizedSearch
+): FullTransportNode {
+  const originalSegment = node.s
+  let newSegment: TransportSegment
   let doesAppearInURL: boolean
   if (typeof originalSegment === 'string') {
     newSegment = originalSegment
     doesAppearInURL = doesStaticSegmentAppearInURL(originalSegment)
   } else {
-    const paramName = originalSegment[0]
-    const paramType = originalSegment[2]
-    const staticSiblings = originalSegment[3]
     const paramValue = parseDynamicParamFromURLPart(
-      paramType,
+      originalSegment.t,
       pathnameParts,
       pathnamePartsIndex
     )
-    const cacheKey = getCacheKeyForDynamicParam(paramValue, renderedSearch)
-    newSegment = [paramName, cacheKey, paramType, staticSiblings]
+    newSegment = {
+      n: originalSegment.n,
+      t: originalSegment.t,
+      k: getCacheKeyForDynamicParam(paramValue, renderedSearch),
+      s: originalSegment.s,
+    }
     doesAppearInURL = true
   }
 
@@ -176,26 +110,34 @@ function fillInFallbackFlightRouterStateImpl(
     ? pathnamePartsIndex + 1
     : pathnamePartsIndex
 
-  const children = flightRouterState[1]
-  const newChildren: { [key: string]: FlightRouterState } = {}
-  for (let key in children) {
-    const childFlightRouterState = children[key]
-    newChildren[key] = fillInFallbackFlightRouterStateImpl(
-      childFlightRouterState,
-      renderedSearch,
-      pathnameParts,
-      childPathnamePartsIndex
-    )
+  const children = node.c
+  let newChildren: Map<string, FullTransportNode> | undefined
+  if (children !== undefined) {
+    newChildren = new Map()
+    for (const [parallelRouteKey, childNode] of children) {
+      newChildren.set(
+        parallelRouteKey,
+        fillInFallbackTransportTree(
+          childNode,
+          pathnameParts,
+          childPathnamePartsIndex,
+          renderedSearch
+        )
+      )
+    }
   }
 
-  const newState: FlightRouterState = [
-    newSegment,
-    newChildren,
-    null,
-    flightRouterState[3],
-    flightRouterState[4],
-  ]
-  return newState
+  const newNode: FullTransportNode = {
+    s: newSegment,
+    d: node.d,
+  }
+  if (node.h !== undefined) {
+    newNode.h = node.h
+  }
+  if (newChildren !== undefined) {
+    newNode.c = newChildren
+  }
+  return newNode
 }
 
 export function getNextFlightSegmentPath(
@@ -204,20 +146,6 @@ export function getNextFlightSegmentPath(
   // Since `FlightSegmentPath` is a repeated tuple of `Segment` and `ParallelRouteKey`, we slice off two items
   // to get the next segment path.
   return flightSegmentPath.slice(2)
-}
-
-export function normalizeFlightData(
-  flightData: FlightData
-): NormalizedFlightData[] | string {
-  // FlightData can be a string when the server didn't respond with a proper flight response,
-  // or when a redirect happens, to signal to the client that it needs to perform an MPA navigation.
-  if (typeof flightData === 'string') {
-    return flightData
-  }
-
-  return flightData.map((flightDataPath) =>
-    getFlightDataPartsFromPath(flightDataPath)
-  )
 }
 
 /**

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,4 +1,9 @@
 import type { ComponentType, ErrorInfo, JSX, ReactNode } from 'react'
+import {
+  convertFlightDataPathsToPartialTransportData,
+  convertInitialFlightDataToFullTransportData,
+} from './transport-adapter'
+import type { PartialTransportData } from '../../shared/lib/rsc-transport'
 import type { RenderOpts, PreloadCallbacks } from './types'
 import type {
   ActionResult,
@@ -8,9 +13,8 @@ import type {
   CacheNodeSeedData,
   RSCPayload,
   NavigationFlightResponse,
-  FlightData,
+  ActionFlightResponse,
   InitialRSCPayload,
-  FlightDataPath,
   PrefetchHints,
 } from '../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../shared/lib/app-router-types'
@@ -684,14 +688,11 @@ async function generateDynamicRSCPayload(
     runtimePrefetchStream?: ReadableStream<Uint8Array>
   }
 ): Promise<RSCPayload> {
-  // Flight data that is going to be passed to the browser.
-  // Currently a single item array but in the future multiple patches might be combined in a single request.
-
-  // We initialize `flightData` to an empty string because the client router knows how to tolerate
-  // it (treating it as an MPA navigation). The only time this function wouldn't generate flight data
-  // is for server actions, if the server action handler instructs this function to skip it. When the server
-  // action reducer sees a falsy value, it'll simply resolve the action with no data.
-  let flightData: FlightData = ''
+  // Transport data that is going to be passed to the browser. Undefined when
+  // the response renders nothing: server actions, if the server action
+  // handler instructs this function to skip rendering. When the server action
+  // reducer sees an absent tree, it resolves the action with no data.
+  let transportData: PartialTransportData | undefined = undefined
 
   const {
     componentMod: {
@@ -755,7 +756,7 @@ async function generateDynamicRSCPayload(
       })
     )
 
-    flightData = (
+    const flightDataPaths = (
       needsFullTree
         ? await createFullTreeFlightDataForNavigation({
             ctx,
@@ -782,6 +783,13 @@ async function generateDynamicRSCPayload(
             hintTree: ctx.renderOpts.prefetchHints?.[ctx.pagePath] ?? null,
           })
     ).map((path) => path.slice(1)) // remove the '' (root) segment
+
+    if (flightDataPaths.length > 0) {
+      transportData = convertFlightDataPathsToPartialTransportData(
+        flightDataPaths,
+        getMetadataVaryParamsAccumulator()
+      )
+    }
   }
 
   // In dev, the Vary header may not reliably reflect whether a route can
@@ -796,19 +804,21 @@ async function generateDynamicRSCPayload(
   // We can rely on this because `ActionResult` will always be a promise, even if
   // the result is falsey.
   if (options?.actionResult) {
-    return maybeAppendBuildIdToRSCPayload(ctx, {
+    const actionResponse: ActionFlightResponse = {
       a: options.actionResult,
-      f: flightData,
       q: getRenderedSearch(query),
       i: !!couldBeIntercepted,
-    })
+    }
+    if (transportData !== undefined) {
+      actionResponse.t = transportData
+    }
+    return maybeAppendBuildIdToRSCPayload(ctx, actionResponse)
   }
 
   // Otherwise, it's a regular RSC response.
   const baseResponse: NavigationFlightResponse = maybeAppendBuildIdToRSCPayload(
     ctx,
     {
-      f: flightData,
       q: getRenderedSearch(query),
       i: !!couldBeIntercepted,
       // Tells the client whether this route supports per-segment prefetching.
@@ -816,10 +826,12 @@ async function generateDynamicRSCPayload(
       // static pages do, because their per-segment prefetch responses are
       // generated during static generation (build or ISR).
       S: ctx.renderCapabilities.supportsPerSegmentPrefetching,
-      h: getMetadataVaryParamsAccumulator(),
       r: getRootParamsVaryParamsAccumulator() ?? undefined,
     }
   )
+  if (transportData !== undefined) {
+    baseResponse.t = transportData
+  }
 
   if (options?.staleTimeIterable !== undefined) {
     baseResponse.s = options.staleTimeIterable
@@ -2239,14 +2251,13 @@ async function getRSCPayload(
     c: prepareInitialCanonicalUrl(url),
     q: getRenderedSearch(query),
     i: !!couldBeIntercepted,
-    f: [
-      [
-        initialTree,
-        seedData,
-        initialHead,
-        isPossiblyPartialHead,
-      ] as FlightDataPath,
-    ],
+    t: convertInitialFlightDataToFullTransportData(
+      initialTree,
+      seedData,
+      initialHead,
+      isPossiblyPartialHead,
+      getMetadataVaryParamsAccumulator()
+    ),
     m: missingSlots,
     G: [GlobalError, globalErrorStyles],
     // Tells the client whether this route supports per-segment prefetching.
@@ -2254,7 +2265,6 @@ async function getRSCPayload(
     // static pages do, because their per-segment prefetch responses are
     // generated during static generation (build or ISR).
     S: ctx.renderCapabilities.supportsPerSegmentPrefetching,
-    h: getMetadataVaryParamsAccumulator(),
     r: getRootParamsVaryParamsAccumulator() ?? undefined,
     s: staleTimeIterable,
     a: shellByteLengthPromise,
@@ -2392,21 +2402,19 @@ async function getErrorRSCPayload(
     q: getRenderedSearch(query),
     m: undefined,
     i: false,
-    f: [
-      [
-        initialTree,
-        seedData,
-        initialHead,
-        isPossiblyPartialHead,
-      ] as FlightDataPath,
-    ],
+    t: convertInitialFlightDataToFullTransportData(
+      initialTree,
+      seedData,
+      initialHead,
+      isPossiblyPartialHead,
+      getMetadataVaryParamsAccumulator()
+    ),
     G: [GlobalError, globalErrorStyles],
     // Tells the client whether this route supports per-segment prefetching.
     // With Cache Components, all routes support it. Without it, only fully
     // static pages do, because their per-segment prefetch responses are
     // generated during static generation (build or ISR).
     S: ctx.renderCapabilities.supportsPerSegmentPrefetching,
-    h: getMetadataVaryParamsAccumulator(),
     r: getRootParamsVaryParamsAccumulator() ?? undefined,
   } satisfies InitialRSCPayload)
 }

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable @next/internal/no-ambiguous-jsx -- Bundled in entry-base so it gets the right JSX runtime. */
 import type {
-  CacheNodeSeedData,
-  FlightRouterState,
   InitialRSCPayload,
   DynamicParamTypesShort,
-  HeadData,
   PrefetchHints,
 } from '../../shared/lib/app-router-types'
 import {
@@ -41,6 +38,10 @@ import {
   printDebugThrownValueForProspectiveRender,
 } from './prospective-render-utils'
 import { workAsyncStorage } from './work-async-storage.external'
+import {
+  type FullTransportNode,
+  transportSegmentToSegment,
+} from '../../shared/lib/rsc-transport'
 
 // Contains metadata about the route tree. The client must fetch this before
 // it can fetch any actual segment data.
@@ -240,39 +241,6 @@ function onSegmentPrerenderError(error: unknown) {
       workStore?.route ?? 'unknown route',
       Phase.SegmentCollection
     )
-  }
-}
-
-/**
- * Extract the FlightRouterState, seed data, and head from a prerendered
- * InitialRSCPayload. Returns null if the payload doesn't match the expected
- * shape: a single root path with no segment prefix, which has 4 elements
- * ([tree, seedData, head, isHeadPartial], per getRSCPayload) or 3 when
- * reconstructed without the isHeadPartial flag (per instant-validation).
- */
-function extractFlightData(initialRSCPayload: InitialRSCPayload): {
-  buildId: string | undefined
-  flightRouterState: FlightRouterState
-  seedData: CacheNodeSeedData
-  head: HeadData
-} | null {
-  const flightDataPaths = initialRSCPayload.f
-  // FlightDataPath is an unsound type, hence the additional checks.
-  if (
-    flightDataPaths.length !== 1 ||
-    (flightDataPaths[0].length !== 3 && flightDataPaths[0].length !== 4)
-  ) {
-    console.error(
-      'Internal Next.js error: InitialRSCPayload does not match the expected ' +
-        'shape for a prerendered page during segment prefetch generation.'
-    )
-    return null
-  }
-  return {
-    buildId: initialRSCPayload.b,
-    flightRouterState: flightDataPaths[0][0],
-    seedData: flightDataPaths[0][1],
-    head: flightDataPaths[0][2],
   }
 }
 
@@ -516,11 +484,10 @@ export async function collectPrefetchHints(
     }
   )
 
-  const flightData = extractFlightData(initialRSCPayload)
-  if (flightData === null) {
-    return { hints: 0, slots: null }
-  }
-  const { buildId, flightRouterState, seedData, head } = flightData
+  const transportData = initialRSCPayload.t
+  const rootNode = transportData.t
+  const buildId = initialRSCPayload.b
+  const head = transportData.h.r
 
   // The hints every node starts from. The static-prefetch-attempt hint is
   // page-global (the tracking that feeds it is), so it goes on every node,
@@ -535,7 +502,7 @@ export async function collectPrefetchHints(
     // bits may be emitted (the client would act on them even though the
     // responses aren't bundled). Just mirror the route tree's shape with
     // the base hints on every node.
-    return createUniformHintTree(flightRouterState, baseHints)
+    return createUniformHintTree(rootNode, baseHints)
   }
   const { maxSize, maxBundleSize } = inlining
 
@@ -568,7 +535,7 @@ export async function collectPrefetchHints(
     staleTimeIterable,
     head,
     HEAD_REQUEST_KEY,
-    initialRSCPayload.h,
+    initialRSCPayload.t.h.v,
     rootVaryParamsIterable,
     clientModules,
     null,
@@ -585,10 +552,9 @@ export async function collectPrefetchHints(
 
   // Walk the tree with the parent-first, child-decides algorithm.
   const { node } = await collectPrefetchHintsImpl(
-    flightRouterState,
+    rootNode,
     buildId,
     staleTimeIterable,
-    seedData,
     clientModules,
     ROOT_SEGMENT_REQUEST_KEY,
     null, // root has no parent to inline
@@ -637,10 +603,9 @@ export async function collectPrefetchHints(
 // both ParentInlinedIntoSelf (on the child) and InlinedIntoChild (on the
 // parent) in a single pass.
 async function collectPrefetchHintsImpl(
-  route: FlightRouterState,
+  node: FullTransportNode,
   buildId: string | undefined,
   staleTimeIterable: AsyncIterable<number>,
-  seedData: CacheNodeSeedData | null,
   clientModules: ManifestNode,
   // TODO: Consider persisting the computed requestKey into the hints output
   // so it doesn't need to be recomputed during the build. This might also
@@ -678,18 +643,19 @@ async function collectPrefetchHintsImpl(
   // runtime request is needed — and are measured and inlined like any other
   // segment.
   const isStaticPrefetchDisabled =
-    ((route[4] ?? 0) & StaticPrefetchDisabled) !== 0
+    ((node.h ?? 0) & StaticPrefetchDisabled) !== 0
 
   // Render current segment and measure its gzip size. Skip measurement for
   // segments with static prefetching disabled since they contribute nothing.
+  const nodeRsc = node.d.r
   let currentGzipSize: number | null = null
-  if (!isStaticPrefetchDisabled && seedData !== null) {
+  if (!isStaticPrefetchDisabled && nodeRsc !== null) {
     const [, buffer] = await renderSegmentPrefetch(
       buildId,
       staleTimeIterable,
-      seedData[0],
+      nodeRsc,
       requestKey,
-      seedData[4],
+      node.d.v,
       rootVaryParamsIterable,
       clientModules,
       null,
@@ -716,8 +682,7 @@ async function collectPrefetchHintsImpl(
   // accepts, we stop offering to remaining siblings — the parent is only
   // inlined into one child. In parallel routes, this avoids duplicating the
   // parent's data across multiple sibling responses.
-  const children = route[1]
-  const seedDataChildren = seedData !== null ? seedData[1] : null
+  const children = node.c
 
   let slots: Record<string, PrefetchHints> | null = null
   let didInlineIntoChild = false
@@ -727,74 +692,64 @@ async function collectPrefetchHintsImpl(
   // can accept its data, the parent's bytes would flow through to the child
   // with the most remaining headroom.
   let smallestChildInlinedBytes = Infinity
-  let hasChildren = false
 
-  for (const parallelRouteKey in children) {
-    hasChildren = true
-    const childRoute = children[parallelRouteKey]
-    const childSegment = childRoute[0]
-    const childSeedData =
-      seedDataChildren !== null
-        ? (seedDataChildren[parallelRouteKey] ?? null)
-        : null
+  if (children === undefined) {
+    // Leaf segment: no children have consumed any budget yet.
+    smallestChildInlinedBytes = 0
+  } else {
+    for (const [parallelRouteKey, childNode] of children) {
+      const childRequestKey = appendSegmentRequestKeyPart(
+        requestKey,
+        parallelRouteKey,
+        createSegmentRequestKeyPart(transportSegmentToSegment(childNode.s))
+      )
 
-    const childRequestKey = appendSegmentRequestKeyPart(
-      requestKey,
-      parallelRouteKey,
-      createSegmentRequestKeyPart(childSegment)
-    )
+      // Determine what size to offer children for inlining. Normally we offer
+      // our own size. But if static prefetching is disabled for this segment,
+      // it has no data of its own — instead it passes the parent's offer
+      // through to children. This allows a static grandparent to inline
+      // through a disabled intermediate segment into a static grandchild.
+      const sizeToOfferChild = isStaticPrefetchDisabled
+        ? parentGzipSize
+        : sizeToInline
 
-    // Determine what size to offer children for inlining. Normally we offer
-    // our own size. But if static prefetching is disabled for this segment,
-    // it has no data of its own — instead it passes the parent's offer
-    // through to children. This allows a static grandparent to inline
-    // through a disabled intermediate segment into a static grandchild.
-    const sizeToOfferChild = isStaticPrefetchDisabled
-      ? parentGzipSize
-      : sizeToInline
+      const childResult = await collectPrefetchHintsImpl(
+        childNode,
+        buildId,
+        staleTimeIterable,
+        clientModules,
+        childRequestKey,
+        // Once a child has accepted us, stop offering to remaining siblings.
+        didInlineIntoChild ? null : sizeToOfferChild,
+        baseHints,
+        maxSize,
+        maxBundleSize,
+        headGzipSize,
+        headInlineState,
+        rootVaryParamsIterable,
+        needsRuntimeRequest,
+        shellStageRelease
+      )
 
-    const childResult = await collectPrefetchHintsImpl(
-      childRoute,
-      buildId,
-      staleTimeIterable,
-      childSeedData,
-      clientModules,
-      childRequestKey,
-      // Once a child has accepted us, stop offering to remaining siblings.
-      didInlineIntoChild ? null : sizeToOfferChild,
-      baseHints,
-      maxSize,
-      maxBundleSize,
-      headGzipSize,
-      headInlineState,
-      rootVaryParamsIterable,
-      needsRuntimeRequest,
-      shellStageRelease
-    )
+      if (slots === null) {
+        slots = {}
+      }
+      slots[parallelRouteKey] = childResult.node
 
-    if (slots === null) {
-      slots = {}
-    }
-    slots[parallelRouteKey] = childResult.node
-
-    if (childResult.node.hints & PrefetchHint.ParentInlinedIntoSelf) {
-      // This child accepted our data — it will include our segment's
-      // response in its own. No need to track headroom anymore since
-      // we already know which child we're inlined into.
-      didInlineIntoChild = true
-      acceptingChildInlinedBytes = childResult.inlinedBytes
-    } else if (!didInlineIntoChild) {
-      // Track the child with the most remaining headroom. Used below
-      // when deciding whether to accept our own parent's data.
-      if (childResult.inlinedBytes < smallestChildInlinedBytes) {
-        smallestChildInlinedBytes = childResult.inlinedBytes
+      if (childResult.node.hints & PrefetchHint.ParentInlinedIntoSelf) {
+        // This child accepted our data — it will include our segment's
+        // response in its own. No need to track headroom anymore since
+        // we already know which child we're inlined into.
+        didInlineIntoChild = true
+        acceptingChildInlinedBytes = childResult.inlinedBytes
+      } else if (!didInlineIntoChild) {
+        // Track the child with the most remaining headroom. Used below
+        // when deciding whether to accept our own parent's data.
+        if (childResult.inlinedBytes < smallestChildInlinedBytes) {
+          smallestChildInlinedBytes = childResult.inlinedBytes
+        }
       }
     }
-  }
-
-  // Leaf segment: no children have consumed any budget yet.
-  if (!hasChildren) {
-    smallestChildInlinedBytes = 0
   }
 
   // Mark this segment as InlinedIntoChild if one of its children accepted.
@@ -835,11 +790,11 @@ async function collectPrefetchHintsImpl(
   // always be reachable through the static responses — inlined into one of
   // them, or outlined.
   const isBundleTerminal = !didInlineIntoChild && !isStaticPrefetchDisabled
-  const segment = route[0]
+  const segment = node.s
   const isPageSegment =
     typeof segment === 'string'
       ? segment === PAGE_SEGMENT_KEY
-      : segment[0] === PAGE_SEGMENT_KEY
+      : segment.n === PAGE_SEGMENT_KEY
   if (!headInlineState.inlined && isBundleTerminal && isPageSegment) {
     // The head counts against the bundle budget.
     if (inlinedBytes + headGzipSize < maxBundleSize) {
@@ -896,19 +851,18 @@ async function collectPrefetchHintsImpl(
 // with the loader tree, so a bit that's missing from a node never reaches the
 // corresponding segment.
 function createUniformHintTree(
-  route: FlightRouterState,
+  node: FullTransportNode,
   hints: number
 ): PrefetchHints {
   let slots: Record<string, PrefetchHints> | null = null
-  const children = route[1]
-  for (const parallelRouteKey in children) {
-    if (slots === null) {
-      slots = {}
+  const children = node.c
+  if (children !== undefined) {
+    for (const [parallelRouteKey, childNode] of children) {
+      if (slots === null) {
+        slots = {}
+      }
+      slots[parallelRouteKey] = createUniformHintTree(childNode, hints)
     }
-    slots[parallelRouteKey] = createUniformHintTree(
-      children[parallelRouteKey],
-      hints
-    )
   }
   return { hints, slots }
 }
@@ -974,11 +928,10 @@ async function PrefetchTreeData({
     }
   )
 
-  const flightData = extractFlightData(initialRSCPayload)
-  if (flightData === null) {
-    return null
-  }
-  const { buildId, flightRouterState, seedData, head } = flightData
+  const transportData = initialRSCPayload.t
+  const rootNode = transportData.t
+  const buildId = initialRSCPayload.b
+  const head = transportData.h.r
 
   // Root params are forwarded once at the top level of each segment
   // response, same as the page response's own root vary params; the client
@@ -1009,14 +962,13 @@ async function PrefetchTreeData({
   // each segment. When prefetch inlining is enabled, small segments are bundled
   // into their children's responses based on the hint bits.
   const headBundle: SegmentBundleNode | null = headIsInlined
-    ? { rsc: head, varyParams: initialRSCPayload.h, next: null }
+    ? { rsc: head, varyParams: initialRSCPayload.t.h.v, next: null }
     : null
   const tree = collectSegmentDataImpl(
     isClientParamParsingEnabled,
-    flightRouterState,
+    rootNode,
     buildId,
     staleTimeIterable,
-    seedData,
     clientModules,
     ROOT_SEGMENT_REQUEST_KEY,
     segmentTasks,
@@ -1040,7 +992,7 @@ async function PrefetchTreeData({
           staleTimeIterable,
           head,
           HEAD_REQUEST_KEY,
-          initialRSCPayload.h,
+          initialRSCPayload.t.h.v,
           rootVaryParamsIterable,
           clientModules,
           null,
@@ -1070,10 +1022,9 @@ async function PrefetchTreeData({
 
 function collectSegmentDataImpl(
   isClientParamParsingEnabled: boolean,
-  route: FlightRouterState,
+  node: FullTransportNode,
   buildId: string | undefined,
   staleTimeIterable: AsyncIterable<number>,
-  seedData: CacheNodeSeedData | null,
   clientModules: ManifestNode,
   requestKey: SegmentRequestKey,
   segmentTasks: Array<Promise<[string, Buffer]>>,
@@ -1098,12 +1049,12 @@ function collectSegmentDataImpl(
   // response produced here always has correct hints, so the client should
   // never see InliningHintsStale in a /_tree response.
   const prefetchHints =
-    ((route[4] ?? 0) | (hintTree !== null ? hintTree.hints : 0)) &
+    ((node.h ?? 0) | (hintTree !== null ? hintTree.hints : 0)) &
     ~PrefetchHint.InliningHintsStale
 
   // The params this segment's own output varies on, forwarded into its
   // response as-is. Root params are forwarded separately, once per response.
-  const varyParams = seedData !== null ? seedData[4] : null
+  const varyParams = node.d.v
 
   // If static prefetching is disabled for this segment
   // (prefetch: 'force-disabled' / instant = false), it still participates in
@@ -1118,7 +1069,8 @@ function collectSegmentDataImpl(
   // attempt a static prefetch before deciding whether the segment's runtime
   // request is actually needed.
   const staticPrefetchDisabled = (prefetchHints & StaticPrefetchDisabled) !== 0
-  const rsc = seedData !== null && !staticPrefetchDisabled ? seedData[0] : null
+  const nodeRsc = node.d.r
+  const rsc = !staticPrefetchDisabled ? nodeRsc : null
 
   // Determine whether this segment's data should be accumulated into a
   // child's response (inlining) or spawned as its own task. When inlining
@@ -1132,7 +1084,7 @@ function collectSegmentDataImpl(
     // of its children's responses. Don't spawn a separate task — prepend
     // this segment's data onto the linked list so the accepting child can
     // bundle it into its response.
-    if (seedData !== null) {
+    if (nodeRsc !== null) {
       childBundle = {
         rsc,
         varyParams,
@@ -1147,7 +1099,7 @@ function collectSegmentDataImpl(
     //
     // Skip spawning a task if rsc is null (disabled segment) — there's no
     // data to serve and the client won't request it.
-    if (seedData !== null && rsc !== null) {
+    if (rsc !== null) {
       let bundle =
         prefetchHints & PrefetchHint.ParentInlinedIntoSelf ? parentBundle : null
       // If this page accepts the head, append it at the tail of the chain.
@@ -1183,63 +1135,56 @@ function collectSegmentDataImpl(
   // there are no children.
   let slotMetadata: { [parallelRouteKey: string]: TreePrefetch } | null = null
 
-  const children = route[1]
-  const seedDataChildren = seedData !== null ? seedData[1] : null
-  for (const parallelRouteKey in children) {
-    const childRoute = children[parallelRouteKey]
-    const childSegment = childRoute[0]
-    const childSeedData =
-      seedDataChildren !== null
-        ? (seedDataChildren[parallelRouteKey] ?? null)
-        : null
-
-    const childRequestKey = appendSegmentRequestKeyPart(
-      requestKey,
-      parallelRouteKey,
-      createSegmentRequestKeyPart(childSegment)
-    )
-    const childHintTree =
-      hintTree !== null && hintTree.slots !== null
-        ? (hintTree.slots[parallelRouteKey] ?? null)
-        : null
-    const childTree = collectSegmentDataImpl(
-      isClientParamParsingEnabled,
-      childRoute,
-      buildId,
-      staleTimeIterable,
-      childSeedData,
-      clientModules,
-      childRequestKey,
-      segmentTasks,
-      prefetchInlining,
-      childHintTree,
-      childBundle,
-      headBundle,
-      rootVaryParamsIterable,
-      isUpgradeableISRFallback,
-      needsRuntimeRequest,
-      shellStageRelease
-    )
-    if (slotMetadata === null) {
-      slotMetadata = {}
+  const children = node.c
+  if (children !== undefined) {
+    for (const [parallelRouteKey, childNode] of children) {
+      const childRequestKey = appendSegmentRequestKeyPart(
+        requestKey,
+        parallelRouteKey,
+        createSegmentRequestKeyPart(transportSegmentToSegment(childNode.s))
+      )
+      const childHintTree =
+        hintTree !== null && hintTree.slots !== null
+          ? (hintTree.slots[parallelRouteKey] ?? null)
+          : null
+      const childTree = collectSegmentDataImpl(
+        isClientParamParsingEnabled,
+        childNode,
+        buildId,
+        staleTimeIterable,
+        clientModules,
+        childRequestKey,
+        segmentTasks,
+        prefetchInlining,
+        childHintTree,
+        childBundle,
+        headBundle,
+        rootVaryParamsIterable,
+        isUpgradeableISRFallback,
+        needsRuntimeRequest,
+        shellStageRelease
+      )
+      if (slotMetadata === null) {
+        slotMetadata = {}
+      }
+      slotMetadata[parallelRouteKey] = childTree
     }
-    slotMetadata[parallelRouteKey] = childTree
   }
 
-  const segment = route[0]
+  const segment = node.s
   let name: string
   let param: TreePrefetchParam | null
   if (typeof segment === 'string') {
     name = segment
     param = null
   } else {
-    name = segment[0]
+    name = segment.n
     param = {
-      type: segment[2],
+      type: segment.t,
       // This value is omitted from the prefetch response when cacheComponents
       // is enabled.
-      key: isClientParamParsingEnabled ? null : segment[1],
-      siblings: segment[3],
+      key: isClientParamParsingEnabled ? null : segment.k,
+      siblings: segment.s,
     }
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1,12 +1,18 @@
 import type {
   CacheNodeSeedData,
-  FlightRouterState,
   HeadData,
   InitialRSCPayload,
   Segment,
 } from '../../../shared/lib/app-router-types'
 import type { VaryParamsIterable } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import { InvariantError } from '../../../shared/lib/invariant-error'
+import { convertInitialFlightDataToFullTransportData } from '../transport-adapter'
+import {
+  transportNodeToFlightRouterState,
+  transportSegmentToSegment,
+  type FullTransportNode,
+  type TransportSegmentData,
+} from '../../../shared/lib/rsc-transport'
 import { RenderStage } from '../staged-rendering'
 import { getServerModuleMap } from '../manifests-singleton'
 import { runInSequentialTasks } from '../app-render-render-utils'
@@ -108,62 +114,34 @@ export type RouteTree = {
 
 function traverseRootSeedDataSegments(
   initialRSCPayload: InitialRSCPayload,
-  processSegment: (
-    segmentPath: SegmentPath,
-    seedData: CacheNodeSeedData
-  ) => void
+  processSegment: (segmentPath: SegmentPath, data: TransportSegmentData) => void
 ) {
-  const { flightRouterState, seedData } =
-    getRootDataFromPayload(initialRSCPayload)
-
-  const [rootSegment] = flightRouterState
-  const rootPath = stringifySegment(rootSegment)
-  return traverseCacheNodeSegments(
-    rootPath,
-    flightRouterState,
-    seedData,
-    processSegment
-  )
+  const rootNode = initialRSCPayload.t.t
+  const rootPath = stringifySegment(transportSegmentToSegment(rootNode.s))
+  return traverseTransportNodeSegments(rootPath, rootNode, processSegment)
 }
 
-function traverseCacheNodeSegments(
+function traverseTransportNodeSegments(
   path: SegmentPath,
-  route: FlightRouterState,
-  seedData: CacheNodeSeedData,
-  processSegment: (
-    segmentPath: SegmentPath,
-    seedData: CacheNodeSeedData
-  ) => void
+  node: FullTransportNode,
+  processSegment: (segmentPath: SegmentPath, data: TransportSegmentData) => void
 ): void {
-  processSegment(path, seedData)
+  processSegment(path, node.d)
 
-  const [_segment, childRoutes] = route
-  const [_node, parallelRoutesData, _loading, _isPartial] = seedData
-
-  for (const parallelRouteKey in childRoutes) {
-    const childSeedData = parallelRoutesData[parallelRouteKey]
-    if (!childSeedData) {
-      throw new InvariantError(
-        `Got unexpected empty seed data during instant validation`
-      )
-    }
-
-    const childRoute = childRoutes[parallelRouteKey]
+  const children = node.c
+  if (children === undefined) {
+    return
+  }
+  for (const [parallelRouteKey, childNode] of children) {
     // NOTE: if this is a __PAGE__ segment, it might have search params appended.
     // Whoever reads from the cache needs to append them as well.
-    const [childSegment] = childRoute
     const childPath = createChildSegmentPath(
       path,
       parallelRouteKey,
-      childSegment
+      transportSegmentToSegment(childNode.s)
     )
 
-    traverseCacheNodeSegments(
-      childPath,
-      childRoute,
-      childSeedData,
-      processSegment
-    )
+    traverseTransportNodeSegments(childPath, childNode, processSegment)
   }
 }
 
@@ -354,7 +332,7 @@ async function collectSegmentDataForStage(
   // We have to preserve the stage information for each of them,
   // so that we can later render each segment in any stage we need.
 
-  const { head } = getRootDataFromPayload(payload)
+  const head = payload.t.h.r
 
   const segments = new Map<SegmentPath, SegmentData>()
   traverseRootSeedDataSegments(payload, (segmentPath, seedData) => {
@@ -664,29 +642,6 @@ export async function createCombinedPayloadStream(
   }
 }
 
-function getRootDataFromPayload(initialRSCPayload: InitialRSCPayload) {
-  // FlightDataPath is an unsound type, hence the additional checks. The
-  // valid shapes are a single root path with no segment prefix: 4 elements
-  // ([tree, seedData, head, isHeadPartial], per getRSCPayload) or 3 when
-  // reconstructed without the isHeadPartial flag (see the payload literals
-  // in this module).
-  const flightDataPaths = initialRSCPayload.f
-  if (
-    flightDataPaths.length !== 1 ||
-    (flightDataPaths[0].length !== 3 && flightDataPaths[0].length !== 4)
-  ) {
-    throw new InvariantError(
-      'InitialRSCPayload does not match the expected shape during instant validation.'
-    )
-  }
-  const flightRouterState: FlightRouterState = flightDataPaths[0][0]
-  const seedData: CacheNodeSeedData = flightDataPaths[0][1]
-  // TODO: handle head
-  const head: HeadData = flightDataPaths[0][2]
-
-  return { flightRouterState, seedData, head }
-}
-
 async function createValidationHead(
   cache: SegmentCache,
   releaseSignal: AbortSignal,
@@ -775,12 +730,11 @@ type SegmentData = {
   varyParams: VaryParamsIterable | null
 }
 
-function createSegmentData(seedData: CacheNodeSeedData): SegmentData {
-  const [node, _parallelRoutesData, _unused, isPartial, varyParams] = seedData
+function createSegmentData(data: TransportSegmentData): SegmentData {
   return {
-    node,
-    isPartial,
-    varyParams,
+    node: data.r,
+    isPartial: data.p,
+    varyParams: data.v,
   }
 }
 type CacheNodeSeedDataSlots = CacheNodeSeedData[1]
@@ -1454,7 +1408,12 @@ export async function createCombinedPayloadAtDepth(
   // that occur above any fork (no slot marker in the component stack).
   slotStacks[0] = createInstantStack
 
-  const { flightRouterState } = getRootDataFromPayload(initialRSCPayload)
+  // Identity + hints of the original payload's tree; zipped with the rebuilt
+  // seed data below. TODO: build the transport tree natively instead (this
+  // dies together with the transport adapter).
+  const flightRouterState = transportNodeToFlightRouterState(
+    initialRSCPayload.t.t
+  )
 
   let headStage: PrefetchedSegmentStage
   switch (prefetchKind) {
@@ -1500,7 +1459,13 @@ export async function createCombinedPayloadAtDepth(
 
   const payload: InitialRSCPayload = {
     ...initialRSCPayload,
-    f: [[flightRouterState, seedData, head]],
+    t: convertInitialFlightDataToFullTransportData(
+      flightRouterState,
+      seedData,
+      head,
+      initialRSCPayload.t.h.p,
+      initialRSCPayload.t.h.v
+    ),
   }
 
   return {

--- a/packages/next/src/server/app-render/transport-adapter.ts
+++ b/packages/next/src/server/app-render/transport-adapter.ts
@@ -1,0 +1,227 @@
+import type {
+  CacheNodeSeedData,
+  FlightDataPath,
+  FlightRouterState,
+  HeadData,
+} from '../../shared/lib/app-router-types'
+import type { VaryParamsIterable } from '../../shared/lib/segment-cache/vary-params-decoding'
+import type {
+  FullTransportData,
+  FullTransportNode,
+  PartialTransportData,
+  PartialTransportNode,
+  TransportSegmentData,
+} from '../../shared/lib/rsc-transport'
+import { segmentToTransportSegment } from '../../shared/lib/rsc-transport'
+
+/**
+ * Adapts the render's internal output — FlightDataPath entries, each carrying
+ * a FlightRouterState patch and a CacheNodeSeedData tree — into the transport
+ * format: a single root-anchored tree where every node carries both its
+ * identity and (optionally) its render output.
+ *
+ * TODO: This is a transitional step. Eventually the render should produce
+ * transport nodes directly, at which point the internal FlightDataPath /
+ * CacheNodeSeedData representation (and this adapter) can be deleted.
+ */
+
+/**
+ * Marks a segment's position as covered by the response without carrying any
+ * output for it. Used for the segments along the path from the root to a
+ * rendered subtree: the client already has them; the response is only
+ * accounting for their position.
+ */
+function createCoveredSegmentData(): TransportSegmentData {
+  return { r: null, p: true, v: null }
+}
+
+/**
+ * Converts a rendered subtree — a FlightRouterState patch zipped with its
+ * CacheNodeSeedData — into a transport node.
+ */
+function convertRenderedSubtree(
+  routerState: FlightRouterState,
+  seedData: CacheNodeSeedData | null
+): PartialTransportNode {
+  const node: PartialTransportNode = {
+    s: segmentToTransportSegment(routerState[0]),
+  }
+  const hints = routerState[4]
+  if (hints !== undefined && hints !== 0) {
+    node.h = hints
+  }
+  if (seedData !== null) {
+    node.d = { r: seedData[0], p: seedData[3], v: seedData[4] }
+  }
+  const routerStateChildren = routerState[1]
+  const seedDataChildren = seedData !== null ? seedData[1] : null
+  let children: Map<string, PartialTransportNode> | undefined
+  for (const parallelRouteKey in routerStateChildren) {
+    const childSeedData =
+      seedDataChildren !== null
+        ? (seedDataChildren[parallelRouteKey] ?? null)
+        : null
+    if (children === undefined) {
+      children = new Map()
+    }
+    children.set(
+      parallelRouteKey,
+      convertRenderedSubtree(
+        routerStateChildren[parallelRouteKey],
+        childSeedData
+      )
+    )
+  }
+  if (children !== undefined) {
+    node.c = children
+  }
+  return node
+}
+
+/**
+ * Converts the output of the shared-layout diff (one or more FlightDataPath
+ * entries, with the root segment already stripped) into a single partial
+ * transport tree.
+ *
+ * Each path is a repeating [parallelRouteKey, segment] prefix followed by
+ * [routerStatePatch, seedData, head, isHeadPartial]. The prefixes become
+ * covered-but-not-rendered nodes; the patches become rendered subtrees. All
+ * paths share the same head, so it's emitted once at the response level.
+ */
+export function convertFlightDataPathsToPartialTransportData(
+  flightDataPaths: FlightDataPath[],
+  headVaryParams: VaryParamsIterable | null
+): PartialTransportData {
+  const root: PartialTransportNode = {
+    s: '',
+  }
+  let head: TransportSegmentData | undefined
+
+  for (const flightDataPath of flightDataPaths) {
+    const prefixLength = flightDataPath.length - 4
+    if (prefixLength > 0 && root.d === undefined) {
+      // The rendered subtree is below the root, so the root is a covered
+      // position.
+      root.d = createCoveredSegmentData()
+    }
+    const routerStatePatch: FlightRouterState = flightDataPath[prefixLength]
+    const seedData: CacheNodeSeedData | null = flightDataPath[prefixLength + 1]
+    const headNode: HeadData = flightDataPath[prefixLength + 2]
+    const isHeadPartial: boolean = flightDataPath[prefixLength + 3]
+
+    if (head === undefined) {
+      // The head is identical across all paths in a response; take the
+      // first one.
+      head = { r: headNode, p: isHeadPartial, v: headVaryParams }
+    }
+
+    // Walk the [parallelRouteKey, segment] prefix, creating covered nodes
+    // along the way, then attach the rendered subtree at the anchor.
+    let parent = root
+    let index = 0
+    while (index < prefixLength - 2) {
+      const parallelRouteKey: string = flightDataPath[index]
+      const segment = flightDataPath[index + 1]
+      let children = parent.c
+      if (children === undefined) {
+        children = parent.c = new Map()
+      }
+      let child = children.get(parallelRouteKey)
+      if (child === undefined) {
+        child = {
+          s: segmentToTransportSegment(segment),
+          d: createCoveredSegmentData(),
+        }
+        children.set(parallelRouteKey, child)
+      }
+      parent = child
+      index += 2
+    }
+
+    const subtree = convertRenderedSubtree(routerStatePatch, seedData)
+    if (prefixLength === 0) {
+      // A root render. The rendered subtree *is* the root of the
+      // transport tree.
+      root.s = subtree.s
+      if (subtree.h !== undefined) {
+        root.h = subtree.h
+      }
+      if (subtree.d !== undefined) {
+        root.d = subtree.d
+      }
+      if (subtree.c !== undefined) {
+        root.c = subtree.c
+      }
+    } else {
+      const parallelRouteKey: string = flightDataPath[prefixLength - 2]
+      let children = parent.c
+      if (children === undefined) {
+        children = parent.c = new Map()
+      }
+      children.set(parallelRouteKey, subtree)
+    }
+  }
+
+  const transportData: PartialTransportData = { t: root }
+  if (head !== undefined) {
+    transportData.h = head
+  }
+  return transportData
+}
+
+/**
+ * Converts the full render of an initial document (or error) payload into a
+ * full transport tree. Structure without seed data — which only occurs in
+ * hand-constructed error payloads, where the seed data covers only the root —
+ * is emitted as covered-but-not-rendered rather than omitted, preserving the
+ * "full trees have no lazy holes" property.
+ */
+export function convertInitialFlightDataToFullTransportData(
+  routerState: FlightRouterState,
+  seedData: CacheNodeSeedData,
+  head: HeadData,
+  isHeadPartial: boolean,
+  headVaryParams: VaryParamsIterable | null
+): FullTransportData {
+  return {
+    t: convertFullSubtree(routerState, seedData),
+    h: { r: head, p: isHeadPartial, v: headVaryParams },
+  }
+}
+
+function convertFullSubtree(
+  routerState: FlightRouterState,
+  seedData: CacheNodeSeedData | null
+): FullTransportNode {
+  const node: FullTransportNode = {
+    s: segmentToTransportSegment(routerState[0]),
+    d:
+      seedData !== null
+        ? { r: seedData[0], p: seedData[3], v: seedData[4] }
+        : createCoveredSegmentData(),
+  }
+  const hints = routerState[4]
+  if (hints !== undefined && hints !== 0) {
+    node.h = hints
+  }
+  const routerStateChildren = routerState[1]
+  const seedDataChildren = seedData !== null ? seedData[1] : null
+  let children: Map<string, FullTransportNode> | undefined
+  for (const parallelRouteKey in routerStateChildren) {
+    const childSeedData =
+      seedDataChildren !== null
+        ? (seedDataChildren[parallelRouteKey] ?? null)
+        : null
+    if (children === undefined) {
+      children = new Map()
+    }
+    children.set(
+      parallelRouteKey,
+      convertFullSubtree(routerStateChildren[parallelRouteKey], childSeedData)
+    )
+  }
+  if (children !== undefined) {
+    node.c = children
+  }
+  return node
+}

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -12,6 +12,7 @@ export type LoadingModuleData =
   | null
 
 import type { VaryParamsIterable } from './segment-cache/vary-params-decoding'
+import type { FullTransportData, PartialTransportData } from './rsc-transport'
 
 /** viewport metadata node */
 export type HeadData = React.ReactNode
@@ -455,19 +456,14 @@ export type InitialRSCPayload = {
   q: string
   /** couldBeIntercepted */
   i: boolean
-  /** initialFlightData */
-  f: FlightDataPath[]
+  /** initial transport data — the tree + head for hydration */
+  t: FullTransportData
   /** missingSlots */
   m: Set<string> | undefined
   /** GlobalError */
   G: [React.ComponentType<any>, React.ReactNode | undefined]
   /** supportsPerSegmentPrefetching */
   S: boolean
-  /**
-   * headVaryParams - vary params for the head (metadata) of the response.
-   * Does not include root params (see `r`).
-   */
-  h: VaryParamsIterable | null
   /**
    * rootVaryParams - the root params accessed anywhere in the response, emitted
    * once. The client unions these into the head and every segment's vary
@@ -532,8 +528,18 @@ export type InitialRSCPayload = {
 export type NavigationFlightResponse = {
   /** buildId, can be empty if the x-nextjs-build-id header is set */
   b?: string
-  /** flightData */
-  f: FlightData
+  /**
+   * transport data — present iff the response carries a SPA payload.
+   * Absent when the response renders nothing (see `n` for MPA navigations).
+   */
+  t?: PartialTransportData
+  /**
+   * MPA navigation URL — present iff the client should hard-navigate to
+   * this URL instead of applying a SPA payload. Reserved: no server path
+   * emits it today (hard navigations are signaled by non-RSC content types
+   * or a build-id mismatch), but the client honors it.
+   */
+  n?: string
   /** supportsPerSegmentPrefetching */
   S: boolean
   /** renderedSearch */
@@ -556,8 +562,6 @@ export type NavigationFlightResponse = {
    * where we have a proper session shell.
    * */
   u?: Promise<boolean>
-  /** headVaryParams. Does not include root params (see `r`). */
-  h: VaryParamsIterable | null
   /**
    * rootVaryParams - the root params accessed anywhere in the response, emitted
    * once. The client unions these into the head and every segment's vary
@@ -588,14 +592,23 @@ export type NavigationFlightResponse = {
   _revealAfter?: Promise<void>
 }
 
-// Response from `createFromFetch` for server actions. Action's flight data can be null
+// Response from `createFromFetch` for server actions.
 export type ActionFlightResponse = {
   /** actionResult */
   a: ActionResult
   /** buildId, can be empty if the x-nextjs-build-id header is set */
   b?: string
-  /** flightData */
-  f: FlightData
+  /**
+   * transport data — present iff the action response re-rendered the page.
+   * Absent when the action rendered nothing (see `n` for MPA navigations).
+   */
+  t?: PartialTransportData
+  /**
+   * MPA navigation URL — present iff the client should hard-navigate to
+   * this URL instead of applying a SPA payload. Reserved: no server path
+   * emits it today, but the client honors it.
+   */
+  n?: string
   /** renderedSearch */
   q: string
   /** couldBeIntercepted */

--- a/packages/next/src/shared/lib/rsc-transport.ts
+++ b/packages/next/src/shared/lib/rsc-transport.ts
@@ -1,0 +1,229 @@
+/**
+ * The transport format for RSC responses.
+ *
+ * Every type in this module is prefixed with `Transport` to distinguish the
+ * wire format from client-local types (`Segment`, `RouteTree`, `CacheNode`,
+ * `FlightRouterState`). Client code converts out of Transport types at the
+ * decode boundary and never stores them.
+ *
+ * A response carries a single tree, anchored at the root segment, where each
+ * node has both its identity and (optionally) its render output. Partial
+ * responses are expressed per node: the convention across the format is that
+ * absence means "nothing here" — an omitted `d` means the segment was not
+ * rendered as part of the response, an omitted slot key means the response
+ * carries no information about that slot.
+ */
+
+import type React from 'react'
+import type {
+  DynamicParamTypesShort,
+  FlightRouterState,
+  Segment,
+} from './app-router-types'
+import type { VaryParamsIterable } from './segment-cache/vary-params-decoding'
+
+/**
+ * Segment identity on the wire. A string for static segments; an object for
+ * dynamic (parameterized) segments.
+ *
+ * TODO: Page segments currently smuggle search params inside the string
+ * (`__PAGE__?{...}`, see addSearchParamsIfPageSegment). This convention is
+ * carried over as-is for now. Consider giving search params a dedicated
+ * field (or removing them from the response entirely, since the client
+ * already knows the rendered search from the response-level `q`).
+ */
+export type TransportSegment = string | TransportDynamicSegment
+
+export type TransportDynamicSegment = {
+  /** name — the param name, e.g. 'id' for [id] */
+  n: string
+  /** type — dynamic param type */
+  t: DynamicParamTypesShort
+  /**
+   * key — the param value / cache key. null when the client is expected to
+   * parse the value from the URL itself, which keeps the response cacheable
+   * across param values.
+   */
+  k: string | null
+  /** siblings — static sibling segments at this URL level; null = unknown */
+  s: readonly string[] | null
+}
+
+/**
+ * Render output for a single segment. Grouped into one object so a node's
+ * "rendered vs skipped" state is a single presence check. Also used for the
+ * head (metadata/viewport), which is output without structure.
+ *
+ * `r` may be null: the response covered this segment's position without
+ * rendering anything for it — e.g. a shared layout the client is expected to
+ * already have. This is distinct from `d` being absent on the node, which
+ * means the response makes no claim about the segment's output at all (the
+ * client should fetch it lazily if it doesn't have it).
+ */
+export type TransportSegmentData = {
+  /** rsc — the React node for this segment; null = covered but not rendered */
+  r: React.ReactNode
+  /** isPartial — contains unresolved dynamic holes (static prerender) */
+  p: boolean
+  /**
+   * varyParams — params this segment's output depends on. Does not include
+   * root params, which are emitted once at the response level (`r` on the
+   * response wrapper).
+   */
+  v: VaryParamsIterable | null
+}
+
+/**
+ * Structure of a segment node, independent of whether render output
+ * is attached. Shared by both response variants.
+ */
+type TransportNodeShape = {
+  /** segment — identity */
+  s: TransportSegment
+  /** hints — PrefetchHint bitmask; omitted when zero or unknown */
+  h?: number
+}
+
+/**
+ * A node in a FULL response tree: every node carries data, and slot maps are
+ * exhaustive. Produced by full renders: the initial document payload and
+ * error payloads. "Full" means every node is covered by the response — there
+ * is nothing for the client to fetch lazily. Data-level holes
+ * (`d.p === true`) and covered-but-not-rendered nodes (`d.r === null`) are
+ * still possible.
+ */
+export type FullTransportNode = TransportNodeShape & {
+  /** data — always present in a full tree */
+  d: TransportSegmentData
+  /**
+   * children — parallel routes; omitted for leaf segments. A Map rather
+   * than a plain object because slot names are app-defined; with a plain
+   * object, every distinct combination of slot names creates a different
+   * hidden class, making keyed access megamorphic.
+   */
+  c?: Map<string, FullTransportNode>
+}
+
+/**
+ * A node in a PARTIAL response tree: produced by navigations, refreshes, and
+ * actions — anywhere the server diffs against client state or renders a
+ * subset of the route.
+ *
+ * The client treats the response as an overlay over its current tree:
+ *
+ * - A node present in the tree is authoritative for that position's identity.
+ * - `d` present: the response accounts for this segment. Its output is `d.r`,
+ *   which may be null when the position is covered without rendering (e.g. a
+ *   shared layout the client already has).
+ * - `d` omitted: the response makes no claim about this segment's output.
+ *   The client keeps what it has, or lazily fetches when it renders (e.g.
+ *   segments beneath a loading boundary in a non-PPR prefetch).
+ * - A slot key omitted from `c` (or `c` omitted): on a covered node
+ *   (`d.r === null`), the response carries no information about that slot
+ *   and the client keeps its subtree untouched. On any other node the
+ *   subtree is authoritative, so an omitted slot is simply absent.
+ * - `h` omitted: on a covered node, the client keeps its existing hints for
+ *   the segment; on any other node it means the hints are zero.
+ *
+ * TODO: A node with `d` omitted currently ends the client's cache write for
+ * its subtree (see writeSeedDataIntoCache), so "skip a middle segment but
+ * render below it" is not expressible yet. Extend the decode/write semantics
+ * when a producer needs that.
+ */
+export type PartialTransportNode = TransportNodeShape & {
+  /** data — omitted when this segment was not rendered in this response */
+  d?: TransportSegmentData
+  /** children — omitted field or key = no information about those slots */
+  c?: Map<string, PartialTransportNode>
+}
+
+/**
+ * Shared type for code that walks either variant. Note: FullTransportNode is
+ * structurally assignable to PartialTransportNode, so this union collapses
+ * to PartialTransportNode for the type checker; the union spelling
+ * documents intent.
+ */
+export type TransportNode = FullTransportNode | PartialTransportNode
+
+/**
+ * The tree + head bundle of a response.
+ */
+export type FullTransportData = {
+  /** tree */
+  t: FullTransportNode
+  /** head — always present and complete in a full response */
+  h: TransportSegmentData
+}
+
+export type PartialTransportData = {
+  t: PartialTransportNode
+  /** omitted = this response carries no head (e.g. router-state-only responses) */
+  h?: TransportSegmentData
+}
+
+export type TransportData = FullTransportData | PartialTransportData
+
+/**
+ * Converts a segment's client/server-internal representation to its wire
+ * representation.
+ */
+export function segmentToTransportSegment(segment: Segment): TransportSegment {
+  if (typeof segment === 'string') {
+    return segment
+  }
+  return {
+    n: segment[0],
+    t: segment[2],
+    k: segment[1],
+    s: segment[3],
+  }
+}
+
+/**
+ * Converts a segment's wire representation to the client/server-internal
+ * `Segment` type.
+ */
+export function transportSegmentToSegment(
+  transportSegment: TransportSegment
+): Segment {
+  if (typeof transportSegment === 'string') {
+    return transportSegment
+  }
+  return [
+    transportSegment.n,
+    // TODO: `k` may be null when the client is expected to parse the param
+    // value from the URL. Navigation responses always include the key today;
+    // this becomes relevant when per-segment prefetch responses converge on
+    // this format.
+    transportSegment.k ?? '',
+    transportSegment.t,
+    transportSegment.s,
+  ]
+}
+
+/**
+ * Derives a FlightRouterState from a transport tree. Used where the client
+ * needs a router-state representation of a full response (e.g. the initial
+ * hydration payload). Render output (`d`) is not carried over; page segments
+ * keep their search params, which travel inside the segment string.
+ */
+export function transportNodeToFlightRouterState(
+  node: TransportNode
+): FlightRouterState {
+  const parallelRoutes: Record<string, FlightRouterState> = {}
+  const children = node.c
+  if (children !== undefined) {
+    for (const [parallelRouteKey, childNode] of children) {
+      parallelRoutes[parallelRouteKey] =
+        transportNodeToFlightRouterState(childNode)
+    }
+  }
+  const flightRouterState: FlightRouterState = [
+    transportSegmentToSegment(node.s),
+    parallelRoutes,
+  ]
+  if (node.h !== undefined) {
+    flightRouterState[4] = node.h
+  }
+  return flightRouterState
+}


### PR DESCRIPTION
Introduces a new type, TransportData, to replace FlightDataPath. The new format is the same regardless of whether the entire page is rendered by the server or if some segments are intentionally omitted.

The type also unifies FlightRouterState and CacheNodeSeedData into a single tree that includes both route information and RSC data. Previously these were sent in two separate trees that were isomorphic by convention, requiring the consumer to walk both in parallel.

These new types are intended to be transport formats only. The client already has its own, richer data structure called RouteTree. The transport format is converted into the client format at the network decoding boundary.

This does not remove FlightRouterState from the codebase entirely; it's still used both for issuing requests to the server (Next-Router-State-Tree) and for tracking state in the browser's history object. A future refactor may replace it for the purpose of issuing requests, but it will likely survive as the format for tracking state in history.

This PR does not yet update the server to produce TransportData directly; a temporary adapter layer is used to convert from the old data formats to the new format. This intermediate step will not land on its own; the next PR in the stack will both update the server and delete the temporary adapter layer.
