### PR TITLE
docs(adapters): document assetsHashes and routing.middlewareMatchers

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/02-creating-an-adapter.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/02-creating-an-adapter.mdx
@@ -48,6 +48,7 @@ export interface NextAdapter {
   onBuildComplete?: (ctx: {
     routing: {
       beforeMiddleware: Array<Route>
+      middlewareMatchers: Array<Route>
       beforeFiles: Array<Route>
       afterFiles: Array<Route>
       dynamicRoutes: Array<Route>

--- a/docs/01-app/03-api-reference/07-adapters/03-api-reference.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/03-api-reference.mdx
@@ -24,6 +24,7 @@ Called after the build process completes with detailed information about routes 
 
 - `context.routing`: Object containing Next.js routing phases and metadata
   - `routing.beforeMiddleware`: Routes executed before middleware (includes header and redirect handling)
+  - `routing.middlewareMatchers`: Middleware matcher definitions for this build, used to decide whether middleware should be invoked for a given request
   - `routing.beforeFiles`: Rewrite routes checked before filesystem route matching
   - `routing.afterFiles`: Rewrite routes checked after filesystem route matching
   - `routing.dynamicRoutes`: Dynamic route matching table

--- a/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
@@ -30,6 +30,7 @@ React pages from the `pages/` directory:
   sourcePage: string   // Original source file path in pages/ directory
   runtime: 'nodejs' | 'edge'
   assets: Record<string, string>  // Traced dependencies (key: relative path from repo root, value: absolute path)
+  assetsHashes: Record<string, string>  // Content hashes of each `assets` entry (key: same as `assets`, value: content hash)
   wasmAssets?: Record<string, string>  // Bundled wasm files (key: name, value: absolute path)
   edgeRuntime?: {
     modulePath: string    // Absolute path to the module registered in the edge runtime
@@ -57,6 +58,7 @@ API routes from `pages/api/`:
   sourcePage: string   // Original relative source file path
   runtime: 'nodejs' | 'edge'
   assets: Record<string, string>  // Traced dependencies (key: relative path from repo root, value: absolute path)
+  assetsHashes: Record<string, string>  // Content hashes of each `assets` entry (key: same as `assets`, value: content hash)
   wasmAssets?: Record<string, string>  // Bundled wasm files (key: name, value: absolute path)
   edgeRuntime?: {
     modulePath: string    // Absolute path to the module registered in the edge runtime
@@ -84,6 +86,7 @@ React pages from the `app/` directory:
   sourcePage: string   // Original relative source file path
   runtime: 'nodejs' | 'edge' // Runtime the route is built for
   assets: Record<string, string>  // Traced dependencies (key: relative path from repo root, value: absolute path)
+  assetsHashes: Record<string, string>  // Content hashes of each `assets` entry (key: same as `assets`, value: content hash)
   wasmAssets?: Record<string, string>  // Bundled wasm files (key: name, value: absolute path)
   edgeRuntime?: {
     modulePath: string    // Absolute path to the module registered in the edge runtime
@@ -111,6 +114,7 @@ API and metadata routes from the `app/` directory:
   sourcePage: string   // Original relative source file path
   runtime: 'nodejs' | 'edge' // Runtime the route is built for
   assets: Record<string, string>  // Traced dependencies (key: relative path from repo root, value: absolute path)
+  assetsHashes: Record<string, string>  // Content hashes of each `assets` entry (key: same as `assets`, value: content hash)
   wasmAssets?: Record<string, string>  // Bundled wasm files (key: name, value: absolute path)
   edgeRuntime?: {
     modulePath: string    // Absolute path to the module registered in the edge runtime
@@ -218,6 +222,7 @@ See [Supporting immutable static assets](/docs/app/api-reference/adapters/immuta
   sourcePage: string    // Always 'middleware'
   runtime: 'nodejs' | 'edge' // Runtime the route is built for
   assets: Record<string, string>  // Traced dependencies (key: relative path from repo root, value: absolute path)
+  assetsHashes: Record<string, string>  // Content hashes of each `assets` entry (key: same as `assets`, value: content hash)
   wasmAssets?: Record<string, string>  // Bundled wasm files (key: name, value: absolute path)
   edgeRuntime?: {
     modulePath: string    // Absolute path to the module registered in the edge runtime

--- a/docs/01-app/03-api-reference/07-adapters/10-routing-information.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/10-routing-information.mdx
@@ -9,6 +9,10 @@ The `routing` object in `onBuildComplete` provides complete routing information 
 
 Routes applied before middleware execution. These include generated header and redirect behavior.
 
+## `routing.middlewareMatchers`
+
+Middleware matcher definitions emitted for this build. Use these to decide whether middleware should be invoked for a given request.
+
 ## `routing.beforeFiles`
 
 Rewrite routes checked before filesystem route matching.


### PR DESCRIPTION
While writing an adapter against `16.3.0-canary.107` I noticed the adapter docs are missing two fields that the shipped `NextAdapter` types already have.

**`assetsHashes`** — every `PAGES` / `PAGES_API` / `APP_PAGE` / `APP_ROUTE` / `MIDDLEWARE` output carries it right next to `assets`, and it's declared with a doc comment in `build-complete.d.ts`, but none of the five shapes in Output Types mention it.

**`routing.middlewareMatchers`** — dumping the `routing` object from a real `onBuildComplete` call gives:

```
afterFiles, beforeFiles, beforeMiddleware, dynamicRoutes, fallback,
middlewareMatchers, onMatch, rsc, shouldNormalizeNextData
```

but the docs list eight of those nine, everywhere the interface appears: the Creating an Adapter snippet (which says "The interface is defined as follows"), the API Reference parameter list, and Routing Information. This one feels worth fixing soon — an adapter that does its own request matching from the documented fields alone has no way to decide when middleware should run. My guess for why nobody has hit it: if you pass `routes: routing` wholesale into `resolveRoutes` from `@next/routing`, everything works without ever looking at the field.

The wording I added comes from the doc comments in the shipped types, not my own descriptions. `middlewareMatchers` is inserted where the type puts it (right after `beforeMiddleware`).

For what it's worth: I checked the rest of the section against the same build while I was at it — the `output: 'export'` behavior, the prerender classification fields, `pprChain.headers`, the fallback fields, the immutable-assets flow, and the `@next/routing` params/result — and everything else matched the docs. These two were the only gaps I found.
