### PR TITLE
Fix request context retention in request props

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1465,5 +1465,8 @@
   "1464": "\\`experimental.turbopackChunkingHeuristics\\` has been renamed to \\`experimental.turbopackChunking\\`. Please update your next.config.js file accordingly.",
   "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead."
+  "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
+  "1468": "Expected workStore and prerenderStore to still be available when accessing searchParams",
+  "1469": "Expected workStore to still be available when accessing searchParams in a cache scope",
+  "1470": "Expected workStore and prerenderStore to still be available when accessing fallback params"
 }

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -325,7 +325,7 @@ export function createPrerenderParamsForClientSegment(
   // We're prerendering in a mode that does not abort. We resolve the promise without
   // any tracking because we're just transporting a value from server to client where the tracking
   // will be applied.
-  return Promise.resolve(underlyingParams)
+  return workStore.runInCleanSnapshot(() => Promise.resolve(underlyingParams))
 }
 
 function createStaticPrerenderParams(
@@ -662,7 +662,7 @@ function createClientParamsInInstantValidation(
     declaredParams,
     workStore.route
   )
-  return Promise.resolve(proxiedUnderlying)
+  return workStore.runInCleanSnapshot(() => Promise.resolve(proxiedUnderlying))
 }
 
 function createRenderParamsInProd(userspaceParams: Params): Promise<Params> {
@@ -764,11 +764,15 @@ function makeErroringParams(
   }
 
   const augmentedUnderlying = { ...underlyingParams }
+  const workStoreRef = new WeakRef(workStore)
+  const prerenderStoreRef = new WeakRef(prerenderStore)
 
   // We don't use makeResolvedReactPromise here because params
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = Promise.resolve(augmentedUnderlying)
+  const promise = workStore.runInCleanSnapshot(() =>
+    Promise.resolve(augmentedUnderlying)
+  )
   CachedParams.set(underlyingParams, promise)
 
   Object.keys(underlyingParams).forEach((prop) => {
@@ -780,25 +784,33 @@ function makeErroringParams(
         Object.defineProperty(augmentedUnderlying, prop, {
           get() {
             const expression = describeStringPropertyAccess('params', prop)
+            const liveWorkStore = workStoreRef.deref()
+            const livePrerenderStore = prerenderStoreRef.deref()
+            if (!liveWorkStore || !livePrerenderStore) {
+              throw new InvariantError(
+                'Expected workStore and prerenderStore to still be available when accessing fallback params'
+              )
+            }
+
             // In most dynamic APIs we also throw if `dynamic = "error"` however
             // for params is only dynamic when we're generating a fallback shell
             // and even when `dynamic = "error"` we still support generating dynamic
             // fallback shells
             // TODO remove this comment when cacheComponents is the default since there
             // will be no `dynamic = "error"`
-            if (prerenderStore.type === 'prerender-ppr') {
+            if (livePrerenderStore.type === 'prerender-ppr') {
               // PPR Prerender (no cacheComponents)
               postponeWithTracking(
-                workStore.route,
+                liveWorkStore.route,
                 expression,
-                prerenderStore.dynamicTracking
+                livePrerenderStore.dynamicTracking
               )
             } else {
               // Legacy Prerender
               throwToInterruptStaticGeneration(
                 expression,
-                workStore,
-                prerenderStore
+                liveWorkStore,
+                livePrerenderStore
               )
             }
           },
@@ -817,7 +829,13 @@ function makeUntrackedParams(underlyingParams: Params): Promise<Params> {
     return cachedParams
   }
 
-  const promise = Promise.resolve(underlyingParams)
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
+  const promise = workStore.runInCleanSnapshot(() =>
+    Promise.resolve(underlyingParams)
+  )
   CachedParams.set(underlyingParams, promise)
 
   return promise

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -169,7 +169,7 @@ export function createPrerenderSearchParamsForClientPage(): Promise<SearchParams
   if (workStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
     // dictionary object.
-    return Promise.resolve({})
+    return workStore.runInCleanSnapshot(() => Promise.resolve({}))
   }
 
   const workUnitStore = workUnitAsyncStorage.getStore()
@@ -206,7 +206,7 @@ export function createPrerenderSearchParamsForClientPage(): Promise<SearchParams
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
-        return Promise.resolve({})
+        return workStore.runInCleanSnapshot(() => Promise.resolve({}))
       default:
         workUnitStore satisfies never
     }
@@ -221,7 +221,7 @@ function createStaticPrerenderSearchParams(
   if (workStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
     // dictionary object.
-    return Promise.resolve({})
+    return workStore.runInCleanSnapshot(() => Promise.resolve({}))
   }
 
   switch (prerenderStore.type) {
@@ -304,7 +304,7 @@ function createRenderSearchParams(
   if (workStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
     // dictionary object.
-    return Promise.resolve({})
+    return workStore.runInCleanSnapshot(() => Promise.resolve({}))
   }
 
   if (process.env.NODE_ENV === 'development') {
@@ -461,24 +461,16 @@ function makeHangingSearchParams(
   return proxiedPromise
 }
 
-function makeErroringSearchParams(
-  workStore: WorkStore,
-  prerenderStore: PrerenderStoreLegacy | PrerenderStorePPR
-): Promise<SearchParams> {
-  const cachedSearchParams = CachedSearchParams.get(workStore)
-  if (cachedSearchParams) {
-    return cachedSearchParams
-  }
+function createErroringSearchParamsProxyHandler(
+  originatingWorkStore: WorkStore,
+  originatingPrerenderStore: PrerenderStoreLegacy | PrerenderStorePPR
+): ProxyHandler<Promise<SearchParams>> {
+  const workStoreRef = new WeakRef(originatingWorkStore)
+  const prerenderStoreRef = new WeakRef(originatingPrerenderStore)
 
-  const underlyingSearchParams = {}
-  // For search params we don't construct a ReactPromise because we want to interrupt
-  // rendering on any property access that was not set from outside and so we only want
-  // to have properties like value and status if React sets them.
-  const promise = Promise.resolve(underlyingSearchParams)
-
-  const proxiedPromise = new Proxy(promise, {
+  return {
     get(target, prop, receiver) {
-      if (Object.hasOwn(promise, prop)) {
+      if (Object.hasOwn(target, prop)) {
         // The promise has this property directly. we must return it.
         // We know it isn't a dynamic access because it can only be something
         // that was previously written to the promise and thus not an underlying searchParam value
@@ -488,6 +480,14 @@ function makeErroringSearchParams(
       if (typeof prop === 'string' && prop === 'then') {
         const expression =
           '`await searchParams`, `searchParams.then`, or similar'
+        const workStore = workStoreRef.deref()
+        const prerenderStore = prerenderStoreRef.deref()
+        if (!workStore || !prerenderStore) {
+          throw new InvariantError(
+            'Expected workStore and prerenderStore to still be available when accessing searchParams'
+          )
+        }
+
         if (workStore.dynamicShouldError) {
           throwWithStaticGenerationBailoutErrorWithDynamicError(
             workStore.route,
@@ -511,7 +511,30 @@ function makeErroringSearchParams(
       }
       return ReflectAdapter.get(target, prop, receiver)
     },
-  })
+  }
+}
+
+function makeErroringSearchParams(
+  workStore: WorkStore,
+  prerenderStore: PrerenderStoreLegacy | PrerenderStorePPR
+): Promise<SearchParams> {
+  const cachedSearchParams = CachedSearchParams.get(workStore)
+  if (cachedSearchParams) {
+    return cachedSearchParams
+  }
+
+  const underlyingSearchParams = {}
+  // For search params we don't construct a ReactPromise because we want to interrupt
+  // rendering on any property access that was not set from outside and so we only want
+  // to have properties like value and status if React sets them.
+  const promise = workStore.runInCleanSnapshot(() =>
+    Promise.resolve(underlyingSearchParams)
+  )
+
+  const proxiedPromise = new Proxy(
+    promise,
+    createErroringSearchParamsProxyHandler(workStore, prerenderStore)
+  )
 
   CachedSearchParams.set(workStore, proxiedPromise)
   return proxiedPromise
@@ -532,11 +555,12 @@ export function makeErroringSearchParamsForUseCache(): Promise<SearchParams> {
     return cachedSearchParams
   }
 
-  const promise = Promise.resolve({})
+  const promise = workStore.runInCleanSnapshot(() => Promise.resolve({}))
+  const workStoreRef = new WeakRef(workStore)
 
   const proxiedPromise = new Proxy(promise, {
     get: function get(target, prop, receiver) {
-      if (Object.hasOwn(promise, prop)) {
+      if (Object.hasOwn(target, prop)) {
         // The promise has this property directly. we must return it. We know it
         // isn't a dynamic access because it can only be something that was
         // previously written to the promise and thus not an underlying
@@ -548,7 +572,14 @@ export function makeErroringSearchParamsForUseCache(): Promise<SearchParams> {
         typeof prop === 'string' &&
         (prop === 'then' || !wellKnownProperties.has(prop))
       ) {
-        throwForSearchParamsAccessInUseCache(workStore, get)
+        const liveWorkStore = workStoreRef.deref()
+        if (!liveWorkStore) {
+          throw new InvariantError(
+            'Expected workStore to still be available when accessing searchParams in a cache scope'
+          )
+        }
+
+        throwForSearchParamsAccessInUseCache(liveWorkStore, get)
       }
 
       return ReflectAdapter.get(target, prop, receiver)
@@ -567,7 +598,13 @@ function makeUntrackedSearchParams(
     return cachedSearchParams
   }
 
-  const promise = Promise.resolve(underlyingSearchParams)
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
+  const promise = workStore.runInCleanSnapshot(() =>
+    Promise.resolve(underlyingSearchParams)
+  )
   CachedSearchParams.set(underlyingSearchParams, promise)
 
   return promise
@@ -789,5 +826,7 @@ function createClientSearchParamsInValidation(
     declaredKeys,
     workStore.route
   )
-  return Promise.resolve(underlyingSearchParams)
+  return workStore.runInCleanSnapshot(() =>
+    Promise.resolve(underlyingSearchParams)
+  )
 }

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -237,6 +237,7 @@
       "test/e2e/app-dir/prefetching-not-found/prefetching-not-found.test.ts",
       "test/e2e/app-dir/prerender-encoding/prerender-encoding.test.ts",
       "test/e2e/app-dir/react-max-headers-length/react-max-headers-length.test.ts",
+      "test/e2e/app-dir/request-context-retention/request-context-retention.test.ts",
       "test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts",
       "test/e2e/app-dir/revalidatetag-rsc/revalidatetag-rsc.test.ts",
       "test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts",

--- a/test/e2e/app-dir/request-context-retention/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/request-context-retention/app/[slug]/page.tsx
@@ -1,0 +1,40 @@
+import { getPromiseContext } from '../promise-context'
+
+export const revalidate = 3600
+
+export function generateStaticParams() {
+  return [{ slug: 'test' }]
+}
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const controlContext = getPromiseContext(Promise.resolve())
+  const paramsContext = getPromiseContext(params)
+  const searchParamsContext = getPromiseContext(searchParams)
+  const { slug } = await params
+
+  return (
+    <main>
+      <h1>{slug}</h1>
+      <p id="control-captures-work-store">{String(controlContext.workStore)}</p>
+      <p id="control-captures-work-unit-store">
+        {String(controlContext.workUnitStore)}
+      </p>
+      <p id="params-captures-work-store">{String(paramsContext.workStore)}</p>
+      <p id="params-captures-work-unit-store">
+        {String(paramsContext.workUnitStore)}
+      </p>
+      <p id="search-params-captures-work-store">
+        {String(searchParamsContext.workStore)}
+      </p>
+      <p id="search-params-captures-work-unit-store">
+        {String(searchParamsContext.workUnitStore)}
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/request-context-retention/app/dynamic/[slug]/page.tsx
+++ b/test/e2e/app-dir/request-context-retention/app/dynamic/[slug]/page.tsx
@@ -1,0 +1,39 @@
+import { connection } from 'next/server'
+import { getPromiseContext } from '../../promise-context'
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  await connection()
+
+  const controlContext = getPromiseContext(Promise.resolve())
+  const paramsContext = getPromiseContext(params)
+  const searchParamsContext = getPromiseContext(searchParams)
+  const { slug } = await params
+  const { query } = await searchParams
+
+  return (
+    <main>
+      <h1>{slug}</h1>
+      <p id="query">{query}</p>
+      <p id="control-captures-work-store">{String(controlContext.workStore)}</p>
+      <p id="control-captures-work-unit-store">
+        {String(controlContext.workUnitStore)}
+      </p>
+      <p id="params-captures-work-store">{String(paramsContext.workStore)}</p>
+      <p id="params-captures-work-unit-store">
+        {String(paramsContext.workUnitStore)}
+      </p>
+      <p id="search-params-captures-work-store">
+        {String(searchParamsContext.workStore)}
+      </p>
+      <p id="search-params-captures-work-unit-store">
+        {String(searchParamsContext.workUnitStore)}
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/request-context-retention/app/layout.tsx
+++ b/test/e2e/app-dir/request-context-retention/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/request-context-retention/app/nested-cache/page.tsx
+++ b/test/e2e/app-dir/request-context-retention/app/nested-cache/page.tsx
@@ -1,0 +1,16 @@
+import { unstable_cache } from 'next/cache'
+
+export const revalidate = 3600
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const query = await unstable_cache(
+    async (params: typeof searchParams) => (await params).query,
+    ['nested-search-params']
+  )(searchParams)
+
+  return <p id="query">{query}</p>
+}

--- a/test/e2e/app-dir/request-context-retention/app/promise-context.ts
+++ b/test/e2e/app-dir/request-context-retention/app/promise-context.ts
@@ -1,0 +1,33 @@
+import { createHook } from 'node:async_hooks'
+import { workAsyncStorage } from 'next/dist/server/app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
+
+const promiseContextSymbol = Symbol.for('next.test.promise-context')
+
+createHook({
+  init(_asyncId, type, _triggerAsyncId, resource) {
+    if (type === 'PROMISE') {
+      Object.defineProperty(resource, promiseContextSymbol, {
+        value: {
+          workStore: workAsyncStorage.getStore() !== undefined,
+          workUnitStore: workUnitAsyncStorage.getStore() !== undefined,
+        },
+      })
+    }
+  },
+}).enable()
+
+type PromiseContext = {
+  workStore: boolean
+  workUnitStore: boolean
+}
+
+export function getPromiseContext(promise: Promise<unknown>): PromiseContext {
+  const context = (
+    promise as unknown as Record<symbol, PromiseContext | undefined>
+  )[promiseContextSymbol]
+  if (!context) {
+    throw new Error('Promise was created before context tracking was enabled')
+  }
+  return context
+}

--- a/test/e2e/app-dir/request-context-retention/request-context-retention.test.ts
+++ b/test/e2e/app-dir/request-context-retention/request-context-retention.test.ts
@@ -1,0 +1,66 @@
+import cheerio from 'cheerio'
+import { nextTestSetup } from 'e2e-utils'
+
+function expectDetachedRequestProps(html: string) {
+  const $ = cheerio.load(html)
+  expect($('#control-captures-work-store').text()).toBe('true')
+  expect($('#control-captures-work-unit-store').text()).toBe('true')
+  expect($('#params-captures-work-store').text()).toBe('false')
+  expect($('#params-captures-work-unit-store').text()).toBe('false')
+  expect($('#search-params-captures-work-store').text()).toBe('false')
+  expect($('#search-params-captures-work-unit-store').text()).toBe('false')
+}
+
+describe('request context retention', () => {
+  const { next, isNextStart, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (!isNextStart && !isNextDeploy) {
+    it.skip('only runs in production modes', () => {})
+    return
+  }
+
+  it('does not retain the prerender context through request props', async () => {
+    let response: Awaited<ReturnType<typeof next.fetch>>
+    if (isNextStart) {
+      const prerenderManifest = await next.readJSON(
+        '.next/prerender-manifest.json'
+      )
+      response = await next.fetch('/test', {
+        headers: {
+          'x-prerender-revalidate': prerenderManifest.preview.previewModeId,
+        },
+      })
+    } else {
+      // Deploy mode cannot access the build output or use the private
+      // revalidation header, but the prerendered response still verifies
+      // the build-time request-prop promise context.
+      response = await next.fetch('/test')
+    }
+
+    expect(response.status).toBe(200)
+    expectDetachedRequestProps(await response.text())
+  })
+
+  it('does not retain a dynamic request context through request props', async () => {
+    const response = await next.fetch('/dynamic/test?query=value')
+
+    expect(response.status).toBe(200)
+
+    const html = await response.text()
+    expectDetachedRequestProps(html)
+    expect(cheerio.load(html)('#query').text()).toBe('value')
+  })
+
+  it('preserves searchParams behavior in a nested cache context', async () => {
+    const response = await next.fetch('/nested-cache?query=value')
+
+    expect(response.status).toBe(200)
+    expect(
+      cheerio
+        .load(await response.text())('#query')
+        .text()
+    ).toBe('value')
+  })
+})


### PR DESCRIPTION
## What?

Prevent immediately resolved App Router `params` and `searchParams` promises from retaining the request async context.

## Why?

RSC and ISR cache entries can retain fulfilled page-prop promises. Those promises were created while the work and work-unit async-local stores were active, so keeping the cached result alive also kept the originating request context alive.

This is observable as delayed collection and elevated retained memory in the reproduction from #96533.

## How?

- Create immediate production `params` and `searchParams` promises inside the work store's clean async snapshot.
- Keep the existing fallback-param, PPR, `dynamic = "error"`, and cache-scope behavior while avoiding strong store references in deferred proxy accessors.
- Add an async-hooks e2e regression that proves ordinary render promises capture the stores while request-prop promises do not, covering ISR, dynamic rendering, nested cache access, deployment mode, webpack, and Turbopack.
- Exclude the legacy ISR fixture from the Cache Components matrix, where route-segment `revalidate` is intentionally unsupported, while retaining normal production and deployment coverage.

Tests:

- `pnpm test-start test/e2e/app-dir/request-context-retention/request-context-retention.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/request-context-retention/request-context-retention.test.ts`
- `pnpm test-start test/e2e/app-dir/dynamic-data`
- `pnpm --filter=next build`
- `pnpm test-types --pretty false`
- ESLint, Prettier, error-code validation, and two-model autoreview

Fixes #96533
