### PR TITLE
Preserve the original host on forwarded Server Action requests

### DIFF
--- a/packages/next/src/server/app-render/action-forwarding.test.ts
+++ b/packages/next/src/server/app-render/action-forwarding.test.ts
@@ -1,0 +1,267 @@
+import type { IncomingHttpHeaders } from 'http'
+import type { BaseNextRequest } from '../base-http'
+import { NEXT_REQUEST_META } from '../request-meta'
+import {
+  getActionForwardingOrigin,
+  getForwardedHostValue,
+  restoreForwardedActionHost,
+} from './action-forwarding'
+
+const ACTION_ID = '00' + 'a'.repeat(40)
+const PRIVATE_ORIGIN = 'http://localhost:3000'
+const INTERNAL_HOST = 'localhost:3000'
+const PUBLIC_HOST = 'tenant.example'
+
+function createRequest({
+  headers,
+  method = 'POST',
+  initURL,
+}: {
+  headers?: IncomingHttpHeaders
+  method?: string
+  initURL?: string
+}): BaseNextRequest {
+  return {
+    method,
+    headers: {
+      'next-action': ACTION_ID,
+      'content-type': 'text/plain;charset=UTF-8',
+      ...headers,
+    },
+    [NEXT_REQUEST_META]: { initURL },
+  } as unknown as BaseNextRequest
+}
+
+// The shape `createForwardedActionResponse` produces: it arrives at the origin
+// we forwarded to, and only `x-forwarded-host` still knows the original host.
+function createForwardedRequest(
+  headers?: IncomingHttpHeaders,
+  initURL?: string
+): BaseNextRequest {
+  return createRequest({
+    headers: {
+      host: INTERNAL_HOST,
+      'x-forwarded-host': PUBLIC_HOST,
+      'x-action-forwarded': '1',
+      ...headers,
+    },
+    initURL,
+  })
+}
+
+describe('getForwardedHostValue', () => {
+  it('reads a single value', () => {
+    expect(getForwardedHostValue({ 'x-forwarded-host': PUBLIC_HOST })).toBe(
+      PUBLIC_HOST
+    )
+  })
+
+  it('reads the first value of a comma-separated list', () => {
+    expect(
+      getForwardedHostValue({
+        'x-forwarded-host': `${PUBLIC_HOST}, proxy.example`,
+      })
+    ).toBe(PUBLIC_HOST)
+  })
+
+  it('reads the first value of a repeated header', () => {
+    expect(
+      getForwardedHostValue({
+        'x-forwarded-host': [PUBLIC_HOST, 'proxy.example'],
+      })
+    ).toBe(PUBLIC_HOST)
+  })
+
+  it('returns undefined when the header is missing or empty', () => {
+    expect(getForwardedHostValue({})).toBeUndefined()
+    expect(getForwardedHostValue({ 'x-forwarded-host': [] })).toBeUndefined()
+  })
+})
+
+describe('getActionForwardingOrigin', () => {
+  const originalPrivateOrigin = process.env.__NEXT_PRIVATE_ORIGIN
+
+  afterEach(() => {
+    process.env.__NEXT_PRIVATE_ORIGIN = originalPrivateOrigin
+  })
+
+  it('prefers the private origin', () => {
+    process.env.__NEXT_PRIVATE_ORIGIN = PRIVATE_ORIGIN
+
+    expect(
+      getActionForwardingOrigin(
+        createRequest({ initURL: 'http://127.0.0.1:4000/some/path' })
+      )
+    ).toBe(PRIVATE_ORIGIN)
+  })
+
+  it('falls back to the origin of initURL', () => {
+    delete process.env.__NEXT_PRIVATE_ORIGIN
+
+    expect(
+      getActionForwardingOrigin(
+        createRequest({ initURL: 'http://localhost:3000/some/path?a=b' })
+      )
+    ).toBe(PRIVATE_ORIGIN)
+  })
+
+  it('throws when initURL is missing', () => {
+    delete process.env.__NEXT_PRIVATE_ORIGIN
+
+    expect(() => getActionForwardingOrigin(createRequest({}))).toThrow(
+      'Missing initURL'
+    )
+  })
+
+  it('throws when initURL is not absolute', () => {
+    delete process.env.__NEXT_PRIVATE_ORIGIN
+
+    // What `attachRequestMeta` produces when the server has no configured
+    // hostname and port and does not trust the host header.
+    expect(() =>
+      getActionForwardingOrigin(createRequest({ initURL: '/some/path' }))
+    ).toThrow('Could not determine origin')
+  })
+})
+
+describe('restoreForwardedActionHost', () => {
+  const originalPrivateOrigin = process.env.__NEXT_PRIVATE_ORIGIN
+
+  beforeEach(() => {
+    process.env.__NEXT_PRIVATE_ORIGIN = PRIVATE_ORIGIN
+  })
+
+  afterEach(() => {
+    process.env.__NEXT_PRIVATE_ORIGIN = originalPrivateOrigin
+  })
+
+  function restore(req: BaseNextRequest, hasConfiguredOrigin = true) {
+    restoreForwardedActionHost(req, { hasConfiguredOrigin })
+    return req.headers['host']
+  }
+
+  it('restores the original host on a forwarded action', () => {
+    expect(restore(createForwardedRequest())).toBe(PUBLIC_HOST)
+  })
+
+  it('restores the first value of an x-forwarded-host list', () => {
+    expect(
+      restore(
+        createForwardedRequest({
+          'x-forwarded-host': `${PUBLIC_HOST}, proxy.example`,
+        })
+      )
+    ).toBe(PUBLIC_HOST)
+
+    expect(
+      restore(
+        createForwardedRequest({
+          'x-forwarded-host': [PUBLIC_HOST, 'proxy.example'],
+        })
+      )
+    ).toBe(PUBLIC_HOST)
+  })
+
+  it('restores a host that carries an explicit port', () => {
+    expect(
+      restore(
+        createForwardedRequest({ 'x-forwarded-host': `${PUBLIC_HOST}:8443` })
+      )
+    ).toBe(`${PUBLIC_HOST}:8443`)
+  })
+
+  it('compares the internal origin with its port', () => {
+    // Same hostname, different port: this request did not arrive at the origin
+    // we forward to.
+    expect(restore(createForwardedRequest({ host: 'localhost:3001' }))).toBe(
+      'localhost:3001'
+    )
+  })
+
+  it('ignores a request that did not arrive at the internal origin', () => {
+    // A client that forges the marker but reaches the server on its public
+    // host must not be able to rewrite `host` from a header it also controls.
+    expect(restore(createForwardedRequest({ host: 'attacker.example' }))).toBe(
+      'attacker.example'
+    )
+  })
+
+  it.each([undefined, '', 'true', '0', '1, 1', 'yes'])(
+    'ignores the marker value %p',
+    (markerValue) => {
+      expect(
+        restore(createForwardedRequest({ 'x-action-forwarded': markerValue }))
+      ).toBe(INTERNAL_HOST)
+    }
+  )
+
+  it('ignores a request that is not a fetch action', () => {
+    // Only a POST carrying an action id is ever forwarded.
+    expect(
+      restore(
+        createRequest({
+          method: 'GET',
+          headers: {
+            host: INTERNAL_HOST,
+            'x-forwarded-host': PUBLIC_HOST,
+            'x-action-forwarded': '1',
+          },
+        })
+      )
+    ).toBe(INTERNAL_HOST)
+
+    expect(
+      restore(
+        createForwardedRequest({
+          // A multipart (MPA) action is never forwarded either.
+          'next-action': undefined,
+          'content-type': 'multipart/form-data; boundary=----x',
+        })
+      )
+    ).toBe(INTERNAL_HOST)
+  })
+
+  it('ignores a request without x-forwarded-host', () => {
+    expect(
+      restore(createForwardedRequest({ 'x-forwarded-host': undefined }))
+    ).toBe(INTERNAL_HOST)
+  })
+
+  it('ignores a malformed private origin', () => {
+    process.env.__NEXT_PRIVATE_ORIGIN = 'not a url'
+
+    expect(restore(createForwardedRequest())).toBe(INTERNAL_HOST)
+  })
+
+  describe('without a private origin', () => {
+    beforeEach(() => {
+      delete process.env.__NEXT_PRIVATE_ORIGIN
+    })
+
+    it('compares against the origin of initURL', () => {
+      expect(
+        restore(
+          createForwardedRequest({}, 'http://localhost:3000/without-action')
+        )
+      ).toBe(PUBLIC_HOST)
+    })
+
+    it('ignores initURL when the server has no configured origin', () => {
+      // `initURL` is then built from this request's own host header, so it
+      // proves nothing about where the request arrived.
+      expect(
+        restore(
+          createForwardedRequest({}, `http://${INTERNAL_HOST}/without-action`),
+          false
+        )
+      ).toBe(INTERNAL_HOST)
+    })
+
+    it('ignores a request when no origin can be determined', () => {
+      expect(restore(createForwardedRequest())).toBe(INTERNAL_HOST)
+      expect(restore(createForwardedRequest({}, '/without-action'))).toBe(
+        INTERNAL_HOST
+      )
+    })
+  })
+})

