### PR TITLE
turbo-tasks: explicit GC root anchoring + cross-session orphan reclamation

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
+    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbo_tasks, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -68,10 +68,18 @@ unsafe impl OperationValue for PathToOutputOperation {}
 type OutputOperationToComputeEntry =
     FxHashMap<OperationVc<ExpandedOutputAssets>, OperationVc<OptionMapEntry>>;
 
-// TODO: Ideally this structure is never persisted, so new sessions start from scratch and don't
-// accumulate entries or force rebuilds of all chunks when a new session is only interested in some
-// of them. If this happens, this should have #[turbo_tasks::value(evict = "never")].
-#[turbo_tasks::value]
+// This map is a dev-only, rebuilt-every-session index over the current session's output assets
+// (populated via `insert_output_assets` during the write/emit phase), not a source of truth — the
+// underlying `ExpandedOutputAssets` operations are the persisted data. So we skip persisting it
+// (`serialization = "skip"`), which keeps the `OperationVc` GC pins it holds (see the pin/unpin
+// calls in the mutation methods below) purely in-session: no persist/restore re-pinning needed. This
+// also means new sessions start from scratch and don't accumulate entries or force rebuilds of all
+// chunks when a new session is only interested in some of them.
+//
+// `evict = "never"` because the op set and the record of what's pinned live in this cell's `State`;
+// evicting the cell would drop that state and (with serialization skipped) it could not be
+// restored, silently resetting the map and orphaning the pins.
+#[turbo_tasks::value(serialization = "skip", evict = "never")]
 pub struct VersionedContentMap {
     // TODO: turn into a bi-directional multimap, ExpandedOutputAssets ->
     // FxIndexSet<FileSystemPath>
@@ -175,7 +183,32 @@ impl VersionedContentMap {
             client_output_path,
         );
         this.map_op_to_compute_entry.update_conditionally(|map| {
-            map.insert(assets_operation, compute_entry) != Some(compute_entry)
+            let previous = map.insert(assets_operation, compute_entry);
+            if previous == Some(compute_entry) {
+                // Nothing changed: the same value was already stored under this key, so the
+                // `insert` replaced `compute_entry` with an identical `compute_entry`. The key op's
+                // pin (taken when it was first inserted) and the value op's pin are both still
+                // correct; no pin bookkeeping needed.
+                return false;
+            }
+            // Pin the operations so GC keeps their tasks alive while they're held in this map (the
+            // map stores them outside the task graph, so nothing else anchors them). This runs in a
+            // task function body — the unguarded region — so acquiring the pin guard is safe.
+            let tt = turbo_tasks();
+            match previous {
+                None => {
+                    // New key: pin both the key op and the value op.
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+                Some(old_compute_entry) => {
+                    // Key already present (its pin stays); the value op changed — unpin the old,
+                    // pin the new.
+                    tt.unpin_task_for_gc(old_compute_entry.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+            }
+            true
         });
         Ok(())
     }
@@ -199,30 +232,42 @@ impl VersionedContentMap {
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
+            // The map stores `assets_operation` outside the task graph, so pin its task for the
+            // duration of each (path -> op) membership: pin on a genuine insert, unpin on a genuine
+            // removal. This runs in a task function body (the unguarded region), so acquiring the
+            // pin guard is safe. Balance is one pin per distinct path bucket the op lives in.
+            let tt = turbo_tasks();
+
             // get current map's keys, subtract keys that don't exist in operation
             let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                let res = map
+                let inserted = map
                     .0
                     .entry(k.clone())
                     .or_default()
                     .0
                     .insert(assets_operation);
+                if inserted {
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                }
                 stale_assets.remove(k);
-                changed = changed || res;
+                changed = changed || inserted;
             }
 
             // Make more efficient with reverse map
             for k in &stale_assets {
-                let res = map
+                let removed = map
                     .0
                     .get_mut(k)
                     // guaranteed
                     .unwrap()
                     .0
                     .swap_remove(&assets_operation);
-                changed = changed || res
+                if removed {
+                    tt.unpin_task_for_gc(assets_operation.task_id());
+                }
+                changed = changed || removed
             }
             changed
         });
@@ -289,7 +334,14 @@ impl VersionedContentMap {
         Ok(Vc::cell(None))
     }
 
-    #[turbo_tasks::function]
+    // `session_dependent` because this reads `map_path_to_op` — a `State` on a
+    // `serialization = "skip"` cell that is NOT persisted. Without it, this task's cached key set
+    // would persist across sessions while the state it depends on is recreated empty on restore
+    // (the read subscription lives in the non-persisted state's own invalidators, so there is no
+    // edge to invalidate this task), causing it to serve a stale, session-A key set (e.g. keeping a
+    // deleted route keyed). `session_dependent` forces re-execution on cross-session restore, so it
+    // recomputes against the fresh (empty) map instead.
+    #[turbo_tasks::function(session_dependent)]
     pub async fn keys_in_path(&self, root: FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
             let map = &self.map_path_to_op.get().0;
@@ -306,7 +358,13 @@ impl VersionedContentMap {
         Ok(Vc::cell(keys))
     }
 
-    #[turbo_tasks::function]
+    // `session_dependent` for the same reason as `keys_in_path`: it reads the non-persisted
+    // `map_path_to_op` / `map_op_to_compute_entry` states. All of
+    // `get`/`get_asset`/`get_source_map` route through this, so marking it here covers the
+    // whole read path. Forcing re-execution on cross-session restore makes a lookup for a
+    // vanished route recompute to `None` against the fresh empty map rather than serving a
+    // stale entry.
+    #[turbo_tasks::function(session_dependent)]
     fn raw_get(&self, path: FileSystemPath) -> Vc<OptionMapEntry> {
         let assets = {
             let map = &self.map_path_to_op.get().0;

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -49,9 +49,9 @@ use tracing::Instrument;
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Effects, FxIndexSet, OperationValue, OperationVc, PrettyPrintError, ReadRef, ResolvedVc,
-    TransientInstance, TryJoinIterExt, TurboTasksApi, TurboTasksCallApi, UpdateInfo, Vc,
-    mark_top_level_task,
+    Effects, FxIndexSet, GcRoot, OperationValue, OperationVc, PrettyPrintError, ReadRef,
+    ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasksApi, TurboTasksCallApi, UpdateInfo,
+    Vc, mark_top_level_task,
     message_queue::{CompilationEvent, Severity},
     read_strongly_consistent_and_apply_effects, take_effects,
     trace::TraceRawVcs,
@@ -413,6 +413,12 @@ pub struct ProjectInstance {
     turbopack_ctx: NextTurbopackContext,
     container: ResolvedVc<ProjectContainer>,
     exit_receiver: tokio::sync::Mutex<Option<ExitReceiver>>,
+    /// Pins the `ProjectContainer` root operation against GC for the lifetime of this instance
+    /// (the whole dev-server/build session). The container is a permanent root that escapes
+    /// the tracked graph — it has no persistent parent, and the `container` `ResolvedVc` above
+    /// points at the container's output, not its root operation task, so it does not anchor
+    /// it. Dropped when the instance is dropped (session teardown), which unpins.
+    _container_gc_root: GcRoot,
 }
 
 #[napi(ts_return_type = "Promise<{ __napiType: \"Project\" }>")]
@@ -608,14 +614,19 @@ pub fn project_new(
             let options = ProjectOptions::from(options);
             let is_dev = options.dev;
             let root_path = options.root_path.clone();
-            let container = turbo_tasks
+            let (container, container_root_task) = turbo_tasks
                 .run(async move {
                     let container_op = ProjectContainer::new_operation(rcstr!("next.js"), is_dev);
                     ProjectContainer::initialize(container_op, options).await?;
-                    container_op.resolve().strongly_consistent().await
+                    let container = container_op.resolve().strongly_consistent().await?;
+                    // The container is a permanent root with no persistent parent. Capture its root
+                    // operation's task id so we can pin it for the session (see
+                    // `_container_gc_root`).
+                    Ok((container, container_op.task_id()))
                 })
                 .or_else(|e| turbopack_ctx.throw_turbopack_internal_result(&e.into()))
                 .await?;
+            let container_gc_root = GcRoot::pin(turbo_tasks.clone(), container_root_task);
 
             if is_dev {
                 Handle::current().spawn({
@@ -656,6 +667,7 @@ pub fn project_new(
                 turbopack_ctx,
                 container,
                 exit_receiver: tokio::sync::Mutex::new(Some(exit_receiver)),
+                _container_gc_root: container_gc_root,
             }))
         }
         .instrument(tracing::info_span!("create project")),

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -41,8 +41,9 @@ use crate::next_api::turbopack_ctx::NextTurbopackContext;
 /// [`turbo_tasks::OperationValue`] and should be dereferenced to an [`OperationVc`] before being
 /// passed to a [`turbo_tasks::function`].
 //
-// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
-#[derive(Clone)]
+/// A `DetachedVc` holds its operation's task alive against garbage collection for as long as the
+/// handle exists: it is a reference that escapes the tracked task graph, so no
+/// persistent parent lists the task as a child and GC would otherwise collect it.
 pub struct DetachedVc<T> {
     turbopack_ctx: NextTurbopackContext,
     /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
@@ -51,11 +52,30 @@ pub struct DetachedVc<T> {
 
 impl<T> DetachedVc<T> {
     pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
+        // Pin the operation's task so GC treats this out-of-graph handle as a root.
+        turbopack_ctx.turbo_tasks().pin_task_for_gc(vc.task_id());
+
         Self { turbopack_ctx, vc }
     }
 
     pub fn turbopack_ctx(&self) -> &NextTurbopackContext {
         &self.turbopack_ctx
+    }
+}
+
+// Manual clone and Drop routines are required for proper reference counting to prevent GC
+
+impl<T> Clone for DetachedVc<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.turbopack_ctx.clone(), self.vc)
+    }
+}
+
+impl<T> Drop for DetachedVc<T> {
+    fn drop(&mut self) {
+        self.turbopack_ctx
+            .turbo_tasks()
+            .unpin_task_for_gc(self.task_id());
     }
 }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -91,12 +91,13 @@ impl<T> Deref for DetachedVc<T> {
 /// [`turbo_tasks::TurboTasks::spawn_root_task`] that can be passed back and forth to JS across the
 /// [`napi`][mod@napi] boundary via [`External`].
 ///
-/// JavaScript code receiving this value **must** call [`root_task_dispose`] in a `try...finally`
-/// block to avoid leaking root tasks.
+/// JavaScript code should call [`root_task_dispose`] in a `try...finally` block to dispose the root
+/// task promptly. If it doesn't, [`Drop`] disposes it as a backstop: disposal releases the root's
+/// activeness, so it stops keeping its whole subtree active/unevictable and re-scheduling. (Fully
+/// reclaiming the subtree also requires tearing down the disposed transient root's edges, a
+/// separate step.)
 ///
 /// This is used by [`subscribe`] to create a computation that re-executes when dependencies change.
-//
-// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
 pub struct RootTask {
     turbopack_ctx: NextTurbopackContext,
     task_id: Option<TaskId>,
@@ -104,7 +105,13 @@ pub struct RootTask {
 
 impl Drop for RootTask {
     fn drop(&mut self) {
-        // TODO stop the root task
+        // Backstop for JS that didn't call `root_task_dispose`. Idempotent: `root_task_dispose`
+        // `take()`s the id, so if it already ran this is `None` and we do nothing (no double
+        // dispose). `dispose_root_task` is a no-op once the backend is stopping, so a `RootTask`
+        // finalized during Node teardown is safe.
+        if let Some(task) = self.task_id.take() {
+            self.turbopack_ctx.turbo_tasks().dispose_root_task(task);
+        }
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/benches/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/gc.rs
@@ -1,0 +1,170 @@
+//! Benchmarks for the `parent_count` garbage-collection pass ([`TurboTasksBackend::gc_collect`],
+//! driven here via the `gc_for_testing` hook).
+//!
+//! Only the collect pass is timed: each iteration's setup builds a fresh backend, materializes a
+//! large graph, and disconnects it (turning it into garbage) — none of which is measured. The
+//! routine then times a single GC pass over that garbage. Throughput is reported in tasks
+//! collected per second, so regressions/improvements in GC scaling are directly visible.
+//!
+//! Gated behind `TURBOPACK_BENCH_GC` (like the other stress benches) because the per-iteration
+//! setup is expensive. Enable with e.g.:
+//!
+//! ```bash
+//! TURBOPACK_BENCH_GC=1 cargo bench -p turbo-tasks-backend --bench mod -- gc
+//! ```
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
+use tokio::runtime::Runtime;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+
+fn enabled() -> bool {
+    !matches!(
+        std::env::var("TURBOPACK_BENCH_GC").ok().as_deref(),
+        None | Some("") | Some("no") | Some("false")
+    )
+}
+
+/// A persistent backend with GC-relevant options. Each benchmark iteration gets a fresh one (the
+/// `TempDir` is returned so it lives as long as the backend). GC is invoked directly via
+/// `gc_for_testing`, which does not consult the `TURBO_ENGINE_GC` env var, so nothing global needs
+/// setting.
+fn create_tt() -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    let dir = tempfile::Builder::new()
+        .prefix("gc-bench-")
+        .tempdir_in(&parent)
+        .unwrap();
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(std::thread::available_parallelism().map_or(4, |n| n.get())),
+            small_preallocation: false,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "bench-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Generation(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_generation() -> Vc<Generation> {
+    Generation(State::new(0)).cell()
+}
+
+// --- WIDE shape: root -> `width` intermediates, each -> a leaf (2 tasks per index). Bumping the
+// generation disconnects the whole previous generation, so a collect tears down ~2*width tasks and
+// exercises the chunked per-task fan-out plus a one-level cascade (intermediate -> its leaf). ---
+
+#[turbo_tasks::function]
+fn wide_leaf(generation: u32, index: u32) -> Vc<u32> {
+    Vc::cell(generation.wrapping_mul(1_000_003).wrapping_add(index))
+}
+
+#[turbo_tasks::function]
+async fn wide_intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *wide_leaf(generation, index).await?))
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn wide_root(generation: ResolvedVc<Generation>, width: u32) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..width {
+        sum = sum.wrapping_add(*wide_intermediate(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// Build generation 0 of the WIDE graph then bump to generation 1, leaving generation 0 fully
+/// disconnected (garbage) and resident. Returns the backend ready for a timed collect.
+fn setup_wide_garbage(
+    rt: &Runtime,
+    width: u32,
+) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    rt.block_on(async move {
+        // `TurboTasks::new` builds a `PriorityRunner` that calls `Handle::current()`, so the
+        // backend must be constructed inside the runtime context.
+        let (tt, dir) = create_tt();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let generation_op = create_generation();
+            let generation_vc = generation_op.resolve().strongly_consistent().await?;
+            let generation = generation_op.read_strongly_consistent().await?;
+            wide_root(generation_vc, width)
+                .read_strongly_consistent()
+                .await?;
+            generation.set(1);
+            wide_root(generation_vc, width)
+                .read_strongly_consistent()
+                .await?;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        (tt, dir)
+    })
+}
+
+pub fn gc(c: &mut Criterion) {
+    if !enabled() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("turbo_tasks_backend_gc");
+    // Setup dominates wall time and each sample runs a full pass over a large graph; keep the
+    // sample count modest.
+    group.sample_size(10);
+
+    for width in [5_000u32, 25_000, 100_000] {
+        // ~2 tasks per index become garbage (intermediate + leaf).
+        let garbage = (2 * width) as u64;
+        group.throughput(Throughput::Elements(garbage));
+        group.bench_with_input(BenchmarkId::new("wide", garbage), &width, |b, &width| {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            // PerIteration: each collect consumes its garbage, so every iteration needs a freshly
+            // built+disconnected graph. Setup is not timed.
+            b.iter_batched(
+                || setup_wide_garbage(&rt, width),
+                |(tt, _dir)| {
+                    // `gc_for_testing` is synchronous but internally uses `scope_unbounded`,
+                    // which needs a tokio runtime context (spawns helpers / may `block_in_place`),
+                    // so run it on a runtime worker via `block_on`. The block_on wrapper is a fixed
+                    // few-µs overhead, negligible next to the ms-scale pass and constant across
+                    // samples.
+                    let collected = rt.block_on(async { tt.backend().gc_for_testing(&tt) });
+                    // Return the backend so its (large) teardown happens on criterion's drop path,
+                    // not inside the measured routine.
+                    (collected, tt, _dir)
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}

--- a/turbopack/crates/turbo-tasks-backend/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/mod.rs
@@ -3,6 +3,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+pub(crate) mod gc;
 pub(crate) mod overhead;
 pub(crate) mod scope_stress;
 pub(crate) mod stress;
@@ -10,6 +11,6 @@ pub(crate) mod stress;
 criterion_group!(
     name = turbo_tasks_backend_stress;
     config = Criterion::default();
-    targets = stress::fibonacci, scope_stress::scope_stress, overhead::overhead
+    targets = stress::fibonacci, scope_stress::scope_stress, overhead::overhead, gc::gc
 );
 criterion_main!(turbo_tasks_backend_stress);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -265,14 +265,17 @@ impl TurboTasksBackend {
             // The target is resident either way: a scan candidate was read out of the resident map,
             // and a cascade child was just decremented through its resident entry.
             let mut task = ctx.task(task_id, TaskDataCategory::All);
-            // Collectibility was checked when this job was queued (by the shard scan's
-            // `gc_maybe_collectible` pre-filter, or by the cascade's per-child check), but jobs run
-            // **concurrently**: between the check and now, a sibling job's cascade can have
-            // collected this very task (it is then `deleted`) or flipped it non-collectible (it
-            // regained `activeness`/`in_progress`, or gained an aggregation edge). Re-check under
-            // the guard we now hold and skip rather than delete — collecting twice would double-run
-            // the edge teardown. A task that is still genuinely garbage is re-selected by a later
-            // pass, so bailing here is safe and self-healing.
+            // Collectibility was checked when this job was seeded (the shard scan's
+            // `gc_maybe_collectible` pre-filter, the aged-out revalidation, or the cascade's
+            // per-child `is_gc_collectible` at spawn), but jobs run **concurrently** under
+            // `scope_unbounded`: in between, a sibling job's cascade can have collected this very
+            // task (it is then `deleted`) or flipped it non-collectible (regain
+            // `activeness`/`in_progress`, gain an aggregation edge, or — critically — pick up a new
+            // anchor). Re-check under the guard we now hold and skip rather than delete; a task
+            // that is still genuinely garbage is re-selected by a later pass, so
+            // bailing here is safe and self-healing. (Deleting unconditionally would
+            // wrongly collect a task that just regained an anchor, or double-run the
+            // edge teardown on one already collected.)
             if !task.is_gc_collectible() {
                 return ControlFlow::Continue(());
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -24,7 +24,7 @@ use crate::backend::{
     TurboTasksBackend,
     operation::{
         AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
-        OutdatedEdge, TaskGuard,
+        TaskGuard, capture_all_outgoing_edges,
     },
     storage::{SpecificTaskDataCategory, TaskDataCategory},
     storage_schema::TaskStorageAccessors,
@@ -214,24 +214,7 @@ impl TurboTasksBackend {
             // (removing this task from its children's `upper` sets) — without it, collected
             // children would keep a dangling upper edge and never become collectible. The op opens
             // `ctx.task(task_id)`, so it must run while `task_id` is still resident.
-            let mut old_edges: Vec<OutdatedEdge> = Vec::new();
-            old_edges.extend(task.iter_children().map(OutdatedEdge::Child));
-            old_edges.extend(
-                task.iter_output_dependencies()
-                    .map(OutdatedEdge::OutputDependency),
-            );
-            old_edges.extend(
-                task.iter_cell_dependencies()
-                    .map(OutdatedEdge::CellDependency),
-            );
-            old_edges.extend(
-                task.iter_cell_dependencies_hashed()
-                    .map(|(r, k)| OutdatedEdge::HashedCellDependency(r, k)),
-            );
-            old_edges.extend(
-                task.iter_collectibles_dependencies()
-                    .map(OutdatedEdge::CollectiblesDependency),
-            );
+            let old_edges = capture_all_outgoing_edges(&task);
             drop(task);
 
             edges_deleted.fetch_add(old_edges.len(), Ordering::Relaxed);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -1,0 +1,330 @@
+//! Garbage collection for the persistent backend.
+//!
+//! GC removes tasks that have become unreachable from the live task graph (their persistent
+//! `parent_count` reached 0) from both memory and the on-disk cache. The pass runs under the
+//! coordinator's GC phase (see
+//! [`SnapshotCoordinator::begin_gc`](crate::backend::snapshot_coordinator)) — which excludes normal
+//! operations — and is driven as a fully parallel, unbounded job pool
+//! (see [`TurboTasksBackend::gc_collect`]).
+//!
+//! This module holds the GC-specific logic (the job types, the pool driver, per-job teardown, and
+//! the pin/unpin bookkeeping) as an `impl TurboTasksBackend`; it is a child of the `backend` module
+//! so it reaches the backend's private state (`storage`, `snapshot_coord`) and the GC-only
+//! `execute_context_gc` directly. Callers (`snapshot_and_persist`, `stop`, the background job loop,
+//! the `Backend` trait's `pin_task_for_gc`/`unpin_task_for_gc`) live in `mod.rs`.
+
+use std::{
+    ops::ControlFlow,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use turbo_tasks::{TaskId, TurboTasks, scope::scope_unbounded};
+
+use crate::backend::{
+    TurboTasksBackend,
+    operation::{
+        AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
+        OutdatedEdge, TaskGuard,
+    },
+    storage::{SpecificTaskDataCategory, TaskDataCategory},
+    storage_schema::TaskStorageAccessors,
+};
+
+/// One unit of GC work. Parallelism is *across* jobs (the unbounded pool in
+/// [`TurboTasksBackend::gc_collect`] runs many on different workers); each job is internally
+/// sequential. Both variants produce more work, which flows straight back into the same pool — so
+/// there is no barrier between scanning and collecting, and none between cascade levels.
+enum GcJob {
+    /// Scan one shard of the resident map (by index) and enqueue its candidates as
+    /// [`GcJob::Collect`].
+    ///
+    /// Seeding the pool with these rather than scanning the whole map up front is what keeps the
+    /// scan off the critical path: the first shard's candidates begin tearing down while the last
+    /// shard is still being read. The scan is a handful of field reads per resident task, so a
+    /// shard job is short relative to a collect.
+    ScanShard(usize),
+    /// Tear down a single task: scrub its edges, drop its children's `parent_count`, and mark it
+    /// soft-deleted. Can discover more work — a child the cleanup drives to `parent_count == 0`
+    /// that is itself collectible.
+    Collect(TaskId),
+}
+
+/// Observability counters for one [`TurboTasksBackend::gc_collect`] pass.
+#[derive(Default)]
+pub(crate) struct GcStats {
+    /// Tasks collected (marked soft-deleted).
+    pub collected: usize,
+    /// Edges torn down across all collected tasks (children + forward-dependency reverse edges).
+    pub edges_deleted: usize,
+}
+
+impl TurboTasksBackend {
+    /// An execute context for the garbage collector that does not take an operation guard. Only
+    /// valid while the caller holds the coordinator's GC phase (which provides exclusion); see
+    /// [`ExecuteContextImpl::new_for_gc`].
+    fn execute_context_gc<'a>(
+        &'a self,
+        turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
+    ) -> impl ExecuteContext<'a> {
+        ExecuteContextImpl::new_for_gc(self, turbo_tasks)
+    }
+
+    /// Runs a garbage-collection pass under the coordinator's GC phase. Scans the resident map for
+    /// collectible tasks (no persistent parent, quiescent, no aggregation edges), re-validates each
+    /// under the exclusion, and tears down the ones that are still collectible: scrubbing their
+    /// reverse-dependency edges, decrementing their children's `parent_count` (cascading to any
+    /// child that reaches 0), marking them deleted, and buffering an on-disk tombstone for the next
+    /// persistence commit.
+    ///
+    /// The pass is fully parallel and unbounded via [`scope_unbounded`]: work is a pool of
+    /// [`GcJob`]s — scan a shard, or collect a task — and both kinds spawn more (a shard yields its
+    /// candidates; collecting a task yields any child driven to `parent_count == 0` that is itself
+    /// collectible). **There are no synchronization barriers anywhere in the pass**: not between
+    /// the scan and the cascade, and not between "levels" of the cascade. Discovered work flows
+    /// straight back into the pool, so the first shard's garbage is being torn down while the
+    /// last shard is still being read.
+    ///
+    /// Why this is safe to run concurrently under the GC phase (which excludes normal operations
+    /// but not the GC jobs from each other):
+    /// - Each job builds its own [`ExecuteContext`] (`execute_context_gc`); the concurrent-lock
+    ///   detector is per-context, so jobs on different threads holding different task guards do not
+    ///   false-positive.
+    /// - The storage map is a sharded dashmap: different tasks hit different shards; same-task
+    ///   access is serialized by the shard lock. A `ScanShard` holds only a **read** lock on its
+    ///   own shard, and a collect elsewhere in the map does not contend with it; a collect landing
+    ///   on the shard being scanned simply waits for that shard's (short) read lock.
+    /// - Interleaving the scan with the cascade cannot miss or double-collect. Nothing is missed:
+    ///   every collectible task is reached either by the scan of the shard it lives in or by the
+    ///   cascade that orphans it. Nothing is collected twice: a queued candidate can be collected
+    ///   by a sibling job before its own `Collect` runs, so `Collect` re-validates
+    ///   `is_gc_collectible` under its write guard and skips if the task is already `deleted` (or
+    ///   has since regained an anchor). That re-check is what makes the scan's lock-free pre-filter
+    ///   safe to act on late.
+    /// - The cascade decrement (`update_and_get_parent_count(-1)`) is a read-modify-write under the
+    ///   child's entry write lock, so if two collected parents decrement the same child
+    ///   concurrently, exactly one observes the count hit 0 and spawns its collect — no
+    ///   double-collect, no lost decrement.
+    /// - A collectible task has `parent_count == 0`, so no *surviving* task lists it as a child: a
+    ///   task becomes a collect target only after its last persistent parent was itself collected
+    ///   (which removed the edge). So a `Collect` never races a decrement of the same task and
+    ///   never `ctx.task`-resurrects a task another job just removed.
+    /// - Per-job results merge into shared accumulators guarded by a mutex/atomic, touched only on
+    ///   the rare collect/retain outcome (not per decrement or per scrub), so they are not a
+    ///   contention hot spot.
+    ///
+    /// `scope_unbounded` runs jobs on the runtime worker threads plus the calling thread, which
+    /// drains the whole (growing) pool itself if no helper is scheduled — so this does not depend
+    /// on free worker threads (robust on thread-limited runtimes). GC runs from a synchronous
+    /// backend context (like `connect_children`, which also fans out onto the scope machinery).
+    ///
+    /// Returns [`GcStats`] for the pass. The on-disk tombstones are not produced here — collected
+    /// tasks are left resident with their `deleted` flag set, and the next snapshot derives the
+    /// tombstones from that flag (see `snapshot_and_persist`).
+    pub(crate) fn gc_collect(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> GcStats {
+        // Seed the pool with the resident-map scan, split one job per shard. Each shard job applies
+        // the cheap `gc_maybe_collectible` pre-filter (a handful of field reads per task under a
+        // shard read lock — the same shape as the eviction scan, which proved this is fast) and
+        // feeds its hits back as `Collect` jobs.
+        //
+        // We scan rather than maintain an incremental candidate set: correctness derives entirely
+        // from each task's durable `parent_count`, so there's nothing to persist across sessions
+        // and nothing to keep in sync (a scan can't miss a task the way a hand-maintained
+        // side-set could). `Collect` re-validates each candidate authoritatively under a
+        // guard. The scan only sees resident tasks; disk-only garbage is collected after it
+        // is next restored.
+        //
+        // TODO(perf): recycle the task ids of collected tasks. `persisted_task_id_factory`
+        // (`IdFactoryWithReuse`) can hand out freed ids, and the persisted `next_free_task_id`
+        // high-water mark only grows today, so the id space grows unboundedly across churn even
+        // though the task set stays flat. Reuse must happen only AFTER the `save_snapshot` that
+        // tombstoned the id has committed (a crash before commit leaves the task on disk — reusing
+        // its id would alias it), and must be guarded against resurrection: between removal and
+        // commit a `get_or_create_task` for the same type could re-mint the id, and the id must not
+        // be handed out while any live `OperationVc`/`DetachedVc` still references it. Feed the
+        // recycled ids into `persisted_task_id_factory` so the high-water mark can stop growing.
+        let seeds: Vec<GcJob> = (0..self.storage.shard_count())
+            .map(GcJob::ScanShard)
+            .collect();
+
+        // Written once per collected task (not per child/dep), so the atomics are not a hot path.
+        let collected = AtomicUsize::new(0);
+        let edges_deleted = AtomicUsize::new(0);
+
+        // Each job builds its own GC `ExecuteContext`; see the doc above for the concurrency
+        // argument. A job may spawn follow-up jobs (a shard's candidates, or children driven to
+        // `parent_count == 0`) that flow straight back into the same pool.
+        scope_unbounded(seeds, |spawner, job| {
+            let task_id = match job {
+                GcJob::ScanShard(index) => {
+                    // Enqueue under the shard read lock — `spawn` is just an accounting bump plus a
+                    // queue push, which is what `gc_scan_shard` requires of its callback.
+                    self.storage
+                        .gc_scan_shard(index, |task_id| spawner.spawn(GcJob::Collect(task_id)));
+                    return ControlFlow::Continue(());
+                }
+                GcJob::Collect(task_id) => task_id,
+            };
+            let mut ctx = self.execute_context_gc(turbo_tasks);
+            // `All` restores Data so the edge capture below can read the Data-category dep sets.
+            // The target is resident either way: a scan candidate was read out of the resident map,
+            // and a cascade child was just decremented through its resident entry.
+            let mut task = ctx.task(task_id, TaskDataCategory::All);
+            // Collectibility was checked when this job was queued (by the shard scan's
+            // `gc_maybe_collectible` pre-filter, or by the cascade's per-child check), but jobs run
+            // **concurrently**: between the check and now, a sibling job's cascade can have
+            // collected this very task (it is then `deleted`) or flipped it non-collectible (it
+            // regained `activeness`/`in_progress`, or gained an aggregation edge). Re-check under
+            // the guard we now hold and skip rather than delete — collecting twice would double-run
+            // the edge teardown. A task that is still genuinely garbage is re-selected by a later
+            // pass, so bailing here is safe and self-healing.
+            if !task.is_gc_collectible() {
+                return ControlFlow::Continue(());
+            }
+
+            // Mark the task soft-deleted on the guard we already hold (order relative to the
+            // `CleanupOldEdges` run below doesn't matter — `deleted` only affects
+            // snapshot/eviction/collectibility, none of which the cleanup consults for `task_id`
+            // itself). Rather than remove the task now (a later `ctx.task` on it would resurrect it
+            // from disk as a zombie), keep it resident: a later step hard-deletes it.
+            task.set_deleted(true);
+            if task.new_task() {
+                // Never persisted: there is nothing on disk to tombstone, so drop it out of the
+                // next snapshot's scan entirely (clearing its modified bits + shard count).
+                // Eviction still removes the resident, soft-`deleted` task.
+                task.discard_modifications_for_gc_new_task();
+            } else {
+                // Persisted: force the task into the next snapshot's scan so `process` tombstones
+                // its on-disk copy. `deleted` is transient (never persisted), so setting it tracks
+                // nothing — explicitly track a meta modification. This matters even in the
+                // collectible states that otherwise leave meta clean (e.g. a pinned parentless task
+                // then unpinned, or one restored parentless from a prior session).
+                let _ = task.track_modification(SpecificTaskDataCategory::Meta, "gc_deleted");
+            }
+            collected.fetch_add(1, Ordering::Relaxed);
+
+            // Capture all of this task's edges and hand them to the same `CleanupOldEdges`
+            // operation a re-executing task uses. Besides dropping each child's `parent_count` and
+            // scrubbing forward-dep reverse edges, this propagates the aggregation rebalance
+            // (removing this task from its children's `upper` sets) — without it, collected
+            // children would keep a dangling upper edge and never become collectible. The op opens
+            // `ctx.task(task_id)`, so it must run while `task_id` is still resident.
+            let mut old_edges: Vec<OutdatedEdge> = Vec::new();
+            old_edges.extend(task.iter_children().map(OutdatedEdge::Child));
+            old_edges.extend(
+                task.iter_output_dependencies()
+                    .map(OutdatedEdge::OutputDependency),
+            );
+            old_edges.extend(
+                task.iter_cell_dependencies()
+                    .map(OutdatedEdge::CellDependency),
+            );
+            old_edges.extend(
+                task.iter_cell_dependencies_hashed()
+                    .map(|(r, k)| OutdatedEdge::HashedCellDependency(r, k)),
+            );
+            old_edges.extend(
+                task.iter_collectibles_dependencies()
+                    .map(OutdatedEdge::CollectiblesDependency),
+            );
+            drop(task);
+
+            edges_deleted.fetch_add(old_edges.len(), Ordering::Relaxed);
+            CleanupOldEdgesOperation::run(
+                task_id,
+                old_edges,
+                AggregationUpdateQueue::new(),
+                &mut ctx,
+            );
+
+            // `CleanupOldEdges` recorded every child whose persistent `parent_count` reached 0.
+            // Re-check collectibility under each child's guard (count 0 alone isn't enough — it
+            // could be pinned, a root, or still hold aggregation edges) and spawn a job for the
+            // collectible ones. Each child reaches 0 exactly once, so there is no double-queueing.
+            // `Meta` suffices — `is_gc_collectible` reads only Meta fields — and a child that turns
+            // out collectible re-opens with `All` in its own `Collect` job (restore is cached), so
+            // fetching `All` here would only waste a Data restore on the non-collectible children.
+            for child in ctx.take_gc_parent_count_zeroed() {
+                debug_assert!(
+                    !child.is_transient(),
+                    "gc: a transient task should never have a persistent parent_count to zero"
+                );
+                // The child had its `parent_count` decremented during this task's cleanup, so it is
+                // resident.
+                if ctx.task(child, TaskDataCategory::Meta).is_gc_collectible() {
+                    spawner.spawn(GcJob::Collect(child));
+                }
+            }
+            ControlFlow::Continue(())
+        });
+
+        GcStats {
+            collected: collected.into_inner(),
+            edges_deleted: edges_deleted.into_inner(),
+        }
+    }
+
+    /// Body of [`Backend::pin_task_for_gc`](turbo_tasks::backend::Backend::pin_task_for_gc); the
+    /// trait method in `mod.rs` delegates here. See the inline comments for the exclusion and
+    /// non-resurrection reasoning.
+    pub(super) fn gc_pin(&self, task: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
+        // Once stopping, GC bookkeeping is irrelevant (the map is torn down in `stop()`), so
+        // pin/unpin become no-ops — also safe against handles finalized during shutdown (a
+        // `DetachedVc` dropped during Node teardown unpins *after* `stop()` dropped the map).
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
+        // An operation-guarded context so pin runs strictly before or after a collection, never
+        // concurrently with it. Deadlock-free: no pin caller already holds a guard, and the GC pass
+        // never pins.
+        let mut ctx = self.execute_context(turbo_tasks);
+        // A pin is an in-session reference from outside the tracked graph (`prevent_gc`, or a
+        // `DetachedVc` holding the task's `OperationVc` across NAPI), counted like a transient
+        // parent's edge: bump `transient_ref_count`, which keeps the task uncollectible and
+        // unevictable while > 0. Counting (not a bool) balances each pin against its own unpin.
+        //
+        // `resident_task` is non-inserting: a pin targets a live reference, so the task must be
+        // resident. A missing entry means a pin of an already-collected task (a "zombie
+        // `OperationVc`") — surfaced via debug_assert rather than papered over with a blank entry.
+        let existed = ctx.resident_task(task);
+        debug_assert!(
+            existed.is_some(),
+            "pin_task_for_gc: task {task} has no resident entry (pinned an already-collected \
+             task?)"
+        );
+        if let Some(mut guard) = existed {
+            guard.update_and_get_transient_ref_count(1);
+        }
+    }
+
+    /// Body of [`Backend::unpin_task_for_gc`](turbo_tasks::backend::Backend::unpin_task_for_gc);
+    /// the trait method in `mod.rs` delegates here.
+    pub(super) fn gc_unpin(&self, task: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
+        // See `gc_pin`: no-op once stopping, so handles finalized during shutdown (after the map is
+        // dropped) don't underflow the count.
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
+        let mut ctx = self.execute_context(turbo_tasks);
+        let existed = ctx.resident_task(task);
+        debug_assert!(
+            existed.is_some(),
+            "unpin_task_for_gc: task {task} has no resident entry (unpinned an already-collected \
+             task?)"
+        );
+        if let Some(mut guard) = existed {
+            guard.update_and_get_transient_ref_count(-1);
+        }
+    }
+
+    /// Runs a full GC pass under the GC phase and returns the number of tasks collected (marked
+    /// soft-deleted). The tombstones are derived by a subsequent snapshot from the `deleted` flag,
+    /// so — unlike before — nothing needs to be threaded to `snapshot_and_evict_for_testing`
+    /// (production runs GC inline in `snapshot_and_persist`). Test-only hook; callers must be idle
+    /// (no task executing).
+    #[doc(hidden)]
+    pub fn gc_for_testing(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
+        let _serialize = self.snapshot_in_progress.lock();
+        let _gc_phase = self.snapshot_coord.begin_gc();
+        self.gc_collect(turbo_tasks).collected
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -16,12 +16,15 @@
 use std::{
     ops::ControlFlow,
     sync::atomic::{AtomicUsize, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use parking_lot::Mutex;
+use rustc_hash::FxHashMap;
 use turbo_tasks::{TaskId, TurboTasks, scope::scope_unbounded};
 
 use crate::backend::{
-    TurboTasksBackend,
+    GC_ROOT_TTL, TurboTasksBackend,
     operation::{
         AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
         TaskGuard, capture_all_outgoing_edges,
@@ -121,18 +124,48 @@ impl TurboTasksBackend {
     /// Returns [`GcStats`] for the pass. The on-disk tombstones are not produced here — collected
     /// tasks are left resident with their `deleted` flag set, and the next snapshot derives the
     /// tombstones from that flag (see `snapshot_and_persist`).
-    pub(crate) fn gc_collect(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> GcStats {
+    /// Runs a GC pass and returns its stats plus the reconciled GC roots map (task ->
+    /// last-anchored-ms) to persist in the same snapshot commit. The roots map is loaded from disk
+    /// at the start of the pass and lives only for its duration — it's per-pass state, not backend
+    /// state, so nothing is held resident between passes (and a backend that never GCs never reads
+    /// it).
+    pub(crate) fn gc_collect(
+        &self,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> (GcStats, Vec<(TaskId, u64)>) {
+        // A single wall-clock reading for the whole pass: every root touched here (scan-time
+        // resident roots, refreshed roots, and cascade-discovered roots) is stamped with the *same*
+        // `now`, so within one pass all timestamps are consistent (and it's one syscall, not
+        // three).
+        let now = Self::now_ms();
+
+        // Load the previous session's roots map (task id -> last-anchored millis; empty on a fresh
+        // or non-persistent database). Maintained locally through this pass and returned
+        // for persistence.
+        let mut roots = self
+            .backing_storage
+            .roots()
+            .unwrap_or_else(|err| {
+                // A corrupt/unreadable roots key shouldn't abort GC — treat it as empty and let the
+                // scan below re-discover the resident roots. Cross-session orphans of a genuinely
+                // unreadable set are collected once their (re-discovered) roots age out.
+                tracing::warn!("failed to read GC roots, treating as empty: {err:?}");
+                Vec::new()
+            })
+            .into_iter()
+            .collect::<FxHashMap<TaskId, u64>>();
+
         // Seed the pool with the resident-map scan, split one job per shard. Each shard job applies
         // the cheap `gc_maybe_collectible` pre-filter (a handful of field reads per task under a
         // shard read lock — the same shape as the eviction scan, which proved this is fast) and
-        // feeds its hits back as `Collect` jobs.
+        // feeds its hits back as `Collect` jobs, so the cascade starts before the scan finishes.
         //
         // We scan rather than maintain an incremental candidate set: correctness derives entirely
         // from each task's durable `parent_count`, so there's nothing to persist across sessions
-        // and nothing to keep in sync (a scan can't miss a task the way a hand-maintained
-        // side-set could). `Collect` re-validates each candidate authoritatively under a
-        // guard. The scan only sees resident tasks; disk-only garbage is collected after it
-        // is next restored.
+        // and nothing to keep in sync (a scan can't miss a task the way a hand-maintained side-set
+        // could). `Collect` re-validates each candidate authoritatively under a guard. The scan
+        // only sees resident tasks; disk-only garbage is collected after it is next
+        // restored.
         //
         // TODO(perf): recycle the task ids of collected tasks. `persisted_task_id_factory`
         // (`IdFactoryWithReuse`) can hand out freed ids, and the persisted `next_free_task_id`
@@ -147,16 +180,61 @@ impl TurboTasksBackend {
             .map(GcJob::ScanShard)
             .collect();
 
+        // Reconcile the carried-forward roots map and decide which roots have aged out (un-anchored
+        // past the TTL) and should be collected. This runs *before* the pool, but it does not need
+        // the shard scan's `resident_roots`: the retain classifies each carried-forward entry with
+        // the same `gc_is_root` predicate the scan uses, so a resident still-root is refreshed here
+        // regardless. Roots the scan newly discovers are folded into the map after the pool drains,
+        // which is what keeps the scan off the critical path.
+        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, Vec::new(), now);
+
+        // Aged-out roots are candidates for collection, but — unlike the pre-filtered resident
+        // candidates the scan produces — they are not guaranteed collectible: one may have been
+        // re-anchored, may still hold aggregation edges, or (once restored) may prove to have a
+        // live child. Re-validate each under a guard (restoring a non-resident root's Meta)
+        // and only seed the genuinely collectible ones; a non-collectible aged-out root is
+        // simply left un-collected this pass. Its entry **stays in the roots map** (the
+        // refresh above keeps every entry, and only an actual collect removes one below),
+        // so it is re-seeded next pass rather than being silently forgotten.
+        let mut aged_out_seeds = Vec::new();
+        {
+            let mut ctx = self.execute_context_gc(turbo_tasks);
+            // Bulk-fetch the aged-out roots' Meta in one batched restore rather than a `task` call
+            // (and per-task disk restore) each. `is_gc_collectible` only reads Meta fields.
+            ctx.for_each_task_meta(aged_out, "gc aged-out root revalidation", |task, _ctx| {
+                if task.is_gc_collectible() {
+                    aged_out_seeds.push(task.id());
+                }
+            });
+        }
+
+        // Newly-orphaned tasks discovered as the cascade decrements children to `parent_count == 0`
+        // but that are NOT collected this pass (e.g. still anchored by a pin) — they are new
+        // durable roots and must enter the map with a fresh timestamp, or they'd never be
+        // tracked/aged.
+        let discovered_roots = Mutex::new(Vec::<TaskId>::new());
+
+        // Tasks this pass actually marked deleted. `gc_roots_refresh_and_age_out` deliberately
+        // leaves every entry in `roots` (it only *seeds* aged-out roots), so this is what tells us
+        // which entries may now be dropped from the persisted map. Recorded at the `set_deleted`
+        // site below, i.e. only for tasks that really were collected — a seed that was re-validated
+        // non-collectible, or never reached, stays in the map and ages again next pass.
+        let collected_ids = Mutex::new(Vec::<TaskId>::new());
+
+        // Roots discovered by the shard scans, folded into the map after the pool drains.
+        let scanned_roots = Mutex::new(Vec::<TaskId>::new());
+
         // Written once per collected task (not per child/dep), so the atomics are not a hot path.
         let collected = AtomicUsize::new(0);
         let edges_deleted = AtomicUsize::new(0);
-        // Durable roots seen by the shard scans. Summed across scan jobs rather than returned by a
-        // whole-map call, since the scan is now spread over the pool.
-        let roots_found = AtomicUsize::new(0);
 
         // Each job builds its own GC `ExecuteContext`; see the doc above for the concurrency
         // argument. A job may spawn follow-up jobs (a shard's candidates, or children driven to
-        // `parent_count == 0`) that flow straight back into the same pool.
+        // `parent_count == 0`) that flow straight back into the same pool. The aged-out seeds ride
+        // in as `Collect` jobs alongside the per-shard scans.
+        let seeds = seeds
+            .into_iter()
+            .chain(aged_out_seeds.iter().copied().map(GcJob::Collect));
         scope_unbounded(seeds, |spawner, job| {
             let task_id = match job {
                 GcJob::ScanShard(index) => {
@@ -165,7 +243,9 @@ impl TurboTasksBackend {
                     let roots = self
                         .storage
                         .gc_scan_shard(index, |task_id| spawner.spawn(GcJob::Collect(task_id)));
-                    roots_found.fetch_add(roots, Ordering::Relaxed);
+                    if !roots.is_empty() {
+                        scanned_roots.lock().extend(roots);
+                    }
                     return ControlFlow::Continue(());
                 }
                 GcJob::Collect(task_id) => task_id,
@@ -207,6 +287,10 @@ impl TurboTasksBackend {
                 let _ = task.track_modification(SpecificTaskDataCategory::Meta, "gc_deleted");
             }
             collected.fetch_add(1, Ordering::Relaxed);
+            // Record the collect so the roots map can drop this entry (if it had one) after the
+            // pass. Touched once per collected task, not per child/dep, so the lock is not a
+            // contention hot spot — same argument as `discovered_roots`.
+            collected_ids.lock().push(task_id);
 
             // Capture all of this task's edges and hand them to the same `CleanupOldEdges`
             // operation a re-executing task uses. Besides dropping each child's `parent_count` and
@@ -241,16 +325,163 @@ impl TurboTasksBackend {
                 // resident.
                 if ctx.task(child, TaskDataCategory::Meta).is_gc_collectible() {
                     spawner.spawn(GcJob::Collect(child));
+                } else {
+                    // Dropped to `parent_count == 0` but not collectible — it's still anchored (a
+                    // pin / transient parent) or holds aggregation edges.
+                    // Either way it just became a durable root; record it so it
+                    // enters the roots map with a fresh timestamp and
+                    // starts aging. (The shard scan may not have caught this newly-orphaned child:
+                    // its shard may already have been scanned before this cascade ran.)
+                    discovered_roots.lock().push(child);
                 }
             }
             ControlFlow::Continue(())
         });
 
-        GcStats {
-            gc_roots: roots_found.into_inner(),
+        // Fold in the roots the shard scans found. Deferred to here (rather than passed into
+        // `gc_roots_refresh_and_age_out`) so the scan never blocks the cascade: `or_insert` leaves
+        // an already-tracked root's refreshed timestamp alone and only adds roots new to the map
+        // this session.
+        //
+        // Then fold in roots discovered during the cascade (orphaned-but-not-collected children),
+        // same rule: new to the map → `now`; already tracked → keep the existing timestamp, since a
+        // cascade re-orphaning doesn't reset an already-running clock.
+        {
+            let map: &mut FxHashMap<TaskId, u64> = &mut roots;
+            for id in scanned_roots.into_inner() {
+                map.entry(id).or_insert(now);
+            }
+            for id in discovered_roots.into_inner() {
+                map.entry(id).or_insert(now);
+            }
+        };
+
+        // Now drop the entries for tasks this pass actually collected.
+        // `gc_roots_refresh_and_age_out` kept every entry (it only seeds aged-out roots),
+        // so this is the *only* place a root leaves the map — which is what keeps the
+        // persisted set from losing a root that was seeded but not collected. A collected
+        // task is gone from the graph, so its entry would otherwise be a permanent stale
+        // key in the roots set.
+        //
+        // Runs after the fold-ins so the two can't fight over an id. They are in fact disjoint (a
+        // cascade child is recorded as *either* spawned-and-collected *or* a discovered root, and a
+        // collected task fails `gc_is_root` so the scan won't report it), but ordering it this way
+        // means a collect always wins, which is the safe direction: the task no longer exists.
+        {
+            let map: &mut FxHashMap<TaskId, u64> = &mut roots;
+            for id in collected_ids.into_inner() {
+                map.remove(&id);
+            }
+        };
+
+        let stats = GcStats {
+            gc_roots: roots.len(),
             collected: collected.into_inner(),
             edges_deleted: edges_deleted.into_inner(),
+        };
+        (stats, roots.into_iter().collect())
+    }
+
+    /// The GC root TTL for this pass. Precedence: the per-backend test override
+    /// (`set_gc_root_ttl_for_testing`, race-free across parallel tests) → the
+    /// `TURBO_ENGINE_GC_ROOT_TTL_MS` env (for the e2e dogfood, where a process-global is fine) →
+    /// [`GC_ROOT_TTL`]. Read each call — GC runs rarely, so this is negligible.
+    fn gc_root_ttl(&self) -> Duration {
+        let override_ms = self.gc_root_ttl_override_ms.load(Ordering::Relaxed);
+        if override_ms != u64::MAX {
+            return Duration::from_millis(override_ms);
         }
+        match std::env::var("TURBO_ENGINE_GC_ROOT_TTL_MS") {
+            Ok(v) => match v.parse::<u64>() {
+                Ok(ms) => Duration::from_millis(ms),
+                Err(_) => GC_ROOT_TTL,
+            },
+            Err(_) => GC_ROOT_TTL,
+        }
+    }
+
+    /// Wall-clock now as millis since the Unix epoch (saturating to 0 before the epoch, which can't
+    /// happen in practice). This is the backend layer, not a task-execution context, so
+    /// `SystemTime` is fine here (same as `snapshot_and_persist`).
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    }
+
+    /// Reconcile the GC roots map against this pass's freshly-scanned resident roots, and return
+    /// the ids of roots that have aged out (gone un-anchored past the TTL) to seed collection.
+    ///
+    /// Order matters: the carried-forward map is reconciled by the `retain` **first**, then the
+    /// freshly-scanned `resident_roots` are `or_insert`ed. So a resident root already tracked is
+    /// refreshed once by the retain (the scan and retain share the `gc_is_root` predicate), and the
+    /// insert only *adds* roots new to the map this session — no entry is stamped twice.
+    ///
+    /// Each carried-forward entry is classified **without restoring** it (a non-inserting
+    /// `with_task`), which is both correct and the point — the roots we most want to age out are
+    /// the non-resident ones, and we must not pull them back into memory just to look:
+    /// - **resident and still a root** ([`TaskStorage::gc_is_root`]: `parent_count == 0 &&
+    ///   transient_ref_count > 0`) → refresh `last_anchored_ms = now`. Using the *full*
+    ///   `gc_is_root` predicate — not just `transient_ref_count > 0` — is what stops a resident
+    ///   task that regained a persistent parent from being refreshed forever as a stale "root" (it
+    ///   fails `gc_is_root`, so it ages out and is dropped).
+    /// - **resident but no longer a root**, or **not resident** → un-anchored: a non-resident task
+    ///   holds no `transient_ref_count` (transient state is in-memory only) and was not re-anchored
+    ///   this session (re-anchoring restores it), so it is correctly treated as orphaned. Keep its
+    ///   timestamp; if `now - last_anchored_ms > TTL`, drop from the map and return it as a
+    ///   collection seed (the aged-out path in `gc_collect` restores + re-validates it before
+    ///   collecting).
+    ///
+    /// Using `gc_is_root` here — the same predicate the scan admits roots with — keeps membership
+    /// and refresh from drifting. Runs under the GC phase (exclusion), so the counts don't race
+    /// pins.
+    fn gc_roots_refresh_and_age_out(
+        &self,
+        map: &mut FxHashMap<TaskId, u64>,
+        resident_roots: Vec<TaskId>,
+        now: u64,
+    ) -> Vec<TaskId> {
+        let ttl_ms = self.gc_root_ttl().as_millis() as u64;
+
+        // Reconcile the carried-forward map (prior-session entries) first. Every entry is
+        // re-classified by the *same* `gc_is_root` predicate the scan uses, so a resident root that
+        // is still a root is refreshed here — we don't need `resident_roots` to touch it.
+        let mut aged_out = Vec::new();
+        map.retain(|&id, last_anchored| {
+            // Non-inserting: a non-resident root reads as `None` → un-anchored → ages (which is
+            // what we want; we don't restore disk-only orphans just to check them). A
+            // resident task is a still-live root only if it passes the full
+            // `gc_is_root` (parent_count 0 AND anchored), so a re-parented resident
+            // task fails here and ages out of the map.
+            let still_root = self
+                .storage
+                .with_task(id, |t| t.gc_is_root())
+                .unwrap_or(false);
+            if still_root {
+                *last_anchored = now;
+                return true;
+            }
+            // Un-anchored: has it aged past the TTL? `now < last_anchored` (clock skew across
+            // sessions) is treated as not-yet-aged (saturating), never negative.
+            if now.saturating_sub(*last_anchored) > ttl_ms {
+                aged_out.push(id);
+                false
+            } else {
+                true
+            }
+        });
+
+        // Now fold in this pass's resident roots. `or_insert` (not `insert`) so that a root already
+        // carried forward keeps the timestamp the retain just refreshed — this only *adds* roots
+        // new to the map this session, stamped `now`. (A resident root already in the map was
+        // handled by the retain above, since the scan and the retain share the `gc_is_root`
+        // predicate; doing this after the retain avoids touching those entries twice.)
+        for id in resident_roots {
+            map.entry(id).or_insert(now);
+        }
+
+        aged_out
     }
 
     /// Body of [`Backend::pin_task_for_gc`](turbo_tasks::backend::Backend::pin_task_for_gc); the
@@ -315,6 +546,6 @@ impl TurboTasksBackend {
     pub fn gc_for_testing(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) -> usize {
         let _serialize = self.snapshot_in_progress.lock();
         let _gc_phase = self.snapshot_coord.begin_gc();
-        self.gc_collect(turbo_tasks).collected
+        self.gc_collect(turbo_tasks).0.collected
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -50,8 +50,9 @@ enum GcJob {
 }
 
 /// Observability counters for one [`TurboTasksBackend::gc_collect`] pass.
-#[derive(Default)]
 pub(crate) struct GcStats {
+    /// Total number of gc roots
+    pub gc_roots: usize,
     /// Tasks collected (marked soft-deleted).
     pub collected: usize,
     /// Edges torn down across all collected tasks (children + forward-dependency reverse edges).
@@ -149,6 +150,9 @@ impl TurboTasksBackend {
         // Written once per collected task (not per child/dep), so the atomics are not a hot path.
         let collected = AtomicUsize::new(0);
         let edges_deleted = AtomicUsize::new(0);
+        // Durable roots seen by the shard scans. Summed across scan jobs rather than returned by a
+        // whole-map call, since the scan is now spread over the pool.
+        let roots_found = AtomicUsize::new(0);
 
         // Each job builds its own GC `ExecuteContext`; see the doc above for the concurrency
         // argument. A job may spawn follow-up jobs (a shard's candidates, or children driven to
@@ -158,8 +162,10 @@ impl TurboTasksBackend {
                 GcJob::ScanShard(index) => {
                     // Enqueue under the shard read lock — `spawn` is just an accounting bump plus a
                     // queue push, which is what `gc_scan_shard` requires of its callback.
-                    self.storage
+                    let roots = self
+                        .storage
                         .gc_scan_shard(index, |task_id| spawner.spawn(GcJob::Collect(task_id)));
+                    roots_found.fetch_add(roots, Ordering::Relaxed);
                     return ControlFlow::Continue(());
                 }
                 GcJob::Collect(task_id) => task_id,
@@ -258,6 +264,7 @@ impl TurboTasksBackend {
         });
 
         GcStats {
+            gc_roots: roots_found.into_inner(),
             collected: collected.into_inner(),
             edges_deleted: edges_deleted.into_inner(),
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use parking_lot::Mutex;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_tasks::{TaskId, TurboTasks, scope::scope_unbounded};
 
 use crate::backend::{
@@ -60,6 +60,11 @@ pub(crate) struct GcStats {
     pub collected: usize,
     /// Edges torn down across all collected tasks (children + forward-dependency reverse edges).
     pub edges_deleted: usize,
+    /// Cross-session roots that aged out past the TTL and seeded collection this pass (a subset of
+    /// the seeds — the resident scan supplies the rest). Recorded on the `gc` span so the e2e
+    /// dogfood can confirm a deleted route's subtree is reclaimed on a *later* session rather than
+    /// in-session.
+    pub aged_out_roots: usize,
 }
 
 impl TurboTasksBackend {
@@ -196,14 +201,19 @@ impl TurboTasksBackend {
         // simply left un-collected this pass. Its entry **stays in the roots map** (the
         // refresh above keeps every entry, and only an actual collect removes one below),
         // so it is re-seeded next pass rather than being silently forgotten.
-        let mut aged_out_seeds = Vec::new();
+        //
+        // The set also drives observability: the collect-site trace below tags seeds that came from
+        // an aged-out cross-session root (as opposed to the resident scan), so the e2e dogfood can
+        // confirm a deleted route's subtree is reclaimed on a *later* session rather than
+        // in-session.
+        let mut aged_out_seeds = FxHashSet::default();
         {
             let mut ctx = self.execute_context_gc(turbo_tasks);
             // Bulk-fetch the aged-out roots' Meta in one batched restore rather than a `task` call
             // (and per-task disk restore) each. `is_gc_collectible` only reads Meta fields.
             ctx.for_each_task_meta(aged_out, "gc aged-out root revalidation", |task, _ctx| {
                 if task.is_gc_collectible() {
-                    aged_out_seeds.push(task.id());
+                    aged_out_seeds.insert(task.id());
                 }
             });
         }
@@ -291,6 +301,17 @@ impl TurboTasksBackend {
             // pass. Touched once per collected task, not per child/dep, so the lock is not a
             // contention hot spot — same argument as `discovered_roots`.
             collected_ids.lock().push(task_id);
+            // A span (not a free-standing event) so the collect shows up as a node in the trace
+            // tree under the `gc` span — the trace server / `next internal trace` MCP surface
+            // spans, and free events attached to no span are not queryable there.
+            // `cross_session_root` tags collects seeded from an aged-out root (the
+            // deleted-route path) vs the resident scan.
+            let _collect_span = tracing::info_span!(
+                "gc collect task",
+                task = %task_id,
+                cross_session_root = aged_out_seeds.contains(&task_id),
+            )
+            .entered();
 
             // Capture all of this task's edges and hand them to the same `CleanupOldEdges`
             // operation a re-executing task uses. Besides dropping each child's `parent_count` and
@@ -378,6 +399,7 @@ impl TurboTasksBackend {
             gc_roots: roots.len(),
             collected: collected.into_inner(),
             edges_deleted: edges_deleted.into_inner(),
+            aged_out_roots: aged_out_seeds.len(),
         };
         (stats, roots.into_iter().collect())
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -191,7 +191,7 @@ impl TurboTasksBackend {
         // the same `gc_is_root` predicate the scan uses, so a resident still-root is refreshed here
         // regardless. Roots the scan newly discovers are folded into the map after the pool drains,
         // which is what keeps the scan off the critical path.
-        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, Vec::new(), now);
+        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now);
 
         // Aged-out roots are candidates for collection, but — unlike the pre-filtered resident
         // candidates the scan produces — they are not guaranteed collectible: one may have been
@@ -229,6 +229,10 @@ impl TurboTasksBackend {
         // which entries may now be dropped from the persisted map. Recorded at the `set_deleted`
         // site below, i.e. only for tasks that really were collected — a seed that was re-validated
         // non-collectible, or never reached, stays in the map and ages again next pass.
+        //
+        // Only collected *roots* can matter here (a non-root collect was never in the map), but
+        // recording every collect and intersecting at the end is cheaper than checking map
+        // membership under the pass's shared lock on the hot path.
         let collected_ids = Mutex::new(Vec::<TaskId>::new());
 
         // Roots discovered by the shard scans, folded into the map after the pool drains.
@@ -435,13 +439,17 @@ impl TurboTasksBackend {
             .unwrap_or(0)
     }
 
-    /// Reconcile the GC roots map against this pass's freshly-scanned resident roots, and return
-    /// the ids of roots that have aged out (gone un-anchored past the TTL) to seed collection.
+    /// Reconcile the carried-forward GC roots map, and return the ids of roots that have aged out
+    /// (gone un-anchored past the TTL) to seed collection.
     ///
-    /// Order matters: the carried-forward map is reconciled by the `retain` **first**, then the
-    /// freshly-scanned `resident_roots` are `or_insert`ed. So a resident root already tracked is
-    /// refreshed once by the retain (the scan and retain share the `gc_is_root` predicate), and the
-    /// insert only *adds* roots new to the map this session — no entry is stamped twice.
+    /// This only reclassifies entries already in the map; it deliberately does **not** take the
+    /// shard scan's freshly-discovered roots. It runs before the job pool, and making it wait for a
+    /// complete scan would put the scan back on the critical path — the thing interleaving exists
+    /// to avoid. It doesn't need them: the retain classifies each entry with the *same*
+    /// `gc_is_root` predicate the scan uses, so a resident still-root is refreshed here regardless
+    /// of whether the scan has reached its shard yet. `gc_collect` folds the scan's roots in with
+    /// `or_insert` after the pool drains, which only *adds* roots new to the map this session and
+    /// leaves the timestamps this retain refreshed alone.
     ///
     /// Each carried-forward entry is classified **without restoring** it (a non-inserting
     /// `with_task`), which is both correct and the point — the roots we most want to age out are
@@ -454,9 +462,18 @@ impl TurboTasksBackend {
     /// - **resident but no longer a root**, or **not resident** → un-anchored: a non-resident task
     ///   holds no `transient_ref_count` (transient state is in-memory only) and was not re-anchored
     ///   this session (re-anchoring restores it), so it is correctly treated as orphaned. Keep its
-    ///   timestamp; if `now - last_anchored_ms > TTL`, drop from the map and return it as a
-    ///   collection seed (the aged-out path in `gc_collect` restores + re-validates it before
-    ///   collecting).
+    ///   timestamp; if `now - last_anchored_ms > TTL`, return it as a collection seed (the aged-out
+    ///   path in `gc_collect` restores + re-validates it before collecting).
+    ///
+    /// **The map is monotone: this function never removes an entry.** An aged-out root is only
+    /// *seeded*; `gc_collect` removes it from the map after the collect job actually marked it
+    /// deleted. Removing it here instead would leak: the returned map is persisted as a whole-key
+    /// rewrite of the roots set, and a seed that is not collected (re-validated non-collectible, or
+    /// — once GC is interruptible — never reached) would be gone from the map while still existing
+    /// on disk. Nothing would ever re-add it: the resident scan only admits `gc_is_root` tasks
+    /// (`transient_ref_count > 0`), which an aged-out root by definition fails, and a **disk-only**
+    /// task isn't scanned at all. It would become unreachable from every GC enumeration path —
+    /// permanently untracked garbage.
     ///
     /// Using `gc_is_root` here — the same predicate the scan admits roots with — keeps membership
     /// and refresh from drifting. Runs under the GC phase (exclusion), so the counts don't race
@@ -464,7 +481,6 @@ impl TurboTasksBackend {
     fn gc_roots_refresh_and_age_out(
         &self,
         map: &mut FxHashMap<TaskId, u64>,
-        resident_roots: Vec<TaskId>,
         now: u64,
     ) -> Vec<TaskId> {
         let ttl_ms = self.gc_root_ttl().as_millis() as u64;
@@ -479,32 +495,42 @@ impl TurboTasksBackend {
             // resident task is a still-live root only if it passes the full
             // `gc_is_root` (parent_count 0 AND anchored), so a re-parented resident
             // task fails here and ages out of the map.
-            let still_root = self
+            match self
                 .storage
-                .with_task(id, |t| t.gc_is_root())
-                .unwrap_or(false);
-            if still_root {
-                *last_anchored = now;
-                return true;
+                .with_task(id, |t| (t.gc_is_root(), t.gc_is_deleted()))
+            {
+                // Already collected (soft-deleted, resident until the tombstone commit + hard
+                // delete). It is not a root any more and there is nothing left to collect, so drop
+                // the entry outright rather than letting it fall through to the aged-out branch —
+                // which would re-seed it every pass forever (the revalidation always rejects a
+                // deleted task) and keep a dead id in the persisted set. This is the one case where
+                // an entry leaves the map *here* rather than via the collected-ids removal in
+                // `gc_collect`: that removal only sees tasks **this** pass collected, and a task
+                // collected by an earlier pass in the same session is still resident when the next
+                // pass reads the map.
+                Some((_, true)) => return false,
+                // Still a live durable root: refresh its clock.
+                Some((true, false)) => {
+                    *last_anchored = now;
+                    return true;
+                }
+                // Resident but no longer a root, or not resident at all: fall through to the
+                // age-out check below.
+                Some((false, false)) | None => {}
             }
             // Un-anchored: has it aged past the TTL? `now < last_anchored` (clock skew across
             // sessions) is treated as not-yet-aged (saturating), never negative.
             if now.saturating_sub(*last_anchored) > ttl_ms {
                 aged_out.push(id);
-                false
-            } else {
-                true
             }
+            // Keep the entry either way — see the "monotone map" note in the doc comment. An
+            // aged-out root is only *seeded* for collection here; the entry is removed by
+            // `gc_collect` after the task is actually marked deleted. Keeping its existing
+            // timestamp (rather than refreshing to `now`) means a root that repeatedly fails to be
+            // collected stays aged-out and is re-seeded every pass, instead of restarting its TTL
+            // clock.
+            true
         });
-
-        // Now fold in this pass's resident roots. `or_insert` (not `insert`) so that a root already
-        // carried forward keeps the timestamp the retain just refreshed — this only *adds* roots
-        // new to the map this session, stamped `now`. (A resident root already in the map was
-        // handled by the retain above, since the scan and the retain share the `gc_is_root`
-        // predicate; doing this after the retain avoids touching those entries twice.)
-        for id in resident_roots {
-            map.entry(id).or_insert(now);
-        }
 
         aged_out
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -66,8 +66,8 @@ use crate::{
             AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext,
             CleanupOldEdgesOperation, ConnectChildOperation, ExecuteContext, ExecuteContextImpl,
             LeafDistanceUpdateQueue, Operation, OutdatedEdge, TaskGuard, TaskType, TaskTypeRef,
-            connect_children, get_aggregation_number, get_uppers, make_task_dirty_internal,
-            prepare_new_children,
+            capture_all_outgoing_edges, connect_children, get_aggregation_number, get_uppers,
+            make_task_dirty_internal, prepare_new_children,
         },
         snapshot_coordinator::{OperationGuard, SnapshotCoordinator},
         storage::Storage,
@@ -3369,6 +3369,14 @@ impl TurboTasksBackend {
     }
 
     fn dispose_root_task(&self, task_id: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
+        // Once stopping, the task map is being torn down in `stop()` (which runs after `stopping()`
+        // sets this flag) — disposing is both irrelevant and unsafe (it would `ctx.task` a dropped
+        // map). `RootTask::Drop` calls this as a backstop and may fire during Node worker teardown,
+        // after shutdown; make that a no-op, mirroring `gc_pin`/`gc_unpin`.
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
+
         #[cfg(feature = "verify_aggregation_graph")]
         self.root_tasks.lock().remove(&task_id);
 
@@ -3382,10 +3390,41 @@ impl TurboTasksBackend {
                 activeness_state.unset_root_type();
                 activeness_state.set_active_until_clean();
             };
-        } else if let Some(activeness_state) = task.take_activeness() {
-            // Technically nobody should be listening to this event, but just in case
-            // we notify it anyway
-            activeness_state.all_clean_event.notify(usize::MAX);
+            // The root is still going to execute to completion; `task_execution_completed` runs its
+            // own edge cleanup, and `unset_root_type` above means it won't re-root afterwards.
+            // Don't tear down its edges here — they may still be in use by the
+            // in-flight execution.
+        } else {
+            if let Some(activeness_state) = task.take_activeness() {
+                // Technically nobody should be listening to this event, but just in case
+                // we notify it anyway
+                activeness_state.all_clean_event.notify(usize::MAX);
+            }
+
+            // The root task is clean and done — nothing else will re-execute it. Tear down its
+            // outgoing edges so the subgraph it anchored can be collected. A transient root's child
+            // edges bump each persistent child's session-only `transient_ref_count`; without
+            // shedding them (and the aggregation follower/upper edges — a root task is
+            // an aggregating node with `aggregation_number == u32::MAX`, so its
+            // children are its followers), the whole subscription subgraph would stay
+            // anchored and uncollectible for the rest of the session. We hand the edges
+            // to the same `CleanupOldEdges` operation a re-executing task and GC
+            // use: for a transient parent it issues `AdjustTransientRefCount { delta: -1 }` per
+            // persistent child and rebalances the aggregation graph. The transient root node itself
+            // is left resident (transient tasks have no removal path and are never
+            // persisted); only its edges are shed — a single empty node per disposed
+            // subscription, re-created each session.
+            let old_edges = capture_all_outgoing_edges(&task);
+            drop(task);
+
+            if !old_edges.is_empty() {
+                CleanupOldEdgesOperation::run(
+                    task_id,
+                    old_edges,
+                    AggregationUpdateQueue::new(),
+                    &mut ctx,
+                );
+            }
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1720,15 +1720,8 @@ impl TurboTasksBackend {
                     // Initialize storage BEFORE making task_id visible in the cache.
                     // This ensures any thread that reads task_id from the cache sees
                     // the storage entry already initialized (restored flags set).
-                    // A task created with no parent is spawned from outside the tracked graph (a
-                    // top-level `run`/NAPI call, `run_once`, or `OperationVc::connect` outside a
-                    // task) — mark it a GC root so it is never collected (it has no persistent
-                    // parent to anchor it).
-                    self.storage.initialize_new_task(
-                        task_id,
-                        Some(task_type.clone()),
-                        parent_task.is_none(),
-                    );
+                    self.storage
+                        .initialize_new_task(task_id, Some(task_type.clone()));
                     // insert() consumes e, releasing the shard write lock.
                     e.insert(task_type, task_id);
                     self.track_cache_miss_by_fn(native_fn);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1067,12 +1067,14 @@ impl TurboTasksBackend {
             let gc_span = tracing::info_span!(
                 parent: parent_span.clone(),
                 "gc",
+                gc_roots = tracing::field::Empty,
                 collected = tracing::field::Empty,
                 edges_deleted = tracing::field::Empty,
             )
             .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
             let stats = self.gc_collect(turbo_tasks);
+            gc_span.record("gc_roots", stats.gc_roots);
             gc_span.record("collected", stats.collected);
             gc_span.record("edges_deleted", stats.edges_deleted);
             gc_phase.into_snapshot()
@@ -1718,8 +1720,15 @@ impl TurboTasksBackend {
                     // Initialize storage BEFORE making task_id visible in the cache.
                     // This ensures any thread that reads task_id from the cache sees
                     // the storage entry already initialized (restored flags set).
-                    self.storage
-                        .initialize_new_task(task_id, Some(task_type.clone()));
+                    // A task created with no parent is spawned from outside the tracked graph (a
+                    // top-level `run`/NAPI call, `run_once`, or `OperationVc::connect` outside a
+                    // task) — mark it a GC root so it is never collected (it has no persistent
+                    // parent to anchor it).
+                    self.storage.initialize_new_task(
+                        task_id,
+                        Some(task_type.clone()),
+                        parent_task.is_none(),
+                    );
                     // insert() consumes e, releasing the shard write lock.
                     e.insert(task_type, task_id);
                     self.track_cache_miss_by_fn(native_fn);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -16,7 +16,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc, LazyLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::SystemTime,
 };
@@ -92,6 +92,13 @@ use crate::{
 /// the operation will be parallelized.
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
 
+/// How long a GC root may go un-anchored before it is collected. A root that is not observed
+/// anchored (no persistent parent, no pin/transient reference) in any GC pass for this long is
+/// treated as a cross-session orphan and its subtree is reclaimed. The grace period tolerates
+/// transient absences — e.g. switching git branches away from and back to a route within the window
+/// keeps its warm cache. Overridable in tests/debugging via `TURBO_ENGINE_GC_ROOT_TTL_MS`.
+const GC_ROOT_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
 /// Priority used to re-schedule a task that became stale during execution.
 ///
 /// Stale tasks must run again, but at a priority that reflects why they're being re-run rather
@@ -147,6 +154,12 @@ pub struct BackendOptions {
     /// This reclaims memory by clearing persisted data that can be re-loaded from disk on demand.
     /// This is an EXPERIMENTAL FEATURE under development
     pub eviction_mode: EvictionMode,
+
+    /// Overrides whether the reference-counting GC runs for this backend. `None` (default) derives
+    /// it from the `TURBO_ENGINE_GC` env var; `Some` forces it on/off (used by tests to run GC
+    /// — and persist the roots map — deterministically without racing the process-global env).
+    /// The debug eviction-safety check in the constructor still applies.
+    pub gc: Option<bool>,
 }
 
 impl Default for BackendOptions {
@@ -158,6 +171,7 @@ impl Default for BackendOptions {
             num_workers: None,
             small_preallocation: false,
             eviction_mode: EvictionMode::Off,
+            gc: None,
         }
     }
 }
@@ -230,6 +244,12 @@ pub struct TurboTasksBackend {
 
     backing_storage: TurboBackingStorage,
 
+    /// Test-only override of the GC root TTL, in milliseconds; `u64::MAX` means "unset" (use
+    /// [`GC_ROOT_TTL`] / the `TURBO_ENGINE_GC_ROOT_TTL_MS` env). A per-backend field rather than
+    /// the process-global env so parallel tests don't race each other. See
+    /// `set_gc_root_ttl_for_testing`.
+    gc_root_ttl_override_ms: AtomicU64,
+
     #[cfg(feature = "verify_aggregation_graph")]
     root_tasks: Mutex<FxHashSet<TaskId>>,
 }
@@ -261,9 +281,12 @@ impl TurboTasksBackend {
         // needed), and `ReadOnly` never persists/GCs. In debug builds, refuse the unsafe combo by
         // forcing GC off with a warning; release builds trust the caller's configuration.
         // Opt-in via `TURBO_ENGINE_GC` until GC has been proven on trusted apps; the eventual
-        // default-on flip gets its own escape hatch.
-        let mut gc_enabled = std::env::var_os("TURBO_ENGINE_GC")
-            .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")));
+        // default-on flip gets its own escape hatch. `options.gc`, when set, overrides the env
+        // (tests use it to run GC deterministically without racing the process-global env).
+        let mut gc_enabled = options.gc.unwrap_or_else(|| {
+            std::env::var_os("TURBO_ENGINE_GC")
+                .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")))
+        });
         if gc_enabled
             && matches!(options.storage_mode, Some(StorageMode::ReadWrite))
             && options.eviction_mode == EvictionMode::Off
@@ -299,6 +322,7 @@ impl TurboTasksBackend {
             is_idle: AtomicBool::new(false),
             task_statistics: TaskStatisticsApi::default(),
             backing_storage,
+            gc_root_ttl_override_ms: AtomicU64::new(u64::MAX),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
         }
@@ -382,6 +406,15 @@ impl TurboTasksBackend {
         self.storage
             .with_task(task, |t| t.gc_transient_ref_count())
             .unwrap_or(0)
+    }
+
+    /// Override the GC root TTL for this backend (milliseconds). `0` ages out any un-anchored root
+    /// on the next GC pass. Per-backend, so parallel tests don't race the global env.
+    /// Test-only.
+    #[doc(hidden)]
+    pub fn set_gc_root_ttl_for_testing(&self, ttl_ms: u64) {
+        self.gc_root_ttl_override_ms
+            .store(ttl_ms, Ordering::Relaxed);
     }
 
     /// Opens `task` with must-exist access and drops the guard. Test-only hook to exercise
@@ -1063,6 +1096,10 @@ impl TurboTasksBackend {
         // When GC is enabled, run the pass and hand its exclusion straight to the snapshot
         // (`into_snapshot`, no operation can run in between), so the collected tasks' tombstones
         // (derived from the `deleted` flag) ride this same commit. Opt-in via `TURBO_ENGINE_GC`.
+        // The GC roots map (task -> last-anchored-ms), refreshed by the GC pass and persisted in
+        // this same commit. `None` when GC didn't run, so `save_snapshot` leaves the prior
+        // set untouched.
+        let mut gc_roots_to_persist: Option<Vec<(TaskId, u64)>> = None;
         let mut snapshot_phase = if self.gc_enabled {
             let gc_span = tracing::info_span!(
                 parent: parent_span.clone(),
@@ -1073,10 +1110,11 @@ impl TurboTasksBackend {
             )
             .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
-            let stats = self.gc_collect(turbo_tasks);
+            let (stats, roots) = self.gc_collect(turbo_tasks);
             gc_span.record("gc_roots", stats.gc_roots);
             gc_span.record("collected", stats.collected);
             gc_span.record("edges_deleted", stats.edges_deleted);
+            gc_roots_to_persist = Some(roots);
             gc_phase.into_snapshot()
         } else {
             // `begin_snapshot` blocks until in-flight operations drain (spanned inside the
@@ -1407,9 +1445,11 @@ impl TurboTasksBackend {
         // Tasks were already consumed by take_snapshot, so a future snapshot
         // would not re-persist them — returning an error signals to the caller
         // that further persist attempts would corrupt the task graph in storage.
-        let snapshot_meta = self
-            .backing_storage
-            .save_snapshot(suspended_operations, task_snapshots)?;
+        let snapshot_meta = self.backing_storage.save_snapshot(
+            suspended_operations,
+            gc_roots_to_persist,
+            task_snapshots,
+        )?;
         span.record("snapshot_meta", display(snapshot_meta));
 
         #[cfg(feature = "print_cache_item_size")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1107,6 +1107,7 @@ impl TurboTasksBackend {
                 gc_roots = tracing::field::Empty,
                 collected = tracing::field::Empty,
                 edges_deleted = tracing::field::Empty,
+                aged_out_roots = tracing::field::Empty,
             )
             .entered();
             let gc_phase = self.snapshot_coord.begin_gc();
@@ -1114,6 +1115,7 @@ impl TurboTasksBackend {
             gc_span.record("gc_roots", stats.gc_roots);
             gc_span.record("collected", stats.collected);
             gc_span.record("edges_deleted", stats.edges_deleted);
+            gc_span.record("aged_out_roots", stats.aged_out_roots);
             gc_roots_to_persist = Some(roots);
             gc_phase.into_snapshot()
         } else {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1,6 +1,7 @@
 mod cell_data;
 mod counter_map;
 mod eviction;
+mod gc;
 mod operation;
 mod snapshot_coordinator;
 mod storage;
@@ -72,7 +73,7 @@ use crate::{
         storage::Storage,
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    backing_storage::{SnapshotItem, compute_task_type_hash},
+    backing_storage::{SnapshotItem, TaskDeletion, compute_task_type_hash},
     data::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
@@ -213,6 +214,11 @@ pub struct TurboTasksBackend {
     /// `stop_and_wait`).
     snapshot_in_progress: Mutex<()>,
 
+    /// Whether the `parent_count` GC pass runs for this backend. Initialized from the
+    /// `TURBO_ENGINE_GC` env var and, in debug builds, forced off if the configuration would
+    /// strand soft-deleted tasks resident — see the constructor.
+    gc_enabled: bool,
+
     stopping: AtomicBool,
     stopping_event: Event,
     idle_start_event: Event,
@@ -247,8 +253,32 @@ impl TurboTasksBackend {
         let next_task_id = backing_storage
             .next_free_task_id()
             .expect("Failed to get task id");
+
+        // GC leaves collected tasks resident (soft-deleted) until a reclaim step removes them. The
+        // background `ReadWrite` loop reclaims them in `evict_after_snapshot`, so GC there REQUIRES
+        // eviction to be on; with eviction off, soft-deleted tasks would accumulate forever. The
+        // `ReadWriteOnShutdown` drain path drops the whole map wholesale (no per-cycle eviction
+        // needed), and `ReadOnly` never persists/GCs. In debug builds, refuse the unsafe combo by
+        // forcing GC off with a warning; release builds trust the caller's configuration.
+        // Opt-in via `TURBO_ENGINE_GC` until GC has been proven on trusted apps; the eventual
+        // default-on flip gets its own escape hatch.
+        let mut gc_enabled = std::env::var_os("TURBO_ENGINE_GC")
+            .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")));
+        if gc_enabled
+            && matches!(options.storage_mode, Some(StorageMode::ReadWrite))
+            && options.eviction_mode == EvictionMode::Off
+        {
+            eprintln!(
+                "warning: TURBO_ENGINE_GC is set but eviction is disabled on a ReadWrite backend; \
+                 GC would leave collected tasks resident forever. Forcing GC off. Enable eviction \
+                 ('auto'/'full') to use GC in this mode."
+            );
+            gc_enabled = false;
+        }
+
         Self {
             options,
+            gc_enabled,
             start_time: Instant::now(),
             persisted_task_id_factory: IdFactoryWithReuse::new(
                 next_task_id,
@@ -330,10 +360,33 @@ impl TurboTasksBackend {
         (had_new_data, counts)
     }
 
-    /// Opens `task` with the must-exist [`ExecuteContext::task`] and drops the guard. Test-only
-    /// hook to exercise the non-fabricating existence guarantee: this panics (debug builds) if
-    /// `task` exists in neither memory nor persistent storage (rather than fabricating a
-    /// blank).
+    /// The number of persistent (non-transient) tasks resident in the map. Test-only hook: this is
+    /// the metric GC affects (transient roots like `run_once` tasks are never collected).
+    #[doc(hidden)]
+    pub fn resident_persistent_task_count_for_testing(&self) -> usize {
+        self.storage.resident_persistent_task_count()
+    }
+
+    /// The persistent `parent_count` of a resident task (0 if absent or not resident). Test-only
+    /// hook for verifying incremental refcount maintenance.
+    #[doc(hidden)]
+    pub fn parent_count_for_testing(&self, task: TaskId) -> u32 {
+        self.storage
+            .with_task(task, |t| t.gc_parent_count())
+            .unwrap_or(0)
+    }
+
+    /// The transient `transient_ref_count` of a resident task (0 if absent or not resident).
+    #[doc(hidden)]
+    pub fn transient_ref_count_for_testing(&self, task: TaskId) -> u32 {
+        self.storage
+            .with_task(task, |t| t.gc_transient_ref_count())
+            .unwrap_or(0)
+    }
+
+    /// Opens `task` with must-exist access and drops the guard. Test-only hook to exercise
+    /// the non-fabricating existence guarantee: this panics (debug builds) if `task` exists in
+    /// neither memory nor persistent storage (rather than fabricating a blank).
     #[doc(hidden)]
     pub fn assert_task_exists_for_testing(
         &self,
@@ -498,6 +551,16 @@ impl TurboTasksBackend {
         });
         let (mut task, mut reader_task) =
             lock_task_and_optional_reader(&mut ctx, task_id, need_reader_task);
+        // A GC-soft-deleted task must never be *read*: it was collected (edges scrubbed) and would
+        // return stale contents. Every re-entry funnels through `resurrect_deleted` at connect,
+        // which clears the flag and re-executes, so reaching a read with it still set means a
+        // resurrection path was missed. (Debug-only; the flag exists only when GC is enabled. This
+        // consumer read is where the invariant belongs — bookkeeping opens legitimately touch a
+        // deleted task mid-resurrection, so `task`/`MustExist` itself does not assert it.)
+        debug_assert!(
+            !task.deleted(),
+            "read_task_output on a GC-deleted task {task_id} — a resurrection path was missed"
+        );
 
         fn listen_to_done_event(
             reader_description: Option<EventDescription>,
@@ -866,6 +929,12 @@ impl TurboTasksBackend {
         });
         let (mut task, reader_task) =
             lock_task_and_optional_reader(&mut ctx, task_id, need_reader_task);
+        // See the matching assert in `try_read_task_output`: a GC-deleted task must be resurrected
+        // (at connect) before any read; reaching a read with the flag still set is a missed path.
+        debug_assert!(
+            !task.deleted(),
+            "read_task_cell on a GC-deleted task {task_id} — a resurrection path was missed"
+        );
 
         let content = if final_read_hint {
             task.remove_cell_data(&cell, &get_value_type(cell.type_id()).persistence)
@@ -990,6 +1059,28 @@ impl TurboTasksBackend {
         // request bit, suspended_operations) assumes only one snapshot runs at
         // a time. Held for the entire snapshot lifecycle.
         let _snapshot_in_progress = self.snapshot_in_progress.lock();
+
+        // When GC is enabled, run the pass and hand its exclusion straight to the snapshot
+        // (`into_snapshot`, no operation can run in between), so the collected tasks' tombstones
+        // (derived from the `deleted` flag) ride this same commit. Opt-in via `TURBO_ENGINE_GC`.
+        let mut snapshot_phase = if self.gc_enabled {
+            let gc_span = tracing::info_span!(
+                parent: parent_span.clone(),
+                "gc",
+                collected = tracing::field::Empty,
+                edges_deleted = tracing::field::Empty,
+            )
+            .entered();
+            let gc_phase = self.snapshot_coord.begin_gc();
+            let stats = self.gc_collect(turbo_tasks);
+            gc_span.record("collected", stats.collected);
+            gc_span.record("edges_deleted", stats.edges_deleted);
+            gc_phase.into_snapshot()
+        } else {
+            // `begin_snapshot` blocks until in-flight operations drain (spanned inside the
+            // coordinator).
+            self.snapshot_coord.begin_snapshot()
+        };
         let start = Instant::now();
         // SystemTime for wall-clock timestamps in trace events (milliseconds
         // since epoch). Instant is monotonic but has no defined epoch, so it
@@ -997,11 +1088,9 @@ impl TurboTasksBackend {
         let wall_start = SystemTime::now();
         debug_assert!(self.should_persist());
 
-        let mut snapshot_phase = {
-            let _span = tracing::info_span!("blocking").entered();
-            self.snapshot_coord.begin_snapshot()
-        };
-        // Enter snapshot mode, which atomically reads and resets the modified count.
+        // Enter snapshot mode, which atomically reads and resets the modified count. GC marks each
+        // collected task modified, so a pass that collected anything makes `has_modifications`
+        // true and the scan below runs and emits the tombstones.
         // Checking after start_snapshot ensures no concurrent increments can race.
         let (snapshot_guard, has_modifications) = self.storage.start_snapshot();
 
@@ -1219,6 +1308,30 @@ impl TurboTasksBackend {
             };
             if task_id.is_transient() {
                 unreachable!("transient task_ids should never be enqueued to be persisted");
+            }
+
+            // A GC-soft-deleted task that reaches the scan is a *persisted* one being tombstoned:
+            // its on-disk copy (task meta/data + `TaskCache` entry) is deleted in this same commit,
+            // riding the shard iterator `save_snapshot` consumes. (GC forced it into the scan via
+            // `track_modification`; a *never-persisted* collected task had its modified bits
+            // cleared by GC — see `discard_modifications_for_gc_new_task` — so it is
+            // never scanned here.)
+            if inner.flags.deleted() {
+                debug_assert!(
+                    !inner.flags.new_task(),
+                    "a scanned GC-deleted task must be persisted; new tasks are discarded by GC"
+                );
+                // Only persistent tasks are collected, so the persistent task type (the `TaskCache`
+                // key) is always present.
+                let task_type_hash = compute_task_type_hash(
+                    inner
+                        .get_persistent_task_type()
+                        .expect("a GC-deleted (non-transient) task must have a task type"),
+                );
+                return SnapshotItem::Delete(TaskDeletion {
+                    task_id,
+                    task_type_hash,
+                });
             }
 
             let encode_meta = inner.flags.meta_modified();
@@ -1450,17 +1563,15 @@ impl TurboTasksBackend {
             self.is_idle.store(false, Ordering::Release);
             self.verify_aggregation_graph(turbo_tasks, false);
         }
-        // eagerly drop the task cache before persisting
+        // The task_cache is a pure perf cache backed by the DB and isn't read during the stop
+        // snapshot (no task creation runs concurrently with stop). Drop it before persisting to
+        // lower peak memory during the serialization/write.
         self.storage.drop_task_cache();
-        if self.should_persist() {
-            // The task_cache is a pure perf cache backed by the DB and isn't read during the
-            // stop snapshot (no task creation runs concurrently with stop). Drop it before
-            // persisting to lower peak memory during the serialization/write.
-            if let Err(err) =
+        if self.should_persist()
+            && let Err(err) =
                 self.snapshot_and_persist(Span::current().into(), SnapshotReason::Stop, turbo_tasks)
-            {
-                eprintln!("Persisting failed during shutdown: {err:?}");
-            }
+        {
+            eprintln!("Persisting failed during shutdown: {err:?}");
         }
         self.storage.drop_contents();
         if let Err(err) = self.backing_storage.shutdown() {
@@ -2097,10 +2208,6 @@ impl TurboTasksBackend {
         let has_new_children = !new_children.is_empty();
         span.record("new_children", new_children.len());
 
-        if has_new_children {
-            self.task_execution_completed_unfinished_children_dirty(&mut ctx, &new_children)
-        }
-
         if has_new_children
             && let Some(stale_priority) =
                 self.task_execution_completed_connect(&mut ctx, task_id, new_children)
@@ -2559,36 +2666,6 @@ impl TurboTasksBackend {
         }
     }
 
-    fn task_execution_completed_unfinished_children_dirty(
-        &self,
-        ctx: &mut impl ExecuteContext<'_>,
-        new_children: &FxHashSet<TaskId>,
-    ) {
-        debug_assert!(!new_children.is_empty());
-
-        let mut queue = AggregationUpdateQueue::new();
-        ctx.for_each_task_all(
-            new_children.iter().copied(),
-            "unfinished children dirty",
-            |child_task, ctx| {
-                if !child_task.has_output() {
-                    let child_id = child_task.id();
-                    make_task_dirty_internal(
-                        child_task,
-                        child_id,
-                        false,
-                        #[cfg(feature = "task_dirty_cause")]
-                        TaskDirtyCause::InitialDirty,
-                        &mut queue,
-                        ctx,
-                    );
-                }
-            },
-        );
-
-        queue.execute(ctx);
-    }
-
     fn task_execution_completed_connect(
         &self,
         ctx: &mut impl ExecuteContext<'_>,
@@ -2971,6 +3048,7 @@ impl TurboTasksBackend {
                         // grouped together in trace viewers.
                         let background_span =
                             tracing::info_span!(parent: None, "background snapshot");
+
                         match self.snapshot_and_persist(background_span.id(), reason, turbo_tasks) {
                             Err(err) => {
                                 // save_snapshot consumed persisted_task_cache_log entries;
@@ -3008,6 +3086,7 @@ impl TurboTasksBackend {
                                         }
                                     }};
                                 }
+
                                 // Evict persisted tasks from memory to reclaim space.
                                 // Like compaction, this runs after snapshot_and_persist
                                 // as a separate concern.
@@ -3739,6 +3818,14 @@ impl Backend for TurboTasksBackend {
 
     fn mark_own_task_as_finished(&self, task_id: TaskId, turbo_tasks: &TurboTasks<Self>) {
         self.mark_own_task_as_finished(task_id, turbo_tasks);
+    }
+
+    fn pin_task_for_gc(&self, task: TaskId, turbo_tasks: &TurboTasks<Self>) {
+        self.gc_pin(task, turbo_tasks);
+    }
+
+    fn unpin_task_for_gc(&self, task: TaskId, turbo_tasks: &TurboTasks<Self>) {
+        self.gc_unpin(task, turbo_tasks);
     }
 
     fn connect_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -417,6 +417,15 @@ impl TurboTasksBackend {
             .store(ttl_ms, Ordering::Relaxed);
     }
 
+    /// The GC roots set as currently persisted on disk (task id -> last-anchored millis). Reads the
+    /// `GcRoots` infra key directly, so it reflects the last committed snapshot — not any in-flight
+    /// pass. Test-only hook for asserting that a root seeded for collection but *not* collected
+    /// stays tracked (see `gc_roots_refresh_and_age_out`'s monotonicity note).
+    #[doc(hidden)]
+    pub fn persisted_gc_roots_for_testing(&self) -> Vec<(TaskId, u64)> {
+        self.backing_storage.roots().unwrap_or_default()
+    }
+
     /// Opens `task` with must-exist access and drops the guard. Test-only hook to exercise
     /// the non-fabricating existence guarantee: this panics (debug builds) if `task` exists in
     /// neither memory nor persistent storage (rather than fabricating a blank).
@@ -1142,9 +1151,27 @@ impl TurboTasksBackend {
         drop(snapshot_phase);
 
         if !has_modifications {
-            // No tasks modified since the last snapshot — drop the guard (which
-            // calls end_snapshot) and skip the expensive O(N) scan.
+            // No tasks modified since the last snapshot — drop the guard (which calls
+            // end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
+            // ...but a GC pass still produced a roots map, and it must be written even though no
+            // task changed. Restoring a task does *not* dirty it, so a perfectly cached graph can
+            // be restored, observed live and anchored, and leave nothing modified — exactly the
+            // case where the refreshed `last_anchored` timestamps matter. Dropping them here let a
+            // rarely-changing route (an API route restored but never modified) keep a stale
+            // timestamp and age out of the roots map, even though every session had seen it alive.
+            //
+            // `save_snapshot` handles an empty task list as a no-op scan, so this writes just the
+            // small `GcRoots` infra key — the O(N) work is still skipped.
+            if let Some(roots) = gc_roots_to_persist {
+                let _span =
+                    tracing::info_span!("persist gc roots only", roots = roots.len()).entered();
+                self.backing_storage.save_snapshot(
+                    suspended_operations,
+                    Some(roots),
+                    Vec::<Vec<SnapshotItem>>::new(),
+                )?;
+            }
             return Ok((start, false));
         }
 
@@ -1429,9 +1456,13 @@ impl TurboTasksBackend {
         let snapshot_duration = start.elapsed();
         let task_count = task_snapshots.len();
 
-        if task_snapshots.is_empty() {
+        if task_snapshots.is_empty() && gc_roots_to_persist.is_none() {
             // This should be impossible — if we got here, modified_count was nonzero, and every
-            // modification that increments the count also failed during encoding.
+            // modification that increments the count also failed during encoding. (With a roots map
+            // to persist we fall through instead: `save_snapshot` treats an empty task list as a
+            // no-op scan, so the `GcRoots` key is still written. See the `!has_modifications` path
+            // above for why dropping a refresh is a correctness problem, not just a missed
+            // optimization.)
             std::hint::cold_path();
             return Ok((snapshot_time, false));
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -29,7 +29,10 @@ use turbo_tasks::{FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, event::
 use crate::{
     backend::{
         TaskDataCategory,
-        operation::{ExecuteContext, Operation, TaskGuard, invalidate::make_task_dirty},
+        operation::{
+            ExecuteContext, Operation, TaskGuard, connect_child::resurrect_deleted,
+            invalidate::make_task_dirty,
+        },
         storage_schema::TaskStorageAccessors,
     },
     data::{ActivenessState, AggregationNumber, CollectibleRef},
@@ -279,6 +282,15 @@ pub enum AggregationUpdateJob {
         upper_id: TaskId,
         lost_follower_ids: TaskIdVec,
         retry: u16,
+    },
+    /// Adjust the persistent `parent_count` of each task in `task_ids` by `delta`
+    AdjustParentCount { task_ids: TaskIdVec, delta: i32 },
+    /// Adjust the session-only `transient_ref_count` of each task in `task_ids` by `delta`
+    AdjustTransientRefCount {
+        #[bincode(skip, default = "unreachable_decode")]
+        task_ids: TaskIdVec,
+        #[bincode(skip, default = "unreachable_decode")]
+        delta: i32,
     },
     /// Notifies an upper task about changed data from an inner task.
     AggregatedDataUpdate(Box<AggregatedDataUpdateJob>),
@@ -872,7 +884,8 @@ mod encode_jobs {
                 AggregationUpdateJob::IncreaseActiveCount { .. }
                 | AggregationUpdateJob::IncreaseActiveCounts { .. }
                 | AggregationUpdateJob::DecreaseActiveCount { .. }
-                | AggregationUpdateJob::DecreaseActiveCounts { .. } => {
+                | AggregationUpdateJob::DecreaseActiveCounts { .. }
+                | AggregationUpdateJob::AdjustTransientRefCount { .. } => {
                     AggregationUpdateJobItem {
                         job: AggregationUpdateJob::Noop,
                         #[cfg(feature = "trace_aggregation_update_queue")]
@@ -1437,6 +1450,39 @@ impl AggregationUpdateQueue {
                             ctx,
                         );
                     }
+                }
+                AggregationUpdateJob::AdjustParentCount { task_ids, delta } => {
+                    // Apply the persistent parent_count delta to each task. Maintained here (rather
+                    // than inline at the edge sites) so the update rides the durable queue: a
+                    // snapshot captures it mid-flight and it replays to completion on restart,
+                    // keeping the count crash-consistent.
+                    //
+                    // A count reaching 0 means the task lost its last persistent parent and may be
+                    // collectible. Outside GC we don't record it (the collectibility is derived
+                    // from the durable `parent_count` directly). During a GC
+                    // pass, the collector runs this decrement (via
+                    // `CleanupOldEdges` on a collected task) and needs to
+                    // discover the newly-parentless children to cascade into:
+                    // `note_gc_parent_count_zeroed` records them on the GC
+                    // context (a no-op for every normal context).
+                    ctx.for_each_task_meta(task_ids, "AdjustParentCount", |mut task, ctx| {
+                        if task.update_and_get_parent_count(delta) == 0 {
+                            let id = task.id();
+                            ctx.note_gc_parent_count_zeroed(id);
+                        }
+                    });
+                }
+                AggregationUpdateJob::AdjustTransientRefCount { task_ids, delta } => {
+                    // Session-only sibling of AdjustParentCount for edges from a transient parent.
+                    // Not persisted/replayed, and reaching 0 is not a collection trigger (only
+                    // losing a persistent parent is).
+                    ctx.for_each_task_meta(
+                        task_ids,
+                        "AdjustTransientRefCount",
+                        |mut task, _ctx| {
+                            task.update_and_get_transient_ref_count(delta);
+                        },
+                    );
                 }
                 AggregationUpdateJob::DecreaseActiveCount { task } => {
                     self.decrease_active_count(ctx, task);
@@ -3140,12 +3186,18 @@ impl AggregationUpdateQueue {
         #[cfg(feature = "trace_aggregation_update")]
         let _span = trace_span!("increase active count").entered();
 
-        let mut task = ctx.task(
+        let task = ctx.task(
             task_id,
             // For performance reasons this should stay Meta and not All.
             // persistent_task_type is now set eagerly in initialize_new_task.
             AGGREGATION_UPDATE_CATEGORY,
         );
+        // Revive the task first if GC soft-deleted it, so the rest of this function (and the
+        // scheduling it drives) sees a live, re-dirtied task. A no-op on the common not-deleted
+        // path (one flag read on the guard we hold), so it is unconditional — only a direct-child
+        // connect can actually observe a deleted task here, but checking always is cheaper than
+        // threading a flag through the job.
+        let mut task = resurrect_deleted(task, task_id, AGGREGATION_UPDATE_CATEGORY, self, ctx);
         self.check_optimization_pending(&task);
         let state = task.get_activeness_mut_or_insert_with(|| ActivenessState::new(task_id));
         let is_new = state.is_empty();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -54,6 +54,34 @@ pub enum OutdatedEdge {
     CollectiblesDependency(CollectiblesRef),
 }
 
+/// Captures *all* of a task's outgoing edges — children and every forward-dependency kind — as
+/// [`OutdatedEdge`]s to hand to [`CleanupOldEdgesOperation::run`]. Used when a task is being fully
+/// torn down (GC collection, disposing a transient root task): removing these edges drops each
+/// child's parent reference count, scrubs the forward-dependency reverse edges on the targets, and
+/// rebalances the aggregation graph. This is the "remove every edge" case; a re-executing task
+/// instead captures only the *outdated* edges (those in the old child/dep set but not the new one).
+pub fn capture_all_outgoing_edges(task: &impl TaskStorageAccessors) -> Vec<OutdatedEdge> {
+    let mut old_edges: Vec<OutdatedEdge> = Vec::new();
+    old_edges.extend(task.iter_children().map(OutdatedEdge::Child));
+    old_edges.extend(
+        task.iter_output_dependencies()
+            .map(OutdatedEdge::OutputDependency),
+    );
+    old_edges.extend(
+        task.iter_cell_dependencies()
+            .map(OutdatedEdge::CellDependency),
+    );
+    old_edges.extend(
+        task.iter_cell_dependencies_hashed()
+            .map(|(r, k)| OutdatedEdge::HashedCellDependency(r, k)),
+    );
+    old_edges.extend(
+        task.iter_collectibles_dependencies()
+            .map(OutdatedEdge::CollectiblesDependency),
+    );
+    old_edges
+}
+
 #[cfg(feature = "trace_aggregation_update_stats")]
 type Stats = super::aggregation_update::AggregationUpdateQueueStats;
 #[cfg(not(feature = "trace_aggregation_update_stats"))]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -96,10 +96,37 @@ impl CleanupOldEdgesOperation {
                                     _ => true,
                                 });
                                 let mut task = ctx.task(task_id, TaskDataCategory::All);
-                                for task_id in children.iter() {
-                                    task.remove_children(task_id);
+                                // Gate on the `remove_children` return so each edge's child-side
+                                // count is adjusted exactly once, even if a resumed CleanupOldEdges
+                                // re-removes the same edges (already-gone edges return false).
+                                let mut removed_persistent_children =
+                                    SmallVec::<[TaskId; 4]>::new();
+                                for child_id in children.iter() {
+                                    if task.remove_children(child_id) && !child_id.is_transient() {
+                                        removed_persistent_children.push(*child_id);
+                                    }
+                                }
+                                // Each removed persistent child loses a parent. The queued job
+                                // drops the right counter (durable
+                                // `parent_count` for a persistent parent,
+                                // session-only `transient_ref_count` for a transient one) and takes
+                                // the child guards, avoiding a second guard while `task` is held.
+                                if !removed_persistent_children.is_empty() {
+                                    let job = if task_id.is_transient() {
+                                        AggregationUpdateJob::AdjustTransientRefCount {
+                                            task_ids: removed_persistent_children,
+                                            delta: -1,
+                                        }
+                                    } else {
+                                        AggregationUpdateJob::AdjustParentCount {
+                                            task_ids: removed_persistent_children,
+                                            delta: -1,
+                                        }
+                                    };
+                                    queue.push(job);
                                 }
                                 if is_aggregating_node(get_aggregation_number(&task)) {
+                                    drop(task);
                                     queue.push(AggregationUpdateJob::InnerOfUpperLostFollowers {
                                         upper_id: task_id,
                                         lost_follower_ids: children,
@@ -172,6 +199,16 @@ impl CleanupOldEdgesOperation {
                                     task: cell_task_id,
                                     cell,
                                 } = forward;
+                                // Under GC the scrub target must already be resident
+                                // (soft-deleted); a non-resident
+                                // target would resurrect an already-collected task
+                                // from disk. `gc_target_resident` is `None` outside GC.
+                                debug_assert!(
+                                    ctx.gc_target_resident(cell_task_id) != Some(false),
+                                    "gc: CleanupOldEdges({task_id}) cell-dep target \
+                                     {cell_task_id} is not resident — would resurrect a collected \
+                                     task"
+                                );
                                 {
                                     let mut task = ctx.task(cell_task_id, TaskDataCategory::Data);
                                     task.remove_cell_dependents(&CellRef {
@@ -213,6 +250,14 @@ impl CleanupOldEdgesOperation {
                                     dependent_task = %task_id
                                 )
                                 .entered();
+                                // See the CellDependency arm: under GC the target must stay
+                                // resident; a non-resident one would resurrect a collected task.
+                                debug_assert!(
+                                    ctx.gc_target_resident(output_task_id) != Some(false),
+                                    "gc: CleanupOldEdges({task_id}) output-dep target \
+                                     {output_task_id} is not resident — would resurrect a \
+                                     collected task"
+                                );
                                 {
                                     let mut task = ctx.task(output_task_id, TaskDataCategory::Data);
                                     task.remove_output_dependent(&task_id);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -301,7 +301,7 @@ impl CleanupOldEdgesOperation {
                             }) => {
                                 {
                                     let mut task =
-                                        ctx.task(dependent_task_id, TaskDataCategory::Data);
+                                        ctx.task(dependent_task_id, TaskDataCategory::Meta);
                                     task.remove_collectibles_dependents(&(
                                         collectible_type,
                                         task_id,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -227,16 +227,17 @@ impl CleanupOldEdgesOperation {
                                     task: cell_task_id,
                                     cell,
                                 } = forward;
-                                // Under GC the scrub target must already be resident
-                                // (soft-deleted); a non-resident
-                                // target would resurrect an already-collected task
-                                // from disk. `gc_target_resident` is `None` outside GC.
-                                debug_assert!(
-                                    ctx.gc_target_resident(cell_task_id) != Some(false),
-                                    "gc: CleanupOldEdges({task_id}) cell-dep target \
-                                     {cell_task_id} is not resident — would resurrect a collected \
-                                     task"
-                                );
+                                // This is a *forward* dependency: `cell_task_id` is an upstream
+                                // producer `task_id` reads from, not one of its children. Under GC
+                                // that producer may be **disk-only** (never restored this session):
+                                // it is a live *persistent* task, not a collected one — dep fields
+                                // are `filter_transient`, so a persisted task's cell deps only ever
+                                // reference persistent targets, ruling out fabricating a transient
+                                // zombie. Opening it `MustExist` restores it from disk so we can
+                                // scrub the now-stale reverse edge (its `cell_dependents` still
+                                // lists the collected `task_id`); it re-persists with the edge
+                                // gone. That is correct — it does
+                                // not resurrect a *collected* task.
                                 {
                                     let mut task = ctx.task(cell_task_id, TaskDataCategory::Data);
                                     task.remove_cell_dependents(&CellRef {
@@ -278,14 +279,11 @@ impl CleanupOldEdgesOperation {
                                     dependent_task = %task_id
                                 )
                                 .entered();
-                                // See the CellDependency arm: under GC the target must stay
-                                // resident; a non-resident one would resurrect a collected task.
-                                debug_assert!(
-                                    ctx.gc_target_resident(output_task_id) != Some(false),
-                                    "gc: CleanupOldEdges({task_id}) output-dep target \
-                                     {output_task_id} is not resident — would resurrect a \
-                                     collected task"
-                                );
+                                // See the CellDependency arm: `output_task_id` is a forward-dep
+                                // producer that may be disk-only under GC. It is a live persistent
+                                // task (deps are `filter_transient`); restoring it `MustExist` to
+                                // scrub the stale reverse edge is correct and does not resurrect a
+                                // collected task.
                                 {
                                     let mut task = ctx.task(output_task_id, TaskDataCategory::Data);
                                     task.remove_output_dependent(&task_id);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -9,11 +9,73 @@ use crate::{
             aggregation_update::{
                 AggregationUpdateJob, AggregationUpdateQueue, get_aggregation_number, is_root_node,
             },
+            invalidate::make_task_dirty_internal,
         },
         storage_schema::TaskStorageAccessors,
     },
     data::{InProgressState, InProgressStateInner},
 };
+
+/// Revive `task_id` if it was GC-soft-deleted, given a guard the caller already holds during the
+/// connect handshake. The caller passes that guard **by value** and unconditionally rebinds the
+/// result: `guard = resurrect_deleted(guard, ..)`. When the task is not deleted (the common case)
+/// this is a no-op that returns the same guard untouched — one `deleted()` flag read, no extra
+/// acquisition. Otherwise it revives the task and returns a freshly re-acquired guard of
+/// `category`.
+///
+/// On the revival path the guard is dropped and an `All` guard re-acquired (needed for the
+/// `immutable()` read), under which `deleted` is **re-checked** — double-checked locking: between
+/// the peek and this re-acquire, a concurrent connect of the same task could have already revived
+/// it. When still deleted, the clear and the re-dirty happen **under that single `All` guard
+/// without an intervening drop**, so no operation can observe the intermediate `!deleted && !dirty`
+/// state (a task that looks live but still holds the stale/empty edges GC scrubbed). A **mutable**
+/// task is cleared and made dirty so it re-executes and rebuilds those edges; an **immutable** task
+/// cannot be made dirty (invariant in `make_task_dirty`) and does not need to be — its output is
+/// deterministic and its edges self-contained — so clearing the marker alone suffices.
+///
+/// GC is the only producer of the `deleted` flag and runs under an exclusion, so once cleared here
+/// it cannot be re-set concurrently.
+pub(super) fn resurrect_deleted<'e, C: ExecuteContext<'e>>(
+    guard: C::TaskGuardImpl,
+    task_id: TaskId,
+    category: TaskDataCategory,
+    queue: &mut AggregationUpdateQueue,
+    ctx: &mut C,
+) -> C::TaskGuardImpl {
+    // Common path: not deleted — hand the guard straight back, no drop/re-acquire.
+    if !guard.deleted() {
+        return guard;
+    }
+    // Release the caller's guard so we can re-acquire `All` for the `immutable()` read.
+    drop(guard);
+    {
+        // `MustExist`: the task is resident here (the early `deleted()` peek only proceeds for a
+        // soft-deleted, still-resident task). `MustExist` no longer asserts `!deleted()`, so
+        // opening this deliberately-deleted task is fine.
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        // Double-check under the re-acquired guard: a concurrent connect may have revived it in the
+        // gap.
+        if task.deleted() {
+            // Clear + re-dirty atomically under this single guard so no observer sees `!deleted`
+            // before the task has been re-validated.
+            task.set_deleted(false);
+            if !task.immutable() {
+                make_task_dirty_internal(
+                    task,
+                    task_id,
+                    true,
+                    #[cfg(feature = "task_dirty_cause")]
+                    turbo_tasks::TaskDirtyCause::Resurrected,
+                    queue,
+                    ctx,
+                );
+            }
+        }
+    }
+    // Hand back a guard of the caller's category so it can continue the handshake. The task is
+    // resident (we only reach here for a soft-deleted, still-resident task).
+    ctx.task(task_id, category)
+}
 
 #[derive(Encode, Decode, Clone, Default)]
 #[allow(clippy::large_enum_variant)]
@@ -32,7 +94,6 @@ impl ConnectChildOperation {
         mut ctx: impl ExecuteContext<'_>,
     ) {
         if let Some(parent_task_id) = parent_task_id {
-            // The parent is the currently-executing task; it must already exist.
             let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
             let Some(InProgressState::InProgress(box InProgressStateInner {
                 new_children, ..
@@ -64,7 +125,7 @@ impl ConnectChildOperation {
 
         let mut queue = AggregationUpdateQueue::new();
 
-        // Handle the transient to persistent boundary by making the persistent task a root task
+        // Handle the transient to persistent boundary by making the persistent task a root task.
         let should_make_root =
             parent_task_id.is_none_or(|id| id.is_transient() && !child_task_id.is_transient());
 
@@ -76,11 +137,27 @@ impl ConnectChildOperation {
                     distance: None,
                 });
             }
+            // Resurrection (if the child was GC-soft-deleted) rides the child guard
+            // `increase_active_count` takes anyway.
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
             });
         } else {
-            let mut child_task = ctx.get_or_create_task(child_task_id, TaskDataCategory::Meta);
+            // Connecting a genuinely-new child: this may be the first time the child's storage is
+            // materialized (threads can race to first-touch a freshly-created task), so it may
+            // legitimately not be resident yet — the one create-capable open here.
+            let child_task = ctx.get_or_create_task(child_task_id, TaskDataCategory::Meta);
+
+            // Revive the child if GC soft-deleted it, before the schedule/root decisions below
+            // (matching the resurrect-first order). No-op on the common not-deleted path.
+            let mut child_task = resurrect_deleted(
+                child_task,
+                child_task_id,
+                TaskDataCategory::Meta,
+                &mut queue,
+                &mut ctx,
+            );
+
             let has_output = child_task.has_output();
             // An already constructed top-level task was made a root when it was first connected.
             // It may still be dirty and need to run; this only avoids repeating the idempotent
@@ -107,12 +184,10 @@ impl ConnectChildOperation {
             }
         }
 
-        if !queue.is_empty() {
-            ConnectChildOperation::UpdateAggregation {
-                aggregation_update: queue,
-            }
-            .execute(&mut ctx);
+        ConnectChildOperation::UpdateAggregation {
+            aggregation_update: queue,
         }
+        .execute(&mut ctx);
 
         if let Some(parent_task_id) = parent_task_id {
             let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -1,15 +1,21 @@
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
+#[cfg(feature = "task_dirty_cause")]
+use turbo_tasks::TaskDirtyCause;
 use turbo_tasks::{
     TaskId,
     scope::scope_and_block,
     util::{good_chunk_size, into_chunks},
 };
 
-use crate::backend::operation::{
-    AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext, Operation,
-    TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob, get_aggregation_number,
-    get_uppers, is_aggregating_node,
+use crate::backend::{
+    operation::{
+        AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
+        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
+        get_aggregation_number, get_uppers, invalidate::make_task_dirty_internal,
+        is_aggregating_node,
+    },
+    storage_schema::TaskStorageAccessors,
 };
 
 pub fn connect_children(
@@ -51,6 +57,68 @@ pub fn connect_children(
         debug_assert!(!new_follower_ids.is_empty());
 
         let mut queue = AggregationUpdateQueue::new();
+
+        // Single pass over the newly-connected children doing two things per child under one guard,
+        // so we don't lock each child twice (once to bump its ref count, once to dirty it):
+        //
+        // 1. Maintain the child-side parent reference count for **persistent** children: a
+        //    persistent parent bumps the durable `parent_count`, a transient parent the
+        //    session-only `transient_ref_count` (not persisted; transient parents re-establish
+        //    their edges by re-executing on restart). Transient children are never collected, so
+        //    they take no count.
+        //
+        //    CRITICAL: this is a **direct** adjustment, NOT a queued `AdjustParentCount` job, and
+        // it    MUST run before `queue.execute` below (the first `operation_suspend_point`
+        // this    function reaches). GC reads `parent_count` to decide collectibility and
+        // only observes    state at suspend points (`begin_gc` drains operations to a
+        // suspended/quiescent state).    If the `+1` rode the `AggregationUpdateQueue`
+        // instead, that queue's per-iteration    suspend point could suspend with the `+1`
+        // still pending — leaving a window where the    `children` edge is committed
+        // (`extend_children` in the caller) but `parent_count` is    not yet incremented. A
+        // GC pass landing in that window would read the under-counted    `parent_count ==
+        // 0`, judge the (genuinely reachable) child collectible, and delete it.    There is
+        // no `operation_suspend_point` between the caller's `extend_children` and here
+        //    (`make_task_dirty_internal` only enqueues; the queue runs later), so no snapshot/GC
+        // can    observe the edge without the count. In the parallelized path this runs on
+        // a child    context (which never suspends — it holds no operation guard), inside
+        // the    `scope_and_block` barrier that completes within the parent operation, so
+        // the property    holds there too. (The `-1` on edge removal in `CleanupOldEdges`
+        // has the opposite,    benign failure mode — a pending `-1` makes GC
+        // *under*-collect for one pass,    self-correcting — so it stays on the durable
+        // queue there.)
+        //
+        // 2. Make any child that has not produced output yet dirty, so it gets scheduled and
+        //    computes. Runs only on the successful connect (not the stale/cancel early-returns in
+        //    `task_execution_completed_connect`), which undo the children's temporarily-increased
+        //    active count rather than keeping them.
+        let parent_is_transient = parent_task_id.is_transient();
+        ctx.for_each_task_all(
+            new_follower_ids.iter().copied(),
+            "connect_children parent_count + dirty",
+            |mut child, ctx| {
+                // Ref-count bump first (persistent children only), on the `&mut` borrow, before the
+                // guard may be consumed by `make_task_dirty_internal` below.
+                if !child.id().is_transient() {
+                    if parent_is_transient {
+                        child.update_and_get_transient_ref_count(1);
+                    } else {
+                        child.update_and_get_parent_count(1);
+                    }
+                }
+                if !child.has_output() {
+                    let child_id = child.id();
+                    make_task_dirty_internal(
+                        child,
+                        child_id,
+                        false,
+                        #[cfg(feature = "task_dirty_cause")]
+                        TaskDirtyCause::InitialDirty,
+                        &mut queue,
+                        ctx,
+                    );
+                }
+            },
+        );
 
         if let Some(upper_ids) = upper_ids {
             // We need to add new followers when there are upper ids as the parent is a leaf node
@@ -133,10 +201,10 @@ pub fn connect_children(
     // This avoids long pauses of more than 30µs * 10k = 300ms.
     // We don't want to parallelize too eagerly as spawning tasks and the temporary allocations have
     // a cost as well.
-    const CONNECT_CHILDREN_PARALLIZATION_THRESHOLD: usize = 10000;
+    const CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD: usize = 10000;
 
     let len = new_follower_ids.len();
-    if len >= CONNECT_CHILDREN_PARALLIZATION_THRESHOLD {
+    if len >= CONNECT_CHILDREN_PARALLELIZATION_THRESHOLD {
         let new_follower_ids = new_follower_ids.into_vec();
         let chunk_size = good_chunk_size(len);
         let _ = scope_and_block(len.div_ceil(chunk_size), |scope| {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -78,6 +78,16 @@ pub trait ExecuteContext<'e>: Sized {
         task_id: TaskId,
         category: TaskDataCategory,
     ) -> Self::TaskGuardImpl;
+    /// Opens an **already-resident** task without restoring from disk and **without** inserting a
+    /// blank entry for a missing key (unlike [`Self::task`], which does both). Returns `None` if
+    /// the task is not resident.
+    ///
+    /// Because it performs no restore, the returned guard may only be used to touch **transient**
+    /// fields (whose accessors don't gate on `check_access`); reading a Meta/Data field through it
+    /// would trip the `check_access` debug assertion. Used for pure in-session bookkeeping on a
+    /// live task — GC pin/unpin adjusting `transient_ref_count` — where a missing entry means
+    /// the caller referenced an already-collected task (a bug) rather than one to resurrect.
+    fn resident_task(&mut self, task_id: TaskId) -> Option<Self::TaskGuardImpl>;
     /// Prepares (as in fetches from persistent storage) a list of tasks.
     /// The iterator should not have duplicates, as this would cause over-fetching.
     fn prepare_tasks(
@@ -129,6 +139,28 @@ pub trait ExecuteContext<'e>: Sized {
     fn operation_suspend_point<T>(&mut self, op: &T)
     where
         T: Clone + Into<AnyOperation>;
+    /// Records that `task_id`'s persistent `parent_count` just reached 0 (it lost its last
+    /// persistent parent). Only the garbage collector's context acts on this — it collects the
+    /// newly-parentless ids so the collecting job can re-check collectibility and cascade a
+    /// `Collect` — so the default is a no-op for all normal operation contexts.
+    fn note_gc_parent_count_zeroed(&mut self, task_id: TaskId) {
+        let _ = task_id;
+    }
+    /// Takes the ids recorded by [`Self::note_gc_parent_count_zeroed`] since the last call. Only
+    /// the GC context collects anything; the default returns empty.
+    fn take_gc_parent_count_zeroed(&mut self) -> Vec<TaskId> {
+        Vec::new()
+    }
+    /// In the GC context only, whether `task_id` is currently resident: `Some(false)` means opening
+    /// it via [`Self::task`] would restore it from disk. Under the GC phase that must never happen
+    /// — a collected task stays resident (soft-deleted) precisely so a forward-dep scrub or cascade
+    /// finds a live entry rather than resurrecting a zombie — so a `Some(false)` is a bug and the
+    /// GC-only callers `debug_assert` against it. `None` for every normal context (where restoring
+    /// a missing task from disk is legitimate), which disables the assertion there.
+    fn gc_target_resident(&self, task_id: TaskId) -> Option<bool> {
+        let _ = task_id;
+        None
+    }
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
@@ -205,6 +237,16 @@ pub struct ExecuteContextImpl<'e> {
     turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
     _operation_guard: Option<OperationGuard<'e, AnyOperation>>,
     task_lock_counter: TaskLockCounter,
+    /// GC-only: ids whose persistent `parent_count` reached 0 during this context's operations
+    /// (recorded by `note_gc_parent_count_zeroed`). `None` for normal operation contexts (the
+    /// recording hook is a no-op there); `Some` only for the GC context, drained by the collector
+    /// via [`Self::take_gc_parent_count_zeroed`] to discover cascade-collectible tasks.
+    // TODO: consider replacing this buffer with a callback so a newly-parentless child is handed
+    // to the collector (and can be spawned) immediately, rather than accumulated and drained
+    // after the whole `CleanupOldEdges` run finishes. Deferred: spawning mid-cleanup would
+    // start a child's collection while the parent still holds guards, so it needs a careful
+    // look at guard/lock ordering before it's worth the reduced latency.
+    gc_zeroed: Option<Vec<TaskId>>,
 }
 
 impl<'e> ExecuteContextImpl<'e> {
@@ -217,9 +259,45 @@ impl<'e> ExecuteContextImpl<'e> {
             turbo_tasks,
             _operation_guard: Some(backend.start_operation()),
             task_lock_counter: TaskLockCounter::new(),
+            gc_zeroed: None,
         }
     }
 
+    /// Constructs a context that does NOT take an operation guard, for use by the garbage
+    /// collector while it holds the coordinator's GC phase.
+    ///
+    /// The GC phase excludes all concurrent operations and task execution, so taking an
+    /// operation guard here would in fact deadlock.
+    ///
+    /// Should only be used by the garbage collector implementation
+    pub(super) fn new_for_gc(
+        backend: &'e TurboTasksBackend,
+        turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
+    ) -> Self {
+        debug_assert!(
+            backend.snapshot_coord.gc_in_progress(),
+            "new_for_gc called outside a held GC phase"
+        );
+        Self {
+            backend,
+            turbo_tasks,
+            _operation_guard: None,
+            task_lock_counter: TaskLockCounter::new(),
+            gc_zeroed: Some(Vec::new()),
+        }
+    }
+
+    /// Backs [`ExecuteContext::task`]: opens a task, restoring the requested `category` from
+    /// persistent storage if needed.
+    ///
+    /// With [`TaskAccess::MaybeCreate`] a missing task is created — `access_mut` inserts a blank
+    /// entry and, if disk has nothing, it stays empty. With [`TaskAccess::MustExist`] a task that
+    /// exists in **neither memory nor disk** is a bug (a stale reference to an
+    /// already-collected/never-created task); rather than fabricate and return a blank (which would
+    /// silently corrupt the graph) this **panics in debug builds** (the check is debug-only for
+    /// now — see `TaskAccess::MustExist`). Existence is judged from residency (a resident entry
+    /// always exists) and the disk-presence flag `restore_task_data` returns for the categories we
+    /// restore.
     fn open_task(
         &mut self,
         task_id: TaskId,
@@ -354,11 +432,17 @@ impl<'e> ExecuteContextImpl<'e> {
                 }
             }
         }
+        // NOTE: `MustExist` only enforces *existence* (not fabrication). It deliberately does NOT
+        // assert `!deleted()`: GC/aggregation bookkeeping legitimately opens a soft-deleted task
+        // during the resurrection window (e.g. `resurrect_deleted`, `increase_active_count`) before
+        // it is revived. The "a read must not see a GC-deleted task" invariant is asserted only on
+        // the consumer read paths (`try_read_task_output`/`try_read_task_cell`), which is where a
+        // stale read would actually escape.
         TaskGuardImpl {
             task,
             task_id,
             #[cfg(debug_assertions)]
-            category,
+            category: Some(category),
             task_lock_counter: self.task_lock_counter.clone(),
         }
     }
@@ -783,7 +867,8 @@ impl<'e> ExecuteContextImpl<'e> {
 struct TaskRestoreEntry {
     task_id: TaskId,
     category: TaskDataCategory,
-    /// Result of restoring the data category (set in Phase 1b, consumed in Phase 1c).
+    /// Result of restoring the data category (set in Phase 1b, consumed in Phase 1c). The `bool`
+    /// is the disk-presence flag; unused on the prefetch path (see `apply_restore_result`).
     data_restore_result: Option<Result<(TaskStorage, bool)>>,
     /// Result of restoring the meta category (set in Phase 1b, consumed in Phase 1c).
     meta_restore_result: Option<Result<(TaskStorage, bool)>>,
@@ -867,6 +952,24 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
         self.open_task(task_id, category, TaskAccess::MaybeCreate)
     }
 
+    fn resident_task(&mut self, task_id: TaskId) -> Option<TaskGuardImpl<'e>> {
+        // Non-inserting lookup: `None` means the task is not resident (do not resurrect a blank
+        // entry). No restore is performed, so the guard must only touch transient fields — see the
+        // trait doc. Acquire the context's lock counter for the returned guard (released on its
+        // Drop), exactly like `task()`.
+        let task = self.backend.storage.access_mut_if_resident(task_id)?;
+        self.task_lock_counter.acquire();
+        Some(TaskGuardImpl {
+            task,
+            task_id,
+            // No category was restored: `None` makes `check_access` reject any Meta/Data read
+            // through this guard. Transient-field accessors (the only intended use) never check.
+            #[cfg(debug_assertions)]
+            category: None,
+            task_lock_counter: self.task_lock_counter.clone(),
+        })
+    }
+
     fn prepare_tasks(
         &mut self,
         task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
@@ -896,7 +999,7 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
                     task,
                     task_id,
                     #[cfg(debug_assertions)]
-                    category: _category,
+                    category: Some(_category),
                     task_lock_counter: task_lock_counter.clone(),
                 };
                 func(guard, this);
@@ -1095,14 +1198,14 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
                 task: task1,
                 task_id: task_id1,
                 #[cfg(debug_assertions)]
-                category,
+                category: Some(category),
                 task_lock_counter: self.task_lock_counter.clone(),
             },
             TaskGuardImpl {
                 task: task2,
                 task_id: task_id2,
                 #[cfg(debug_assertions)]
-                category,
+                category: Some(category),
                 task_lock_counter: self.task_lock_counter.clone(),
             },
         )
@@ -1128,7 +1231,33 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
     }
 
     fn operation_suspend_point<T: Clone + Into<AnyOperation>>(&mut self, op: &T) {
+        // The GC context holds no operation guard: the GC phase already owns the coordinator's
+        // exclusion, so there is nothing to yield to and `suspend_point` (which decrements the
+        // in-progress-operations count it never incremented) must not run. Skip it entirely.
+        if self._operation_guard.is_none() {
+            return;
+        }
         self.backend.operation_suspend_point(|| op.clone().into());
+    }
+
+    fn note_gc_parent_count_zeroed(&mut self, task_id: TaskId) {
+        if let Some(zeroed) = self.gc_zeroed.as_mut() {
+            zeroed.push(task_id);
+        }
+    }
+
+    fn take_gc_parent_count_zeroed(&mut self) -> Vec<TaskId> {
+        self.gc_zeroed
+            .as_mut()
+            .map(std::mem::take)
+            .unwrap_or_default()
+    }
+
+    fn gc_target_resident(&self, task_id: TaskId) -> Option<bool> {
+        // Only the GC context (the one collecting zeroed ids) reports residency.
+        self.gc_zeroed
+            .is_some()
+            .then(|| self.backend.storage.with_task(task_id, |_| ()).is_some())
     }
 
     fn should_track_dependencies(&self) -> bool {
@@ -1192,6 +1321,7 @@ impl<'e> ChildExecuteContext<'e> for ChildExecuteContextImpl<'e> {
             turbo_tasks: self.turbo_tasks,
             _operation_guard: None,
             task_lock_counter: TaskLockCounter::new(),
+            gc_zeroed: None,
         }
     }
 }
@@ -1237,6 +1367,11 @@ impl Display for TaskType {
 pub trait TaskGuard: Debug + TaskStorageAccessors {
     fn id(&self) -> TaskId;
 
+    /// GC-only: for a collected task that was never persisted (`new_task`), clear its modified bits
+    /// and shard modified count so the next snapshot skips it (nothing on disk to tombstone).
+    /// See [`crate::backend::storage::StorageWriteGuard::discard_modifications_for_gc_new_task`].
+    fn discard_modifications_for_gc_new_task(&mut self);
+
     /// Get mutable reference to the activeness state, inserting a new one if not present
     fn get_activeness_mut_or_insert_with<F>(&mut self, f: F) -> &mut ActivenessState
     where
@@ -1278,6 +1413,53 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
             self.set_aggregated_current_session_clean_container_count(new_value);
         }
         new_value
+    }
+
+    /// Adjust the count of **persistent** parents referencing this task by `delta` (+1 when a
+    /// persistent parent connects it as a child, -1 when one disconnects it) and return the new
+    /// value. A value of 0 means no persistent parent lists this task — a prerequisite for
+    /// collection. Panics on underflow/overflow: the count must equal the true number of
+    /// `children`-edge references, so a decrement below 0 (or a wrap past `u32::MAX`) means it has
+    /// drifted from that invariant and must fail loudly rather than corrupt collectibility.
+    fn update_and_get_parent_count(&mut self, delta: i32) -> u32 {
+        let current = self.get_parent_count().copied().unwrap_or(0);
+        let new_value = current
+            .checked_add_signed(delta)
+            .expect("parent_count underflow: decremented below the number of persistent parents");
+        self.set_parent_count(new_value);
+        new_value
+    }
+
+    /// Like [`Self::update_and_get_parent_count`], but for the transient (session-only) parent
+    /// reference count that keeps a persistent task alive while a transient parent references it.
+    /// Panics on underflow/overflow for the same reason (an accounting drift, not a recoverable
+    /// condition).
+    fn update_and_get_transient_ref_count(&mut self, delta: i32) -> u32 {
+        let current = self.get_transient_ref_count().copied().unwrap_or(0);
+        let new_value = current
+            .checked_add_signed(delta)
+            .expect("transient_ref_count underflow");
+        self.set_transient_ref_count(new_value);
+        new_value
+    }
+
+    /// Whether a GC pass may collect this task: it is non-transient, has no persistent or transient
+    /// parents, is quiescent (not active, not in progress), and holds no aggregation edges
+    /// (`upper`/`followers`).
+    ///
+    /// The storage-only checks live in [`TaskStorage::gc_maybe_collectible`] so GC's resident-map
+    /// scan can reuse them without a guard; this authoritative form adds the transient-*id* check
+    /// and enforces Meta-restoration (`check_access`) — the storage fields it reads are lazy
+    /// Meta fields that read as absent (0/empty) when Meta was evicted, so a task with evicted
+    /// Meta must not be judged collectible from stale absence. GC always opens the task with
+    /// `All` before calling this, so the check passes.
+    fn is_gc_collectible(&self) -> bool {
+        // Transient-ness is a property of the id, not the storage; transient tasks are never
+        // collected.
+        !self.id().is_transient() && {
+            self.check_access(crate::backend::storage::SpecificTaskDataCategory::Meta);
+            self.typed().gc_maybe_collectible()
+        }
     }
 
     fn invalidate_serialization(&mut self);
@@ -1526,8 +1708,13 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
 pub struct TaskGuardImpl<'a> {
     task_id: TaskId,
     task: StorageWriteGuard<'a>,
+    /// Which category was restored when this guard was opened, gating `check_access`. `None` means
+    /// **no** category was restored (e.g. the non-inserting [`ExecuteContext::resident_task`]
+    /// path, used for transient-only bookkeeping): any Meta/Data access through such a guard
+    /// is a bug and `check_access` rejects it. Transient-field accessors never call
+    /// `check_access`, so they work regardless.
     #[cfg(debug_assertions)]
-    category: TaskDataCategory,
+    category: Option<TaskDataCategory>,
     task_lock_counter: TaskLockCounter,
 }
 
@@ -1547,8 +1734,10 @@ impl TaskGuardImpl<'_> {
             SpecificTaskDataCategory::Data => {
                 #[cfg(debug_assertions)]
                 debug_assert!(
-                    self.category == TaskDataCategory::Data
-                        || self.category == TaskDataCategory::All,
+                    matches!(
+                        self.category,
+                        Some(TaskDataCategory::Data | TaskDataCategory::All)
+                    ),
                     "To read data of {:?} the task need to be accessed with this category (It's \
                      accessed with {:?})",
                     category,
@@ -1558,8 +1747,10 @@ impl TaskGuardImpl<'_> {
             SpecificTaskDataCategory::Meta => {
                 #[cfg(debug_assertions)]
                 debug_assert!(
-                    self.category == TaskDataCategory::Meta
-                        || self.category == TaskDataCategory::All,
+                    matches!(
+                        self.category,
+                        Some(TaskDataCategory::Meta | TaskDataCategory::All)
+                    ),
                     "To read data of {:?} the task need to be accessed with this category (It's \
                      accessed with {:?})",
                     category,
@@ -1582,6 +1773,10 @@ impl Debug for TaskGuardImpl<'_> {
 impl TaskGuard for TaskGuardImpl<'_> {
     fn id(&self) -> TaskId {
         self.task_id
+    }
+
+    fn discard_modifications_for_gc_new_task(&mut self) {
+        self.task.discard_modifications_for_gc_new_task();
     }
 
     fn invalidate_serialization(&mut self) {
@@ -1667,6 +1862,7 @@ impl TaskStorageAccessors for TaskGuardImpl<'_> {
         self.task.undo_track_modification(outcome);
     }
 
+    #[track_caller]
     fn check_access(&self, category: crate::backend::storage::SpecificTaskDataCategory) {
         self.check_access(category);
     }
@@ -1785,7 +1981,7 @@ mod filter_transient_tracking_tests {
             task: write,
             task_id,
             #[cfg(debug_assertions)]
-            category: TaskDataCategory::All,
+            category: Some(TaskDataCategory::All),
             task_lock_counter: TaskLockCounter::new(),
         }
     }
@@ -2054,7 +2250,7 @@ mod cell_data_tracking_tests {
             task: write,
             task_id,
             #[cfg(debug_assertions)]
-            category: TaskDataCategory::All,
+            category: Some(TaskDataCategory::All),
             task_lock_counter: TaskLockCounter::new(),
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1457,7 +1457,7 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         // Transient-ness is a property of the id, not the storage; transient tasks are never
         // collected.
         !self.id().is_transient() && {
-            self.check_access(crate::backend::storage::SpecificTaskDataCategory::Meta);
+            self.check_access(SpecificTaskDataCategory::Meta);
             self.typed().gc_maybe_collectible()
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1932,7 +1932,7 @@ pub use self::{
         AggregatedDataUpdate, AggregationUpdateJob, get_aggregation_number, get_uppers,
         is_aggregating_node, is_root_node,
     },
-    cleanup_old_edges::OutdatedEdge,
+    cleanup_old_edges::{OutdatedEdge, capture_all_outgoing_edges},
     connect_children::connect_children,
     invalidate::make_task_dirty_internal,
     prepare_new_children::prepare_new_children,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -151,16 +151,6 @@ pub trait ExecuteContext<'e>: Sized {
     fn take_gc_parent_count_zeroed(&mut self) -> Vec<TaskId> {
         Vec::new()
     }
-    /// In the GC context only, whether `task_id` is currently resident: `Some(false)` means opening
-    /// it via [`Self::task`] would restore it from disk. Under the GC phase that must never happen
-    /// — a collected task stays resident (soft-deleted) precisely so a forward-dep scrub or cascade
-    /// finds a live entry rather than resurrecting a zombie — so a `Some(false)` is a bug and the
-    /// GC-only callers `debug_assert` against it. `None` for every normal context (where restoring
-    /// a missing task from disk is legitimate), which disables the assertion there.
-    fn gc_target_resident(&self, task_id: TaskId) -> Option<bool> {
-        let _ = task_id;
-        None
-    }
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
     fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
@@ -1251,13 +1241,6 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
             .as_mut()
             .map(std::mem::take)
             .unwrap_or_default()
-    }
-
-    fn gc_target_resident(&self, task_id: TaskId) -> Option<bool> {
-        // Only the GC context (the one collecting zeroed ids) reports residency.
-        self.gc_zeroed
-            .is_some()
-            .then(|| self.backend.storage.with_task(task_id, |_| ()).is_some())
     }
 
     fn should_track_dependencies(&self) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -1,15 +1,22 @@
-//! Coordinator that gates concurrent operations against snapshotting.
+//! Coordinator that gates concurrent operations against snapshotting and garbage collection.
 //!
-//! Backend operations and snapshot work share a single [`SnapshotCoordinator`]
-//! that enforces the protocol:
+//! Backend operations, snapshot work, and garbage collection share a single
+//! [`SnapshotCoordinator`] that enforces the protocol:
 //!
-//! - When no snapshot is in flight, [`begin_operation`](SnapshotCoordinator::begin_operation) is a
-//!   single uncontended atomic increment.
-//! - When a snapshot is requested, new operations block until the snapshot finishes, and operations
-//!   already in flight either complete or call
+//! - When neither a snapshot nor a GC pass is in flight,
+//!   [`begin_operation`](SnapshotCoordinator::begin_operation) is a single uncontended atomic
+//!   increment.
+//! - When a snapshot or GC pass is requested, new operations block until it finishes, and
+//!   operations already in flight either complete or call
 //!   [`suspend_point`](SnapshotCoordinator::suspend_point) to suspend.
-//! - The snapshotter waits for every in-flight operation to drain or suspend, takes its snapshot,
-//!   then wakes everyone.
+//! - The snapshotter / collector waits for every in-flight operation to drain or suspend, does its
+//!   work, then wakes everyone.
+//!
+//! Snapshots and GC use two distinct request bits ([`SNAPSHOT_REQUESTED_BIT`] and
+//! [`GC_REQUESTED_BIT`]) so they can be reasoned about independently — a snapshot's exclusion is
+//! never interrupted, whereas a GC pass may abort mid-mark. Operations drain/suspend for either
+//! bit. Snapshots and GC are themselves mutually exclusive; callers serialize them with the
+//! `snapshot_in_progress` mutex in `mod.rs` (the coordinator does not own that mutex).
 
 use std::sync::{
     Arc,
@@ -18,17 +25,32 @@ use std::sync::{
 
 use parking_lot::{Condvar, Mutex};
 use rustc_hash::FxHashSet;
+use tracing::info_span;
 
 use crate::{backend::AnyOperation, utils::ptr_eq_arc::PtrEqArc};
 
-/// High bit: set while a snapshot is requested or in flight.
-/// Low bits: count of operations currently executing (not suspended).
+/// Top bit: set while a snapshot is requested or in flight.
 const SNAPSHOT_REQUESTED_BIT: usize = 1 << (usize::BITS - 1);
+/// Second-from-top bit: set while a garbage-collection pass is requested or in flight.
+const GC_REQUESTED_BIT: usize = 1 << (usize::BITS - 2);
+/// Mask of all "exclusion requested" bits. Operations must drain/suspend while any is set.
+/// The remaining low bits hold the count of operations currently executing (not suspended).
+const REQUEST_BITS: usize = SNAPSHOT_REQUESTED_BIT | GC_REQUESTED_BIT;
+
+/// Whether an `in_progress_operations` value represents a fully-drained state that a waiting
+/// snapshotter/collector should be woken for: at least one request bit is set (someone is waiting
+/// to drain) and the operation count (low bits) has reached zero.
+#[inline]
+fn is_drained(value: usize) -> bool {
+    (value & REQUEST_BITS) != 0 && (value & !REQUEST_BITS) == 0
+}
 
 /// State protected by the mutex.
 struct State<O> {
     /// `true` between `begin_snapshot` and `SnapshotPhase::drop`.
     snapshot_requested: bool,
+    /// `true` between `begin_gc` and `GcPhase::drop`.
+    gc_requested: bool,
     /// Operations that called [`SnapshotCoordinator::suspend_point`] and have
     /// not yet resumed. Returned to the snapshotter via
     /// [`SnapshotPhase::suspended_operations`] so it can persist them in the
@@ -36,21 +58,22 @@ struct State<O> {
     suspended_operations: FxHashSet<PtrEqArc<O>>,
 }
 
-/// Coordinates operation/snapshot interleaving.
+/// Coordinates operation/snapshot/GC interleaving.
 ///
 /// Generic over the operation type the caller wants to suspend. The
 /// coordinator only requires `O: Send + Sync + 'static`; it never inspects
 /// the value, just stores it via [`PtrEqArc`].
 pub struct SnapshotCoordinator<O = AnyOperation> {
-    /// Combined count + bit. See [`SNAPSHOT_REQUESTED_BIT`].
+    /// Combined count + request bits. See [`SNAPSHOT_REQUESTED_BIT`], [`GC_REQUESTED_BIT`].
     in_progress_operations: AtomicUsize,
     state: Mutex<State<O>>,
-    /// Notified by the last operation to drain (count drops to `BIT` while
-    /// `SNAPSHOT_REQUESTED_BIT` is set). Awaited by [`begin_snapshot`].
+    /// Notified by the last operation to drain (count drops to zero while a request bit is set).
+    /// Awaited by [`begin_snapshot`] and [`begin_gc`].
     operations_drained: Condvar,
-    /// Notified by [`SnapshotPhase::drop`]. Awaited by operations that hit a
-    /// suspend point or arrive while a snapshot is in flight.
-    snapshot_completed: Condvar,
+    /// Notified by [`SnapshotPhase::drop`] and [`GcPhase::drop`]. Awaited by operations that hit a
+    /// suspend point or arrive while a snapshot or GC pass is in flight. Operations wait while
+    /// either `snapshot_requested` or `gc_requested` holds.
+    exclusion_completed: Condvar,
 }
 
 impl<O> Default for SnapshotCoordinator<O> {
@@ -65,58 +88,63 @@ impl<O> SnapshotCoordinator<O> {
             in_progress_operations: AtomicUsize::new(0),
             state: Mutex::new(State {
                 snapshot_requested: false,
+                gc_requested: false,
                 suspended_operations: FxHashSet::default(),
             }),
             operations_drained: Condvar::new(),
-            snapshot_completed: Condvar::new(),
+            exclusion_completed: Condvar::new(),
         }
     }
 
-    /// Cheap check used by hot paths. Returns `true` while a snapshot is in
-    /// flight (or being requested). May return `false` racily if a snapshot
-    /// is just about to start; the actual coordination happens in
-    /// [`suspend_point`](Self::suspend_point) and [`begin_operation`](Self::begin_operation).
-    pub fn snapshot_pending(&self) -> bool {
-        // Acquire so that observing the bit synchronizes with anything the
-        // snapshotter wrote before setting it.
-        (self.in_progress_operations.load(Ordering::Acquire) & SNAPSHOT_REQUESTED_BIT) != 0
+    /// Cheap check used by hot paths. Returns `true` while a snapshot or GC pass is in flight (or
+    /// being requested). May return `false` racily if one is just about to start; the actual
+    /// coordination happens in [`suspend_point`](Self::suspend_point) and
+    /// [`begin_operation`](Self::begin_operation).
+    pub fn exclusion_pending(&self) -> bool {
+        // Acquire so that observing a request bit synchronizes with anything the snapshotter /
+        // collector wrote before setting it.
+        (self.in_progress_operations.load(Ordering::Acquire) & REQUEST_BITS) != 0
+    }
+
+    /// Whether a GC phase is currently held (the `GC_REQUESTED_BIT` is set). Used by the GC-only
+    /// execute context to `debug_assert` it is running under the exclusion it requires.
+    pub fn gc_in_progress(&self) -> bool {
+        (self.in_progress_operations.load(Ordering::Acquire) & GC_REQUESTED_BIT) != 0
     }
 
     /// Begin an operation. Returns a guard that decrements on drop.
     ///
-    /// If a snapshot is in flight, blocks until the snapshot finishes before
-    /// returning the guard.
+    /// If a snapshot or GC pass is in flight, blocks until it finishes before returning the guard.
     pub fn begin_operation(&self) -> OperationGuard<'_, O> {
-        // Fast path: no snapshot in flight, single atomic increment.
+        // Fast path: no snapshot or GC in flight, single atomic increment.
         let prev = self.in_progress_operations.fetch_add(1, Ordering::AcqRel);
-        if (prev & SNAPSHOT_REQUESTED_BIT) == 0 {
+        if (prev & REQUEST_BITS) == 0 {
             return OperationGuard { coord: Some(self) };
         }
         #[cold]
-        fn wait_for_snapshot_to_complete<O>(this: &SnapshotCoordinator<O>) {
+        fn wait_for_exclusion_to_complete<O>(this: &SnapshotCoordinator<O>) {
             // We arrive here holding our +1 (the fetch_add in begin_operation).
             // Two cases:
-            //   - Snapshot is still in flight: back out our +1, wait for it to finish, then re-add.
-            //     The drop balances the re-add.
-            //   - Snapshot already finished between our fetch_add and acquiring this mutex: leave
-            //     our +1 in place; the drop balances it directly. No extra atomics needed.
+            //   - A snapshot/GC pass is still in flight: back out our +1, wait for it to finish,
+            //     then re-add. The drop balances the re-add.
+            //   - It already finished between our fetch_add and acquiring this mutex: leave our +1
+            //     in place; the drop balances it directly. No extra atomics needed.
             let mut state = this.state.lock();
-            if state.snapshot_requested {
+            if state.snapshot_requested || state.gc_requested {
                 let prev = this.in_progress_operations.fetch_sub(1, Ordering::AcqRel);
-                if prev - 1 == SNAPSHOT_REQUESTED_BIT {
+                if is_drained(prev - 1) {
                     this.operations_drained.notify_all();
                 }
-                this.snapshot_completed
-                    .wait_while(&mut state, |s| s.snapshot_requested);
-                // Re-add now that the snapshot is done. Bit is cleared because
-                // we just observed `snapshot_requested == false` under the
-                // mutex.
+                this.exclusion_completed
+                    .wait_while(&mut state, |s| s.snapshot_requested || s.gc_requested);
+                // Re-add now that the exclusion is done. Both bits are cleared because we just
+                // observed both flags false under the mutex.
                 this.in_progress_operations.fetch_add(1, Ordering::AcqRel);
             }
         }
-        // Slow path: a snapshot is in flight (or just requested). Back out
-        // the increment, wait for the snapshot to complete, then re-increment.
-        wait_for_snapshot_to_complete(self);
+        // Slow path: a snapshot or GC pass is in flight (or just requested). Back out the
+        // increment, wait for it to complete, then re-increment.
+        wait_for_exclusion_to_complete(self);
         OperationGuard { coord: Some(self) }
     }
 
@@ -125,36 +153,44 @@ impl<O> SnapshotCoordinator<O> {
     /// produce a handle to this operation so the snapshotter can persist it
     /// for replay on the next startup.
     pub fn suspend_point(&self, suspend: impl FnOnce() -> O) {
-        if !self.snapshot_pending() {
+        if !self.exclusion_pending() {
             return;
         }
         #[cold]
         fn suspend_point_cold<O>(this: &SnapshotCoordinator<O>, suspend: impl FnOnce() -> O) {
-            let op = Arc::new(suspend());
             let mut state = this.state.lock();
-            if !state.snapshot_requested {
-                // Race: snapshot finished between the `snapshot_pending` check
-                // and acquiring the mutex. Nothing to do.
+            if !state.snapshot_requested && !state.gc_requested {
+                // Race: the snapshot/GC pass finished between the `exclusion_pending` check and
+                // acquiring the mutex. Nothing to do.
                 return;
             }
+            // Record the suspended operation in the uncompleted-operations set unconditionally,
+            // even when only a GC pass is in flight. A GC pass may hand its exclusion straight to a
+            // snapshot (`GcPhase::into_snapshot`) without this operation resuming first; that
+            // snapshot persists the operation's partial in-memory mutations, so it MUST also record
+            // the operation for replay — otherwise a crash leaves the persisted graph inconsistent.
+            // A standalone GC pass (ended via `GcPhase::Drop`, no snapshot) never persists, so the
+            // recorded entry is simply never read; the cost of running `suspend()` there is
+            // acceptable for the correctness guarantee.
+            let op = Arc::new(suspend());
             state
                 .suspended_operations
                 .insert(PtrEqArc::from(op.clone()));
-            // Decrement the count so the snapshotter can drain.
+            // Decrement the count so the snapshotter / collector can drain.
             let prev = this.in_progress_operations.fetch_sub(1, Ordering::AcqRel);
             // Protocol violation if either invariant fails. Keep as a regular
             // `assert!` so production builds also catch it: the alternative is
-            // a corrupted counter that hangs the next snapshot indefinitely.
+            // a corrupted counter that hangs the next snapshot/GC indefinitely.
             assert!(
-                (prev & SNAPSHOT_REQUESTED_BIT) != 0 && (prev & !SNAPSHOT_REQUESTED_BIT) > 0,
+                (prev & REQUEST_BITS) != 0 && (prev & !REQUEST_BITS) > 0,
                 "suspend_point called without a live operation: prev={prev:#x}"
             );
-            if prev - 1 == SNAPSHOT_REQUESTED_BIT {
+            if is_drained(prev - 1) {
                 this.operations_drained.notify_all();
             }
-            // Wait for the snapshot to finish.
-            this.snapshot_completed
-                .wait_while(&mut state, |s| s.snapshot_requested);
+            // Wait for the snapshot / GC pass to finish.
+            this.exclusion_completed
+                .wait_while(&mut state, |s| s.snapshot_requested || s.gc_requested);
             // Resume: re-increment and remove ourselves from the suspended set.
             this.in_progress_operations.fetch_add(1, Ordering::AcqRel);
             state.suspended_operations.remove(&PtrEqArc::from(op));
@@ -162,56 +198,131 @@ impl<O> SnapshotCoordinator<O> {
         suspend_point_cold(self, suspend);
     }
 
+    /// Shared core of [`begin_snapshot`](Self::begin_snapshot) and [`begin_gc`](Self::begin_gc):
+    /// asserts no snapshot or GC is already in flight, sets the requesting flag + request bit, and
+    /// blocks until every in-flight operation has drained or suspended. Returns the still-held
+    /// state lock so the caller can read `suspended_operations` (snapshot) before releasing it.
+    ///
+    /// `what` ("snapshot" / "gc") only labels the assertion messages and the drain span. Snapshot
+    /// and GC are mutually exclusive; production callers serialize them via the
+    /// `snapshot_in_progress` mutex in `mod.rs` (the coordinator doesn't own that mutex —
+    /// callers interleave work between phases). The mutual-exclusion asserts are promoted from
+    /// debug_assert because silently ignoring a violation leads straight to a stuck counter and
+    /// a hung process.
+    fn begin_exclusion(
+        &self,
+        what: Exclusion,
+        set_requested: impl FnOnce(&mut State<O>),
+    ) -> parking_lot::MutexGuard<'_, State<O>> {
+        let request_bit = what.request_bit();
+        let mut state = self.state.lock();
+        assert!(
+            !state.snapshot_requested && !state.gc_requested,
+            "{} called while a {} was already in flight (snapshot and GC must be serialized)",
+            what.begin_fn(),
+            if state.snapshot_requested {
+                "snapshot"
+            } else {
+                "GC pass"
+            }
+        );
+        set_requested(&mut state);
+        // AcqRel so the writes leading up to setting the bit are visible to the operation hot
+        // path's Acquire load in `exclusion_pending`.
+        let active = self
+            .in_progress_operations
+            .fetch_or(request_bit, Ordering::AcqRel);
+        assert!(
+            (active & request_bit) == 0,
+            "{} request bit was already set when {} ran: {active:#x}",
+            what.label(),
+            what.begin_fn()
+        );
+        if (active & !REQUEST_BITS) != 0 {
+            // Some operations are in flight. Wait for them to drain or suspend. The predicate is
+            // Acquire-loaded so we synchronize with the AcqRel decrement that woke us. This can
+            // block for a while under load (until every in-flight operation reaches a suspend point
+            // or finishes), so it gets its own span for latency attribution.
+            let num_operations = active & !REQUEST_BITS;
+            let _span = match what {
+                Exclusion::Snapshot => {
+                    info_span!("snapshot: await operations settle", num_operations)
+                }
+                Exclusion::Gc => info_span!("gc: await operations settle", num_operations),
+            }
+            .entered();
+            self.operations_drained.wait_while(&mut state, |_| {
+                (self.in_progress_operations.load(Ordering::Acquire) & !REQUEST_BITS) != 0
+            });
+        }
+        state
+    }
+
     /// Begin a snapshot. Sets the snapshot bit, blocks until all in-flight
     /// operations have drained or suspended, and returns a [`SnapshotPhase`]
     /// guard that releases the bit on drop.
     ///
-    /// Concurrent callers panic via the debug assertion. Production callers
-    /// must serialize themselves (see `snapshot_in_progress` lock in
-    /// `mod.rs`); the coordinator does not own that mutex because some
-    /// callers want to interleave additional work between phases.
+    /// Concurrent callers panic (see [`begin_exclusion`](Self::begin_exclusion)).
     pub fn begin_snapshot(&self) -> SnapshotPhase<'_, O> {
-        let mut state = self.state.lock();
-        // Protocol violation: callers must serialize snapshots themselves.
-        // Promoted from debug_assert: silently ignoring this leads directly
-        // to a stuck counter and a hung process.
-        assert!(
-            !state.snapshot_requested,
-            "begin_snapshot called while another snapshot was already in flight"
-        );
-        state.snapshot_requested = true;
-        // AcqRel so the writes leading up to setting the bit are visible to
-        // the operation hot path's Acquire load in `snapshot_pending`.
-        let active = self
-            .in_progress_operations
-            .fetch_or(SNAPSHOT_REQUESTED_BIT, Ordering::AcqRel);
-        assert!(
-            (active & SNAPSHOT_REQUESTED_BIT) == 0,
-            "snapshot bit was already set when begin_snapshot ran: {active:#x}"
-        );
-        if (active & !SNAPSHOT_REQUESTED_BIT) != 0 {
-            // Some operations are in flight. Wait for them to drain or
-            // suspend. The predicate is Acquire-loaded so we synchronize
-            // with the AcqRel decrement that woke us.
-            self.operations_drained.wait_while(&mut state, |_| {
-                self.in_progress_operations.load(Ordering::Acquire) != SNAPSHOT_REQUESTED_BIT
-            });
-        }
-        // Snapshot ranges that follow can read the suspended_operations
-        // list; we leave the mutex held until the caller drops the phase.
+        let state = self.begin_exclusion(Exclusion::Snapshot, |s| s.snapshot_requested = true);
+        // Snapshot ranges that follow can read the suspended_operations list; we read it while
+        // still holding the lock, then release so the snapshotter does the heavy work
+        // without it. Operations attempting to start during this window observe the bit set
+        // and either suspend or wait on `exclusion_completed`.
         let suspended_operations: Vec<Arc<O>> = state
             .suspended_operations
             .iter()
             .map(|op| op.arc().clone())
             .collect();
-        // Release the mutex now — the snapshotter does the heavy work
-        // without holding it. Operations attempting to start during this
-        // window observe the bit set and either suspend or wait on
-        // `snapshot_completed`.
         drop(state);
         SnapshotPhase {
             coord: self,
             suspended_operations,
+        }
+    }
+
+    /// Begin a garbage-collection pass. Sets the GC bit, blocks until all in-flight operations have
+    /// drained or suspended, and returns a [`GcPhase`] guard that releases the bit on drop. While
+    /// the guard is held, no operation can be running, so the collector may mutate the task graph
+    /// without racing.
+    ///
+    /// Concurrent callers panic (see [`begin_exclusion`](Self::begin_exclusion)).
+    pub fn begin_gc(&self) -> GcPhase<'_, O> {
+        let state = self.begin_exclusion(Exclusion::Gc, |s| s.gc_requested = true);
+        drop(state);
+        GcPhase { coord: self }
+    }
+}
+
+/// Which kind of exclusion [`SnapshotCoordinator::begin_exclusion`] is starting. Selects the
+/// request bit and the labels used in assertion messages and the drain span.
+#[derive(Clone, Copy)]
+enum Exclusion {
+    Snapshot,
+    Gc,
+}
+
+impl Exclusion {
+    fn request_bit(self) -> usize {
+        match self {
+            Exclusion::Snapshot => SNAPSHOT_REQUESTED_BIT,
+            Exclusion::Gc => GC_REQUESTED_BIT,
+        }
+    }
+
+    /// Human label for the exclusion kind (used in the "bit already set" assert).
+    fn label(self) -> &'static str {
+        match self {
+            Exclusion::Snapshot => "snapshot",
+            Exclusion::Gc => "GC",
+        }
+    }
+
+    /// Name of the public entry point, for assertion messages.
+    fn begin_fn(self) -> &'static str {
+        match self {
+            Exclusion::Snapshot => "begin_snapshot",
+            Exclusion::Gc => "begin_gc",
         }
     }
 }
@@ -241,10 +352,10 @@ impl<O> Drop for OperationGuard<'_, O> {
         // promoted from debug_assert because the alternative is silently
         // wrapping to usize::MAX and breaking every subsequent snapshot.
         assert!(
-            (prev & !SNAPSHOT_REQUESTED_BIT) > 0,
+            (prev & !REQUEST_BITS) > 0,
             "OperationGuard::drop underflow: in_progress_operations was {prev:#x}"
         );
-        if prev - 1 == SNAPSHOT_REQUESTED_BIT {
+        if is_drained(prev - 1) {
             #[cold]
             fn notify_drained<O>(coord: &SnapshotCoordinator<O>) {
                 // Take the state mutex around `notify_all`. This is defensive against
@@ -300,7 +411,82 @@ impl<O> Drop for SnapshotPhase<'_, O> {
         );
         // Notify everyone waiting for the snapshot to finish under the
         // mutex (correctness against parking_lot's notify_all fast path).
-        self.coord.snapshot_completed.notify_all();
+        self.coord.exclusion_completed.notify_all();
+    }
+}
+
+/// Guard returned by [`SnapshotCoordinator::begin_gc`]. Holds the GC bit; on drop, releases it and
+/// wakes any operations parked on `exclusion_completed`.
+pub struct GcPhase<'a, O> {
+    coord: &'a SnapshotCoordinator<O>,
+}
+
+impl<'a, O> GcPhase<'a, O> {
+    /// Atomically transitions from the GC phase directly into a snapshot phase **without ever
+    /// releasing operation exclusion**. Under the state lock it clears the GC request bit and sets
+    /// the snapshot request bit in one critical section, so no operation can start in between (an
+    /// operation blocks while *either* bit is set). This closes the race where a mutation could
+    /// resurrect a just-collected task in the gap between the GC pass and the snapshot: with an
+    /// atomic hand-off there is no such gap, so the GC cascade's `parent_count` decrements and the
+    /// snapshot see a consistent graph. `begin_gc` already drained operations to zero, so no
+    /// further draining is needed.
+    pub fn into_snapshot(self) -> SnapshotPhase<'a, O> {
+        let coord = self.coord;
+        // Do not run `GcPhase::Drop` — we are handing the exclusion off to the snapshot phase, not
+        // releasing it. `forget` leaves the GC bit set; we clear it (and set the snapshot bit)
+        // below under the lock.
+        std::mem::forget(self);
+
+        let mut state = coord.state.lock();
+        debug_assert!(state.gc_requested, "into_snapshot: GC phase was not active");
+        debug_assert!(
+            !state.snapshot_requested,
+            "into_snapshot: a snapshot was already in flight"
+        );
+        state.gc_requested = false;
+        state.snapshot_requested = true;
+        // Swap the bits atomically: clear GC, set snapshot, in one AcqRel RMW. Operations that
+        // observe the value either before or after still see a request bit set, so none can start.
+        let prev = coord.in_progress_operations.fetch_add(
+            SNAPSHOT_REQUESTED_BIT.wrapping_sub(GC_REQUESTED_BIT),
+            Ordering::AcqRel,
+        );
+        assert!(
+            (prev & GC_REQUESTED_BIT) != 0 && (prev & SNAPSHOT_REQUESTED_BIT) == 0,
+            "into_snapshot: unexpected request bits {prev:#x}"
+        );
+        debug_assert!(
+            (prev & !REQUEST_BITS) == 0,
+            "into_snapshot: operations in flight during hand-off {prev:#x}"
+        );
+        let suspended_operations: Vec<Arc<O>> = state
+            .suspended_operations
+            .iter()
+            .map(|op| op.arc().clone())
+            .collect();
+        drop(state);
+        SnapshotPhase {
+            coord,
+            suspended_operations,
+        }
+    }
+}
+
+impl<O> Drop for GcPhase<'_, O> {
+    fn drop(&mut self) {
+        let mut state = self.coord.state.lock();
+        state.gc_requested = false;
+        let prev = self
+            .coord
+            .in_progress_operations
+            .fetch_sub(GC_REQUESTED_BIT, Ordering::AcqRel);
+        assert!(
+            (prev & GC_REQUESTED_BIT) != 0,
+            "GcPhase::drop: GC bit was already cleared (prev={prev:#x})"
+        );
+        // Notify everyone waiting for the exclusion to finish, under the mutex (correctness against
+        // parking_lot's notify_all fast path).
+        self.coord.exclusion_completed.notify_all();
     }
 }
 
@@ -326,7 +512,7 @@ mod tests {
     /// fixed `thread::sleep` waits — those introduced both flakiness (too
     /// short) and slowness (too long).
     fn wait_for_snapshot_pending<O>(coord: &SnapshotCoordinator<O>) {
-        while !coord.snapshot_pending() {
+        while !coord.exclusion_pending() {
             thread::yield_now();
         }
     }
@@ -334,7 +520,7 @@ mod tests {
     #[test]
     fn no_snapshot_pending_initially() {
         let coord = SnapshotCoordinator::<Op>::new();
-        assert!(!coord.snapshot_pending());
+        assert!(!coord.exclusion_pending());
     }
 
     #[test]
@@ -350,10 +536,10 @@ mod tests {
     fn snapshot_with_no_ops_proceeds_immediately() {
         let coord = SnapshotCoordinator::<Op>::new();
         let phase = coord.begin_snapshot();
-        assert!(coord.snapshot_pending());
+        assert!(coord.exclusion_pending());
         assert!(phase.suspended_operations().is_empty());
         drop(phase);
-        assert!(!coord.snapshot_pending());
+        assert!(!coord.exclusion_pending());
     }
 
     #[test]
@@ -594,5 +780,167 @@ mod tests {
             0,
             "in_progress_operations should be 0 after all ops and snapshots done"
         );
+    }
+
+    // === Garbage-collection gate ===
+
+    #[test]
+    fn gc_with_no_ops_proceeds_immediately() {
+        let coord = SnapshotCoordinator::<Op>::new();
+        let phase = coord.begin_gc();
+        assert!(coord.exclusion_pending());
+        drop(phase);
+        assert!(!coord.exclusion_pending());
+    }
+
+    #[test]
+    fn gc_waits_for_ops_to_drain() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let g = coord.begin_operation();
+        let started_gc = Arc::new(AtomicUsize::new(0));
+
+        let coord2 = coord.clone();
+        let gc_thread = thread::spawn({
+            let started_gc = started_gc.clone();
+            move || {
+                let _phase = coord2.begin_gc();
+                started_gc.store(1, Ordering::Release);
+            }
+        });
+
+        // The collector can't proceed past begin_gc while we hold `g`.
+        wait_for_snapshot_pending(&coord);
+        assert_eq!(started_gc.load(Ordering::Acquire), 0);
+
+        drop(g);
+        gc_thread.join().unwrap();
+        assert_eq!(started_gc.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn new_operation_blocks_during_gc() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let phase = coord.begin_gc();
+        let started_op = Arc::new(AtomicUsize::new(0));
+        let arrived = Arc::new(AtomicUsize::new(0));
+
+        let coord2 = coord.clone();
+        let op_thread = thread::spawn({
+            let started_op = started_op.clone();
+            let arrived = arrived.clone();
+            move || {
+                arrived.store(1, Ordering::Release);
+                let _guard = coord2.begin_operation();
+                started_op.store(1, Ordering::Release);
+            }
+        });
+
+        while arrived.load(Ordering::Acquire) == 0 {
+            thread::yield_now();
+        }
+        assert_eq!(started_op.load(Ordering::Acquire), 0);
+
+        drop(phase);
+        op_thread.join().unwrap();
+        assert_eq!(started_op.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn into_snapshot_keeps_operations_excluded_across_handoff() {
+        // The GC->snapshot hand-off must never open a window in which an operation can start:
+        // exclusion is held continuously from `begin_gc` through the snapshot phase.
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let gc_phase = coord.begin_gc();
+
+        let started_op = Arc::new(AtomicUsize::new(0));
+        let arrived = Arc::new(AtomicUsize::new(0));
+        let coord2 = coord.clone();
+        let op_thread = thread::spawn({
+            let started_op = started_op.clone();
+            let arrived = arrived.clone();
+            move || {
+                arrived.store(1, Ordering::Release);
+                let _guard = coord2.begin_operation();
+                started_op.store(1, Ordering::Release);
+            }
+        });
+
+        // Wait until the op thread is trying to begin (and thus blocked on the GC bit).
+        while arrived.load(Ordering::Acquire) == 0 {
+            thread::yield_now();
+        }
+        assert_eq!(started_op.load(Ordering::Acquire), 0);
+
+        // Hand off GC -> snapshot. The op must remain blocked (the snapshot bit is now set).
+        let snapshot_phase = gc_phase.into_snapshot();
+        // Give the op thread a chance to (wrongly) proceed if there were a gap.
+        for _ in 0..1000 {
+            thread::yield_now();
+        }
+        assert_eq!(
+            started_op.load(Ordering::Acquire),
+            0,
+            "operation started during the GC->snapshot hand-off — exclusion was released"
+        );
+
+        // Only once the snapshot phase ends may the operation proceed.
+        drop(snapshot_phase);
+        op_thread.join().unwrap();
+        assert_eq!(started_op.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn suspend_point_lets_gc_proceed() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let g = coord.begin_operation();
+
+        let gc_done = Arc::new(AtomicUsize::new(0));
+        let coord_gc = coord.clone();
+        let gc_thread = thread::spawn({
+            let gc_done = gc_done.clone();
+            move || {
+                let _phase = coord_gc.begin_gc();
+                gc_done.store(1, Ordering::Release);
+                thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        wait_for_snapshot_pending(&coord);
+        // The collector is waiting for our operation to drain. Suspending lets it proceed. The
+        // suspend closure IS invoked and the operation IS recorded even for a GC suspension, so
+        // that if the GC phase hands off to a snapshot (`into_snapshot`) the operation is
+        // carried into the replay log (a GC-only pass simply never reads the recorded set).
+        let recorded = Arc::new(AtomicUsize::new(0));
+        let recorded_in_closure = recorded.clone();
+        coord.suspend_point(move || {
+            recorded_in_closure.fetch_add(1, Ordering::Release);
+            0u32
+        });
+        assert_eq!(gc_done.load(Ordering::Acquire), 1);
+        assert_eq!(
+            recorded.load(Ordering::Acquire),
+            1,
+            "the suspend closure must run so the operation is recorded for a possible snapshot"
+        );
+
+        gc_thread.join().unwrap();
+        drop(g);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be serialized")]
+    fn gc_during_snapshot_panics() {
+        let coord = SnapshotCoordinator::<Op>::new();
+        let _snap = coord.begin_snapshot();
+        // Callers must serialize GC vs snapshot; doing both at once is a protocol violation.
+        let _gc = coord.begin_gc();
+    }
+
+    #[test]
+    #[should_panic(expected = "must be serialized")]
+    fn snapshot_during_gc_panics() {
+        let coord = SnapshotCoordinator::<Op>::new();
+        let _gc = coord.begin_gc();
+        let _snap = coord.begin_snapshot();
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -272,16 +272,10 @@ impl Storage {
     /// Mark a newly allocated task as restored (skip DB queries) and new (include in persistence
     /// snapshots). Optionally sets the `persistent_task_type` eagerly so it's available for
     /// persistence snapshots without needing to propagate it through `connect_child`.
-    pub fn initialize_new_task(
-        &self,
-        task_id: TaskId,
-        task_type: Option<CachedTaskTypeArc>,
-        is_gc_root: bool,
-    ) {
+    pub fn initialize_new_task(&self, task_id: TaskId, task_type: Option<CachedTaskTypeArc>) {
         let mut task = self.access_mut(task_id);
         task.flags.set_restored(TaskDataCategory::All);
         task.flags.set_new_task(true);
-        task.flags.set_gc_root(is_gc_root);
         if let Some(task_type) = task_type {
             task.set_persistent_task_type(task_type);
             if !task_id.is_transient() {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -566,11 +566,18 @@ impl Storage {
         self.map.shards().len()
     }
 
-    /// Scans a **single** shard by index, invoking `on_candidate` for each resident, non-transient
-    /// task whose storage passes the cheap [`TaskStorage::gc_maybe_collectible`] pre-filter (a
-    /// handful of field reads, the same shape as the eviction scan). Returns the number of durable
-    /// GC **roots** seen in this shard — parent-less tasks that are *not* collectible because they
-    /// are anchored — which GC sums across shards for its stats.
+    /// Scans a **single** shard of the resident map by index, classifying its non-transient tasks:
+    ///
+    /// - **candidates** — tasks passing the cheap [`TaskStorage::gc_maybe_collectible`] pre-filter
+    ///   (no parent, no transient ref, quiescent) — are passed to `on_candidate`. GC enqueues each
+    ///   as a collect job and re-validates it authoritatively under a guard.
+    /// - **roots** — durable roots ([`TaskStorage::gc_is_root`]): `parent_count == 0` **and**
+    ///   anchored from outside the graph (`transient_ref_count > 0`), such as the pinned
+    ///   `ProjectContainer` op or a live endpoint — are returned. GC uses them to maintain the
+    ///   persisted roots map (refresh last-anchored timestamps / age out orphans).
+    ///
+    /// The two sets are **disjoint**: a `parent_count == 0` task either has an anchor (a root) or
+    /// does not (a collectible candidate — ordinary garbage). GC never treats one as both.
     ///
     /// GC drives one of these per shard as a job in its main pool, so discovered candidates flow
     /// straight into the same queue the collect jobs drain — the cascade starts while later shards
@@ -578,27 +585,32 @@ impl Storage {
     /// shard **read lock is held**, so it must be cheap and must not re-enter the map; GC only
     /// enqueues the id.
     ///
-    /// The scan only sees resident tasks; disk-only garbage is collected after it is next restored.
+    /// The scan sees only resident tasks; disk-only garbage is collected after it is next restored,
+    /// and disk-only roots ride the carried-forward roots map instead (which is where a root whose
+    /// anchor later drops is aged out).
     ///
     /// # Panics
     ///
     /// If `index >= self.shard_count()`.
-    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) -> usize {
+    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) -> Vec<TaskId> {
         let shard = self.map.shards()[index].read();
-        let mut roots_found = 0usize;
+        let mut roots = Vec::new();
         // SAFETY: we hold the shard read lock for the duration of iteration.
         for bucket in unsafe { shard.iter() } {
             // SAFETY: the read lock guard outlives the bucket reference.
             let (task_id, shared_value) = unsafe { bucket.as_ref() };
-            if !task_id.is_transient() {
-                if shared_value.get().gc_maybe_collectible() {
-                    on_candidate(*task_id);
-                } else if shared_value.get().flags.gc_root() {
-                    roots_found += 1;
-                }
+            if task_id.is_transient() {
+                continue;
+            }
+            let storage = shared_value.get();
+            if storage.gc_maybe_collectible() {
+                on_candidate(*task_id);
+            }
+            if storage.gc_is_root() {
+                roots.push(*task_id);
             }
         }
-        roots_found
+        roots
     }
 
     pub fn access_pair_mut(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -518,6 +518,81 @@ impl Storage {
         }
     }
 
+    /// Read-only access to a resident task without inserting a blank entry for a missing key
+    /// (unlike [`Storage::access_mut`]). Returns `None` if the task is not resident. The closure
+    /// runs while a shard read lock is held, so it must be cheap and must not re-enter the map.
+    pub fn with_task<R>(&self, key: TaskId, f: impl FnOnce(&TaskStorage) -> R) -> Option<R> {
+        let task = self.map.get(&key)?;
+        Some(f(task.value()))
+    }
+
+    /// Mutable access to a resident task **without** inserting a blank entry for a missing key
+    /// (unlike [`Storage::access_mut`], which resurrects a blank `TaskStorage`). Returns `None` if
+    /// the task is not resident. Used by the non-inserting
+    /// [`ExecuteContext::resident_task`](crate::backend::operation::ExecuteContext::resident_task)
+    /// path (GC pin/unpin), where a missing entry means the caller is referencing an
+    /// already-collected task and inserting a blank would be a bug.
+    pub fn access_mut_if_resident(&self, key: TaskId) -> Option<StorageWriteGuard<'_>> {
+        let inner = self.map.get_mut(&key)?;
+        Some(StorageWriteGuard {
+            storage: self,
+            inner: inner.into(),
+        })
+    }
+
+    /// The number of **persistent** (non-transient) tasks resident in the map. GC only collects
+    /// persistent tasks (transient tasks are never collected), so this is the metric that must
+    /// return to a flat baseline across re-rooting; the raw `resident_task_count` also includes
+    /// transient roots (e.g. `run_once`/Once tasks) that GC never touches.
+    pub fn resident_persistent_task_count(&self) -> usize {
+        let mut persistent = 0;
+        for shard in self.map.shards() {
+            let shard = shard.read();
+            for bucket in unsafe { shard.iter() } {
+                let (task_id, _) = unsafe { bucket.as_ref() };
+                if !task_id.is_transient() {
+                    persistent += 1;
+                }
+            }
+        }
+        persistent
+    }
+
+    /// The number of shards in the resident map. GC seeds one `ScanShard` job per index; the slice
+    /// returned by `map.shards()` is fixed for the map's lifetime, so an index is a stable handle
+    /// to one shard (the same property `shard_modified_counts` and the `snapshots` map already
+    /// rely on).
+    pub fn shard_count(&self) -> usize {
+        self.map.shards().len()
+    }
+
+    /// Scans a **single** shard by index, invoking `on_candidate` for each resident, non-transient
+    /// task whose storage passes the cheap [`TaskStorage::gc_maybe_collectible`] pre-filter (a
+    /// handful of field reads, the same shape as the eviction scan).
+    ///
+    /// GC drives one of these per shard as a job in its main pool, so discovered candidates flow
+    /// straight into the same queue the collect jobs drain — the cascade starts while later shards
+    /// are still being scanned, instead of after a whole-map barrier. `on_candidate` runs while the
+    /// shard **read lock is held**, so it must be cheap and must not re-enter the map; GC only
+    /// enqueues the id.
+    ///
+    /// The scan only sees resident tasks; disk-only garbage is collected after it is next restored.
+    ///
+    /// # Panics
+    ///
+    /// If `index >= self.shard_count()`.
+    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) {
+        let shard = self.map.shards()[index].read();
+        // SAFETY: we hold the shard read lock for the duration of iteration.
+        for bucket in unsafe { shard.iter() } {
+            // SAFETY: the read lock guard outlives the bucket reference.
+            let (task_id, shared_value) = unsafe { bucket.as_ref() };
+            if !task_id.is_transient() && shared_value.get().gc_maybe_collectible() {
+                on_candidate(*task_id);
+            }
+        }
+    }
+
     pub fn access_pair_mut(
         &self,
         key1: TaskId,
@@ -585,6 +660,30 @@ impl Storage {
                 let (task_id, task) = unsafe { bucket.as_mut() };
                 if task_id.is_transient() {
                     evicted.unevictable_reasons[UnevictableReason::Transient.index()] += 1;
+                    continue;
+                }
+                // GC hard-delete: a task still flagged `deleted` here was collected and its on-disk
+                // copy was tombstoned by the snapshot that just committed (its `deleted` flag is
+                // re-checked under this shard write lock — a resurrection between the snapshot and
+                // now clears the flag, in which case we fall through to normal eviction). Its whole
+                // map entry + task_cache mapping can now be dropped. This is the reclaim path for
+                // the background `ReadWrite` loop; the shutdown drain snapshot drops the whole map
+                // wholesale instead, so it never reaches here.
+                if task.get().flags.deleted() {
+                    if let Some(task_type) = task.get().get_persistent_task_type() {
+                        // Best-effort inline; defer on contention (same lock-order caution as
+                        // below).
+                        match try_lock_and_remove(&self.task_cache, task_type.as_ref()) {
+                            TryLockAndRemove::Removed | TryLockAndRemove::NotFound => {}
+                            TryLockAndRemove::WouldBlock => {
+                                deferred_task_cache_removals.push(task_type.clone());
+                            }
+                        }
+                    }
+                    unsafe {
+                        shard.erase(bucket);
+                    }
+                    evicted.full += 1;
                     continue;
                 }
                 let (key_evictability, value_evictability) = task.get().evictability();
@@ -819,6 +918,30 @@ impl StorageWriteGuard<'_> {
                 }
             }
         }
+    }
+
+    /// Clears all modified/new flags for a GC-collected task that was **never persisted**
+    /// (`new_task`), dropping it out of the next snapshot's modified scan (decrementing the shard
+    /// modified count to match). There is nothing on disk to tombstone, so the snapshot must skip
+    /// it entirely; eviction still removes the (soft-`deleted`) task from memory. Must be called
+    /// outside snapshot mode (GC runs before the snapshot starts), so it only touches the
+    /// pre-snapshot `modified` flags + shard count, mirroring `track_modification`'s `bumped`.
+    pub fn discard_modifications_for_gc_new_task(&mut self) {
+        debug_assert!(
+            !self.storage.snapshot_mode(),
+            "discard_modifications_for_gc_new_task must run before the snapshot starts"
+        );
+        debug_assert!(
+            self.inner.flags.new_task(),
+            "only a never-persisted (new_task) collected task may be discarded this way"
+        );
+        if self.inner.flags.any_modified() {
+            let shard_idx = self.storage.shard_index(self.inner.key());
+            self.storage.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
+        }
+        self.inner.flags.set_meta_modified(false);
+        self.inner.flags.set_data_modified(false);
+        self.inner.flags.set_new_task(false);
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -272,10 +272,16 @@ impl Storage {
     /// Mark a newly allocated task as restored (skip DB queries) and new (include in persistence
     /// snapshots). Optionally sets the `persistent_task_type` eagerly so it's available for
     /// persistence snapshots without needing to propagate it through `connect_child`.
-    pub fn initialize_new_task(&self, task_id: TaskId, task_type: Option<CachedTaskTypeArc>) {
+    pub fn initialize_new_task(
+        &self,
+        task_id: TaskId,
+        task_type: Option<CachedTaskTypeArc>,
+        is_gc_root: bool,
+    ) {
         let mut task = self.access_mut(task_id);
         task.flags.set_restored(TaskDataCategory::All);
         task.flags.set_new_task(true);
+        task.flags.set_gc_root(is_gc_root);
         if let Some(task_type) = task_type {
             task.set_persistent_task_type(task_type);
             if !task_id.is_transient() {
@@ -568,7 +574,9 @@ impl Storage {
 
     /// Scans a **single** shard by index, invoking `on_candidate` for each resident, non-transient
     /// task whose storage passes the cheap [`TaskStorage::gc_maybe_collectible`] pre-filter (a
-    /// handful of field reads, the same shape as the eviction scan).
+    /// handful of field reads, the same shape as the eviction scan). Returns the number of durable
+    /// GC **roots** seen in this shard — parent-less tasks that are *not* collectible because they
+    /// are anchored — which GC sums across shards for its stats.
     ///
     /// GC drives one of these per shard as a job in its main pool, so discovered candidates flow
     /// straight into the same queue the collect jobs drain — the cascade starts while later shards
@@ -581,16 +589,22 @@ impl Storage {
     /// # Panics
     ///
     /// If `index >= self.shard_count()`.
-    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) {
+    pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) -> usize {
         let shard = self.map.shards()[index].read();
+        let mut roots_found = 0usize;
         // SAFETY: we hold the shard read lock for the duration of iteration.
         for bucket in unsafe { shard.iter() } {
             // SAFETY: the read lock guard outlives the bucket reference.
             let (task_id, shared_value) = unsafe { bucket.as_ref() };
-            if !task_id.is_transient() && shared_value.get().gc_maybe_collectible() {
-                on_candidate(*task_id);
+            if !task_id.is_transient() {
+                if shared_value.get().gc_maybe_collectible() {
+                    on_candidate(*task_id);
+                } else if shared_value.get().flags.gc_root() {
+                    roots_found += 1;
+                }
             }
         }
+        roots_found
     }
 
     pub fn access_pair_mut(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -263,6 +263,10 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     deleted: bool,
 
+    /// Marks the task as a GC root meaning it can never be collected via reference counting.
+    #[field(storage = "flag", category = "meta")]
+    gc_root: bool,
+
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -919,15 +923,28 @@ impl TaskStorage {
     /// The aggregation-edges check is conservative: a disconnected task is typically removed from
     /// the aggregation graph, but that can lag and race GC, so we back off rather than collect.
     pub fn gc_maybe_collectible(&self) -> bool {
+        // Note: this intentionally does NOT gate on `Data` being resident. Data holds
+        // `persistent_task_type` (needed to tombstone the `TaskCache` entry), but the collect path
+        // opens the task with `All`, restoring Data before it reads the type. Gating here would
+        // instead strand a truly-unreferenced Data-evicted task forever (it would never be
+        // selected, so its Data would never be restored) — a disk-space leak. Accepting the
+        // extra Data restore for a task about to be deleted is the better trade.
         self.flags.is_restored(TaskDataCategory::Meta)
             // Already collected this session (soft-deleted, awaiting tombstone + hard-delete):
             // don't re-select it, or a second pass would collect it again while it is still
             // resident.
             && !self.flags.deleted()
+            // A GC root (a task spawned with no parent, see the `gc_root` flag) is held from
+            // outside the tracked graph and has no persistent parent — never collect it.
+            && !self.flags.gc_root()
+            // Refcounts must be 0
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
+            // Must not be in progress or being connected
             && self.get_activeness().is_none()
             && self.get_in_progress().is_none()
+            // Must not be participating in the aggregation graph.  Getting disconnected from parents
+            // should clear these but that process isn't atomic.
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
     }
@@ -1181,23 +1198,25 @@ mod tests {
         storage.flags.set_current_session_clean(true);
         assert!(storage.flags.current_session_clean());
 
-        // Test persisted_bits only includes non-transient flags
-        // optimization_pending=bit 0 (meta, persisted)
-        // invalidator=bit 1, immutable=bit 2 (data, persisted)
-        // current_session_clean=bit 3 (transient)
+        // Test persisted_bits only includes non-transient flags.
+        // Persisted flags are laid out meta-first then data (each in declaration order):
+        //   optimization_pending=bit 0, gc_root=bit 1 (meta, persisted)
+        //   invalidator=bit 2, immutable=bit 3 (data, persisted)
+        //   current_session_clean and later (transient)
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b110); // invalidator + immutable
+        assert_eq!(persisted, 0b1100); // invalidator (bit 2) + immutable (bit 3)
 
         // Test TaskFlags constants
-        assert_eq!(TaskFlags::PERSISTED_MASK, 0b111); // 3 persisted flags
+        assert_eq!(TaskFlags::PERSISTED_MASK, 0b1111); // 4 persisted flags
 
         // Test set_persisted_bits preserves transient flags
         let mut storage2 = TaskStorage::new();
         storage2.flags.set_current_session_clean(true); // Set transient flag
-        storage2.flags.set_persisted_bits(0b100); // Set immutable only
+        storage2.flags.set_persisted_bits(0b1000); // Set immutable only (bit 3)
         assert!(storage2.flags.immutable());
         assert!(!storage2.flags.invalidator());
         assert!(!storage2.flags.optimization_pending());
+        assert!(!storage2.flags.gc_root());
         assert!(storage2.flags.current_session_clean()); // Transient flag preserved
     }
 
@@ -1238,14 +1257,14 @@ mod tests {
         assert!(storage.flags.prefetched());
 
         // Verify these are all transient (not in persisted_bits)
-        // Only invalidator, immutable should be persisted
+        // Only optimization_pending/gc_root (meta) and invalidator/immutable (data) are persisted.
         let persisted = storage.flags.persisted_bits();
         assert_eq!(persisted, 0b00); // No persisted flags set
 
         // Set a persisted flag and verify internal state flags are still transient
         storage.flags.set_immutable(true);
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b100); // Only immutable (bit 2)
+        assert_eq!(persisted, 0b1000); // Only immutable (bit 3)
     }
 
     // Helper to create encoder

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -84,7 +84,7 @@ struct TaskStorageSchema {
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    output_dependent: AutoSet<TaskId, 6>,
+    output_dependent: AutoSet<TaskId, 4>,
 
     /// The task's output value.
     /// Filtered during serialization to skip transient outputs (referencing transient tasks).
@@ -141,6 +141,39 @@ struct TaskStorageSchema {
     /// Individual clean containers in current session (transient).
     #[field(storage = "counter_map", category = "transient")]
     aggregated_current_session_clean_containers: CounterMap<TaskId, i32, 3>,
+
+    /// Number of **persistent** parent tasks that list this task in their `children` set.
+    /// Absent = 0. Maintained incrementally at the two `children`-edge mutation sites (via the
+    /// durable `AdjustParentCount` aggregation-update job): incremented in `connect_children`,
+    /// decremented in `CleanupOldEdges`. When it reaches 0 (and no transient parent references the
+    /// task, and it is not a root/pinned/in-progress), the task is unreachable from persistent
+    /// roots and may be tombstoned instead of persisted, then dropped from memory during eviction.
+    ///
+    /// This replaces scan-based GC: a count can only drop to 0 while the parent is in memory (a
+    /// parent re-executed and dropped the child), so collectibility is detectable at that moment
+    /// with no DB scan.
+    // Stored inline (not lazy): `parent_count` is near-universal and mutated on every child-edge
+    // change, so a lazy-Vec scan per access is wasteful. `AutoSet`/`AutoMap` are backed by
+    // `InlineVec` whose size shrinks with the inline-capacity const, which brought `TaskStorage`
+    // down far enough to afford two inline `u32` counts within the size budget (see
+    // `test_schema_size`). `default` gives absent==0 semantics with a bare `u32` (no `Option`).
+    #[field(storage = "direct", category = "meta", inline, default)]
+    parent_count: u32,
+
+    /// Number of **transient** in-session references to this task that are not persistent parent
+    /// edges (this session only; never persisted). Two sources bump it:
+    /// - a **transient parent** connecting this task as a child (transient parents are never
+    ///   persisted, so their edge can't count toward the durable `parent_count`), and
+    /// - a **detached handle** that holds this task's `OperationVc` outside the tracked graph
+    ///   (e.g. a `DetachedVc` passed to JS across the NAPI boundary), which pins it like a GC
+    ///   root.
+    ///
+    /// A persistent task with `parent_count == 0` but `transient_ref_count > 0` is kept alive
+    /// in-session (uncollectible) — it is still referenced, just not by a persistent parent. On
+    /// restart these references are re-established (transient parents re-execute; detached handles
+    /// are re-created), so the count is never persisted.
+    #[field(storage = "direct", category = "transient", inline, default)]
+    transient_ref_count: u32,
 
     // =========================================================================
     // FLAGS (meta) - Boolean flags stored in TaskFlags bitfield
@@ -217,6 +250,19 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     pub new_task: bool,
 
+    /// GC soft-deletion marker. Set by the garbage collector when a task is collected: its edges
+    /// have been scrubbed and it is destined for deletion, but it stays **resident** (this is a
+    /// transient flag, so eviction's `drop_partial` keeps it as residue) until the next snapshot
+    /// tombstones its on-disk copy and a later step hard-deletes it. Keeping it resident closes
+    /// the resurrection window — any `ctx.task` on it during the pass finds a real entry
+    /// rather than restoring a zombie from disk. Cleared (and the task marked dirty) if the
+    /// task is resurrected by a connect before the hard-delete. Never persisted (a crash just
+    /// leaves the task on disk to be re-collected next session). Because it is transient, setting
+    /// it does not implicitly track a modification, so the GC mark explicitly calls
+    /// `track_modification(Meta)` to force the task into the next snapshot's scan.
+    #[field(storage = "flag", category = "transient")]
+    deleted: bool,
+
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -255,7 +301,7 @@ struct TaskStorageSchema {
         shrink_on_completion,
         drop_on_completion_if_immutable
     )]
-    cell_dependencies: AutoSet<CellRef, 2>,
+    cell_dependencies: AutoSet<CellRef, 3>,
 
     /// Cells this task depends on, narrowed to a hashed sub-value (`CellDependency::Hash`). Rare.
     #[field(
@@ -283,7 +329,7 @@ struct TaskStorageSchema {
 
     /// Outdated keyless cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
-    outdated_cell_dependencies: AutoSet<CellRef, 2>,
+    outdated_cell_dependencies: AutoSet<CellRef, 3>,
 
     /// Outdated hashed cell dependencies to be cleaned up (transient).
     #[field(storage = "auto_set", category = "transient", shrink_on_completion)]
@@ -305,7 +351,7 @@ struct TaskStorageSchema {
         filter_transient,
         drop_on_completion_if_immutable
     )]
-    cell_dependents: AutoSet<CellRef, 2>,
+    cell_dependents: AutoSet<CellRef, 3>,
 
     /// Tasks that depend on a hashed sub-value of this task's cells. Reverse of
     /// `cell_dependencies_hashed`.
@@ -563,6 +609,17 @@ impl TaskStorage {
             Some(arc) if arc.count() == 1 => KeyEvictability::AlreadyEvicted,
             Some(_) => KeyEvictability::Evictable,
         };
+        // A task with a live transient reference (a `prevent_gc` pin, a detached handle, or a
+        // transient parent — see `transient_ref_count`) is NOT forced fully resident. It falls
+        // through to the normal Meta/Data evictability below: `drop_partial` retains non-default
+        // *transient* fields, so `transient_ref_count` survives as residue and the map entry is
+        // kept (see `DropPartialOutcome::HasResidue`), while the Meta/Data it no longer
+        // needs are reclaimed. Losing the count to eviction (which would expose the
+        // still-referenced task to collection) can't happen. After such a partial eviction
+        // the task's Meta is gone, so it is not immediately GC-collectible even once
+        // unpinned — `is_gc_collectible` requires Meta resident — which is safe
+        // (under-collection; a later access restores Meta and a later pass collects it).
+        //
         // All these flags imply that the task is currently being used in some way
         // either literally executing, or about to
         if self.get_in_progress().is_some()
@@ -829,6 +886,56 @@ impl TaskStorage {
             aggregated_dirty_containers: self.aggregated_dirty_containers().map_or(0, |c| c.len()),
         }
     }
+
+    /// The number of persistent parents referencing this task (0 when the field is absent).
+    /// Read-only accessor over a bare `&TaskStorage` for GC and tests, without widening the
+    /// generated lazy getter's visibility.
+    pub fn gc_parent_count(&self) -> u32 {
+        self.get_parent_count().copied().unwrap_or(0)
+    }
+
+    /// The number of transient (session-only) parents referencing this task (0 when absent).
+    pub fn gc_transient_ref_count(&self) -> u32 {
+        self.get_transient_ref_count().copied().unwrap_or(0)
+    }
+
+    /// The storage-only part of GC collectibility: `Meta` is resident, no persistent or transient
+    /// parents, quiescent (not active, not in progress), and no aggregation edges
+    /// (`upper`/`followers`). Does NOT include the transient-*id* check (a `TaskStorage` has no id)
+    /// — the caller must also confirm `!task_id.is_transient()`. [`TaskGuard::is_gc_collectible`]
+    /// is the authoritative predicate; it adds the id check and delegates here. GC uses this
+    /// bare form to cheaply pre-filter the resident map (see `gc_collect`) without opening a
+    /// guard per task.
+    ///
+    /// **The `is_restored(Meta)` gate is load-bearing.** `parent_count` and the aggregation-edge
+    /// fields are Meta-category, so a task whose `Meta` has been evicted (`drop_partial`) reads
+    /// them as their defaults — `parent_count == 0`, empty `upper`/`followers` — which would
+    /// look collectible even though the task's *persisted* Meta may say otherwise (a nonzero
+    /// parent count, live edges). This raw predicate has no guard to restore Meta from disk, so
+    /// it must refuse to judge an unrestored task and leave it for a pass after it is next
+    /// restored. (`is_gc_collectible` reaches here through a restoring `ctx.task(.., All)`
+    /// guard, so the gate is trivially satisfied on that path.)
+    ///
+    /// The aggregation-edges check is conservative: a disconnected task is typically removed from
+    /// the aggregation graph, but that can lag and race GC, so we back off rather than collect.
+    pub fn gc_maybe_collectible(&self) -> bool {
+        self.flags.is_restored(TaskDataCategory::Meta)
+            // Already collected this session (soft-deleted, awaiting tombstone + hard-delete):
+            // don't re-select it, or a second pass would collect it again while it is still
+            // resident.
+            && !self.flags.deleted()
+            && self.gc_parent_count() == 0
+            && self.gc_transient_ref_count() == 0
+            && self.get_activeness().is_none()
+            && self.get_in_progress().is_none()
+            && self.upper().is_empty()
+            && self.followers().is_none_or(|f| f.is_empty())
+    }
+
+    // GC collectibility (`is_gc_collectible`) lives on the `TaskGuard` trait, so that the Meta
+    // fields it reads (`parent_count`/`upper`/`followers`) go through the guard's `check_access`
+    // machinery, which enforces that the task was opened with Meta restored. See
+    // `TaskGuard::is_gc_collectible`.
 }
 
 /// Counts for aggregation tree and collectibles fields.
@@ -1178,6 +1285,10 @@ mod tests {
         original
             .aggregated_dirty_containers_mut()
             .insert(TaskId::new(50).unwrap(), 2);
+        // Persisted parent count.
+        original.set_parent_count(3);
+        // Transient parent count (should NOT be serialized).
+        original.set_transient_ref_count(9);
 
         // Set transient flag (should NOT be serialized)
         original.flags.set_current_session_clean(true);
@@ -1223,6 +1334,10 @@ mod tests {
             decoded.aggregated_dirty_containers(),
             original.aggregated_dirty_containers()
         );
+        // Persisted parent_count survives the round-trip.
+        assert_eq!(decoded.get_parent_count(), Some(&3));
+        // Transient parent count is NOT serialized; it stays at its default (absent == 0).
+        assert_eq!(decoded.get_transient_ref_count(), None);
 
         // Note: invalidator and immutable are data category flags, not meta
         // They should NOT have changed during meta encode/decode
@@ -1711,6 +1826,38 @@ mod tests {
     }
 
     // ==========================================================================
+    // GC soft-deletion
+    // ==========================================================================
+
+    /// The `deleted` marker round-trips through its accessors, and — because it is a *transient*
+    /// flag, not Meta — it survives a Meta `drop_partial` (partial eviction). The mark therefore
+    /// remains observable no matter what normal eviction does to the Meta/Data payload, so the
+    /// tombstone + hard-delete logic (which keys off the flag) can't be fooled by a partial
+    /// eviction between the mark and the commit.
+    #[test]
+    fn deleted_marker_is_transient_residue() {
+        let mut storage = TaskStorage::new();
+        storage.flags.set_new_task(false);
+        storage.flags.set_data_restored(true);
+        storage.flags.set_meta_restored(true);
+        assert!(!storage.flags.deleted());
+
+        storage.flags.set_deleted(true);
+        assert!(storage.flags.deleted());
+
+        // A Meta drop_partial (what partial eviction does) must NOT clear the transient marker.
+        let _ = storage.drop_partial(/* data */ false, /* meta */ true);
+        assert!(
+            storage.flags.deleted(),
+            "the `deleted` marker is transient and must survive a Meta drop_partial"
+        );
+
+        // Resurrection clears it.
+        storage.flags.set_deleted(false);
+        assert!(!storage.flags.deleted());
+    }
+
+    // ==========================================================================
     // Schema Size Tests
     // ==========================================================================
 
@@ -1720,13 +1867,13 @@ mod tests {
         assert_eq!(
             size_of::<TaskStorage>(),
             128,
-            "TaskStorage size changed! Run print_schema_sizes and update this test."
+            "TaskStorage size changed! Update this test."
         );
         // `LazyField` is 40 B = 32 B largest payload + 8 B discriminant.
         assert_eq!(
             size_of::<LazyField>(),
             40,
-            "LazyField size changed! Run print_schema_sizes and update this test."
+            "LazyField size changed! Update this test."
         );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -986,6 +986,17 @@ impl TaskStorage {
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() > 0
     }
+
+    /// Whether this task has already been collected by a GC pass this session: soft-`deleted`, but
+    /// still resident until the snapshot writes its tombstone and eviction drops it.
+    ///
+    /// Used by `gc_roots_refresh_and_age_out` to evict such a task's entry from the roots map. It
+    /// fails both [`Self::gc_is_root`] and [`Self::gc_maybe_collectible`] (both check
+    /// `!deleted()`), so without this it would land on the "un-anchored, aged out" branch and be
+    /// re-seeded every pass forever while the revalidation kept rejecting it.
+    pub fn gc_is_deleted(&self) -> bool {
+        self.flags.deleted()
+    }
 }
 
 /// Counts for aggregation tree and collectibles fields.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -949,10 +949,47 @@ impl TaskStorage {
             && self.followers().is_none_or(|f| f.is_empty())
     }
 
-    // GC collectibility (`is_gc_collectible`) lives on the `TaskGuard` trait, so that the Meta
-    // fields it reads (`parent_count`/`upper`/`followers`) go through the guard's `check_access`
-    // machinery, which enforces that the task was opened with Meta restored. See
-    // `TaskGuard::is_gc_collectible`.
+    /// Whether this task is a durable GC *root* worth tracking in the roots map: `Meta` is
+    /// resident, it has **no persistent parent** (`parent_count == 0`), and it is **anchored
+    /// from outside the persistent graph** (`transient_ref_count > 0` — a `pin_task_for_gc`
+    /// pin, e.g. the pinned `ProjectContainer` op / a live endpoint, or a transient parent's
+    /// edge).
+    ///
+    /// The `transient_ref_count > 0` requirement is what distinguishes a root from ordinary
+    /// garbage: a `parent_count == 0` task with *no* anchor is not a root — it is exactly the
+    /// disconnected task the [`Self::gc_maybe_collectible`] candidate path collects this
+    /// session, so recording it as a root would be both meaningless and wrong (it would double
+    /// as a "root" and a collectible). A root, by contrast, escapes collection this session
+    /// precisely because of its anchor; the roots map exists to notice when that anchor is gone
+    /// across sessions and reclaim it.
+    ///
+    /// (An anchor also makes the task resident + unevictable, so a genuine root is always resident
+    /// to be discovered here; a root whose anchor later drops is aged out via the
+    /// carried-forward map in `gc_roots_refresh_and_age_out`, not re-discovered by this scan.)
+    ///
+    /// Why `transient_ref_count > 0` and not the broader `!gc_maybe_collectible` (parent-less but
+    /// non-collectible for *any* reason)? The other things that make a parent-less task
+    /// non-collectible — `activeness`, `in_progress`, lingering `upper`/`followers` — are
+    /// *transient session state that resolves*, not cross-session anchors: an
+    /// active/in-progress task finishes, and the conservative aggregation-edge back-off clears
+    /// as the disconnection cascade catches up. Only `transient_ref_count` represents a genuine
+    /// external reference whose disappearance across sessions is the orphaning signal the roots
+    /// map tracks. Keeping the membership predicate equal to the "anchored" test used by
+    /// `gc_roots_refresh_and_age_out` also means the two can't drift: a task is refreshed
+    /// while, and only while, it would still be admitted here.
+    ///
+    /// The `is_restored(Meta)` gate is load-bearing for the same reason as in
+    /// `gc_maybe_collectible` (an evicted-Meta task reads `parent_count` as 0 and would look
+    /// like a spurious root). Callers must also confirm `!task_id.is_transient()` (a
+    /// `TaskStorage` has no id). Used by [`Storage::gc_scan_candidates`] to seed the roots map.
+    ///
+    /// [`Storage::gc_scan_candidates`]: crate::backend::storage::Storage::gc_scan_candidates
+    pub fn gc_is_root(&self) -> bool {
+        self.flags.is_restored(TaskDataCategory::Meta)
+            && !self.flags.deleted()
+            && self.gc_parent_count() == 0
+            && self.gc_transient_ref_count() > 0
+    }
 }
 
 /// Counts for aggregation tree and collectibles fields.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -263,10 +263,6 @@ struct TaskStorageSchema {
     #[field(storage = "flag", category = "transient")]
     deleted: bool,
 
-    /// Marks the task as a GC root meaning it can never be collected via reference counting.
-    #[field(storage = "flag", category = "meta")]
-    gc_root: bool,
-
     // =========================================================================
     // CHILDREN & AGGREGATION (meta)
     // =========================================================================
@@ -934,10 +930,10 @@ impl TaskStorage {
             // don't re-select it, or a second pass would collect it again while it is still
             // resident.
             && !self.flags.deleted()
-            // A GC root (a task spawned with no parent, see the `gc_root` flag) is held from
-            // outside the tracked graph and has no persistent parent — never collect it.
-            && !self.flags.gc_root()
-            // Refcounts must be 0
+            // Refcounts must be 0. A parent-less task with no external anchor is ordinary garbage;
+            // one that IS anchored (`transient_ref_count > 0`) fails the next clause and is instead
+            // recorded as a durable root (see `gc_is_root`). GC roots are no longer a persisted
+            // flag — reachability is entirely reference-counted.
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
             // Must not be in progress or being connected
@@ -1237,23 +1233,22 @@ mod tests {
 
         // Test persisted_bits only includes non-transient flags.
         // Persisted flags are laid out meta-first then data (each in declaration order):
-        //   optimization_pending=bit 0, gc_root=bit 1 (meta, persisted)
-        //   invalidator=bit 2, immutable=bit 3 (data, persisted)
+        //   optimization_pending=bit 0 (meta, persisted)
+        //   invalidator=bit 1, immutable=bit 2 (data, persisted)
         //   current_session_clean and later (transient)
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b1100); // invalidator (bit 2) + immutable (bit 3)
+        assert_eq!(persisted, 0b110); // invalidator (bit 1) + immutable (bit 2)
 
         // Test TaskFlags constants
-        assert_eq!(TaskFlags::PERSISTED_MASK, 0b1111); // 4 persisted flags
+        assert_eq!(TaskFlags::PERSISTED_MASK, 0b111); // 3 persisted flags
 
         // Test set_persisted_bits preserves transient flags
         let mut storage2 = TaskStorage::new();
         storage2.flags.set_current_session_clean(true); // Set transient flag
-        storage2.flags.set_persisted_bits(0b1000); // Set immutable only (bit 3)
+        storage2.flags.set_persisted_bits(0b100); // Set immutable only (bit 2)
         assert!(storage2.flags.immutable());
         assert!(!storage2.flags.invalidator());
         assert!(!storage2.flags.optimization_pending());
-        assert!(!storage2.flags.gc_root());
         assert!(storage2.flags.current_session_clean()); // Transient flag preserved
     }
 
@@ -1294,14 +1289,14 @@ mod tests {
         assert!(storage.flags.prefetched());
 
         // Verify these are all transient (not in persisted_bits)
-        // Only optimization_pending/gc_root (meta) and invalidator/immutable (data) are persisted.
+        // Only optimization_pending (meta) and invalidator/immutable (data) are persisted.
         let persisted = storage.flags.persisted_bits();
         assert_eq!(persisted, 0b00); // No persisted flags set
 
         // Set a persisted flag and verify internal state flags are still transient
         storage.flags.set_immutable(true);
         let persisted = storage.flags.persisted_bits();
-        assert_eq!(persisted, 0b1000); // Only immutable (bit 3)
+        assert_eq!(persisted, 0b100); // Only immutable (bit 2)
     }
 
     // Helper to create encoder

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -24,11 +24,6 @@ pub enum SnapshotItem {
         task_type_hash: Option<TaskTypeHash>,
     },
     /// Tombstone a GC-collected task (see [`TaskDeletion`]).
-    ///
-    /// Not yet constructed: this PR lands the persistence-side delete mechanism (the
-    /// `save_snapshot` handling below + its tests). The GC pass that emits `Delete` for
-    /// soft-deleted tasks lands in a later PR in the stack.
-    #[allow(dead_code)]
     Delete(TaskDeletion),
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -404,6 +404,10 @@ impl TurboBackingStorage {
         Ok(task_ids)
     }
 
+    /// Restores `category` for `task_id` into `storage`, returning whether the key was **present**
+    /// in the database. `Ok(false)` means the key is absent (nothing decoded, `storage` left
+    /// untouched) — callers that require the task to exist use this to distinguish a real (possibly
+    /// empty) on-disk task from one that was never persisted or has been tombstoned.
     pub(crate) fn lookup_data(
         &self,
         task_id: TaskId,

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -34,8 +34,29 @@ use crate::{
     db_invalidation::invalidation_reasons,
 };
 
-const META_KEY_OPERATIONS: u32 = 0;
-const META_KEY_NEXT_FREE_TASK_ID: u32 = 1;
+/// The fixed keys in the [`KeySpace::Infra`] keyspace. Each is a distinct singleton (the task
+/// keyspaces are keyed by `TaskId` instead — see [`IntKey`]). The discriminant is the on-disk key
+/// byte value and MUST remain stable across versions; only append new variants.
+#[derive(Clone, Copy)]
+#[repr(u32)]
+enum InfraKey {
+    /// The suspended/uncompleted `AnyOperation` log (crash-recovery journal).
+    Operations = 0,
+    /// The high-water mark for allocating new persistent task ids.
+    NextFreeTaskId = 1,
+    /// The persisted GC roots set: `Vec<(TaskId, last_anchored_ms)>`. Each entry is a durable root
+    /// (a persisted task reachable only from outside the persistent graph) and the wall-clock time
+    /// (millis since the Unix epoch) it was last observed anchored. Maintained in the GC phase and
+    /// used to age out roots that have gone un-anchored past the TTL. See `TurboTasksBackend`'s
+    /// roots map.
+    GcRoots = 2,
+}
+
+impl InfraKey {
+    fn key(self) -> IntKey {
+        IntKey::new(self as u32)
+    }
+}
 
 struct IntKey([u8; 4]);
 
@@ -187,9 +208,9 @@ impl TurboBackingStorageInner {
     }
 
     /// Used to read the next free task ID from the database.
-    fn get_infra_u32(&self, key: u32) -> Result<Option<u32>> {
+    fn get_infra_u32(&self, key: InfraKey) -> Result<Option<u32>> {
         self.database
-            .get(KeySpace::Infra, IntKey::new(key).as_ref())?
+            .get(KeySpace::Infra, key.key().as_ref())?
             .map(as_u32)
             .transpose()
     }
@@ -210,7 +231,7 @@ impl TurboBackingStorage {
     pub(crate) fn next_free_task_id(&self) -> Result<TaskId> {
         Ok(self
             .inner
-            .get_infra_u32(META_KEY_NEXT_FREE_TASK_ID)
+            .get_infra_u32(InfraKey::NextFreeTaskId)
             .context("Unable to read next free task id from database")?
             .map_or(Ok(TaskId::MIN), TaskId::try_from)?)
     }
@@ -218,7 +239,7 @@ impl TurboBackingStorage {
     pub(crate) fn uncompleted_operations(&self) -> Result<Vec<AnyOperation>> {
         fn get(database: &TurboKeyValueDatabase) -> Result<Vec<AnyOperation>> {
             let Some(operations) =
-                database.get(KeySpace::Infra, IntKey::new(META_KEY_OPERATIONS).as_ref())?
+                database.get(KeySpace::Infra, InfraKey::Operations.key().as_ref())?
             else {
                 return Ok(Vec::new());
             };
@@ -228,9 +249,25 @@ impl TurboBackingStorage {
         get(&self.inner.database).context("Unable to read uncompleted operations from database")
     }
 
+    /// Reads the persisted GC roots set (see [`InfraKey::GcRoots`]): each durable root's `TaskId`
+    /// paired with the wall-clock millis-since-epoch at which it was last observed anchored.
+    /// Empty on a fresh database.
+    pub(crate) fn roots(&self) -> Result<Vec<(TaskId, u64)>> {
+        fn get(database: &TurboKeyValueDatabase) -> Result<Vec<(TaskId, u64)>> {
+            let Some(roots) = database.get(KeySpace::Infra, InfraKey::GcRoots.key().as_ref())?
+            else {
+                return Ok(Vec::new());
+            };
+            let roots = turbo_bincode_decode(roots.borrow())?;
+            Ok(roots)
+        }
+        get(&self.inner.database).context("Unable to read GC roots from database")
+    }
+
     pub(crate) fn save_snapshot<I>(
         &self,
         operations: Vec<Arc<AnyOperation>>,
+        roots: Option<Vec<(TaskId, u64)>>,
         snapshots: Vec<I>,
     ) -> Result<SnapshotMeta>
     where
@@ -362,7 +399,7 @@ impl TurboBackingStorage {
             let mut next_task_id = get_next_free_task_id(&batch)?;
             next_task_id = next_task_id.max(snapshot_meta.max_next_task_id + 1);
 
-            save_infra(&batch, next_task_id, operations)?;
+            save_infra(&batch, next_task_id, operations, roots)?;
             {
                 let _span = tracing::trace_span!("commit").entered();
                 // Byte totals are the physical on-disk bytes (post-compression, including .sst /
@@ -528,10 +565,7 @@ fn apply_task_cache_deletions(
 
 fn get_next_free_task_id(batch: &TurboWriteBatch<'_>) -> Result<u32, anyhow::Error> {
     Ok(
-        match batch.get(
-            KeySpace::Infra,
-            IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref(),
-        )? {
+        match batch.get(KeySpace::Infra, InfraKey::NextFreeTaskId.key().as_ref())? {
             Some(bytes) => u32::from_le_bytes(Borrow::<[u8]>::borrow(&bytes).try_into()?),
             None => 1,
         },
@@ -542,11 +576,12 @@ fn save_infra(
     batch: &TurboWriteBatch<'_>,
     next_task_id: u32,
     operations: Vec<Arc<AnyOperation>>,
+    roots: Option<Vec<(TaskId, u64)>>,
 ) -> Result<(), anyhow::Error> {
     batch
         .put(
             KeySpace::Infra,
-            WriteBuffer::Borrowed(IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref()),
+            WriteBuffer::Borrowed(InfraKey::NextFreeTaskId.key().as_ref()),
             WriteBuffer::Borrowed(&next_task_id.to_le_bytes()),
         )
         .context("Unable to write next free task id")?;
@@ -558,10 +593,23 @@ fn save_infra(
         batch
             .put(
                 KeySpace::Infra,
-                WriteBuffer::Borrowed(IntKey::new(META_KEY_OPERATIONS).as_ref()),
+                WriteBuffer::Borrowed(InfraKey::Operations.key().as_ref()),
                 WriteBuffer::SmallVec(operations),
             )
             .context("Unable to write operations")?;
+    }
+    // Only rewrite the roots key when the GC phase produced an updated set; `None` leaves the
+    // previously-persisted set untouched (e.g. GC disabled, or a snapshot with no GC pass).
+    if let Some(roots) = roots {
+        let _span = tracing::trace_span!("update roots", roots = roots.len()).entered();
+        let roots = turbo_bincode_encode(&roots).context("Unable to serialize GC roots")?;
+        batch
+            .put(
+                KeySpace::Infra,
+                WriteBuffer::Borrowed(InfraKey::GcRoots.key().as_ref()),
+                WriteBuffer::SmallVec(roots),
+            )
+            .context("Unable to write GC roots")?;
     }
     // Safety: save_infra is called after all concurrent writes to Infra are done.
     unsafe { batch.flush(KeySpace::Infra)? };
@@ -907,6 +955,7 @@ mod tests {
         // Snapshot with no task data, just the one deletion (carried inline as a delete item).
         storage.save_snapshot(
             Vec::new(),
+            None,
             vec![vec![SnapshotItem::Delete(TaskDeletion {
                 task_id: deleted_id,
                 task_type_hash: collision_hash.to_le_bytes(),

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_resurrection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_resurrection.rs
@@ -1,0 +1,387 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+//! Regression tests for GC teardown of a cleanly-disconnected subtree whose tasks hold real
+//! forward-dependency edges on each other.
+//!
+//! The central invariant: when a task `S` that is the `upper` of its children is collected, GC
+//! must **rebalance the aggregation graph** — remove `S` from each child's `upper` set — so the
+//! children (now both parentless and upper-less) become collectible and cascade in the same pass.
+//! GC does this by running the same `CleanupOldEdges` operation a re-executing task uses. Without
+//! it, a collected `S`'s children were left with a dangling `upper` edge to the deleted `S` and
+//! stayed stuck non-collectible (leaked until eviction).
+//!
+//! For a child to record a forward-dependency edge on / from `S` at all, the tasks involved must
+//! be **mutable** (immutable/constant tasks never record dependency edges — see
+//! `add_cell_dependency`), and the subtree must be disconnected *cleanly* (dropping the parent's
+//! reference, not invalidating the children — invalidation runs `cleanup_old_edges`, which strips
+//! the outgoing deps first). We make the leaves mutable by having them read a long-lived `State`
+//! whose value never changes.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Selector(State<bool>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_selector(initial: bool) -> Vc<Selector> {
+    Selector(State::new(initial)).cell()
+}
+
+/// A separate long-lived State whose *value never changes*, only read by the leaves. Reading it
+/// makes each leaf **mutable** (so a reader records a real dependency edge on the leaf) WITHOUT the
+/// aggregation-heavy `session_dependent` machinery that keeps a task active. The state task is a
+/// root, so it stays alive; the leaves depend on it via a dependency edge (not a child edge), so
+/// disconnecting the leaves as children should still let them lose activeness.
+#[turbo_tasks::value(transparent)]
+struct Constant(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_constant() -> Vc<Constant> {
+    Constant(State::new(0)).cell()
+}
+
+/// The forward-dependency *target*. Reading `constant`'s State makes it mutable (records
+/// dependents) — an immutable constant task would record none. `FANOUT` distinct leaves per reader
+/// give many chances for the racing interleaving.
+#[turbo_tasks::function]
+async fn sd_leaf(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
+    let base = *constant.await?.get();
+    Ok(Vc::cell(base.wrapping_add(index)))
+}
+
+const FANOUT: u32 = 400;
+
+/// The *reader* `S`: reads every `sd_leaf`, so it (a) connects each leaf as a child and (b) records
+/// an outgoing dependency on each. When `reader` is collected while still holding those deps,
+/// `Collect(reader)` spawns scrub jobs referencing all leaves — and every leaf is itself
+/// collectible (cascaded from `reader`'s decrement), so each is a resurrection candidate.
+#[turbo_tasks::function]
+async fn reader(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..FANOUT {
+        sum = sum.wrapping_add(*sd_leaf(*constant, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// A *sibling* forward-dependency target for the diamond fixture (`B`). Mutable (reads the
+/// constant State), so a reader records a real dependency edge on it.
+#[turbo_tasks::function]
+async fn diamond_target(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
+    let base = *constant.await?.get();
+    Ok(Vc::cell(base.wrapping_add(index).wrapping_mul(7)))
+}
+
+/// A diamond *reader* (`A`): reads the cell of a `diamond_target` (`B`) that is **passed in as an
+/// already-resolved `Vc`** — so `A` records a forward (cell) dependency on `B` WITHOUT connecting
+/// `B` as `A`'s child (a child edge is only created by *calling* a task; here `B` was called by
+/// `diamond_root`). This decoupling is the crux: `B`'s only parent is `diamond_root`, so when the
+/// root is collected BOTH `A` and `B` reach `parent_count 0` at the same time and cascade-collect
+/// concurrently — while `A` still holds a forward-dep on `B` to scrub.
+#[turbo_tasks::function]
+async fn diamond_reader(target: ResolvedVc<u32>) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *target.await?))
+}
+
+/// The diamond root: for each index, calls `diamond_target(index)` (`B`, so `B` is the root's
+/// child) and `diamond_reader(B)` (`A`, passing `B`'s resolved Vc in, so `A` is the root's child
+/// and forward-deps on `B` but does NOT parent it). Disconnecting the root drops both `A` and `B`
+/// as siblings; collecting the root cascades a `Collect` for every `A` and `B` at once. If a `B` is
+/// collected+removed before the `Collect(A)` whose `CleanupOldEdges` opens it, the immediate-remove
+/// design resurrects `B`.
+#[turbo_tasks::function]
+async fn diamond_root(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..FANOUT {
+        let target = diamond_target(*constant, index).to_resolved().await?;
+        sum = sum.wrapping_add(*target.await?);
+        sum = sum.wrapping_add(*diamond_reader(*target).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// A root that reads `reader()` only while the selector is `false`. Flipping the selector to `true`
+/// drops `reader` (and, transitively, all `sd_leaf`s) from the live graph **without invalidating
+/// them** — so they stay clean and retain their outgoing dependency edges, then all become
+/// `parent_count 0` and collectible in a single pass.
+#[turbo_tasks::function(operation, root)]
+async fn select_reader(
+    selector: ResolvedVc<Selector>,
+    constant: ResolvedVc<Constant>,
+) -> Result<Vc<u32>> {
+    let use_reader = !*selector.await?.get();
+    let value = if use_reader {
+        *reader(*constant).await?
+    } else {
+        // A trivial branch with no dependency on `reader`/`sd_leaf`.
+        0u32
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Selector-gated root for the diamond fixture: reads `diamond_root` only while the selector is
+/// `false`, so flipping to `true` disconnects the whole diamond subtree cleanly.
+#[turbo_tasks::function(operation, root)]
+async fn select_diamond(
+    selector: ResolvedVc<Selector>,
+    constant: ResolvedVc<Constant>,
+) -> Result<Vc<u32>> {
+    let use_diamond = !*selector.await?.get();
+    let value = if use_diamond {
+        *diamond_root(*constant).await?
+    } else {
+        0u32
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Regression test for the missing **aggregation-graph rebalance** in GC.
+///
+/// `reader` is the sole `upper` of each `sd_leaf` (it reads them, and they are mutable so the edge
+/// is recorded). When the `reader` subtree is disconnected cleanly and collected, GC must remove
+/// `reader` from each leaf's `upper` set (the `CleanupOldEdges` rebalance) so the leaves — now
+/// parentless *and* upper-less — cascade-collect in the **same pass**. Before the fix, GC dropped
+/// the leaves' `parent_count` but left a dangling `upper` edge to the deleted `reader`, so every
+/// leaf failed `gc_maybe_collectible` (`upper().is_empty()` false) and only `reader` was collected
+/// (`collected == 1`); the leaves leaked until eviction hid them. This asserts the whole subtree
+/// (`reader` + all `FANOUT` leaves) is collected in one pass and leaves memory with nothing
+/// stranded.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_shared_forward_dep_no_resurrection() {
+    let (tt, _persistence_dir) = create_tt("gc_shared_forward_dep_no_resurrection");
+    let tt2 = tt.clone();
+
+    // Build the graph (selector=false: select_reader -> reader -> FANOUT sd_leaves), then flip to
+    // disconnect the whole reader subtree cleanly.
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+
+        let output = select_reader(selector_vc, constant_vc);
+        output.read_strongly_consistent().await?;
+
+        // Disconnect reader + all sd_leaves in one shot (no invalidation of the children).
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // Baseline resident count with the reader subtree disconnected but not yet collected.
+    let baseline = tt2.backend().resident_persistent_task_count_for_testing();
+
+    // A single GC pass. `reader` and all FANOUT `sd_leaf`s should be collected together: the
+    // aggregation rebalance frees the leaves' `upper` edge so they cascade in the same pass.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let after = tt2.backend().resident_persistent_task_count_for_testing();
+
+    // reader + FANOUT leaves = FANOUT + 1 tasks collected in one pass.
+    assert_eq!(
+        collected,
+        FANOUT as usize + 1,
+        "reader and all {FANOUT} sd_leaves should be collected in one pass (missing aggregation \
+         rebalance would strand the leaves with a dangling upper edge and collect only reader)"
+    );
+    // The whole subtree left memory: the resident count dropped by exactly what was collected.
+    assert_eq!(
+        after,
+        baseline - (FANOUT as usize + 1),
+        "resident count must drop by exactly the collected subtree"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// The **residual resurrection** race (the one soft-deletion is for). In the diamond, every
+/// `diamond_reader` `A` and its `diamond_target` `B` are direct children of `diamond_root`, and `A`
+/// holds a forward dependency on `B`. Collecting the root cascades a `Collect` for every `A` and
+/// `B` concurrently. When `A`'s teardown runs `CleanupOldEdges(A)`, its dependency arm opens `B`
+/// via `ctx.task(B, Data)` to scrub the reverse edge — and if `B`'s own `Collect` already removed
+/// `B` from the map, `ctx.task` restores it from disk into a zombie (memory/disk diverge).
+///
+/// Under the current immediate-remove `Collect`, this resurrects `B`s and leaves the resident count
+/// above baseline−collected. After soft-deletion (a collected task stays resident until after the
+/// tombstoning snapshot commits) `ctx.task` always finds a resident entry and the count returns to
+/// exactly baseline−collected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_diamond_forward_dep_no_resurrection() {
+    let (tt, _persistence_dir) = create_tt("gc_diamond_forward_dep_no_resurrection");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+
+        let output = select_diamond(selector_vc, constant_vc);
+        output.read_strongly_consistent().await?;
+
+        // Disconnect the whole diamond subtree cleanly (no invalidation).
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let baseline = tt2.backend().resident_persistent_task_count_for_testing();
+
+    // diamond_root + FANOUT readers (A) + FANOUT targets (B) = 2*FANOUT + 1 collected in one pass.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let after = tt2.backend().resident_persistent_task_count_for_testing();
+
+    assert_eq!(
+        collected,
+        2 * FANOUT as usize + 1,
+        "diamond_root + {FANOUT} readers + {FANOUT} targets should all be collected in one pass"
+    );
+    // No `diamond_target` was resurrected by a sibling reader's CleanupOldEdges scrub: the resident
+    // count dropped by exactly the collected subtree. A resurrected B leaves `after` above this.
+    assert_eq!(
+        after,
+        baseline - (2 * FANOUT as usize + 1),
+        "resident count must drop by exactly the collected subtree — a higher count means a \
+         CleanupOldEdges scrub resurrected an already-collected diamond_target"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// Resurrection-on-connect: a task marked `deleted` by GC but reconnected **before** the
+/// tombstoning snapshot must come back to life (marker cleared, made dirty, re-executed) rather
+/// than being tombstoned/hard-deleted. We run `gc_for_testing` (which marks the disconnected
+/// `reader` subtree `deleted` but leaves it resident, and does NOT snapshot), then reconnect the
+/// subtree and read it: it must recompute to the correct value, and a subsequent snapshot+evict
+/// must NOT have removed it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_resurrect_on_reconnect() {
+    let (tt, _persistence_dir) = create_tt("gc_resurrect_on_reconnect");
+    let tt2 = tt.clone();
+    let expected: u32 = (0..FANOUT).fold(0u32, |a, b| a.wrapping_add(b));
+
+    // Build (reader connected), then disconnect the reader subtree cleanly.
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+
+        let output = select_reader(selector_vc, constant_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // Mark the disconnected subtree `deleted` (still resident — no snapshot yet).
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected,
+        FANOUT as usize + 1,
+        "reader + {FANOUT} leaves should be marked collected"
+    );
+
+    // Reconnect the subtree (selector back to false) BEFORE any snapshot. Reading `reader` again
+    // connects it, which must resurrect it (and its leaves, as it re-reads them) and recompute the
+    // correct value — proving the deleted tasks came back rather than being read stale.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+        selector.set(false);
+        let output = select_reader(selector_vc, constant_vc);
+        assert_eq!(
+            *output.read_strongly_consistent().await?,
+            expected,
+            "resurrected reader must recompute the correct value"
+        );
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // A snapshot+evict now must NOT have tombstoned/hard-deleted the resurrected subtree: reading
+    // it once more still yields the correct value (it is live, not gone).
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let tt4 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let constant_op = create_constant();
+        let constant_vc = constant_op.resolve().strongly_consistent().await?;
+        let output = select_reader(selector_vc, constant_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+        let _ = &tt4;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -1,0 +1,281 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Generation(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_generation() -> Vc<Generation> {
+    Generation(State::new(0)).cell()
+}
+
+/// A leaf keyed by (generation, index). Bumping the generation makes `wide_root` read an entirely
+/// fresh set of these, disconnecting the whole previous generation.
+#[turbo_tasks::function]
+fn leaf(generation: u32, index: u32) -> Vc<u32> {
+    Vc::cell(generation.wrapping_mul(1000).wrapping_add(index))
+}
+
+/// An intermediate that reads one leaf — a shared-dependency layer so the disconnected garbage is a
+/// subtree (intermediate + leaf), exercising the cascade rather than single-node collection.
+#[turbo_tasks::function]
+async fn intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *leaf(generation, index).await?))
+}
+
+const WIDTH: u32 = 24;
+
+/// Reads WIDTH intermediates (each reading a leaf) for the current generation. Bumping the
+/// generation re-executes this and connects a fresh generation's worth of tasks, disconnecting the
+/// entire previous generation (2*WIDTH tasks) as garbage.
+#[turbo_tasks::function(operation, root)]
+async fn wide_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..WIDTH {
+        sum = sum.wrapping_add(*intermediate(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// The pathology this whole effort targets: repeatedly swapping a wide set of common dependencies
+/// (as happens when a project is re-rooted or its dependencies churn) must NOT grow the resident
+/// task set monotonically. Each round bumps the generation (disconnecting the previous generation's
+/// 2*WIDTH tasks), then snapshots + GCs + evicts. The resident count must return to a flat baseline
+/// each round rather than climbing with the number of rounds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_re_rooting_stays_flat() {
+    let (tt, _persistence_dir) = create_tt("gc_re_rooting_stays_flat");
+    let tt2 = tt.clone();
+
+    const ROUNDS: u32 = 20;
+
+    // Each round runs in its own `run_once` so the root's activeness is released before GC (a
+    // `run_once` root keeps everything it touched active until it returns). Returns the resident
+    // count measured after that round's snapshot + GC + evict.
+    async fn round(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u32) -> (usize, usize) {
+        let tt_inner = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // `create_generation` is a cached root operation, so this returns the same task each
+            // round.
+            let generation_op = create_generation();
+            let generation_vc = generation_op.resolve().strongly_consistent().await?;
+            if gen_value > 0 {
+                let generation = generation_op.read_strongly_consistent().await?;
+                generation.set(gen_value);
+            }
+            let output = wide_root(generation_vc);
+            output.read_strongly_consistent().await?;
+            let _ = &tt_inner;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+
+        // GC runs BEFORE eviction (matching the production background cycle: snapshot -> GC ->
+        // evict), so the disconnected garbage is still resident when GC scans it. Running eviction
+        // first would drop the garbage to disk-only where the in-memory GC can't collect or
+        // tombstone it. Return the number GC collected this round alongside the resident count.
+        let collected = tt.backend().gc_for_testing(tt);
+        tt.backend().snapshot_and_evict_for_testing(tt);
+        // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
+        // roots (each round's `run_once`/Once task) are never collected and accumulate
+        // independently of GC — including them would mask the real signal.
+        (
+            collected,
+            tt.backend().resident_persistent_task_count_for_testing(),
+        )
+    }
+
+    // Warm up: build generation 0, then measure the steady-state baseline after one full cycle.
+    let (_, baseline) = round(&tt2, 0).await;
+    println!("baseline persistent resident after gen 0: {baseline}");
+
+    // Churn: swap the whole dependency set many times. Track the max resident count and the total
+    // collected, so we assert both that memory stays flat AND that GC (not just eviction) is
+    // actually doing the collecting.
+    let mut max_resident = baseline;
+    let mut total_collected = 0usize;
+    for gen_value in 1..=ROUNDS {
+        let (collected, resident) = round(&tt2, gen_value).await;
+        println!("gen {gen_value}: collected={collected} persistent_resident={resident}");
+        max_resident = max_resident.max(resident);
+        total_collected += collected;
+    }
+
+    let no_gc_growth = baseline + (2 * WIDTH as usize) * (ROUNDS as usize);
+    println!(
+        "baseline={baseline} max_resident={max_resident} total_collected={total_collected} \
+         no_gc_growth_would_be={no_gc_growth}"
+    );
+    // Flat-baseline assertion on the PERSISTENT resident set: without GC it would climb by ~2*WIDTH
+    // per round (each generation's intermediates + leaves persisted forever). With GC each
+    // generation's garbage subtree is collected, so the persistent set stays within a small
+    // constant of the baseline regardless of the number of rounds.
+    assert!(
+        max_resident <= baseline + 2 * WIDTH as usize,
+        "persistent resident set grew too much across re-rooting (max={max_resident}, \
+         baseline={baseline}); GC is not returning to a flat baseline"
+    );
+    // GC must be doing the work: each round disconnects a full generation (2*WIDTH tasks), so over
+    // ROUNDS rounds GC should have collected on the order of 2*WIDTH*ROUNDS tasks. Assert it
+    // collected at least most of that (allowing slack for tasks that settle across passes), proving
+    // the flat baseline is due to GC collecting garbage — not merely eviction hiding it on disk.
+    let expected_min_collected = (2 * WIDTH as usize) * (ROUNDS as usize) / 2;
+    assert!(
+        total_collected >= expected_min_collected,
+        "GC collected too little ({total_collected}); expected >= {expected_min_collected} across \
+         {ROUNDS} re-rootings — GC is not doing the collection"
+    );
+
+    // The live graph must still compute correctly after all the churn.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        let output = wide_root(generation_vc);
+        // generation is ROUNDS; sum = WIDTH intermediates each = 1 + leaf(ROUNDS, i).
+        let expected: u32 = (0..WIDTH)
+            .map(|i| 1 + (ROUNDS.wrapping_mul(1000).wrapping_add(i)))
+            .fold(0u32, |a, b| a.wrapping_add(b));
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}
+
+const FANOUT: u32 = 5000;
+
+/// A root that reads `FANOUT` leaves *directly*, so it accumulates ~`FANOUT` children in one task
+/// (and, via reading each leaf's cell, a large forward-dependency set). Keyed by generation so
+/// bumping it disconnects the entire previous fan-out at once.
+#[turbo_tasks::function(operation, root)]
+async fn huge_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..FANOUT {
+        sum = sum.wrapping_add(*leaf(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// Exercises the *per-task* fan-out of the parallel collector (the chunked `Decrement`/`Scrub*`
+/// jobs): a single collected task has thousands of children and forward dependencies, which must be
+/// torn down across worker threads in bounded chunks rather than by one serial job. Collecting the
+/// disconnected generation's `huge_root` (≈FANOUT children) + its FANOUT leaves must fully reclaim
+/// the subtree, and the graph must still recompute afterwards.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_collects_wide_fanout_task() {
+    let (tt, _persistence_dir) = create_tt("gc_collects_wide_fanout_task");
+    let tt2 = tt.clone();
+
+    // Build generation 0 (huge_root + FANOUT leaves), then flip to generation 1 which disconnects
+    // the entire generation-0 fan-out.
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        let generation = generation_op.read_strongly_consistent().await?;
+
+        let output = huge_root(generation_vc);
+        output.read_strongly_consistent().await?;
+
+        // Disconnect the whole generation-0 fan-out in one shot.
+        generation.set(1);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // Baseline after building + reading generation 1 (once, to settle), then collect the
+    // disconnected generation-0 subtree.
+    let baseline = tt2.backend().resident_persistent_task_count_for_testing();
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let after = tt2.backend().resident_persistent_task_count_for_testing();
+
+    println!(
+        "wide-fanout: baseline={baseline} collected={collected} after={after} (fanout={FANOUT})"
+    );
+    // Collecting one wide-fanout generation tears down ~FANOUT+1 tasks (huge_root + its leaves)
+    // spread across worker threads via the chunked jobs. Assert the pass collected the bulk of a
+    // full generation (allowing slack for tasks that settle across passes), proving the per-task
+    // fan-out actually reclaims the whole subtree rather than pinning/starving.
+    assert!(
+        collected >= (FANOUT as usize) / 2,
+        "wide-fanout GC collected too little ({collected}); expected >= {} — per-task fan-out is \
+         not tearing down the whole subtree",
+        FANOUT / 2
+    );
+
+    // The live graph must still compute correctly after the wide teardown.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        let output = huge_root(generation_vc);
+        // generation is 1; sum = sum of leaf(1, i) for i in 0..FANOUT.
+        let expected: u32 = (0..FANOUT)
+            .map(|i| 1u32.wrapping_mul(1000).wrapping_add(i))
+            .fold(0u32, |a, b| a.wrapping_add(b));
+        assert_eq!(*output.read_strongly_consistent().await?, expected);
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -117,6 +117,14 @@ async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
+/// A plain leaf used to test the "spawned with no parent → GC root" rule. When called at the top
+/// level of a `run` (where the current task is `None`), its task is created with `parent == None`
+/// and marked a GC root, so it must never be collected even once disconnected.
+#[turbo_tasks::function]
+async fn gc_root_leaf() -> Result<Vc<u32>> {
+    Ok(Vc::cell(77))
+}
+
 /// `parent_count` must track the number of persistent parents, incremented when a parent connects a
 /// child and decremented when it disconnects it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -424,6 +432,60 @@ async fn gc_does_not_collect_pinned_task() {
         tt2.backend().gc_for_testing(&tt2),
         0,
         "pinned task must survive eviction and not be collected"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// A task spawned with **no parent** — called at the top level of a `run`, where the current task
+/// is `None` — is marked a GC root at creation and must never be collected, even with
+/// `parent_count == 0`. This is what keeps externally-spawned root operations (project container,
+/// endpoints, per-request source-map ops) alive: their handles live outside the tracked graph, so
+/// nothing else anchors them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_does_not_collect_parentless_root_task() {
+    let (tt, _persistence_dir) = create_tt("gc_does_not_collect_parentless_root_task");
+    let tt2 = tt.clone();
+    let tt3 = tt.clone();
+
+    let root_id = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        // Called directly in the `run` future: the current task is `None`, so gc_root_leaf's task
+        // is created with `parent == None` and marked a GC root. It has NO persistent parent edge.
+        assert_eq!(*gc_root_leaf().await?, 77);
+
+        let root_id = task_id_of(gc_root_leaf().resolve().await?);
+        // No parent connected it, so its parent_count is 0 from the start — yet it is a GC root.
+        assert_eq!(
+            tt3.backend().parent_count_for_testing(root_id),
+            0,
+            "a parentless root has no persistent parent edge"
+        );
+
+        anyhow::Ok(root_id)
+    })
+    .await
+    .unwrap();
+
+    // parent_count is 0 and it is disconnected, but the gc_root flag must keep it uncollectible.
+    assert_eq!(
+        tt2.backend().parent_count_for_testing(root_id),
+        0,
+        "still parent_count 0 after the run"
+    );
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 0,
+        "a parentless (gc_root) task must not be collected even with parent_count 0"
+    );
+
+    // Survives snapshot + eviction too (the gc_root flag is persisted meta).
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "gc_root task must survive eviction and not be collected"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -1,0 +1,570 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TaskId, TurboTasks, Vc, prevent_gc,
+    unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+
+/// Creates a fresh per-call persistence directory rooted under `CARGO_TARGET_TMPDIR/.cache/`.
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+/// Opens a backend rooted at `path`. Reusing the same `path` (after the previous backend has been
+/// stopped) reopens the persisted database — used to verify `parent_count` survives a restart.
+fn open_tt_at(path: &std::path::Path) -> Arc<TurboTasks<TurboTasksBackend>> {
+    TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            path,
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            false,
+            true,
+            true,
+        )
+        .unwrap()
+        .0,
+    ))
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = open_tt_at(dir.path());
+    (tt, dir)
+}
+
+/// The `TaskId` backing a resolved `Vc` (its `TaskOutput` node).
+fn task_id_of<T>(vc: Vc<T>) -> TaskId {
+    Vc::into_raw(vc)
+        .try_get_task_id()
+        .expect("a resolved Vc should be backed by a task")
+}
+
+#[turbo_tasks::value(transparent)]
+struct Selector(State<bool>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_selector(initial: bool) -> Vc<Selector> {
+    Selector(State::new(initial)).cell()
+}
+
+#[turbo_tasks::function]
+fn leaf(n: u32) -> Vc<u32> {
+    Vc::cell(n)
+}
+
+#[turbo_tasks::function]
+async fn branch_a() -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *leaf(10).await?))
+}
+
+#[turbo_tasks::function]
+async fn branch_b() -> Result<Vc<u32>> {
+    Ok(Vc::cell(2 + *leaf(20).await?))
+}
+
+/// A task that pins itself against GC while executing (as code handing a value across an untracked
+/// boundary — e.g. a `spawn_detached` future sending a `Vc` over a channel — would). Once pinned it
+/// must survive collection even after it is disconnected.
+#[turbo_tasks::function]
+async fn pinned_branch() -> Result<Vc<u32>> {
+    prevent_gc();
+    Ok(Vc::cell(99))
+}
+
+/// Reads exactly one branch depending on the selector; flipping it re-executes and disconnects the
+/// previously-read branch (and its subtree), which should drop that branch's `parent_count` to 0.
+#[turbo_tasks::function(operation, root)]
+async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    let use_b = *selector.await?.get();
+    let value = if use_b {
+        *branch_b().await?
+    } else {
+        *branch_a().await?
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Like `select`, but reads `pinned_branch` instead of `branch_a` when the selector is false.
+#[turbo_tasks::function(operation, root)]
+async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    let use_b = *selector.await?.get();
+    let value = if use_b {
+        *branch_b().await?
+    } else {
+        *pinned_branch().await?
+    };
+    Ok(Vc::cell(value))
+}
+
+/// `parent_count` must track the number of persistent parents, incremented when a parent connects a
+/// child and decremented when it disconnects it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_tracks_connect_and_disconnect() {
+    let (tt, _persistence_dir) = create_tt("parent_count_tracks_connect_and_disconnect");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        // Build the connected graph: select -> branch_a -> leaf(10).
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+        // Resolve the branch task ids (calling the cached functions returns the same tasks).
+        let branch_a_id = task_id_of(branch_a().resolve().await?);
+        let leaf10_id = task_id_of(leaf(10).resolve().await?);
+        let branch_b_id = task_id_of(branch_b().resolve().await?);
+
+        // While connected, branch_a and leaf(10) each have exactly one persistent parent.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_a_id),
+            1,
+            "branch_a has one parent (select) while connected"
+        );
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(leaf10_id),
+            1,
+            "leaf(10) has one parent (branch_a) while connected"
+        );
+
+        // Flip: select re-executes reading branch_b, disconnecting branch_a + leaf(10).
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        // branch_a is now disconnected from select: its parent_count drops to 0.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_a_id),
+            0,
+            "branch_a lost its only parent (select) after the flip"
+        );
+        // leaf(10) is still listed as a child by the (now-garbage) branch_a — nothing re-executed
+        // branch_a to drop that edge — so its parent_count stays 1. It only drops to 0 once
+        // branch_a is torn down (the eager-teardown cascade, wired in a later stage). The
+        // count accurately reflects the live `children` edges at all times.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(leaf10_id),
+            1,
+            "leaf(10)'s parent branch_a still lists it (branch_a is garbage but not yet torn down)"
+        );
+        // branch_b + leaf(20) are now connected.
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_b_id),
+            1,
+            "branch_b gained a parent (select) after the flip"
+        );
+
+        // Flip back: branch_a reconnects (recomputed), branch_b disconnects.
+        selector.set(false);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_b_id),
+            0,
+            "branch_b lost its parent after flipping back"
+        );
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// `parent_count` is a persisted meta field: it must survive a snapshot + DB reopen. This exercises
+/// the durability path — the count is written into the task's meta blob and restored on the next
+/// session (and any in-flight `AdjustParentCount` job replays via the durable operation queue).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_survives_reopen() {
+    let dir = create_test_persistence_dir("parent_count_survives_reopen");
+
+    // Session 1: build select -> branch_a -> leaf(10), then stop (persists on shutdown).
+    let (branch_a_id, leaf10_id) = {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let ids = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+
+            let selector_op = create_selector(false);
+            let selector_vc = selector_op.resolve().strongly_consistent().await?;
+
+            let output = select(selector_vc);
+            assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+            let branch_a_id = task_id_of(branch_a().resolve().await?);
+            let leaf10_id = task_id_of(leaf(10).resolve().await?);
+            assert_eq!(tt2.backend().parent_count_for_testing(branch_a_id), 1);
+            assert_eq!(tt2.backend().parent_count_for_testing(leaf10_id), 1);
+            anyhow::Ok((branch_a_id, leaf10_id))
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+        ids
+    };
+
+    // Session 2: reopen the same DB, re-read the graph (restoring the persisted tasks), and assert
+    // their parent_count was restored from disk (not reset to 0). Task ids are stable across the
+    // reopen because they are persisted.
+    {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let result = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+
+            // Re-read the same graph so the cached tasks are restored from disk.
+            let selector_op = create_selector(false);
+            let selector_vc = selector_op.resolve().strongly_consistent().await?;
+            let output = select(selector_vc);
+            assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+            // Force the branch tasks resident (reading them restores their meta, incl.
+            // parent_count, from disk). These are cached, so they are not re-executed.
+            assert_eq!(*branch_a().await?, 11);
+            assert_eq!(*leaf(10).await?, 10);
+
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(branch_a_id),
+                1,
+                "branch_a's parent_count must be restored from disk after reopen"
+            );
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(leaf10_id),
+                1,
+                "leaf(10)'s parent_count must be restored from disk after reopen"
+            );
+            anyhow::Ok(())
+        })
+        .await;
+        tt.stop_and_wait().await;
+        result.unwrap();
+    }
+}
+
+/// A decrement (disconnect) must survive a snapshot + eviction and stay correct when the affected
+/// tasks are restored from disk — exercising the `-1` `AdjustParentCount` path through the durable
+/// queue within a single session (so task identity is stable). After the flip, branch_b has 1
+/// persistent parent and branch_a has 0; those counts must be intact after a snapshot/evict cycle
+/// pushes them to disk and a subsequent read restores them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_decrement_survives_snapshot_evict() {
+    let (tt, _persistence_dir) = create_tt("parent_count_decrement_survives_snapshot_evict");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+        // Flip so select drops branch_a (-1) and connects branch_b (+1).
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        let branch_a_id = task_id_of(branch_a().resolve().await?);
+        let branch_b_id = task_id_of(branch_b().resolve().await?);
+        assert_eq!(tt2.backend().parent_count_for_testing(branch_a_id), 0);
+        assert_eq!(tt2.backend().parent_count_for_testing(branch_b_id), 1);
+
+        // Snapshot + evict: pushes quiescent tasks (with their parent_count) to disk.
+        tt2.backend().snapshot_and_evict_for_testing(&tt2);
+
+        // Re-read the live output, restoring branch_b from disk; its parent_count must still be 1
+        // (the persisted, decrement-consistent value — not doubled, not lost).
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+        assert_eq!(*branch_b().await?, 22);
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(branch_b_id),
+            1,
+            "branch_b's parent_count must round-trip through snapshot/evict as 1"
+        );
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// A GC pass collects a disconnected subtree via the parent_count cascade: disconnecting branch_a
+/// drops its count to 0 (branch_a is collected), which decrements its child leaf(10) to 0 (leaf(10)
+/// is then collected too). The live branch (branch_b + leaf(20)) is untouched and the graph still
+/// computes; flipping back recomputes branch_a fresh, proving no dangling references.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_collects_disconnected_subtree() {
+    let (tt, _persistence_dir) = create_tt("gc_collects_disconnected_subtree");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+
+        // Flip: select drops branch_a; branch_a (parent_count 0) becomes a candidate.
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // GC runs in a fresh `run_once` after the first completes: a `run_once` root keeps every task
+    // it touched active (active_counter > 0) until it returns, so a task disconnected *within*
+    // that run is not yet collectible. Once the run ends the active counts are released and the
+    // disconnected branch_a (parent_count 0) becomes collectible; the cascade then drops
+    // leaf(10) to 0 too.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 2,
+        "branch_a and its cascaded child leaf(10) should both be collected"
+    );
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "nothing left to collect"
+    );
+
+    // The live graph still computes, and flipping back recomputes branch_a fresh (it was collected)
+    // — proving collection left no dangling references.
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        let selector_op = create_selector(true);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let output = select(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+        selector.set(false);
+        assert_eq!(*output.read_strongly_consistent().await?, 11);
+        let _ = &tt3;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    tt.stop_and_wait().await;
+}
+
+/// A task that pins itself via `prevent_gc()` must survive collection even after it is disconnected
+/// from the live graph — covering values that escape the tracked task graph (e.g. `spawn_detached`
+/// sending a `Vc` across a channel). Unlike `branch_a`, `pinned_branch` is not collected once
+/// disconnected, because the pin makes it a GC root.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_does_not_collect_pinned_task() {
+    let (tt, _persistence_dir) = create_tt("gc_does_not_collect_pinned_task");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        // select_pinned reads pinned_branch, which pins itself during execution.
+        let output = select_pinned(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 99);
+
+        // Flip: select_pinned re-executes, reads branch_b, and disconnects pinned_branch.
+        selector.set(true);
+        assert_eq!(*output.read_strongly_consistent().await?, 22);
+
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    // GC (after the run releases activeness) must NOT collect pinned_branch even though it is now
+    // disconnected (parent_count 0), because it pinned itself. Its child leaf from branch_b is
+    // live.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 0,
+        "a pinned task must not be collected even when disconnected"
+    );
+
+    // A snapshot + evict must not lose the (transient) pin. A pinned task is no longer forced fully
+    // resident — its Meta/Data may be partially evicted — but the session-only
+    // `transient_ref_count` is retained as residue (the map entry is kept), so the task stays
+    // uncollectible and a subsequent GC still collects nothing.
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "pinned task must survive eviction and not be collected"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// Unpinning a task after the backend has started stopping must not panic. This mirrors the real
+/// shutdown ordering: a `DetachedVc` handed to JS across NAPI is finalized (dropped, which unpins)
+/// during Node worker teardown, which can run *after* `stop()` has dropped the whole task map.
+/// pin/unpin are gated on the `stopping` flag (set before the map is dropped) so a late unpin is a
+/// no-op rather than resurrecting a blank entry and underflowing `transient_ref_count`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unpin_after_stop_does_not_panic() {
+    let (tt, _persistence_dir) = create_tt("unpin_after_stop_does_not_panic");
+
+    // Pin a real task inside a session (as `prevent_gc` / `DetachedVc::new` would).
+    let tt2 = tt.clone();
+    let leaf_id = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let id = task_id_of(leaf(7).resolve().await?);
+        tt2.pin_task_for_gc(id);
+        anyhow::Ok(id)
+    })
+    .await
+    .unwrap();
+
+    // Stop the backend — this drops the in-memory task map, so the pinned task is no longer
+    // resident (exactly as at `next build` shutdown).
+    tt.stop_and_wait().await;
+
+    // Unpin after teardown, as a `DetachedVc`'s `Drop` finalized during Node worker cleanup would.
+    // The task is gone from the map, so this must be a harmless no-op — not an underflow panic.
+    tt.unpin_task_for_gc(leaf_id);
+}
+
+/// Reads a *stable* child (`leaf(30)`) on every execution, plus a `State` that drives
+/// re-execution. Flipping the state re-executes the parent while it keeps the same child edge.
+#[turbo_tasks::function(operation, root)]
+async fn stable_child_parent(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    // Read the selector so we re-execute when it flips...
+    let bump = if *selector.await?.get() { 100 } else { 0 };
+    // ...but always connect the SAME child regardless.
+    let child = *leaf(30).await?;
+    Ok(Vc::cell(bump + child))
+}
+
+/// One leaf per index — distinct tasks, so a wide parent accumulates that many distinct children.
+#[turbo_tasks::function]
+fn wide_leaf(index: u32) -> Vc<u32> {
+    Vc::cell(index)
+}
+
+/// Reads `WIDE_FANOUT` distinct children — deliberately above `connect_children`'s 10_000
+/// parallelization threshold, so the child-side `parent_count` bump runs through the chunked,
+/// parallel `process_new_children` path (each chunk on its own worker context) rather than the
+/// serial one.
+const WIDE_FANOUT: u32 = 12_000;
+
+#[turbo_tasks::function(operation, root)]
+async fn wide_parent() -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..WIDE_FANOUT {
+        sum = sum.wrapping_add(*wide_leaf(index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// The parallelized `connect_children` path (≥10_000 children, chunked across worker contexts)
+/// must bump each persistent child's `parent_count` exactly once — no child dropped by a chunk
+/// boundary, none double-counted. Connect >10_000 distinct children in one parent and assert a
+/// spread of them (first / middle / last, covering multiple chunks) each end at exactly 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_count_wide_fanout_parallel_path() {
+    let (tt, _persistence_dir) = create_tt("parent_count_wide_fanout_parallel_path");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let output = wide_parent();
+        output.read_strongly_consistent().await?;
+
+        // Sample across the full range so at least one child from each chunk is checked.
+        for index in [0, 1, WIDE_FANOUT / 2, WIDE_FANOUT - 2, WIDE_FANOUT - 1] {
+            let child_id = task_id_of(wide_leaf(index).resolve().await?);
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(child_id),
+                1,
+                "wide_leaf({index}) must have parent_count == 1 after the parallel connect \
+                 (chunked +1 must bump every child exactly once)"
+            );
+        }
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// Re-validation must not double-count. When a parent re-executes and connects a child it was
+/// *already* connected to (the child is still in its persistent `children` set), the child must NOT
+/// gain a second `parent_count`: `connect_children` only bumps the *genuinely-new* children (those
+/// not already present in `children`), so the count stays at exactly 1 across arbitrarily many
+/// re-executions that keep the edge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parent_count_not_double_counted_on_revalidation() {
+    let (tt, _persistence_dir) = create_tt("parent_count_not_double_counted_on_revalidation");
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = stable_child_parent(selector_vc);
+        assert_eq!(*output.read_strongly_consistent().await?, 30);
+
+        let leaf30_id = task_id_of(leaf(30).resolve().await?);
+        assert_eq!(
+            tt2.backend().parent_count_for_testing(leaf30_id),
+            1,
+            "leaf(30) has exactly one parent after the first execution"
+        );
+
+        // Re-execute the parent several times; it keeps the same child edge each time.
+        for i in 0..5 {
+            selector.set(i % 2 == 0);
+            output.read_strongly_consistent().await?;
+            assert_eq!(
+                tt2.backend().parent_count_for_testing(leaf30_id),
+                1,
+                "leaf(30)'s parent_count must stay 1 across re-validation (iteration {i}), not \
+                 grow — the child edge already existed so no new count is taken"
+            );
+        }
+
+        anyhow::Ok(())
+    })
+    .await;
+    tt.stop_and_wait().await;
+    result.unwrap();
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use turbo_tasks::{
-    ResolvedVc, State, TaskId, TurboTasks, Vc, prevent_gc,
+    GcRoot, ResolvedVc, State, TaskId, TurboTasks, Vc, prevent_gc,
     unmark_top_level_task_may_leak_eventually_consistent_state,
 };
 use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
@@ -117,9 +117,10 @@ async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
-/// A plain leaf used to test the "spawned with no parent → GC root" rule. When called at the top
-/// level of a `run` (where the current task is `None`), its task is created with `parent == None`
-/// and marked a GC root, so it must never be collected even once disconnected.
+/// A plain leaf read at the top level of a `run_once`. The current task is `None` there, so the
+/// leaf's task is created with no persistent parent — but the transient `Once` task that reads it
+/// connects it as a child, anchoring it via `transient_ref_count`. That transient anchor (not a
+/// persisted "root" flag) is what keeps such a top-level-read task alive.
 #[turbo_tasks::function]
 async fn gc_root_leaf() -> Result<Vc<u32>> {
     Ok(Vc::cell(77))
@@ -437,30 +438,86 @@ async fn gc_does_not_collect_pinned_task() {
     tt.stop_and_wait().await;
 }
 
-/// A task spawned with **no parent** — called at the top level of a `run`, where the current task
-/// is `None` — is marked a GC root at creation and must never be collected, even with
-/// `parent_count == 0`. This is what keeps externally-spawned root operations (project container,
-/// endpoints, per-request source-map ops) alive: their handles live outside the tracked graph, so
-/// nothing else anchors them.
+/// A [`GcRoot`] guard pins a task for its lifetime and unpins it on drop. This is the anchor a
+/// permanent root uses (e.g. the `ProjectContainer` operation held by a NAPI `ProjectInstance`):
+/// while the guard lives the task is uncollectible even at `parent_count == 0`; dropping the guard
+/// releases the pin so it becomes collectible. The guard owns exactly one pin and is not `Clone`,
+/// so it can't double-unpin (which would underflow `transient_ref_count`).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn gc_does_not_collect_parentless_root_task() {
-    let (tt, _persistence_dir) = create_tt("gc_does_not_collect_parentless_root_task");
+async fn gc_root_guard_pins_until_dropped() {
+    let (tt, _persistence_dir) = create_tt("gc_root_guard_pins_until_dropped");
+    let tt2 = tt.clone();
+
+    // A parentless leaf read inside a `run`, then guarded by a `GcRoot` created *outside* the run
+    // (as `project_new` does for the container — `run` returns the task id; the guard is built
+    // after). `run` (unlike `run_once`) creates no lingering transient root anchoring it, so
+    // the guard is its only anchor.
+    let leaf_id = tt
+        .run(async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let leaf_vc = leaf(55);
+            let _ = *leaf_vc.await?;
+            Ok(task_id_of(leaf_vc.resolve().await?))
+        })
+        .await
+        .unwrap();
+    let guard = GcRoot::pin(tt2.clone(), leaf_id);
+
+    assert_eq!(guard.task_id(), leaf_id);
+    assert_eq!(
+        tt.backend().transient_ref_count_for_testing(leaf_id),
+        1,
+        "the GcRoot guard pins the task (transient_ref_count 1)"
+    );
+    assert_eq!(
+        tt.backend().gc_for_testing(&tt),
+        0,
+        "a task pinned by a live GcRoot must not be collected"
+    );
+
+    // Drop the guard: it unpins, so the now-unanchored parentless leaf becomes collectible.
+    drop(guard);
+    assert_eq!(
+        tt.backend().transient_ref_count_for_testing(leaf_id),
+        0,
+        "dropping the GcRoot released the pin"
+    );
+    assert_eq!(
+        tt.backend().gc_for_testing(&tt),
+        1,
+        "the task is collectible once its GcRoot is dropped"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// A parentless task read at the top level of a `run_once` is no longer force-kept as a persisted
+/// topology "root" (we removed that blanket flagging). It is instead kept alive only by a real
+/// anchor: here, the never-disposed transient `Once` task of the `run_once` that read it keeps it
+/// reachable/active, so it is not collected while that anchor exists. (This is the same "a
+/// `run_once` root keeps everything it touched active until — and here, because it is never
+/// disposed, beyond — it returns" behavior that `gc_re_rooting_stays_flat` accounts for by
+/// measuring the *persistent* resident set. The leak fix for disposable ops is covered by
+/// `gc_collects_disconnected_subtree` and `dispose_root_task_releases_anchored_subgraph`.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parentless_top_level_task_kept_by_transient_root_not_a_topology_flag() {
+    let (tt, _persistence_dir) =
+        create_tt("parentless_top_level_task_kept_by_transient_root_not_a_topology_flag");
     let tt2 = tt.clone();
     let tt3 = tt.clone();
 
     let root_id = turbo_tasks::run_once(tt.clone(), async move {
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
-        // Called directly in the `run` future: the current task is `None`, so gc_root_leaf's task
-        // is created with `parent == None` and marked a GC root. It has NO persistent parent edge.
         assert_eq!(*gc_root_leaf().await?, 77);
 
         let root_id = task_id_of(gc_root_leaf().resolve().await?);
-        // No parent connected it, so its parent_count is 0 from the start — yet it is a GC root.
+        // No persistent parent connected it, so parent_count is 0 — it is not a persistent-graph
+        // child of anything.
         assert_eq!(
             tt3.backend().parent_count_for_testing(root_id),
             0,
-            "a parentless root has no persistent parent edge"
+            "a parentless top-level task has no persistent parent edge"
         );
 
         anyhow::Ok(root_id)
@@ -468,7 +525,9 @@ async fn gc_does_not_collect_parentless_root_task() {
     .await
     .unwrap();
 
-    // parent_count is 0 and it is disconnected, but the gc_root flag must keep it uncollectible.
+    // Its `run_once`'s `Once` task is never disposed and keeps it anchored, so GC does not collect
+    // it — but note this is an in-session transient anchor, NOT the removed persisted topology
+    // flag.
     assert_eq!(
         tt2.backend().parent_count_for_testing(root_id),
         0,
@@ -477,15 +536,7 @@ async fn gc_does_not_collect_parentless_root_task() {
     let collected = tt2.backend().gc_for_testing(&tt2);
     assert_eq!(
         collected, 0,
-        "a parentless (gc_root) task must not be collected even with parent_count 0"
-    );
-
-    // Survives snapshot + eviction too (the gc_root flag is persisted meta).
-    tt2.backend().snapshot_and_evict_for_testing(&tt2);
-    assert_eq!(
-        tt2.backend().gc_for_testing(&tt2),
-        0,
-        "gc_root task must survive eviction and not be collected"
+        "kept alive by its (undisposed) transient Once root, not by a topology flag"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -491,6 +491,99 @@ async fn gc_does_not_collect_parentless_root_task() {
     tt.stop_and_wait().await;
 }
 
+/// Disposing a root task (as `RootTask::Drop` / `root_task_dispose` does when JS stops listening to
+/// a subscription) must release the anchor its child edges placed on the persistent tasks it read,
+/// so the subscription's subgraph becomes collectible. A transient root task bumps each persistent
+/// child's `transient_ref_count`; `dispose_root_task` tears the (clean) root's edges down via
+/// `CleanupOldEdges`, which sheds that count (and rebalances the aggregation graph). Also checks
+/// the contract `RootTask::Drop` relies on: disposal is idempotent and safe after the backend
+/// stopped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispose_root_task_releases_anchored_subgraph() {
+    let (tt, _persistence_dir) = create_tt("dispose_root_task_releases_anchored_subgraph");
+
+    // Spawn a real root task (as `subscribe` does) whose body reads a persistent leaf, connecting
+    // it as a child of the transient root — bumping the leaf's transient_ref_count. The root sends
+    // the leaf's id out via a oneshot so we can inspect it WITHOUT a separate `run_once` probe (a
+    // probe would be its own transient `Once` task that also connects the leaf — Once tasks are
+    // never disposed, so it would pollute the leaf's transient_ref_count and never drop to 0).
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+    let root_id = tt.spawn_root_task(move || {
+        let tx = tx.lock().unwrap().take();
+        Box::pin(async move {
+            // The root body runs as a top-level task; unmark so the eventually-consistent leaf read
+            // is allowed (as `subscribe`'s HMR handler does).
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let leaf_vc = leaf(88);
+            let value = *leaf_vc.await?;
+            if let Some(tx) = tx {
+                let _ = tx.send(task_id_of(leaf_vc.resolve().await?));
+            }
+            anyhow::Ok(Vc::<u32>::cell(value))
+        })
+    });
+
+    // The root connects the leaf as its only anchor: no persistent parent (parent_count 0), one
+    // transient child edge (transient_ref_count 1).
+    let leaf_id = rx.await.unwrap();
+    for _ in 0..100 {
+        if tt.backend().transient_ref_count_for_testing(leaf_id) > 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        tt.backend().parent_count_for_testing(leaf_id),
+        0,
+        "leaf read only by the root task has no persistent parent"
+    );
+    assert_eq!(
+        tt.backend().transient_ref_count_for_testing(leaf_id),
+        1,
+        "the transient root task anchors the leaf via exactly one child edge"
+    );
+
+    // While the root task is live, the leaf is anchored and must not be collected.
+    assert_eq!(
+        tt.backend().gc_for_testing(&tt),
+        0,
+        "leaf anchored by the live root task must not be collected"
+    );
+
+    // Dispose the root task (as `RootTask::Drop` now does when JS skipped `root_task_dispose`). Its
+    // `CleanupOldEdges` sheds the leaf's transient_ref_count.
+    tt.dispose_root_task(root_id);
+    // Idempotent: disposing again (the shape of explicit JS dispose + a later `Drop`) must not
+    // panic and must not underflow the child's count (the edges were already removed).
+    tt.dispose_root_task(root_id);
+
+    assert_eq!(
+        tt.backend().transient_ref_count_for_testing(leaf_id),
+        0,
+        "disposing the root task released its transient_ref_count anchor on the leaf"
+    );
+
+    // Collect in a fresh run (a `run_once` keeps touched tasks active until it returns, so GC runs
+    // after it). The leaf is now unanchored, quiescent, and collectible.
+    turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        tt.backend().gc_for_testing(&tt),
+        1,
+        "the leaf becomes collectible once the root task that anchored it is disposed"
+    );
+
+    // Disposal must be safe after the backend has stopped, as a `RootTask` finalized during Node
+    // worker teardown would be (the whole task map is dropped by `stop`).
+    tt.stop_and_wait().await;
+    tt.dispose_root_task(root_id);
+}
+
 /// Unpinning a task after the backend has started stopping must not panic. This mirrors the real
 /// shutdown ordering: a `DetachedVc` handed to JS across NAPI is finalized (dropped, which unpins)
 /// during Node worker teardown, which can run *after* `stop()` has dropped the whole task map.

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -30,6 +30,9 @@ fn open_tt_at(path: &std::path::Path) -> Arc<TurboTasks<TurboTasksBackend>> {
             small_preallocation: true,
             storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
             eviction_mode: EvictionMode::Full,
+            // Force GC on so the stop-time snapshot runs a GC pass and persists the roots map
+            // (deterministic, no dependence on the process-global TURBO_ENGINE_GC).
+            gc: Some(true),
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(
@@ -71,6 +74,22 @@ fn create_selector(initial: bool) -> Vc<Selector> {
 #[turbo_tasks::function]
 fn leaf(n: u32) -> Vc<u32> {
     Vc::cell(n)
+}
+
+/// A distinct leaf keyed by `n`, used as the child of a persisted root in the cross-session tests
+/// so its collection can be observed independently of the shared `leaf`.
+#[turbo_tasks::function]
+fn orphan_leaf(n: u32) -> Vc<u32> {
+    Vc::cell(n)
+}
+
+/// A `(operation, root)` op that reads `orphan_leaf(n)` — a small "root -> subtree" used to test
+/// cross-session orphan collection. Read at the top level of a `run` it has no persistent parent
+/// (`parent_count == 0`), so it is a durable root; its child `orphan_leaf(n)` gets `parent_count
+/// 1`.
+#[turbo_tasks::function(operation, root)]
+async fn root_with_child(n: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(*orphan_leaf(n).await? + 1))
 }
 
 #[turbo_tasks::function]
@@ -773,4 +792,112 @@ async fn parent_count_not_double_counted_on_revalidation() {
     .await;
     tt.stop_and_wait().await;
     result.unwrap();
+}
+
+/// Cross-session orphan collection (Piece B). A root persisted in session 1 that is *not*
+/// re-requested in session 2 ages out of the persisted roots map and its subtree is collected — the
+/// disk-only garbage the resident-scan GC can't reach. With the TTL forced to 0, the first GC pass
+/// in session 2 (which never re-anchors the root) collects it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_collects_cross_session_orphan_root() {
+    let dir = create_test_persistence_dir("gc_collects_cross_session_orphan_root");
+
+    // Session 1: create the root + child, persist on shutdown.
+    let (root_id, child_id) = {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let ids = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let output = root_with_child(42);
+            assert_eq!(*output.read_strongly_consistent().await?, 43);
+            // `root_with_child` is `(operation, root)` -> `OperationVc`; its task is the root op.
+            let root_id = output.task_id();
+            let child_id = task_id_of(orphan_leaf(42).resolve().await?);
+            // The root has no persistent parent; the child hangs off it.
+            assert_eq!(tt2.backend().parent_count_for_testing(root_id), 0);
+            assert_eq!(tt2.backend().parent_count_for_testing(child_id), 1);
+            anyhow::Ok((root_id, child_id))
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+        ids
+    };
+
+    // Session 2: reopen, but NEVER request `root_with_child(42)` — it's a cross-session orphan.
+    // With TTL 0 the first GC pass ages it out of the roots map and collects it + its subtree.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(0);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let collected = tt2.backend().gc_for_testing(&tt2);
+            assert!(
+                collected >= 2,
+                "the orphaned root and its child should be collected (got {collected})"
+            );
+            let _ = root_id;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
+
+    // Session 3: reopen and confirm re-requesting recomputes cleanly (no dangling refs from the
+    // cross-session collection).
+    {
+        let tt = open_tt_at(dir.path());
+        let result = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            assert_eq!(*root_with_child(42).read_strongly_consistent().await?, 43);
+            let _ = (root_id, child_id);
+            anyhow::Ok(())
+        })
+        .await;
+        tt.stop_and_wait().await;
+        result.unwrap();
+    }
+}
+
+/// A root re-requested in the next session must NOT be collected: re-anchoring refreshes its
+/// last-anchored timestamp, resetting the TTL clock. Same setup as the orphan test, but session 2
+/// re-requests the root before GC.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_keeps_reanchored_cross_session_root() {
+    let dir = create_test_persistence_dir("gc_keeps_reanchored_cross_session_root");
+
+    {
+        let tt = open_tt_at(dir.path());
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            assert_eq!(*root_with_child(7).read_strongly_consistent().await?, 8);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
+
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(0);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // Re-request the root: this re-anchors it (its transient Once reader gives it a
+            // transient_ref_count), so the GC pass must refresh its timestamp, not collect it.
+            assert_eq!(*root_with_child(7).read_strongly_consistent().await?, 8);
+            let collected = tt2.backend().gc_for_testing(&tt2);
+            assert_eq!(
+                collected, 0,
+                "a re-requested (re-anchored) root must not be collected even at TTL 0"
+            );
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -913,6 +913,186 @@ async fn gc_collects_cross_session_orphan_root() {
     }
 }
 
+/// The persisted roots map must be **monotone**: a root that ages out and is seeded for collection
+/// but then proves *non-collectible* has to stay in the map, so a later pass re-seeds it.
+///
+/// Regression for a leak in `gc_roots_refresh_and_age_out`, which used to drop the aged-out entry
+/// eagerly (in the `retain`) before anything was collected. Because the returned map is persisted
+/// as a whole-key rewrite of the roots set, a seed that wasn't collected vanished from the map
+/// while still existing on disk — and nothing could re-add it: the resident scan only admits
+/// `gc_is_root` tasks (`transient_ref_count > 0`), which an aged-out root by definition fails, and
+/// a **disk-only** task isn't scanned at all. It became unreachable from every GC enumeration path:
+/// permanently untracked garbage.
+///
+/// Two persisted roots let one pass exercise both outcomes:
+/// - `root_with_child(1)` is never touched in session 2, so it ages out and *is* collected. Its
+///   entry must leave the map. Collecting it is also what gives the snapshot modifications to write
+///   — with an empty pass, `snapshot_and_persist` short-circuits before `save_snapshot` and the
+///   roots key is never rewritten at all.
+/// - `root_with_child(2)` is re-requested in session 2. Read at the top level of a `run_once` it is
+///   left `parent_count == 0` *and* `transient_ref_count == 0`, so it fails `gc_is_root`, ages out
+///   and is seeded — but the revalidation rejects it (the reading `Once` task keeps it active), so
+///   it is **not** collected. Its entry must survive.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_keeps_uncollected_aged_out_root_in_roots_map() {
+    let dir = create_test_persistence_dir("gc_keeps_uncollected_aged_out_root_in_roots_map");
+
+    // Session 1: persist both roots.
+    let (collected_root, kept_root) = {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let ids = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let a = root_with_child(1);
+            let b = root_with_child(2);
+            assert_eq!(*a.read_strongly_consistent().await?, 2);
+            assert_eq!(*b.read_strongly_consistent().await?, 3);
+            assert_eq!(tt2.backend().parent_count_for_testing(a.task_id()), 0);
+            assert_eq!(tt2.backend().parent_count_for_testing(b.task_id()), 0);
+            anyhow::Ok((a.task_id(), b.task_id()))
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+        let roots = tt.backend().persisted_gc_roots_for_testing();
+        for id in [ids.0, ids.1] {
+            assert!(
+                roots.iter().any(|(r, _)| *r == id),
+                "session 1 should persist {id} as a durable root; got {roots:?}"
+            );
+        }
+        ids
+    };
+
+    // Session 2: re-request only `kept_root`, then snapshot — which runs one GC pass and persists
+    // the roots map that pass produced.
+    {
+        let tt = open_tt_at(dir.path());
+        // TTL 0 so both carried-forward entries age out immediately and are seeded.
+        tt.backend().set_gc_root_ttl_for_testing(0);
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            assert_eq!(*root_with_child(2).read_strongly_consistent().await?, 3);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Outside the `run_once`, so this is the only GC pass between here and the assertions.
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+
+        let roots = tt.backend().persisted_gc_roots_for_testing();
+        assert!(
+            roots.iter().any(|(id, _)| *id == kept_root),
+            "an aged-out root that was seeded but NOT collected must stay in the persisted roots \
+             map — otherwise nothing can re-discover it (the resident scan only admits anchored \
+             roots, and a disk-only task isn't scanned at all), so it becomes permanently \
+             untracked garbage. persisted roots: {roots:?}"
+        );
+        assert!(
+            !roots.iter().any(|(id, _)| *id == collected_root),
+            "a root that WAS collected must be dropped from the map, not left as a dead id. \
+             persisted roots: {roots:?}"
+        );
+
+        tt.stop_and_wait().await;
+    }
+}
+
+/// A root that is restored and observed **live** must have its refreshed timestamp persisted, even
+/// when the session modified nothing.
+///
+/// Restoring a task from disk does not dirty it, so a perfectly cached graph can be reopened,
+/// re-read (cache hit, no recompute), and observed anchored while leaving `has_modifications`
+/// false. `snapshot_and_persist` used to return early in that case *before* handing the roots map
+/// to `save_snapshot`, silently dropping every refresh the pass computed.
+///
+/// That is a correctness bug, not a missed optimization: a rarely-changing route (an API route that
+/// is restored every session but never modified) would keep its original timestamp forever and
+/// eventually age out of the roots map — collected as a "cross-session orphan" even though every
+/// session had seen it alive. This test pins the sequence: session 2 refreshes-without-modifying,
+/// and session 3 must find the root still live rather than aged out.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_persists_root_refresh_when_nothing_was_modified() {
+    let dir = create_test_persistence_dir("gc_persists_root_refresh_clean_pass");
+
+    // Session 1: create the root and persist it, capturing its initial timestamp.
+    let (root_id, first_ts) = {
+        let tt = open_tt_at(dir.path());
+        let root_id = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let output = root_with_child(11);
+            assert_eq!(*output.read_strongly_consistent().await?, 12);
+            anyhow::Ok(output.task_id())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+        let roots = tt.backend().persisted_gc_roots_for_testing();
+        let ts = roots
+            .iter()
+            .find(|(id, _)| *id == root_id)
+            .map(|(_, ts)| *ts)
+            .expect("session 1 should persist the root");
+        (root_id, ts)
+    };
+
+    // The stored timestamp is wall-clock millis, so make sure a later refresh is distinguishable
+    // from the original. This is the only place the test depends on real time passing.
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    // Session 2: reopen and re-read the *same* value. The graph is fully cached, so the root is
+    // restored and reused without being modified — `has_modifications` is false. The GC pass must
+    // still persist the refreshed timestamp.
+    {
+        let tt = open_tt_at(dir.path());
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // Identical read: a cache hit, no recompute, nothing dirtied.
+            assert_eq!(*root_with_child(11).read_strongly_consistent().await?, 12);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+        tt.stop_and_wait().await;
+
+        let roots = tt.backend().persisted_gc_roots_for_testing();
+        let ts = roots
+            .iter()
+            .find(|(id, _)| *id == root_id)
+            .map(|(_, ts)| *ts)
+            .expect("the live root must still be tracked after a clean session");
+        assert!(
+            ts > first_ts,
+            "a restored, still-live root must have its refreshed timestamp persisted even when \
+             the session modified nothing (was {first_ts}, still {ts}); otherwise its TTL clock \
+             never restarts and it eventually ages out despite being alive every session"
+        );
+    }
+
+    // Session 3: with a zero TTL, an un-refreshed root would age out and be collected here. The
+    // refresh from session 2 is what keeps it alive — and re-reading it refreshes it again.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(0);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            assert_eq!(*root_with_child(11).read_strongly_consistent().await?, 12);
+            let collected = tt2.backend().gc_for_testing(&tt2);
+            assert_eq!(
+                collected, 0,
+                "a root that is live in this session must not be collected (got {collected})"
+            );
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
+}
+
 /// A root re-requested in the next session must NOT be collected: re-anchoring refreshes its
 /// last-anchored timestamp, resetting the TTL clock. Same setup as the orphan test, but session 2
 /// re-requests the root before GC.

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -92,6 +92,58 @@ async fn root_with_child(n: u32) -> Result<Vc<u32>> {
     Ok(Vc::cell(*orphan_leaf(n).await? + 1))
 }
 
+// --- Diamond fixture for the cross-session disk-only forward-dep scrub test ---
+//
+// A "diamond": a reader `A` (`diamond_reader`) holds a **forward cell-dependency** on a target `B`
+// (`diamond_target`) that is *not* its child — `B` is called by the root and its resolved `Vc` is
+// passed into `A`, so reading it records a dep edge without a child edge. Both `A` and `B` are
+// children of the diamond root. This is the shape that, cross-session under GC, can require
+// scrubbing a **disk-only** forward-dep target: when the orphaned root is collected, `A` and `B`
+// cascade together, and `A`'s `CleanupOldEdges` may open `B` to remove the stale reverse edge while
+// `B` has not yet been restored from disk this session.
+//
+// The target must be **mutable** to record dependents at all (an immutable constant records none),
+// so it reads a long-lived `State` whose value never changes.
+
+#[turbo_tasks::value(transparent)]
+struct Constant(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_constant() -> Vc<Constant> {
+    Constant(State::new(0)).cell()
+}
+
+/// The forward-dependency *target* `B`. Reading `constant`'s `State` makes it mutable so a reader
+/// records a real `cell_dependents` reverse edge on it.
+#[turbo_tasks::function]
+async fn diamond_target(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
+    let base = *constant.await?.get();
+    Ok(Vc::cell(base.wrapping_add(index).wrapping_mul(7)))
+}
+
+/// The diamond *reader* `A`: reads the cell of a `diamond_target` (`B`) passed in as an
+/// already-resolved `Vc`, so `A` forward-deps on `B` without parenting it.
+#[turbo_tasks::function]
+async fn diamond_reader(target: ResolvedVc<u32>) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *target.await?))
+}
+
+const DIAMOND_FANOUT: u32 = 64;
+
+/// The diamond root: for each index, calls `diamond_target(index)` (`B`, the root's child) and
+/// `diamond_reader(B)` (`A`, the root's child that forward-deps on `B`). `FANOUT` distinct A/B
+/// pairs give many chances for the racing interleaving where an `A` scrubs a not-yet-restored `B`.
+#[turbo_tasks::function(operation, root)]
+async fn diamond_root(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..DIAMOND_FANOUT {
+        let target = diamond_target(*constant, index).to_resolved().await?;
+        sum = sum.wrapping_add(*target.await?);
+        sum = sum.wrapping_add(*diamond_reader(*target).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
 #[turbo_tasks::function]
 async fn branch_a() -> Result<Vc<u32>> {
     Ok(Vc::cell(1 + *leaf(10).await?))
@@ -899,5 +951,77 @@ async fn gc_keeps_reanchored_cross_session_root() {
         .await
         .unwrap();
         tt.stop_and_wait().await;
+    }
+}
+
+/// Regression for the cross-session cascade panic found by the gc-04 dogfood: collecting an
+/// orphaned root whose subtree contains a **forward cell-dependency** to a target that is
+/// **disk-only** (not restored this session) must scrub that stale reverse edge by restoring the
+/// live target — not panic on a "target not resident, would resurrect a collected task" guard.
+///
+/// Setup (see the diamond fixture): each `diamond_reader` `A` holds a forward cell-dep on a
+/// `diamond_target` `B` that is *not* its child; both are children of `diamond_root`. In session 1
+/// we build and persist the whole diamond. In session 2 we reopen (nothing re-requests the root, so
+/// with TTL 0 it ages out) and run one GC pass: the root is collected and its `A`/`B` children
+/// cascade concurrently. When an `A`'s `CleanupOldEdges` opens its target `B` to remove the stale
+/// `cell_dependents` edge, `B` may not yet have been restored from disk — the disk-only case the
+/// old `gc_target_resident` debug_assert wrongly rejected. The whole pass completing without a
+/// panic is the assertion; session 3 confirms a clean recompute (no dangling reverse edge
+/// survived).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_collect_scrubs_disk_only_forward_dep_target() {
+    let dir = create_test_persistence_dir("gc_collect_scrubs_disk_only_forward_dep_target");
+
+    // Session 1: build the diamond and persist it.
+    {
+        let tt = open_tt_at(dir.path());
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let constant_op = create_constant();
+            let constant_vc = constant_op.resolve().strongly_consistent().await?;
+            // Read the root so the whole diamond is built and persisted.
+            diamond_root(constant_vc).read_strongly_consistent().await?;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
+
+    // Session 2: reopen, TTL 0, run one GC pass. The diamond root is never re-requested, so it ages
+    // out; collecting it cascades to every A/B pair. B targets are disk-only until the cascade
+    // restores them — an A that scrubs its target before that must restore it, not panic.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(0);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // No panic in this pass is the assertion (the old guard fired inside CleanupOldEdges).
+            let collected = tt2.backend().gc_for_testing(&tt2);
+            assert!(
+                collected >= 1,
+                "the orphaned diamond root subtree should be collected (got {collected})"
+            );
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
+
+    // Session 3: a clean recompute must still work — no dangling reverse edge left on any target.
+    {
+        let tt = open_tt_at(dir.path());
+        let result = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let constant_op = create_constant();
+            let constant_vc = constant_op.resolve().strongly_consistent().await?;
+            diamond_root(constant_vc).read_strongly_consistent().await?;
+            anyhow::Ok(())
+        })
+        .await;
+        tt.stop_and_wait().await;
+        result.unwrap();
     }
 }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1025,20 +1025,18 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
     let data_count = grouped_fields.persisted_data_flags_count();
     let persisted_count = meta_count + data_count;
 
-    // Ensure counts fit within u16 bitfield (and u8 for individual categories)
+    // Ensure counts fit within u32 bitfield (and u8 for individual categories)
     assert!(
-        meta_count <= 8,
-        "Too many persisted meta flags ({meta_count}), maximum is 8 (though this could be \
-         expanded)"
+        meta_count <= 16,
+        "Too many persisted meta flags ({meta_count}), maximum is 16"
     );
     assert!(
-        data_count <= 8,
-        "Too many persisted data flags ({data_count}), maximum is 8 (though this could be \
-         expanded)"
+        data_count <= 16,
+        "Too many persisted data flags ({data_count}), maximum is 16"
     );
     assert!(
-        all_flags.len() <= 16,
-        "Too many total flags ({}), maximum is 16 (though this could be expanded)",
+        all_flags.len() <= 32,
+        "Too many total flags ({}), maximum is 32",
         all_flags.len()
     );
 
@@ -1063,17 +1061,17 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
     // Data flags are in bits meta_count..meta_count+data_count
     // Combined persisted mask covers both
     let meta_mask = if meta_count > 0 {
-        (1u16 << meta_count) - 1
+        (1u32 << meta_count) - 1
     } else {
         0
     };
     let data_mask = if data_count > 0 {
-        ((1u16 << data_count) - 1) << meta_count
+        ((1u32 << data_count) - 1) << meta_count
     } else {
         0
     };
     let persisted_mask = if persisted_count > 0 {
-        (1u16 << persisted_count) - 1
+        (1u32 << persisted_count) - 1
     } else {
         0
     };
@@ -1085,7 +1083,7 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
             #[doc = "Bit layout: [meta flags: 0..M] [data flags: M..M+D] [transient: M+D..]"]
             #[doc = "This ordering allows separate masks for per-category serialization."]
             #[derive(Clone, Default, PartialEq, Eq)]
-            pub struct TaskFlags(u16);
+            pub struct TaskFlags(u32);
             impl Debug;
 
             #(#bitfield_accessors;)*
@@ -1094,54 +1092,54 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
         #[automatically_derived]
         impl TaskFlags {
             #[doc = "Mask for persisted meta flags"]
-            pub const META_MASK: u16 = #meta_mask;
+            pub const META_MASK: u32 = #meta_mask;
 
             #[doc = "Mask for persisted data flags"]
-            pub const DATA_MASK: u16 = #data_mask;
+            pub const DATA_MASK: u32 = #data_mask;
 
             #[doc = "Mask for all persisted flags (meta + data)"]
-            pub const PERSISTED_MASK: u16 = #persisted_mask;
+            pub const PERSISTED_MASK: u32 = #persisted_mask;
 
             #[doc = "Get the raw bits value"]
-            pub fn bits(&self) -> u16 {
+            pub fn bits(&self) -> u32 {
                 self.0
             }
 
             #[doc = "Get only the persisted meta bits (for meta serialization)"]
-            pub fn persisted_meta_bits(&self) -> u8 {
+            pub fn persisted_meta_bits(&self) -> u16 {
                 // Meta bits are in the lowest positions (bits 0..meta_count),
-                // and we assert meta_count <= 8, so this fits in a u8
-                (self.0 & Self::META_MASK) as u8
+                // and we assert meta_count <= 16, so this fits in a u16
+                (self.0 & Self::META_MASK) as u16
             }
 
             #[doc = "Get only the persisted data bits (for data serialization)"]
-            pub fn persisted_data_bits(&self) -> u8 {
+            pub fn persisted_data_bits(&self) -> u16 {
                 // Data bits are in positions meta_count..meta_count+data_count,
                 // so we shift right to get them into the low bits.
-                // We assert data_count <= 8, so this fits in a u8
-                ((self.0 & Self::DATA_MASK) >> #meta_count) as u8
+                // We assert data_count <= 16, so this fits in a u16
+                ((self.0 & Self::DATA_MASK) >> #meta_count) as u16
             }
 
             #[doc = "Get all persisted bits (for serialization)"]
-            pub fn persisted_bits(&self) -> u16 {
+            pub fn persisted_bits(&self) -> u32 {
                 self.0 & Self::PERSISTED_MASK
             }
 
             #[doc = "Set meta bits from a raw value, preserving other flags"]
-            pub fn set_persisted_meta_bits(&mut self, bits: u8) {
+            pub fn set_persisted_meta_bits(&mut self, bits: u16) {
                 // Meta bits go in the lowest positions (bits 0..meta_count)
-                self.0 = (self.0 & !Self::META_MASK) | (bits as u16 & Self::META_MASK);
+                self.0 = (self.0 & !Self::META_MASK) | (bits as u32 & Self::META_MASK);
             }
 
             #[doc = "Set data bits from a raw value, preserving other flags"]
-            pub fn set_persisted_data_bits(&mut self, bits: u8) {
+            pub fn set_persisted_data_bits(&mut self, bits: u16) {
                 // Data bits go in positions meta_count..meta_count+data_count,
                 // so we shift left to place them correctly
-                self.0 = (self.0 & !Self::DATA_MASK) | (((bits as u16) << #meta_count) & Self::DATA_MASK);
+                self.0 = (self.0 & !Self::DATA_MASK) | (((bits as u32) << #meta_count) & Self::DATA_MASK);
             }
 
             #[doc = "Set all persisted bits from a raw value, preserving transient flags"]
-            pub fn set_persisted_bits(&mut self, bits: u16) {
+            pub fn set_persisted_bits(&mut self, bits: u32) {
                 self.0 = (self.0 & !Self::PERSISTED_MASK) | (bits & Self::PERSISTED_MASK);
             }
 
@@ -1162,7 +1160,7 @@ fn generate_task_flags_bitfield(grouped_fields: &GroupedFields) -> TokenStream {
             }
 
             #[doc = "Create from raw bits (for deserialization)"]
-            pub fn from_bits(bits: u16) -> Self {
+            pub fn from_bits(bits: u32) -> Self {
                 Self(bits)
             }
         }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1676,6 +1676,7 @@ fn generate_task_storage_accessors_trait(grouped_fields: &GroupedFields) -> Toke
             #[doc = "- `Data` or `Meta`: Checks that the task was accessed with that category"]
             #[doc = ""]
             #[doc = "Implementors should check that the provided category matches how the task was accessed."]
+            #[track_caller]
             fn check_access(&self, category: crate::backend::storage::SpecificTaskDataCategory);
 
             #[doc = "Shrink all collection fields to fit their current contents."]
@@ -3087,9 +3088,15 @@ fn generate_drop_method(grouped_fields: &GroupedFields) -> TokenStream {
             StorageType::AutoMap | StorageType::AutoSet | StorageType::CounterMap => quote! {
                 self.#field_name.is_empty()
             },
-            StorageType::Direct => quote! {
-                self.#field_name == Default::default()
-            },
+            StorageType::Direct => {
+                // Fully-qualified `Default` so a bare scalar field (e.g. `u32`) doesn't trip
+                // `Default::default()` type-inference ambiguity — the newtype direct fields infer
+                // fine, but a primitive needs the type spelled out.
+                let field_type = &field.field_type;
+                quote! {
+                    self.#field_name == <#field_type as Default>::default()
+                }
+            }
             StorageType::Flag => unreachable!(),
         }
     }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -735,6 +735,18 @@ pub trait Backend: Sized + Sync + Send {
         // Do nothing by default
     }
 
+    /// Pin a task against garbage collection (via [`prevent_gc`](crate::prevent_gc)). A pinned task
+    /// is treated as a GC root, keeping alive references that escape the tracked task graph. The
+    /// default is a no-op for backends without GC.
+    fn pin_task_for_gc(&self, _task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // Do nothing by default
+    }
+
+    /// Removes a pin added by [`pin_task_for_gc`](Backend::pin_task_for_gc).
+    fn unpin_task_for_gc(&self, _task: TaskId, _turbo_tasks: &TurboTasks<Self>) {
+        // Do nothing by default
+    }
+
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -97,7 +97,7 @@ pub use crate::{
     },
     join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt},
     manager::{
-        CurrentCellRef, InputResolution, ReadCellTracking, ReadConsistency, ReadTracking,
+        CurrentCellRef, GcRoot, InputResolution, ReadCellTracking, ReadConsistency, ReadTracking,
         TaskPersistence, TaskPriority, TurboTasks, TurboTasksApi, TurboTasksCallApi, Unused,
         UpdateInfo, dynamic_call, emit, get_serialization_invalidator, mark_finished,
         mark_stateful, mark_top_level_task, prevent_gc, run, run_once, run_once_with_reason,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1969,6 +1969,43 @@ pub fn prevent_gc() {
     }
 }
 
+/// An RAII guard that pins a task against garbage collection for as long as the guard is alive,
+/// unpinning it on drop. Use this to anchor a task whose lifetime is owned by a Rust value that
+/// lives outside the tracked task graph — e.g. a permanent root operation held by a long-lived
+/// handle (the `ProjectContainer` operation held by a NAPI `ProjectInstance` for the session).
+///
+/// This is the balanced, drop-safe form of [`TurboTasks::pin_task_for_gc`] /
+/// [`unpin_task_for_gc`](TurboTasks::unpin_task_for_gc): the pin and unpin are paired by the
+/// guard's lifetime, so there is no hand-written unpin to forget or double-call.
+/// `unpin_task_for_gc` is itself a no-op once the backend is stopping, so dropping a `GcRoot`
+/// during shutdown is safe.
+///
+/// Not `Clone`: each guard owns exactly one pin. To share one pin across several owners, wrap the
+/// guard in an [`Arc`].
+pub struct GcRoot {
+    tt: Arc<dyn TurboTasksApi>,
+    task: TaskId,
+}
+
+impl GcRoot {
+    /// Pins `task`, returning a guard that unpins it on drop.
+    pub fn pin(tt: Arc<dyn TurboTasksApi>, task: TaskId) -> Self {
+        tt.pin_task_for_gc(task);
+        Self { tt, task }
+    }
+
+    /// The task this guard is pinning.
+    pub fn task_id(&self) -> TaskId {
+        self.task
+    }
+}
+
+impl Drop for GcRoot {
+    fn drop(&mut self) {
+        self.tt.unpin_task_for_gc(self.task);
+    }
+}
+
 pub fn emit<T: VcValueTrait + ?Sized>(collectible: ResolvedVc<T>) {
     with_turbo_tasks(|tt| {
         let raw_vc = collectible.node.node;

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -185,6 +185,13 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     );
     fn mark_own_task_as_finished(&self, task: TaskId);
 
+    /// Pin a task against garbage collection. Delegates to
+    /// [`Backend::pin_task_for_gc`](crate::backend::Backend::pin_task_for_gc).
+    fn pin_task_for_gc(&self, task: TaskId);
+
+    /// Removes a pin added by [`pin_task_for_gc`](TurboTasksApi::pin_task_for_gc).
+    fn unpin_task_for_gc(&self, task: TaskId);
+
     fn connect_task(&self, task: TaskId);
 
     /// Wraps the given future in the current task.
@@ -689,6 +696,18 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
     pub fn dispose_root_task(&self, task_id: TaskId) {
         self.backend.dispose_root_task(task_id, self);
+    }
+
+    /// Pins a task against garbage collection (a transient, session-only reference). Balanced by
+    /// [`unpin_task_for_gc`](Self::unpin_task_for_gc). Used for references that escape the tracked
+    /// task graph — e.g. a `DetachedVc` holding an `OperationVc` across the NAPI boundary.
+    pub fn pin_task_for_gc(&self, task_id: TaskId) {
+        self.backend.pin_task_for_gc(task_id, self);
+    }
+
+    /// Releases a pin added by [`pin_task_for_gc`](Self::pin_task_for_gc).
+    pub fn unpin_task_for_gc(&self, task_id: TaskId) {
+        self.backend.unpin_task_for_gc(task_id, self);
     }
 
     // TODO make sure that all dependencies settle before reading them
@@ -1605,6 +1624,14 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.mark_own_task_as_finished(task, self);
     }
 
+    fn pin_task_for_gc(&self, task: TaskId) {
+        self.backend.pin_task_for_gc(task, self);
+    }
+
+    fn unpin_task_for_gc(&self, task: TaskId) {
+        self.backend.unpin_task_for_gc(task, self);
+    }
+
     /// Creates a future that inherits the current task id and task state. The current global task
     /// will wait for this future to be dropped before exiting.
     fn spawn_detached_for_testing(&self, fut: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
@@ -1929,8 +1956,17 @@ pub fn unmark_top_level_task_may_leak_eventually_consistent_state() {
     }
 }
 
+/// Pins the current task against garbage collection for the rest of the session, keeping it (and,
+/// via the reachability it anchors, the values it produced) alive even if it becomes disconnected
+/// from the live task graph. Use this when a value escapes the tracked graph — e.g. a `Vc` sent out
+/// of a `spawn_detached` future across a channel, or handed across the NAPI boundary — so no
+/// persistent parent lists it as a child and it would otherwise be collected.
+///
+/// No-op outside a task context, and on backends without garbage collection.
 pub fn prevent_gc() {
-    // TODO implement garbage collection
+    if let Some(task) = current_task_if_available("prevent_gc") {
+        with_turbo_tasks(|tt| tt.pin_task_for_gc(task));
+    }
 }
 
 pub fn emit<T: VcValueTrait + ?Sized>(collectible: ResolvedVc<T>) {

--- a/turbopack/crates/turbo-tasks/src/task_dirty_cause.rs
+++ b/turbopack/crates/turbo-tasks/src/task_dirty_cause.rs
@@ -21,6 +21,9 @@ pub enum TaskDirtyCause {
         collectible_type: TraitTypeId,
     },
     Invalidator,
+    /// Re-dirtied because a GC-soft-deleted task was resurrected by a new connection before its
+    /// hard-delete: its edges were scrubbed, so it must re-execute to rebuild them.
+    Resurrected,
     Unknown,
 }
 
@@ -83,6 +86,7 @@ impl std::fmt::Display for TaskDirtyCause {
                 )
             }
             TaskDirtyCause::Invalidator => write!(f, "invalidator"),
+            TaskDirtyCause::Resurrected => write!(f, "resurrected"),
             TaskDirtyCause::Unknown => write!(f, "unknown"),
         }
     }

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -192,6 +192,10 @@ impl<T: ?Sized> OperationVc<T> {
     {
         self.connect().into_trait_ref().strongly_consistent()
     }
+
+    pub fn task_id(self) -> TaskId {
+        self.task
+    }
 }
 
 impl<T> Copy for OperationVc<T> where T: ?Sized {}


### PR DESCRIPTION
### What?

Reworks how the reference-counting GC decides what is a **root** (a task that must not be collected), and adds a durable path to reclaim cross-session orphans.

This PR stacks on #95977 (which added `parent_count`/`transient_ref_count` reference counting and wired GC into the app). It replaces the "every parent-less task is a permanent root" rule with explicit anchoring, and closes the two leaks that rule was papering over:

1. **In-session** — disposable top-level ops (the `initialize`/`update` stubs, per-request source-map ops) no longer leak for the whole session.
2. **Cross-session** — a persisted subtree whose root is never re-requested in a later session (a deleted route, or a root left pinned by the shutdown race) is now aged out and collected instead of leaking on disk forever.

### Why?

The previous strategy flagged **any task created with no parent** as a permanent, persisted `gc_root` that hard-vetoed collection. Two problems fell out of that:

- **Disposable roots never died.** Top-level stub ops (e.g. the `update`/`initialize` container hacks, per-request source-map ops) are read once and dropped, but being created parent-less flagged them uncollectible for the whole session — so each such op is a permanent leak. Being a root should mean "something is actually holding this," not "this happened to be created at the top level."
- **The GC only scans the resident map.** A route deleted between session A and session B — if its subtree is never brought back into memory — had its on-disk reference count decremented by nothing, so it (and everything transitively reachable from it) leaked on disk permanently. The resident-only scan structurally cannot reach that garbage.

### How?

**Anchor roots explicitly instead of by topology.** A task is now kept alive only while a *real* anchor holds it — a live parent (`parent_count > 0`) or an external hold (`transient_ref_count > 0`, i.e. a transient parent or an explicit pin). The blanket `parent_task.is_none()` flagging is removed. A new `GcRoot` RAII guard (pins on construct, unpins on drop, not `Clone`) anchors the one genuinely permanent root — the `ProjectContainer` operation — for the lifetime of the JS-held `ProjectInstance`. This is what lets the disposable stubs collect right after their single read: they're held only by activeness while the read is in flight, and GC only runs at quiescence.

**Persisted roots set + TTL age-out (the cross-session backstop).** A new Infra-keyspace `GcRoots` entry persists `Vec<(TaskId, last_anchored_ms)>`. Every GC pass refreshes the timestamp of each root that is still anchored, keeps the timestamp of roots that aren't, and collects any root un-anchored past a wall-clock TTL (default 24h) — re-validating collectibility under a guard before seeding the cascade, never blind-deleting. So "orphaned for 24h" = "not anchored in any GC pass for 24h"; a branch-switch-back re-anchors a root lazily on demand and resets its clock, while a genuinely-deleted route ages out. This also subsumes the shutdown race for free: a root left pinned at teardown persists, and if the next session never re-anchors it, it ages out on the same path as a deleted route.

**Dispose transient root tasks on drop.** `RootTask::Drop` was a no-op, so a subscription's transient root task leaked whenever JS skipped explicit disposal. `Drop` now disposes as an idempotent backstop, and disposing a clean root tears down its outgoing edges via `CleanupOldEdges` — shedding the `transient_ref_count` its child edges placed on the persistent tasks it read (and rebalancing the aggregation graph) — so the subscription's subgraph becomes collectible. Disposal is a no-op once `stopping`, mirroring `gc_pin`/`gc_unpin`, so a root finalized during Node teardown is safe.

**Remove the now-dead `gc_root` flag** from the task storage schema (the roots map fully replaces its veto role), shifting the persisted flag-bit layout. The on-disk cache is versioned by git-describe, so the layout change is safe across released binaries.

**Fixes found by dogfooding the cross-session path** (all unreachable by the small unit-test subtrees, only surfaced by a real deleted-route restart with GC on):
- `CleanupOldEdges` cell/output-dependency arms asserted the scrub target was resident. But a forward-dependency target is an upstream *producer* the task reads from, not a child; under a cross-session cascade that producer can be disk-only — a live persistent task, not a collected one. Restore it `MustExist` and scrub the stale reverse edge (correct), instead of asserting.
- Seeded-cascade collectibility was a `debug_assert!`, but jobs run concurrently under `scope_unbounded` and a sibling cascade can flip a task non-collectible between spawn and execution. Re-check `is_gc_collectible` under the held guard and skip instead of asserting — self-healing (still-garbage tasks are re-selected next pass).
- The `CollectiblesDependency` arm opened its dependent with `Data` access, but `collectibles_dependents` is a `Meta`-category field, so scrubbing that edge panicked `check_access`. Open it with `Meta`.

Also adds GC tracing (`NEXT_TURBOPACK_TRACING=turbo-tasks`) so the dogfood can confirm a deleted route's subtree is reclaimed in a *later* session, tagging cross-session-root collects distinctly from resident-scan collects.

### Testing

- Backend suites green with `TURBO_ENGINE_GC=1`: `parent_count` (incl. new `gc_collects_cross_session_orphan_root`, `gc_keeps_reanchored_cross_session_root`, `gc_collect_scrubs_disk_only_forward_dep_target`, and the root-disposal tests), `gc_stress`, `gc_resurrection`, `detached`.
- End-to-end dogfood: `next dev` on an example app with `TURBO_ENGINE_GC=1 TURBO_ENGINE_IGNORE_DIRTY=1` — all routes served, HMR works across edits, clean shutdown runs stop-time GC, and a cross-session restart with a route deleted serves the surviving routes, 404s the deleted route, and (with `TURBO_ENGINE_GC_ROOT_TTL_MS=0`) reclaims the deleted route's subtree — with zero panics.
