### PR TITLE
fix(typescript): emit bundler moduleResolution for commonjs on TS 6+

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
@@ -143,6 +143,60 @@ describe('writeConfigurationDefaults()', () => {
       )
     })
 
+    it('uses bundler moduleResolution for commonjs on TypeScript 6+', async () => {
+      await writeFile(
+        tsConfigPath,
+        JSON.stringify({ compilerOptions: { module: 'commonjs' } }),
+        { encoding: 'utf8' }
+      )
+
+      await writeConfigurationDefaults(
+        '6.0.0',
+        tsConfigPath,
+        isFirstTimeSetup,
+        hasAppDir,
+        distDir,
+        hasPagesDir,
+        experimentalStrictRouteTypes
+      )
+
+      const tsConfig = JSON.parse(
+        await readFile(tsConfigPath, { encoding: 'utf8' })
+      )
+
+      expect(tsConfig.compilerOptions.moduleResolution).toBe('bundler')
+      expect(stripAnsi(consoleLogSpy.mock.calls.flat().join('\n'))).toContain(
+        '- moduleResolution was set to bundler (to match modern bundler resolution)'
+      )
+    })
+
+    it('keeps node moduleResolution for commonjs on TypeScript 5', async () => {
+      await writeFile(
+        tsConfigPath,
+        JSON.stringify({ compilerOptions: { module: 'commonjs' } }),
+        { encoding: 'utf8' }
+      )
+
+      await writeConfigurationDefaults(
+        '5.9.3',
+        tsConfigPath,
+        isFirstTimeSetup,
+        hasAppDir,
+        distDir,
+        hasPagesDir,
+        experimentalStrictRouteTypes
+      )
+
+      const tsConfig = JSON.parse(
+        await readFile(tsConfigPath, { encoding: 'utf8' })
+      )
+
+      expect(tsConfig.compilerOptions.moduleResolution).toBe('node')
+      expect(stripAnsi(consoleLogSpy.mock.calls.flat().join('\n'))).toContain(
+        '- moduleResolution was set to node (to match webpack resolution)'
+      )
+    })
+
     it('uses bundler moduleResolution for TypeScript 6+', async () => {
       await writeFile(tsConfigPath, JSON.stringify({ compilerOptions: {} }), {
         encoding: 'utf8',

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -41,10 +41,15 @@ function getDesiredCompilerOptions(
     typeof userTsConfig?.compilerOptions?.module === 'string'
       ? userTsConfig.compilerOptions.module.toLowerCase()
       : undefined
+  // TypeScript 6.0 dropped `moduleResolution: node` (node10) in favor of the
+  // `bundler` mode, which it now allows together with `module: commonjs`.
+  // Older TypeScript versions reject that combination (TS5095), so keep
+  // emitting `node` for them until they are no longer supported.
   const preferBundlerResolution =
     semver.gte(typescriptVersion, '5.0.0') &&
-    configuredModule !== moduleKindCommonJS &&
-    configuredModule !== moduleKindAMD
+    configuredModule !== moduleKindAMD &&
+    (configuredModule !== moduleKindCommonJS ||
+      semver.gte(typescriptVersion, '6.0.0'))
 
   // Jsx
   const jsxEmitReactJSX = 'react-jsx'

--- a/test/production/tsconfig-verifier/tsconfig-verifier.test.ts
+++ b/test/production/tsconfig-verifier/tsconfig-verifier.test.ts
@@ -331,11 +331,11 @@ describe('tsconfig.json verifier', () => {
     }
   })
 
-  // `module: commonjs` forces `moduleResolution: node`, which TypeScript 6
-  // deprecates (TS5107). The commonjs case is tested in a separate describe
-  // block below that pins TypeScript 5.9 until we stop emitting the deprecated
-  // resolution. See the `tsconfig.json verifier 5.x` block at the end of this
-  // file.
+  // `module: commonjs` uses `moduleResolution: bundler` on TypeScript 6+.
+  // TypeScript 5 cannot combine `bundler` with `commonjs` (TS5095), so it
+  // still emits the legacy `node` resolution there. The commonjs case is
+  // tested in a separate describe block below that pins TypeScript 5.9. See
+  // the `tsconfig.json verifier 5.x` block at the end of this file.
 
   it('allows you to set es2020 module mode', async () => {
     expect(await next.hasFile('tsconfig.json')).toBe(false)
@@ -394,6 +394,102 @@ describe('tsconfig.json verifier', () => {
            "compilerOptions": {
              "esModuleInterop": true,
              "module": "es2020",
+             "target": "ES2017",
+             "lib": [
+               "dom",
+               "dom.iterable",
+               "esnext"
+             ],
+             "allowJs": true,
+             "skipLibCheck": true,
+             "strict": false,
+             "noEmit": true,
+             "incremental": true,
+             "moduleResolution": "bundler",
+             "resolveJsonModule": true,
+             "isolatedModules": true,
+             "jsx": "react-jsx",
+             "plugins": [
+               {
+                 "name": "next"
+               }
+             ],
+             "strictNullChecks": true
+           },
+           "include": [
+             "next-env.d.ts",
+             ".next/types/**/*.ts",
+             ".next/dev/types/**/*.ts",
+             "**/*.mts",
+             "**/*.ts",
+             "**/*.tsx"
+           ],
+           "exclude": [
+             "node_modules"
+           ]
+         }
+         "
+        `)
+    }
+  })
+
+  it('allows you to set commonjs module mode', async () => {
+    expect(await next.hasFile('tsconfig.json')).toBe(false)
+
+    await next.patchFile(
+      'tsconfig.json',
+      `{ "compilerOptions": { "esModuleInterop": false, "module": "commonjs" } }`
+    )
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    const { exitCode } = await next.build()
+    expect(exitCode).toBe(0)
+
+    if (strictRouteTypes) {
+      expect(await next.readFile('tsconfig.json')).toMatchInlineSnapshot(`
+         "{
+           "compilerOptions": {
+             "esModuleInterop": true,
+             "module": "commonjs",
+             "target": "ES2017",
+             "lib": [
+               "dom",
+               "dom.iterable",
+               "esnext"
+             ],
+             "allowJs": true,
+             "skipLibCheck": true,
+             "strict": false,
+             "noEmit": true,
+             "incremental": true,
+             "moduleResolution": "bundler",
+             "resolveJsonModule": true,
+             "isolatedModules": true,
+             "jsx": "react-jsx",
+             "plugins": [
+               {
+                 "name": "next"
+               }
+             ],
+             "strictNullChecks": true
+           },
+           "include": [
+             "next-env.d.ts",
+             "**/*.mts",
+             "**/*.ts",
+             "**/*.tsx"
+           ],
+           "exclude": [
+             "node_modules"
+           ]
+         }
+         "
+        `)
+    } else {
+      expect(await next.readFile('tsconfig.json')).toMatchInlineSnapshot(`
+         "{
+           "compilerOptions": {
+             "esModuleInterop": true,
+             "module": "commonjs",
              "target": "ES2017",
              "lib": [
                "dom",
@@ -1124,9 +1220,10 @@ describe('tsconfig.json verifier', () => {
   })
 })
 
-// `module: commonjs` forces Next.js to emit `moduleResolution: node`, which
-// TypeScript 6 deprecates (TS5107). Pin TypeScript 5.9 for this case until we
-// stop emitting the deprecated resolution.
+// TypeScript 5 cannot combine `moduleResolution: bundler` with
+// `module: commonjs` (TS5095), so Next.js still emits the legacy `node`
+// resolution there. Pin TypeScript 5.9 for this case to keep that behavior
+// covered until TypeScript 5 is no longer supported.
 describe('tsconfig.json verifier 5.x', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
Fixes #82017

## What

`moduleResolution: node` (node10) is deprecated and removed in TypeScript 6.0,
so Next.js can no longer emit it as the default for projects that use
`module: commonjs`.

TypeScript 6 accepts `moduleResolution: bundler` together with
`module: commonjs` (the TS5095 mismatch error only fires on TS 5.x). This
changes the default so:

- TS 6+: `moduleResolution: bundler` is emitted for commonjs modules
- TS 5.x and older: `moduleResolution: node` is still emitted (unchanged)

## Validation

- New unit tests in `writeConfigurationDefaults.test.ts` for TS 6 (bundler)
  and TS 5.9 (node)
- New production test in `test/production/tsconfig-verifier` running against
  TS 6.0.2 (bundler) and TS 5.9 (node)
- `pnpm jest packages/next/src/lib/typescript/` and
  `pnpm test-start-turbo test/production/tsconfig-verifier/tsconfig-verifier.test.ts`
  both pass