### PR TITLE
Warn that `experimental.useCache` is deprecated

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1462,5 +1462,6 @@
   "1461": "Expected segment cache to have data for stage '%s'",
   "1462": "Unexpected chunk emitted in Before stage",
   "1463": "\\`experimental.turbopackGenerateComponentChunks\\` has been moved to \\`experimental.turbopackChunking.generateComponentChunks\\`. Please update your next.config.js file accordingly.",
-  "1464": "\\`experimental.turbopackChunkingHeuristics\\` has been renamed to \\`experimental.turbopackChunking\\`. Please update your next.config.js file accordingly."
+  "1464": "\\`experimental.turbopackChunkingHeuristics\\` has been renamed to \\`experimental.turbopackChunking\\`. Please update your next.config.js file accordingly.",
+  "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s."
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1605,6 +1605,32 @@ function assignDefaultsAndValidate(
     result.experimental.ppr = true
   }
 
+  // `experimental.useCache` is deprecated in favor of the top-level
+  // `cacheComponents` option. A defined value means the user set the option
+  // explicitly, because it's only backfilled from `cacheComponents` below.
+  if (result.experimental.useCache !== undefined) {
+    // Disabling the directive that Cache Components is built around leaves the
+    // app in a state where every `"use cache"` fails to compile with an error
+    // that asks for the already-enabled `cacheComponents` option.
+    if (!result.experimental.useCache && result.cacheComponents) {
+      throw new Error(
+        `\`experimental.useCache\` cannot be disabled when \`cacheComponents\` is enabled, because Cache Components relies on the \`"use cache"\` directive. Please remove it from ${configFileName}.`
+      )
+    }
+
+    if (!silent) {
+      if (result.cacheComponents) {
+        Log.warnOnce(
+          `\`experimental.useCache\` is no longer needed, because \`cacheComponents\` already enables the \`"use cache"\` directive. You can remove it from ${configFileName}.`
+        )
+      } else {
+        Log.warnOnce(
+          `\`experimental.useCache\` is deprecated. Please use the top-level \`cacheComponents\` option instead in ${configFileName}.`
+        )
+      }
+    }
+  }
+
   // "use cache" was originally implicitly enabled with the cacheComponents flag, so
   // we transfer the value for cacheComponents to the explicit useCache flag to ensure
   // backwards compatibility.

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -44,6 +44,20 @@ describe('use-cache', () => {
     )
   })
 
+  it('should warn that the `experimental.useCache` config option is deprecated', async () => {
+    // The fixture enables `experimental.useCache`, so the warning is emitted
+    // when the server loads the config, shortly after it reports readiness.
+    // Which of the two variants is printed depends on whether `cacheComponents`
+    // already enables the directive.
+    await retry(async () => {
+      expect(stripAnsi(next.cliOutput)).toContain(
+        withCacheComponents
+          ? '`experimental.useCache` is no longer needed, because `cacheComponents` already enables the `"use cache"` directive. You can remove it from next.config.js.'
+          : '`experimental.useCache` is deprecated. Please use the top-level `cacheComponents` option instead in next.config.js.'
+      )
+    })
+  })
+
   it('should cache results', async () => {
     const browser = await next.browser(`/?n=1`)
     expect(await browser.waitForElementByCss('#x').text()).toBe('1')

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -275,4 +275,45 @@ describe('config', () => {
       expect(config.partialPrefetching).toBe(true)
     })
   })
+
+  describe('experimental.useCache config', () => {
+    it('Should throw when `useCache` is disabled while `cacheComponents` is enabled', async () => {
+      await expect(async () => {
+        await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>-uc-conflict', {
+          customConfig: {
+            cacheComponents: true,
+            experimental: { useCache: false },
+          },
+        })
+      }).rejects.toThrow(
+        /`experimental.useCache` cannot be disabled when `cacheComponents` is enabled/
+      )
+    })
+
+    it('Should accept `useCache: false` when `cacheComponents` is not enabled', async () => {
+      const config = await loadConfig(
+        PHASE_DEVELOPMENT_SERVER,
+        '<rootDir>-uc-off',
+        {
+          customConfig: {
+            experimental: { useCache: false },
+          },
+        }
+      )
+      expect(config.experimental.useCache).toBe(false)
+    })
+
+    it('Should backfill `useCache` from `cacheComponents` when it is not set', async () => {
+      const config = await loadConfig(
+        PHASE_DEVELOPMENT_SERVER,
+        '<rootDir>-uc-backfill',
+        {
+          customConfig: {
+            cacheComponents: true,
+          },
+        }
+      )
+      expect(config.experimental.useCache).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
The `experimental.useCache` option has carried a `@deprecated` JSDoc annotation since #92316, but nothing surfaced that at runtime, so users had no signal to migrate unless their editor happened to show the annotation. This change logs a warning whenever the option is set explicitly, pointing at the top-level `cacheComponents` option instead. When `cacheComponents` is already enabled the option is redundant, so the message says it can be removed; otherwise it asks the user to switch.

Disabling the option while `cacheComponents` is enabled is now rejected outright. That combination is contradictory: it turns off the very directive Cache Components is built around, and the resulting compile error asks the user to enable `cacheComponents`, which they already have on. Throwing here matches how `cachedNavigations` and `partialPrefetching` reject configurations that require `cacheComponents`.

The checks live in `assignDefaultsAndValidate` rather than alongside the other deprecations in `checkDeprecations`, because the latter runs before `enforceExperimentalFeatures` and would therefore not see a `cacheComponents` value that was enabled through the environment. A defined `experimental.useCache` value is what identifies an explicit user setting, since the option is otherwise backfilled from `cacheComponents` immediately below the new checks.