### PR TITLE
Remove obsolete static generation plumbing

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -921,7 +921,6 @@ export function createAppPageEntrypoint({
               ? {
                   isBuildTimePrerendering: true,
                   supportsDynamicResponse: false,
-                  isStaticGeneration: true,
                   isDebugDynamicAccesses: isDebugDynamicAccesses,
                 }
               : {}),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -8144,18 +8144,6 @@ type PrerenderToStreamResult = {
   renderResumeDataCache?: RenderResumeDataCache
 }
 
-/**
- * Determines whether we should generate static flight data.
- */
-// TODO: This helper used to exclude fallback route params. It now only checks
-// static generation inside prerenderToStream and can be removed. LOE: low.
-function shouldGenerateStaticFlightData(workStore: WorkStore): boolean {
-  const { isStaticGeneration } = workStore
-  if (!isStaticGeneration) return false
-
-  return true
-}
-
 async function continueStaticPrerenderWithInlinedData(
   htmlStream: AnyStream,
   reactServerResult: ReactServerPrerenderResult,
@@ -8836,12 +8824,10 @@ async function prerenderToStream(
         finalServerPayload.s = staleTimeIterable
       }
 
-      if (shouldGenerateStaticFlightData(workStore)) {
-        // Embed the runtime data access tracking in the payload so
-        // collectSegmentData can replay it per stage. Only needed when the
-        // Flight data will be decomposed into segment prefetches below.
-        finalServerPayload.u = runtimeDataAccessed.promise
-      }
+      // Embed the runtime data access tracking in the payload so
+      // collectSegmentData can replay it per stage. Only needed when the
+      // Flight data will be decomposed into segment prefetches below.
+      finalServerPayload.u = runtimeDataAccessed.promise
 
       const serverDynamicTracking = createDynamicTrackingState(
         isDebugDynamicAccesses
@@ -9056,30 +9042,28 @@ async function prerenderToStream(
       reactServerPrerenderResultIsDynamic = resultIsPartial
       reactServerPrerenderStore = finalServerPrerenderStore
 
-      if (shouldGenerateStaticFlightData(workStore)) {
-        metadata.flightData = Buffer.concat(
-          cachedNavigations
-            ? prependIsPartialByteToChunks(
-                reactServerResult.asChunks(),
-                resultIsPartial
-              )
-            : reactServerResult.asChunks()
-        )
+      metadata.flightData = Buffer.concat(
+        cachedNavigations
+          ? prependIsPartialByteToChunks(
+              reactServerResult.asChunks(),
+              resultIsPartial
+            )
+          : reactServerResult.asChunks()
+      )
 
-        // collectSegmentData needs the raw flight data without the marker byte.
-        const flightData = cachedNavigations
-          ? metadata.flightData.subarray(1)
-          : metadata.flightData
+      // collectSegmentData needs the raw flight data without the marker byte.
+      const flightData = cachedNavigations
+        ? metadata.flightData.subarray(1)
+        : metadata.flightData
 
-        await collectSegmentData(
-          flightData,
-          finalServerPrerenderStore,
-          ComponentMod,
-          renderOpts,
-          ctx.pagePath,
-          metadata
-        )
-      }
+      await collectSegmentData(
+        flightData,
+        finalServerPrerenderStore,
+        ComponentMod,
+        renderOpts,
+        ctx.pagePath,
+        metadata
+      )
 
       const clientDynamicTracking = createDynamicTrackingState(
         isDebugDynamicAccesses
@@ -9407,17 +9391,15 @@ async function prerenderToStream(
       // parts of the React Server render that might not be used in the SSR render.
       const flightData = await streamToBuffer(reactServerResult.asStream())
 
-      if (shouldGenerateStaticFlightData(workStore)) {
-        metadata.flightData = flightData
-        await collectSegmentData(
-          flightData,
-          ssrPrerenderStore,
-          ComponentMod,
-          renderOpts,
-          ctx.pagePath,
-          metadata
-        )
-      }
+      metadata.flightData = flightData
+      await collectSegmentData(
+        flightData,
+        ssrPrerenderStore,
+        ComponentMod,
+        renderOpts,
+        ctx.pagePath,
+        metadata
+      )
 
       const { prelude, preludeIsEmpty } =
         await processPreludeOp(unprocessedPrelude)
@@ -9619,18 +9601,16 @@ async function prerenderToStream(
         { waitForAllReady: true }
       )
 
-      if (shouldGenerateStaticFlightData(workStore)) {
-        const flightData = await streamToBuffer(reactServerResult.asStream())
-        metadata.flightData = flightData
-        await collectSegmentData(
-          flightData,
-          prerenderLegacyStore,
-          ComponentMod,
-          renderOpts,
-          ctx.pagePath,
-          metadata
-        )
-      }
+      const flightData = await streamToBuffer(reactServerResult.asStream())
+      metadata.flightData = flightData
+      await collectSegmentData(
+        flightData,
+        prerenderLegacyStore,
+        ComponentMod,
+        renderOpts,
+        ctx.pagePath,
+        metadata
+      )
 
       const getServerInsertedHTML = makeGetServerInsertedHTML({
         polyfills,
@@ -10165,20 +10145,18 @@ async function prerenderToStream(
         { waitForAllReady: true }
       )
 
-      if (shouldGenerateStaticFlightData(workStore)) {
-        const flightData = await streamToBuffer(
-          reactServerPrerenderResult.asStream()
-        )
-        metadata.flightData = flightData
-        await collectSegmentData(
-          flightData,
-          prerenderLegacyStore,
-          ComponentMod,
-          renderOpts,
-          ctx.pagePath,
-          metadata
-        )
-      }
+      const flightData = await streamToBuffer(
+        reactServerPrerenderResult.asStream()
+      )
+      metadata.flightData = flightData
+      await collectSegmentData(
+        flightData,
+        prerenderLegacyStore,
+        ComponentMod,
+        renderOpts,
+        ctx.pagePath,
+        metadata
+      )
 
       return {
         digestErrorsMap: reactServerErrorsByDigest,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -214,8 +214,6 @@ export interface RenderOptsPartial {
    */
   prefetchHints?: Record<string, PrefetchHints>
 
-  isStaticGeneration?: boolean
-
   /**
    * When true, the page is prerendered as a fallback shell, while allowing any
    * dynamic accesses to result in an empty shell. This is the case when there


### PR DESCRIPTION
## Summary

- Removes the unused `RenderOptsPartial.isStaticGeneration` option and its debug-render write. `WorkStore` derives this value independently.
- Removes `shouldGenerateStaticFlightData` and its redundant guards. These checks only occur inside `prerenderToStream`, which is exclusively entered when `isStaticGeneration` is true.

<!-- NEXT_JS_LLM -->