### PR TITLE
Show Server Action execution in Request Insights

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -422,6 +422,50 @@ describe('request insights trace viewer', () => {
     ])
   })
 
+  it('shows named Server Action spans in the default trace', () => {
+    const request = createRequest({
+      spans: [
+        {
+          name: 'POST /account',
+          spanId: 'root',
+          startTime: 100,
+          durationMs: 20,
+          attributes: {
+            'next.span_type': 'BaseServer.handleRequest',
+          },
+        },
+        {
+          name: 'AppRender.executeServerAction',
+          spanId: 'server-action',
+          parentSpanId: 'root',
+          startTime: 105,
+          durationMs: 5,
+          attributes: {
+            'next.span_category': 'application',
+            'next.span_name': 'run Server Action updateAccount',
+            'next.span_type': 'AppRender.executeServerAction',
+            'next.server_action.name': 'updateAccount',
+          },
+        },
+      ],
+    })
+
+    expect(
+      getTraceItems(request, false).map(({ label, category, depth }) => ({
+        label,
+        category,
+        depth,
+      }))
+    ).toEqual([
+      { label: 'POST /account', category: 'nextjs', depth: 0 },
+      {
+        label: 'run Server Action updateAccount',
+        category: 'application',
+        depth: 1,
+      },
+    ])
+  })
+
   it('gives every displayed span a human readable name', () => {
     const request = createRequest({
       spans: [

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -26,6 +26,7 @@ export type TraceRange = {
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
 
 const FETCH_SPAN_TYPE = 'AppRender.fetch'
+const SERVER_ACTION_SPAN_TYPE = 'AppRender.executeServerAction'
 const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'BaseServer.handleRequest',
   'Middleware.execute',
@@ -36,6 +37,7 @@ const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'AppRender.prepareAppPageResponse',
   'AppRender.initializeRender',
   'AppRender.getBodyResult',
+  SERVER_ACTION_SPAN_TYPE,
   'NextNodeServer.createComponentTree',
   'AppRender.startRSCStream',
   'AppRender.renderRSCResponse',
@@ -346,6 +348,11 @@ function getSpanLabel(span: RequestInsightSpan): string {
     typeof explicitName === 'string' && explicitName.trim().length > 0
       ? explicitName
       : span.name
+
+  if (span.attributes?.['next.span_type'] === SERVER_ACTION_SPAN_TYPE) {
+    return name
+  }
+
   const displayName = name
     .replace(FIZZ_WORD, 'HTML')
     .replace(FLIGHT_WORD, 'RSC')

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -401,4 +401,33 @@ describe('request insights', () => {
       })
     )
   })
+
+  it('retains safe Server Action metadata', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'AppRender.executeServerAction',
+      requestId: 'req_server_action',
+      route: '/account',
+      attributes: {
+        'next.span_category': 'application',
+        'next.span_name': 'run Server Action updateAccount',
+        'next.span_type': 'AppRender.executeServerAction',
+        'next.server_action.name': 'updateAccount',
+        'next.server_action.file': 'app/account/actions.ts',
+        'next.server_action.id': 'private-action-id',
+        'custom.argument': 'private-action-argument',
+      },
+    })
+
+    expect(
+      getRequestInsightsSnapshot().requests[0].spans[0].attributes
+    ).toEqual({
+      'next.span_category': 'application',
+      'next.span_name': 'run Server Action updateAccount',
+      'next.span_type': 'AppRender.executeServerAction',
+      'next.server_action.name': 'updateAccount',
+      'next.server_action.file': 'app/account/actions.ts',
+    })
+  })
 })

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -40,6 +40,8 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.route',
   'next.rsc',
   'next.segment',
+  'next.server_action.file',
+  'next.server_action.name',
   'next.span_category',
   'next.span_name',
   'next.span_type',

--- a/test/development/app-dir/request-insights/app/server-actions/actions.ts
+++ b/test/development/app-dir/request-insights/app/server-actions/actions.ts
@@ -1,0 +1,6 @@
+'use server'
+
+export async function trackedServerAction(argument: string) {
+  void argument
+  return 'server-action-complete'
+}

