### PR TITLE
Reload a stale dev document after a back navigation

### DIFF
--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -33,7 +33,7 @@ import { checkIsOnDemandRevalidate } from '../../server/api-utils'
 import { CloseController } from '../../server/web/web-on-close'
 import { parseMaxPostponedStateSize } from '../../shared/lib/size-limit'
 import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
-import type { RequestMeta } from '../../server/request-meta'
+import { addRequestMeta, type RequestMeta } from '../../server/request-meta'
 
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler
@@ -64,6 +64,17 @@ async function requestHandler(
   const relativeUrl = `${req.nextUrl.pathname}${req.nextUrl.search}`
   const baseReq = new WebNextRequest(req)
   const baseRes = new WebNextResponse(undefined)
+
+  // The edge request is rebuilt from HTTP data alone, so the dev server's
+  // server-components generation arrives as a sandbox global rather than as
+  // request metadata (see `server/web/sandbox/sandbox.ts`). Put it back on the
+  // request so the render embeds it in the document like a Node render does.
+  if (process.env.NODE_ENV === 'development') {
+    const hmrRefreshHash = (globalThis as any).__hmrRefreshHash
+    if (typeof hmrRefreshHash === 'string') {
+      addRequestMeta(baseReq, 'hmrRefreshHash', hmrRefreshHash)
+    }
+  }
 
   const pageRouteModule = pageMod.routeModule as AppPageRouteModule
   const prepareResult = await pageRouteModule.prepare(baseReq, null, {

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -33,7 +33,7 @@ import {
 } from '../../server/lib/trace/tracer'
 import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
-import type { RequestMeta } from '../../server/request-meta'
+import { addRequestMeta, type RequestMeta } from '../../server/request-meta'
 import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
 
 // injected by the loader afterwards.
@@ -100,6 +100,18 @@ async function requestHandler(
 
   const relativeUrl = `${req.nextUrl.pathname}${req.nextUrl.search}`
   const baseReq = new WebNextRequest(req)
+
+  // The edge request is rebuilt from HTTP data alone, so the dev server's
+  // server-components generation arrives as a sandbox global rather than as
+  // request metadata (see `server/web/sandbox/sandbox.ts`). Put it back on the
+  // request so the render embeds it in the document like a Node render does.
+  if (process.env.NODE_ENV === 'development') {
+    const hmrRefreshHash = (globalThis as any).__hmrRefreshHash
+    if (typeof hmrRefreshHash === 'string') {
+      addRequestMeta(baseReq, 'hmrRefreshHash', hmrRefreshHash)
+    }
+  }
+
   const pageRouteModule = pageMod.routeModule as RouteModule
   const prepareResult = await pageRouteModule.prepare(baseReq, null, {
     srcPage,

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -74,6 +74,12 @@ declare global {
      * request ID, dev-only
      */
     __next_r?: string
+    /**
+     * The server-components generation this document was rendered against,
+     * dev-only. Compared against the server's current generation when the HMR
+     * socket (re)connects; see `client/dev/hot-reloader/app/web-socket.ts`.
+     */
+    __next_hmr_refresh_hash?: string
     __next_f: NextFlight
   }
 }

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -102,19 +102,6 @@ function isUpdateAvailable() {
   return mostRecentCompilationHash !== __webpack_hash__
 }
 
-/**
- * Whether the client bundle this page loaded belongs to an older compilation
- * than `hash`. Turbopack has no `__webpack_hash__` equivalent, so this can only
- * answer the question for webpack and reports `false` otherwise.
- */
-export function isClientBundleOutdated(hash: string) {
-  if (process.env.TURBOPACK) {
-    return false
-  }
-
-  return hash !== __webpack_hash__
-}
-
 // Webpack disallows updates in other states.
 function canApplyUpdates() {
   return module.hot.status() === 'idle'

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -102,6 +102,19 @@ function isUpdateAvailable() {
   return mostRecentCompilationHash !== __webpack_hash__
 }
 
+/**
+ * Whether the client bundle this page loaded belongs to an older compilation
+ * than `hash`. Turbopack has no `__webpack_hash__` equivalent, so this can only
+ * answer the question for webpack and reports `false` otherwise.
+ */
+export function isClientBundleOutdated(hash: string) {
+  if (process.env.TURBOPACK) {
+    return false
+  }
+
+  return hash !== __webpack_hash__
+}
+
 // Webpack disallows updates in other states.
 function canApplyUpdates() {
   return module.hot.status() === 'idle'

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -4,10 +4,12 @@ import { getSocketUrl } from '../get-socket-url'
 import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type HmrMessageSentToBrowser,
+  type SyncMessage,
   type TurbopackMessageSentToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import { reportInvalidHmrMessage } from '../shared'
 import {
+  isClientBundleOutdated,
   performFullReload,
   processMessage,
   type StaticIndicatorState,
@@ -20,6 +22,21 @@ let reconnections = 0
 let reloading = false
 let serverSessionId: number | null = null
 let mostRecentCompilationHash: string | null = null
+
+/**
+ * The server-components generation the code this document is executing belongs
+ * to. Seeded from the value the server embedded in the document
+ * (`self.__next_hmr_refresh_hash`), then kept current as the page applies
+ * updates in place: `built` and `server-component-changes` both report the
+ * generation they left the server on.
+ *
+ * When the socket (re)connects, `sync` reports the server's current generation.
+ * If it differs from this one, the page is executing code that has since been
+ * recompiled and can only recover with a full reload — see
+ * `isRunningOutdatedCode`.
+ */
+let currentRefreshHash: string | undefined =
+  typeof self === 'undefined' ? undefined : self.__next_hmr_refresh_hash
 
 export function createWebSocket(
   assetPrefix: string,
@@ -104,6 +121,32 @@ export function createWebSocket(
           mostRecentCompilationHash = message.hash
         }
 
+        // The page may be executing code that the server has already
+        // recompiled — most commonly because the browser restored this document
+        // from its HTTP cache (or from the bfcache) on a back/forward
+        // navigation, which re-runs the cached scripts without consulting the
+        // server. HMR can't repair that: it only pushes the edits made while a
+        // page was connected, so edits made while this document was away are
+        // never replayed. Reload instead.
+        if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.SYNC) {
+          if (isRunningOutdatedCode(message)) {
+            window.location.reload()
+            reloading = true
+            return
+          }
+        } else if (
+          message.type === HMR_MESSAGE_SENT_TO_BROWSER.BUILT ||
+          message.type === HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
+        ) {
+          // The page is being brought up to date in place, so record the
+          // generation it is moving to. Without this, the next `sync` would see
+          // a newer server generation and reload a page that is already
+          // current.
+          if (message.hmrRefreshHash !== undefined) {
+            currentRefreshHash = message.hmrRefreshHash
+          }
+        }
+
         processMessage(
           message,
           sendMessage,
@@ -165,6 +208,36 @@ export function createWebSocket(
   window.addEventListener('online', handleOnlineEvent)
 
   return init()
+}
+
+/**
+ * Whether the code this page is executing predates what the server has now.
+ *
+ * The authoritative signal is the server-components generation: the server
+ * embeds the current one in every document it renders, and reports the current
+ * one on `sync`. A restored document re-runs cached scripts, so it carries the
+ * generation from whenever it was first rendered — if that no longer matches,
+ * the module graph the page is running has been recompiled since.
+ *
+ * Either side can be missing a generation — webpack has none until its first
+ * server-components recompile. Absent a generation there is nothing to compare,
+ * so the page is left alone rather than reloaded on a guess.
+ *
+ * That leaves webpack's client-only edits, which never advance the generation.
+ * The loaded bundle's own compilation hash covers those. It is only meaningful
+ * when the compilation succeeded — a failing compile reports the *server*
+ * compiler's stats on `sync`, whose hash never matches the client bundle.
+ */
+function isRunningOutdatedCode(message: SyncMessage): boolean {
+  if (
+    currentRefreshHash !== undefined &&
+    message.hmrRefreshHash !== undefined &&
+    message.hmrRefreshHash !== currentRefreshHash
+  ) {
+    return true
+  }
+
+  return message.errors.length === 0 && isClientBundleOutdated(message.hash)
 }
 
 export function createProcessTurbopackMessage(

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -4,12 +4,10 @@ import { getSocketUrl } from '../get-socket-url'
 import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type HmrMessageSentToBrowser,
-  type SyncMessage,
   type TurbopackMessageSentToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import { reportInvalidHmrMessage } from '../shared'
 import {
-  isClientBundleOutdated,
   performFullReload,
   processMessage,
   type StaticIndicatorState,
@@ -129,7 +127,7 @@ export function createWebSocket(
         // page was connected, so edits made while this document was away are
         // never replayed. Reload instead.
         if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.SYNC) {
-          if (isRunningOutdatedCode(message)) {
+          if (isRunningOutdatedCode(message.hmrRefreshHash)) {
             window.location.reload()
             reloading = true
             return
@@ -213,31 +211,30 @@ export function createWebSocket(
 /**
  * Whether the code this page is executing predates what the server has now.
  *
- * The authoritative signal is the server-components generation: the server
- * embeds the current one in every document it renders, and reports the current
- * one on `sync`. A restored document re-runs cached scripts, so it carries the
- * generation from whenever it was first rendered — if that no longer matches,
- * the module graph the page is running has been recompiled since.
+ * The signal is the server-components generation: the server embeds the current
+ * one in every document it renders, and reports the current one on `sync`. A
+ * restored document re-runs cached scripts, so it carries the generation from
+ * whenever it was first rendered — if that no longer matches, the module graph
+ * the page is running has been recompiled since.
  *
  * Either side can be missing a generation — webpack has none until its first
  * server-components recompile. Absent a generation there is nothing to compare,
  * so the page is left alone rather than reloaded on a guess.
  *
- * That leaves webpack's client-only edits, which never advance the generation.
- * The loaded bundle's own compilation hash covers those. It is only meaningful
- * when the compilation succeeded — a failing compile reports the *server*
- * compiler's stats on `sync`, whose hash never matches the client bundle.
+ * Deliberately *not* also comparing webpack's client compilation hash: it
+ * advances for on-demand compiles of other routes and for updates this page has
+ * already applied, so a mismatch does not mean the running document is stale.
+ * `isUpdateAvailable()` can use it because it only triggers Fast Refresh;
+ * reloading on it wipes redboxes and console output from healthy pages. The cost
+ * is that a webpack edit touching only client code never advances the generation
+ * and so is not recovered.
  */
-function isRunningOutdatedCode(message: SyncMessage): boolean {
-  if (
+function isRunningOutdatedCode(hmrRefreshHash: string | undefined): boolean {
+  return (
     currentRefreshHash !== undefined &&
-    message.hmrRefreshHash !== undefined &&
-    message.hmrRefreshHash !== currentRefreshHash
-  ) {
-    return true
-  }
-
-  return message.errors.length === 0 && isClientBundleOutdated(message.hash)
+    hmrRefreshHash !== undefined &&
+    hmrRefreshHash !== currentRefreshHash
+  )
 }
 
 export function createProcessTurbopackMessage(

--- a/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
@@ -51,7 +51,6 @@ import type {
   HmrMessageSentToBrowser,
   ReloadPageMessage,
   RemovedPageMessage,
-  SyncMessage,
   TurbopackMessageSentToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import {
@@ -293,37 +292,30 @@ let reloadingForOutdatedCode = false
  * The browser restores a document from its HTTP cache on a back/forward
  * navigation without consulting the server, re-running the cached scripts. HMR
  * can't repair that: it only pushes the edits made while a page was connected,
- * so edits made while this document was away are never replayed. Comparing what
- * the page is running against what the server has is what detects it.
+ * so edits made while this document was away are never replayed. Comparing the
+ * generation the document was rendered against with the server's current one is
+ * what detects it.
  *
- * Two signals, because neither covers both bundlers. The server-components
- * generation is authoritative when present, but webpack only advances it on a
- * server-components recompile, so a Pages Router edit never moves it; there the
- * loaded bundle's own compilation hash answers instead. The bundle hash is only
- * meaningful when the compilation succeeded — a failing compile reports the
- * *server* compiler's stats on `sync`, whose hash never matches the client
- * bundle. Turbopack has no `__webpack_hash__` equivalent and relies on the
- * generation.
+ * Either side can be missing a generation — a document rendered before the
+ * bundler had one carries none. Absent a generation there is nothing to
+ * compare, so the page is left alone rather than reloaded on a guess.
  *
- * Where neither side has a generation and there is no bundle hash to compare,
- * the page is left alone rather than reloaded on a guess.
+ * Deliberately *not* also comparing webpack's client compilation hash: it
+ * advances for on-demand compiles of other routes and for updates this page has
+ * already applied, so a mismatch does not mean the running document is stale,
+ * and reloading on it wipes redboxes and console output from healthy pages.
+ * webpack never advances the generation for a Pages Router edit either, so on
+ * webpack this check simply does not fire and recovery is left to the Fast
+ * Refresh path in `handleSuccess`, which repairs the page in place.
  */
-function isRunningOutdatedCode(message: SyncMessage): boolean {
+function isRunningOutdatedCode(hmrRefreshHash: string | undefined): boolean {
   const documentRefreshHash = getCurrentRefreshHash()
 
-  if (
+  return (
     documentRefreshHash !== undefined &&
-    message.hmrRefreshHash !== undefined &&
-    message.hmrRefreshHash !== documentRefreshHash
-  ) {
-    return true
-  }
-
-  if (process.env.TURBOPACK) {
-    return false
-  }
-
-  return message.errors.length === 0 && message.hash !== __webpack_hash__
+    hmrRefreshHash !== undefined &&
+    hmrRefreshHash !== documentRefreshHash
+  )
 }
 
 export function handleStaticIndicator() {
@@ -377,7 +369,7 @@ function processMessage(message: HmrMessageSentToBrowser) {
         // recompiled, most commonly because the browser restored this document
         // from its HTTP cache on a back/forward navigation. Only a full reload
         // can bring it up to date.
-        if (isRunningOutdatedCode(message)) {
+        if (isRunningOutdatedCode(message.hmrRefreshHash)) {
           reloadingForOutdatedCode = true
           window.location.reload()
           return

--- a/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
@@ -51,6 +51,7 @@ import type {
   HmrMessageSentToBrowser,
   ReloadPageMessage,
   RemovedPageMessage,
+  SyncMessage,
   TurbopackMessageSentToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import {
@@ -252,6 +253,79 @@ function handleAvailableHash(hash: string) {
   mostRecentCompilationHash = hash
 }
 
+/**
+ * The server-components generation the code this document is executing belongs
+ * to. Seeded from the value the server embedded in the document (carried in
+ * `__NEXT_DATA__`), then kept current as the page applies updates in place:
+ * `built` and `server-component-changes` both report the generation they left
+ * the server on.
+ *
+ * When the socket (re)connects, `sync` reports the server's current generation.
+ * If it differs from this one, the page is executing code that has since been
+ * recompiled and can only recover with a full reload — see
+ * `isRunningOutdatedCode`.
+ *
+ * Read lazily: this module is evaluated by the dev entry before
+ * `window.__NEXT_DATA__` is assigned, so it cannot be seeded at module scope.
+ */
+let currentRefreshHash: string | undefined
+let hasReadDocumentRefreshHash = false
+
+function getCurrentRefreshHash(): string | undefined {
+  if (!hasReadDocumentRefreshHash) {
+    hasReadDocumentRefreshHash = true
+    currentRefreshHash = window.__NEXT_DATA__?.hmrRefreshHash
+  }
+
+  return currentRefreshHash
+}
+
+function setCurrentRefreshHash(hash: string) {
+  hasReadDocumentRefreshHash = true
+  currentRefreshHash = hash
+}
+
+let reloadingForOutdatedCode = false
+
+/**
+ * Whether the code this page is executing predates what the server has now.
+ *
+ * The browser restores a document from its HTTP cache on a back/forward
+ * navigation without consulting the server, re-running the cached scripts. HMR
+ * can't repair that: it only pushes the edits made while a page was connected,
+ * so edits made while this document was away are never replayed. Comparing what
+ * the page is running against what the server has is what detects it.
+ *
+ * Two signals, because neither covers both bundlers. The server-components
+ * generation is authoritative when present, but webpack only advances it on a
+ * server-components recompile, so a Pages Router edit never moves it; there the
+ * loaded bundle's own compilation hash answers instead. The bundle hash is only
+ * meaningful when the compilation succeeded — a failing compile reports the
+ * *server* compiler's stats on `sync`, whose hash never matches the client
+ * bundle. Turbopack has no `__webpack_hash__` equivalent and relies on the
+ * generation.
+ *
+ * Where neither side has a generation and there is no bundle hash to compare,
+ * the page is left alone rather than reloaded on a guess.
+ */
+function isRunningOutdatedCode(message: SyncMessage): boolean {
+  const documentRefreshHash = getCurrentRefreshHash()
+
+  if (
+    documentRefreshHash !== undefined &&
+    message.hmrRefreshHash !== undefined &&
+    message.hmrRefreshHash !== documentRefreshHash
+  ) {
+    return true
+  }
+
+  if (process.env.TURBOPACK) {
+    return false
+  }
+
+  return message.errors.length === 0 && message.hash !== __webpack_hash__
+}
+
 export function handleStaticIndicator() {
   if (process.env.__NEXT_DEV_INDICATOR) {
     const routeInfo = window.next.router.components[window.next.router.pathname]
@@ -273,6 +347,10 @@ export function handleStaticIndicator() {
 
 /** Handles messages from the server for the Pages Router. */
 function processMessage(message: HmrMessageSentToBrowser) {
+  if (reloadingForOutdatedCode) {
+    return
+  }
+
   switch (message.type) {
     case HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST: {
       isrManifest = message.data
@@ -293,6 +371,23 @@ function processMessage(message: HmrMessageSentToBrowser) {
     case HMR_MESSAGE_SENT_TO_BROWSER.BUILT:
     case HMR_MESSAGE_SENT_TO_BROWSER.SYNC: {
       dispatcher.buildingIndicatorHide()
+
+      if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.SYNC) {
+        // The page may be executing code that the server has already
+        // recompiled, most commonly because the browser restored this document
+        // from its HTTP cache on a back/forward navigation. Only a full reload
+        // can bring it up to date.
+        if (isRunningOutdatedCode(message)) {
+          reloadingForOutdatedCode = true
+          window.location.reload()
+          return
+        }
+      } else if (message.hmrRefreshHash !== undefined) {
+        // The page is being brought up to date in place, so record the
+        // generation it is moving to. Without this, the next `sync` would see a
+        // newer server generation and reload a page that is already current.
+        setCurrentRefreshHash(message.hmrRefreshHash)
+      }
 
       if (message.hash) handleAvailableHash(message.hash)
 
@@ -340,6 +435,11 @@ function processMessage(message: HmrMessageSentToBrowser) {
       return handleSuccess()
     }
     case HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES: {
+      // The page is about to refresh in place, so record the generation it is
+      // moving to (see the `built` case above).
+      if (message.hmrRefreshHash !== undefined) {
+        setCurrentRefreshHash(message.hmrRefreshHash)
+      }
       turbopackHmr?.onServerComponentChanges()
       if (hasCompileErrors || RuntimeErrorHandler.hadRuntimeError) {
         window.location.reload()

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3255,6 +3255,41 @@ type RSCInitialPayloadPartialDev = {
   c?: InitialRSCPayload['c']
 }
 
+/**
+ * The globals a development document must carry for the HMR client, evaluated
+ * before the bootstrap script:
+ *
+ * - `self.__next_r` — this document's request ID, read during hydration to
+ *   attach the debug channel to the matching HMR stream. For MPA navigations
+ *   (page reload, direct URL entry) there is no request ID header, so we
+ *   generate a random one.
+ * - `self.__next_hmr_refresh_hash` — the server-components generation this
+ *   document was rendered against. The HMR client compares it against the
+ *   server's current generation when the socket (re)connects; a mismatch means
+ *   the document is executing code that has since been recompiled, so it
+ *   recovers with a single reload. This is how a document the browser restored
+ *   from its HTTP cache (or from the bfcache) on a back/forward navigation
+ *   notices that it is stale — such a restore re-runs the cached scripts
+ *   without asking the server for anything. Omitted when no generation is
+ *   available — webpack reports one only from the first server-components
+ *   recompile onwards — in which case the client skips the comparison rather
+ *   than reloading on a guess.
+ */
+function getDevBootstrapScriptContent(
+  requestId: string | undefined,
+  hmrRefreshHash: string | undefined
+): string {
+  let content = `self.__next_r=${JSON.stringify(
+    requestId ?? crypto.randomUUID()
+  )}`
+
+  if (hmrRefreshHash !== undefined) {
+    content += `;self.__next_hmr_refresh_hash=${JSON.stringify(hmrRefreshHash)}`
+  }
+
+  return content
+}
+
 async function renderToStream(
   requestStore: RequestStore,
   req: BaseNextRequest,
@@ -3335,15 +3370,15 @@ async function renderToStream(
     page
   )
 
-  // In development mode, set the request ID as a global variable, before the
-  // bootstrap script is executed, which depends on it during hydration.
-  // For MPA navigations (page reload, direct URL entry), the request ID
-  // header is not present, so we generate a random one.
+  // In development mode, set the request ID and the server-components
+  // generation as global variables, before the bootstrap script is executed,
+  // which depends on the request ID during hydration.
   let bootstrapScriptContent: string | undefined
   if (process.env.__NEXT_DEV_SERVER) {
-    bootstrapScriptContent = `self.__next_r=${JSON.stringify(
-      requestId ?? crypto.randomUUID()
-    )}`
+    bootstrapScriptContent = getDevBootstrapScriptContent(
+      requestId,
+      getRequestMeta(req, 'hmrRefreshHash')
+    )
   } else if (
     buildManifest.pagesChunkGroupBootstrapParams &&
     buildManifest.chunkLoadingGlobal
@@ -8339,13 +8374,18 @@ async function prerenderToStream(
   }
 
   // In development the static shell is served without a dynamic resume, so it
-  // must carry the debug-channel request id (self.__next_r) itself for
-  // app-index to initialize the HMR/debug channel. renderToStream provides this
-  // for dynamic renders; prepend it here so it runs before the bootstrap
-  // module.
+  // must carry the debug-channel request id (self.__next_r) and the
+  // server-components generation (self.__next_hmr_refresh_hash) itself for
+  // app-index to initialize the HMR/debug channel. renderToStream provides
+  // these for dynamic renders; prepend them here so they run before the
+  // bootstrap module.
   if (process.env.__NEXT_DEV_SERVER && bootstrapScriptContent) {
     bootstrapScriptContent =
-      `self.__next_r=${JSON.stringify(ctx.requestId ?? crypto.randomUUID())};` +
+      getDevBootstrapScriptContent(
+        ctx.requestId,
+        getRequestMeta(req, 'hmrRefreshHash')
+      ) +
+      ';' +
       bootstrapScriptContent
   }
 

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -88,7 +88,13 @@ export class WebpackHotMiddleware {
     private versionInfo: VersionInfo,
     private devtoolsFrontendUrl: string | undefined,
     private config: NextConfigComplete,
-    private devToolsConfig: DevToolsConfig
+    private devToolsConfig: DevToolsConfig,
+    /**
+     * Reads the hot reloader's current server-components generation, forwarded
+     * to the browser on the `sync` event so a document can tell whether the
+     * code it is executing has since been recompiled.
+     */
+    private getServerComponentsHmrRefreshHash: () => string | undefined
   ) {
     compilers[0].hooks.invalid.tap(
       'webpack-hot-middleware',
@@ -200,6 +206,9 @@ export class WebpackHotMiddleware {
       this.publish({
         type: HMR_MESSAGE_SENT_TO_BROWSER.SYNC,
         hash: stats.hash!,
+        // The generation the connecting document must be on to be running
+        // current code. See `SyncMessage.hmrRefreshHash`.
+        hmrRefreshHash: this.getServerComponentsHmrRefreshHash(),
         errors: [...(stats.errors || []), ...(middlewareStats.errors || [])],
         warnings: [
           ...(stats.warnings || []),
@@ -231,6 +240,12 @@ export class WebpackHotMiddleware {
     this.publish({
       type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
       hash: stats.hash!,
+      // A server-components recompile updates the generation from the
+      // multi-compiler's `done` hook, which runs after this one, so the value
+      // here can lag by a compilation. `server-component-changes`, sent at the
+      // moment the generation actually advances, is what keeps the browser in
+      // sync; this is only a best-effort snapshot.
+      hmrRefreshHash: this.getServerComponentsHmrRefreshHash(),
       warnings: stats.warnings || [],
       errors: stats.errors || [],
     })

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -816,6 +816,7 @@ export async function createHotReloaderTurbopack(
   function sendServerComponentChanges() {
     sendHmr('server-component-changes', {
       type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+      hmrRefreshHash: String(hmrHash),
     })
   }
 
@@ -1592,6 +1593,9 @@ export async function createHotReloaderTurbopack(
             errors,
             warnings: [],
             hash: '',
+            // The generation the connecting document must be on to be running
+            // current code. See `SyncMessage.hmrRefreshHash`.
+            hmrRefreshHash: String(hmrHash),
             versionInfo,
             debug: {
               devtoolsFrontendUrl,
@@ -1777,6 +1781,7 @@ export async function createHotReloaderTurbopack(
         await clearAllModuleContexts()
         this.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+          hmrRefreshHash: String(hmrHash),
         })
       }
     },
@@ -2073,6 +2078,10 @@ export async function createHotReloaderTurbopack(
               // compilation is not itself an edit, and this hash is not
               // consumed by the Turbopack client.
               hash: String(hmrHash),
+              // The generation this compilation left the server on, so a
+              // browser that applied the update in place stays in sync and
+              // isn't later told its code is stale.
+              hmrRefreshHash: String(hmrHash),
               errors: [...clientErrors.values()],
               warnings: [],
             })
@@ -2113,6 +2122,7 @@ export async function createHotReloaderTurbopack(
     if (hasCompilationErrors()) return
     hotReloader.send({
       type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+      hmrRefreshHash: String(hmrHash),
     })
   }
 

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -82,6 +82,15 @@ export interface CompilationError {
 export interface SyncMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.SYNC
   hash: string
+  /**
+   * The server-components generation the server is currently on, i.e. the value
+   * `getServerComponentsHmrRefreshHash()` returns. The browser compares it
+   * against the generation embedded in its document
+   * (`self.__next_hmr_refresh_hash`) to find out whether the code it is
+   * executing has since been recompiled. Undefined when the bundler has no
+   * generation yet.
+   */
+  hmrRefreshHash: string | undefined
   errors: ReadonlyArray<CompilationError>
   warnings: ReadonlyArray<CompilationError>
   versionInfo: VersionInfo
@@ -95,6 +104,12 @@ export interface SyncMessage {
 export interface BuiltMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT
   hash: string
+  /**
+   * The server-components generation reached by this compilation. See
+   * `SyncMessage.hmrRefreshHash`; the browser tracks it so an update it applied
+   * in place isn't later mistaken for stale code.
+   */
+  hmrRefreshHash: string | undefined
   errors: ReadonlyArray<CompilationError>
   warnings: ReadonlyArray<CompilationError>
   updatedModules?: ReadonlyArray<string>
@@ -117,6 +132,12 @@ export interface ReloadPageMessage {
 
 export interface ServerComponentChangesMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
+  /**
+   * The server-components generation this change advanced the server to. See
+   * `SyncMessage.hmrRefreshHash`; the browser tracks it so the refresh it is
+   * about to perform isn't later mistaken for stale code.
+   */
+  hmrRefreshHash: string | undefined
 }
 
 /**

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -435,6 +435,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.serverComponentsHmrRefreshHash = hash
     this.send({
       type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+      // The generation this change advanced the server to, so a browser that
+      // refreshes in place stays in sync and isn't later told its code is
+      // stale.
+      hmrRefreshHash: hash,
       // TODO: granular reloading of changes
       // entrypoints: serverComponentChanges,
     })
@@ -1614,7 +1618,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       this.versionInfo,
       this.devtoolsFrontendUrl,
       this.config,
-      initialDevToolsConfig
+      initialDevToolsConfig,
+      () => this.getServerComponentsHmrRefreshHash()
     )
 
     let booted = false

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -2093,6 +2093,7 @@ export default class NextNodeServer extends BaseServer<
         params.req,
         'serverComponentsHmrCache'
       ),
+      hmrRefreshHash: getRequestMeta(params.req, 'hmrRefreshHash'),
       clientAssetToken: this.nextConfig.supportsImmutableAssets
         ? ''
         : this.deploymentId,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1520,6 +1520,9 @@ export async function renderToHTMLImpl(
         notFoundSrcPage && process.env.__NEXT_DEV_SERVER
           ? notFoundSrcPage
           : undefined,
+      hmrRefreshHash: process.env.__NEXT_DEV_SERVER
+        ? getRequestMeta(req, 'hmrRefreshHash')
+        : undefined,
     },
     nonce,
     buildManifest: filteredBuildManifest,

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -37,6 +37,12 @@ interface RunnerFnParams {
   distDir: string
   incrementalCache?: any
   serverComponentsHmrCache?: ServerComponentsHmrCache
+  /**
+   * The dev server's current server-components generation. Request metadata
+   * doesn't cross into the sandbox — the edge request is rebuilt from HTTP data
+   * alone — so it is handed over as a global, like `serverComponentsHmrCache`.
+   */
+  hmrRefreshHash?: string
   clientAssetToken: string
 }
 
@@ -95,6 +101,10 @@ export async function getRuntimeContext(
   if (params.serverComponentsHmrCache) {
     runtime.context.globalThis.__serverComponentsHmrCache =
       params.serverComponentsHmrCache
+  }
+
+  if (params.hmrRefreshHash !== undefined) {
+    runtime.context.globalThis.__hmrRefreshHash = params.hmrRefreshHash
   }
 
   if (params.clientAssetToken) {

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -113,6 +113,15 @@ export type NEXT_DATA = {
   scriptLoader?: any[]
   isPreview?: boolean
   notFoundSrcPage?: string
+  /**
+   * The server-components generation this document was rendered against
+   * (dev only). The HMR client compares it against the server's current
+   * generation when the socket (re)connects and reloads if the document is
+   * executing code that has since been recompiled — which is how a document the
+   * browser restored from its HTTP cache on a back/forward navigation recovers.
+   * See `client/dev/hot-reloader/pages/hot-reloader-pages.ts`.
+   */
+  hmrRefreshHash?: string
 }
 
 /**

--- a/test/development/app-dir/dev-full-navigation-back/app/about/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/about/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="about">About</p>
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/client-value.ts
+++ b/test/development/app-dir/dev-full-navigation-back/app/client-value.ts
@@ -1,0 +1,1 @@
+export const clientValue = 'Client A'

--- a/test/development/app-dir/dev-full-navigation-back/app/client/client-component.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/client/client-component.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useState } from 'react'
+import { clientValue } from '../client-value'
+
+export function ClientComponent() {
+  const [count, setCount] = useState(0)
+  return (
+    <>
+      <p id="client-value">{clientValue}</p>
+      <button id="increment" onClick={() => setCount(count + 1)}>
+        Count: {count}
+      </button>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/client/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/client/page.tsx
@@ -1,0 +1,14 @@
+import { clientValue } from '../client-value'
+import { ClientComponent } from './client-component'
+
+export default function Page() {
+  return (
+    <>
+      <p id="server-value">{clientValue}</p>
+      <ClientComponent />
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/edge-value.ts
+++ b/test/development/app-dir/dev-full-navigation-back/app/edge-value.ts
@@ -1,0 +1,1 @@
+export const edgeValue = 'Edge A'

--- a/test/development/app-dir/dev-full-navigation-back/app/edge/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/edge/page.tsx
@@ -1,0 +1,14 @@
+import { edgeValue } from '../edge-value'
+
+export const runtime = 'edge'
+
+export default function Page() {
+  return (
+    <>
+      <p id="edge-value">{edgeValue}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/layout.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/page.tsx
@@ -1,0 +1,12 @@
+import { value } from './value'
+
+export default function Page() {
+  return (
+    <>
+      <p id="value">{value}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/stable-value.ts
+++ b/test/development/app-dir/dev-full-navigation-back/app/stable-value.ts
@@ -1,0 +1,1 @@
+export const stableValue = 'Stable A'

--- a/test/development/app-dir/dev-full-navigation-back/app/stable/page.tsx
+++ b/test/development/app-dir/dev-full-navigation-back/app/stable/page.tsx
@@ -1,0 +1,12 @@
+import { stableValue } from '../stable-value'
+
+export default function Page() {
+  return (
+    <>
+      <p id="stable-value">{stableValue}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-full-navigation-back/app/value.ts
+++ b/test/development/app-dir/dev-full-navigation-back/app/value.ts
@@ -1,0 +1,1 @@
+export const value = 'Value A'

--- a/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -195,38 +195,49 @@ describe('dev-full-navigation-back', () => {
 
   // A render in the edge runtime is rebuilt from HTTP data alone, so the
   // generation reaches it through a sandbox global rather than request metadata.
-  it('shows an edit to a page rendered in the edge runtime after full navigation and back navigation', async () => {
-    const loads = countLoads('/edge')
-    const browser = await next.browser('/edge', {
-      beforePageLoad: loads.beforePageLoad,
-    })
-    expect(await browser.elementByCss('#edge-value').text()).toBe('Edge A')
+  //
+  // Skipped with Cache Components: `export const runtime = 'edge'` is rejected
+  // outright there ("Route segment config \"runtime\" is not compatible with
+  // `nextConfig.cacheComponents`"), so the fixture page cannot even compile.
+  ;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
+    'edge runtime',
+    () => {
+      it('shows an edit to an edge page after full navigation and back navigation', async () => {
+        const loads = countLoads('/edge')
+        const browser = await next.browser('/edge', {
+          beforePageLoad: loads.beforePageLoad,
+        })
+        expect(await browser.elementByCss('#edge-value').text()).toBe('Edge A')
 
-    // The debug channel isn't persisted for an edge render, so there is no
-    // `__NEXT_DEBUG_CHANNEL_PERSISTED` flag to await here. Recovery doesn't
-    // depend on it — it is driven by the HMR socket — so just let the page
-    // settle before navigating away.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    expect(await browser.eval('typeof self.__next_r')).toBe('string')
+        // The debug channel isn't persisted for an edge render, so there is no
+        // `__NEXT_DEBUG_CHANNEL_PERSISTED` flag to await here. Recovery doesn't
+        // depend on it — it is driven by the HMR socket — so just let the page
+        // settle before navigating away.
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        expect(await browser.eval('typeof self.__next_r')).toBe('string')
 
-    await browser.elementByCss('#to-about').click()
-    await browser.waitForElementByCss('#about')
+        await browser.elementByCss('#to-about').click()
+        await browser.waitForElementByCss('#about')
 
-    await editFile('app/edge-value.ts', 'Edge A', 'Edge B')
-    await retry(async () => {
-      const $ = await next.render$('/edge')
-      expect($('#edge-value').text()).toBe('Edge B')
-    })
+        await editFile('app/edge-value.ts', 'Edge A', 'Edge B')
+        await retry(async () => {
+          const $ = await next.render$('/edge')
+          expect($('#edge-value').text()).toBe('Edge B')
+        })
 
-    const loadsBeforeBack = loads.state.count
+        const loadsBeforeBack = loads.state.count
 
-    await browser.back({ waitUntil: 'commit' })
-    await retry(async () => {
-      expect(await browser.elementByCss('#edge-value').text()).toBe('Edge B')
-    })
+        await browser.back({ waitUntil: 'commit' })
+        await retry(async () => {
+          expect(await browser.elementByCss('#edge-value').text()).toBe(
+            'Edge B'
+          )
+        })
 
-    expect(loads.state.count - loadsBeforeBack).toBe(2)
+        expect(loads.state.count - loadsBeforeBack).toBe(2)
 
-    await assertNoUnexpectedConsoleOutput(browser)
-  })
+        await assertNoUnexpectedConsoleOutput(browser)
+      })
+    }
+  )
 })

--- a/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/app-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -1,0 +1,210 @@
+import { nextTestSetup, Playwright } from 'e2e-utils'
+import { assertNoConsoleErrors, retry } from 'next-test-utils'
+import { readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+import type { Page } from 'playwright'
+
+describe('dev-full-navigation-back', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  /**
+   * Counts `load` events for a single pathname. A back navigation that restores
+   * the document from the browser's HTTP cache fires one; a recovery reload
+   * fires a second one. Anything above 2 would be a reload loop.
+   */
+  function countLoads(pathname: string) {
+    const state = { count: 0 }
+    return {
+      state,
+      beforePageLoad(page: Page) {
+        page.on('load', () => {
+          if (new URL(page.url()).pathname === pathname) {
+            state.count++
+          }
+        })
+      },
+    }
+  }
+
+  /**
+   * The debug channel for the current document is persisted to IndexedDB from an
+   * idle callback. Navigating before it commits aborts the transaction, so wait
+   * for the flag the page sets once the write landed.
+   */
+  async function waitForDebugChannelPersisted(browser: Playwright) {
+    await retry(async () => {
+      expect(
+        await browser.eval(() => (self as any).__NEXT_DEBUG_CHANNEL_PERSISTED)
+      ).toBe(true)
+    })
+  }
+
+  async function editFile(relativePath: string, from: string, to: string) {
+    const file = join(next.testDir, relativePath)
+    const content = await readFile(file, 'utf8')
+    await writeFile(file, content.replace(from, to))
+  }
+
+  it('shows an edit after full navigation and back navigation', async () => {
+    const loads = countLoads('/')
+    const browser = await next.browser('/', {
+      beforePageLoad: loads.beforePageLoad,
+    })
+    expect(await browser.elementByCss('#value').text()).toBe('Value A')
+
+    await waitForDebugChannelPersisted(browser)
+
+    await browser.elementByCss('#to-about').click()
+    await browser.waitForElementByCss('#about')
+
+    await editFile('app/value.ts', 'Value A', 'Value B')
+    await retry(async () => {
+      const $ = await next.render$('/')
+      expect($('#value').text()).toBe('Value B')
+    })
+
+    const loadsBeforeBack = loads.state.count
+    await browser.back({ waitUntil: 'commit' })
+    await retry(async () => {
+      expect(await browser.elementByCss('#value').text()).toBe('Value B')
+    })
+
+    // The back navigation restored the document from the browser's HTTP cache
+    // (one load) and the recovery reloaded it once more, and it stays there —
+    // the reloaded document is rendered with the current generation, so it must
+    // not reload again.
+    expect(loads.state.count - loadsBeforeBack).toBe(2)
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+    expect(loads.state.count - loadsBeforeBack).toBe(2)
+
+    await assertNoConsoleErrors(browser)
+  })
+
+  it('runs edited client component code after full navigation and back navigation', async () => {
+    const loads = countLoads('/client')
+    const browser = await next.browser('/client', {
+      beforePageLoad: loads.beforePageLoad,
+    })
+    expect(await browser.elementByCss('#server-value').text()).toBe('Client A')
+    expect(await browser.elementByCss('#client-value').text()).toBe('Client A')
+
+    await waitForDebugChannelPersisted(browser)
+
+    await browser.elementByCss('#to-about').click()
+    await browser.waitForElementByCss('#about')
+
+    await editFile('app/client-value.ts', 'Client A', 'Client B')
+    await retry(async () => {
+      const $ = await next.render$('/client')
+      expect($('#server-value').text()).toBe('Client B')
+    })
+
+    const loadsBeforeBack = loads.state.count
+
+    await browser.back({ waitUntil: 'commit' })
+
+    // The client bundle is restored from the HTTP cache too, and dev chunk URLs
+    // are not content-hashed, so the client component would keep rendering the
+    // old value if the page recovered by refetching data instead of reloading.
+    await retry(async () => {
+      expect(await browser.elementByCss('#client-value').text()).toBe(
+        'Client B'
+      )
+    })
+    expect(await browser.elementByCss('#server-value').text()).toBe('Client B')
+
+    // Still interactive after the recovery.
+    await browser.elementByCss('#increment').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#increment').text()).toBe('Count: 1')
+    })
+
+    expect(loads.state.count - loadsBeforeBack).toBe(2)
+
+    await assertNoConsoleErrors(browser)
+  })
+
+  it('does not reload on back navigation when the code did not change', async () => {
+    const outputIndex = next.cliOutput.length
+    const loads = countLoads('/stable')
+    const browser = await next.browser('/stable', {
+      beforePageLoad: loads.beforePageLoad,
+    })
+    expect(await browser.elementByCss('#stable-value').text()).toBe('Stable A')
+
+    await waitForDebugChannelPersisted(browser)
+
+    await browser.elementByCss('#to-about').click()
+    await browser.waitForElementByCss('#about')
+
+    const loadsBeforeBack = loads.state.count
+
+    await browser.back({ waitUntil: 'commit' })
+    await retry(async () => {
+      expect(await browser.elementByCss('#stable-value').text()).toBe(
+        'Stable A'
+      )
+    })
+
+    // Give a reload time to happen if it were going to.
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    // The document was restored from the browser's HTTP cache and must be left
+    // alone: only the restore's own load event, and no second request for it.
+    expect(loads.state.count - loadsBeforeBack).toBe(1)
+    const requests = next.cliOutput
+      .slice(outputIndex)
+      .match(/GET \/stable(?:\s|\?)/g)
+    expect(requests).toHaveLength(1)
+
+    // Fast Refresh still applies an edit in place, without a reload.
+    await editFile('app/stable-value.ts', 'Stable A', 'Stable B')
+    await retry(async () => {
+      expect(await browser.elementByCss('#stable-value').text()).toBe(
+        'Stable B'
+      )
+    })
+    expect(loads.state.count - loadsBeforeBack).toBe(1)
+
+    await assertNoConsoleErrors(browser)
+  })
+
+  // A render in the edge runtime is rebuilt from HTTP data alone, so the
+  // generation reaches it through a sandbox global rather than request metadata.
+  it('shows an edit to a page rendered in the edge runtime after full navigation and back navigation', async () => {
+    const loads = countLoads('/edge')
+    const browser = await next.browser('/edge', {
+      beforePageLoad: loads.beforePageLoad,
+    })
+    expect(await browser.elementByCss('#edge-value').text()).toBe('Edge A')
+
+    // The debug channel isn't persisted for an edge render, so there is no
+    // `__NEXT_DEBUG_CHANNEL_PERSISTED` flag to await here. Recovery doesn't
+    // depend on it — it is driven by the HMR socket — so just let the page
+    // settle before navigating away.
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    expect(await browser.eval('typeof self.__next_r')).toBe('string')
+
+    await browser.elementByCss('#to-about').click()
+    await browser.waitForElementByCss('#about')
+
+    await editFile('app/edge-value.ts', 'Edge A', 'Edge B')
+    await retry(async () => {
+      const $ = await next.render$('/edge')
+      expect($('#edge-value').text()).toBe('Edge B')
+    })
+
+    const loadsBeforeBack = loads.state.count
+
+    await browser.back({ waitUntil: 'commit' })
+    await retry(async () => {
+      expect(await browser.elementByCss('#edge-value').text()).toBe('Edge B')
+    })
+
+    expect(loads.state.count - loadsBeforeBack).toBe(2)
+
+    await assertNoConsoleErrors(browser)
+  })
+})

--- a/test/development/app-dir/dev-full-navigation-back/next.config.js
+++ b/test/development/app-dir/dev-full-navigation-back/next.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value:
+              'public, max-age=0, s-maxage=31536000, stale-while-revalidate=86400',
+          },
+        ],
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/pages-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/pages-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import type { Page } from 'playwright'
 
 describe('pages dev-full-navigation-back', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
 
@@ -56,6 +56,21 @@ describe('pages dev-full-navigation-back', () => {
     expect(unexpected).toEqual([])
   }
 
+  /**
+   * How the two bundlers recover differs, so the tests pin each shape rather
+   * than accepting either.
+   *
+   * Turbopack has no staleness check of its own, so recovery is the reload this
+   * change adds: the HTTP-cache restore plus one reload.
+   *
+   * webpack never advances the server-components generation for a Pages Router
+   * edit, so that reload never fires. Its existing `handleSuccess` path notices
+   * the loaded bundle is behind on the first `sync` and Fast Refreshes the
+   * module in place instead, which is strictly nicer — the restore's own load is
+   * the only one.
+   */
+  const expectedLoadsAfterStaleBack = isTurbopack ? 2 : 1
+
   it('shows an edit after full navigation and back navigation', async () => {
     const loads = countLoads('/')
     const browser = await next.browser('/', {
@@ -79,13 +94,15 @@ describe('pages dev-full-navigation-back', () => {
       expect(await browser.elementByCss('#value').text()).toBe('Value B')
     })
 
-    // The back navigation restored the document from the browser's HTTP cache
-    // (one load) and the recovery reloaded it once more, and it stays there —
-    // the reloaded document is rendered with the current generation, so it must
-    // not reload again.
-    expect(loads.state.count - loadsBeforeBack).toBe(2)
+    // Whatever the recovery shape, it settles: a reloaded document is rendered
+    // with the current generation, so it must not reload again.
+    expect(loads.state.count - loadsBeforeBack).toBe(
+      expectedLoadsAfterStaleBack
+    )
     await new Promise((resolve) => setTimeout(resolve, 2000))
-    expect(loads.state.count - loadsBeforeBack).toBe(2)
+    expect(loads.state.count - loadsBeforeBack).toBe(
+      expectedLoadsAfterStaleBack
+    )
 
     await assertNoUnexpectedConsoleOutput(browser)
   })
@@ -158,7 +175,9 @@ describe('pages dev-full-navigation-back', () => {
       expect(await browser.elementByCss('#edge-value').text()).toBe('Edge B')
     })
 
-    expect(loads.state.count - loadsBeforeBack).toBe(2)
+    expect(loads.state.count - loadsBeforeBack).toBe(
+      expectedLoadsAfterStaleBack
+    )
 
     await assertNoUnexpectedConsoleOutput(browser)
   })

--- a/test/development/pages-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
+++ b/test/development/pages-dir/dev-full-navigation-back/dev-full-navigation-back.test.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile } from 'fs/promises'
 import { join } from 'path'
 import type { Page } from 'playwright'
 
-describe('dev-full-navigation-back', () => {
+describe('pages dev-full-navigation-back', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
@@ -26,19 +26,6 @@ describe('dev-full-navigation-back', () => {
         })
       },
     }
-  }
-
-  /**
-   * The debug channel for the current document is persisted to IndexedDB from an
-   * idle callback. Navigating before it commits aborts the transaction, so wait
-   * for the flag the page sets once the write landed.
-   */
-  async function waitForDebugChannelPersisted(browser: Playwright) {
-    await retry(async () => {
-      expect(
-        await browser.eval(() => (self as any).__NEXT_DEBUG_CHANNEL_PERSISTED)
-      ).toBe(true)
-    })
   }
 
   async function editFile(relativePath: string, from: string, to: string) {
@@ -76,18 +63,17 @@ describe('dev-full-navigation-back', () => {
     })
     expect(await browser.elementByCss('#value').text()).toBe('Value A')
 
-    await waitForDebugChannelPersisted(browser)
-
     await browser.elementByCss('#to-about').click()
     await browser.waitForElementByCss('#about')
 
-    await editFile('app/value.ts', 'Value A', 'Value B')
+    await editFile('pages/value.ts', 'Value A', 'Value B')
     await retry(async () => {
       const $ = await next.render$('/')
       expect($('#value').text()).toBe('Value B')
     })
 
     const loadsBeforeBack = loads.state.count
+
     await browser.back({ waitUntil: 'commit' })
     await retry(async () => {
       expect(await browser.elementByCss('#value').text()).toBe('Value B')
@@ -104,50 +90,6 @@ describe('dev-full-navigation-back', () => {
     await assertNoUnexpectedConsoleOutput(browser)
   })
 
-  it('runs edited client component code after full navigation and back navigation', async () => {
-    const loads = countLoads('/client')
-    const browser = await next.browser('/client', {
-      beforePageLoad: loads.beforePageLoad,
-    })
-    expect(await browser.elementByCss('#server-value').text()).toBe('Client A')
-    expect(await browser.elementByCss('#client-value').text()).toBe('Client A')
-
-    await waitForDebugChannelPersisted(browser)
-
-    await browser.elementByCss('#to-about').click()
-    await browser.waitForElementByCss('#about')
-
-    await editFile('app/client-value.ts', 'Client A', 'Client B')
-    await retry(async () => {
-      const $ = await next.render$('/client')
-      expect($('#server-value').text()).toBe('Client B')
-    })
-
-    const loadsBeforeBack = loads.state.count
-
-    await browser.back({ waitUntil: 'commit' })
-
-    // The client bundle is restored from the HTTP cache too, and dev chunk URLs
-    // are not content-hashed, so the client component would keep rendering the
-    // old value if the page recovered by refetching data instead of reloading.
-    await retry(async () => {
-      expect(await browser.elementByCss('#client-value').text()).toBe(
-        'Client B'
-      )
-    })
-    expect(await browser.elementByCss('#server-value').text()).toBe('Client B')
-
-    // Still interactive after the recovery.
-    await browser.elementByCss('#increment').click()
-    await retry(async () => {
-      expect(await browser.elementByCss('#increment').text()).toBe('Count: 1')
-    })
-
-    expect(loads.state.count - loadsBeforeBack).toBe(2)
-
-    await assertNoUnexpectedConsoleOutput(browser)
-  })
-
   it('does not reload on back navigation when the code did not change', async () => {
     const outputIndex = next.cliOutput.length
     const loads = countLoads('/stable')
@@ -155,8 +97,6 @@ describe('dev-full-navigation-back', () => {
       beforePageLoad: loads.beforePageLoad,
     })
     expect(await browser.elementByCss('#stable-value').text()).toBe('Stable A')
-
-    await waitForDebugChannelPersisted(browser)
 
     await browser.elementByCss('#to-about').click()
     await browser.waitForElementByCss('#about')
@@ -182,7 +122,7 @@ describe('dev-full-navigation-back', () => {
     expect(requests).toHaveLength(1)
 
     // Fast Refresh still applies an edit in place, without a reload.
-    await editFile('app/stable-value.ts', 'Stable A', 'Stable B')
+    await editFile('pages/stable-value.ts', 'Stable A', 'Stable B')
     await retry(async () => {
       expect(await browser.elementByCss('#stable-value').text()).toBe(
         'Stable B'
@@ -202,17 +142,10 @@ describe('dev-full-navigation-back', () => {
     })
     expect(await browser.elementByCss('#edge-value').text()).toBe('Edge A')
 
-    // The debug channel isn't persisted for an edge render, so there is no
-    // `__NEXT_DEBUG_CHANNEL_PERSISTED` flag to await here. Recovery doesn't
-    // depend on it — it is driven by the HMR socket — so just let the page
-    // settle before navigating away.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    expect(await browser.eval('typeof self.__next_r')).toBe('string')
-
     await browser.elementByCss('#to-about').click()
     await browser.waitForElementByCss('#about')
 
-    await editFile('app/edge-value.ts', 'Edge A', 'Edge B')
+    await editFile('pages/edge-value.ts', 'Edge A', 'Edge B')
     await retry(async () => {
       const $ = await next.render$('/edge')
       expect($('#edge-value').text()).toBe('Edge B')

--- a/test/development/pages-dir/dev-full-navigation-back/pages/about.tsx
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/about.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <p id="about">About</p>
+}

--- a/test/development/pages-dir/dev-full-navigation-back/pages/edge-value.ts
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/edge-value.ts
@@ -1,0 +1,1 @@
+export const edgeValue = 'Edge A'

--- a/test/development/pages-dir/dev-full-navigation-back/pages/edge.tsx
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/edge.tsx
@@ -1,0 +1,14 @@
+import { edgeValue } from './edge-value'
+
+export const config = { runtime: 'experimental-edge' }
+
+export default function Edge() {
+  return (
+    <>
+      <p id="edge-value">{edgeValue}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/pages-dir/dev-full-navigation-back/pages/index.tsx
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/index.tsx
@@ -1,0 +1,12 @@
+import { value } from './value'
+
+export default function Page() {
+  return (
+    <>
+      <p id="value">{value}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/pages-dir/dev-full-navigation-back/pages/stable-value.ts
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/stable-value.ts
@@ -1,0 +1,1 @@
+export const stableValue = 'Stable A'

--- a/test/development/pages-dir/dev-full-navigation-back/pages/stable.tsx
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/stable.tsx
@@ -1,0 +1,12 @@
+import { stableValue } from './stable-value'
+
+export default function Stable() {
+  return (
+    <>
+      <p id="stable-value">{stableValue}</p>
+      <a id="to-about" href="/about">
+        About
+      </a>
+    </>
+  )
+}

--- a/test/development/pages-dir/dev-full-navigation-back/pages/value.ts
+++ b/test/development/pages-dir/dev-full-navigation-back/pages/value.ts
@@ -1,0 +1,1 @@
+export const value = 'Value A'


### PR DESCRIPTION
### What

In development, a document restored by the browser on a back/forward navigation can be
executing code the server has already recompiled. It now notices and recovers — and a
document that is still up to date does nothing at all, so Back stays instant. Covers
**both the App Router and the Pages Router**.

Fixes the reproduction in #96503 (that PR's fixture and first test case are included
here, since it isn't merged).

### Why the report's "bfcache" framing is a red herring

`pageshow.persisted` is `false` — in dev the open HMR WebSocket disqualifies the page
from the bfcache. The document is restored from the **HTTP cache** on a `back_forward`
navigation (`transferSize: 0`, non-zero `encodedBodySize`): browsers reuse cached
responses on history navigations without revalidating, even for `no-cache,
must-revalidate`, which is what dev serves.

The `Cache-Control` header in the repro's `next.config.js` is a red herring too: dev
overwrites the document's `Cache-Control` unconditionally (`build/templates/app-page-runtime.ts`
for App Router, `server/route-modules/pages/pages-handler.ts` for Pages Router), so that
header never took effect. The bug reproduces identically without it.

Dev chunk URLs are path-derived rather than content-hashed, so the cached HTML *and* the
cached module graph come back together. HMR doesn't repair the server-rendered half: it
only pushes edits made while a page was connected, so an edit made while the document was
away is never replayed for it on reconnect. (The client half can self-heal once the socket
reconnects and the updated chunk arrives — but the page is still rendering stale server
output from stale code.)

**A data refresh is not sufficient.** With a `'use client'` component importing the
edited module, measured immediately after Back:

| | server `#value` | client `#client-value` |
|---|---|---|
| after Back | `Value A` | `Value A` |
| after `router.refresh()` | **`Value B`** | `Value A` |

The page is hydrated and interactive — it is just running the old module graph.

### Approach: compare code generations, don't detect navigations

The dev server already keeps a per-recompile generation, exposed as
`getServerComponentsHmrRefreshHash()` (a counter for Turbopack, the server-components
compilation hash for webpack) and already threaded to the renderer as the
`hmrRefreshHash` request meta.

- every dev document records the generation it was rendered against — the App Router
  emits `self.__next_hmr_refresh_hash` beside the existing `self.__next_r`, the Pages
  Router carries it in `__NEXT_DATA__`;
- `sync`, `built` and `server-component-changes` carry the server's generation;
- the browser tracks the generation it is *actually running*, advancing it whenever it
  applies an update in place;
- when the socket (re)connects, `sync` reports the server's — on a mismatch the page
  reloads once.

This subsumes back/forward and cache-restore detection entirely: a freshly served
document always carries the current generation, so only genuinely stale code reloads. It
is loop-safe by construction — the reloaded document is rendered with the current
generation, so it matches. By the same token it covers a real bfcache restore and a dev
server restarted while the tab was away, since both reconnect the socket.

Where no generation is available there is nothing to compare, so the page is left alone
rather than reloaded on a guess. The generation is the **only** signal used. An earlier
revision also compared webpack's client compilation hash (`sync.hash` vs
`__webpack_hash__`); that is unsound and was removed — webpack's hash advances for
on-demand compiles of unrelated routes and for updates the page has already applied, so a
mismatch says nothing about whether *this* document is stale. Reloading on it wiped
redboxes (`ReactRefreshLogBox-app-doc`) and lost asserted console output
(`next-image-new/app-dir`). `isUpdateAvailable()` can use that hash because it only
attempts Fast Refresh.

The cost is that webpack never advances the generation for a client-only edit, so that
narrow case is not recovered on webpack; closing it needs a real per-compilation
generation from the webpack hot reloader and is left as follow-up work.

Edge renders rebuild the request from HTTP data alone, so request metadata doesn't reach
them. The generation is handed to the sandbox as a global, like
`serverComponentsHmrCache`, and put back on the request by the edge templates.

### The two bundlers recover differently in the Pages Router

Turbopack's `handleSuccess()` had no staleness check at all and never recovered; it now
recovers via the reload above. webpack never advances the generation for a Pages Router
edit, so the reload never fires there — instead its existing `isUpdateAvailable()` +
`tryApplyUpdatesWebpack()` path Fast Refreshes the module in place, which is strictly
nicer since no client state is lost. The tests pin each shape exactly rather than
accepting either.

### Scope

Development only. This change does not touch `Cache-Control` at all, and history
traversal in the router (`restoreReducer` / `readFromBFCache`) is untouched. Production
back/forward is unaffected — chunks there are content-hashed and immutable, so a restored
document is self-consistent.

### Tests

`test/development/app-dir/dev-full-navigation-back` and
`test/development/pages-dir/dev-full-navigation-back` — passing on **both** bundlers:

- server-rendered content recovers after an edit made while the page was away;
- a `'use client'` component's code recovers too (the case a refresh cannot fix);
- **no reload and no extra server request** when nothing changed, and Fast Refresh still
  applies a later edit in place;
- the recovery settles — asserted via `load`-event counts, per bundler (Turbopack: the
  cache restore plus exactly one reload; webpack Pages Router: the restore only), with no
  further load after a settle;
- an edge-runtime page recovers as well. The App Router edge case is skipped under Cache
  Components, where `export const runtime = 'edge'` is rejected outright ("Route segment
  config \"runtime\" is not compatible with `nextConfig.cacheComponents`").

Regression suites: `app-hmr/hmr`, `app-hmr/server-restart`, `app-edge`,
`bfcache-regression`, `back-forward-cache`, `development-hmr-refresh`,
`dev-cache-control-no-cache`, plus `acceptance/ReactRefreshLogBox-app-doc` and
`e2e/next-image-new/app-dir` as guards against spurious reloads.
