### PR TITLE
Optimistic routing: never predict URLs that may belong to the Pages Router

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -90,6 +90,9 @@ export const NextBuildContext: Partial<{
   clientRouterFilters: Parameters<
     typeof getBaseWebpackConfig
   >[1]['clientRouterFilters']
+  pagesRouterFilters: Parameters<
+    typeof getBaseWebpackConfig
+  >[1]['pagesRouterFilters']
   previewModeId: string
   fetchCacheKeyPrefix?: string
   allowedRevalidateHeaderKeys?: string[]

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -23,6 +23,10 @@ export interface DefineEnvOptions {
     staticFilter: BloomFilter
     dynamicFilter: BloomFilter
   }
+  pagesRouterFilters?: {
+    staticFilter: BloomFilter
+    dynamicFilter: BloomFilter
+  }
   config: NextConfigComplete
   dev: boolean
   distDir: string
@@ -106,6 +110,7 @@ function getImageConfig(
 export function getDefineEnv({
   isTurbopack,
   clientRouterFilters,
+  pagesRouterFilters,
   config,
   dev,
   distDir,
@@ -247,6 +252,13 @@ export function getDefineEnv({
       clientRouterFilters?.staticFilter ?? false,
     'process.env.__NEXT_CLIENT_ROUTER_D_FILTER':
       clientRouterFilters?.dynamicFilter ?? false,
+    // Bloom filters of Pages Router routes, consumed by the App Router's
+    // optimistic route matcher: a URL that may belong to the Pages Router
+    // must never be optimistically predicted from an App Router pattern.
+    'process.env.__NEXT_PAGES_ROUTER_S_FILTER':
+      pagesRouterFilters?.staticFilter ?? false,
+    'process.env.__NEXT_PAGES_ROUTER_D_FILTER':
+      pagesRouterFilters?.dynamicFilter ?? false,
     'process.env.__NEXT_CLIENT_VALIDATE_RSC_REQUEST_HEADERS': Boolean(
       config.experimental.validateRSCRequestHeaders
     ),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1695,6 +1695,9 @@ export default async function build(
       let clientRouterFilters:
         | undefined
         | ReturnType<typeof createClientRouterFilter>
+      let pagesRouterFilters:
+        | undefined
+        | ReturnType<typeof createClientRouterFilter>
 
       if (config.experimental.clientRouterFilter) {
         const nonInternalRedirects = (config._originalRedirects || []).filter(
@@ -1708,6 +1711,20 @@ export default async function build(
           config.experimental.clientRouterFilterAllowedRate
         )
         NextBuildContext.clientRouterFilters = clientRouterFilters
+
+        // The mirror-image filter: Pages Router routes, consumed by the App
+        // Router's optimistic route matcher. A URL that may belong to the
+        // Pages Router must never be predicted from a learned App Router
+        // pattern (e.g. pages/docs.tsx shadowing app/docs/[[...slug]]).
+        const userPagesPaths = pagesPageKeys.filter((p) => !p.startsWith('/_'))
+        if (userPagesPaths.length > 0) {
+          pagesRouterFilters = createClientRouterFilter(
+            userPagesPaths,
+            [],
+            config.experimental.clientRouterFilterAllowedRate
+          )
+          NextBuildContext.pagesRouterFilters = pagesRouterFilters
+        }
       }
 
       // Ensure commonjs handling is used for files in the distDir (generally .next)

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -440,6 +440,7 @@ type RustifiedOptionEnv = { name: string; value: string | undefined }[]
 export function createDefineEnv({
   isTurbopack,
   clientRouterFilters,
+  pagesRouterFilters,
   config,
   dev,
   distDir,
@@ -463,6 +464,7 @@ export function createDefineEnv({
       getDefineEnv({
         isTurbopack,
         clientRouterFilters,
+        pagesRouterFilters,
         config,
         dev,
         distDir,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -96,6 +96,7 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
     defineEnv: createDefineEnv({
       isTurbopack: true,
       clientRouterFilters: NextBuildContext.clientRouterFilters!,
+      pagesRouterFilters: NextBuildContext.pagesRouterFilters,
       config,
       dev,
       distDir,

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -154,6 +154,7 @@ export async function webpackBuildImpl(
     originalRedirects: NextBuildContext.originalRedirects,
     noMangling: NextBuildContext.noMangling!,
     clientRouterFilters: NextBuildContext.clientRouterFilters!,
+    pagesRouterFilters: NextBuildContext.pagesRouterFilters,
     previewProps: NextBuildContext.previewProps!,
     allowedRevalidateHeaderKeys: NextBuildContext.allowedRevalidateHeaderKeys!,
     fetchCacheKeyPrefix: NextBuildContext.fetchCacheKeyPrefix!,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -348,6 +348,7 @@ export default async function getBaseWebpackConfig(
     resolvedBaseUrl,
     supportedBrowsers,
     clientRouterFilters,
+    pagesRouterFilters,
     fetchCacheKeyPrefix,
     isCompileMode,
     previewProps,
@@ -375,6 +376,14 @@ export default async function getBaseWebpackConfig(
     resolvedBaseUrl: ResolvedBaseUrl
     supportedBrowsers: string[] | undefined
     clientRouterFilters?: {
+      staticFilter: ReturnType<
+        import('../shared/lib/bloom-filter').BloomFilter['export']
+      >
+      dynamicFilter: ReturnType<
+        import('../shared/lib/bloom-filter').BloomFilter['export']
+      >
+    }
+    pagesRouterFilters?: {
       staticFilter: ReturnType<
         import('../shared/lib/bloom-filter').BloomFilter['export']
       >
@@ -2075,6 +2084,7 @@ export default async function getBaseWebpackConfig(
           isNodeServer,
           middlewareMatchers,
           omitNonDeterministic: isCompileMode,
+          pagesRouterFilters,
           rewrites,
         })
       ),

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -58,6 +58,7 @@ import { isValueExpired } from './cache-map'
 import { doesStaticSegmentAppearInURL } from '../../route-params'
 import type { NormalizedPathname, NormalizedSearch } from './cache-key'
 import { splitPathnameIntoParts } from './cache-key'
+import { mayBelongToPagesRouter } from './pages-router-filter'
 import {
   appendLayoutVaryPath,
   finalizeLayoutVaryPath,
@@ -612,6 +613,16 @@ export function matchKnownRoute(
   pathname: string,
   search: NormalizedSearch
 ): FulfilledRouteCacheEntry | null {
+  // The known route tree only describes App Router routes. If this URL may be
+  // owned by the Pages Router — which can shadow App Router patterns, e.g. a
+  // pages/docs.tsx page shadowing the zero-segment match of
+  // app/docs/[[...slug]] — predicting a route for it would commit an App
+  // Router tree for a URL the server resolves to an entirely different
+  // renderer. Bail out to server resolution instead.
+  if (mayBelongToPagesRouter(pathname)) {
+    return null
+  }
+
   const pathnameParts = splitPathnameIntoParts(pathname)
   const resolvedParams: ResolvedParams = new Map()
   const match = matchKnownRoutePart(

--- a/packages/next/src/client/components/segment-cache/pages-router-filter.ts
+++ b/packages/next/src/client/components/segment-cache/pages-router-filter.ts
@@ -1,0 +1,114 @@
+import { BloomFilter } from '../../../shared/lib/bloom-filter'
+import { removeTrailingSlash } from '../../../shared/lib/router/utils/remove-trailing-slash'
+import { removeBasePath } from '../../remove-base-path'
+import { hasBasePath } from '../../has-base-path'
+
+/**
+ * Bloom filters of Pages Router routes, injected at build time (see
+ * `pagesRouterFilters` in define-env). These are the mirror image of the
+ * `__NEXT_CLIENT_ROUTER_S_FILTER`/`D_FILTER` filters that the Pages Router
+ * runtime uses to detect App Router destinations.
+ *
+ * The optimistic route matcher fabricates route trees for URLs that match a
+ * learned App Router pattern without consulting the server. That is only
+ * sound if the App Router actually owns the URL. The Pages Router can own
+ * URLs that fit an App Router pattern — most notably a page at the same
+ * specificity as an optional catch-all (`pages/docs.tsx` alongside
+ * `app/docs/[[...slug]]/page.tsx`, where `/docs` belongs to the Pages Router
+ * but matches the catch-all with zero segments), and static pages shadowing
+ * catch-all or dynamic params (`pages/docs/intro.tsx` shadowing
+ * `/docs/[[...slug]]`). Within the App Router these conflicts are rejected at
+ * build time or covered by `staticSiblings`, but routes in the Pages Router
+ * are invisible to the route tree, so we check these filters before
+ * predicting.
+ *
+ * A false positive merely skips the prediction and falls back to server
+ * resolution — correct, just less optimized — so the filters' small error
+ * rate is safe by construction.
+ */
+
+type FilterData = ReturnType<BloomFilter['export']> | false
+
+type PagesRouterFilters = {
+  staticFilter: BloomFilter | null
+  dynamicFilter: BloomFilter | null
+}
+
+let filters: PagesRouterFilters | null = null
+
+function getFilters(): PagesRouterFilters {
+  if (filters !== null) {
+    return filters
+  }
+
+  const staticFilterData: FilterData = process.env
+    .__NEXT_PAGES_ROUTER_S_FILTER as any
+  const dynamicFilterData: FilterData = process.env
+    .__NEXT_PAGES_ROUTER_D_FILTER as any
+
+  let staticFilter: BloomFilter | null = null
+  if (staticFilterData && staticFilterData.numHashes) {
+    staticFilter = new BloomFilter(
+      staticFilterData.numItems,
+      staticFilterData.errorRate
+    )
+    staticFilter.import(staticFilterData)
+  }
+
+  let dynamicFilter: BloomFilter | null = null
+  if (dynamicFilterData && dynamicFilterData.numHashes) {
+    dynamicFilter = new BloomFilter(
+      dynamicFilterData.numItems,
+      dynamicFilterData.errorRate
+    )
+    dynamicFilter.import(dynamicFilterData)
+  }
+
+  filters = { staticFilter, dynamicFilter }
+  return filters
+}
+
+/**
+ * Returns true if the given pathname may be owned by the Pages Router, in
+ * which case the App Router must not predict a route for it client-side.
+ *
+ * Mirrors the matching performed by the Pages Router's `_bfl` check: the
+ * static filter holds exact route paths, and the dynamic filter holds the
+ * static prefixes of dynamic routes (`/docs` for `pages/docs/[id].tsx`), so
+ * any prefix hit means a dynamic Pages route may match the URL.
+ *
+ * (Pages routes that begin with a dynamic segment are stored as normalized
+ * `[]` patterns, which require knowing the matched route shape to check; the
+ * optimistic matcher checks before matching, so those are not consulted here.
+ * Such routes would shadow every URL shape, which in practice does not occur
+ * alongside App Router patterns.)
+ */
+export function mayBelongToPagesRouter(pathname: string): boolean {
+  const { staticFilter, dynamicFilter } = getFilters()
+  if (staticFilter === null && dynamicFilter === null) {
+    return false
+  }
+
+  let normalized = removeTrailingSlash(pathname)
+  if (hasBasePath(normalized)) {
+    normalized = removeTrailingSlash(removeBasePath(normalized))
+  }
+
+  if (staticFilter !== null && staticFilter.contains(normalized)) {
+    return true
+  }
+
+  if (dynamicFilter !== null) {
+    // If any sub-path of the pathname matches a dynamic filter entry, a
+    // dynamic Pages route anchored at that prefix may own the URL.
+    const parts = normalized.split('/')
+    for (let i = 1; i < parts.length + 1; i++) {
+      const prefix = parts.slice(0, i).join('/')
+      if (prefix !== '' && dynamicFilter.contains(prefix)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -415,6 +415,7 @@ async function startWatcher(
     const fileWatchTimes = new Map()
     let enabledTypeScript = await verifyTypeScript(opts)
     let previousClientRouterFilters: any
+    let previousPagesRouterFilters: any
     let previousConflictingPagePaths: Set<string> = new Set()
 
     const routeTypesFilePath = path.join(distDir, 'types', 'routes.d.ts')
@@ -777,6 +778,7 @@ async function startWatcher(
       previousConflictingPagePaths = conflictingAppPagePaths
 
       let clientRouterFilters: any
+      let pagesRouterFilters: any
       if (nextConfig.experimental.clientRouterFilter) {
         clientRouterFilters = createClientRouterFilter(
           Object.keys(appPaths),
@@ -795,6 +797,26 @@ async function startWatcher(
         ) {
           envChange = true
           previousClientRouterFilters = clientRouterFilters
+        }
+
+        // The mirror-image filter: Pages Router routes, consumed by the App
+        // Router's optimistic route matcher so that a URL that may belong to
+        // the Pages Router is never predicted from an App Router pattern.
+        const userPagesPaths = routedPages.filter((p) => !p.startsWith('/_'))
+        if (userPagesPaths.length > 0) {
+          pagesRouterFilters = createClientRouterFilter(
+            userPagesPaths,
+            [],
+            nextConfig.experimental.clientRouterFilterAllowedRate
+          )
+        }
+
+        if (
+          JSON.stringify(previousPagesRouterFilters) !==
+          JSON.stringify(pagesRouterFilters)
+        ) {
+          envChange = true
+          previousPagesRouterFilters = pagesRouterFilters
         }
       }
 
@@ -821,6 +843,7 @@ async function startWatcher(
             defineEnv: createDefineEnv({
               isTurbopack: true,
               clientRouterFilters,
+              pagesRouterFilters,
               config: nextConfig,
               dev: true,
               distDir,
@@ -916,6 +939,7 @@ async function startWatcher(
                   const newDefine = getDefineEnv({
                     isTurbopack: false,
                     clientRouterFilters,
+                    pagesRouterFilters,
                     config: nextConfig,
                     dev: true,
                     distDir,

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/docs/[[...slug]]/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/docs/[[...slug]]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="docs-loading">Loading docs</div>
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/docs/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,12 @@
+export default async function DocsCatchAll({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>
+}) {
+  const { slug } = await params
+  return (
+    <div id="app-catchall" data-slug={slug === undefined ? '' : slug.join('/')}>
+      APP CATCHALL
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/app/page.tsx
@@ -1,0 +1,26 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>HOME</h1>
+      <ul>
+        {/* Prefetching this teaches the router the /docs/[[...slug]]
+            pattern (App Router optional catch-all). */}
+        <li>
+          <LinkAccordion href="/docs/a">Docs A</LinkAccordion>
+        </li>
+        {/* Click target — /docs is served by the Pages Router
+            (pages/docs.tsx), which shadows the zero-segment case of the
+            App Router optional catch-all. prefetch={false} so revealing
+            it fires no request; the router must not fabricate an
+            optimistic App Router tree for it. */}
+        <li>
+          <LinkAccordion href="/docs" prefetch={false}>
+            Docs root
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: LinkProps['href']
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/next.config.js
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    optimisticRouting: true,
+    varyParams: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/optimistic-routing-mixed-router-catchall.test.ts
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/optimistic-routing-mixed-router-catchall.test.ts
@@ -1,0 +1,140 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+
+describe('optimistic routing - mixed router optional catch-all shadowing', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Optimistic routing is a production-build feature; in dev mode the
+    // router does not have complete information about which routes
+    // exist, so prediction is disabled.
+    test('skipped in dev mode', () => {})
+    return
+  }
+
+  // The app defines an App Router optional catch-all at
+  // /docs/[[...slug]] AND a Pages Router page at /docs (pages/docs.tsx).
+  // This builds successfully: the same-specificity validation only runs
+  // within the App Router, and the cross-router conflict check only
+  // rejects exact path collisions. At runtime the static Pages route
+  // wins for /docs, while the App catch-all serves /docs/<anything>.
+  //
+  // After the client learns the /docs/[[...slug]] pattern (by
+  // prefetching /docs/a), a navigation to /docs must NOT be predicted
+  // from that pattern — /docs belongs to the Pages Router, which the
+  // optimistic route matcher cannot see. With the bug, the router
+  // fabricates a synthetic App Router entry for /docs (optional
+  // catch-all matched with zero segments) and instantly commits the
+  // App Router tree; the Pages content only appears after the
+  // mismatch-correction machinery kicks in, if at all.
+  it('does not predict an optional catch-all match for a URL owned by the Pages Router', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    let capturedPage: any = null
+    const browser = await next.browser('/', {
+      beforePageLoad(page: any) {
+        act = createRouterAct(page)
+        capturedPage = page
+      },
+    })
+
+    // Reveal the /docs/a link and let its prefetch complete. This
+    // teaches the router the /docs/[[...slug]] pattern.
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/docs/a"]'
+        )
+        await toggle.click()
+      },
+      // The catch-all has no generateStaticParams, so the prefetched
+      // shell contains the loading boundary, not the page content.
+      { includes: 'Loading docs' }
+    )
+
+    // Reveal the /docs link. prefetch={false}, so no request fires and
+    // the route cache has no entry for /docs.
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        'input[data-link-accordion="/docs"]'
+      )
+      await toggle.click()
+    }, 'no-requests')
+
+    // Record every request issued from here on. If the router
+    // mispredicts, it commits a synthetic App Router tree and fetches
+    // its segments; if it behaves correctly, it issues a single dynamic
+    // request for the unknown route and then hard-navigates.
+    const requests: Array<{ url: string; segment: string | null }> = []
+    if (capturedPage) {
+      capturedPage.on('request', (request: any) => {
+        const url: string = request.url()
+        if (url.includes('/docs')) {
+          requests.push({
+            url,
+            segment: request.headers()['next-router-segment-prefetch'] ?? null,
+          })
+        }
+      })
+    }
+
+    // Watch for any App Router content flashing in, no matter how
+    // briefly. A MutationObserver catches commits that resolve faster
+    // than a polling interval.
+    await browser.eval(`
+      window.__sawAppRouterRender = null
+      const check = () => {
+        if (document.getElementById('docs-loading')) {
+          window.__sawAppRouterRender = 'docs-loading'
+        } else if (document.getElementById('app-catchall')) {
+          window.__sawAppRouterRender = 'app-catchall'
+        }
+      }
+      check()
+      const observer = new MutationObserver(check)
+      observer.observe(document.body, { childList: true, subtree: true })
+    `)
+
+    // Click /docs. The pages route has a 500ms server-side delay, so a
+    // transient misprediction cannot be corrected faster than we can
+    // observe it.
+    const link = await browser.elementByCss('a[href="/docs"]')
+    await link.click()
+
+    let sawAppRouterRender: string | null = null
+    for (let i = 0; i < 120; i++) {
+      const state: { saw: string | null; done: boolean } | null = await browser
+        .eval(
+          `({
+            saw: window.__sawAppRouterRender ?? null,
+            done: !!document.getElementById('pages-docs'),
+          })`
+        )
+        // The corrective MPA navigation can destroy the eval context
+        // mid-flight; treat that as "nothing observed on this tick".
+        .catch(() => null)
+      if (state?.saw) {
+        sawAppRouterRender = state.saw
+        break
+      }
+      if (state?.done) {
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    expect(sawAppRouterRender).toBe(null)
+
+    // The navigation must end on the Pages Router page.
+    await browser.waitForElementByCss('#pages-docs', 10_000)
+    expect(await browser.elementById('pages-docs').text()).toBe(
+      'PAGES DOCS PAGE'
+    )
+
+    // Diagnostic: surface how the router resolved the navigation. A
+    // misprediction manifests as per-segment prefetch requests for the
+    // fabricated /docs tree.
+    const segmentRequests = requests.filter((r) => r.segment !== null)
+    expect(segmentRequests).toEqual([])
+  })
+})

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/pages/docs.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-mixed-router-catchall/pages/docs.tsx
@@ -1,0 +1,11 @@
+export default function PagesDocs() {
+  return <div id="pages-docs">PAGES DOCS PAGE</div>
+}
+
+// Server-side delay so that any transient client-side misprediction
+// stays observable: the corrective navigation cannot complete faster
+// than this.
+export async function getServerSideProps() {
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return { props: {} }
+}


### PR DESCRIPTION
## Bug

The optimistic route matcher (`matchKnownRoute`) fabricates a synthetic App Router tree for any URL that fits a learned route pattern, without consulting the server. That is only sound if the App Router actually owns the URL. Pages Router routes are invisible to the known route tree, and they can shadow App Router patterns:

- `pages/docs.tsx` owns `/docs` while `app/docs/[[...slug]]/page.tsx` matches it with **zero segments**. The same-specificity conflict is a build error *within* the App Router (`validateAppPaths`), but not across routers — this combination builds successfully, and the static Pages route wins at runtime.
- `pages/docs/intro.tsx` owns `/docs/intro` while the catch-all matches `'intro'` (`staticSiblings` only lists App Router siblings).

**Observed behavior (e2e-confirmed, Turbopack + webpack prod):** after the client learns `/docs/[[...slug]]` (e.g. by prefetching `/docs/a`), clicking a link to `/docs` instantly commits the fabricated App Router tree — the catch-all's loading boundary renders — before the mismatch-correction machinery detects the bad prediction and recovers with an MPA navigation. The wrong page flashes and the navigation is slower than if we had never predicted. Prefetch-enabled links are affected too: `readRouteCacheEntry` serves the synthetic entry to prefetches, so the server is never consulted at all.

The bug shipped with the original optimistic routing feature (#88965) and became reachable by default when `experimental.optimisticRouting` was enabled by default (#94011).

### Not the cause: the `[]` → `''` change in #96169

This investigation started from suspicion of `resolvedParams.set(paramName, '')` (optimistic-routes.ts:818, changed from `[]` in #96169). That change is behaviorally inert: the map's only reader immediately collapsed `[]` via `join('/')` to the same `''`, which is also the server's canonical cache-key encoding for an empty optional catch-all (`get-dynamic-param.ts`). The zero-match *branch* predates it and mispredicts identically with either value.

## Fix

Build bloom filters of the Pages Router's routes — the mirror image of the `__NEXT_CLIENT_ROUTER_S_FILTER`/`D_FILTER` filters the Pages Router runtime uses to detect App Router destinations — inject them via defines (`__NEXT_PAGES_ROUTER_S_FILTER`/`D_FILTER`), and bail out of `matchKnownRoute` when the target pathname may belong to the Pages Router.

- A bloom false positive just skips the prediction and falls back to server resolution — correct, merely less optimized — so the filter error rate is safe by construction.
- Pure App Router apps are unaffected: no filter is emitted and the check returns `false` immediately.
- Wired through prod builds (webpack + Turbopack) and the dev bundler's env-change loop. Gated on `experimental.clientRouterFilter` like its pages-side sibling.

Known limitation (documented in `pages-router-filter.ts`): pages routes that *begin* with a dynamic segment (e.g. `pages/[lang]/docs.tsx`) are stored as normalized `[]` patterns that require the matched route shape to check; those aren't consulted here. That shape did not have protection before either.

## Test plan

- New e2e `optimistic-routing-mixed-router-catchall`: fails before the fix (a MutationObserver catches the transient `docs-loading` commit after clicking `/docs`; the pages route has a 500ms delay so the flash can't outrun observation), passes after — `test-start-turbo` and `test-start-webpack`.
- Existing suites pass: `optimistic-route-cache-keying-regression`, `optimistic-routing-parallel-slot-catchall-regression`, `optimistic-routing-rewrite-detection-regression` (5 tests).
- `pnpm --filter=next types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)