--- a/packages/next/src/server/app-render/action-forwarding.ts
+++ b/packages/next/src/server/app-render/action-forwarding.ts
@@ -1,0 +1,64 @@
+import type { IncomingHttpHeaders } from 'http'
+
+/**
+ * Set by `createForwardedActionResponse` on a Server Action request that it has
+ * forwarded to a different worker, so the receiving worker knows the request has
+ * already been forwarded once.
+ */
+export const ACTION_FORWARDED_HEADER = 'x-action-forwarded'
+
+/**
+ * Reads the first value of `x-forwarded-host`, which can arrive either as a
+ * repeated header or as a single comma-separated list.
+ */
+export function getForwardedHostValue(
+  headers: IncomingHttpHeaders
+): string | undefined {
+  const forwardedHostHeader = headers['x-forwarded-host']
+
+  return Array.isArray(forwardedHostHeader)
+    ? forwardedHostHeader[0]
+    : forwardedHostHeader?.split(',')?.[0]?.trim()
+}
+
+/**
+ * A Server Action POST that lands on a route which doesn't bundle the action is
+ * forwarded to a worker that does, by fetching our own internal origin (see
+ * `createForwardedActionResponse`). `host` is a forbidden `fetch` header, so it
+ * can't be carried over, and the subrequest arrives claiming to be for the
+ * internal origin instead of the host the user actually requested.
+ *
+ * `x-forwarded-host` does survive the forward, so restore `host` from it.
+ * Otherwise `headers().get('host')` inside a forwarded action reports
+ * `localhost:PORT`, which silently breaks host-based multi-tenancy for exactly
+ * those actions that happen to get forwarded.
+ */
+export function restoreForwardedActionHost(headers: IncomingHttpHeaders): void {
+  if (!headers[ACTION_FORWARDED_HEADER]) {
+    return
+  }
+
+  // Only rewrite a request that really did arrive over the internal forward.
+  // When the origin isn't set, `createForwardedActionResponse` falls back to the
+  // initial request URL, which already carries the original host.
+  const internalOrigin = process.env.__NEXT_PRIVATE_ORIGIN
+  if (!internalOrigin) {
+    return
+  }
+
+  let internalHost: string
+  try {
+    internalHost = new URL(internalOrigin).host
+  } catch {
+    return
+  }
+
+  if (headers['host'] !== internalHost) {
+    return
+  }
+
+  const forwardedHost = getForwardedHostValue(headers)
+  if (forwardedHost) {
+    headers['host'] = forwardedHost
+  }
+}

