### PR TITLE
Enable Turbopack build filesystem cache by default

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
@@ -8,9 +8,7 @@ description: Learn how to enable FileSystem Caching for Turbopack builds
 
 Turbopack FileSystem Cache enables Turbopack to reduce work across `next dev` or `next build` commands. When enabled, Turbopack will save and restore data to the `.next` folder between builds, which can greatly speed up subsequent builds and dev sessions.
 
-> **Good to know:** The FileSystem Cache is **enabled by default** for `next dev`. It is enabled by default when running `next build` locally or on Vercel, where the cache is likely to persist between builds. You can explicitly enable or disable it with the flags below.
-
-> **For deployment providers:** Other providers can enable the build cache by default on their platform by setting `experimental.turbopackFileSystemCacheForBuild: true` from their adapter's [`modifyConfig`](/docs/app/api-reference/adapters/creating-an-adapter) hook. Do this when your infrastructure preserves the `.next/cache` directory between builds, and only when the user has not set an explicit value for the flag.
+> **Good to know:** The FileSystem Cache is **enabled by default** for `next dev` and `next build`. You can explicitly disable it with the flags below when your build environment does not preserve the `.next/cache` directory between builds.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -41,9 +39,9 @@ module.exports = nextConfig
 
 ## Version Changes
 
