### PR TITLE
fix docs: add missing export default and UserContext.Provider

### DIFF
--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -287,7 +287,7 @@ To reduce resource usage without fully disabling prefetch, you can prefetch only
 import Link from 'next/link'
 import { useState } from 'react'
 
-function HoverPrefetchLink({
+export default function HoverPrefetchLink({
   href,
   children,
 }: {
@@ -314,7 +314,7 @@ function HoverPrefetchLink({
 import Link from 'next/link'
 import { useState } from 'react'
 
-function HoverPrefetchLink({ href, children }) {
+export default function HoverPrefetchLink({ href, children }) {
   const [active, setActive] = useState(false)
 
   return (

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -2,10 +2,9 @@
 title: Fetching Data
 description: Learn how to fetch data and stream content that depends on data.
 related:
-  title: Next steps
-  description: Learn more about advanced data-fetching patterns and the features mentioned in this page.
+  title: API Reference
+  description: Learn more about the features mentioned in this page by reading the API Reference.
   links:
-    - app/guides/single-page-applications
     - app/guides/data-security
     - app/api-reference/functions/fetch
     - app/api-reference/file-conventions/loading
@@ -314,8 +313,6 @@ export default function Posts({ posts }) {
 
 In the example above, the `<Posts>` component is wrapped in a [`<Suspense>` boundary](https://react.dev/reference/react/Suspense). This means the fallback will be shown while the promise is being resolved. Learn more about [streaming](#streaming).
 
-You can resolve a promise on the server with `await` or in a Client Component with `use()`. React covers [when to resolve a Promise in a Server or Client Component](https://react.dev/reference/react/use#resolve-promise-in-server-or-client-component). To share one promise with many Client Components instead of passing it as a prop, provide it through context. See [Using React's `use` within a Context Provider](/docs/app/guides/single-page-applications#using-reacts-use-within-a-context-provider).
-
 #### Community libraries
 
 You can use a community library like [SWR](https://swr.vercel.app/) or [React Query](https://tanstack.com/query/latest) to fetch data in Client Components. These libraries have their own semantics for caching, streaming, and other features. For example, with SWR:
@@ -541,9 +538,11 @@ export default async function Page({ params }) {
 
 > **Good to know:** If one request fails when using `Promise.all`, the entire operation will fail. To handle this, you can use the [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) method instead.
 
-### Reusing data with `React.cache`
+### Sharing data with context and `React.cache`
 
-Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:
+You can share fetched data across both Server and Client Components by combining [`React.cache`](https://react.dev/reference/react/cache) with context providers.
+
+Create a cached function that fetches data:
 
 ```ts filename="app/lib/user.ts" switcher
 import { cache } from 'react'
@@ -563,7 +562,144 @@ export const getUser = cache(async () => {
 })
 ```
 
-Server Components can call `getUser()` directly:
+Create a context provider that stores the promise:
+
+```tsx filename="app/user-provider.tsx" switcher
+'use client'
+
+import { createContext } from 'react'
+
+type User = {
+  id: string
+  name: string
+}
+
+export const UserContext = createContext<Promise<User> | null>(null)
+
+export default function UserProvider({
+  children,
+  userPromise,
+}: {
+  children: React.ReactNode
+  userPromise: Promise<User>
+}) {
+  return <UserContext.Provider value={userPromise}>{children}</UserContext.Provider>
+}
+```
+
+```jsx filename="app/user-provider.js" switcher
+'use client'
+
+import { createContext } from 'react'
+
+export const UserContext = createContext(null)
+
+export default function UserProvider({ children, userPromise }) {
+  return <UserContext.Provider value={userPromise}>{children}</UserContext.Provider>
+}
+```
+
+In a layout, pass the promise to the provider without awaiting:
+
+```tsx filename="app/layout.tsx" switcher
+import UserProvider from './user-provider'
+import { getUser } from './lib/user'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const userPromise = getUser() // Don't await
+
+  return (
+    <html>
+      <body>
+        <UserProvider userPromise={userPromise}>{children}</UserProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+```jsx filename="app/layout.js" switcher
+import UserProvider from './user-provider'
+import { getUser } from './lib/user'
+
+export default function RootLayout({ children }) {
+  const userPromise = getUser() // Don't await
+
+  return (
+    <html>
+      <body>
+        <UserProvider userPromise={userPromise}>{children}</UserProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+Client Components use [`use()`](https://react.dev/reference/react/use) to resolve the promise from context, wrapped in `<Suspense>` for fallback UI:
+
+```tsx filename="app/ui/profile.tsx" switcher
+'use client'
+
+import { use, useContext } from 'react'
+import { UserContext } from '../user-provider'
+
+export function Profile() {
+  const userPromise = useContext(UserContext)
+  if (!userPromise) {
+    throw new Error('useContext must be used within a UserProvider')
+  }
+  const user = use(userPromise)
+  return <p>Welcome, {user.name}</p>
+}
+```
+
+```jsx filename="app/ui/profile.js" switcher
+'use client'
+
+import { use, useContext } from 'react'
+import { UserContext } from '../user-provider'
+
+export function Profile() {
+  const userPromise = useContext(UserContext)
+  if (!userPromise) {
+    throw new Error('useContext must be used within a UserProvider')
+  }
+  const user = use(userPromise)
+  return <p>Welcome, {user.name}</p>
+}
+```
+
+```tsx filename="app/page.tsx" switcher
+import { Suspense } from 'react'
+import { Profile } from './ui/profile'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading profile...</div>}>
+      <Profile />
+    </Suspense>
+  )
+}
+```
+
+```jsx filename="app/page.js" switcher
+import { Suspense } from 'react'
+import { Profile } from './ui/profile'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading profile...</div>}>
+      <Profile />
+    </Suspense>
+  )
+}
+```
+
+Server Components can also call `getUser()` directly:
 
 ```tsx filename="app/dashboard/page.tsx" switcher
 import { getUser } from '../lib/user'


### PR DESCRIPTION
Adds missing default export and UserContext.Provider to docs examples.