### PR TITLE
fix(codemod): rename middleware files even when AST is unchanged

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-reexport.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-reexport.input.ts
@@ -1,0 +1,6 @@
+export { auth as default } from './auth'
+
+// Optionally, don't invoke Middleware on some paths
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-reexport.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-reexport.output.ts
@@ -1,0 +1,6 @@
+export { auth as default } from './auth'
+
+// Optionally, don't invoke Middleware on some paths
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+}

--- a/packages/next-codemod/transforms/__tests__/middleware-to-proxy.test.js
+++ b/packages/next-codemod/transforms/__tests__/middleware-to-proxy.test.js
@@ -1,8 +1,9 @@
 /* global jest */
 jest.autoMockOff()
 const defineTest = require('jscodeshift/dist/testUtils').defineTest
-const { readdirSync } = require('fs')
+const { readdirSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } = require('fs')
 const { join } = require('path')
+const { tmpdir } = require('os')
 
 const fixtureDir = 'middleware-to-proxy'
 const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
@@ -14,3 +15,66 @@ for (const fixture of fixtures) {
   const prefix = `${fixtureDir}/${fixture}`
   defineTest(__dirname, fixtureDir, null, prefix, { parser: 'ts' })
 }
+
+describe('middleware-to-proxy file rename', () => {
+  let originalNodeEnv
+  let testDir
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV
+    // Force the real rename path (skipped when NODE_ENV === 'test').
+    process.env.NODE_ENV = 'production'
+    testDir = join(
+      tmpdir(),
+      `middleware-to-proxy-rename-${Date.now()}-${(Math.random() * 1000) | 0}`
+    )
+    mkdirSync(testDir, { recursive: true })
+    // Re-require so the transform sees the updated NODE_ENV for path checks.
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
+    if (testDir && existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('renames middleware.ts to proxy.ts when no content changes are needed', () => {
+    const transformer = require('../middleware-to-proxy').default
+    const middlewarePath = join(testDir, 'middleware.ts')
+    const source = `export { auth as default } from "./auth";
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};
+`
+    writeFileSync(middlewarePath, source)
+
+    const result = transformer({ path: middlewarePath, source }, {})
+
+    expect(result).toBe('')
+    expect(existsSync(middlewarePath)).toBe(false)
+    expect(existsSync(join(testDir, 'proxy.ts'))).toBe(true)
+    expect(readFileSync(join(testDir, 'proxy.ts'), 'utf8')).toBe(source)
+  })
+
+  it('renames middleware.ts to proxy.ts when content is transformed', () => {
+    const transformer = require('../middleware-to-proxy').default
+    const middlewarePath = join(testDir, 'middleware.ts')
+    const source = `export function middleware() {
+  return Response.next()
+}
+`
+    writeFileSync(middlewarePath, source)
+
+    const result = transformer({ path: middlewarePath, source }, {})
+
+    expect(result).toBe('')
+    expect(existsSync(middlewarePath)).toBe(false)
+    expect(existsSync(join(testDir, 'proxy.ts'))).toBe(true)
+    expect(readFileSync(join(testDir, 'proxy.ts'), 'utf8')).toContain(
+      'export function proxy()'
+    )
+  })
+})

--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -74,7 +74,12 @@ export default function transformer(file: FileInfo) {
     hasChanges = hasChanges || hasConfigChanges
   }
 
+  // Middleware files must still be renamed to proxy.* even when the source
+  // does not need AST edits (e.g. `export { auth as default } from './auth'`).
   if (!hasChanges) {
+    if (isMiddlewareFile) {
+      return handleMiddlewareFileRename(file, file.source)
+    }
     return file.source
   }
 


### PR DESCRIPTION
## Summary

Fixes the `middleware-to-proxy` codemod skipping the `middleware.* → proxy.*` rename when the file contents don't require any AST transformations.

This commonly occurs with Auth.js-style middleware that only re-exports a handler:

```ts
export { auth as default } from "./auth";

export const config = {
  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
};
```

Since there are no middleware identifiers, runtime config changes, or type imports to rewrite, `hasChanges` remained `false`. The transform returned early and never called `handleMiddlewareFileRename`, leaving `middleware.ts` unchanged.

With this change, middleware entry files are always renamed to `proxy.*`, even when their contents don't change. Existing content transformations continue to behave exactly as before.

Fixes #86478.

## Why

Next.js 16 renamed `middleware` to `proxy`, and the official codemod is the recommended migration path. The official Auth.js example is a common no-op transformation case, so users could run the codemod successfully but still be left with a deprecated `middleware.ts` file.

## Changes

* Update `packages/next-codemod/transforms/middleware-to-proxy.ts`
* When `hasChanges === false` but the file is a middleware entry, call:

  ```ts
  handleMiddlewareFileRename(file, file.source)
  ```

  instead of returning early.
* Preserve existing behavior for all content transformations.

## Test Plan

* Reproduced locally with an Auth.js-style `middleware.ts` that only re-exports `auth`.

  * **Before:** File was not renamed.
  * **After:** File is correctly renamed to `proxy.ts` with identical contents.
* Added a `default-reexport` fixture covering the no-AST-change scenario.
* Added unit tests (forcing the real rename path with `NODE_ENV=production`) to verify:

  * Middleware files with no content changes are renamed.
  * Middleware files with content transformations are still renamed.

```bash
cd packages/next-codemod
pnpm build
pnpm test transforms/__tests__/middleware-to-proxy.test.js
```

**Result:** 26/26 tests passed.