-| Version   | Changes                                                                              |
-| --------- | ------------------------------------------------------------------------------------ |
-| `v16.3.0` | FileSystem caching is enabled by default for builds (depends on CI platform support) |
-| `v16.1.0` | FileSystem caching is enabled by default for development                             |
-| `v16.0.0` | Beta release with separate flags for build and dev                                   |
-| `v15.5.0` | Persistent caching released as experimental on canary releases                       |
+| Version   | Changes                                                        |
+| --------- | -------------------------------------------------------------- |
+| `v16.3.0` | FileSystem caching is enabled by default for builds            |
+| `v16.1.0` | FileSystem caching is enabled by default for development       |
+| `v16.0.0` | Beta release with separate flags for build and dev             |
+| `v15.5.0` | Persistent caching released as experimental on canary releases |

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -349,9 +349,7 @@ This can lead to subtle rendering differences when migrating from webpack to Tur
 Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar feature. Starting with Next 16, Turbopack's filesystem cache is controlled by the following experimental flags:
 
 - [`experimental.turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled by default
-- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled by default for local builds and on Vercel, where the build cache is likely to persist.
-
-Other deployment providers can enable the build cache by default on their platform by setting `experimental.turbopackFileSystemCacheForBuild: true` from their adapter's [`modifyConfig`](/docs/app/api-reference/adapters/creating-an-adapter) hook, when their infrastructure preserves the `.next/cache` directory between builds.
+- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled by default
 
 > **Good to know:** For this reason, when comparing webpack and Turbopack performance, make sure to delete the `.next` folder between builds to see a fair cold build comparison or enable the turbopack filesystem cache feature to compare warm builds.
 
@@ -422,9 +420,8 @@ Additionally, the following experimental options are available under `experiment
 | [`turbopackLocalPostcssConfig`](/docs/app/api-reference/config/next-config-js/turbopackLocalPostcssConfig)   | Resolve `postcss.config.js` from the CSS file's directory first, then the project root.                                                      | `false`       | `false`                       |
 | `turbopackWorkerAssetPrefix`                                                                                 | Custom asset prefix for Web Worker URLs (entrypoint + module chunks), overriding `assetPrefix`. Mirrors webpack's `output.workerPublicPath`. | `undefined`   | `undefined`                   |
 
-<sup>1</sup> Enabled by default for local builds and on CI platforms (including
-Vercel) where the build cache is likely to persist. Disabled by default on CI
-platforms that have not yet opted into the feature.
+<sup>1</sup> Enabled by default. Set the option to `false` when the build
+environment does not preserve the `.next/cache` directory between builds.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -16,7 +16,6 @@ import { INFINITE_CACHE } from '../lib/constants'
 import type { FallbackRouteParam } from '../build/static-paths/types'
 import type { MemoryEvictionMode } from '../build/swc/types'
 import type { CacheLife } from './use-cache/cache-life'
-import { isCI } from './ci-info'
 
 /**
  * The `cacheLife` profiles after config normalization. `config.ts` always
@@ -881,7 +880,7 @@ export interface ExperimentalConfig {
   /**
    * Enable filesystem cache for the turbopack build.
    *
-   * Defaults to `true` in canary/preview builds, `false` in production.
+   * Defaults to `true`.
    */
   turbopackFileSystemCacheForBuild?: boolean
 
@@ -2250,19 +2249,13 @@ export const defaultConfig = Object.freeze({
     hideLogsAfterAbort: false,
     mcpServer: true,
     turbopackFileSystemCacheForDev: true,
-    turbopackFileSystemCacheForBuild: turbopackFileSystemCacheForBuildDefault(),
+    turbopackFileSystemCacheForBuild: true,
     turbopackInferModuleSideEffects: true,
     turbopackPluginRuntimeStrategy: 'childProcesses',
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,
 } satisfies NextConfig)
-
-function turbopackFileSystemCacheForBuildDefault() {
-  // Disable in most CI environments, because we don't know if the cache will persist across builds.
-  // Providers: Override the default behavior using `modifyConfig` in your adapter.
-  return !isCI || Boolean(process.env.NOW_BUILDER)
-}
 
 export async function normalizeConfig(phase: string, config: any) {
   if (typeof config === 'function') {

--- a/test/e2e/filesystem-cache/build-cache-default.test.ts
+++ b/test/e2e/filesystem-cache/build-cache-default.test.ts
@@ -2,20 +2,13 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
 import fs from 'fs/promises'
 import path from 'path'
 
-// `experimental.turbopackFileSystemCacheForBuild` is enabled by default, except
-// in CI environments that haven't opted in (`isCI && !NOW_BUILDER`), where the
-// cache is unlikely to persist between builds. It can always be disabled
-// explicitly with `turbopackFileSystemCacheForBuild: false`.
+// `experimental.turbopackFileSystemCacheForBuild` is enabled by default in all
+// environments. It can be disabled explicitly with
+// `turbopackFileSystemCacheForBuild: false`.
 //
-// This is a Turbopack + build (start) mode test. It runs `next build` with a
-// controlled environment (the default depends on ambient `isCI`/`NOW_BUILDER`,
-// and the test runner itself runs in CI) and checks whether anything is written
+// This is a Turbopack + build (start) mode test. It runs `next build` with
+// controlled local and CI environments and checks whether anything is written
 // to `.next/cache/turbopack`.
-//
-// `next/dist/compiled/ci-info` computes
-//   isCI = !!(CI || CONTINUOUS_INTEGRATION || BUILD_NUMBER || RUN_ID || <vendor>)
-// so clearing those signals forces a non-CI environment, and setting `CI=1`
-// (with `NOW_BUILDER` unset) forces a CI environment that hasn't opted in.
 ;(process.env.IS_TURBOPACK_TEST && isNextStart ? describe : describe.skip)(
   'filesystem-cache build default',
   () => {
@@ -29,8 +22,7 @@ import path from 'path'
       return
     }
 
-    // Simulate a non-CI (local) environment by clearing every CI signal that
-    // `ci-info` looks at.
+    // Simulate a non-CI (local) environment by clearing the common CI signals.
     const NON_CI_ENV = {
       CI: '',
       CONTINUOUS_INTEGRATION: '',
@@ -89,7 +81,7 @@ import path from 'path'
       await setConfig()
     })
 
-    it('writes the cache by default (no config, non-CI environment)', async () => {
+    it('writes the cache by default (no config, local environment)', async () => {
       await cleanBuildOutput()
       await setConfig()
 
@@ -109,17 +101,17 @@ import path from 'path'
       expect(await getCacheSize()).toBe(0)
     })
 
-    it('writes nothing by default in CI that has not opted in', async () => {
+    it('writes the cache by default in CI', async () => {
       await cleanBuildOutput()
       await setConfig()
 
       const { exitCode } = await next.build({
-        // Force a CI environment that hasn't opted in: `isCI` true, `NOW_BUILDER` unset.
+        // Force a generic CI environment.
         env: { ...NON_CI_ENV, CI: '1' },
       })
       expect(exitCode).toBe(0)
 
-      expect(await getCacheSize()).toBe(0)
+      expect(await getCacheSize()).toBeGreaterThan(0)
     })
   }
 )


### PR DESCRIPTION
## Summary

Enable `experimental.turbopackFileSystemCacheForBuild` by default in all environments, including generic CI. Explicitly setting the option to `false` remains the opt-out. Update the focused coverage and documentation to match.

## Verification

- `IS_TURBOPACK_TEST=1 pnpm test-start-turbo test/e2e/filesystem-cache/build-cache-default.test.ts`
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check packages/next/src/server/config-shared.ts test/e2e/filesystem-cache/build-cache-default.test.ts docs/01-app/03-api-reference/08-turbopack.mdx docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx`
- Not run: `pnpm --filter=next build` (the checkout has 11 pre-existing TypeScript errors in unrelated files)

<!-- NEXT_JS_LLM -->