### PR TITLE
fix(router): align has/missing header matching behavior with Vercel router

### DIFF
--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -1,4 +1,5 @@
-import { parseDestination } from './prepare-destination'
+import type { IncomingMessage } from 'http'
+import { parseDestination, matchHas } from './prepare-destination'
 
 describe('parseDestination', () => {
   it('should parse the destination', () => {
@@ -86,5 +87,147 @@ describe('parseDestination', () => {
        "slashes": true,
      }
     `)
+  })
+})
+
+describe('matchHas', () => {
+  it('should handle a has with an empty string value', () => {
+    let req = {
+      headers: {
+        'x-now-route-matches': '',
+      },
+    } as unknown as IncomingMessage
+
+    let result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual({})
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ]
+    )
+
+    expect(result).toEqual(false)
+
+    // Remove the header entirely.
+    delete req.headers['x-now-route-matches']
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ]
+    )
+
+    expect(result).toEqual({})
+
+    result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual(false)
+  })
+
+  it('should handle a has without a value', () => {
+    let req = {
+      headers: {
+        'x-now-route-matches': '',
+      },
+    } as unknown as IncomingMessage
+
+    let result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual({
+      xnowroutematches: '',
+    })
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ]
+    )
+
+    expect(result).toEqual(false)
+
+    // Remove the header entirely.
+    delete req.headers['x-now-route-matches']
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ]
+    )
+
+    expect(result).toEqual({})
+
+    result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual(false)
   })
 })

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -89,10 +89,22 @@ export function matchHas(
       }
     }
 
-    if (!hasItem.value && value) {
+    if (
+      // Aligning this logic with the Vercel router, we consider empty strings
+      // as valid values.
+      typeof hasItem.value !== 'string' &&
+      (typeof value === 'string' || Array.isArray(value))
+    ) {
       params[getSafeParamName(key!)] = value
       return true
-    } else if (value) {
+    } else if (
+      // Aligning this logic with the Vercel router, we consider empty strings
+      // as valid values.
+      typeof value === 'string' ||
+      // The code below uses slice, grabbing the last item in the array. This
+      // check prevents a runtime error that would occur with an empty array.
+      (Array.isArray(value) && value.length > 0)
+    ) {
       const matcher = new RegExp(`^${hasItem.value}$`)
       const matches = Array.isArray(value)
         ? value.slice(-1)[0].match(matcher)


### PR DESCRIPTION
Aligns the has/missing header matching behavior in the pages router with the Vercel router for edge cases.