### PR TITLE
Pass explicit prefetch hint policy through App Render

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -127,7 +127,11 @@ import { dynamicParamTypes } from './get-short-dynamic-param-type'
 import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param'
 import { getScriptNonceFromHeader } from './get-script-nonce-from-header'
 import { parseAndValidateFlightRouterState } from './parse-and-validate-flight-router-state'
-import { createFlightRouterStateFromLoaderTree } from './create-flight-router-state-from-loader-tree'
+import {
+  createFlightRouterStateFromLoaderTree,
+  getMissingPrefetchHintPolicy,
+  type MissingPrefetchHintPolicy,
+} from './create-flight-router-state-from-loader-tree'
 import { handleAction } from './action-handler'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { warn, error } from '../../build/output/log'
@@ -353,6 +357,7 @@ export type AppSharedContext = {
 export type AppRenderContext = {
   sharedContext: AppSharedContext
   workStore: WorkStore
+  missingPrefetchHintPolicy: MissingPrefetchHintPolicy
   url: ReturnType<typeof parseRelativeUrl>
   componentMod: AppPageModule
   renderOpts: RenderOpts
@@ -2098,10 +2103,8 @@ async function getRSCPayload(
     tree,
     hints,
     prefetchInliningEnabled,
-    ctx.renderOpts.cacheComponents,
+    ctx.missingPrefetchHintPolicy,
     ctx.renderOpts.partialPrefetching,
-    workStore.executionMode === 'prerender',
-    ctx.renderOpts.isBuildTimePrerendering ?? false,
     getDynamicParamFromSegment,
     query
   )
@@ -2302,10 +2305,8 @@ async function getErrorRSCPayload(
     tree,
     errorHints,
     errorPrefetchInliningEnabled,
-    ctx.renderOpts.cacheComponents,
+    ctx.missingPrefetchHintPolicy,
     ctx.renderOpts.partialPrefetching,
-    workStore.executionMode === 'prerender',
-    ctx.renderOpts.isBuildTimePrerendering ?? false,
     getDynamicParamFromSegment,
     query
   )
@@ -2773,6 +2774,11 @@ async function renderToHTMLOrFlightImpl(
     url,
     renderOpts,
     workStore,
+    missingPrefetchHintPolicy: getMissingPrefetchHintPolicy(
+      renderOpts.isBuildTimePrerendering ?? false,
+      isStaticGeneration,
+      renderOpts.cacheComponents
+    ),
     parsedRequestHeaders,
     getDynamicParamFromSegment,
     interpolatedParams,
@@ -7963,6 +7969,11 @@ async function validateInstantConfigInBuildWithSample(
       url: sampleUrlWithoutQuery,
       renderOpts: outerCtx.renderOpts,
       workStore,
+      missingPrefetchHintPolicy: getMissingPrefetchHintPolicy(
+        outerCtx.renderOpts.isBuildTimePrerendering ?? false,
+        false,
+        outerCtx.renderOpts.cacheComponents
+      ),
       parsedRequestHeaders: outerCtx.parsedRequestHeaders,
       getDynamicParamFromSegment,
       interpolatedParams: sampleParams,

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.test.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.test.ts
@@ -1,0 +1,27 @@
+import { getMissingPrefetchHintPolicy } from './create-flight-router-state-from-loader-tree'
+
+describe('getMissingPrefetchHintPolicy', () => {
+  it('marks missing build-time hints as stale', () => {
+    expect(getMissingPrefetchHintPolicy(true, true, false)).toBe('mark-stale')
+  })
+
+  it('gives the build-time policy precedence over runtime fallbacks', () => {
+    expect(getMissingPrefetchHintPolicy(true, false, true)).toBe('mark-stale')
+  })
+
+  it('disables prefetching for runtime prerenders', () => {
+    expect(getMissingPrefetchHintPolicy(false, true, false)).toBe(
+      'disable-prefetching'
+    )
+  })
+
+  it('disables prefetching for dynamic Cache Components routes', () => {
+    expect(getMissingPrefetchHintPolicy(false, false, true)).toBe(
+      'disable-prefetching'
+    )
+  })
+
+  it('does not apply a fallback to dynamic routes without Cache Components', () => {
+    expect(getMissingPrefetchHintPolicy(false, false, false)).toBe('none')
+  })
+})

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -9,14 +9,41 @@ import type { GetDynamicParamFromSegment } from './app-render'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 
+export type MissingPrefetchHintPolicy =
+  | 'mark-stale'
+  | 'disable-prefetching'
+  | 'none'
+
+/**
+ * Selects the client fallback when prefetch inlining is enabled but no hint
+ * tree is available.
+ */
+export function getMissingPrefetchHintPolicy(
+  isBuildTimePrerendering: boolean,
+  isPrerendering: boolean,
+  cacheComponents: boolean
+): MissingPrefetchHintPolicy {
+  if (isBuildTimePrerendering) {
+    return 'mark-stale'
+  }
+
+  if (isPrerendering || cacheComponents) {
+    // TODO(#91407): Runtime prerenders should always have hints from the
+    // manifest. Until that is guaranteed, disable prefetching when they are
+    // missing. Fully dynamic Cache Components routes have no manifest entry,
+    // so disabling prefetching is their permanent fallback.
+    return 'disable-prefetching'
+  }
+
+  return 'none'
+}
+
 async function createFlightRouterStateFromLoaderTreeImpl(
   loaderTree: LoaderTree,
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
-  cacheComponents: boolean,
+  missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
   partialPrefetching: boolean | 'unstable_eager' | undefined,
-  isStaticGeneration: boolean,
-  isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   searchParams: any,
   didFindRootLayout: boolean
@@ -58,34 +85,25 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   if (hintTree !== null) {
     prefetchHints |= hintTree.hints
   } else if (prefetchInliningEnabled) {
-    if (isBuildTimePrerendering) {
+    if (missingPrefetchHintPolicy === 'mark-stale') {
       // Prefetch inlining is enabled but no hint tree was provided during a
       // build-time prerender. This happens for the initial RSC payload
       // generated before collectPrefetchHints has run. Mark so the client
       // can expire the route cache entry and re-fetch the tree with correct
       // hints.
       prefetchHints |= PrefetchHint.InliningHintsStale
-    } else if (isStaticGeneration) {
-      // TODO(#91407): Temporary mitigation: when hints are missing during
-      // runtime static generation, fall back to treating every segment as
-      // unprefetchable. This currently happens for routes with
-      // `instant = false` at the root segment, which causes the prerender
-      // to run per-request instead of being cached, and the prefetch hints
-      // manifest is not available.
-      //
-      // Once that bug is fixed, this branch should become an error again —
-      // hints should always be available from the manifest during ISR.
-      prefetchHints |= PrefetchHint.PrefetchDisabled
-    } else if (cacheComponents) {
-      // At runtime with no hint tree, this is a fully dynamic route with no
-      // manifest entry. Treat every segment as unprefetchable. Do NOT set
-      // InliningHintsStale — that would cause the client to enter an
-      // infinite re-fetch loop trying to get hints that will never exist.
+    } else if (missingPrefetchHintPolicy === 'disable-prefetching') {
+      // At runtime with no hint tree, treat every segment as unprefetchable.
+      // This covers both runtime static generation, where a manifest entry
+      // should exist but may be missing, and fully dynamic Cache Components
+      // routes, which never have a manifest entry. Do NOT set
+      // InliningHintsStale because the latter would enter an infinite
+      // re-fetch loop trying to get hints that will never exist.
       prefetchHints |= PrefetchHint.PrefetchDisabled
     } else {
-      // Without cacheComponents, dynamic pages have no static shell so
-      // hints are never computed. Don't disable prefetching — just skip
-      // the inlining hint system and let prefetching proceed normally.
+      // Dynamic pages without Cache Components have no static shell, so hints
+      // are never computed. Don't disable prefetching — just skip the inlining
+      // hint system and let prefetching proceed normally.
     }
   }
 
@@ -142,10 +160,8 @@ async function createFlightRouterStateFromLoaderTreeImpl(
       parallelRoutes[parallelRouteKey],
       childHintNode,
       prefetchInliningEnabled,
-      cacheComponents,
+      missingPrefetchHintPolicy,
       partialPrefetching,
-      isStaticGeneration,
-      isBuildTimePrerendering,
       getDynamicParamFromSegment,
       searchParams,
       didFindRootLayout
@@ -169,10 +185,8 @@ export async function createFlightRouterStateFromLoaderTree(
   loaderTree: LoaderTree,
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
-  cacheComponents: boolean,
+  missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
   partialPrefetching: boolean | 'unstable_eager' | undefined,
-  isStaticGeneration: boolean,
-  isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   searchParams: any,
   // Whether a root layout was already found above this loader tree slice, so a
@@ -184,10 +198,8 @@ export async function createFlightRouterStateFromLoaderTree(
     loaderTree,
     hintTree,
     prefetchInliningEnabled,
-    cacheComponents,
+    missingPrefetchHintPolicy,
     partialPrefetching,
-    isStaticGeneration,
-    isBuildTimePrerendering,
     getDynamicParamFromSegment,
     searchParams,
     didFindRootLayout
@@ -198,10 +210,8 @@ export async function createRouteTreePrefetch(
   loaderTree: LoaderTree,
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
-  cacheComponents: boolean,
+  missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
   partialPrefetching: boolean | 'unstable_eager' | undefined,
-  isStaticGeneration: boolean,
-  isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   // See note on createFlightRouterStateFromLoaderTree's didFindRootLayout.
   didFindRootLayout: boolean = false
@@ -214,10 +224,8 @@ export async function createRouteTreePrefetch(
     loaderTree,
     hintTree,
     prefetchInliningEnabled,
-    cacheComponents,
+    missingPrefetchHintPolicy,
     partialPrefetching,
-    isStaticGeneration,
-    isBuildTimePrerendering,
     getDynamicParamFromSegment,
     searchParams,
     didFindRootLayout

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -60,14 +60,9 @@ export async function walkTreeWithFlightRouterState({
     isPrefetch,
     getDynamicParamFromSegment,
     parsedRequestHeaders,
-    workStore,
   } = ctx
   const prefetchInliningEnabled = Boolean(experimental.prefetchInlining)
-  const cacheComponents = ctx.renderOpts.cacheComponents
   const partialPrefetching = ctx.renderOpts.partialPrefetching
-  const isStaticGeneration = workStore.executionMode === 'prerender'
-  const isBuildTimePrerendering =
-    ctx.renderOpts.isBuildTimePrerendering ?? false
 
   const [segment, parallelRoutes, modules] = loaderTreeToFilter
 
@@ -163,10 +158,8 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
-          cacheComponents,
+          ctx.missingPrefetchHintPolicy,
           partialPrefetching,
-          isStaticGeneration,
-          isBuildTimePrerendering,
           getDynamicParamFromSegment,
           rootLayoutIncluded
         )
@@ -174,10 +167,8 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
-          cacheComponents,
+          ctx.missingPrefetchHintPolicy,
           partialPrefetching,
-          isStaticGeneration,
-          isBuildTimePrerendering,
           getDynamicParamFromSegment,
           query,
           rootLayoutIncluded
@@ -207,20 +198,16 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
-          cacheComponents,
+          ctx.missingPrefetchHintPolicy,
           partialPrefetching,
-          isStaticGeneration,
-          isBuildTimePrerendering,
           getDynamicParamFromSegment
         )
       : await createFlightRouterStateFromLoaderTree(
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
-          cacheComponents,
+          ctx.missingPrefetchHintPolicy,
           partialPrefetching,
-          isStaticGeneration,
-          isBuildTimePrerendering,
           getDynamicParamFromSegment,
           query,
           rootLayoutIncluded
@@ -251,10 +238,8 @@ export async function walkTreeWithFlightRouterState({
       loaderTreeToFilter,
       hintTree,
       prefetchInliningEnabled,
-      cacheComponents,
+      ctx.missingPrefetchHintPolicy,
       partialPrefetching,
-      isStaticGeneration,
-      isBuildTimePrerendering,
       getDynamicParamFromSegment,
       query,
       rootLayoutIncluded
@@ -375,7 +360,6 @@ export async function createFullTreeFlightDataForNavigation({
     query,
     getDynamicParamFromSegment,
     pagePath,
-    workStore: workStoreForInitialRender,
   } = ctx
 
   const hintTreeForInitialRender =
@@ -385,10 +369,8 @@ export async function createFullTreeFlightDataForNavigation({
     loaderTree,
     hintTreeForInitialRender,
     Boolean(experimental.prefetchInlining),
-    ctx.renderOpts.cacheComponents,
+    ctx.missingPrefetchHintPolicy,
     ctx.renderOpts.partialPrefetching,
-    workStoreForInitialRender.executionMode === 'prerender',
-    ctx.renderOpts.isBuildTimePrerendering ?? false,
     getDynamicParamFromSegment,
     query
   )


### PR DESCRIPTION
## Summary

- derive an explicit missing-prefetch-hint policy at the App Render boundary
- pass that policy through the Flight router-state builders instead of exposing execution mode and related render options

Stacked on #96570.