### PR TITLE
test: skip hybrid not-found coverage for the legacy builder

### DIFF
--- a/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
+++ b/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
@@ -1,8 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
+
 describe('pages-router-app-not-found', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // The legacy builder incorrectly replaces this response with the Pages
+    // Router error page. The adapter preserves the App Router not-found page.
+    skipDeployment: !isAdapterTest,
   })
 
   it('fully renders an app not-found selected by a pages route', async () => {


### PR DESCRIPTION
## Summary

The `pages-router-app-not-found` test verifies behavior implemented by the Next.js adapter. The legacy `@vercel/next` builder has a pre-existing behavior where it prefers the Pages Router error page for this hybrid routing case.

Skip this test when deployment tests run without the adapter. It will continue running in development, `next start`, and adapter deployment tests.

## Verification

- `NEXT_TEST_MODE=deploy NEXT_ENABLE_ADAPTER=0 pnpm testheadless test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts`
- `pnpm testheadless test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts`