### PR TITLE
fix(pages): restore dynamic CSS manifest on ISR revalidation

### DIFF
--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -149,6 +149,7 @@ export const getHandler = ({
       nextFontManifest,
       serverFilesManifest,
       reactLoadableManifest,
+      dynamicCssManifest,
       prerenderManifest,
       isDraftMode,
       isOnDemandRevalidate,
@@ -304,6 +305,9 @@ export const getHandler = ({
                     : buildManifest,
                   nextFontManifest,
                   reactLoadableManifest,
+                  // Required so ISR/runtime renders omit `data-n-p` for CSS that
+                  // is also loaded via next/dynamic (see #72959 / #96429).
+                  dynamicCssManifest,
 
                   assetPrefix: nextConfig.assetPrefix,
                   previewProps: prerenderManifest.preview,

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -391,7 +391,9 @@ export abstract class RouteModule<
         loadManifestFromRelativePath<any>({
           projectDir,
           distDir: this.distDir,
-          manifest: DYNAMIC_CSS_MANIFEST,
+          // Emitted as `dynamic-css-manifest.json` (constant omits the extension
+          // because the edge runtime also emits `server/dynamic-css-manifest.js`).
+          manifest: `${DYNAMIC_CSS_MANIFEST}.json`,
           shouldCache: !this.isDev,
           handleMissing: true,
         }),
@@ -419,7 +421,11 @@ export abstract class RouteModule<
           ?.__RSC_MANIFEST?.[srcPage.replace(/%5F/g, '_')],
         serverActionsManifest,
         subresourceIntegrityManifest,
-        dynamicCssManifest,
+        // `handleMissing` returns `{}` when the file is absent (e.g. Turbopack).
+        // Normalize to `undefined` so callers can safely do `new Set(...)`.
+        dynamicCssManifest: Array.isArray(dynamicCssManifest)
+          ? dynamicCssManifest
+          : undefined,
         prefetchHintsManifest,
         interceptionRoutePatterns: routesManifest.rewrites.beforeFiles
           .filter(isInterceptionRouteRewrite)

--- a/test/production/isr-dynamic-css-manifest/components/box.js
+++ b/test/production/isr-dynamic-css-manifest/components/box.js
@@ -1,0 +1,9 @@
+import classes from './box.module.css'
+
+export function Box() {
+  return (
+    <div id="styled-box" className={classes.box}>
+      Styled box
+    </div>
+  )
+}

--- a/test/production/isr-dynamic-css-manifest/components/box.module.css
+++ b/test/production/isr-dynamic-css-manifest/components/box.module.css
@@ -1,0 +1,5 @@
+.box {
+  padding: 40px;
+  background: #2f6f4f;
+  color: #fff;
+}

--- a/test/production/isr-dynamic-css-manifest/isr-dynamic-css-manifest.test.ts
+++ b/test/production/isr-dynamic-css-manifest/isr-dynamic-css-manifest.test.ts
@@ -1,0 +1,69 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+/**
+ * Regression for https://github.com/vercel/next.js/issues/96429
+ *
+ * After ISR revalidation, Pages Router runtime renders must still consult
+ * `dynamic-css-manifest.json` so shared CSS modules loaded via `next/dynamic`
+ * are not marked `data-n-p` and subsequently removed on client navigation.
+ *
+ * This only applies to webpack production builds (Turbopack does not emit /
+ * consume this manifest).
+ */
+;(process.env.IS_WEBPACK_TEST ? describe : describe.skip)(
+  'isr-dynamic-css-manifest',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+    })
+
+    async function waitForHomeIsr() {
+      const initialHtml = await next.render('/')
+      const initialNow = initialHtml.match(/id="home-now">(\d+)</)?.[1]
+      expect(initialNow).toBeTruthy()
+
+      await retry(async () => {
+        const html = await next.render('/')
+        const now = html.match(/id="home-now">(\d+)</)?.[1]
+        expect(now).toBeTruthy()
+        expect(now).not.toBe(initialNow)
+      })
+    }
+
+    it('should not mark shared dynamic CSS with data-n-p after ISR revalidation', async () => {
+      const initialHtml = await next.render('/')
+      expect(initialHtml).toMatch(/rel="stylesheet"[^>]*href="[^"]+\.css"/)
+      // Fresh build HTML should not tag the shared CSS as page-only.
+      expect(initialHtml).not.toMatch(
+        /rel="stylesheet"[^>]*href="[^"]+\.css"[^>]*data-n-p=""/
+      )
+
+      await waitForHomeIsr()
+
+      const revalidatedHtml = await next.render('/')
+      // After ISR, runtime render must still omit data-n-p for CSS present in
+      // dynamic-css-manifest.json.
+      expect(revalidatedHtml).not.toMatch(
+        /rel="stylesheet"[^>]*href="[^"]+\.css"[^>]*data-n-p=""/
+      )
+    })
+
+    it('should keep CSS module styles after client navigation following ISR revalidation', async () => {
+      await waitForHomeIsr()
+
+      const browser = await next.browser('/')
+      await browser.elementByCss('#to-second').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#styled-box').text()).toBe(
+          'Styled box'
+        )
+        const bg = await browser.eval(
+          `window.getComputedStyle(document.querySelector('#styled-box')).backgroundColor`
+        )
+        expect(bg).toBe('rgb(47, 111, 79)')
+      })
+    })
+  }
+)

--- a/test/production/isr-dynamic-css-manifest/pages/index.js
+++ b/test/production/isr-dynamic-css-manifest/pages/index.js
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import { Box } from '../components/box'
+
+export default function Home({ now }) {
+  return (
+    <main>
+      <p id="home-now">{now}</p>
+      <Box />
+      <Link href="/second" id="to-second">
+        Go to second
+      </Link>
+    </main>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      now: Date.now(),
+    },
+    // Short window so the test can wait for ISR regeneration.
+    revalidate: 1,
+  }
+}

--- a/test/production/isr-dynamic-css-manifest/pages/second.js
+++ b/test/production/isr-dynamic-css-manifest/pages/second.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import dynamic from 'next/dynamic'
+
+const Box = dynamic(() => import('../components/box').then((mod) => mod.Box))
+
+export default function Second({ now }) {
+  return (
+    <main>
+      <p id="second-now">{now}</p>
+      <Box />
+      <Link href="/" id="to-home">
+        Back home
+      </Link>
+    </main>
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      now: Date.now(),
+    },
+    revalidate: 1,
+  }
+}


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #96429`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs

## Summary

After ISR revalidation in the Pages Router (webpack production), CSS modules shared between a statically imported page and a `next/dynamic` page were marked with `data-n-p`. On client navigation, Next removed that stylesheet and never put it back, so the dynamic page rendered unstyled.

Build-time HTML was fine because `load-components` loaded `dynamic-css-manifest.json` correctly. Runtime ISR renders went through the Pages route handler, which did not forward `dynamicCssManifest` into `renderOpts`, and also tried to load the manifest without the `.json` extension.

This PR:
- Loads `dynamic-css-manifest.json` in `route-module`
- Passes `dynamicCssManifest` through `pages-handler` into `renderOpts`
- Adds a webpack production regression test for ISR HTML + client navigation

## Verification

- `HEADLESS=true pnpm test-start-webpack test/production/isr-dynamic-css-manifest/isr-dynamic-css-manifest.test.ts`

Fixes #96429