--- a/test/development/app-dir/request-insights/app/server-actions/cached.ts
+++ b/test/development/app-dir/request-insights/app/server-actions/cached.ts
@@ -1,0 +1,5 @@
+'use cache'
+
+export async function clientDispatchedCachedFunction() {
+  return 'cached-function-complete'
+}

--- a/test/development/app-dir/request-insights/app/server-actions/client.tsx
+++ b/test/development/app-dir/request-insights/app/server-actions/client.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+import { clientDispatchedCachedFunction } from './cached'
+
+export function ServerActionControls({
+  trackedServerAction,
+}: {
+  trackedServerAction: (argument: string) => Promise<string>
+}) {
+  const [result, setResult] = useState('idle')
+  const [, startTransition] = useTransition()
+
+  return (
+    <>
+      <button
+        id="run-tracked-server-action"
+        type="button"
+        onClick={() => {
+          startTransition(async () => {
+            setResult(
+              await trackedServerAction('private-server-action-argument')
+            )
+          })
+        }}
+      >
+        Run Server Action
+      </button>
+      <button
+        id="run-client-cached-function"
+        type="button"
+        onClick={() => {
+          startTransition(async () => {
+            setResult(await clientDispatchedCachedFunction())
+          })
+        }}
+      >
+        Run cached function
+      </button>
+      <p id="server-action-result">{result}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/server-actions/page.tsx
+++ b/test/development/app-dir/request-insights/app/server-actions/page.tsx
@@ -1,0 +1,6 @@
+import { trackedServerAction } from './actions'
+import { ServerActionControls } from './client'
+
+export default function Page() {
+  return <ServerActionControls trackedServerAction={trackedServerAction} />
+}

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -170,6 +170,185 @@ describe('request insights', () => {
     })
   })
 
