### PR TITLE
Edits to turbopackFileSystemCache

### DIFF
--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -276,32 +276,7 @@ export default nextConfig
 
 ### Turbopack File System Caching
 
-Turbopack stores compiler artifacts on disk between runs, for significantly faster compile times across restarts. Starting with 16.3, filesystem caching is enabled by default for both `next dev` and `next build`. See [`turbopackFileSystemCache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) to configure or disable it.
-
-On 16.0 through 16.2, filesystem caching was in beta and opt-in:
-
-```ts filename="next.config.ts" switcher
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  experimental: {
-    turbopackFileSystemCacheForDev: true,
-  },
-}
-
-export default nextConfig
-```
-
-```js filename="next.config.js" switcher
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    turbopackFileSystemCacheForDev: true,
-  },
-}
-
-module.exports = nextConfig
-```
+Turbopack stores compiler artifacts on disk between runs, for significantly faster compile times across restarts. Filesystem caching is enabled by default for both `next dev` and `next build`. See [`turbopackFileSystemCache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) to configure or disable it.
 
 ## Async Request APIs (Breaking change)
 

--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -274,11 +274,11 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-### Turbopack File System Caching (beta)
+### Turbopack File System Caching
 
-Turbopack now supports filesystem caching in development, storing compiler artifacts on disk between runs for significantly faster compile times across restarts.
+Turbopack stores compiler artifacts on disk between runs, for significantly faster compile times across restarts. Starting with 16.3, filesystem caching is enabled by default for both `next dev` and `next build`. See [`turbopackFileSystemCache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) to configure or disable it.
 
-Enable filesystem caching in your configuration:
+On 16.0 through 16.2, filesystem caching was in beta and opt-in:
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
@@ -6,7 +6,7 @@ description: Learn how to enable and configure FileSystem Caching for Turbopack 
 
 ## Usage
 
-Turbopack FileSystem Cache enables Turbopack to reduce work across `next dev` or `next build` commands. When enabled, Turbopack will save and restore data to the `.next/cache` directory between builds, which can greatly speed up subsequent builds and dev sessions.
+Turbopack FileSystem Cache enables Turbopack to reduce work across `next dev` or `next build` commands. When enabled, Turbopack will save and restore data under the `.next` directory between runs, which can greatly speed up subsequent builds and dev sessions.
 
 Two options control the cache, one for `next dev` and one for `next build`. Both are enabled by default:
 
@@ -37,8 +37,8 @@ module.exports = nextConfig
 
 ## Options
 
-- **`turbopackFileSystemCacheForDev`** (default: `true`): caches Turbopack's work for `next dev`. Restarting the dev server reuses the previous compilation.
-- **`turbopackFileSystemCacheForBuild`** (default: `true`): caches Turbopack's work for `next build`. Subsequent builds start warm. See [Build environments](#build-environments).
+- **`turbopackFileSystemCacheForDev`** (default: `true`): caches Turbopack's work for `next dev` in `.next/dev/cache/turbopack`. Restarting the dev server reuses the previous compilation.
+- **`turbopackFileSystemCacheForBuild`** (default: `true`): caches Turbopack's work for `next build` in `.next/cache/turbopack`. Subsequent builds start warm. See [Build environments](#build-environments).
 
 Set either option to `false` to opt out.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
@@ -1,21 +1,20 @@
 ---
 title: Turbopack FileSystem Caching
 nav_title: turbopackFileSystemCache
-description: Learn how to enable FileSystem Caching for Turbopack builds
+description: Learn how to enable and configure FileSystem Caching for Turbopack builds
 ---
 
 ## Usage
 
-Turbopack FileSystem Cache enables Turbopack to reduce work across `next dev` or `next build` commands. When enabled, Turbopack will save and restore data to the `.next` folder between builds, which can greatly speed up subsequent builds and dev sessions.
+Turbopack FileSystem Cache enables Turbopack to reduce work across `next dev` or `next build` commands. When enabled, Turbopack will save and restore data to the `.next/cache` directory between builds, which can greatly speed up subsequent builds and dev sessions.
 
-> **Good to know:** The FileSystem Cache is **enabled by default** for `next dev` and `next build`. You can explicitly disable it with the flags below when your build environment does not preserve the `.next/cache` directory between builds.
+Two options control the cache, one for `next dev` and one for `next build`. Both are enabled by default:
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   experimental: {
-    // Filesystem caching is enabled by default; set to `false` to disable it.
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: true,
   },
@@ -28,7 +27,6 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    // Filesystem caching is enabled by default; set to `false` to disable it.
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: true,
   },
@@ -37,7 +35,23 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-## Version Changes
+## Options
+
+- **`turbopackFileSystemCacheForDev`** (default: `true`): caches Turbopack's work for `next dev`. Restarting the dev server reuses the previous compilation.
+- **`turbopackFileSystemCacheForBuild`** (default: `true`): caches Turbopack's work for `next build`. Subsequent builds start warm. See [Build environments](#build-environments).
+
+Set either option to `false` to opt out.
+
+## Build environments
+
+The build cache lives in `.next/cache`. Builds only get faster when that directory is restored before each build.
+
+- **Self-hosted builds**: reuse the same working directory between builds. Containerized builds start from a clean layer and do not carry `.next/cache` over unless you cache or mount it explicitly.
+- **CI providers**: [configure build caching](/docs/app/guides/ci-build-caching) for `.next/cache`.
+
+If your build environment never preserves `.next/cache`, set `turbopackFileSystemCacheForBuild: false` to skip writing a cache that will not be read.
+
+## Version History
 
 | Version   | Changes                                                        |
 | --------- | -------------------------------------------------------------- |

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -346,12 +346,12 @@ This can lead to subtle rendering differences when migrating from webpack to Tur
 
 ### Build Caching
 
-Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar feature. Starting with Next 16, Turbopack's filesystem cache is controlled by the following experimental flags:
+Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar feature, with separate options for `next dev` and `next build`. **Both are enabled by default**:
 
-- [`experimental.turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled by default
-- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled by default
+- [`experimental.turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) for the dev server.
+- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) for builds. Builds only get faster in [environments that preserve `.next/cache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache#build-environments).
 
-> **Good to know:** For this reason, when comparing webpack and Turbopack performance, make sure to delete the `.next` folder between builds to see a fair cold build comparison or enable the turbopack filesystem cache feature to compare warm builds.
+> **Good to know:** Both bundlers write their build cache under `.next/cache`. A second build in the same directory is warm. When comparing webpack and Turbopack cold build performance, delete the `.next` folder between builds.
 
 ### Webpack plugins
 
@@ -420,13 +420,15 @@ Additionally, the following experimental options are available under `experiment
 | [`turbopackLocalPostcssConfig`](/docs/app/api-reference/config/next-config-js/turbopackLocalPostcssConfig)   | Resolve `postcss.config.js` from the CSS file's directory first, then the project root.                                                      | `false`       | `false`                       |
 | `turbopackWorkerAssetPrefix`                                                                                 | Custom asset prefix for Web Worker URLs (entrypoint + module chunks), overriding `assetPrefix`. Mirrors webpack's `output.workerPublicPath`. | `undefined`   | `undefined`                   |
 
-<sup>1</sup> Enabled by default. Set the option to `false` when the build
-environment does not preserve the `.next/cache` directory between builds.
+**Table notes:**
+
+1. Enabled by default. Set the option to `false` when the build environment does not preserve the `.next/cache` directory between builds.
+
+For example, to configure an alias and a custom file extension under the `turbopack` key:
 
 ```js filename="next.config.js"
 module.exports = {
   turbopack: {
-    // Example: adding an alias and custom file extension
     resolveAlias: {
       underscore: 'lodash',
     },

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -13,7 +13,7 @@ We built Turbopack to push the performance of Next.js, including:
 
 - **Unified Graph:** Next.js supports multiple output environments (e.g., client and server). Managing multiple compilers and stitching bundles together can be tedious. Turbopack uses a **single, unified graph** for all environments.
 - **Bundling vs Native ESM:** Some tools skip bundling in development and rely on the browser's native ESM. This works well for small apps but can slow down large apps due to excessive network requests. Turbopack **bundles** in dev, but in an optimized way to keep large apps fast.
-- **Incremental Computation:** Turbopack parallelizes work across cores and **caches** results down to the function level. Once a piece of work is done, Turbopack won’t repeat it.
+- **Incremental Computation:** Turbopack parallelizes work across cores and **caches** results down to the function level. Once a piece of work is done, Turbopack won’t repeat it. Results persist to disk between runs.
 - **Lazy Bundling:** Turbopack only bundles what is actually requested by the dev server. This lazy approach can reduce initial compile times and memory usage.
 
 ## Supported platforms
@@ -119,10 +119,11 @@ Turbopack in Next.js has **zero-configuration** for the common use cases. Below 
 
 ### Performance and Fast Refresh
 
-| Feature                  | Status        | Notes                                                                                    |
-| ------------------------ | ------------- | ---------------------------------------------------------------------------------------- |
-| **Fast Refresh**         | **Supported** | Updates JavaScript, TypeScript, and CSS without a full refresh.                          |
-| **Incremental Bundling** | **Supported** | Turbopack lazily builds only what's requested by the dev server, speeding up large apps. |
+| Feature                  | Status        | Notes                                                                                                                                                       |
+| ------------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fast Refresh**         | **Supported** | Updates JavaScript, TypeScript, and CSS without a full refresh.                                                                                             |
+| **Incremental Bundling** | **Supported** | Turbopack lazily builds only what's requested by the dev server, speeding up large apps.                                                                    |
+| **FileSystem Cache**     | **Supported** | Persists compiler artifacts to disk between runs. See [`turbopackFileSystemCache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache). |
 
 ### Magic Comments
 
@@ -343,15 +344,6 @@ Turbopack uses [Lightning CSS](https://lightningcss.dev/) to compile CSS. Lightn
 - **Turbopack:** `line-height: 1.47059` (5 digits)
 
 This can lead to subtle rendering differences when migrating from webpack to Turbopack, especially for properties like `line-height`, `letter-spacing`, or other calculated values where high precision matters.
-
-### Build Caching
-
-Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar feature, with separate options for `next dev` and `next build`. **Both are enabled by default**:
-
-- [`experimental.turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) for the dev server.
-- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) for builds. Builds only get faster in [environments that preserve `.next/cache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache#build-environments).
-
-> **Good to know:** Both bundlers write their build cache under `.next/cache`. A second build in the same directory is warm. When comparing webpack and Turbopack cold build performance, delete the `.next` folder between builds.
 
 ### Webpack plugins
 


### PR DESCRIPTION
- Rework the `/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache` API reference.
- Adjust the table notes in `/docs/app/api-reference/turbopack#configuration` — `[^1]` works well, but the table notes are auto-magically placed at the bottom of the page. Going with this hand rolled table notes for now.
- Tidy the Build Caching section in `/docs/app/api-reference/turbopack#configuration`
- Update the Upgrade to version 16 section on dev/build cache
- Removed the `Build caching` from Webpack gaps
  - Added Filesystem caching to Performance and Fast Refresh 