--- a/packages/next/src/server/app-render/action-forwarding.ts
+++ b/packages/next/src/server/app-render/action-forwarding.ts
@@ -1,4 +1,8 @@
 import type { IncomingHttpHeaders } from 'http'
+import type { BaseNextRequest } from '../base-http'
+import { getRequestMeta } from '../request-meta'
+import { getServerActionRequestMetadata } from '../lib/server-action-request-meta'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 /**
  * Set by `createForwardedActionResponse` on a Server Action request that it has
@@ -6,6 +10,14 @@ import type { IncomingHttpHeaders } from 'http'
  * already been forwarded once.
  */
 export const ACTION_FORWARDED_HEADER = 'x-action-forwarded'
+
+/**
+ * The only value `createForwardedActionResponse` ever sends. The header is not
+ * in `INTERNAL_HEADERS` (it can't be — the same ingress filter runs on the
+ * loopback request and would strip the genuine marker), so an external client
+ * can send it too. Matching the value exactly keeps the checks below narrow.
+ */
+export const ACTION_FORWARDED_VALUE = '1'
 
 /**
  * Reads the first value of `x-forwarded-host`, which can arrive either as a
@@ -22,43 +34,104 @@ export function getForwardedHostValue(
 }
 
 /**
+ * The origin Next.js fetches when it forwards a request to itself: action
+ * forwarding (`createForwardedActionResponse`) and app-relative redirect
+ * streaming (`createRedirectRenderResult`) both go here, and
+ * `restoreForwardedActionHost` uses it to recognize a request that arrived over
+ * such a forward. The send and receive sides have to agree, so they share this.
+ *
+ * Throws when no origin can be determined, which is a hard error on the send
+ * side — there is nowhere to forward to.
+ */
+export function getActionForwardingOrigin(req: BaseNextRequest): string {
+  // TODO: Remove __NEXT_PRIVATE_ORIGIN
+  const privateOrigin = process.env.__NEXT_PRIVATE_ORIGIN
+  if (privateOrigin !== undefined) {
+    return privateOrigin
+  }
+
+  const initURL = getRequestMeta(req, 'initURL')
+  if (initURL === undefined) {
+    throw new InvariantError('Missing initURL')
+  }
+
+  try {
+    return new URL(initURL).origin
+  } catch (error) {
+    throw new Error(
+      'Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.',
+      { cause: error }
+    )
+  }
+}
+
+/**
  * A Server Action POST that lands on a route which doesn't bundle the action is
- * forwarded to a worker that does, by fetching our own internal origin (see
+ * forwarded to a worker that does, by fetching our own forwarding origin (see
  * `createForwardedActionResponse`). `host` is a forbidden `fetch` header, so it
- * can't be carried over, and the subrequest arrives claiming to be for the
+ * can't be carried over, and the subrequest arrives claiming to be for that
  * internal origin instead of the host the user actually requested.
  *
  * `x-forwarded-host` does survive the forward, so restore `host` from it.
  * Otherwise `headers().get('host')` inside a forwarded action reports
  * `localhost:PORT`, which silently breaks host-based multi-tenancy for exactly
  * those actions that happen to get forwarded.
+ *
+ * `x-action-forwarded` is not an authenticated marker, so it is treated as a
+ * hint rather than as proof: the rewrite additionally requires the request to
+ * be a fetch action (the only shape that is ever forwarded) that arrived at the
+ * origin we would have forwarded to.
  */
