### PR TITLE
Persist DevTools configuration atomically

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -199,6 +199,31 @@ describe('request insights trace viewer', () => {
     ])
   })
 
+  it('uses Proxy terminology without changing the recorded OTel span', () => {
+    const middlewareSpan = {
+      name: 'middleware POST',
+      startTime: 100,
+      durationMs: 10,
+      attributes: {
+        'http.method': 'POST',
+        'next.span_name': 'middleware POST',
+        'next.span_type': 'Middleware.execute',
+      },
+    }
+    const request = createRequest({ spans: [middlewareSpan] })
+
+    expect(getTraceItems(request, false)[0]?.label).toBe('proxy POST')
+    expect(middlewareSpan).toEqual(
+      expect.objectContaining({
+        name: 'middleware POST',
+        attributes: expect.objectContaining({
+          'next.span_name': 'middleware POST',
+          'next.span_type': 'Middleware.execute',
+        }),
+      })
+    )
+  })
+
   it('orders spans by their recorded parent-child hierarchy', () => {
     const request = createRequest({
       spans: [

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -26,9 +26,10 @@ export type TraceRange = {
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
 
 const FETCH_SPAN_TYPE = 'AppRender.fetch'
+const MIDDLEWARE_SPAN_TYPE = 'Middleware.execute'
 const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'BaseServer.handleRequest',
-  'Middleware.execute',
+  MIDDLEWARE_SPAN_TYPE,
   'NextNodeServer.matchRoute',
   'DevRouteMatcherManager.ensureRoute',
   'BaseServer.render',
@@ -349,6 +350,13 @@ function getSpanLabel(span: RequestInsightSpan): string {
   const displayName = name
     .replace(FIZZ_WORD, 'HTML')
     .replace(FLIGHT_WORD, 'RSC')
+
+  if (span.attributes?.['next.span_type'] === MIDDLEWARE_SPAN_TYPE) {
+    const method = span.attributes['http.method']
+    return typeof method === 'string' && method.length > 0
+      ? `proxy ${method}`
+      : displayName.replace(/^middleware\b/i, 'proxy')
+  }
 
   if (displayName === 'resolve segment modules') {
     return 'resolve segment'

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
+type DevToolsWindow = Window & {
+  [PAGEHIDE_LISTENER_KEY]?: () => void
+}
+
+const originalFetch = global.fetch
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function removePagehideListener() {
+  const devToolsWindow = window as DevToolsWindow
+  const listener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+
+  if (listener) {
+    window.removeEventListener('pagehide', listener)
+    delete devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  }
+}
+
+describe('saveDevToolsConfig', () => {
+  let fetchMock: jest.Mock
+  let warnMock: jest.SpyInstance
+
+  beforeEach(() => {
+    removePagehideListener()
+    jest.resetModules()
+    jest.useFakeTimers()
+    fetchMock = jest.fn()
+    global.fetch = fetchMock
+    warnMock = jest.spyOn(console, 'warn').mockImplementation()
+  })
+
+  afterEach(async () => {
+    await flushMicrotasks()
+    removePagehideListener()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    global.fetch = originalFetch
+    warnMock.mockRestore()
+  })
+
+  it('serializes writes and retries a merged patch after a failed response', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let activeRequests = 0
+    let maximumActiveRequests = 0
+
+    fetchMock
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return new Promise<{ ok: boolean }>((resolve) => {
+          resolveFirstRequest = resolve
+        }).finally(() => {
+          activeRequests--
+        })
+      })
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return Promise.resolve({ ok: true }).finally(() => {
+          activeRequests--
+        })
+      })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({
+      requestInsights: { showInternal: true, verbose: false },
+    })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveFirstRequest!({ ok: false })
+    await jest.advanceTimersByTimeAsync(0)
+
+    await jest.advanceTimersByTimeAsync(239)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    expect(maximumActiveRequests).toBe(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: false },
+      }
+    )
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: true },
+      }
+    )
+  })
+
+  it('retries a patch when fetch throws synchronously without logging it', async () => {
+    fetchMock
+      .mockImplementationOnce(() => {
+        throw new Error('sensitive value: dark')
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ theme: 'dark' })
+    jest.advanceTimersByTime(120)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('dark')
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('sensitive')
+
+    await jest.advanceTimersByTimeAsync(240)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({ theme: 'dark' }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a pending patch immediately on pagehide with keepalive', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/__nextjs_devtools_config',
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: { showInternal: true },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a queued patch on pagehide while a save is in flight', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(
+      fetchMock.mock.calls.map((call) => JSON.parse(call[1].body))
+    ).toEqual([
+      { requestInsights: { showInternal: true } },
+      {
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      },
+    ])
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ keepalive: true })
+    )
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+  })
+
+  it('retries a failed pagehide flush after the in-flight save completes', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let rejectPagehideRequest: (error: Error) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((_resolve, reject) => {
+            rejectPagehideRequest = reject
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+    rejectPagehideRequest!(new Error('page was hidden'))
+    await flushMicrotasks()
+
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: {
+            showInternal: true,
+            verbose: true,
+          },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('does not restore an older failed patch after a newer pagehide flush succeeds', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { verbose: false } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      requestInsights: { verbose: true },
+    })
+
+    resolveFirstRequest!({ ok: false })
+    await flushMicrotasks()
+    await jest.advanceTimersByTimeAsync(5_000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
@@ -2,29 +2,124 @@ import type { DevToolsConfig } from '../shared'
 import { devToolsConfigSchema } from '../../shared/devtools-config-schema'
 import { deepMerge } from '../../shared/deepmerge'
 
+const SAVE_DEBOUNCE_DELAY = 120
+const INITIAL_RETRY_DELAY = 240
+const MAX_RETRY_DELAY = 5_000
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
 let queuedConfigPatch: DevToolsConfig = {}
 let timer: ReturnType<typeof setTimeout> | null = null
+let flushInFlight: Promise<void> | null = null
+let inFlightFlush:
+  | {
+      patch: DevToolsConfig
+      supersedingPatch?: DevToolsConfig
+      supersedingFlush?: Promise<void>
+      supersedingVersion: number
+    }
+  | undefined
+let flushImmediatelyAfterInFlight = false
+let retryDelay = INITIAL_RETRY_DELAY
 
-function flushPatch() {
-  if (Object.keys(queuedConfigPatch).length === 0) {
-    return
+function hasQueuedPatch() {
+  return Object.keys(queuedConfigPatch).length > 0
+}
+
+function scheduleFlush(delay: number) {
+  if (timer) {
+    clearTimeout(timer)
   }
 
-  const body = JSON.stringify(queuedConfigPatch)
-  queuedConfigPatch = {}
+  timer = setTimeout(flushPatch, delay)
+}
 
-  fetch('/__nextjs_devtools_config', {
+async function sendConfigPatch(body: string) {
+  const response = await fetch('/__nextjs_devtools_config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body,
     // keepalive in case of fetch interrupted, e.g. navigation or reload
     keepalive: true,
-  }).catch((error) => {
-    console.warn('[Next.js DevTools] Failed to save config:', {
-      data: body,
-      error,
-    })
   })
+
+  if (!response.ok) {
+    throw new Error('Failed to save DevTools config')
+  }
+}
+
+function flushPatch(immediatelyAfterInFlight = false) {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+
+  if (flushInFlight) {
+    flushImmediatelyAfterInFlight ||= immediatelyAfterInFlight
+    return
+  }
+
+  if (!hasQueuedPatch()) {
+    return
+  }
+
+  const patch = queuedConfigPatch
+  const body = JSON.stringify(patch)
+  queuedConfigPatch = {}
+
+  const currentFlush: NonNullable<typeof inFlightFlush> = {
+    patch,
+    supersedingVersion: 0,
+  }
+  inFlightFlush = currentFlush
+  const request = sendConfigPatch(body)
+
+  flushInFlight = request
+    .then(() => {
+      retryDelay = INITIAL_RETRY_DELAY
+    })
+    .catch(async () => {
+      // A pagehide write contains this patch plus everything queued after it.
+      // Let that newer write own restoration so an older failed request can
+      // never overwrite a successful newer one.
+      if (currentFlush.supersedingFlush) {
+        await currentFlush.supersedingFlush
+        return
+      }
+
+      // Restore the failed patch without overwriting changes queued while the
+      // request was in flight.
+      queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+
+      const delay = retryDelay
+      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY)
+      scheduleFlush(delay)
+
+      // Do not include the request body or error details here. Config patches
+      // can contain user-defined shortcut values.
+      console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+    })
+    .finally(() => {
+      if (inFlightFlush === currentFlush) {
+        inFlightFlush = undefined
+      }
+      flushInFlight = null
+
+      if (!hasQueuedPatch()) {
+        flushImmediatelyAfterInFlight = false
+        return
+      }
+
+      if (flushImmediatelyAfterInFlight) {
+        flushImmediatelyAfterInFlight = false
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        flushPatch(true)
+      } else if (!timer) {
+        scheduleFlush(0)
+      }
+    })
 }
 
 export function saveDevToolsConfig(patch: DevToolsConfig) {
@@ -43,5 +138,59 @@ export function saveDevToolsConfig(patch: DevToolsConfig) {
     clearTimeout(timer)
   }
 
-  timer = setTimeout(flushPatch, 120)
+  timer = setTimeout(flushPatch, SAVE_DEBOUNCE_DELAY)
+}
+
+if (typeof window !== 'undefined') {
+  const devToolsWindow = window as Window & {
+    [PAGEHIDE_LISTENER_KEY]?: () => void
+  }
+  const previousListener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  if (typeof previousListener === 'function') {
+    previousListener()
+    window.removeEventListener('pagehide', previousListener)
+  }
+
+  // A reload can happen before the debounced write starts. Flush the pending
+  // patch while the page is still alive; keepalive lets the request finish
+  // during page teardown.
+  const flushPatchOnPagehide = () => {
+    if (flushInFlight && inFlightFlush && hasQueuedPatch()) {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      const currentFlush = inFlightFlush
+      const patch = deepMerge(
+        currentFlush.supersedingPatch ?? currentFlush.patch,
+        queuedConfigPatch
+      )
+      queuedConfigPatch = {}
+      const version = ++currentFlush.supersedingVersion
+      currentFlush.supersedingPatch = patch
+      currentFlush.supersedingFlush = sendConfigPatch(JSON.stringify(patch))
+        .then(() => {
+          retryDelay = INITIAL_RETRY_DELAY
+        })
+        .catch(() => {
+          // Ignore an older pagehide failure when a newer cumulative write is
+          // already responsible for the same data.
+          if (version !== currentFlush.supersedingVersion) {
+            return
+          }
+
+          // The document may survive through the back-forward cache. Restore
+          // the complete superseding patch and retry it without logging user
+          // config values.
+          queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+          scheduleFlush(0)
+          console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+        })
+      return
+    }
+
+    flushPatch(true)
+  }
+  window.addEventListener('pagehide', flushPatchOnPagehide)
+  devToolsWindow[PAGEHIDE_LISTENER_KEY] = flushPatchOnPagehide
 }

--- a/packages/next/src/next-devtools/server/devtools-config-middleware.ts
+++ b/packages/next/src/next-devtools/server/devtools-config-middleware.ts
@@ -1,9 +1,9 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { DevToolsConfig } from '../dev-overlay/shared'
 
-import { existsSync } from 'fs'
-import { readFile, writeFile, mkdir } from 'fs/promises'
-import { dirname, join } from 'path'
+import * as fsPromises from 'fs/promises'
+import { randomUUID } from 'crypto'
+import { basename, dirname, join } from 'path'
 
 import { middlewareResponse } from './middleware-response'
 import { devToolsConfigSchema } from '../shared/devtools-config-schema'
@@ -11,6 +11,8 @@ import { deepMerge } from '../shared/deepmerge'
 
 const DEVTOOLS_CONFIG_FILENAME = 'next-devtools-config.json'
 const DEVTOOLS_CONFIG_MIDDLEWARE_ENDPOINT = '/__nextjs_devtools_config'
+const DEVTOOLS_CONFIG_BODY_LIMIT = 64 * 1024
+const configUpdateQueues = new Map<string, Promise<void>>()
 
 export function devToolsConfigMiddleware({
   distDir,
@@ -36,36 +38,63 @@ export function devToolsConfigMiddleware({
       return middlewareResponse.methodNotAllowed(res)
     }
 
-    const currentConfig = await getDevToolsConfig(distDir)
+    const previousUpdate = (
+      configUpdateQueues.get(configPath) ?? Promise.resolve()
+    ).catch(() => {})
+    let releaseUpdate!: () => void
+    const updateCompleted = new Promise<void>((resolve) => {
+      releaseUpdate = resolve
+    })
+    const queueTail = previousUpdate.then(() => updateCompleted)
+    configUpdateQueues.set(configPath, queueTail)
+    void queueTail.then(() => {
+      if (configUpdateQueues.get(configPath) === queueTail) {
+        configUpdateQueues.delete(configPath)
+      }
+    })
 
-    const chunks: Buffer[] = []
-    for await (const chunk of req) {
-      chunks.push(Buffer.from(chunk))
-    }
-
-    let body = Buffer.concat(chunks).toString('utf8')
     try {
-      body = JSON.parse(body)
-    } catch (error) {
-      console.error('[Next.js DevTools] Invalid config body passed:', error)
-      return middlewareResponse.badRequest(res)
-    }
+      const chunks: Buffer[] = []
+      let bodySize = 0
+      for await (const chunk of req) {
+        const buffer = Buffer.from(chunk)
+        bodySize += buffer.byteLength
+        if (bodySize > DEVTOOLS_CONFIG_BODY_LIMIT) {
+          return middlewareResponse.payloadTooLarge(res)
+        }
+        chunks.push(buffer)
+      }
 
-    const validation = devToolsConfigSchema.safeParse(body)
-    if (!validation.success) {
-      console.error(
-        '[Next.js DevTools] Invalid config passed:',
-        validation.error.message
+      let body = Buffer.concat(chunks).toString('utf8')
+      try {
+        body = JSON.parse(body)
+      } catch (error) {
+        console.error('[Next.js DevTools] Invalid config body passed:', error)
+        return middlewareResponse.badRequest(res)
+      }
+
+      const validation = devToolsConfigSchema.safeParse(body)
+      if (!validation.success) {
+        console.error(
+          '[Next.js DevTools] Invalid config passed:',
+          validation.error.message
+        )
+        return middlewareResponse.badRequest(res)
+      }
+
+      await previousUpdate
+      const currentConfig = await getDevToolsConfig(distDir)
+      const newConfig = deepMerge(currentConfig, validation.data)
+      await writeDevToolsConfigAtomically(
+        configPath,
+        JSON.stringify(newConfig, null, 2)
       )
-      return middlewareResponse.badRequest(res)
+      sendUpdateSignal(newConfig)
+
+      return middlewareResponse.noContent(res)
+    } finally {
+      releaseUpdate()
     }
-
-    const newConfig = deepMerge(currentConfig, validation.data)
-    await writeFile(configPath, JSON.stringify(newConfig, null, 2))
-
-    sendUpdateSignal(newConfig)
-
-    return middlewareResponse.noContent(res)
   }
 }
 
@@ -74,11 +103,41 @@ export async function getDevToolsConfig(
 ): Promise<DevToolsConfig> {
   const configPath = join(distDir, 'cache', DEVTOOLS_CONFIG_FILENAME)
 
-  if (!existsSync(configPath)) {
-    await mkdir(dirname(configPath), { recursive: true })
-    await writeFile(configPath, JSON.stringify({}))
-    return {}
+  try {
+    const parsed = JSON.parse(await fsPromises.readFile(configPath, 'utf8'))
+    const validation = devToolsConfigSchema.safeParse(parsed)
+    return validation.success ? validation.data : {}
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {}
+    }
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return {}
+    }
+    throw error
   }
+}
 
-  return JSON.parse(await readFile(configPath, 'utf8'))
+async function writeDevToolsConfigAtomically(
+  configPath: string,
+  contents: string
+): Promise<void> {
+  const temporaryPath = join(
+    dirname(configPath),
+    `.${basename(configPath)}.${process.pid}.${randomUUID()}.tmp`
+  )
+
+  try {
+    await fsPromises.mkdir(dirname(configPath), { recursive: true })
+    await fsPromises.writeFile(temporaryPath, contents)
+    await fsPromises.rename(temporaryPath, configPath)
+  } catch (error) {
+    await fsPromises.unlink(temporaryPath).catch(() => {})
+    throw error
+  }
 }

--- a/packages/next/src/next-devtools/server/middleware-response.ts
+++ b/packages/next/src/next-devtools/server/middleware-response.ts
@@ -23,6 +23,10 @@ export const middlewareResponse = {
     res.statusCode = 405
     res.end('Method Not Allowed')
   },
+  payloadTooLarge(res: ServerResponse) {
+    res.statusCode = 413
+    res.end('Payload Too Large')
+  },
   internalServerError(res: ServerResponse, error?: unknown) {
     res.statusCode = 500
     res.setHeader('Content-Type', 'text/plain')

--- a/test/unit/devtools-config-middleware/index.test.ts
+++ b/test/unit/devtools-config-middleware/index.test.ts
@@ -1,0 +1,364 @@
+import type { IncomingMessage, ServerResponse } from 'http'
+import * as fsPromises from 'fs/promises'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  devToolsConfigMiddleware,
+  getDevToolsConfig,
+} from 'next/dist/next-devtools/server/devtools-config-middleware'
+
+jest.mock('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises')
+  return {
+    ...actual,
+    rename: jest.fn(actual.rename),
+    writeFile: jest.fn(actual.writeFile),
+  }
+})
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function createRequest(
+  body: object,
+  {
+    bodyRequested,
+    bodyConsumed,
+    releaseBody,
+  }: {
+    bodyRequested?: ReturnType<typeof createDeferred>
+    bodyConsumed?: ReturnType<typeof createDeferred>
+    releaseBody?: Promise<void>
+  } = {}
+): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      bodyRequested?.resolve()
+      await releaseBody
+      yield Buffer.from(JSON.stringify(body))
+      bodyConsumed?.resolve()
+    },
+  } as IncomingMessage
+}
+
+function createResponse(): ServerResponse {
+  return {
+    end: jest.fn(),
+    setHeader: jest.fn(),
+  } as unknown as ServerResponse
+}
+
+function createChunkedRequest(chunks: Buffer[]): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      yield* chunks
+    },
+  } as IncomingMessage
+}
+
+describe('DevTools config middleware', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    distDir = await mkdtemp(join(tmpdir(), 'next-devtools-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(distDir, { recursive: true, force: true })
+  })
+
+  it('commits concurrent patches in request arrival order', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const bodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstResponse = createResponse()
+    const secondResponse = createResponse()
+
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { showInternal: true, verbose: false } },
+        {
+          bodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      firstResponse,
+      jest.fn()
+    )
+
+    await bodyRequested.promise
+    const secondBodyConsumed = createDeferred()
+    const secondRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: secondBodyConsumed }
+      ),
+      secondResponse,
+      jest.fn()
+    )
+
+    await secondBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, secondRequest])
+
+    const config = JSON.parse(
+      await readFile(
+        join(distDir, 'cache', 'next-devtools-config.json'),
+        'utf8'
+      )
+    )
+    expect(config).toEqual({
+      requestInsights: {
+        showInternal: true,
+        verbose: true,
+      },
+    })
+    expect(firstResponse.statusCode).toBe(204)
+    expect(secondResponse.statusCode).toBe(204)
+    expect(sendUpdateSignal).toHaveBeenLastCalledWith(config)
+  })
+
+  it('keeps a queue reservation after an invalid request finishes early', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    const firstBodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: false } },
+        {
+          bodyRequested: firstBodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await firstBodyRequested.promise
+    const invalidResponse = createResponse()
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      invalidResponse,
+      jest.fn()
+    )
+    expect(invalidResponse.statusCode).toBe(413)
+
+    const thirdBodyConsumed = createDeferred()
+    const thirdRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: thirdBodyConsumed }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await thirdBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, thirdRequest])
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { verbose: true },
+    })
+  })
+
+  it('keeps the previous config readable until an update is complete', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    const writeStarted = createDeferred()
+    const releaseWrite = createDeferred()
+    const { writeFile } =
+      jest.requireActual<typeof import('fs/promises')>('fs/promises')
+    const writeFileMock = jest.mocked(fsPromises.writeFile)
+    writeFileMock.mockImplementation(async (path, contents, options) => {
+      const serialized = String(contents)
+      if (serialized.includes('"verbose": true')) {
+        await writeFile(path, serialized.slice(0, serialized.length / 2))
+        writeStarted.resolve()
+        await releaseWrite.promise
+      }
+      return writeFile(path, contents, options)
+    })
+
+    try {
+      const update = middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+      await writeStarted.promise
+
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: { showInternal: true },
+      })
+
+      releaseWrite.resolve()
+      await update
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      })
+    } finally {
+      releaseWrite.resolve()
+      writeFileMock.mockImplementation(writeFile)
+      writeFileMock.mockClear()
+    }
+  })
+
+  it('does not let a missing-file read overwrite the first update', async () => {
+    const writeFile = jest.mocked(fsPromises.writeFile)
+    writeFile.mockClear()
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+    expect(writeFile).not.toHaveBeenCalled()
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a corrupted config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, '{not valid JSON')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a schema-invalid config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, JSON.stringify({ theme: 123 }))
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('keeps the previous config and releases the queue after a failed rename', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    sendUpdateSignal.mockClear()
+
+    jest
+      .mocked(fsPromises.rename)
+      .mockRejectedValueOnce(new Error('rename failed'))
+
+    await expect(
+      middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+    ).rejects.toThrow('rename failed')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(fsPromises.readdir(join(distDir, 'cache'))).resolves.toEqual([
+      'next-devtools-config.json',
+    ])
+
+    await middleware(
+      createRequest({ requestInsights: { verbose: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true, verbose: true },
+    })
+  })
+
+  it('rejects config request bodies larger than 64 KiB', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const response = createResponse()
+
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      response,
+      jest.fn()
+    )
+
+    expect(response.statusCode).toBe(413)
+    expect(response.end).toHaveBeenCalledWith('Payload Too Large')
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary

- Serialize and retry DevTools configuration patches so concurrent UI changes cannot overwrite one another.
- Flush pending settings during page teardown, recover invalid cached configuration, and commit server-side updates through bounded atomic writes.

Stacked on #96449.

## Verification

- `pnpm exec jest --runInBand packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts test/unit/devtools-config-middleware/index.test.ts`
- `pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts -t "persists verbose trace settings"`
- `pnpm test-dev-webpack test/development/app-dir/request-insights/request-insights.test.ts -t "persists verbose trace settings"`
