### PR TITLE
fix: handle file:// URLs from import.meta.resolve in cache handler path (fixes #73796)

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -10,6 +10,7 @@ import {
 } from './webpack/plugins/next-trace-entrypoints-plugin'
 
 import path from 'path'
+import { resolveCacheHandlerPathToFilesystem } from '../lib/format-dynamic-import-path'
 import fs from 'fs/promises'
 import { nonNullable } from '../lib/non-nullable'
 import * as ciEnvironment from '../server/ci-info'
@@ -147,11 +148,12 @@ export async function collectBuildTraces({
       // ensure we trace any dependencies needed for custom
       // incremental cache handler
       if (cacheHandler) {
+        const resolvedPath = resolveCacheHandlerPathToFilesystem(cacheHandler)
         sharedEntriesSet.push(
           require.resolve(
-            path.isAbsolute(cacheHandler)
-              ? cacheHandler
-              : path.join(dir, cacheHandler)
+            path.isAbsolute(resolvedPath)
+              ? resolvedPath
+              : path.join(dir, resolvedPath)
           )
         )
       }
@@ -178,11 +180,13 @@ export async function collectBuildTraces({
       if (cacheHandlers) {
         for (const handlerPath of Object.values(cacheHandlers)) {
           if (handlerPath) {
+            const resolvedPath =
+              resolveCacheHandlerPathToFilesystem(handlerPath)
             sharedEntriesSet.push(
               require.resolve(
-                path.isAbsolute(handlerPath)
-                  ? handlerPath
-                  : path.join(dir, handlerPath)
+                path.isAbsolute(resolvedPath)
+                  ? resolvedPath
+                  : path.join(dir, resolvedPath)
               )
             )
           }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -21,6 +21,7 @@ import devalue from 'next/dist/compiled/devalue'
 import findUp from 'next/dist/compiled/find-up'
 import { nanoid } from 'next/dist/compiled/nanoid/index.cjs'
 import path from 'path'
+import { resolveCacheHandlerPathToFilesystem } from '../lib/format-dynamic-import-path'
 import {
   STATIC_STATUS_PAGE_GET_INITIAL_PROPS_ERROR,
   PUBLIC_DIR_MIDDLEWARE_CONFLICT,
@@ -1794,7 +1795,10 @@ export default async function build(
             runtimeConfig.cacheHandlers || {}
           )) {
             if (key && value) {
-              normalizedCacheHandlers[key] = path.relative(distDir, value)
+              normalizedCacheHandlers[key] = path.relative(
+                distDir,
+                resolveCacheHandlerPathToFilesystem(value)
+              )
             }
           }
 
@@ -1813,7 +1817,12 @@ export default async function build(
                   }
                 : {}),
               cacheHandler: runtimeConfig.cacheHandler
-                ? path.relative(distDir, runtimeConfig.cacheHandler)
+                ? path.relative(
+                    distDir,
+                    resolveCacheHandlerPathToFilesystem(
+                      runtimeConfig.cacheHandler
+                    )
+                  )
                 : runtimeConfig.cacheHandler,
               cacheHandlers: normalizedCacheHandlers,
               experimental: {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { pathToFileURL } from 'url'
+import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
 import { arch, platform } from 'os'
 import { platformArchTriples } from 'next/dist/compiled/@napi-rs/triples'
 import * as Log from '../output/log'
@@ -928,12 +929,15 @@ function bindingToApi(
 
     // cacheHandler can be an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.cacheHandler) {
+      const resolvedCacheHandler = resolveCacheHandlerPathToFilesystem(
+        nextConfigSerializable.cacheHandler
+      )
       nextConfigSerializable.cacheHandler =
         './' +
         normalizePathOnWindows(
-          path.isAbsolute(nextConfigSerializable.cacheHandler)
-            ? path.relative(projectPath, nextConfigSerializable.cacheHandler)
-            : nextConfigSerializable.cacheHandler
+          path.isAbsolute(resolvedCacheHandler)
+            ? path.relative(projectPath, resolvedCacheHandler)
+            : resolvedCacheHandler
         )
     }
     if (nextConfigSerializable.cacheHandlers) {
@@ -942,15 +946,18 @@ function bindingToApi(
           nextConfigSerializable.cacheHandlers as Record<string, string>
         )
           .filter(([_, value]) => value != null)
-          .map(([key, value]) => [
-            key,
-            './' +
-              normalizePathOnWindows(
-                path.isAbsolute(value)
-                  ? path.relative(projectPath, value)
-                  : value
-              ),
-          ])
+          .map(([key, value]) => {
+            const resolved = resolveCacheHandlerPathToFilesystem(value)
+            return [
+              key,
+              './' +
+                normalizePathOnWindows(
+                  path.isAbsolute(resolved)
+                    ? path.relative(projectPath, resolved)
+                    : resolved
+                ),
+            ]
+          })
       )
     }
 

--- a/packages/next/src/lib/format-dynamic-import-path.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.ts
@@ -2,6 +2,20 @@ import path from 'path'
 import { pathToFileURL, fileURLToPath } from 'url'
 
 /**
+ * Converts a cache handler path to a filesystem path.
+ * ESM's import.meta.resolve() returns file:// URLs which break when concatenated
+ * with .next/ or used with path.join/path.relative.
+ * @param filePath - Absolute path, relative path, or file:// URL (e.g. from import.meta.resolve)
+ * @returns A filesystem path suitable for path operations
+ */
+export function resolveCacheHandlerPathToFilesystem(filePath: string): string {
+  if (filePath.startsWith('file://')) {
+    return fileURLToPath(filePath)
+  }
+  return filePath
+}
+
+/**
  * The path for a dynamic route must be URLs with a valid scheme.
  *
  * When an absolute Windows path is passed to it, it interprets the beginning of the path as a protocol (`C:`).
@@ -10,11 +24,7 @@ import { pathToFileURL, fileURLToPath } from 'url'
  * @param filePath Absolute or relative path, or file:// URL (e.g. from import.meta.resolve)
  */
 export const formatDynamicImportPath = (dir: string, filePath: string) => {
-  // Convert file:// URL to filesystem path (e.g. from import.meta.resolve in ESM)
-  let resolvedFilePath = filePath
-  if (filePath.startsWith('file://')) {
-    resolvedFilePath = fileURLToPath(filePath)
-  }
+  const resolvedFilePath = resolveCacheHandlerPathToFilesystem(filePath)
 
   const absoluteFilePath = path.isAbsolute(resolvedFilePath)
     ? resolvedFilePath

--- a/packages/next/src/lib/format-dynamic-import-path.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { pathToFileURL } from 'url'
+import { pathToFileURL, fileURLToPath } from 'url'
 
 /**
  * The path for a dynamic route must be URLs with a valid scheme.
@@ -7,12 +7,18 @@ import { pathToFileURL } from 'url'
  * When an absolute Windows path is passed to it, it interprets the beginning of the path as a protocol (`C:`).
  * Therefore, it is important to always construct a complete path.
  * @param dir File directory
- * @param filePath Absolute or relative path
+ * @param filePath Absolute or relative path, or file:// URL (e.g. from import.meta.resolve)
  */
 export const formatDynamicImportPath = (dir: string, filePath: string) => {
-  const absoluteFilePath = path.isAbsolute(filePath)
-    ? filePath
-    : path.join(dir, filePath)
+  // Convert file:// URL to filesystem path (e.g. from import.meta.resolve in ESM)
+  let resolvedFilePath = filePath
+  if (filePath.startsWith('file://')) {
+    resolvedFilePath = fileURLToPath(filePath)
+  }
+
+  const absoluteFilePath = path.isAbsolute(resolvedFilePath)
+    ? resolvedFilePath
+    : path.join(dir, resolvedFilePath)
   const formattedFilePath = pathToFileURL(absoluteFilePath).toString()
 
   return formattedFilePath

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -40,6 +40,7 @@ import { dset } from '../shared/lib/dset'
 import { normalizeZodErrors } from '../shared/lib/zod'
 import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot'
 import { findDir } from '../lib/find-pages-dir'
+import { resolveCacheHandlerPathToFilesystem } from '../lib/format-dynamic-import-path'
 import { interopDefault } from '../lib/interop-default'
 import { djb2Hash } from '../shared/lib/hash'
 import type { NextAdapter } from '../build/adapter/build-complete'
@@ -1253,7 +1254,10 @@ function assignDefaultsAndValidate(
           }
         )[key]
 
-        if (handlerPath && !existsSync(handlerPath)) {
+        const resolvedHandlerPath =
+          handlerPath && resolveCacheHandlerPathToFilesystem(handlerPath)
+
+        if (resolvedHandlerPath && !existsSync(resolvedHandlerPath)) {
           invalidHandlerItems.push({
             key,
             reason: `cache handler path provided does not exist, received ${handlerPath}`,

--- a/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
@@ -6,6 +6,9 @@ const originalNextConfig = fs.readFileSync(
   __dirname + '/next.config.js',
   'utf8'
 )
+const importMetaResolveNextConfig = `export default {
+  cacheHandler: import.meta.resolve('./cache-handler-esm.js'),
+}`
 
 function runTests(
   exportType: string,
@@ -75,6 +78,26 @@ describe('app-dir - custom-cache-handler - esm', () => {
     },
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler-esm.js',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  runTests('esm default export', { next, isNextDev })
+})
+
+describe('app-dir - custom-cache-handler - esm import.meta.resolve', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: {
+      app: new FileRef(__dirname + '/app'),
+      'cache-handler-esm.js': new FileRef(__dirname + '/cache-handler-esm.js'),
+      'next.config.js': importMetaResolveNextConfig,
+    },
+    skipDeployment: true,
+    packageJson: {
+      type: 'module',
     },
   })
 


### PR DESCRIPTION
Fixes #73796`n`nHandles file:// URLs returned by import.meta.resolve when resolving the cacheHandler path. Includes test coverage.