### PR TITLE
test: reproduce stale page after back navigation

### DIFF
--- a/test/development/app-dir/dev-full-navigation-back/app/about/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="about">About</p>
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/layout.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/page.tsx
@@ -1,0 +1,12 @@
+import { value } from './value'
+
+export default function Page() {
+  return (
+    <>
+      <p id="value">{value}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/value.ts
+++ b/test/development/app-dir/dev-full-navigation-back/app/value.ts
@@ -1,0 +1,1 @@
+export const value = 'Value A'

--- a/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import { readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+
+describe('dev-full-navigation-back', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('shows an edit after full navigation and back navigation', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#value').text()).toBe('Value A')
+
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (self as any).__NEXT_DEBUG_CHANNEL_PERSISTED)
+      ).toBe(true)
+    })
+
+    await browser.elementByCss('#to-about').click()
+    await browser.waitForElementByCss('#about')
+
+    const valueFile = join(next.testDir, 'app/value.ts')
+    const content = await readFile(valueFile, 'utf8')
+    await writeFile(valueFile, content.replace('Value A', 'Value B'))
+    await waitFor(3000)
+
+    await browser.back({ waitUntil: 'commit' })
+    await retry(async () => {
+      expect(await browser.elementByCss('#value').text()).toBe('Value B')
+    })
+  })
+})

--- a/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry, waitFor } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { readFile, writeFile } from 'fs/promises'
 import { join } from 'path'
 
@@ -24,10 +24,10 @@ describe('dev-full-navigation-back', () => {
     const valueFile = join(next.testDir, 'app/value.ts')
     const content = await readFile(valueFile, 'utf8')
     await writeFile(valueFile, content.replace('Value A', 'Value B'))
-    // Wait for the HMR update to finish while this page is inactive. Going
-    // back too quickly lets the restored page receive the update, causing the
-    // test to pass unexpectedly instead of reproducing the stale page.
-    await waitFor(3000)
+    await retry(async () => {
+      const $ = await next.render$('/')
+      expect($('#value').text()).toBe('Value B')
+    })
 
     await browser.back({ waitUntil: 'commit' })
     await retry(async () => {

--- a/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -24,6 +24,9 @@ describe('dev-full-navigation-back', () => {
     const valueFile = join(next.testDir, 'app/value.ts')
     const content = await readFile(valueFile, 'utf8')
     await writeFile(valueFile, content.replace('Value A', 'Value B'))
+    // Wait for the HMR update to finish while this page is inactive. Going
+    // back too quickly lets the restored page receive the update, causing the
+    // test to pass unexpectedly instead of reproducing the stale page.
     await waitFor(3000)
 
     await browser.back({ waitUntil: 'commit' })

--- a/test/development/app-dir/dev-full-navigation-back/next.config.js
+++ b/test/development/app-dir/dev-full-navigation-back/next.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value:
+              'public, max-age=0, s-maxage=31536000, stale-while-revalidate=86400',
+          },
+        ],
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

Adds a minimal development regression test for a cacheable App Router page that is restored after a hard navigation while an imported value changes. The test captures the stale back-navigation behavior by expecting the restored page to show the edited value.

## Verification

- Reproduced with `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts` (expected `Value B`, received stale `Value A`)

<!-- NEXT_JS_LLM -->