### PR TITLE
Remove implicit Partial Prefetching opt-in from `instant`

### DIFF
--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -594,7 +594,7 @@ function processQueueInMicrotask() {
           // Finished prefetching the route tree. The two-phase (Shell then
           // Speculative) flow only applies to routes that have opted into
           // Partial Prefetching — either globally via the `partialPrefetching`
-          // config or per segment (`instant`, `prefetch: 'partial'`, or
+          // config or per segment (`prefetch: 'partial'` or
           // `'unstable_eager'`), all surfaced as the
           // `SubtreeHasPartialPrefetching` hint on the route tree. Every other
           // route skips the Shell phase and goes straight to Speculative.
@@ -839,18 +839,19 @@ function pingRootRouteTree(
       // `cacheComponents`, where every route is PPR.
       let fetchStrategy: FetchStrategy
       if (tree.prefetchHints & PrefetchHint.SubtreeHasPartialPrefetching) {
-        // If `instant` is defined anywhere on the target route, ignore the
-        // fetch strategy and switch to unified strategy used by Cache
-        // Components (called `PPR` for now, will likely be renamed).
+        // If Partial Prefetching is enabled anywhere on the target route,
+        // ignore the fetch strategy and switch to unified strategy used by
+        // Cache Components (called `PPR` for now, will likely be renamed).
         //
         // In practice, this just means that a "full" prefetch (<Link
         // prefetch={true}>) has no effect. You're meant to use Runtime
         // Prefetching instead — that's the new pattern that replaces
         // prefetch={true}.
         //
-        // The reason we check for `instant` rather than the `cacheComponents`
-        // flag is to support incremental adoption. `prefetch={true}` will
-        // continue to work until you opt into `instant`.
+        // The reason we check for the Partial Prefetching opt-in rather than
+        // the `cacheComponents` flag is to support incremental adoption.
+        // `prefetch={true}` will continue to work until you opt into
+        // Partial Prefetching.
         fetchStrategy = FetchStrategy.PPR
       } else if (task.fetchStrategy === FetchStrategy.PPR) {
         fetchStrategy = route.supportsPerSegmentPrefetching

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -99,12 +99,7 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     }
   }
 
-  const isInstant =
-    instantConfig === true ||
-    (typeof instantConfig === 'object' && instantConfig !== null)
-  if (isInstant) {
-    prefetchHints |= PrefetchHint.SubtreeHasPartialPrefetching
-  } else if (instantConfig === false) {
+  if (instantConfig === false) {
     // The segment explicitly opts out of Partial Prefetching. We don't change
     // the prefetch behavior, but we record it so the dev-time
     // `<Link prefetch={true}>` warning can be suppressed for this route.
@@ -125,11 +120,10 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   }
 
   // Mark the segment as "eager" unless its effective prefetch strategy is
-  // 'partial'. A truthy instant is treated as 'partial' (not eager).
-  // 'unstable_eager' already set the bit above. Under App Shells, a subtree
-  // with no eager segment skips its Speculative prefetch and relies on the
-  // shared app shell instead.
-  if (!isInstant && prefetchConfig !== 'partial') {
+  // 'partial'. 'unstable_eager' already set the bit above. Under App Shells,
+  // a subtree with no eager segment skips its Speculative prefetch and relies
+  // on the shared app shell instead.
+  if (prefetchConfig !== 'partial') {
     prefetchHints |= PrefetchHint.SubtreeHasEagerPrefetch
   }
 

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -187,10 +187,10 @@ export const enum PrefetchHint {
   // considering caches populated by older builds.
 
   // This segment or one of its descendants opts into Partial Prefetching, i.e.
-  // uses the two-phase (Shell then Speculative) prefetch flow. Set when a
-  // truthy instant config is present, or `prefetch` is 'partial' or
-  // 'unstable_eager'. Propagates upward so the root segment reflects the
-  // entire subtree.
+  // uses the two-phase (Shell then Speculative) prefetch flow. Set when
+  // `prefetch` is 'partial' or 'unstable_eager' (including the defaults
+  // implied by the global `partialPrefetching` config). Propagates upward so
+  // the root segment reflects the entire subtree.
   //
   // Partial Prefetching segments require RUNTIME COMPLETENESS: a prefetch
   // isn't considered done for such a segment until an entry at least as

--- a/test/e2e/app-dir/prefetch-true-instant/app/instant-only/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/instant-only/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+// Only `instant = true` — no `prefetch` export. `instant` alone does not opt
+// the route into Partial Prefetching, so a <Link prefetch={true}> to this page
+// still performs a full prefetch that includes dynamic content.
+export const instant = true
+
+export default async function Page() {
+  return (
+    <main>
+      <Suspense fallback={<div>Loading cached...</div>}>
+        <Cached />
+      </Suspense>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Cached() {
+  'use cache'
+  return <div id="cached-content">Cached content</div>
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Dynamic content</div>
+}

--- a/test/e2e/app-dir/prefetch-true-instant/app/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/page.tsx
@@ -15,6 +15,11 @@ export default function Page() {
             /layout-instant (prefetch=true, instant on layout)
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/instant-only" prefetch={true}>
+            /instant-only (prefetch=true, instant = true, no prefetch config)
+          </LinkAccordion>
+        </li>
       </ul>
     </main>
   )

--- a/test/e2e/app-dir/prefetch-true-instant/prefetch-true-instant.test.ts
+++ b/test/e2e/app-dir/prefetch-true-instant/prefetch-true-instant.test.ts
@@ -126,4 +126,44 @@ describe('prefetch={true} with instant route', () => {
       'Dynamic content'
     )
   })
+
+  it('does not downgrade the prefetch when the route only has instant, without a prefetch config', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // The route exports `instant = true` but no `prefetch` config, so it has
+    // not opted into Partial Prefetching. The full prefetch should include
+    // the dynamic content.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/instant-only"]'
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Cached content',
+      },
+      {
+        includes: 'Dynamic content',
+      },
+    ])
+
+    // Since the full prefetch already included the dynamic content, the
+    // navigation should not issue any additional requests, and both parts
+    // should be visible immediately.
+    await act(async () => {
+      await browser.elementByCss('a[href="/instant-only"]').click()
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Dynamic content'
+      )
+    }, 'no-requests')
+  })
 })


### PR DESCRIPTION
Previously, adding a truthy `instant` config to a route segment (e.g. `export const instant = true`) did two things: it enabled instant navigation validation, and it implicitly opted the route into Partial Prefetching.

Now those concerns are fully separate. `instant` only controls validation, so enabling it no longer silently changes how a route is prefetched. Partial Prefetching is enabled with the `prefetch` segment config (`'partial'` or `'unstable_eager'`), or globally with the `partialPrefetching` option in next.config.

For routes whose only opt-in was a truthy `instant`, `<Link prefetch={true}>` goes back to performing a legacy full prefetch instead of being downgraded to a partial one. `instant = false` still opts a route out of the dev-time `prefetch={true}` warning.

Adds a regression test asserting that a route that only exports `instant = true` keeps the full-prefetch behavior.
