### PR TITLE
Harden and classify Request Insights activity

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -11,6 +11,7 @@ function createRequest(
 ): RequestInsight {
   return {
     requestId: 'request-1',
+    source: 'unknown',
     htmlRequestId: 'html-1',
     startTime: 100,
     durationMs: 100,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -199,6 +199,31 @@ describe('request insights trace viewer', () => {
     ])
   })
 
+  it('uses Proxy terminology without changing the recorded OTel span', () => {
+    const middlewareSpan = {
+      name: 'middleware POST',
+      startTime: 100,
+      durationMs: 10,
+      attributes: {
+        'http.method': 'POST',
+        'next.span_name': 'middleware POST',
+        'next.span_type': 'Middleware.execute',
+      },
+    }
+    const request = createRequest({ spans: [middlewareSpan] })
+
+    expect(getTraceItems(request, false)[0]?.label).toBe('proxy POST')
+    expect(middlewareSpan).toEqual(
+      expect.objectContaining({
+        name: 'middleware POST',
+        attributes: expect.objectContaining({
+          'next.span_name': 'middleware POST',
+          'next.span_type': 'Middleware.execute',
+        }),
+      })
+    )
+  })
+
   it('orders spans by their recorded parent-child hierarchy', () => {
     const request = createRequest({
       spans: [

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -26,9 +26,10 @@ export type TraceRange = {
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
 
 const FETCH_SPAN_TYPE = 'AppRender.fetch'
+const MIDDLEWARE_SPAN_TYPE = 'Middleware.execute'
 const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'BaseServer.handleRequest',
-  'Middleware.execute',
+  MIDDLEWARE_SPAN_TYPE,
   'NextNodeServer.matchRoute',
   'DevRouteMatcherManager.ensureRoute',
   'DevRouteMatcherManager.reloadMatchers',
@@ -351,6 +352,13 @@ function getSpanLabel(span: RequestInsightSpan): string {
   const displayName = name
     .replace(FIZZ_WORD, 'HTML')
     .replace(FLIGHT_WORD, 'RSC')
+
+  if (span.attributes?.['next.span_type'] === MIDDLEWARE_SPAN_TYPE) {
+    const method = span.attributes['http.method']
+    return typeof method === 'string' && method.length > 0
+      ? `proxy ${method}`
+      : displayName.replace(/^middleware\b/i, 'proxy')
+  }
 
   if (displayName === 'resolve segment modules') {
     return 'resolve segment'

--- a/packages/next/src/next-devtools/dev-overlay/shared.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.test.ts
@@ -23,6 +23,7 @@ function createRequestInsight(
   return {
     requestId: 'shared-request',
     kind,
+    source: kind === 'instant-insights' ? 'instant-insights' : 'page',
     htmlRequestId: 'shared-html',
     route: '/dashboard',
     startTime: 100,

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
+type DevToolsWindow = Window & {
+  [PAGEHIDE_LISTENER_KEY]?: () => void
+}
+
+const originalFetch = global.fetch
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function removePagehideListener() {
+  const devToolsWindow = window as DevToolsWindow
+  const listener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+
+  if (listener) {
+    window.removeEventListener('pagehide', listener)
+    delete devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  }
+}
+
+describe('saveDevToolsConfig', () => {
+  let fetchMock: jest.Mock
+  let warnMock: jest.SpyInstance
+
+  beforeEach(() => {
+    removePagehideListener()
+    jest.resetModules()
+    jest.useFakeTimers()
+    fetchMock = jest.fn()
+    global.fetch = fetchMock
+    warnMock = jest.spyOn(console, 'warn').mockImplementation()
+  })
+
+  afterEach(async () => {
+    await flushMicrotasks()
+    removePagehideListener()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    global.fetch = originalFetch
+    warnMock.mockRestore()
+  })
+
+  it('serializes writes and retries a merged patch after a failed response', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let activeRequests = 0
+    let maximumActiveRequests = 0
+
+    fetchMock
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return new Promise<{ ok: boolean }>((resolve) => {
+          resolveFirstRequest = resolve
+        }).finally(() => {
+          activeRequests--
+        })
+      })
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return Promise.resolve({ ok: true }).finally(() => {
+          activeRequests--
+        })
+      })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({
+      requestInsights: { showInternal: true, verbose: false },
+    })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveFirstRequest!({ ok: false })
+    await jest.advanceTimersByTimeAsync(0)
+
+    await jest.advanceTimersByTimeAsync(239)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    expect(maximumActiveRequests).toBe(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: false },
+      }
+    )
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: true },
+      }
+    )
+  })
+
+  it('retries a patch when fetch throws synchronously without logging it', async () => {
+    fetchMock
+      .mockImplementationOnce(() => {
+        throw new Error('sensitive value: dark')
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ theme: 'dark' })
+    jest.advanceTimersByTime(120)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('dark')
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('sensitive')
+
+    await jest.advanceTimersByTimeAsync(240)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({ theme: 'dark' }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a pending patch immediately on pagehide with keepalive', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/__nextjs_devtools_config',
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: { showInternal: true },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a queued patch on pagehide while a save is in flight', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(
+      fetchMock.mock.calls.map((call) => JSON.parse(call[1].body))
+    ).toEqual([
+      { requestInsights: { showInternal: true } },
+      {
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      },
+    ])
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ keepalive: true })
+    )
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+  })
+
+  it('retries a failed pagehide flush after the in-flight save completes', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let rejectPagehideRequest: (error: Error) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((_resolve, reject) => {
+            rejectPagehideRequest = reject
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+    rejectPagehideRequest!(new Error('page was hidden'))
+    await flushMicrotasks()
+
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: {
+            showInternal: true,
+            verbose: true,
+          },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('does not restore an older failed patch after a newer pagehide flush succeeds', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { verbose: false } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      requestInsights: { verbose: true },
+    })
+
+    resolveFirstRequest!({ ok: false })
+    await flushMicrotasks()
+    await jest.advanceTimersByTimeAsync(5_000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
@@ -2,29 +2,124 @@ import type { DevToolsConfig } from '../shared'
 import { devToolsConfigSchema } from '../../shared/devtools-config-schema'
 import { deepMerge } from '../../shared/deepmerge'
 
+const SAVE_DEBOUNCE_DELAY = 120
+const INITIAL_RETRY_DELAY = 240
+const MAX_RETRY_DELAY = 5_000
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
 let queuedConfigPatch: DevToolsConfig = {}
 let timer: ReturnType<typeof setTimeout> | null = null
+let flushInFlight: Promise<void> | null = null
+let inFlightFlush:
+  | {
+      patch: DevToolsConfig
+      supersedingPatch?: DevToolsConfig
+      supersedingFlush?: Promise<void>
+      supersedingVersion: number
+    }
+  | undefined
+let flushImmediatelyAfterInFlight = false
+let retryDelay = INITIAL_RETRY_DELAY
 
-function flushPatch() {
-  if (Object.keys(queuedConfigPatch).length === 0) {
-    return
+function hasQueuedPatch() {
+  return Object.keys(queuedConfigPatch).length > 0
+}
+
+function scheduleFlush(delay: number) {
+  if (timer) {
+    clearTimeout(timer)
   }
 
-  const body = JSON.stringify(queuedConfigPatch)
-  queuedConfigPatch = {}
+  timer = setTimeout(flushPatch, delay)
+}
 
-  fetch('/__nextjs_devtools_config', {
+async function sendConfigPatch(body: string) {
+  const response = await fetch('/__nextjs_devtools_config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body,
     // keepalive in case of fetch interrupted, e.g. navigation or reload
     keepalive: true,
-  }).catch((error) => {
-    console.warn('[Next.js DevTools] Failed to save config:', {
-      data: body,
-      error,
-    })
   })
+
+  if (!response.ok) {
+    throw new Error('Failed to save DevTools config')
+  }
+}
+
+function flushPatch(immediatelyAfterInFlight = false) {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+
+  if (flushInFlight) {
+    flushImmediatelyAfterInFlight ||= immediatelyAfterInFlight
+    return
+  }
+
+  if (!hasQueuedPatch()) {
+    return
+  }
+
+  const patch = queuedConfigPatch
+  const body = JSON.stringify(patch)
+  queuedConfigPatch = {}
+
+  const currentFlush: NonNullable<typeof inFlightFlush> = {
+    patch,
+    supersedingVersion: 0,
+  }
+  inFlightFlush = currentFlush
+  const request = sendConfigPatch(body)
+
+  flushInFlight = request
+    .then(() => {
+      retryDelay = INITIAL_RETRY_DELAY
+    })
+    .catch(async () => {
+      // A pagehide write contains this patch plus everything queued after it.
+      // Let that newer write own restoration so an older failed request can
+      // never overwrite a successful newer one.
+      if (currentFlush.supersedingFlush) {
+        await currentFlush.supersedingFlush
+        return
+      }
+
+      // Restore the failed patch without overwriting changes queued while the
+      // request was in flight.
+      queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+
+      const delay = retryDelay
+      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY)
+      scheduleFlush(delay)
+
+      // Do not include the request body or error details here. Config patches
+      // can contain user-defined shortcut values.
+      console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+    })
+    .finally(() => {
+      if (inFlightFlush === currentFlush) {
+        inFlightFlush = undefined
+      }
+      flushInFlight = null
+
+      if (!hasQueuedPatch()) {
+        flushImmediatelyAfterInFlight = false
+        return
+      }
+
+      if (flushImmediatelyAfterInFlight) {
+        flushImmediatelyAfterInFlight = false
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        flushPatch(true)
+      } else if (!timer) {
+        scheduleFlush(0)
+      }
+    })
 }
 
 export function saveDevToolsConfig(patch: DevToolsConfig) {
@@ -43,5 +138,59 @@ export function saveDevToolsConfig(patch: DevToolsConfig) {
     clearTimeout(timer)
   }
 
-  timer = setTimeout(flushPatch, 120)
+  timer = setTimeout(flushPatch, SAVE_DEBOUNCE_DELAY)
+}
+
+if (typeof window !== 'undefined') {
+  const devToolsWindow = window as Window & {
+    [PAGEHIDE_LISTENER_KEY]?: () => void
+  }
+  const previousListener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  if (typeof previousListener === 'function') {
+    previousListener()
+    window.removeEventListener('pagehide', previousListener)
+  }
+
+  // A reload can happen before the debounced write starts. Flush the pending
+  // patch while the page is still alive; keepalive lets the request finish
+  // during page teardown.
+  const flushPatchOnPagehide = () => {
+    if (flushInFlight && inFlightFlush && hasQueuedPatch()) {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      const currentFlush = inFlightFlush
+      const patch = deepMerge(
+        currentFlush.supersedingPatch ?? currentFlush.patch,
+        queuedConfigPatch
+      )
+      queuedConfigPatch = {}
+      const version = ++currentFlush.supersedingVersion
+      currentFlush.supersedingPatch = patch
+      currentFlush.supersedingFlush = sendConfigPatch(JSON.stringify(patch))
+        .then(() => {
+          retryDelay = INITIAL_RETRY_DELAY
+        })
+        .catch(() => {
+          // Ignore an older pagehide failure when a newer cumulative write is
+          // already responsible for the same data.
+          if (version !== currentFlush.supersedingVersion) {
+            return
+          }
+
+          // The document may survive through the back-forward cache. Restore
+          // the complete superseding patch and retry it without logging user
+          // config values.
+          queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+          scheduleFlush(0)
+          console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+        })
+      return
+    }
+
+    flushPatch(true)
+  }
+  window.addEventListener('pagehide', flushPatchOnPagehide)
+  devToolsWindow[PAGEHIDE_LISTENER_KEY] = flushPatchOnPagehide
 }

--- a/packages/next/src/next-devtools/server/devtools-config-middleware.ts
+++ b/packages/next/src/next-devtools/server/devtools-config-middleware.ts
@@ -1,9 +1,9 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { DevToolsConfig } from '../dev-overlay/shared'
 
-import { existsSync } from 'fs'
-import { readFile, writeFile, mkdir } from 'fs/promises'
-import { dirname, join } from 'path'
+import * as fsPromises from 'fs/promises'
+import { randomUUID } from 'crypto'
+import { basename, dirname, join } from 'path'
 
 import { middlewareResponse } from './middleware-response'
 import { devToolsConfigSchema } from '../shared/devtools-config-schema'
@@ -11,6 +11,8 @@ import { deepMerge } from '../shared/deepmerge'
 
 const DEVTOOLS_CONFIG_FILENAME = 'next-devtools-config.json'
 const DEVTOOLS_CONFIG_MIDDLEWARE_ENDPOINT = '/__nextjs_devtools_config'
+const DEVTOOLS_CONFIG_BODY_LIMIT = 64 * 1024
+const configUpdateQueues = new Map<string, Promise<void>>()
 
 export function devToolsConfigMiddleware({
   distDir,
@@ -36,36 +38,63 @@ export function devToolsConfigMiddleware({
       return middlewareResponse.methodNotAllowed(res)
     }
 
-    const currentConfig = await getDevToolsConfig(distDir)
+    const previousUpdate = (
+      configUpdateQueues.get(configPath) ?? Promise.resolve()
+    ).catch(() => {})
+    let releaseUpdate!: () => void
+    const updateCompleted = new Promise<void>((resolve) => {
+      releaseUpdate = resolve
+    })
+    const queueTail = previousUpdate.then(() => updateCompleted)
+    configUpdateQueues.set(configPath, queueTail)
+    void queueTail.then(() => {
+      if (configUpdateQueues.get(configPath) === queueTail) {
+        configUpdateQueues.delete(configPath)
+      }
+    })
 
-    const chunks: Buffer[] = []
-    for await (const chunk of req) {
-      chunks.push(Buffer.from(chunk))
-    }
-
-    let body = Buffer.concat(chunks).toString('utf8')
     try {
-      body = JSON.parse(body)
-    } catch (error) {
-      console.error('[Next.js DevTools] Invalid config body passed:', error)
-      return middlewareResponse.badRequest(res)
-    }
+      const chunks: Buffer[] = []
+      let bodySize = 0
+      for await (const chunk of req) {
+        const buffer = Buffer.from(chunk)
+        bodySize += buffer.byteLength
+        if (bodySize > DEVTOOLS_CONFIG_BODY_LIMIT) {
+          return middlewareResponse.payloadTooLarge(res)
+        }
+        chunks.push(buffer)
+      }
 
-    const validation = devToolsConfigSchema.safeParse(body)
-    if (!validation.success) {
-      console.error(
-        '[Next.js DevTools] Invalid config passed:',
-        validation.error.message
+      let body = Buffer.concat(chunks).toString('utf8')
+      try {
+        body = JSON.parse(body)
+      } catch (error) {
+        console.error('[Next.js DevTools] Invalid config body passed:', error)
+        return middlewareResponse.badRequest(res)
+      }
+
+      const validation = devToolsConfigSchema.safeParse(body)
+      if (!validation.success) {
+        console.error(
+          '[Next.js DevTools] Invalid config passed:',
+          validation.error.message
+        )
+        return middlewareResponse.badRequest(res)
+      }
+
+      await previousUpdate
+      const currentConfig = await getDevToolsConfig(distDir)
+      const newConfig = deepMerge(currentConfig, validation.data)
+      await writeDevToolsConfigAtomically(
+        configPath,
+        JSON.stringify(newConfig, null, 2)
       )
-      return middlewareResponse.badRequest(res)
+      sendUpdateSignal(newConfig)
+
+      return middlewareResponse.noContent(res)
+    } finally {
+      releaseUpdate()
     }
-
-    const newConfig = deepMerge(currentConfig, validation.data)
-    await writeFile(configPath, JSON.stringify(newConfig, null, 2))
-
-    sendUpdateSignal(newConfig)
-
-    return middlewareResponse.noContent(res)
   }
 }
 
@@ -74,11 +103,41 @@ export async function getDevToolsConfig(
 ): Promise<DevToolsConfig> {
   const configPath = join(distDir, 'cache', DEVTOOLS_CONFIG_FILENAME)
 
-  if (!existsSync(configPath)) {
-    await mkdir(dirname(configPath), { recursive: true })
-    await writeFile(configPath, JSON.stringify({}))
-    return {}
+  try {
+    const parsed = JSON.parse(await fsPromises.readFile(configPath, 'utf8'))
+    const validation = devToolsConfigSchema.safeParse(parsed)
+    return validation.success ? validation.data : {}
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {}
+    }
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return {}
+    }
+    throw error
   }
+}
 
-  return JSON.parse(await readFile(configPath, 'utf8'))
+async function writeDevToolsConfigAtomically(
+  configPath: string,
+  contents: string
+): Promise<void> {
+  const temporaryPath = join(
+    dirname(configPath),
+    `.${basename(configPath)}.${process.pid}.${randomUUID()}.tmp`
+  )
+
+  try {
+    await fsPromises.mkdir(dirname(configPath), { recursive: true })
+    await fsPromises.writeFile(temporaryPath, contents)
+    await fsPromises.rename(temporaryPath, configPath)
+  } catch (error) {
+    await fsPromises.unlink(temporaryPath).catch(() => {})
+    throw error
+  }
 }

--- a/packages/next/src/next-devtools/server/middleware-response.ts
+++ b/packages/next/src/next-devtools/server/middleware-response.ts
@@ -23,6 +23,10 @@ export const middlewareResponse = {
     res.statusCode = 405
     res.end('Method Not Allowed')
   },
+  payloadTooLarge(res: ServerResponse) {
+    res.statusCode = 413
+    res.end('Payload Too Large')
+  },
   internalServerError(res: ServerResponse, error?: unknown) {
     res.statusCode = 500
     res.setHeader('Content-Type', 'text/plain')

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -1,10 +1,19 @@
-import type { RequestInsightKind } from '../../shared/lib/request-insights'
+import type {
+  RequestInsightKind,
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../shared/lib/request-insights'
 
 export {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
   type RequestInsightIdentity,
   type RequestInsightKind,
+  type RequestInsightProxyStatus,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../shared/lib/request-insights'
 
 type RequestInsightAttributeValue =
@@ -54,6 +63,10 @@ export type RequestInsightFetch = {
 export type RequestInsight = {
   requestId: string
   kind?: RequestInsightKind
+  source: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId: string
   route?: string
   url?: string

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -65,6 +65,7 @@ import {
   extractInfoFromServerReferenceId,
   mightBeServerReferenceId,
 } from '../../shared/lib/server-reference-info'
+import { isUseCacheFunction } from '../../lib/client-and-server-references'
 import type { ServerActionLogInfo } from '../dev/server-action-logger'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { synchronizeMutableCookies } from '../async-storage/request-store'
@@ -752,6 +753,9 @@ export async function handleAction({
     // action in the current handler, so we forward the request to a worker that
     // has the action.
     if (forwardedWorker) {
+      if (extractInfoFromServerReferenceId(actionId).type === 'server-action') {
+        markServerActionRequest()
+      }
       return {
         type: 'done',
         result: await createForwardedActionResponse(
@@ -869,6 +873,10 @@ export async function handleAction({
               const action = await decodeAction(formData, serverModuleMap)
               if (typeof action === 'function') {
                 // an MPA action.
+
+                if (!isUseCacheFunction(action)) {
+                  markServerActionRequest()
+                }
 
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
@@ -1079,6 +1087,10 @@ export async function handleAction({
               if (typeof action === 'function') {
                 // an MPA action.
 
+                if (!isUseCacheFunction(action)) {
+                  markServerActionRequest()
+                }
+
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
@@ -1175,6 +1187,9 @@ export async function handleAction({
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
         const { type: actionType } = extractInfoFromServerReferenceId(actionId!)
+        if (actionType !== 'use-cache') {
+          markServerActionRequest()
+        }
         if (
           process.env.NODE_ENV === 'development' &&
           ctx.renderOpts.logServerFunctions &&
@@ -1372,6 +1387,19 @@ export async function handleAction({
  * stack overflow during `action.apply()` from malicious requests.
  */
 const SERVER_ACTION_ARGS_LIMIT = 1000
+
+function markServerActionRequest(): void {
+  if (process.env.__NEXT_DEV_SERVER && process.env.NEXT_RUNTIME !== 'edge') {
+    const { getRequestInsightsIdentity } =
+      require('../lib/trace/request-insights-identity') as typeof import('../lib/trace/request-insights-identity')
+    const identity = getRequestInsightsIdentity()
+    if (identity) {
+      const { recordRequestInsightServerAction } =
+        require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
+      recordRequestInsightServerAction(identity)
+    }
+  }
+}
 
 async function executeActionAndPrepareForRender<
   TFn extends (...args: any[]) => Promise<any>,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -115,6 +115,7 @@ import {
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
+import { getRequestInsightRouterActivity } from '../lib/trace/request-insights-router-activity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { createOneShotTracePhase } from '../lib/trace/phase'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
@@ -2775,7 +2776,18 @@ async function prepareAppPageRender(
 
   const { flightRouterState, isPrefetchRequest, nonce } = parsedRequestHeaders
 
-  if (parsedRequestHeaders.requestId) {
+  const routerActivity = requestInsightsIdentity
+    ? getRequestInsightRouterActivity(req.headers)
+    : undefined
+  if (requestInsightsIdentity && routerActivity) {
+    const { recordRequestInsightRouterActivity } =
+      require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
+    recordRequestInsightRouterActivity(requestInsightsIdentity, routerActivity)
+  }
+
+  if (requestInsightsIdentity?.debugRequestId) {
+    requestId = requestInsightsIdentity.debugRequestId
+  } else if (parsedRequestHeaders.requestId) {
     // If the client has provided a request ID (in development mode), we use it.
     requestId = parsedRequestHeaders.requestId
   } else if (requestInsightsIdentity) {
@@ -5002,7 +5014,7 @@ async function runInstantInsightsWithTracing<T>(
 
   return runWithRequestInsightsIdentity(
     {
-      requestId: ctx.requestId,
+      requestId: getRequestInsightsIdentity()?.requestId ?? ctx.requestId,
       kind: 'instant-insights',
       htmlRequestId: ctx.htmlRequestId,
       url: ctx.url.href,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -118,7 +118,10 @@ import {
 import { getRequestInsightRouterActivity } from '../lib/trace/request-insights-router-activity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { createOneShotTracePhase } from '../lib/trace/phase'
-import { traceLocalSpan } from '../lib/trace/local-span-recorder'
+import {
+  getActiveLocalSpan,
+  traceLocalSpan,
+} from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
 import { createHTMLRenderCompletionTracker } from './html-render-completion'
@@ -1371,12 +1374,10 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     requestId,
     workStore,
     componentMod: {
-      createElement,
       routeModule: {
         userland: { loaderTree },
       },
     },
-    url,
   } = ctx
 
   const {
@@ -1413,26 +1414,37 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     (initialRequestStore.isHmrRefresh === true ||
       (await anySegmentNeedsInstantValidationInDev(loaderTree)))
 
-  const getPayload = async (requestStore: RequestStore) => {
+  const getPayload = async (
+    requestStore: RequestStore,
+    payloadCtx: AppRenderContext = ctx
+  ) => {
+    const {
+      componentMod: { createElement: payloadCreateElement },
+      url: payloadUrl,
+      workStore: payloadWorkStore,
+    } = payloadCtx
     const payload: RSCPayload &
       RSCPayloadDevProperties &
       RSCInitialPayloadPartialDev = await workUnitAsyncStorage.run(
       requestStore,
       generateDynamicRSCPayload,
-      ctx,
+      payloadCtx,
       undefined
     )
 
-    if (isBypassingCachesInDev(requestStore, workStore)) {
+    if (isBypassingCachesInDev(requestStore, payloadWorkStore)) {
       // Mark the RSC payload to indicate that caches were bypassed in dev.
       // This lets the client know not to cache anything based on this render.
-      payload._bypassCachesInDev = createElement(WarnForBypassCachesInDev, {
-        route: workStore.route,
-      })
+      payload._bypassCachesInDev = payloadCreateElement(
+        WarnForBypassCachesInDev,
+        {
+          route: payloadWorkStore.route,
+        }
+      )
     } else if (shouldValidate) {
       // If this payload will be used for validation, it needs to contain the
       // canonical URL. Without it we'd get an error.
-      payload.c = prepareInitialCanonicalUrl(url)
+      payload.c = prepareInitialCanonicalUrl(payloadUrl)
     }
 
     return payload
@@ -3762,28 +3774,35 @@ async function renderToStream(
       ) {
         let debugChannelClientStream: ReplayableNodeStream | undefined
 
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        const getPayload = async (requestStore: RequestStore) => {
+        const getPayload = async (
+          payloadRequestStore: RequestStore,
+          payloadCtx: AppRenderContext = ctx
+        ) => {
           const payload: InitialRSCPayload & RSCPayloadDevProperties =
             await workUnitAsyncStorage.run(
-              requestStore,
+              payloadRequestStore,
               getRSCPayload,
               tree,
-              ctx,
+              payloadCtx,
               { is404: res.statusCode === 404, isPrerendering: false }
             )
 
-          if (isBypassingCachesInDev(requestStore, workStore)) {
+          if (
+            isBypassingCachesInDev(payloadRequestStore, payloadCtx.workStore)
+          ) {
             // Mark the RSC payload to indicate that caches were bypassed in dev.
             // This lets the client know not to cache anything based on this render.
-            if (renderOpts.setCacheStatus) {
+            if (payloadCtx.renderOpts.setCacheStatus) {
               // we know this is available  when cacheComponents is enabled, but typeguard to be safe
-              renderOpts.setCacheStatus('bypass', htmlRequestId)
+              payloadCtx.renderOpts.setCacheStatus(
+                'bypass',
+                payloadCtx.htmlRequestId
+              )
             }
             payload._bypassCachesInDev = createElement(
               WarnForBypassCachesInDev,
               {
-                route: workStore.route,
+                route: payloadCtx.workStore.route,
               }
             )
           }
@@ -4798,7 +4817,10 @@ function runDevValidationInBackground(
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   getDevRenderDidError: () => boolean,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    requestStore: RequestStore,
+    payloadCtx?: AppRenderContext
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   validationGeneration: DevValidationGeneration
 ): void {
@@ -4823,137 +4845,158 @@ function runDevValidationInBackground(
         return
       }
 
-      return runInstantInsightsWithTracing(ctx, async (runSpan) => {
-        // Read whether the streamed render errored only now that it has fully
-        // settled.
-        const devRenderDidError = getDevRenderDidError()
-
-        const [instantInputs, staticInputs] = await runSpan(
-          AppRenderSpan.instantInsightsPrepareValidation,
-          'Prepare validation inputs',
-          async () => {
-            const lazyInputs = await prepareValidationInputs(
-              prefetchMode,
-              navigationKind,
-              result,
-              requestStore,
-              validationDebugChannel,
-              ctx,
-              prerenderResumeDataCache,
-              createRequestStore,
-              getPayload,
-              onError,
-              validationAbortSignal
-            )
-
-            // If we need to do multiple renders, do them in parallel.
-            // `runValidationInDev` currently needs `instantInputs` eagerly
-            // right before using `staticInputs` for static shell validation,
-            // so there's no point delaying one of the renders.
-            // We bail out (after logging an error during
-            // `resolveLazyDevValidationInputs`) if sync IO or invalid dynamic
-            // errors happen in either.
-            return Promise.all([
-              lazyInputs.instantInputs
-                ? resolveLazyDevValidationInputs(lazyInputs.instantInputs, ctx)
-                : null,
-              resolveLazyDevValidationInputs(lazyInputs.staticInputs, ctx),
-            ])
-          }
-        )
-        if (
-          instantInputs === VALIDATION_BAILOUT ||
-          staticInputs === VALIDATION_BAILOUT
-        ) {
-          return
-        }
-
-        // A newer render may have superseded this work while we prepared the
-        // validation inputs above (which can itself render).
-        if (validationAbortSignal.aborted) {
-          logValidationAborted(ctx)
-          return
-        }
-
-        return runSpan(
-          AppRenderSpan.instantInsightsRunValidation,
-          'Run validation',
-          async () => {
-            // Hand the whole validation to the worker when one is installed. It
-            // runs on a worker thread (off the main thread), emits its own
-            // lifecycle markers, logs code frames on its piped stdio, and
-            // returns the overlay Flight bytes for the main thread to forward.
-            // The worker is absent when `experimental.devValidationWorker` is
-            // false, and validation runs in-process instead.
-            const devValidationWorker = getDevValidationWorker()
-
-            if (devValidationWorker) {
-              const snapshot = await buildDevValidationSnapshot(
-                ctx,
-                instantInputs,
-                staticInputs,
-                prefetchMode,
-                fallbackRouteParams,
-                devRenderDidError
+      return runInstantInsightsWithTracing(
+        ctx,
+        async (runSpan, instantInsightsCtx) => {
+          const getValidationPayload = (validationRequestStore: RequestStore) =>
+            getPayload(validationRequestStore, instantInsightsCtx)
+          const validationOnError = isRequestInsightsEnabled()
+            ? createReactServerErrorHandler(
+                true,
+                false,
+                instantInsightsCtx.workStore.reactServerErrorsByDigest,
+                () => {},
+                getActiveLocalSpan()
               )
+            : onError
 
-              const chunks = await devValidationWorker(
-                snapshot,
+          // Read whether the streamed render errored only now that it has fully
+          // settled.
+          const devRenderDidError = getDevRenderDidError()
+
+          const [instantInputs, staticInputs] = await runSpan(
+            AppRenderSpan.instantInsightsPrepareValidation,
+            'Prepare validation inputs',
+            async () => {
+              const lazyInputs = await prepareValidationInputs(
+                prefetchMode,
+                navigationKind,
+                result,
+                requestStore,
+                validationDebugChannel,
+                instantInsightsCtx,
+                prerenderResumeDataCache,
+                createRequestStore,
+                getValidationPayload,
+                validationOnError,
                 validationAbortSignal
               )
 
-              // A newer navigation may have superseded this validation while
-              // the worker ran; don't surface stale insights for a page the user
-              // left.
-              if (chunks && !validationAbortSignal.aborted) {
-                const { sendErrorsToBrowser } = ctx.renderOpts
-                if (!sendErrorsToBrowser) {
-                  throw new InvariantError(
-                    'Expected `sendErrorsToBrowser` to be defined in renderOpts.'
-                  )
-                }
-                sendErrorsToBrowser(
-                  createNodeStreamFromChunks(chunks),
-                  ctx.htmlRequestId
-                )
-              }
-            } else {
-              // In-process path, taken when `experimental.devValidationWorker`
-              // is false or no worker is installed (e.g. during a build).
-              // Validation computes the errors; the caller delivers them to the
-              // dev overlay. `runWithDevValidationLogging` encloses both the
-              // render and the delivery in the test-mode lifecycle markers so
-              // tests that assert the delivered error between
-              // `validation_start` and `validation_end` capture it.
-              await runWithDevValidationLogging(
-                ctx,
-                validationAbortSignal,
-                async () => {
-                  const validationErrors = await runValidationInDev(
-                    prefetchMode,
-                    instantInputs,
-                    staticInputs,
-                    toValidationRenderContext(ctx),
-                    fallbackRouteParams,
-                    devRenderDidError,
-                    validationAbortSignal
-                  )
+              // If we need to do multiple renders, do them in parallel.
+              // `runValidationInDev` currently needs `instantInputs` eagerly
+              // right before using `staticInputs` for static shell validation,
+              // so there's no point delaying one of the renders.
+              // We bail out (after logging an error during
+              // `resolveLazyDevValidationInputs`) if sync IO or invalid dynamic
+              // errors happen in either.
+              return Promise.all([
+                lazyInputs.instantInputs
+                  ? resolveLazyDevValidationInputs(
+                      lazyInputs.instantInputs,
+                      instantInsightsCtx
+                    )
+                  : null,
+                resolveLazyDevValidationInputs(
+                  lazyInputs.staticInputs,
+                  instantInsightsCtx
+                ),
+              ])
+            }
+          )
+          if (
+            instantInputs === VALIDATION_BAILOUT ||
+            staticInputs === VALIDATION_BAILOUT
+          ) {
+            return
+          }
 
-                  if (
-                    validationErrors !== undefined &&
-                    !validationAbortSignal.aborted
-                  ) {
-                    await logMessagesAndSendErrorsToBrowser(
-                      validationErrors,
-                      ctx
+          // A newer render may have superseded this work while we prepared the
+          // validation inputs above (which can itself render).
+          if (validationAbortSignal.aborted) {
+            logValidationAborted(instantInsightsCtx)
+            return
+          }
+
+          return runSpan(
+            AppRenderSpan.instantInsightsRunValidation,
+            'Run validation',
+            async () => {
+              // Hand the whole validation to the worker when one is installed. It
+              // runs on a worker thread (off the main thread), emits its own
+              // lifecycle markers, logs code frames on its piped stdio, and
+              // returns the overlay Flight bytes for the main thread to forward.
+              // The worker is absent when `experimental.devValidationWorker` is
+              // false, and validation runs in-process instead.
+              const devValidationWorker = getDevValidationWorker()
+
+              if (devValidationWorker) {
+                const snapshot = await buildDevValidationSnapshot(
+                  instantInsightsCtx,
+                  instantInputs,
+                  staticInputs,
+                  prefetchMode,
+                  fallbackRouteParams,
+                  devRenderDidError
+                )
+
+                const chunks = await devValidationWorker(
+                  snapshot,
+                  validationAbortSignal
+                )
+
+                // A newer navigation may have superseded this validation while
+                // the worker ran; don't surface stale insights for a page the user
+                // left.
+                if (chunks && !validationAbortSignal.aborted) {
+                  const { sendErrorsToBrowser } = instantInsightsCtx.renderOpts
+                  if (!sendErrorsToBrowser) {
+                    throw new InvariantError(
+                      'Expected `sendErrorsToBrowser` to be defined in renderOpts.'
                     )
                   }
+                  sendErrorsToBrowser(
+                    createNodeStreamFromChunks(chunks),
+                    instantInsightsCtx.htmlRequestId
+                  )
                 }
-              )
+              } else {
+                // In-process path, taken when `experimental.devValidationWorker`
+                // is false or no worker is installed (e.g. during a build).
+                // Validation computes the errors; the caller delivers them to the
+                // dev overlay. `runWithDevValidationLogging` encloses both the
+                // render and the delivery in the test-mode lifecycle markers so
+                // tests that assert the delivered error between
+                // `validation_start` and `validation_end` capture it.
+                await runWithDevValidationLogging(
+                  instantInsightsCtx,
+                  validationAbortSignal,
+                  async () => {
+                    const validationErrors = await runValidationInDev(
+                      prefetchMode,
+                      instantInputs,
+                      staticInputs,
+                      toValidationRenderContext(instantInsightsCtx),
+                      fallbackRouteParams,
+                      devRenderDidError,
+                      validationAbortSignal
+                    )
+
+                    if (
+                      validationErrors !== undefined &&
+                      !validationAbortSignal.aborted
+                    ) {
+                      await logMessagesAndSendErrorsToBrowser(
+                        validationErrors,
+                        instantInsightsCtx
+                      )
+                    }
+                  }
+                )
+              }
             }
-          }
-        )
-      })
+          )
+        }
+      )
     })
     // The catch keeps a failed render, or anything thrown inside validation,
     // from surfacing as an unhandled rejection.
@@ -5006,34 +5049,51 @@ function runWithoutInstantInsightsSpan<T>(
 
 async function runInstantInsightsWithTracing<T>(
   ctx: AppRenderContext,
-  fn: (runSpan: RunInstantInsightsSpan) => Promise<T>
+  fn: (
+    runSpan: RunInstantInsightsSpan,
+    instantInsightsCtx: AppRenderContext
+  ) => Promise<T>
 ): Promise<T> {
-  if (!isRequestInsightsEnabled()) {
-    return fn(runWithoutInstantInsightsSpan)
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (isRequestInsightsEnabled()) {
+      const { createInstantInsightsWorkStore } =
+        require('./instant-insights-work-store') as typeof import('./instant-insights-work-store')
+      const workStore = createInstantInsightsWorkStore(ctx.workStore)
+      const instantInsightsCtx: AppRenderContext = {
+        ...ctx,
+        workStore,
+      }
+      const outerRequestInsightsIdentity = getRequestInsightsIdentity()
+      const instantInsightsIdentity = {
+        requestId: outerRequestInsightsIdentity?.requestId ?? ctx.requestId,
+        debugRequestId: outerRequestInsightsIdentity?.debugRequestId,
+        kind: 'instant-insights' as const,
+        htmlRequestId:
+          outerRequestInsightsIdentity?.htmlRequestId ?? ctx.htmlRequestId,
+        url: ctx.url.href,
+      }
+
+      return runWithRequestInsightsIdentity(instantInsightsIdentity, () =>
+        workAsyncStorage.run(workStore, () =>
+          traceLocalSpan(
+            {
+              name: 'Instant Insights',
+              parentSpan: null,
+              attributes: {
+                'next.span_category': 'nextjs',
+                'next.span_name': 'Instant Insights',
+                'next.span_type': AppRenderSpan.instantInsights,
+                'next.route': ctx.pagePath,
+              },
+            },
+            () => fn(runInstantInsightsSpan, instantInsightsCtx)
+          )
+        )
+      )
+    }
   }
 
-  return runWithRequestInsightsIdentity(
-    {
-      requestId: getRequestInsightsIdentity()?.requestId ?? ctx.requestId,
-      kind: 'instant-insights',
-      htmlRequestId: ctx.htmlRequestId,
-      url: ctx.url.href,
-    },
-    () =>
-      traceLocalSpan(
-        {
-          name: 'Instant Insights',
-          parentSpan: null,
-          attributes: {
-            'next.span_category': 'nextjs',
-            'next.span_name': 'Instant Insights',
-            'next.span_type': AppRenderSpan.instantInsights,
-            'next.route': ctx.pagePath,
-          },
-        },
-        () => fn(runInstantInsightsSpan)
-      )
-  )
+  return fn(runWithoutInstantInsightsSpan, ctx)
 }
 
 /**

--- a/packages/next/src/server/app-render/instant-insights-work-store.ts
+++ b/packages/next/src/server/app-render/instant-insights-work-store.ts
@@ -1,0 +1,137 @@
+import type { WorkStore } from './work-async-storage.external'
+import { workAsyncStorage } from './work-async-storage.external'
+import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import {
+  getActiveLocalSpan,
+  withLocalSpan,
+} from '../lib/trace/local-span-recorder'
+import {
+  getRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from '../lib/trace/request-insights-identity'
+
+type WorkStoreFieldTreatment = 'inherit' | 'reset'
+
+// Keep this exhaustive so new WorkStore state cannot silently flow into the
+// isolated Instant Insights render through the object spread below.
+type InstantInsightsWorkStoreFieldTreatments = {
+  page: 'inherit'
+  route: 'inherit'
+  incrementalCache: 'inherit'
+  cacheLifeProfiles: 'inherit'
+  useCacheTimeout: 'inherit'
+  staticPageGenerationTimeout: 'inherit'
+  isOnDemandRevalidate: 'reset'
+  isBuildTimePrerendering: 'reset'
+  forceDynamic: 'inherit'
+  fetchCache: 'inherit'
+  forceStatic: 'inherit'
+  dynamicShouldError: 'inherit'
+  pendingRevalidates: 'reset'
+  pendingRevalidateWrites: 'reset'
+  afterContext: 'reset'
+  dynamicUsageDescription: 'reset'
+  dynamicUsageStack: 'reset'
+  invalidDynamicUsageError: 'reset'
+  nextFetchId: 'reset'
+  pathWasRevalidated: 'reset'
+  pendingRevalidatedTags: 'reset'
+  previouslyRevalidatedTags: 'reset'
+  requestStartTime: 'inherit'
+  refreshTagsByCacheKind: 'reset'
+  fetchMetrics: 'reset'
+  shouldTrackFetchMetrics: 'reset'
+  pendingCacheInvocations: 'reset'
+  completedCacheInvocations: 'reset'
+  useCacheProbeMode: 'inherit'
+  isDraftMode: 'inherit'
+  isUnstableNoStore: 'inherit'
+  isPrefetchRequest: 'inherit'
+  requestId: 'inherit'
+  htmlRequestId: 'inherit'
+  requestInsightsIdentity: 'reset'
+  deploymentId: 'inherit'
+  buildId: 'inherit'
+  reactLoadableManifest: 'inherit'
+  assetPrefix: 'inherit'
+  nonce: 'inherit'
+  cacheComponentsEnabled: 'inherit'
+  validationLevel: 'inherit'
+  additionalClientReferenceManifestPages: 'reset'
+  runInCleanSnapshot: 'reset'
+  reactServerErrorsByDigest: 'reset'
+}
+
+type AssertNever<T extends never> = T
+
+type _AssertInstantInsightsWorkStoreTreatmentsAreExhaustive = AssertNever<
+  | Exclude<keyof WorkStore, keyof InstantInsightsWorkStoreFieldTreatments>
+  | Exclude<keyof InstantInsightsWorkStoreFieldTreatments, keyof WorkStore>
+  | Exclude<
+      InstantInsightsWorkStoreFieldTreatments[keyof InstantInsightsWorkStoreFieldTreatments],
+      WorkStoreFieldTreatment
+    >
+>
+
+export function createInstantInsightsWorkStore(
+  outerWorkStore: WorkStore
+): WorkStore {
+  const { AfterContext } =
+    require('../after/after-context') as typeof import('../after/after-context')
+  const workStore: WorkStore = {
+    ...outerWorkStore,
+    isBuildTimePrerendering: false,
+    isOnDemandRevalidate: false,
+    invalidDynamicUsageError: undefined,
+    dynamicUsageDescription: undefined,
+    dynamicUsageStack: undefined,
+    nextFetchId: undefined,
+    pathWasRevalidated: undefined,
+    pendingRevalidates: {},
+    pendingRevalidateWrites: [],
+    pendingRevalidatedTags: [],
+    previouslyRevalidatedTags: [],
+    refreshTagsByCacheKind: new Map(),
+    fetchMetrics: [],
+    shouldTrackFetchMetrics: false,
+    pendingCacheInvocations: new Map(),
+    completedCacheInvocations: new Map(),
+    reactServerErrorsByDigest: new Map(),
+    afterContext: new AfterContext({
+      waitUntil(promise) {
+        promise.catch(() => {})
+      },
+      onClose() {},
+      onTaskError() {},
+    }),
+    additionalClientReferenceManifestPages:
+      outerWorkStore.additionalClientReferenceManifestPages === undefined
+        ? undefined
+        : new Set(outerWorkStore.additionalClientReferenceManifestPages),
+    runInCleanSnapshot<R, TArgs extends any[]>(
+      fn: (...args: TArgs) => R,
+      ...args: TArgs
+    ): R {
+      const requestInsightsIdentity = getRequestInsightsIdentity()
+      const activeLocalSpan = getActiveLocalSpan()
+
+      return outerWorkStore.runInCleanSnapshot(() =>
+        workUnitAsyncStorage.exit(() =>
+          workAsyncStorage.run(workStore, () => {
+            const run = () => fn(...args)
+            const runWithIdentity = () =>
+              requestInsightsIdentity
+                ? runWithRequestInsightsIdentity(requestInsightsIdentity, run)
+                : run()
+
+            return activeLocalSpan
+              ? withLocalSpan(activeLocalSpan, runWithIdentity)
+              : runWithIdentity()
+          })
+        )
+      )
+    },
+  }
+
+  return workStore
+}

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -13,6 +13,7 @@ import { workAsyncStorageInstance } from './work-async-storage-instance' with { 
 import type { LazyResult } from '../lib/lazy-result'
 import type { DigestedError } from './create-error-handler'
 import type { ActionRevalidationKind } from '../../shared/lib/action-revalidation-kind'
+import type { RequestInsightsIdentity } from '../lib/trace/request-insights-identity'
 
 export interface WorkStore {
   /**
@@ -154,6 +155,7 @@ export interface WorkStore {
    */
   requestId?: string
   htmlRequestId?: string
+  requestInsightsIdentity?: RequestInsightsIdentity
 
   /**
    * This only exists because it's needed in use-cache-wrapper

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -114,7 +114,10 @@ import {
   SpanStatusCode,
 } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
-import { runWithRequestInsightsIdentity } from './lib/trace/request-insights-identity'
+import {
+  resolveRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './lib/trace/request-insights-identity'
 import { isRequestInsightsEnabled } from './lib/trace/span-store'
 import { I18NProvider } from './lib/i18n-provider'
 import { sendResponse } from './send-response'
@@ -1002,25 +1005,33 @@ export default abstract class Server<
       return handleRequest()
     }
 
-    const requestIdHeader = req.headers[NEXT_REQUEST_ID_HEADER]
-    const requestId =
-      typeof requestIdHeader === 'string' ? requestIdHeader : nanoid()
-    const htmlRequestIdHeader = req.headers[NEXT_HTML_REQUEST_ID_HEADER]
+    const requestInsightsIdentity = resolveRequestInsightsIdentity({
+      previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+      requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+      htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+      url: req.url,
+      createRequestId: nanoid,
+    })
+    const isMiddlewareInvoke = getRequestMeta(req, 'middlewareInvoke') === true
+    const sourceBeforeMiddleware = requestInsightsIdentity.source
+    if (isMiddlewareInvoke) {
+      requestInsightsIdentity.source = 'proxy'
+    }
+    addRequestMeta(req, 'requestInsightsIdentity', requestInsightsIdentity)
 
     // The request root and route-matching spans start before App Render creates
     // its workStore. Carry their identity in this outer scope; App Render copies
     // it into the workStore so the complete timeline uses one request ID.
-    return runWithRequestInsightsIdentity(
-      {
-        requestId,
-        htmlRequestId:
-          typeof htmlRequestIdHeader === 'string'
-            ? htmlRequestIdHeader
-            : requestId,
-        url: req.url,
-      },
-      handleRequest
-    )
+    try {
+      return await runWithRequestInsightsIdentity(
+        requestInsightsIdentity,
+        handleRequest
+      )
+    } finally {
+      if (isMiddlewareInvoke && requestInsightsIdentity.source === 'proxy') {
+        requestInsightsIdentity.source = sourceBeforeMiddleware
+      }
+    }
   }
 
   private async handleRequestImpl(

--- a/packages/next/src/server/lib/dev-request-id.ts
+++ b/packages/next/src/server/lib/dev-request-id.ts
@@ -1,0 +1,44 @@
+import {
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from '../../client/components/app-router-headers'
+
+type HeaderValue = string | string[] | undefined
+
+const REQUEST_ID_PATTERN = /^[0-9a-f]{1,8}$/
+const HTML_REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
+
+export function getValidatedDevRequestId(
+  value: HeaderValue
+): string | undefined {
+  return typeof value === 'string' && REQUEST_ID_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function getValidatedDevHtmlRequestId(
+  value: HeaderValue
+): string | undefined {
+  return typeof value === 'string' && HTML_REQUEST_ID_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function filterInvalidDevRequestIdHeaders(
+  headers: Record<string, HeaderValue>
+): void {
+  if (
+    headers[NEXT_REQUEST_ID_HEADER] !== undefined &&
+    getValidatedDevRequestId(headers[NEXT_REQUEST_ID_HEADER]) === undefined
+  ) {
+    delete headers[NEXT_REQUEST_ID_HEADER]
+  }
+
+  if (
+    headers[NEXT_HTML_REQUEST_ID_HEADER] !== undefined &&
+    getValidatedDevHtmlRequestId(headers[NEXT_HTML_REQUEST_ID_HEADER]) ===
+      undefined
+  ) {
+    delete headers[NEXT_HTML_REQUEST_ID_HEADER]
+  }
+}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -71,7 +71,15 @@ import { getNextConfigRuntime, type NextConfigComplete } from '../config-shared'
 import {
   getRequestInsightsSnapshot,
   isRequestInsightsEnabled,
+  recordRequestInsightSource,
 } from './trace/request-insights'
+import {
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from '../../client/components/app-router-headers'
+import { nanoid } from 'next/dist/compiled/nanoid'
+import { filterInvalidDevRequestIdHeaders } from './dev-request-id'
+import { resolveRequestInsightsIdentity } from './trace/request-insights-identity'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -252,9 +260,21 @@ export async function initialize(opts: {
       filterInternalHeaders(req.headers)
     }
 
+    if (opts.dev) {
+      filterInvalidDevRequestIdHeaders(req.headers)
+    }
+
     if (opts.dev && req.url) {
       if (config.experimental.requestInsights) {
         process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+        const identity = resolveRequestInsightsIdentity({
+          previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+          requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+          htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+          url: req.url,
+          createRequestId: nanoid,
+        })
+        addRequestMeta(req, 'requestInsightsIdentity', identity)
       }
 
       const urlParts = req.url.split('?', 1)
@@ -619,6 +639,15 @@ export async function initialize(opts: {
         }
 
         try {
+          if (config.experimental.requestInsights) {
+            const requestInsightsIdentity = getRequestMeta(
+              req,
+              'requestInsightsIdentity'
+            )
+            if (requestInsightsIdentity) {
+              recordRequestInsightSource(requestInsightsIdentity, 'asset')
+            }
+          }
           return await serveStatic(req, res, matchedOutput.itemPath, {
             root: matchedOutput.itemsRoot,
             // Ensures that etags are not generated for static files when disabled.

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -32,7 +32,7 @@ import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-p
 import { NextDataPathnameNormalizer } from '../../normalizers/request/next-data'
 import { BasePathPathnameNormalizer } from '../../normalizers/request/base-path'
 
-import { addRequestMeta } from '../../request-meta'
+import { addRequestMeta, getRequestMeta } from '../../request-meta'
 import { isRSCRequestHeader } from '../is-rsc-request'
 import {
   compileNonPath,
@@ -565,7 +565,7 @@ export function getResolveRoutes(
             /* non-fatal we can't decode so can't match it */
           }
 
-          if (
+          const matchesMiddleware =
             // @ts-expect-error BaseNextRequest stuff
             match?.(parsedUrl.pathname, req, parsedUrl.query) ||
             match?.(
@@ -574,7 +574,17 @@ export function getResolveRoutes(
               req,
               parsedUrl.query
             )
-          ) {
+          const requestInsightsIdentity = getRequestMeta(
+            req,
+            'requestInsightsIdentity'
+          )
+          if (requestInsightsIdentity && match) {
+            requestInsightsIdentity.proxyStatus = matchesMiddleware
+              ? 'matched'
+              : 'bypassed'
+          }
+
+          if (matchesMiddleware) {
             if (ensureMiddleware) {
               await ensureMiddleware(req.url)
             }

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -6,12 +6,16 @@ import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
 import { createLocalSpan, traceLocalSpan } from './local-span-recorder'
-import { runWithRequestInsightsIdentity } from './request-insights-identity'
+import {
+  resolveRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './request-insights-identity'
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 import {
   workAsyncStorage,
   type WorkStore,
 } from '../../app-render/work-async-storage.external'
+import { filterInvalidDevRequestIdHeaders } from '../dev-request-id'
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const spanRecords: SpanStoreRecord[] = []
@@ -67,6 +71,98 @@ describe('local recording span', () => {
         },
       }),
     ])
+  })
+
+  it('keeps browser debug IDs separate from server-owned storage IDs', () => {
+    const identity = resolveRequestInsightsIdentity({
+      previousIdentity: undefined,
+      requestIdHeader: '1a2b3c4d',
+      htmlRequestIdHeader: 'html_request',
+      url: '/dashboard',
+      createRequestId: () => 'server_request',
+    })
+
+    expect(identity).toEqual({
+      requestId: 'server_request',
+      debugRequestId: '1a2b3c4d',
+      htmlRequestId: 'html_request',
+      url: '/dashboard',
+    })
+    expect(
+      resolveRequestInsightsIdentity({
+        previousIdentity: identity,
+        requestIdHeader: 'ffffffff',
+        htmlRequestIdHeader: 'other_html',
+        url: '/rewritten',
+        createRequestId: () => 'other_server_request',
+      })
+    ).toBe(identity)
+  })
+
+  it('records the framework-owned request source from the request identity', () => {
+    runWithRequestInsightsIdentity(
+      {
+        requestId: 'asset-request',
+        source: 'asset',
+        htmlRequestId: 'asset-request',
+        url: '/asset.svg',
+      },
+      () => {
+        const span = createLocalSpan({ name: 'serve static asset' })
+        span.end()
+      }
+    )
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        requestId: 'asset-request',
+        requestInsightSource: 'asset',
+        url: '/asset.svg',
+      }),
+    ])
+  })
+
+  it('rejects malformed browser IDs instead of using them as storage keys', () => {
+    expect(
+      resolveRequestInsightsIdentity({
+        previousIdentity: undefined,
+        requestIdHeader: 'not a request id',
+        htmlRequestIdHeader: '../not-safe',
+        url: '/',
+        createRequestId: () => 'server_request',
+      })
+    ).toEqual({
+      requestId: 'server_request',
+      debugRequestId: undefined,
+      htmlRequestId: 'server_request',
+      url: '/',
+    })
+  })
+
+  it('drops malformed development correlation headers at router ingress', () => {
+    const headers = {
+      'x-nextjs-request-id': 'not a request id',
+      'x-nextjs-html-request-id': '../not-safe',
+    }
+
+    filterInvalidDevRequestIdHeaders(headers)
+
+    expect(headers).toEqual({})
+  })
+
+  it('does not merge independent requests that reuse a valid browser ID', () => {
+    const createIdentity = (requestId: string) =>
+      resolveRequestInsightsIdentity({
+        previousIdentity: undefined,
+        requestIdHeader: '1a2b3c4d',
+        htmlRequestIdHeader: undefined,
+        url: '/',
+        createRequestId: () => requestId,
+      })
+
+    expect(createIdentity('server_request_1').requestId).not.toBe(
+      createIdentity('server_request_2').requestId
+    )
   })
 
   it('ignores undefined values when setting attributes', () => {

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -14,6 +14,11 @@ import {
   type SpanStoreLink,
 } from './span-store'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 
 export { isLocalSpanRecordingEnabled } from './span-store'
 
@@ -169,6 +174,10 @@ function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {
 type RequestIdentity = {
   requestId?: string
   requestInsightKind?: RequestInsightKind
+  requestInsightSource?: RequestInsightSource
+  requestInsightProxyStatus?: RequestInsightProxyStatus
+  requestInsightRouterActivity?: RequestInsightRouterActivity
+  requestInsightServerAction?: true
   htmlRequestId?: string
   route?: string
   url?: string
@@ -371,6 +380,12 @@ class LocalRecordingSpan implements Span {
       parentSpanId: this.parentSpanId,
       requestId: this.requestIdentity.requestId,
       requestInsightKind: this.requestIdentity.requestInsightKind,
+      requestInsightSource: this.requestIdentity.requestInsightSource,
+      requestInsightProxyStatus: this.requestIdentity.requestInsightProxyStatus,
+      requestInsightRouterActivity:
+        this.requestIdentity.requestInsightRouterActivity,
+      requestInsightServerAction:
+        this.requestIdentity.requestInsightServerAction,
       htmlRequestId: this.requestIdentity.htmlRequestId,
       route:
         getStringAttribute(recordAttributes, 'next.route') ??
@@ -565,6 +580,10 @@ function getCurrentRequestIdentity(): RequestIdentity {
     return {
       requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
       requestInsightKind: requestInsightsIdentity?.kind,
+      requestInsightSource: requestInsightsIdentity?.source,
+      requestInsightProxyStatus: requestInsightsIdentity?.proxyStatus,
+      requestInsightRouterActivity: requestInsightsIdentity?.routerActivity,
+      requestInsightServerAction: requestInsightsIdentity?.serverAction,
       htmlRequestId:
         requestInsightsIdentity?.htmlRequestId ?? workStore?.htmlRequestId,
       route: workStore?.route,

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -1,12 +1,55 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+import {
+  getValidatedDevHtmlRequestId,
+  getValidatedDevRequestId,
+} from '../dev-request-id'
 
 export type RequestInsightsIdentity = {
+  // This is a server-owned storage key. Browser-provided IDs are only used by
+  // the development debug channel and must never become Request Insights keys.
   requestId: string
+  debugRequestId?: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId: string
   url: string | undefined
+}
+
+export function resolveRequestInsightsIdentity({
+  previousIdentity,
+  requestIdHeader,
+  htmlRequestIdHeader,
+  url,
+  createRequestId,
+}: {
+  previousIdentity: RequestInsightsIdentity | undefined
+  requestIdHeader: string | string[] | undefined
+  htmlRequestIdHeader: string | string[] | undefined
+  url: string | undefined
+  createRequestId: () => string
+}): RequestInsightsIdentity {
+  if (previousIdentity) {
+    return previousIdentity
+  }
+
+  const requestId = createRequestId()
+  return {
+    requestId,
+    debugRequestId: getValidatedDevRequestId(requestIdHeader),
+    htmlRequestId:
+      getValidatedDevHtmlRequestId(htmlRequestIdHeader) ?? requestId,
+    url,
+  }
 }
 
 // This storage covers the part of BaseServer request handling that runs before

--- a/packages/next/src/server/lib/trace/request-insights-router-activity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-router-activity.ts
@@ -1,0 +1,36 @@
+import {
+  NEXT_HMR_REFRESH_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  RSC_HEADER,
+} from '../../../client/components/app-router-headers'
+import type { RequestInsightRouterActivity } from '../../../shared/lib/request-insights'
+import { isRSCRequestHeader } from '../is-rsc-request'
+
+type RouterHeaders = Record<string, string | string[] | undefined>
+
+export function getRequestInsightRouterActivity(
+  headers: RouterHeaders
+): RequestInsightRouterActivity | undefined {
+  if (!isRSCRequestHeader(headers[RSC_HEADER])) {
+    return undefined
+  }
+
+  if (headers[NEXT_HMR_REFRESH_HEADER] === '1') {
+    return 'hmr-refresh'
+  }
+
+  const prefetch = headers[NEXT_ROUTER_PREFETCH_HEADER]
+  if (prefetch !== '1' && prefetch !== '2' && prefetch !== '3') {
+    return undefined
+  }
+
+  if (
+    prefetch === '1' &&
+    typeof headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === 'string'
+  ) {
+    return 'segment-prefetch'
+  }
+
+  return 'prefetch'
+}

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -2,9 +2,13 @@ import {
   clearRequestInsightsForTest,
   getRequestInsightsSnapshot,
   recordRequestInsightFetch,
+  recordRequestInsightRouterActivity,
+  recordRequestInsightServerAction,
+  recordRequestInsightSource,
   subscribeRequestInsights,
 } from './request-insights'
 import { recordSpan } from './span-store'
+import { getRequestInsightRouterActivity } from './request-insights-router-activity'
 
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -183,6 +187,224 @@ describe('request insights', () => {
         durationMs: 50,
       })
     )
+  })
+
+  it('classifies framework request sources without letting the root span erase a specific source', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'run app route',
+      requestId: 'req_source',
+      attributes: {
+        'next.span_type': 'AppRouteRouteHandlers.runHandler',
+      },
+    })
+    recordSpan({
+      name: 'GET /api/items',
+      requestId: 'req_source',
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source: 'app-route' })
+    )
+  })
+
+  it.each([
+    ['Node.runHandler', 'pages-api'],
+    ['NextNodeServer.imageOptimizer', 'image'],
+    ['Middleware.execute', 'proxy'],
+  ] as const)('classifies %s spans as %s requests', (spanType, source) => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: spanType,
+      requestId: `req_${source}`,
+      attributes: {
+        'next.span_type': spanType,
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source })
+    )
+  })
+
+  it('records an authoritative static asset source after tracing starts', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity: Parameters<typeof recordRequestInsightSource>[0] = {
+      requestId: 'req_asset',
+    }
+
+    recordSpan({
+      name: 'GET /asset.svg',
+      requestId: identity.requestId,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    recordRequestInsightSource(identity, 'asset')
+
+    expect(identity.source).toBe('asset')
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source: 'asset' })
+    )
+  })
+
+  it('does not create a request only because a source was recorded', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordRequestInsightSource({ requestId: 'untraced-asset' }, 'asset')
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([])
+  })
+
+  it('does not classify the middleware pass as a page before an App Route runs', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = {
+      requestId: 'middleware-app-route',
+      source: 'proxy' as const,
+    }
+
+    recordSpan({
+      name: 'proxy POST /api/stream',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 1,
+      attributes: {
+        'next.span_type': 'Middleware.execute',
+      },
+    })
+    recordSpan({
+      name: 'POST /api/stream',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 2,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'proxy',
+      }),
+    ])
+
+    recordRequestInsightSource(identity, 'app-route')
+    recordSpan({
+      name: 'execute route handler',
+      requestId: identity.requestId,
+      startTime: 3,
+      attributes: {
+        'next.span_type': 'AppRouteRouteHandlers.runHandler',
+      },
+    })
+
+    const requests = getRequestInsightsSnapshot().requests
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toEqual(
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'app-route',
+      })
+    )
+    expect(
+      requests[0].spans.map((span) => span.attributes?.['next.span_type'])
+    ).toEqual([
+      'Middleware.execute',
+      'BaseServer.handleRequest',
+      'AppRouteRouteHandlers.runHandler',
+    ])
+  })
+
+  it('classifies the route pass as a page after middleware completes', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = {
+      requestId: 'middleware-page',
+      source: 'proxy' as 'proxy' | undefined,
+    }
+
+    recordSpan({
+      name: 'proxy GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 1,
+      attributes: {
+        'next.span_type': 'Middleware.execute',
+      },
+    })
+    recordSpan({
+      name: 'GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 2,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    identity.source = undefined
+    recordSpan({
+      name: 'GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 3,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'page',
+      }),
+    ])
+  })
+
+  it('records normalized router activity and confirmed Server Actions', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = { requestId: 'req_activity' }
+
+    recordSpan({
+      name: 'render route (app) /dashboard',
+      requestId: identity.requestId,
+    })
+
+    recordRequestInsightRouterActivity(identity, 'segment-prefetch')
+    recordRequestInsightServerAction(identity)
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        source: 'unknown',
+        routerActivity: 'segment-prefetch',
+        serverAction: true,
+      })
+    )
+  })
+
+  it('derives router activity only from valid RSC protocol headers', () => {
+    expect(
+      getRequestInsightRouterActivity({
+        rsc: '1',
+        'next-router-prefetch': '1',
+        'next-router-segment-prefetch': '/dashboard',
+      })
+    ).toBe('segment-prefetch')
+    expect(
+      getRequestInsightRouterActivity({
+        'next-router-prefetch': '1',
+      })
+    ).toBeUndefined()
+    expect(
+      getRequestInsightRouterActivity({
+        rsc: '1',
+        'next-hmr-refresh': '1',
+      })
+    ).toBe('hmr-refresh')
   })
 
   it('keeps request and Instant Insights data separate for the same request ID', () => {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -8,6 +8,12 @@ import type { RequestInsightKind } from '../../../shared/lib/request-insights'
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  type RequestInsightProxyStatus,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { SpanStoreRecord } from './span-store'
 export { isRequestInsightsEnabled } from './span-store'
@@ -21,6 +27,10 @@ type RequestInsightsListener = (insight: RequestInsight) => void
 type RequestInsightIdentity = {
   requestId?: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId?: string
   route?: string
   url?: string
@@ -38,6 +48,7 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.fetch.cache_status',
   'next.fetch.idx',
   'next.route',
+  'next.request_source',
   'next.rsc',
   'next.segment',
   'next.span_category',
@@ -65,6 +76,10 @@ class InMemoryRequestInsightsStore {
       {
         requestId: span.requestId,
         kind: span.requestInsightKind,
+        source: span.requestInsightSource,
+        proxyStatus: span.requestInsightProxyStatus,
+        routerActivity: span.requestInsightRouterActivity,
+        serverAction: span.requestInsightServerAction,
         htmlRequestId: span.htmlRequestId,
         route: span.route,
         url: span.url,
@@ -74,6 +89,17 @@ class InMemoryRequestInsightsStore {
 
     const spanStartTime = span.startTime ?? span.timestamp
     insight.htmlRequestId = span.htmlRequestId ?? insight.htmlRequestId
+    this.updateClassification(
+      insight,
+      {
+        kind: span.requestInsightKind,
+        source: span.requestInsightSource,
+        proxyStatus: span.requestInsightProxyStatus,
+        routerActivity: span.requestInsightRouterActivity,
+        serverAction: span.requestInsightServerAction,
+      },
+      span
+    )
     insight.route = insight.route ?? span.route
     insight.url = insight.url ?? sanitizeUrl(span.url)
     this.updateTiming(
@@ -120,6 +146,25 @@ class InMemoryRequestInsightsStore {
     const insight = this.getOrCreateRequest(identity, fetchStartTime)
     this.updateTiming(insight, fetchStartTime, fetch.durationMs, false)
     this.recordFetchForInsight(insight, sanitizeFetchInsight(fetch))
+    this.notify(insight)
+  }
+
+  recordClassification(identity: RequestInsightIdentity): void {
+    if (!identity.requestId) {
+      return
+    }
+
+    const insight = this.requests.get(
+      getRequestInsightKey({
+        requestId: identity.requestId,
+        kind: identity.kind,
+      })
+    )
+    if (!insight) {
+      return
+    }
+
+    this.updateClassification(insight, identity)
     this.notify(insight)
   }
 
@@ -193,6 +238,10 @@ class InMemoryRequestInsightsStore {
       insight = {
         requestId,
         kind: getRequestInsightKind(identity),
+        source: getRequestInsightSource(identity),
+        proxyStatus: identity.proxyStatus,
+        routerActivity: identity.routerActivity,
+        serverAction: identity.serverAction,
         htmlRequestId: identity.htmlRequestId ?? requestId,
         route: identity.route,
         url: sanitizeUrl(identity.url),
@@ -207,11 +256,24 @@ class InMemoryRequestInsightsStore {
     }
 
     insight.htmlRequestId = identity.htmlRequestId ?? insight.htmlRequestId
+    this.updateClassification(insight, identity)
     insight.route = insight.route ?? identity.route
     insight.url = insight.url ?? sanitizeUrl(identity.url)
     insight.startTime = Math.min(insight.startTime, startTime)
 
     return insight
+  }
+
+  private updateClassification(
+    insight: RequestInsight,
+    identity: RequestInsightIdentity,
+    span?: SpanStoreRecord
+  ): void {
+    const source = identity.source ?? getSourceFromSpan(span)
+    insight.source = refineSource(insight.source, source)
+    insight.proxyStatus = identity.proxyStatus ?? insight.proxyStatus
+    insight.routerActivity = identity.routerActivity ?? insight.routerActivity
+    insight.serverAction = identity.serverAction ?? insight.serverAction
   }
 
   private recordFetchForInsight(
@@ -244,6 +306,28 @@ class InMemoryRequestInsightsStore {
   }
 }
 
+function refineSource(
+  current: RequestInsightSource,
+  candidate: RequestInsightSource | undefined
+): RequestInsightSource {
+  if (!candidate || candidate === 'unknown') {
+    return current
+  }
+  if (
+    candidate === 'app-route' ||
+    candidate === 'pages-api' ||
+    candidate === 'image' ||
+    candidate === 'asset' ||
+    candidate === 'instant-insights'
+  ) {
+    return candidate
+  }
+  if (current === 'unknown' || current === 'proxy') {
+    return candidate
+  }
+  return current
+}
+
 export function recordRequestInsightSpan(span: SpanStoreRecord): void {
   if (
     span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
@@ -259,6 +343,29 @@ export function recordRequestInsightFetch(
   fetch: RequestInsightFetch
 ): void {
   getRequestInsightsStore().recordFetch(identity, fetch)
+}
+
+export function recordRequestInsightRouterActivity(
+  identity: RequestInsightIdentity,
+  routerActivity: RequestInsightRouterActivity
+): void {
+  identity.routerActivity = routerActivity
+  getRequestInsightsStore().recordClassification(identity)
+}
+
+export function recordRequestInsightServerAction(
+  identity: RequestInsightIdentity
+): void {
+  identity.serverAction = true
+  getRequestInsightsStore().recordClassification(identity)
+}
+
+export function recordRequestInsightSource(
+  identity: RequestInsightIdentity,
+  source: RequestInsightSource
+): void {
+  identity.source = source
+  getRequestInsightsStore().recordClassification(identity)
 }
 
 export function getRequestInsightsSnapshot(): RequestInsightsSnapshot {
@@ -301,6 +408,39 @@ function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
     cacheReason: getStringAttribute(attributes['next.fetch.cache_reason']),
     index: getNumberAttribute(attributes['next.fetch.idx']),
   }
+}
+
+function getSourceFromSpan(
+  span: SpanStoreRecord | undefined
+): RequestInsightSource | undefined {
+  if (!span) {
+    return undefined
+  }
+
+  const spanType = getStringAttribute(span.attributes?.['next.span_type'])
+  const markedSource = getStringAttribute(
+    span.attributes?.['next.request_source']
+  )
+  if (markedSource === 'image' || markedSource === 'asset') {
+    return markedSource
+  }
+
+  if (spanType === 'AppRouteRouteHandlers.runHandler') {
+    return 'app-route'
+  }
+  if (spanType === 'Node.runHandler') {
+    return 'pages-api'
+  }
+  if (spanType === 'NextNodeServer.imageOptimizer') {
+    return 'image'
+  }
+  if (spanType === REQUEST_INSIGHT_REQUEST_SPAN_TYPE) {
+    return 'page'
+  }
+  if (spanType === REQUEST_INSIGHT_PROXY_SPAN_TYPE) {
+    return 'proxy'
+  }
+  return undefined
 }
 
 function sanitizeFetchInsight(fetch: RequestInsightFetch): RequestInsightFetch {

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -1,5 +1,10 @@
 import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 
 export type SpanStoreAttributes = Record<string, AttributeValue>
 
@@ -26,6 +31,10 @@ export type SpanStoreRecord = {
   parentSpanId?: string
   requestId?: string
   requestInsightKind?: RequestInsightKind
+  requestInsightSource?: RequestInsightSource
+  requestInsightProxyStatus?: RequestInsightProxyStatus
+  requestInsightRouterActivity?: RequestInsightRouterActivity
+  requestInsightServerAction?: true
   htmlRequestId?: string
   route?: string
   url?: string

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -14,6 +14,7 @@ import type { OpaqueFallbackRouteParams } from './request/fallback-params'
 import type { IncrementalCache } from './lib/incremental-cache'
 import type { RevalidateFn } from './lib/router-utils/router-server-context'
 import type { NextRequest } from './web/exports'
+import type { RequestInsightsIdentity } from './lib/trace/request-insights-identity'
 
 // FIXME: (wyattjoh) this is a temporary solution to allow us to pass data between bundled modules
 export const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
@@ -49,6 +50,8 @@ export type OnCacheEntryHandler = (
 ) => Promise<boolean | void> | boolean | void
 
 export interface RequestMeta {
+  /** Server-owned identity for the development Request Insights timeline. */
+  requestInsightsIdentity?: RequestInsightsIdentity
   /**
    * The query that was used to make the request.
    */

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -91,6 +91,37 @@ import { InvariantError } from '../../../shared/lib/invariant-error'
 import { LazyModule } from '../../lib/lazy-module'
 import { createPrerenderResumeDataCache } from '../../resume-data-cache/resume-data-cache'
 
+type AppRouteRequestInsightsRuntime = {
+  getRequestInsightsIdentity: typeof import('../../lib/trace/request-insights-identity').getRequestInsightsIdentity
+  recordRequestInsightSource: typeof import('../../lib/trace/request-insights').recordRequestInsightSource
+}
+
+let appRouteRequestInsightsRuntime: AppRouteRequestInsightsRuntime | undefined
+
+function markAppRouteRequestSource(): void {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!appRouteRequestInsightsRuntime) {
+      const { getRequestInsightsIdentity } =
+        require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
+      const { recordRequestInsightSource } =
+        require('../../lib/trace/request-insights') as typeof import('../../lib/trace/request-insights')
+
+      appRouteRequestInsightsRuntime = {
+        getRequestInsightsIdentity,
+        recordRequestInsightSource,
+      }
+    }
+
+    const identity = appRouteRequestInsightsRuntime.getRequestInsightsIdentity()
+    if (identity) {
+      appRouteRequestInsightsRuntime.recordRequestInsightSource(
+        identity,
+        'app-route'
+      )
+    }
+  }
+}
+
 export class WrappedNextRouterError {
   constructor(
     public readonly error: RedirectError,
@@ -838,6 +869,8 @@ export class AppRouteRouteModule extends RouteModule<
     req: NextRequest,
     context: AppRouteRouteHandlerContext
   ): Promise<PreparedAppRouteExecution> {
+    markAppRouteRequestSource()
+
     // Ensure userland is fully loaded (handles async modules with top-level
     // await, where require() returns a Promise instead of the module).
     await this.ensureUserland()

--- a/packages/next/src/shared/lib/request-insights.ts
+++ b/packages/next/src/shared/lib/request-insights.ts
@@ -1,14 +1,52 @@
 export type RequestInsightKind = 'request' | 'instant-insights'
 
+export const REQUEST_INSIGHT_REQUEST_SPAN_TYPE = 'BaseServer.handleRequest'
+export const REQUEST_INSIGHT_PROXY_SPAN_TYPE = 'Middleware.execute'
+
+export const REQUEST_INSIGHT_SOURCES = [
+  'page',
+  'app-route',
+  'pages-api',
+  'image',
+  'asset',
+  'proxy',
+  'instant-insights',
+  'unknown',
+] as const
+
+export type RequestInsightSource = (typeof REQUEST_INSIGHT_SOURCES)[number]
+export type RequestInsightProxyStatus = 'matched' | 'bypassed'
+
+export const REQUEST_INSIGHT_ROUTER_ACTIVITIES = [
+  'prefetch',
+  'segment-prefetch',
+  'hmr-refresh',
+] as const
+
+export type RequestInsightRouterActivity =
+  (typeof REQUEST_INSIGHT_ROUTER_ACTIVITIES)[number]
+
 export type RequestInsightIdentity = {
   requestId: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
 }
 
 export function getRequestInsightKind(
   insight: Pick<RequestInsightIdentity, 'kind'>
 ): RequestInsightKind {
   return insight.kind ?? 'request'
+}
+
+export function getRequestInsightSource(
+  insight: Pick<RequestInsightIdentity, 'kind' | 'source'>
+): RequestInsightSource {
+  if (getRequestInsightKind(insight) === 'instant-insights') {
+    return 'instant-insights'
+  }
+  return insight.source ?? 'unknown'
 }
 
 export function getRequestInsightKey(insight: RequestInsightIdentity): string {

--- a/packages/next/src/telemetry/post-telemetry-payload.test.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.test.ts
@@ -45,6 +45,92 @@ describe('postNextTelemetryPayload', () => {
     )
   })
 
+  it('bypasses only the Next.js patched fetch wrapper', async () => {
+    const originFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    const patchedFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      (input, init) => originFetch(input, init)
+    )
+    Object.assign(patchedFetch, {
+      __nextPatched: true,
+      _nextOriginalFetch: originFetch,
+    })
+    global.fetch = patchedFetch
+
+    const payload = {
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    }
+
+    await postNextTelemetryPayload(payload)
+
+    expect(patchedFetch).not.toHaveBeenCalled()
+    expect(originFetch).toHaveBeenCalledTimes(1)
+
+    await global.fetch('https://telemetry.nextjs.org/api/v1/record')
+
+    expect(patchedFetch).toHaveBeenCalledTimes(1)
+    expect(originFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not trust an unbranded _nextOriginalFetch property', async () => {
+    const unrelatedOriginalFetch = jest.fn(
+      async () => new Response(null, { status: 204 })
+    )
+    const customFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    Object.assign(customFetch, {
+      _nextOriginalFetch: unrelatedOriginalFetch,
+    })
+    global.fetch = customFetch
+
+    await postNextTelemetryPayload({
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    })
+
+    expect(customFetch).toHaveBeenCalledTimes(1)
+    expect(unrelatedOriginalFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not trust a non-callable _nextOriginalFetch property', async () => {
+    const customFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    Object.assign(customFetch, {
+      __nextPatched: true,
+      _nextOriginalFetch: 'not a function',
+    })
+    global.fetch = customFetch
+
+    await postNextTelemetryPayload({
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    })
+
+    expect(customFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('retries on failure', async () => {
     const mockFetch = jest
       .fn()

--- a/packages/next/src/telemetry/post-telemetry-payload.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.ts
@@ -15,6 +15,23 @@ interface Payload {
   }>
 }
 
+type MaybePatchedFetch = typeof fetch & {
+  readonly __nextPatched?: true
+  readonly _nextOriginalFetch?: typeof fetch
+}
+
+function getTelemetryFetch(): typeof fetch {
+  const currentFetch = globalThis.fetch as MaybePatchedFetch
+
+  // Framework telemetry is process activity, not application request work.
+  // Avoid inheriting an active render's patched-fetch context while preserving
+  // any user-provided fetch implementation when Next has not patched it.
+  return currentFetch.__nextPatched === true &&
+    typeof currentFetch._nextOriginalFetch === 'function'
+    ? currentFetch._nextOriginalFetch
+    : currentFetch
+}
+
 export function postNextTelemetryPayload(payload: Payload, signal?: any) {
   if (!signal && 'timeout' in AbortSignal) {
     signal = AbortSignal.timeout(5000)
@@ -22,7 +39,7 @@ export function postNextTelemetryPayload(payload: Payload, signal?: any) {
   return (
     retry(
       () =>
-        fetch('https://telemetry.nextjs.org/api/v1/record', {
+        getTelemetryFetch()('https://telemetry.nextjs.org/api/v1/record', {
           method: 'POST',
           body: JSON.stringify(payload),
           headers: { 'content-type': 'application/json' },

--- a/test/development/app-dir/request-insights/app/actions/cached-function-button.tsx
+++ b/test/development/app-dir/request-insights/app/actions/cached-function-button.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { runCachedFunction } from './cached'
+
+export function CachedFunctionButton() {
+  const [result, setResult] = useState('idle')
+  const [, startTransition] = useTransition()
+
+  return (
+    <>
+      <button
+        id="run-cached-function"
+        type="button"
+        onClick={() => {
+          startTransition(async () => {
+            setResult(await runCachedFunction())
+          })
+        }}
+      >
+        Run cached function
+      </button>
+      <p id="cached-function-result">{result}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/actions/cached.ts
+++ b/test/development/app-dir/request-insights/app/actions/cached.ts
@@ -1,0 +1,5 @@
+'use cache'
+
+export async function runCachedFunction() {
+  return 'cached-function-complete'
+}

--- a/test/development/app-dir/request-insights/app/actions/page.tsx
+++ b/test/development/app-dir/request-insights/app/actions/page.tsx
@@ -1,0 +1,18 @@
+import { CachedFunctionButton } from './cached-function-button'
+
+export default function ActionsPage() {
+  async function runAction() {
+    'use server'
+  }
+
+  return (
+    <>
+      <form action={runAction}>
+        <button id="run-server-action" type="submit">
+          Run action
+        </button>
+      </form>
+      <CachedFunctionButton />
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/api/app-stream-lifecycle/route.ts
+++ b/test/development/app-dir/request-insights/app/api/app-stream-lifecycle/route.ts
@@ -1,0 +1,46 @@
+const requestInsightsGlobal = globalThis as typeof globalThis & {
+  requestInsightsPendingAppRouteHandlers?: Map<string, () => void>
+}
+const pendingHandlers =
+  (requestInsightsGlobal.requestInsightsPendingAppRouteHandlers ??= new Map())
+
+export async function GET(request: Request) {
+  const waitKey = new URL(request.url).searchParams.get('wait')
+  if (waitKey) {
+    await new Promise<void>((resolve) => {
+      pendingHandlers.set(waitKey, resolve)
+    })
+  }
+
+  const encoder = new TextEncoder()
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('started\n'))
+        queueMicrotask(() => {
+          controller.enqueue(encoder.encode('finished\n'))
+          controller.close()
+        })
+      },
+    }),
+    {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      status: 202,
+    }
+  )
+}
+
+export function POST(request: Request) {
+  const waitKey = new URL(request.url).searchParams.get('release')
+  const release = waitKey ? pendingHandlers.get(waitKey) : undefined
+  if (!waitKey || !release) {
+    return new Response(null, { status: 404 })
+  }
+
+  pendingHandlers.delete(waitKey)
+  release()
+  return new Response(null, { status: 204 })
+}

--- a/test/development/app-dir/request-insights/app/api/proxied-page/page.tsx
+++ b/test/development/app-dir/request-insights/app/api/proxied-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>proxied page</p>
+}

--- a/test/development/app-dir/request-insights/app/api/source/route.ts
+++ b/test/development/app-dir/request-insights/app/api/source/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ source: 'app-route' })
+}

--- a/test/development/app-dir/request-insights/app/behind-proxy/page.tsx
+++ b/test/development/app-dir/request-insights/app/behind-proxy/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>behind proxy</p>
+}

--- a/test/development/app-dir/request-insights/app/instant-insights/page.tsx
+++ b/test/development/app-dir/request-insights/app/instant-insights/page.tsx
@@ -1,5 +1,17 @@
 export const instant = { level: 'experimental-error' }
 
-export default function Page() {
-  return <p>instant insights</p>
+async function fillCache() {
+  'use cache'
+
+  return 'instant insights'
+}
+
+export default async function Page() {
+  const message = await fetch('data:text/plain,instant insights', {
+    cache: 'force-cache',
+  }).then((response) => response.text())
+
+  await fillCache()
+
+  return <p>{message}</p>
 }

--- a/test/development/app-dir/request-insights/proxy.ts
+++ b/test/development/app-dir/request-insights/proxy.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  if (
+    request.nextUrl.pathname === '/request-insights-asset.svg' &&
+    request.nextUrl.searchParams.has('rewrite-to-page')
+  ) {
+    return NextResponse.rewrite(new URL('/behind-proxy', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/:path*', '/request-insights-asset.svg'],
+}

--- a/test/development/app-dir/request-insights/public/request-insights-asset.svg
+++ b/test/development/app-dir/request-insights/public/request-insights-asset.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path d="M0 0h1v1H0z" />
+</svg>

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -10,6 +10,18 @@ import {
 type RequestInsight = {
   requestId: string
   kind?: 'request' | 'instant-insights'
+  source:
+    | 'page'
+    | 'app-route'
+    | 'pages-api'
+    | 'image'
+    | 'asset'
+    | 'proxy'
+    | 'instant-insights'
+    | 'unknown'
+  proxyStatus?: 'matched' | 'bypassed'
+  routerActivity?: 'prefetch' | 'segment-prefetch' | 'hmr-refresh'
+  serverAction?: true
   htmlRequestId: string
   route: string
   url?: string
@@ -41,6 +53,7 @@ describe('request insights', () => {
   function createRequest(index: number, fetchCount = 0): RequestInsight {
     return {
       requestId: `request-${index}`,
+      source: 'page',
       htmlRequestId: `page-${index}`,
       route: `/route-${index}`,
       startTime: index,
@@ -356,6 +369,61 @@ describe('request insights', () => {
           'AppRender.getBodyResult',
         ])
       )
+    })
+  })
+
+  it('classifies static files as assets in the serialized snapshot', async () => {
+    const response = await next.fetch('/request-insights-asset.svg')
+    expect(response.status).toBe(200)
+    await response.text()
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/request-insights-asset.svg' &&
+          candidate.kind !== 'instant-insights'
+      )
+
+      expect(request).toEqual(expect.objectContaining({ source: 'asset' }))
+    })
+  })
+
+  it('does not classify an asset URL rewritten by proxy as an asset', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((insightsResponse) => insightsResponse.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const response = await next.fetch(
+      '/request-insights-asset.svg?rewrite-to-page=1'
+    )
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('behind proxy')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.route === '/behind-proxy' &&
+          !existingRequestIds.has(candidate.requestId) &&
+          candidate.kind !== 'instant-insights'
+      )
+
+      expect(request).toEqual(expect.objectContaining({ source: 'page' }))
     })
   })
 
@@ -739,6 +807,269 @@ describe('request insights', () => {
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
+    })
+  })
+
+  it('classifies framework-owned request activity without retaining action IDs', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const routeResponse = await next.fetch('/api/source')
+    expect(routeResponse.status).toBe(200)
+    const prefetchResponse = await next.fetch('/?activity=prefetch', {
+      headers: {
+        rsc: '1',
+        'next-router-prefetch': '2',
+      },
+    })
+    expect(prefetchResponse.status).toBe(200)
+    const actionIds: string[] = []
+    const browser = await next.browser('/actions', {
+      beforePageLoad(page) {
+        page.route('**/actions**', async (route) => {
+          const actionId = (await route.request().allHeaders())['next-action']
+          if (actionId) {
+            actionIds.push(actionId)
+          }
+          await route.continue()
+        })
+      },
+    })
+    await browser.eval(() => {
+      document.querySelector<HTMLButtonElement>('#run-server-action')?.click()
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const requests = snapshot.requests.filter(
+        (request) => !existingRequestIds.has(request.requestId)
+      )
+
+      expect(requests.find((request) => request.url === '/api/source')).toEqual(
+        expect.objectContaining({
+          source: 'app-route',
+          proxyStatus: 'matched',
+        })
+      )
+      expect(
+        requests.find((request) => request.routerActivity === 'prefetch')
+      ).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          proxyStatus: 'bypassed',
+          routerActivity: 'prefetch',
+        })
+      )
+      expect(
+        requests.find(
+          (request) =>
+            request.route === '/actions' && request.serverAction === true
+        )
+      ).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          serverAction: true,
+        })
+      )
+
+      const serialized = JSON.stringify(requests)
+      expect(actionIds).toHaveLength(1)
+      expect(actionIds[0]).toMatch(/^[0-9a-f]{42}$/)
+      for (const actionId of actionIds) {
+        expect(serialized).not.toContain(actionId)
+      }
+      expect(serialized).not.toContain('next-action')
+    })
+
+    const requestIdsAfterAction = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    await browser.elementById('run-cached-function').click()
+    await retry(async () => {
+      expect(await browser.elementById('cached-function-result').text()).toBe(
+        'cached-function-complete'
+      )
+    })
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const cacheRequests = snapshot.requests.filter(
+        (request) =>
+          !requestIdsAfterAction.has(request.requestId) &&
+          request.route === '/actions' &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'POST'
+          )
+      )
+
+      expect(cacheRequests).toHaveLength(1)
+      expect(cacheRequests[0].serverAction).toBeUndefined()
+      expect(actionIds).toHaveLength(2)
+      expect(JSON.stringify(cacheRequests[0])).not.toContain(actionIds[1])
+    })
+  })
+
+  it('classifies an App Route before its handler completes', async () => {
+    const waitKey = `active-${Date.now()}`
+    const requestPath = `/api/app-stream-lifecycle?wait=${waitKey}`
+    const responsePromise = next.fetch(requestPath)
+
+    try {
+      await retry(async () => {
+        const snapshot = (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+        const matchingRequests = snapshot.requests.filter(
+          (request) => request.url === requestPath
+        )
+
+        expect(matchingRequests).toHaveLength(1)
+        expect(matchingRequests[0]).toEqual(
+          expect.objectContaining({
+            source: 'app-route',
+            proxyStatus: 'matched',
+          })
+        )
+      })
+    } finally {
+      const release = await next.fetch(
+        `/api/app-stream-lifecycle?release=${waitKey}`,
+        { method: 'POST' }
+      )
+      expect(release.status).toBe(204)
+    }
+
+    const response = await responsePromise
+    expect(response.status).toBe(202)
+    expect(await response.text()).toContain('finished')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const matchingRequests = snapshot.requests.filter(
+        (request) =>
+          request.url === requestPath && request.kind !== 'instant-insights'
+      )
+
+      expect(matchingRequests).toHaveLength(1)
+      expect(
+        matchingRequests[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'Middleware.execute',
+          'BaseServer.handleRequest',
+          'AppRouteRouteHandlers.runHandler',
+        ])
+      )
+    })
+  })
+
+  it('classifies a Page after proxy completes', async () => {
+    const requestPath = `/api/proxied-page?run=${Date.now()}`
+    const response = await next.fetch(requestPath)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('proxied page')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const matchingRequests = snapshot.requests.filter(
+        (request) =>
+          request.url === requestPath && request.kind !== 'instant-insights'
+      )
+
+      expect(matchingRequests).toHaveLength(1)
+      expect(matchingRequests[0]).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          proxyStatus: 'matched',
+        })
+      )
+      expect(
+        matchingRequests[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'Middleware.execute',
+          'BaseServer.handleRequest',
+          'AppRender.getBodyResult',
+        ])
+      )
+    })
+  })
+
+  it('does not trust an unrecognized Server Action header', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const forgedActionId = '00'.repeat(21)
+
+    const response = await next.fetch('/actions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'text/plain',
+        'next-action': forgedActionId,
+      },
+      body: '[]',
+    })
+    expect(response.ok).toBe(false)
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const forgedRequest = snapshot.requests.find(
+        (request) =>
+          !existingRequestIds.has(request.requestId) &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'POST'
+          )
+      )
+
+      expect(forgedRequest).toBeDefined()
+      expect(forgedRequest?.serverAction).toBeUndefined()
+      expect(JSON.stringify(forgedRequest)).not.toContain(forgedActionId)
     })
   })
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -559,6 +559,16 @@ describe('request insights', () => {
         })
       )
       expect(instantInsights?.htmlRequestId).toBe(request?.htmlRequestId)
+      expect(request?.fetches).toEqual([
+        expect.objectContaining({
+          url: 'data:text/plain,instant insights',
+        }),
+      ])
+      expect(instantInsights?.fetches).toEqual([
+        expect.objectContaining({
+          url: 'data:text/plain,instant insights',
+        }),
+      ])
       const rootSpans = instantInsights?.spans.filter(
         (span) =>
           span.attributes?.['next.span_type'] === 'AppRender.instantInsights' &&

--- a/test/unit/devtools-config-middleware/index.test.ts
+++ b/test/unit/devtools-config-middleware/index.test.ts
@@ -1,0 +1,364 @@
+import type { IncomingMessage, ServerResponse } from 'http'
+import * as fsPromises from 'fs/promises'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  devToolsConfigMiddleware,
+  getDevToolsConfig,
+} from 'next/dist/next-devtools/server/devtools-config-middleware'
+
+jest.mock('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises')
+  return {
+    ...actual,
+    rename: jest.fn(actual.rename),
+    writeFile: jest.fn(actual.writeFile),
+  }
+})
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function createRequest(
+  body: object,
+  {
+    bodyRequested,
+    bodyConsumed,
+    releaseBody,
+  }: {
+    bodyRequested?: ReturnType<typeof createDeferred>
+    bodyConsumed?: ReturnType<typeof createDeferred>
+    releaseBody?: Promise<void>
+  } = {}
+): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      bodyRequested?.resolve()
+      await releaseBody
+      yield Buffer.from(JSON.stringify(body))
+      bodyConsumed?.resolve()
+    },
+  } as IncomingMessage
+}
+
+function createResponse(): ServerResponse {
+  return {
+    end: jest.fn(),
+    setHeader: jest.fn(),
+  } as unknown as ServerResponse
+}
+
+function createChunkedRequest(chunks: Buffer[]): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      yield* chunks
+    },
+  } as IncomingMessage
+}
+
+describe('DevTools config middleware', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    distDir = await mkdtemp(join(tmpdir(), 'next-devtools-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(distDir, { recursive: true, force: true })
+  })
+
+  it('commits concurrent patches in request arrival order', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const bodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstResponse = createResponse()
+    const secondResponse = createResponse()
+
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { showInternal: true, verbose: false } },
+        {
+          bodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      firstResponse,
+      jest.fn()
+    )
+
+    await bodyRequested.promise
+    const secondBodyConsumed = createDeferred()
+    const secondRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: secondBodyConsumed }
+      ),
+      secondResponse,
+      jest.fn()
+    )
+
+    await secondBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, secondRequest])
+
+    const config = JSON.parse(
+      await readFile(
+        join(distDir, 'cache', 'next-devtools-config.json'),
+        'utf8'
+      )
+    )
+    expect(config).toEqual({
+      requestInsights: {
+        showInternal: true,
+        verbose: true,
+      },
+    })
+    expect(firstResponse.statusCode).toBe(204)
+    expect(secondResponse.statusCode).toBe(204)
+    expect(sendUpdateSignal).toHaveBeenLastCalledWith(config)
+  })
+
+  it('keeps a queue reservation after an invalid request finishes early', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    const firstBodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: false } },
+        {
+          bodyRequested: firstBodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await firstBodyRequested.promise
+    const invalidResponse = createResponse()
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      invalidResponse,
+      jest.fn()
+    )
+    expect(invalidResponse.statusCode).toBe(413)
+
+    const thirdBodyConsumed = createDeferred()
+    const thirdRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: thirdBodyConsumed }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await thirdBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, thirdRequest])
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { verbose: true },
+    })
+  })
+
+  it('keeps the previous config readable until an update is complete', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    const writeStarted = createDeferred()
+    const releaseWrite = createDeferred()
+    const { writeFile } =
+      jest.requireActual<typeof import('fs/promises')>('fs/promises')
+    const writeFileMock = jest.mocked(fsPromises.writeFile)
+    writeFileMock.mockImplementation(async (path, contents, options) => {
+      const serialized = String(contents)
+      if (serialized.includes('"verbose": true')) {
+        await writeFile(path, serialized.slice(0, serialized.length / 2))
+        writeStarted.resolve()
+        await releaseWrite.promise
+      }
+      return writeFile(path, contents, options)
+    })
+
+    try {
+      const update = middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+      await writeStarted.promise
+
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: { showInternal: true },
+      })
+
+      releaseWrite.resolve()
+      await update
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      })
+    } finally {
+      releaseWrite.resolve()
+      writeFileMock.mockImplementation(writeFile)
+      writeFileMock.mockClear()
+    }
+  })
+
+  it('does not let a missing-file read overwrite the first update', async () => {
+    const writeFile = jest.mocked(fsPromises.writeFile)
+    writeFile.mockClear()
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+    expect(writeFile).not.toHaveBeenCalled()
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a corrupted config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, '{not valid JSON')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a schema-invalid config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, JSON.stringify({ theme: 123 }))
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('keeps the previous config and releases the queue after a failed rename', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    sendUpdateSignal.mockClear()
+
+    jest
+      .mocked(fsPromises.rename)
+      .mockRejectedValueOnce(new Error('rename failed'))
+
+    await expect(
+      middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+    ).rejects.toThrow('rename failed')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(fsPromises.readdir(join(distDir, 'cache'))).resolves.toEqual([
+      'next-devtools-config.json',
+    ])
+
+    await middleware(
+      createRequest({ requestInsights: { verbose: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true, verbose: true },
+    })
+  })
+
+  it('rejects config request bodies larger than 64 KiB', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const response = createResponse()
+
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      response,
+      jest.fn()
+    )
+
+    expect(response.statusCode).toBe(413)
+    expect(response.end).toHaveBeenCalledWith('Payload Too Large')
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+  })
+})

