### PR TITLE
Trace development route compilation

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -403,6 +403,7 @@ describe('request insights trace viewer', () => {
       { label: 'GET', depth: 0 },
       { label: 'match route', depth: 1 },
       { label: 'prepare route', depth: 2 },
+      { label: 'compile route', depth: 3 },
       { label: 'reload route matchers', depth: 2 },
       { label: 'render', depth: 2 },
       { label: 'load components', depth: 3 },

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -32,6 +32,7 @@ const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'NextNodeServer.matchRoute',
   'DevRouteMatcherManager.ensureRoute',
   'DevRouteMatcherManager.reloadMatchers',
+  'DevBundlerService.ensurePage',
   'BaseServer.render',
   'LoadComponents.loadComponents',
   'AppRender.prepareAppPageResponse',

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -9,7 +9,9 @@ import {
   type HmrMessageSentToBrowser,
   type NextJsHotReloaderInterface,
 } from '../dev/hot-reloader-types'
+import { DevBundlerServiceSpan } from './trace/constants'
 import { subscribeRequestInsights } from './trace/request-insights'
+import { getTracer } from './trace/tracer'
 
 /**
  * The DevBundlerService provides an interface to perform tasks with the
@@ -61,7 +63,11 @@ export class DevBundlerService {
     definition
   ) => {
     // TODO: remove after ensure is pulled out of server
-    return await this.bundler.hotReloader.ensurePage(definition)
+    return await getTracer().trace(
+      DevBundlerServiceSpan.ensurePage,
+      { spanName: 'compile route' },
+      () => this.bundler.hotReloader.ensurePage(definition)
+    )
   }
 
   public getServerComponentsHmrRefreshHash(): string | undefined {

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -99,6 +99,10 @@ enum DevRouteMatcherManagerSpan {
   reloadMatchers = 'DevRouteMatcherManager.reloadMatchers',
 }
 
+enum DevBundlerServiceSpan {
+  ensurePage = 'DevBundlerService.ensurePage',
+}
+
 enum RouterSpan {
   executeRoute = 'Router.executeRoute',
 }
@@ -130,6 +134,7 @@ type SpanTypes =
   | `${RouterSpan}`
   | `${AppRenderSpan}`
   | `${DevRouteMatcherManagerSpan}`
+  | `${DevBundlerServiceSpan}`
   | `${NodeSpan}`
   | `${AppRouteRouteHandlersSpan}`
   | `${ResolveMetadataSpan}`
@@ -173,6 +178,7 @@ export {
   RouterSpan,
   AppRenderSpan,
   DevRouteMatcherManagerSpan,
+  DevBundlerServiceSpan,
   NodeSpan,
   AppRouteRouteHandlersSpan,
   ResolveMetadataSpan,

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -25,6 +25,7 @@ describe('request-insights-route-preparation', () => {
 
   const routePreparationSpanType = 'DevRouteMatcherManager.ensureRoute'
   const matcherReloadSpanType = 'DevRouteMatcherManager.reloadMatchers'
+  const routeCompilationSpanType = 'DevBundlerService.ensurePage'
 
   async function getRequestInsights() {
     return (await next
@@ -67,6 +68,10 @@ describe('request-insights-route-preparation', () => {
           insight.spans.some(
             (span) =>
               span.attributes?.['next.span_type'] === matcherReloadSpanType
+          ) &&
+          insight.spans.some(
+            (span) =>
+              span.attributes?.['next.span_type'] === routeCompilationSpanType
           )
       )
 
@@ -140,6 +145,32 @@ describe('request-insights-route-preparation', () => {
       }
       expect(ancestor?.spanId).toBe(rootSpan?.spanId)
     }
+
+    const routePreparationSpan = routePreparationSpans[0]
+    const routeCompilationSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === routeCompilationSpanType &&
+        span.parentSpanId === routePreparationSpan.spanId
+    )
+    expect(routeCompilationSpans).toHaveLength(1)
+
+    const routeCompilationSpan = routeCompilationSpans[0]
+    expect(routeCompilationSpan).toEqual(
+      expect.objectContaining({
+        name: 'compile route',
+        durationMs: expect.any(Number),
+        status: 'ok',
+        parentSpanId: routePreparationSpan.spanId,
+        attributes: {
+          'next.span_category': 'nextjs',
+          'next.span_name': 'compile route',
+          'next.span_type': routeCompilationSpanType,
+        },
+      })
+    )
+    expect(Number.isFinite(routeCompilationSpan.durationMs)).toBe(true)
+    expect(routeCompilationSpan.durationMs).toBeGreaterThanOrEqual(0)
+    expect(routeCompilationSpan.traceId).toBe(rootSpan?.traceId)
   }
 
   it('records route preparation for first and subsequent App Page requests', async () => {


### PR DESCRIPTION
## Summary

- Trace development route compilation through `DevBundlerService.ensurePage` after route preparation selects a route.
- Present the existing development bundler work as `compile route` in Request Insights so cold compilation can be distinguished from route matching.
- Keep the span internal by default without expanding the default public OpenTelemetry allowlist.
- Preserve compilation error propagation and the existing route-preparation parentage.

Warm requests can still record the span when `ensurePage` runs, but the work is normally negligible after the route is compiled.

## Verification

- `HEADLESS=true pnpm test-dev-turbo test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts`
- `HEADLESS=true pnpm test-dev-webpack test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts`
- Both bundlers passed 2/2 tests at the final stack head.
- `pnpm --filter=next build`
