### PR TITLE
[turbopack] Add test for sideEffects with optimizePackageImports

### DIFF
--- a/test/production/app-dir/optimize-package-imports-side-effects/app/layout.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/app/page.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/app/page.js
@@ -1,0 +1,15 @@
+import { Trap } from 'sidecar-lib'
+import { Widget } from 'side-effectful-lib'
+
+export default function Page() {
+  return (
+    <>
+      <p id="sidecar-lib-effects">
+        <Trap />
+      </p>
+      <p id="side-effectful-lib-effects">
+        <Widget />
+      </p>
+    </>
+  )
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/next.config.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    optimizePackageImports: ['sidecar-lib', 'side-effectful-lib'],
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/index.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/index.js
@@ -1,0 +1,2 @@
+export { Widget } from './widget.js'
+export { Unused } from './unused.js'

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/medium.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/medium.js
@@ -1,0 +1,1 @@
+export const effects = []

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/package.json
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "side-effectful-lib",
+  "type": "module",
+  "exports": "./index.js",
+  "sideEffects": true
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/register.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/register.js
@@ -1,0 +1,5 @@
+// The package declares `sideEffects: true`, so this registration must survive tree shaking
+// even though the package is assumed to be side effect free.
+import { effects } from './medium.js'
+
+effects.push('register.js')

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/unused.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/unused.js
@@ -1,0 +1,3 @@
+export function Unused() {
+  return 'unused'
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/widget.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/side-effectful-lib/widget.js
@@ -1,0 +1,6 @@
+import './register.js'
+import { effects } from './medium.js'
+
+export function Widget() {
+  return effects.length ? effects.join(',') : 'none'
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/index.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/index.js
@@ -1,0 +1,2 @@
+export { Trap } from './trap.js'
+export { Unused } from './unused.js'

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/medium.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/medium.js
@@ -1,0 +1,1 @@
+export const effects = []

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/other.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/other.js
@@ -1,0 +1,5 @@
+// Not listed in the `sideEffects` glob of package.json, so this registration is expected
+// to be dropped.
+import { effects } from './medium.js'
+
+effects.push('other.js')

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/package.json
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sidecar-lib",
+  "type": "module",
+  "exports": "./index.js",
+  "sideEffects": [
+    "**/sidecar.js"
+  ]
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/sidecar.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/sidecar.js
@@ -1,0 +1,5 @@
+// Listed in the `sideEffects` glob of package.json, so this registration must survive
+// tree shaking even though the package is assumed to be side effect free.
+import { effects } from './medium.js'
+
+effects.push('sidecar.js')

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/trap.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/trap.js
@@ -1,0 +1,7 @@
+import './sidecar.js'
+import './other.js'
+import { effects } from './medium.js'
+
+export function Trap() {
+  return effects.length ? effects.join(',') : 'none'
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/unused.js
+++ b/test/production/app-dir/optimize-package-imports-side-effects/node_modules/sidecar-lib/unused.js
@@ -1,0 +1,3 @@
+export function Unused() {
+  return 'unused'
+}

--- a/test/production/app-dir/optimize-package-imports-side-effects/optimize-package-imports-side-effects.test.ts
+++ b/test/production/app-dir/optimize-package-imports-side-effects/optimize-package-imports-side-effects.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// `optimizePackageImports` assumes the listed packages are side effect free. A package that
+// declares `sideEffects` in its package.json must still win over that assumption, otherwise
+// side-effect-only registration modules (the `sidecar` pattern used by react-focus-lock and
+// react-remove-scroll) get tree shaken away. See https://github.com/vercel/next.js/issues/96333
+describe('optimizePackageImports - sideEffects declared in package.json', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should keep a module matching the sideEffects glob of an optimized package', async () => {
+    const $ = await next.render$('/')
+    expect($('#sidecar-lib-effects').text()).toContain('sidecar.js')
+  })
+
+  it('should still drop a module not matching the sideEffects glob of an optimized package', async () => {
+    const $ = await next.render$('/')
+    expect($('#sidecar-lib-effects').text()).not.toContain('other.js')
+  })
+
+  it('should keep a module of an optimized package declaring sideEffects: true', async () => {
+    const $ = await next.render$('/')
+    expect($('#side-effectful-lib-effects').text()).toContain('register.js')
+  })
+})


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/96383. This test passes with Webpack, failed with Turbopack before the change, and passes now.