-export function restoreForwardedActionHost(headers: IncomingHttpHeaders): void {
-  if (!headers[ACTION_FORWARDED_HEADER]) {
+export function restoreForwardedActionHost(
+  req: BaseNextRequest,
+  {
+    hasConfiguredOrigin,
+  }: {
+    /**
+     * Whether the server was started with an explicit hostname and port, and so
+     * builds `initURL` from its own origin rather than from the incoming `host`
+     * header. See `attachRequestMeta` in `next-server.ts`.
+     */
+    hasConfiguredOrigin: boolean
+  }
+): void {
+  // Not a truthiness check: the header is forgeable, so only the exact value we
+  // send counts. A repeated header arrives here comma-joined, which also fails.
+  if (req.headers[ACTION_FORWARDED_HEADER] !== ACTION_FORWARDED_VALUE) {
     return
   }
 
-  // Only rewrite a request that really did arrive over the internal forward.
-  // When the origin isn't set, `createForwardedActionResponse` falls back to the
-  // initial request URL, which already carries the original host.
-  const internalOrigin = process.env.__NEXT_PRIVATE_ORIGIN
-  if (!internalOrigin) {
+  // `handleAction` only forwards when it has an action id on a POST, so no
+  // other request shape can have reached us through the forwarding path.
+  if (!getServerActionRequestMetadata(req).isFetchAction) {
+    return
+  }
+
+  const forwardedHost = getForwardedHostValue(req.headers)
+  if (!forwardedHost) {
+    return
+  }
+
+  // Without a private origin the forwarding origin comes from `initURL`, which
+  // is the server's own origin only when it was started with a hostname and
+  // port. Otherwise `initURL` is built from this request's own `host` header,
+  // which would make the origin comparison below vacuously true.
+  if (process.env.__NEXT_PRIVATE_ORIGIN === undefined && !hasConfiguredOrigin) {
     return
   }
 
   let internalHost: string
   try {
-    internalHost = new URL(internalOrigin).host
+    internalHost = new URL(getActionForwardingOrigin(req)).host
   } catch {
+    // We can't tell where a forward would have gone, so don't rewrite anything.
     return
   }
 
-  if (headers['host'] !== internalHost) {
+  // The request has to have arrived at the origin we forward to.
+  if (req.headers['host'] !== internalHost) {
     return
   }
 
-  const forwardedHost = getForwardedHostValue(headers)
-  if (forwardedHost) {
-    headers['host'] = forwardedHost
-  }
+  req.headers['host'] = forwardedHost
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -48,6 +48,10 @@ import {
 import { getServerActionRequestMetadata } from '../lib/server-action-request-meta'
 import { isCsrfOriginAllowed } from './csrf-protection'
 import { warn } from '../../build/output/log'
+import {
+  ACTION_FORWARDED_HEADER,
+  getForwardedHostValue,
+} from './action-forwarding'
 import { RequestCookies, ResponseCookies } from '../web/spec-extension/cookies'
 import { HeadersAdapter } from '../web/spec-extension/adapters/headers'
 import { fromNodeOutgoingHttpHeaders } from '../web/utils'
@@ -225,7 +229,7 @@ async function createForwardedActionResponse(
   // indicate that this action request was forwarded from another worker
   // we use this to skip rendering the flight tree so that we don't update the UI
   // with the response from the forwarded worker
-  forwardedHeaders.set('x-action-forwarded', '1')
+  forwardedHeaders.set(ACTION_FORWARDED_HEADER, '1')
 
   // TODO: Remove __NEXT_PRIVATE_ORIGIN
   let origin: string | undefined = process.env.__NEXT_PRIVATE_ORIGIN
@@ -512,11 +516,7 @@ export function parseHostHeader(
   headers: IncomingHttpHeaders,
   originDomain?: string
 ) {
-  const forwardedHostHeader = headers['x-forwarded-host']
-  const forwardedHostHeaderValue =
-    forwardedHostHeader && Array.isArray(forwardedHostHeader)
-      ? forwardedHostHeader[0]
-      : forwardedHostHeader?.split(',')?.[0]?.trim()
+  const forwardedHostHeaderValue = getForwardedHostValue(headers)
   const hostHeader = headers['host']
 
   if (originDomain) {
@@ -754,7 +754,7 @@ export async function handleAction({
     'no-cache, no-store, max-age=0, must-revalidate'
   )
 
-  const actionWasForwarded = Boolean(req.headers['x-action-forwarded'])
+  const actionWasForwarded = Boolean(req.headers[ACTION_FORWARDED_HEADER])
   // A fetch action targeting a fallback route has no concrete params with
   // which to resume the destination page.
   const isActionOnlyFallbackRequest =

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -50,6 +50,8 @@ import { isCsrfOriginAllowed } from './csrf-protection'
 import { warn } from '../../build/output/log'
 import {
   ACTION_FORWARDED_HEADER,
+  ACTION_FORWARDED_VALUE,
+  getActionForwardingOrigin,
   getForwardedHostValue,
 } from './action-forwarding'
 import { RequestCookies, ResponseCookies } from '../web/spec-extension/cookies'
@@ -229,26 +231,9 @@ async function createForwardedActionResponse(
   // indicate that this action request was forwarded from another worker
   // we use this to skip rendering the flight tree so that we don't update the UI
   // with the response from the forwarded worker
-  forwardedHeaders.set(ACTION_FORWARDED_HEADER, '1')
+  forwardedHeaders.set(ACTION_FORWARDED_HEADER, ACTION_FORWARDED_VALUE)
 
-  // TODO: Remove __NEXT_PRIVATE_ORIGIN
-  let origin: string | undefined = process.env.__NEXT_PRIVATE_ORIGIN
-  if (origin === undefined) {
-    const initUrl = getRequestMeta(req, 'initURL')
-    if (initUrl !== undefined) {
-      try {
-        const parsedUrl = new URL(initUrl)
-        origin = parsedUrl.origin
-      } catch (error) {
-        throw new Error(
-          'Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.',
-          { cause: error }
-        )
-      }
-    } else {
-      throw new InvariantError('Missing initURL')
-    }
-  }
+  const origin = getActionForwardingOrigin(req)
 
   const fetchUrl = new URL(`${origin}${basePath}${workerPathname}`)
 
@@ -401,25 +386,7 @@ async function createRedirectRenderResult(
     const forwardedHeaders = getForwardedHeaders(req, res)
     forwardedHeaders.set(RSC_HEADER, '1')
 
-    // TODO: Remove __NEXT_PRIVATE_ORIGIN
-    let origin: string | undefined = process.env.__NEXT_PRIVATE_ORIGIN
-    if (origin === undefined) {
-      const initUrl = getRequestMeta(req, 'initURL')
-      if (initUrl !== undefined) {
-        try {
-          const parsedUrl = new URL(initUrl)
-
-          origin = parsedUrl.origin
-        } catch (error) {
-          throw new Error(
-            'Could not determine origin for forwarded Server Actions request. This can happen if port or hostname are not configured for this server.',
-            { cause: error }
-          )
-        }
-      } else {
-        throw new InvariantError('Missing initURL')
-      }
-    }
+    const origin = getActionForwardingOrigin(req)
 
     const fetchUrl = new URL(
       `${origin}${appRelativeRedirectUrl.pathname}${appRelativeRedirectUrl.search}`

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -274,9 +274,9 @@ async function createForwardedActionResponse(
       },
     })
 
-    if (
-      response.headers.get('content-type')?.startsWith(RSC_CONTENT_TYPE_HEADER)
-    ) {
+    const responseContentType = response.headers.get('content-type')
+
+    if (responseContentType?.startsWith(RSC_CONTENT_TYPE_HEADER)) {
       // copy the headers from the redirect response to the response we're sending
       for (const [key, value] of response.headers) {
         if (!actionsForbiddenHeaders.includes(key)) {
@@ -298,6 +298,14 @@ async function createForwardedActionResponse(
       res.statusCode = 404
       return RenderResult.fromStatic('Server action not found.', 'text/plain')
     }
+
+    console.error(
+      `Failed to forward Server Action response: expected an RSC response but received status ${response.status}${
+        responseContentType
+          ? ` with content type \`${limitUntrustedHeaderValueForLogs(responseContentType)}\``
+          : ''
+      }.`
+    )
   } catch (err) {
     // we couldn't stream the forwarded response, so we'll just return an empty response
     console.error(`failed to forward action response`, err)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1090,11 +1090,20 @@ export default abstract class Server<
       req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http'
       req.headers['x-forwarded-for'] ??= originalRequest?.socket?.remoteAddress
 
-      restoreForwardedActionHost(req.headers)
-
       // This should be done before any normalization of the pathname happens as
       // it captures the initial URL.
       this.attachRequestMeta(req, parsedUrl)
+
+      // A Server Action that we forwarded to another worker arrives over an
+      // internal self-fetch, which replaces `host` with the origin we forwarded
+      // to. This runs after `attachRequestMeta`, because the forwarding origin
+      // can come from `initURL`, and before the first consumers of `host`:
+      // domain locale detection below, and later `headers()` inside the action.
+      restoreForwardedActionHost(req, {
+        // Mirrors the condition `attachRequestMeta` uses to build `initURL`
+        // from this server's own hostname and port.
+        hasConfiguredOrigin: Boolean(this.fetchHostname && this.port),
+      })
 
       let finished = await this.handleRSCRequest(req, res, parsedUrl)
       if (finished) return

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -130,6 +130,7 @@ import { matchNextDataPathname } from './lib/match-next-data-pathname'
 import getRouteFromAssetPath from '../shared/lib/router/utils/get-route-from-asset-path'
 import { RSCPathnameNormalizer } from './normalizers/request/rsc'
 import { stripFlightHeaders } from './app-render/strip-flight-headers'
+import { restoreForwardedActionHost } from './app-render/action-forwarding'
 import {
   isAppPageRouteModule,
   isAppRouteRouteModule,
@@ -1088,6 +1089,8 @@ export default abstract class Server<
           : '80'
       req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http'
       req.headers['x-forwarded-for'] ??= originalRequest?.socket?.remoteAddress
+
+      restoreForwardedActionHost(req.headers)
 
       // This should be done before any normalization of the pathname happens as
       // it captures the initial URL.

--- a/test/e2e/app-dir/action-forward-host/action-forward-host.test.ts
+++ b/test/e2e/app-dir/action-forward-host/action-forward-host.test.ts
@@ -6,6 +6,9 @@ import http from 'http'
 // internal loopback origin.
 const HOST = 'example.test'
 
+// The host a client would try to smuggle in through `x-forwarded-host`.
+const FORGED_HOST = 'forged.test'
+
 type ObservedHeaders = {
   host: string | null
   xForwardedHost: string | null
@@ -13,16 +16,27 @@ type ObservedHeaders = {
 }
 
 describe('server action forwarding - original host', () => {
-  const { next } = nextTestSetup({
+  // The behaviour under test only exists on a self-hosted server: the action is
+  // forwarded over a private loopback fetch to the server's own origin. The
+  // test needs a local port to connect to, has to send a `Host` that isn't the
+  // one it connected to, and reads the action's output from the running
+  // server's stdout — none of which a deployment gives us.
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
   })
+
+  if (skipped) {
+    return
+  }
 
   // `next.fetch` goes through `undici`, which refuses to set `host` because it
   // is a forbidden header. Use the raw http client so we can send an arbitrary
   // `Host`, the way a reverse proxy in front of `next start` would.
   function postAction(
     pathname: string,
-    actionId: string
+    actionId: string,
+    extraHeaders?: Record<string, string>
   ): Promise<{ status: number }> {
     return new Promise((resolve, reject) => {
       const request = http.request(
@@ -36,6 +50,7 @@ describe('server action forwarding - original host', () => {
             origin: `http://${HOST}`,
             'content-type': 'text/plain;charset=UTF-8',
             'next-action': actionId,
+            ...extraHeaders,
           },
         },
         (response) => {
@@ -64,12 +79,13 @@ describe('server action forwarding - original host', () => {
   }
 
   async function collectObservedHeaders(
-    pathname: string
+    pathname: string,
+    extraHeaders?: Record<string, string>
   ): Promise<ObservedHeaders> {
     const actionId = await getActionId()
     const outputIndex = next.cliOutput.length
 
-    const { status } = await postAction(pathname, actionId)
+    const { status } = await postAction(pathname, actionId, extraHeaders)
     expect(status).toBe(200)
 
     const output = next.cliOutput.slice(outputIndex)
@@ -100,6 +116,21 @@ describe('server action forwarding - original host', () => {
 
     // The forward is an internal self-fetch to the loopback origin, which
     // replaces `Host`. The original host must survive it.
+    expect(observed.host).toBe(HOST)
+  })
+
+  it('ignores a forged forwarding marker', async () => {
+    // `x-action-forwarded` is not an internal header, so a client can send it.
+    // This request arrives on the public host rather than the origin we forward
+    // to, so the marker must not turn `x-forwarded-host` into `host`. `origin`
+    // matches the forged `x-forwarded-host` only to get past the CSRF check.
+    const observed = await collectObservedHeaders('/with-action', {
+      'x-action-forwarded': '1',
+      'x-forwarded-host': FORGED_HOST,
+      origin: `http://${FORGED_HOST}`,
+    })
+
+    expect(observed.xForwardedHost).toBe(FORGED_HOST)
     expect(observed.host).toBe(HOST)
   })
 })

--- a/test/e2e/app-dir/action-forward-host/action-forward-host.test.ts
+++ b/test/e2e/app-dir/action-forward-host/action-forward-host.test.ts
@@ -1,0 +1,105 @@
+import { nextTestSetup } from 'e2e-utils'
+import http from 'http'
+
+// A host that is deliberately not the origin the server listens on, so that a
+// forwarded action's `headers().get('host')` is distinguishable from the
+// internal loopback origin.
+const HOST = 'example.test'
+
+type ObservedHeaders = {
+  host: string | null
+  xForwardedHost: string | null
+  actionForwarded: string | null
+}
+
+describe('server action forwarding - original host', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // `next.fetch` goes through `undici`, which refuses to set `host` because it
+  // is a forbidden header. Use the raw http client so we can send an arbitrary
+  // `Host`, the way a reverse proxy in front of `next start` would.
+  function postAction(
+    pathname: string,
+    actionId: string
+  ): Promise<{ status: number }> {
+    return new Promise((resolve, reject) => {
+      const request = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: next.appPort,
+          path: pathname,
+          method: 'POST',
+          headers: {
+            host: HOST,
+            origin: `http://${HOST}`,
+            'content-type': 'text/plain;charset=UTF-8',
+            'next-action': actionId,
+          },
+        },
+        (response) => {
+          response.resume()
+          response.on('end', () => resolve({ status: response.statusCode! }))
+          response.on('error', reject)
+        }
+      )
+
+      request.on('error', reject)
+      request.end('[]')
+    })
+  }
+
+  // Read the action id out of the rendered form rather than the build manifest,
+  // so this works the same in dev and in start.
+  async function getActionId(): Promise<string> {
+    const html = await next.render('/with-action')
+    const match = html.match(/\$ACTION_ID_([0-9a-f]{42})/)
+
+    if (!match) {
+      throw new Error(`Could not find an action id in:\n${html}`)
+    }
+
+    return match[1]
+  }
+
+  async function collectObservedHeaders(
+    pathname: string
+  ): Promise<ObservedHeaders> {
+    const actionId = await getActionId()
+    const outputIndex = next.cliOutput.length
+
+    const { status } = await postAction(pathname, actionId)
+    expect(status).toBe(200)
+
+    const output = next.cliOutput.slice(outputIndex)
+    const match = output.match(/\[reportHost\](\{.*\})/)
+
+    if (!match) {
+      throw new Error(`The action did not run. Server output was:\n${output}`)
+    }
+
+    return JSON.parse(match[1])
+  }
+
+  it('observes the request host when the action is not forwarded', async () => {
+    const observed = await collectObservedHeaders('/with-action')
+
+    // Sanity check: this route bundles the action, so nothing was forwarded.
+    expect(observed.actionForwarded).toBeNull()
+    expect(observed.host).toBe(HOST)
+  })
+
+  it('observes the request host when the action is forwarded to another worker', async () => {
+    const observed = await collectObservedHeaders('/without-action')
+
+    // Sanity check: this route does not bundle the action, so the request
+    // really did go through the forwarding path.
+    expect(observed.actionForwarded).toBe('1')
+    expect(observed.xForwardedHost).toBe(HOST)
+
+    // The forward is an internal self-fetch to the loopback origin, which
+    // replaces `Host`. The original host must survive it.
+    expect(observed.host).toBe(HOST)
+  })
+})

--- a/test/e2e/app-dir/action-forward-host/action-forward-host.test.ts
+++ b/test/e2e/app-dir/action-forward-host/action-forward-host.test.ts
@@ -37,7 +37,7 @@ describe('server action forwarding - original host', () => {
     pathname: string,
     actionId: string,
     extraHeaders?: Record<string, string>
-  ): Promise<{ status: number }> {
+  ): Promise<{ status: number; body: string }> {
     return new Promise((resolve, reject) => {
       const request = http.request(
         {
@@ -54,8 +54,14 @@ describe('server action forwarding - original host', () => {
           },
         },
         (response) => {
-          response.resume()
-          response.on('end', () => resolve({ status: response.statusCode! }))
+          let body = ''
+          response.setEncoding('utf8')
+          response.on('data', (chunk) => {
+            body += chunk
+          })
+          response.on('end', () =>
+            resolve({ status: response.statusCode!, body })
+          )
           response.on('error', reject)
         }
       )
@@ -132,5 +138,26 @@ describe('server action forwarding - original host', () => {
 
     expect(observed.xForwardedHost).toBe(FORGED_HOST)
     expect(observed.host).toBe(HOST)
+  })
+
+  it('logs an unexpected response from the forwarded worker', async () => {
+    const actionId = await getActionId()
+    const outputIndex = next.cliOutput.length
+
+    // The proxy lets the original request through, then turns the internal
+    // forwarded request into a non-RSC error response. This exercises the
+    // fallback that otherwise converts the worker failure into a 200 with an
+    // empty action result.
+    const response = await postAction('/without-action', actionId, {
+      'x-test-forwarded-response': 'unexpected',
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toBe('{}')
+
+    const output = next.cliOutput.slice(outputIndex)
+    expect(output).toContain('Failed to forward Server Action response')
+    expect(output).toContain('status 500')
+    expect(output).toContain('text/plain')
   })
 })

--- a/test/e2e/app-dir/action-forward-host/app/layout.tsx
+++ b/test/e2e/app-dir/action-forward-host/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/action-forward-host/app/unexpected-forwarded-response/route.ts
+++ b/test/e2e/app-dir/action-forward-host/app/unexpected-forwarded-response/route.ts
@@ -1,0 +1,10 @@
+export async function POST(request: Request) {
+  await request.arrayBuffer()
+
+  return new Response(null, {
+    status: 500,
+    headers: {
+      'content-type': 'text/plain',
+    },
+  })
+}

--- a/test/e2e/app-dir/action-forward-host/app/with-action/actions.ts
+++ b/test/e2e/app-dir/action-forward-host/app/with-action/actions.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { headers } from 'next/headers'
+
+// Logged to the terminal so the test can assert on what the action actually
+// observed. The test sends a `Host` that differs from the server's own origin,
+// which a browser cannot do, so this is the only way to see the difference.
+export async function reportHost() {
+  const headerList = await headers()
+
+  console.log(
+    `[reportHost]` +
+      JSON.stringify({
+        host: headerList.get('host'),
+        xForwardedHost: headerList.get('x-forwarded-host'),
+        actionForwarded: headerList.get('x-action-forwarded'),
+      })
+  )
+}

--- a/test/e2e/app-dir/action-forward-host/app/with-action/page.tsx
+++ b/test/e2e/app-dir/action-forward-host/app/with-action/page.tsx
@@ -1,0 +1,15 @@
+import { reportHost } from './actions'
+
+// This page imports the action, so it is the only entry in the action's
+// `workers` set. A POST carrying this action's id to any other route has to be
+// forwarded here.
+export default function Page() {
+  return (
+    <main>
+      <h1 id="with-action-page">with-action</h1>
+      <form action={reportHost}>
+        <button id="run-action">Run action</button>
+      </form>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/action-forward-host/app/without-action/page.tsx
+++ b/test/e2e/app-dir/action-forward-host/app/without-action/page.tsx
@@ -1,0 +1,5 @@
+// Deliberately does not import the action, so an action POST that lands here
+// goes through `createForwardedActionResponse`.
+export default function Page() {
+  return <main id="without-action-page">without-action</main>
+}

--- a/test/e2e/app-dir/action-forward-host/next.config.js
+++ b/test/e2e/app-dir/action-forward-host/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/action-forward-host/proxy.ts
+++ b/test/e2e/app-dir/action-forward-host/proxy.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  if (
+    request.headers.get('x-action-forwarded') === '1' &&
+    request.headers.get('x-test-forwarded-response') === 'unexpected'
+  ) {
+    const url = request.nextUrl.clone()
+    url.pathname = '/unexpected-forwarded-response'
+    return NextResponse.rewrite(url)
+  }
+
+  return NextResponse.next()
+}


### PR DESCRIPTION
### What

Restores the original `Host` header on a Server Action request that Next.js forwarded to another worker, so `headers().get('host')` inside the action reports the host the user requested instead of the server's internal origin.

Fixes #96344

### Why

When an action POST lands on a route whose page doesn't bundle that action, `handleAction` forwards it to a worker that does (`selectWorkerForForwarding` → `createForwardedActionResponse`). The forward is an HTTP self-fetch to the server's own origin, normally `http://localhost:PORT`.

`host` is a forbidden `fetch` header, so it can't be carried onto the subrequest; `fetch` derives `Host` from the URL it is given. The action ends up seeing:

    POST /a  (page bundles the action)   host: "repro.example"    x-forwarded-host: "repro.example"
    POST /b  (page does NOT bundle it)   host: "localhost:4111"   x-forwarded-host: "repro.example"

Reading the tenant from `headers().get('host')` is a common self-hosting pattern, and it breaks only for the subset of actions that happen to get forwarded, which depends on the build's static import graph versus where the action is actually invoked. Shared client components and intercepted or parallel routes routinely land a POST on a route that doesn't bundle the action. The reporter measures about 1,000 failed actions a day across 9 domains, all surfacing as "project not found: localhost:3000".

`x-forwarded-host` does survive the forward and still carries the original host, so the information is recoverable.

### How

`restoreForwardedActionHost` rewrites `host` from `x-forwarded-host`. It runs in `base-server.ts` immediately after `attachRequestMeta`, and the placement is load-bearing in both directions. It has to be after `attachRequestMeta`, because the origin it compares against can come from the `initURL` request meta, and that call is what sets it. It has to be before `i18nProvider.detectDomainLocale`, a few lines further down, which is the first thing in the request lifecycle to read `host`. Doing the rewrite inside `handleAction` would leave the locale lookup reading the internal origin.

The marker header is not authenticated, so it is treated as a hint rather than proof. The rewrite requires all four of:

1. `x-action-forwarded` is exactly `1`, the only value `createForwardedActionResponse` ever sends. A repeated header arrives comma-joined and fails this.
2. The request is a fetch action. `handleAction` only forwards a POST carrying an action id, so no other request shape can have come through the forwarding path.
3. `x-forwarded-host` is present.
4. `host` matches the host of the origin this server forwards to, port included.

The send and receive sides have to agree on that origin, so both now go through `getActionForwardingOrigin(req)`: `__NEXT_PRIVATE_ORIGIN` when it is set, otherwise the origin of `initURL`. That also replaces two identical copies of the resolution block, in `createForwardedActionResponse` and `createRedirectRenderResult`.

The `initURL` fallback needed a correction from the first version of this PR, which claimed `initURL` already carries the right host. It only does under `experimental.trustHostHeader`. When the server is started with a hostname and port, which is the self-hosted case in the issue, `attachRequestMeta` builds `initURL` as `${protocol}://${fetchHostname}:${port}${req.url}` and the bug is still live, so that path now gets the rewrite too. The `trustHostHeader` case is deliberately excluded: there `initURL` comes from the request's own `host` header, which would make guard 4 vacuously true. `base-server` passes `hasConfiguredOrigin: Boolean(this.fetchHostname && this.port)`, mirroring the condition in `attachRequestMeta`, and the helper bails when there is neither a private origin nor a configured one.

On trust. `parseHostHeader` already prefers `x-forwarded-host` over `host` for the action CSRF origin check, so the value itself isn't newly trusted. What is new is that it becomes visible as `headers().get('host')`, and that is the value host-based tenancy reads. So, plainly: the marker is a hint, not authentication. In the normal topology the forwarding origin is loopback and unreachable from outside, so guard 4 can't be satisfied over the network. A proxy that presents an internal `Host` to Next.js while also passing through a client-controlled `x-forwarded-host` would satisfy all four guards. Authenticating the marker with a per-server secret would close that. I left it out because it's a larger change than the issue calls for, and I'd rather have a maintainer opinion on it first.

The obvious alternative doesn't work: `x-action-forwarded` can't just be added to `INTERNAL_HEADERS`. `filterInternalHeaders` runs on every ingress in `router-server.ts`, including the genuine loopback request, so listing it there would strip the real marker.

`ACTION_FORWARDED_HEADER`, `ACTION_FORWARDED_VALUE`, `getForwardedHostValue`, `getActionForwardingOrigin` and `restoreForwardedActionHost` now live in `app-render/action-forwarding.ts`, shared between `base-server.ts` and `action-handler.ts`. `getForwardedHostValue` is the existing `x-forwarded-host` list parsing lifted out of `parseHostHeader` rather than duplicated.

### Tests

Unit, `action-forwarding.test.ts`, 25 cases. Both list forms of `x-forwarded-host`, both origin sources, and the rejection paths: a forged marker arriving at a host that isn't the internal one, marker values `""`, `"true"`, `"0"`, `"1, 1"` and `"yes"`, non fetch-action requests, missing `x-forwarded-host`, a malformed private origin, and the `trustHostHeader` shape where `initURL` is derived from the request.

e2e, `test/e2e/app-dir/action-forward-host`. `/with-action` bundles the action and `/without-action` doesn't, so a POST to the latter goes through the forwarding path. Both arms are asserted, so the test pins the invariant rather than only the symptom, and it checks `x-action-forwarded` to prove forwarding actually ran. A third case sends a forged marker together with a forged `x-forwarded-host` and asserts `host` comes through unchanged.

It uses raw `node:http` instead of `next.fetch`, because undici refuses to set `host`. Same forbidden-header rule that causes the bug.

`skipDeployment: true`. The test needs a local port to connect to, has to send a `Host` different from the one it connected to, and reads the action's output from the running server's stdout. A deploy instance has a remote URL, no local app port, and build logs rather than live server output. The behaviour under test is a loopback self-fetch to the server's own origin, which is inherently self-hosted.

Before and after:

    before   host=localhost:54034   actionForwarded="1"   ✗ Expected "example.test"
    after    host=example.test      actionForwarded="1"   ✓

Green after rebasing onto current canary: the new suite in dev and start for both webpack and Turbopack, `action-forward-loop`, `actions-allowed-origins` including "should error if x-forwarded-host does not match the origin", the new unit suite, and `tsc`.

### Out of scope

`createRedirectRenderResult` does a second self-fetch for app-relative redirect streaming and loses `Host` the same way. It shares the origin resolver now, but not the restoration: it sets `x-action-forwarded` only when the original action was itself forwarded, so it needs its own marker and the same provenance decision as above. Happy to follow up separately.

For an Edge action target, `runEdgeFunction` builds the request URL from `initURL`, so `request.url` still shows the internal origin even though `headers().get('host')` is restored.