### PR TITLE
fix: re-arm Navigation Inspector capture on history traversal

### DIFF
--- a/packages/next/src/client/components/render-tree.ts
+++ b/packages/next/src/client/components/render-tree.ts
@@ -2330,3 +2330,15 @@ export function resetNavigationLockToPending(): void {
     reset()
   }
 }
+
+/**
+ * Ends a captured lock scope and re-arms a fresh pending one after a history
+ * restore. No-op when the testing API is disabled or no capture is active.
+ */
+export function rearmNavigationLockAfterTraversal(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    const { rearmNavigationLockAfterTraversal: rearm } =
+      require('../segment-cache/navigation-testing-lock') as typeof import('../segment-cache/navigation-testing-lock')
+    rearm()
+  }
+}

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -6,6 +6,8 @@ import type {
 import { extractPathFromFlightRouterState } from '../compute-changed-path'
 import {
   FreshnessPolicy,
+  getCurrentNavigationLock,
+  rearmNavigationLockAfterTraversal,
   resetNavigationLockToPending,
   spawnDynamicRequests,
   startPPRNavigation,
@@ -109,11 +111,9 @@ export function restoreReducer(
     // Not an HMR refresh, so there's no request generation to cancel.
     undefined
   )
-  // Instant Navigation Testing API: a traversal resets the lock to a fresh
-  // pending scope — releasing any data withheld by prior forward navigations and
-  // returning the panel to "awaiting" — without ending the testing session.
-  // No-op when the testing API is disabled or no lock is held.
-  resetNavigationLockToPending()
+  // After spawnDynamicRequests so the requests spawned above hold the
+  // released scope's lock and their gated writes flush immediately.
+  rearmNavigationLockAfterTraversal()
   return completeTraverseNavigation(
     state,
     restoredUrl,

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.disabled.ts
@@ -58,6 +58,8 @@ export function getCurrentNavigationGate(): Promise<void> | null {
   return null
 }
 
+export function rearmNavigationLockAfterTraversal(): void {}
+
 export function resetNavigationLockToPending(): void {}
 
 export function shouldRestrictNavigationToShell(

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -526,6 +526,38 @@ export function getCurrentNavigationGate(): Promise<void> | null {
 }
 
 /**
+ * Called when the router applies a history restore (back/forward traversal,
+ * external pushState/replaceState, bfcache document restore) while a capture
+ * is active. The captured navigation is no longer what's on screen, so end
+ * its scope and immediately start a fresh pending one: dynamic writes gated
+ * on the old scope flush, and the next navigation is captured. Pending
+ * scopes are left alone.
+ *
+ * The cookie transitions from captured back to pending without ever being
+ * absent. Deleting it would disarm shell rendering for any document request
+ * that races the re-arm, and would trigger the unlock refresh, which the
+ * restored page doesn't need.
+ */
+export function rearmNavigationLockAfterTraversal(): void {
+  if (lockState === null || typeof document === 'undefined') {
+    return
+  }
+  const target = NEXT_INSTANT_TEST_COOKIE + '='
+  for (const segment of document.cookie.split(';')) {
+    const trimmed = segment.trim()
+    if (trimmed.startsWith(target)) {
+      const state = parseCookieValue(trimmed.slice(target.length))
+      if (state === 'mpa' || state === 'spa') {
+        releaseLock()
+        acquireLock()
+        writeCookieValue([0, `c${Math.random()}`])
+      }
+      return
+    }
+  }
+}
+
+/**
  * Decides whether segment reads during a navigation should be restricted to
  * shell entries (every param substituted with Fallback) rather than matching
  * entries that vary on concrete route params.


### PR DESCRIPTION
Re-arms Navigation Inspector capture when history traversal occurs.