+  it('records Server Actions without treating client cache calls as actions', async () => {
+    const actionIds: string[] = []
+    const browser = await next.browser('/server-actions', {
+      beforePageLoad(page) {
+        page.route('**/server-actions**', async (route) => {
+          const actionId = (await route.request().allHeaders())['next-action']
+          if (actionId) {
+            actionIds.push(actionId)
+          }
+          await route.continue()
+        })
+      },
+    })
+
+    await browser.elementById('run-tracked-server-action').click()
+    await retry(async () => {
+      expect(await browser.elementById('server-action-result').text()).toBe(
+        'server-action-complete'
+      )
+    })
+
+    let snapshotAfterAction: { requests: RequestInsight[] } = { requests: [] }
+    await retry(async () => {
+      snapshotAfterAction = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const actionRequests = snapshotAfterAction.requests.filter(
+        (request) =>
+          request.route === '/server-actions' &&
+          request.spans.some(
+            (span) =>
+              span.attributes?.['next.span_type'] ===
+              'AppRender.executeServerAction'
+          )
+      )
+      expect(actionRequests).toHaveLength(1)
+      expect(actionRequests[0].requestId).not.toBe(
+        actionRequests[0].htmlRequestId
+      )
+      expect(
+        snapshotAfterAction.requests.some(
+          (request) => request.requestId === actionRequests[0].htmlRequestId
+        )
+      ).toBe(true)
+
+      const actionSpans = actionRequests[0].spans.filter(
+        (span) =>
+          span.attributes?.['next.span_type'] ===
+          'AppRender.executeServerAction'
+      )
+      expect(actionSpans).toEqual([
+        expect.objectContaining({
+          name: 'AppRender.executeServerAction',
+          attributes: expect.objectContaining({
+            'next.span_category': 'application',
+            'next.span_name': 'run Server Action trackedServerAction',
+            'next.span_type': 'AppRender.executeServerAction',
+            'next.server_action.name': 'trackedServerAction',
+            'next.server_action.file': 'app/server-actions/actions.ts',
+          }),
+        }),
+      ])
+
+      const spansById = new Map(
+        actionRequests[0].spans
+          .filter((span) => span.spanId)
+          .map((span) => [span.spanId!, span])
+      )
+      let parentSpanId = actionSpans[0].parentSpanId
+      let hasRequestAncestor = false
+      while (parentSpanId) {
+        const parent = spansById.get(parentSpanId)
+        if (!parent) break
+        if (
+          parent.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+        ) {
+          hasRequestAncestor = true
+          break
+        }
+        parentSpanId = parent.parentSpanId
+      }
+      expect(hasRequestAncestor).toBe(true)
+
+      const serializedRequest = JSON.stringify(actionRequests[0])
+      expect(serializedRequest).not.toContain('private-server-action-argument')
+      expect(actionIds).toHaveLength(1)
+      expect(actionIds[0]).toMatch(/^[0-9a-f]{42}$/)
+      expect(serializedRequest).not.toContain(actionIds[0])
+    })
+
+    const actionRequest = snapshotAfterAction.requests.find(
+      (request) =>
+        request.route === '/server-actions' &&
+        request.spans.some(
+          (span) =>
+            span.attributes?.['next.server_action.name'] ===
+            'trackedServerAction'
+        )
+    )!
+    const existingRequestIds = new Set(
+      snapshotAfterAction.requests.map((request) => request.requestId)
+    )
+    await browser.elementById('run-client-cached-function').click()
+    await retry(async () => {
+      expect(await browser.elementById('server-action-result').text()).toBe(
+        'cached-function-complete'
+      )
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const cacheRequests = snapshot.requests.filter(
+        (request) =>
+          !existingRequestIds.has(request.requestId) &&
+          request.route === '/server-actions' &&
+          request.spans.some(
+            (span) =>
+              span.attributes?.['next.span_type'] ===
+                'BaseServer.handleRequest' &&
+              span.attributes?.['http.method'] === 'POST'
+          )
+      )
+      expect(cacheRequests).toHaveLength(1)
+      expect(cacheRequests[0].htmlRequestId).toBe(actionRequest.htmlRequestId)
+      expect(
+        cacheRequests[0].spans.filter(
+          (span) =>
+            span.attributes?.['next.span_type'] ===
+            'AppRender.executeServerAction'
+        )
+      ).toHaveLength(0)
+      expect(actionIds).toHaveLength(2)
+      expect(actionIds[1]).toMatch(/^[0-9a-f]{42}$/)
+      expect(JSON.stringify(cacheRequests[0])).not.toContain(actionIds[1])
+    })
+
+    const panelBrowser = await next.browser('/server-actions')
+    await openRequestInsightsPanel(panelBrowser)
+    await retry(async () => {
+      const actionSpanVisible = await panelBrowser.eval(async () => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const requestRows = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).filter(
+          (row) =>
+            row.textContent?.includes('/server-actions') &&
+            !row.textContent.includes('Page load')
+        )
+
+        for (const requestRow of requestRows) {
+          requestRow.click()
+          await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => resolve())
+          )
+
+          if (
+            Array.from(
+              root?.querySelectorAll('.request-insights-span-row') ?? []
+            ).some((row) =>
+              row.textContent?.includes('run Server Action trackedServerAction')
+            )
+          ) {
+            return true
+          }
+        }
+
+        return false
+      })
+      expect(actionSpanVisible).toBe(true)
+    })
+  })
+
   it('does not attribute Request Insights bookkeeping to the app', async () => {
     const outputIndex = next.cliOutput.length
     const browser = await next.browser('/safe-clock')


### PR DESCRIPTION
## Summary

- retain the safe Server Action name and development source attributes in Request Insights snapshots
- show AppRender.executeServerAction in the default request trace with its exact human span name
- keep the existing generic snapshot contract so DevTools, the endpoint, CLI, and MCP observe the same execution span without a separate action data model

## Verification

- `pnpm test-unit packages/next/src/server/lib/trace/request-insights.test.ts packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts`
- `pnpm test-dev-turbo test/development/app-dir/request-insights/request-insights.test.ts`
- `pnpm test-dev-webpack test/development/app-dir/request-insights/request-insights.test.ts`
- `pnpm --filter=next types`
- `pnpm --filter=next build`