### PR TITLE
Flag newly disabled deploy tests

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,3 @@
+# Test review instructions
+
+- During code review, flag any change that newly disables, skips, or omits deploy-mode tests or assertions, including `skipDeployment: true` and `isNextDeploy` conditionals. Only allow this when the assertion is inherently specific to self-hosted behavior; even then, prefer an explicit deploy-mode assertion that documents the different deployed semantics.

--- a/test/e2e/bigint/bigint.test.ts
+++ b/test/e2e/bigint/bigint.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('bigint API route support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should return 200', async () => {

--- a/test/e2e/bigint/bigint.test.ts
+++ b/test/e2e/bigint/bigint.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('bigint API route support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
   })
 
   it('should return 200', async () => {


### PR DESCRIPTION
## What changed

Added scoped review guidance under `test/` so Vercel Agent flags changes that newly disable deploy-mode tests or assertions.

## Why

Deploy coverage should only be disabled for assertions that are inherently self-hosted-specific. When deployed behavior differs, the test should prefer documenting those semantics instead of skipping deploy mode.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build-all`
- Hosted Vercel Agent E2E: an intentional `skipDeployment: true` probe was flagged inline, then removed
- Hosted Vercel Agent Review passed on the final diff
