### PR TITLE
fix(next/image): don't hang cold transforms when the requester aborts

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -978,10 +978,12 @@ export async function fetchInternalImage(
     // Coerce HEAD to GET to avoid issues with the image optimizer
     const method = !_req.method || _req.method === 'HEAD' ? 'GET' : _req.method
 
+    // Don't wire the requester's socket into the coalesced internal request:
+    // one client aborting would tear down the shared stream and wedge the
+    // cache entry for every other waiter.
     const mocked = createRequestResponseMocks({
       url: href,
       method,
-      socket: _req.socket,
       maximumResponseBody,
     })
 

--- a/test/unit/image-optimizer/fetch-internal-image.test.ts
+++ b/test/unit/image-optimizer/fetch-internal-image.test.ts
@@ -3,7 +3,12 @@ import {
   fetchInternalImage,
   ImageError,
 } from 'next/dist/server/image-optimizer'
+import { serveStatic } from 'next/dist/server/serve-static'
 import type { IncomingMessage, ServerResponse } from 'http'
+import { EventEmitter } from 'events'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 describe('fetchInternalImage', () => {
   describe('response size limit', () => {
@@ -147,6 +152,38 @@ describe('fetchInternalImage', () => {
 
       expect(result.buffer).toBeInstanceOf(Buffer)
       expect(result.buffer.length).toBe(maximumResponseBody)
+    })
+  })
+
+  describe('requester disconnect', () => {
+    it('should still complete when the requester socket is already gone', async () => {
+      const size = 4 * 1024 * 1024
+      const filePath = join(tmpdir(), `fetch-internal-image-${Date.now()}.bin`)
+      await fs.writeFile(filePath, Buffer.alloc(size, 1))
+
+      // A disconnected client's socket reports `writable: false`, which is what
+      // `send` reads to decide the response is done and destroy the stream.
+      const socket = Object.assign(new EventEmitter(), { writable: false })
+      const mockReq = { method: 'GET', socket } as unknown as IncomingMessage
+      const mockRes = {} as ServerResponse
+
+      try {
+        const result = await Promise.race([
+          fetchInternalImage(
+            '/test-image.jpg',
+            mockReq,
+            mockRes,
+            50_000_000,
+            (req, res) => serveStatic(req, res, filePath)
+          ),
+          new Promise((resolve) => setTimeout(() => resolve('timeout'), 5_000)),
+        ])
+
+        expect(result).not.toBe('timeout')
+        expect((result as { buffer: Buffer }).buffer.length).toBe(size)
+      } finally {
+        await fs.unlink(filePath).catch(() => {})
+      }
     })
   })
 })


### PR DESCRIPTION
On self-hosted `next start`, a client aborting a cold `/_next/image` request mid-transform permanently hangs that exact transform URL for every later request, with nothing logged, until the server restarts.

The coalesced internal fetch wires its mock response to the aborting client's real socket, so `send`'s `on-finished` treats the response as finished when that socket closes and tears down the file stream without ever ending the mock. `hasStreamed` never settles, the generator never settles, and the batcher never releases the cache key.

This stops passing the requester's socket into the internal request, so the shared transform completes regardless of any single client's connection state.

Fixes #96538
