### PR TITLE
Upgrade actions/cache to version 5

### DIFF
--- a/docs/01-app/02-guides/ci-build-caching.mdx
+++ b/docs/01-app/02-guides/ci-build-caching.mdx
@@ -75,7 +75,7 @@ cache:
 Using GitHub's [actions/cache](https://github.com/actions/cache), add the following step in your workflow file:
 
 ```yaml
-uses: actions/cache@v4
+uses: actions/cache@v5
 with:
   # See here for caching with `yarn`, `bun` or other package managers https://github.com/actions/cache/blob/main/examples.md or you can leverage caching with actions/setup-node https://github.com/actions/setup-node
   path: |


### PR DESCRIPTION
This pull request updates the GitHub Actions cache version in the CI build caching guide to ensure compatibility with the latest features and improvements.

- **CI Workflow Updates:**
  * Updated the example in the documentation to use `actions/cache@v5` instead of `v4` for caching dependencies in CI workflows.