### PR TITLE
Trace development route preparation

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -292,6 +292,16 @@ describe('request insights trace viewer', () => {
           },
         },
         {
+          name: 'reload route matchers',
+          spanId: 'reload-matchers',
+          parentSpanId: 'match',
+          startTime: 109,
+          durationMs: 1,
+          attributes: {
+            'next.span_type': 'DevRouteMatcherManager.reloadMatchers',
+          },
+        },
+        {
           name: 'render',
           spanId: 'base-render',
           parentSpanId: 'match',
@@ -393,6 +403,7 @@ describe('request insights trace viewer', () => {
       { label: 'GET', depth: 0 },
       { label: 'match route', depth: 1 },
       { label: 'prepare route', depth: 2 },
+      { label: 'reload route matchers', depth: 2 },
       { label: 'render', depth: 2 },
       { label: 'load components', depth: 3 },
       { label: 'prepare app page response', depth: 3 },
@@ -409,6 +420,7 @@ describe('request insights trace viewer', () => {
       'match route',
       'prepare route',
       'compile route',
+      'reload route matchers',
       'render',
       'resolve page components',
       'load components',

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -272,7 +272,7 @@ describe('request insights trace viewer', () => {
           attributes: { 'next.span_type': 'NextNodeServer.matchRoute' },
         },
         {
-          name: 'compile and prepare route',
+          name: 'prepare route',
           spanId: 'ensure',
           parentSpanId: 'match',
           startTime: 107,
@@ -392,7 +392,7 @@ describe('request insights trace viewer', () => {
     ).toEqual([
       { label: 'GET', depth: 0 },
       { label: 'match route', depth: 1 },
-      { label: 'compile and prepare route', depth: 2 },
+      { label: 'prepare route', depth: 2 },
       { label: 'render', depth: 2 },
       { label: 'load components', depth: 3 },
       { label: 'prepare app page response', depth: 3 },
@@ -407,7 +407,7 @@ describe('request insights trace viewer', () => {
       'GET',
       'prepare request',
       'match route',
-      'compile and prepare route',
+      'prepare route',
       'compile route',
       'render',
       'resolve page components',

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -31,6 +31,7 @@ const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'Middleware.execute',
   'NextNodeServer.matchRoute',
   'DevRouteMatcherManager.ensureRoute',
+  'DevRouteMatcherManager.reloadMatchers',
   'BaseServer.render',
   'LoadComponents.loadComponents',
   'AppRender.prepareAppPageResponse',

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -96,6 +96,7 @@ enum AppRenderSpan {
 
 enum DevRouteMatcherManagerSpan {
   ensureRoute = 'DevRouteMatcherManager.ensureRoute',
+  reloadMatchers = 'DevRouteMatcherManager.reloadMatchers',
 }
 
 enum RouterSpan {

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -94,6 +94,10 @@ enum AppRenderSpan {
   instantInsightsRunValidation = 'AppRender.instantInsights.runValidation',
 }
 
+enum DevRouteMatcherManagerSpan {
+  ensureRoute = 'DevRouteMatcherManager.ensureRoute',
+}
+
 enum RouterSpan {
   executeRoute = 'Router.executeRoute',
 }
@@ -124,6 +128,7 @@ type SpanTypes =
   | `${RenderSpan}`
   | `${RouterSpan}`
   | `${AppRenderSpan}`
+  | `${DevRouteMatcherManagerSpan}`
   | `${NodeSpan}`
   | `${AppRouteRouteHandlersSpan}`
   | `${ResolveMetadataSpan}`
@@ -166,6 +171,7 @@ export {
   RenderSpan,
   RouterSpan,
   AppRenderSpan,
+  DevRouteMatcherManagerSpan,
   NodeSpan,
   AppRouteRouteHandlersSpan,
   ResolveMetadataSpan,

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -7,6 +7,8 @@ import path from '../../shared/lib/isomorphic/path'
 import * as Log from '../../build/output/log'
 import { cyan } from '../../lib/picocolors'
 import type { RouteMatcher } from '../route-matchers/route-matcher'
+import { DevRouteMatcherManagerSpan } from '../lib/trace/constants'
+import { getTracer } from '../lib/trace/tracer'
 
 export interface RouteEnsurer {
   ensure(match: RouteMatch, pathname: string): Promise<void>
@@ -70,8 +72,16 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     for await (const developmentMatch of super.matchAll(pathname, options)) {
       // We're here, which means that we haven't seen this match yet, so we
       // should try to ensure it and recompile the production matcher.
-      await this.ensurer.ensure(developmentMatch, pathname)
-      await this.production.reload()
+      await getTracer().trace(
+        DevRouteMatcherManagerSpan.ensureRoute,
+        {
+          spanName: 'prepare route',
+        },
+        async () => {
+          await this.ensurer.ensure(developmentMatch, pathname)
+          await this.production.reload()
+        }
+      )
 
       // Iterate over the production matches again, this time we should be able
       // to match it against the production matcher unless there's an error.

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -77,10 +77,14 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
         {
           spanName: 'prepare route',
         },
-        async () => {
-          await this.ensurer.ensure(developmentMatch, pathname)
-          await this.production.reload()
-        }
+        () => this.ensurer.ensure(developmentMatch, pathname)
+      )
+      await getTracer().trace(
+        DevRouteMatcherManagerSpan.reloadMatchers,
+        {
+          spanName: 'reload route matchers',
+        },
+        () => this.production.reload()
       )
 
       // Iterate over the production matches again, this time we should be able

--- a/test/development/app-dir/request-insights-route-preparation/app/api/route-preparation/route.ts
+++ b/test/development/app-dir/request-insights-route-preparation/app/api/route-preparation/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ route: 'prepared' })
+}

--- a/test/development/app-dir/request-insights-route-preparation/app/layout.tsx
+++ b/test/development/app-dir/request-insights-route-preparation/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/request-insights-route-preparation/app/page.tsx
+++ b/test/development/app-dir/request-insights-route-preparation/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>route preparation page</p>
+}

--- a/test/development/app-dir/request-insights-route-preparation/next.config.js
+++ b/test/development/app-dir/request-insights-route-preparation/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    requestInsights: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -24,6 +24,7 @@ describe('request-insights-route-preparation', () => {
   }
 
   const routePreparationSpanType = 'DevRouteMatcherManager.ensureRoute'
+  const matcherReloadSpanType = 'DevRouteMatcherManager.reloadMatchers'
 
   async function getRequestInsights() {
     return (await next
@@ -62,6 +63,10 @@ describe('request-insights-route-preparation', () => {
           insight.spans.some(
             (span) =>
               span.attributes?.['next.span_type'] === routePreparationSpanType
+          ) &&
+          insight.spans.some(
+            (span) =>
+              span.attributes?.['next.span_type'] === matcherReloadSpanType
           )
       )
 
@@ -84,21 +89,36 @@ describe('request-insights-route-preparation', () => {
     const routePreparationSpans = request.spans.filter(
       (span) => span.attributes?.['next.span_type'] === routePreparationSpanType
     )
+    const matcherReloadSpans = request.spans.filter(
+      (span) => span.attributes?.['next.span_type'] === matcherReloadSpanType
+    )
 
     expect(rootSpan?.spanId).toBeDefined()
     expect(rootSpan?.traceId).toBeDefined()
     expect(routePreparationSpans).toHaveLength(1)
+    expect(matcherReloadSpans).toHaveLength(1)
+    expect(routePreparationSpans[0].spanId).toBeDefined()
+    expect(matcherReloadSpans[0].spanId).toBeDefined()
+    expect(matcherReloadSpans[0].spanId).not.toBe(
+      routePreparationSpans[0].spanId
+    )
+    expect(matcherReloadSpans[0].parentSpanId).toBe(
+      routePreparationSpans[0].parentSpanId
+    )
 
-    for (const span of routePreparationSpans) {
+    for (const [span, name, type] of [
+      [routePreparationSpans[0], 'prepare route', routePreparationSpanType],
+      [matcherReloadSpans[0], 'reload route matchers', matcherReloadSpanType],
+    ] as const) {
       expect(span).toEqual(
         expect.objectContaining({
-          name: 'prepare route',
+          name,
           durationMs: expect.any(Number),
           status: 'ok',
           attributes: {
             'next.span_category': 'nextjs',
-            'next.span_name': 'prepare route',
-            'next.span_type': routePreparationSpanType,
+            'next.span_name': name,
+            'next.span_type': type,
           },
         })
       )

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -1,0 +1,157 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('request-insights-route-preparation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  type RequestInsightSpan = {
+    name: string
+    durationMs?: number
+    status?: 'ok' | 'error'
+    traceId?: string
+    spanId?: string
+    parentSpanId?: string
+    attributes?: Record<string, string | number | boolean>
+  }
+
+  type RequestInsight = {
+    requestId: string
+    route?: string
+    status: 'ok' | 'error' | 'pending'
+    spans: RequestInsightSpan[]
+  }
+
+  const routePreparationSpanType = 'DevRouteMatcherManager.ensureRoute'
+
+  async function getRequestInsights() {
+    return (await next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())) as {
+      requests: RequestInsight[]
+    }
+  }
+
+  async function captureRequest(
+    route: string,
+    request: () => Promise<unknown>
+  ) {
+    const existingRequestIds = new Set(
+      (await getRequestInsights()).requests
+        .filter((insight) => insight.route === route)
+        .map((insight) => insight.requestId)
+    )
+
+    await request()
+
+    let capturedRequest: RequestInsight | undefined
+    await retry(async () => {
+      capturedRequest = (await getRequestInsights()).requests.find(
+        (insight) =>
+          insight.route === route &&
+          insight.status === 'ok' &&
+          !existingRequestIds.has(insight.requestId) &&
+          insight.spans.some(
+            (span) =>
+              span.attributes?.['next.span_type'] ===
+                'BaseServer.handleRequest' &&
+              span.status === 'ok' &&
+              typeof span.durationMs === 'number'
+          ) &&
+          insight.spans.some(
+            (span) =>
+              span.attributes?.['next.span_type'] === routePreparationSpanType
+          )
+      )
+
+      expect(capturedRequest).toBeDefined()
+    }, 10_000)
+
+    return capturedRequest!
+  }
+
+  function expectRoutePreparationSpans(request: RequestInsight) {
+    const spanById = new Map(
+      request.spans.flatMap((span) =>
+        span.spanId ? [[span.spanId, span] as const] : []
+      )
+    )
+    const rootSpan = request.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+    )
+    const routePreparationSpans = request.spans.filter(
+      (span) => span.attributes?.['next.span_type'] === routePreparationSpanType
+    )
+
+    expect(rootSpan?.spanId).toBeDefined()
+    expect(rootSpan?.traceId).toBeDefined()
+    expect(routePreparationSpans).toHaveLength(1)
+
+    for (const span of routePreparationSpans) {
+      expect(span).toEqual(
+        expect.objectContaining({
+          name: 'prepare route',
+          durationMs: expect.any(Number),
+          status: 'ok',
+          attributes: {
+            'next.span_category': 'nextjs',
+            'next.span_name': 'prepare route',
+            'next.span_type': routePreparationSpanType,
+          },
+        })
+      )
+      expect(Number.isFinite(span.durationMs)).toBe(true)
+      expect(span.durationMs).toBeGreaterThanOrEqual(0)
+      expect(span.traceId).toBe(rootSpan?.traceId)
+
+      let ancestor = span.parentSpanId
+        ? spanById.get(span.parentSpanId)
+        : undefined
+      const visited = new Set<string>()
+      while (
+        ancestor?.spanId !== rootSpan?.spanId &&
+        ancestor?.parentSpanId &&
+        !visited.has(ancestor.parentSpanId)
+      ) {
+        visited.add(ancestor.parentSpanId)
+        ancestor = spanById.get(ancestor.parentSpanId)
+      }
+      expect(ancestor?.spanId).toBe(rootSpan?.spanId)
+    }
+  }
+
+  it('records route preparation for first and subsequent App Page requests', async () => {
+    const coldRequest = await captureRequest('/', async () => {
+      const response = await next.fetch('/')
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('route preparation page')
+    })
+    const warmRequest = await captureRequest('/', async () => {
+      const response = await next.fetch('/')
+      expect(response.status).toBe(200)
+      await response.text()
+    })
+
+    expectRoutePreparationSpans(coldRequest)
+    expectRoutePreparationSpans(warmRequest)
+  })
+
+  it('records route preparation for first and subsequent App Route requests', async () => {
+    const route = '/api/route-preparation'
+    const coldRequest = await captureRequest(route, async () => {
+      const response = await next.fetch(route)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ route: 'prepared' })
+    })
+    const warmRequest = await captureRequest(route, async () => {
+      const response = await next.fetch(route)
+      expect(response.status).toBe(200)
+      await response.text()
+    })
+
+    expectRoutePreparationSpans(coldRequest)
+    expectRoutePreparationSpans(warmRequest)
+  })
+})


### PR DESCRIPTION
## Summary

This PR introduces the first bounded route-preparation phases used by Request Insights. It instruments existing matcher and bundler boundaries without changing their behavior or making the spans default-public OpenTelemetry data.

- trace development route matching and route preparation while a route is ensured
- keep production matcher reload as a separate sibling phase so reload work is not charged to matching
- surface the internal phases as `match route`, `prepare route`, and `reload route matchers` in Request Insights
- cover cold and warm page, App Route/API, and dynamic-route behavior in both development bundlers
- preserve the existing matcher results, errors, and public OTel allowlist

## Verification

- `pnpm test-dev-turbo test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts`
- `pnpm test-dev-webpack test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts`
- `pnpm --filter=next types`
