### PR TITLE
Rename static generation stream option to waitForAllReady

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3296,6 +3296,7 @@ async function renderToStream(
   } = renderOpts
 
   const { cachedNavigations } = renderOpts.experimental
+  const waitForAllReady = supportsDynamicResponse !== true
 
   const { ServerInsertedHTMLProvider, renderServerInsertedHTML } =
     createServerInsertedHTML()
@@ -3886,8 +3887,6 @@ async function renderToStream(
           tracingMetadata: tracingMetadata,
         })
 
-        const generateStaticHTML = supportsDynamicResponse !== true
-
         const appElement = (
           <App
             reactServerStream={reactServerResult.tee()}
@@ -3923,7 +3922,7 @@ async function renderToStream(
               renderToNodeFizzStream,
               appElement,
               fizzOptions,
-              { waitForAllReady: generateStaticHTML }
+              { waitForAllReady }
             )
         )
 
@@ -3938,7 +3937,7 @@ async function renderToStream(
             nonce,
             formState
           ),
-          isStaticGeneration: generateStaticHTML,
+          waitForAllReady,
           allReady,
           deploymentId: ctx.sharedContext.deploymentId,
           getServerInsertedHTML,
@@ -4029,8 +4028,6 @@ async function renderToStream(
           tracingMetadata: tracingMetadata,
         })
 
-        const generateStaticHTML = supportsDynamicResponse !== true
-
         const appElement = (
           <App
             reactServerStream={reactServerResult.tee()}
@@ -4075,7 +4072,7 @@ async function renderToStream(
             nonce,
             formState
           ),
-          isStaticGeneration: generateStaticHTML,
+          waitForAllReady,
           allReady,
           deploymentId: ctx.sharedContext.deploymentId,
           getServerInsertedHTML,
@@ -4206,8 +4203,6 @@ async function renderToStream(
         }
 
         try {
-          const generateStaticHTML = supportsDynamicResponse !== true
-
           const { stream: errorHtmlStream, allReady: errorAllReady } =
             await workUnitAsyncStorage.run(
               requestStore,
@@ -4225,7 +4220,7 @@ async function renderToStream(
                 bootstrapScripts: [errorBootstrapScript],
                 formState,
               },
-              { waitForAllReady: generateStaticHTML }
+              { waitForAllReady }
             )
 
           errorAllReady.finally(() => {
@@ -4241,7 +4236,7 @@ async function renderToStream(
               nonce,
               formState
             ),
-            isStaticGeneration: generateStaticHTML,
+            waitForAllReady,
             deploymentId: ctx.sharedContext.deploymentId,
             getServerInsertedHTML: makeGetServerInsertedHTML({
               polyfills,
@@ -4304,8 +4299,6 @@ async function renderToStream(
         }
 
         try {
-          const generateStaticHTML = supportsDynamicResponse !== true
-
           const { stream: errorHtmlStream, allReady: errorAllReady } =
             await workUnitAsyncStorage.run(
               requestStore,
@@ -4338,7 +4331,7 @@ async function renderToStream(
               nonce,
               formState
             ),
-            isStaticGeneration: generateStaticHTML,
+            waitForAllReady,
             deploymentId: ctx.sharedContext.deploymentId,
             getServerInsertedHTML: makeGetServerInsertedHTML({
               polyfills,
@@ -9628,7 +9621,7 @@ async function prerenderToStream(
             nonce,
             formState
           ),
-          isStaticGeneration: true,
+          waitForAllReady: true,
           getServerInsertedHTML,
           getServerInsertedMetadata,
           deploymentId: ctx.sharedContext.deploymentId,
@@ -10167,7 +10160,7 @@ async function prerenderToStream(
             nonce,
             formState
           ),
-          isStaticGeneration: true,
+          waitForAllReady: true,
           getServerInsertedHTML: makeGetServerInsertedHTML({
             polyfills,
             renderServerInsertedHTML,

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -695,7 +695,7 @@ export async function continueFizzStream(
   {
     suffix,
     inlinedDataStream,
-    isStaticGeneration,
+    waitForAllReady,
     allReady,
     deploymentId,
     getServerInsertedHTML,
@@ -706,7 +706,7 @@ export async function continueFizzStream(
   // Suffix itself might contain close tags at the end, so we need to split it.
   const suffixUnclosed = suffix ? suffix.split(CLOSE_TAG, 1)[0] : null
 
-  if (isStaticGeneration) {
+  if (waitForAllReady) {
     if (allReady) {
       await allReady
     }

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -45,7 +45,7 @@ export type ContinueStreamSharedOptions = {
 
 export type ContinueFizzStreamOptions = ContinueStreamSharedOptions & {
   inlinedDataStream: AnyStream | undefined
-  isStaticGeneration: boolean
+  waitForAllReady: boolean
   allReady?: Promise<void>
   validateRootLayout?: boolean
   suffix?: string

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -910,7 +910,7 @@ export function chainTransformers<T>(
 
 export type ContinueStreamOptions = {
   inlinedDataStream: ReadableStream<Uint8Array> | undefined
-  isStaticGeneration: boolean
+  waitForAllReady: boolean
   deploymentId: string | undefined
   getServerInsertedHTML: () => Promise<string>
   getServerInsertedMetadata: () => Promise<string>
@@ -926,7 +926,7 @@ export async function continueFizzStream(
   {
     suffix,
     inlinedDataStream,
-    isStaticGeneration,
+    waitForAllReady,
     deploymentId,
     getServerInsertedHTML,
     getServerInsertedMetadata,
@@ -936,8 +936,8 @@ export async function continueFizzStream(
   // Suffix itself might contain close tags at the end, so we need to split it.
   const suffixUnclosed = suffix ? suffix.split(CLOSE_TAG, 1)[0] : null
 
-  if (isStaticGeneration) {
-    // If we're generating static HTML we need to wait for it to resolve before continuing.
+  if (waitForAllReady) {
+    // Wait for all Suspense boundaries to resolve before continuing.
     await renderStream.allReady
   } else {
     // Otherwise, we want to make sure Fizz is done with all microtasky work


### PR DESCRIPTION
## Summary

- rename the `isStaticGeneration` stream option to `waitForAllReady`
- derive the value once from `supportsDynamicResponse` and reuse it across render paths
- clarify that the option controls waiting for React’s `allReady`, rather than representing the broader static-generation mode

Stacked on #96563.