--- a/test/unit/request-insights-instant-context/index.test.ts
+++ b/test/unit/request-insights-instant-context/index.test.ts
@@ -1,0 +1,173 @@
+import { createSnapshot } from '../../../packages/next/src/server/app-render/async-local-storage'
+import { createInstantInsightsWorkStore } from '../../../packages/next/src/server/app-render/instant-insights-work-store'
+import {
+  workAsyncStorage,
+  type WorkStore,
+} from '../../../packages/next/src/server/app-render/work-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  type RequestStore,
+} from '../../../packages/next/src/server/app-render/work-unit-async-storage.external'
+import {
+  createLocalSpan,
+  getActiveLocalSpan,
+  withLocalSpan,
+} from '../../../packages/next/src/server/lib/trace/local-span-recorder'
+import {
+  getRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+  type RequestInsightsIdentity,
+} from '../../../packages/next/src/server/lib/trace/request-insights-identity'
+
+function createTestWorkStore(): WorkStore {
+  return {
+    route: '/instant-insights',
+    invalidDynamicUsageError: new Error('foreground'),
+    dynamicUsageDescription: 'foreground',
+    dynamicUsageStack: 'foreground',
+    nextFetchId: 1,
+    pathWasRevalidated: 'tag',
+    pendingRevalidates: { foreground: Promise.resolve() },
+    pendingRevalidateWrites: [Promise.resolve()],
+    pendingRevalidatedTags: [
+      { tag: 'foreground', revalidatedAt: performance.now() },
+    ],
+    previouslyRevalidatedTags: ['foreground'],
+    refreshTagsByCacheKind: new Map([['foreground', Promise.resolve()]]),
+    fetchMetrics: [{}],
+    shouldTrackFetchMetrics: true,
+    pendingCacheInvocations: new Map([['foreground', Promise.resolve({})]]),
+    completedCacheInvocations: new Map([['foreground', Promise.resolve({})]]),
+    reactServerErrorsByDigest: new Map([
+      ['foreground', new Error('foreground')],
+    ]),
+    additionalClientReferenceManifestPages: new Set(['/foreground']),
+    runInCleanSnapshot: (fn, ...args) => fn(...args),
+  } as unknown as WorkStore
+}
+
+describe('Instant Insights work store', () => {
+  const originalNextDevServer = process.env.__NEXT_DEV_SERVER
+
+  beforeAll(() => {
+    process.env.__NEXT_DEV_SERVER = '1'
+  })
+
+  afterAll(() => {
+    if (originalNextDevServer === undefined) {
+      delete process.env.__NEXT_DEV_SERVER
+    } else {
+      process.env.__NEXT_DEV_SERVER = originalNextDevServer
+    }
+  })
+
+  it('isolates validation state and restores diagnostic ownership in clean snapshots', () => {
+    const foregroundIdentity: RequestInsightsIdentity = {
+      requestId: 'request',
+      htmlRequestId: 'page',
+      url: '/instant-insights',
+    }
+    const instantInsightsIdentity: RequestInsightsIdentity = {
+      ...foregroundIdentity,
+      kind: 'instant-insights',
+    }
+    const foregroundWorkStore = createTestWorkStore()
+    const foregroundWorkUnitStore = {
+      type: 'request',
+      phase: 'render',
+    } as unknown as RequestStore
+    const foregroundSpan = createLocalSpan({ name: 'foreground' })
+    const foregroundAfterContext = foregroundWorkStore.afterContext
+
+    workAsyncStorage.run(foregroundWorkStore, () =>
+      workUnitAsyncStorage.run(foregroundWorkUnitStore, () =>
+        runWithRequestInsightsIdentity(foregroundIdentity, () =>
+          withLocalSpan(foregroundSpan, () => {
+            foregroundWorkStore.runInCleanSnapshot = createSnapshot()
+          })
+        )
+      )
+    )
+
+    const instantInsightsWorkStore =
+      createInstantInsightsWorkStore(foregroundWorkStore)
+    const instantInsightsSpan = createLocalSpan({ name: 'Instant Insights' })
+
+    let observed:
+      | {
+          identity: RequestInsightsIdentity | undefined
+          workStore: WorkStore | undefined
+          workUnitStore: RequestStore | undefined
+          span: ReturnType<typeof getActiveLocalSpan>
+        }
+      | undefined
+
+    workAsyncStorage.run(instantInsightsWorkStore, () =>
+      runWithRequestInsightsIdentity(instantInsightsIdentity, () =>
+        withLocalSpan(instantInsightsSpan, () =>
+          instantInsightsWorkStore.runInCleanSnapshot(() => {
+            observed = {
+              identity: getRequestInsightsIdentity(),
+              workStore: workAsyncStorage.getStore(),
+              workUnitStore: workUnitAsyncStorage.getStore() as
+                | RequestStore
+                | undefined,
+              span: getActiveLocalSpan(),
+            }
+          })
+        )
+      )
+    )
+
+    expect(observed).toEqual({
+      identity: instantInsightsIdentity,
+      workStore: instantInsightsWorkStore,
+      workUnitStore: undefined,
+      span: instantInsightsSpan,
+    })
+    expect(instantInsightsWorkStore.fetchMetrics).toEqual([])
+    expect(instantInsightsWorkStore.fetchMetrics).not.toBe(
+      foregroundWorkStore.fetchMetrics
+    )
+    expect(instantInsightsWorkStore.pendingCacheInvocations).toEqual(new Map())
+    expect(instantInsightsWorkStore.pendingCacheInvocations).not.toBe(
+      foregroundWorkStore.pendingCacheInvocations
+    )
+    expect(instantInsightsWorkStore.completedCacheInvocations).toEqual(
+      new Map()
+    )
+    expect(instantInsightsWorkStore.completedCacheInvocations).not.toBe(
+      foregroundWorkStore.completedCacheInvocations
+    )
+    expect(instantInsightsWorkStore.pendingRevalidates).toEqual({})
+    expect(instantInsightsWorkStore.pendingRevalidateWrites).toEqual([])
+    expect(instantInsightsWorkStore.pendingRevalidatedTags).toEqual([])
+    expect(instantInsightsWorkStore.previouslyRevalidatedTags).toEqual([])
+    expect(instantInsightsWorkStore.refreshTagsByCacheKind).toEqual(new Map())
+    expect(instantInsightsWorkStore.shouldTrackFetchMetrics).toBe(false)
+    expect(instantInsightsWorkStore.afterContext).toBeDefined()
+    expect(instantInsightsWorkStore.afterContext).not.toBe(
+      foregroundAfterContext
+    )
+    expect(instantInsightsWorkStore.reactServerErrorsByDigest).toEqual(
+      new Map()
+    )
+    expect(instantInsightsWorkStore.reactServerErrorsByDigest).not.toBe(
+      foregroundWorkStore.reactServerErrorsByDigest
+    )
+    expect(instantInsightsWorkStore.invalidDynamicUsageError).toBeUndefined()
+    expect(instantInsightsWorkStore.dynamicUsageDescription).toBeUndefined()
+    expect(instantInsightsWorkStore.dynamicUsageStack).toBeUndefined()
+    expect(instantInsightsWorkStore.nextFetchId).toBeUndefined()
+    expect(instantInsightsWorkStore.pathWasRevalidated).toBeUndefined()
+    expect(
+      instantInsightsWorkStore.additionalClientReferenceManifestPages
+    ).toEqual(new Set(['/foreground']))
+    expect(
+      instantInsightsWorkStore.additionalClientReferenceManifestPages
+    ).not.toBe(foregroundWorkStore.additionalClientReferenceManifestPages)
+
+    instantInsightsSpan.end()
+    foregroundSpan.end()
+  })
+})


