### PR TITLE
[testmode] Fix infinite recursion in testmode passthrough fetch

### DIFF
--- a/packages/next/src/experimental/testmode/fetch.ts
+++ b/packages/next/src/experimental/testmode/fetch.ts
@@ -82,6 +82,18 @@ function buildResponse(proxyResponse: ProxyFetchResponse): Response {
   })
 }
 
+function passthroughFetch(
+  originalFetch: Fetch,
+  request: Request
+): Promise<Response> {
+  // Mark the request so the ClientRequest interception in `httpget.ts` sends it
+  // to the real server instead of intercepting it again. @mswjs/interceptors
+  // intercepts at the TCP level, so an unmarked passthrough would re-enter the
+  // interception listener from within itself, recursing indefinitely.
+  request.headers.set('next-test-internal', '1')
+  return originalFetch(request)
+}
+
 export async function handleFetch(
   originalFetch: Fetch,
   request: Request
@@ -89,7 +101,7 @@ export async function handleFetch(
   const testInfo = getTestReqInfo(request, reader)
   if (!testInfo) {
     // Passthrough non-test requests.
-    return originalFetch(request)
+    return passthroughFetch(originalFetch, request)
   }
 
   const { testData, proxyPort } = testInfo
@@ -119,7 +131,7 @@ export async function handleFetch(
   const { api } = proxyResponse
   switch (api) {
     case 'continue':
-      return originalFetch(request)
+      return passthroughFetch(originalFetch, request)
     case 'abort':
     case 'unhandled':
       throw new Error(

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -56,6 +56,11 @@ describe('testmode', () => {
       expect(html).not.toContain('<pre>test1</pre>')
     })
 
+    it('should pass http.get through to the real server when Next-Test-* headers are not present', async () => {
+      const html = await (await next.fetch('/app/rsc-httpget')).text()
+      expect(html).toContain('Example Domain')
+    })
+
     it('should handle RSC with fetch in serverless function', async () => {
       const html = await (await fetchForTest('/app/rsc-fetch')).text()
       expect(html).toContain('<pre>test1</pre>')


### PR DESCRIPTION
With `experimental.testProxy` on, `@mswjs/interceptors` (switched to socket-level interception in #96059) also catches the passthrough `fetch` that `handleFetch` makes for non-test requests. That request has no `next-test-internal` marker, so the interceptor calls `handleFetch` again, takes the passthrough branch again, and loops until it errors. So any server-side request made outside a test context never resolves during a test run.

This adds the `next-test-internal` marker to the passthrough request, and to the `continue` case that has the same problem. It is the guard #96059 already added for the proxy-protocol request, so the request reaches the real server instead of being intercepted again.

Fixes #96521
Closes https://github.com/vercel/next.js/pull/97257