### PR DESCRIPTION
## Summary

This PR establishes the trusted Request Insights classification and isolation foundation. It changes how internal data is interpreted locally without renaming stable public OpenTelemetry definitions.

- `Use Proxy terminology in Request Insights`
  - presents the existing `Middleware.execute` span as Proxy activity only in the Request Insights viewer
  - leaves the public span name and attributes unchanged for existing OTel consumers
- `Persist DevTools configuration atomically`
  - routes Request Insights settings through the shared bounded atomic DevTools configuration writer
  - ensures persisted Internal activity is available on the initial overlay load instead of requiring an off/on toggle
- `Avoid instrumenting Next.js telemetry requests`
  - excludes framework-owned telemetry transport from application request/fetch activity
  - prevents validation and telemetry traffic from leaking into foreground records
- `Classify framework request activity`
  - adds normalized Page, App Route/API, Pages API, image, static asset, RSC, Proxy, and confirmed Server Action classifications
  - derives classifications from trusted framework evidence rather than URL naming alone
  - detects streaming App Routes before their handler completes
  - records only `serverAction: true`; raw action IDs are never retained
  - rejects malformed or forged correlation/action headers
- `Isolate Instant Insights render state`
  - creates an isolated Instant Insights WorkStore instead of copying mutable foreground diagnostic state
  - resets metrics, cache invocation maps, revalidation state, errors, identity, and after-context while preserving safe route/build configuration
  - includes an exhaustive type-only inherit/reset policy for every WorkStore field so future fields fail typechecking until explicitly classified
  - introduces the optional Request Insights identity declaration in the same layer as its first use, keeping every intermediate PR head type-correct

Security boundary: `x-nextjs-request-id` and `x-nextjs-html-request-id` are bounded dev-only correlation hints. Malformed values are removed at ingress, and neither value is authoritative for server-owned capture identity.

## Verification

- exact layer head passes `pnpm --filter=next types`
- focused Proxy wording, configuration persistence, telemetry exclusion, trusted classification, forged-header, and Instant-context tests
- WorkStore guard covers all current fields and emits no runtime JavaScript
- Request Insights suite covers pages, streaming APIs, Pages APIs, images, assets, RSC activity, Proxy activity, confirmed actions, and forged action rejection in both bundlers
- public OTel audit confirms no new default-public definition or allowlist entry
- final Fable 5 corrected-stack review: `SHIP`, zero blockers
