### PR TITLE
Pass explicit render capabilities through App Render

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -354,10 +354,26 @@ export type AppSharedContext = {
   clientAssetToken: string
 }
 
+type AppRenderCapabilities = {
+  /** Whether this render may postpone dynamic subtrees. */
+  canPostpone: boolean
+  /**
+   * Whether the response may contain postponed holes. This is conservatively
+   * true for prerenders with PPR enabled, even when the response turns out to
+   * be fully static, because a false negative could cause the client to skip
+   * fetching dynamic data. Per-segment prefetch responses replace this with a
+   * more precise value during segment-data collection.
+   */
+  isPossiblyPartialResponse: boolean
+  /** Whether this route supports per-segment prefetching in the client protocol. */
+  supportsPerSegmentPrefetching: boolean
+}
+
 export type AppRenderContext = {
   sharedContext: AppSharedContext
   workStore: WorkStore
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy
+  renderCapabilities: AppRenderCapabilities
   url: ReturnType<typeof parseRelativeUrl>
   componentMod: AppPageModule
   renderOpts: RenderOpts
@@ -796,9 +812,7 @@ async function generateDynamicRSCPayload(
       // With Cache Components, all routes support it. Without it, only fully
       // static pages do, because their per-segment prefetch responses are
       // generated during static generation (build or ISR).
-      S:
-        workStore.executionMode === 'prerender' ||
-        ctx.renderOpts.cacheComponents,
+      S: ctx.renderCapabilities.supportsPerSegmentPrefetching,
       h: getMetadataVaryParamsAccumulator(),
       r: getRootParamsVaryParamsAccumulator() ?? undefined,
     }
@@ -2186,10 +2200,8 @@ async function getRSCPayload(
   // client Segment Cache after a prefetch to determine if it can skip the
   // second request to fill in the dynamic data.
   //
-  // See similar comment in create-component-tree.tsx for more context.
-  const isPossiblyPartialHead =
-    workStore.executionMode === 'prerender' &&
-    ctx.renderOpts.experimental.isRoutePPREnabled === true
+  // See AppRenderCapabilities.isPossiblyPartialResponse for more context.
+  const isPossiblyPartialHead = ctx.renderCapabilities.isPossiblyPartialResponse
 
   return maybeAppendBuildIdToRSCPayload(ctx, {
     // See the comment above the `Preloads` component (below) for why this is part of the payload
@@ -2213,8 +2225,7 @@ async function getRSCPayload(
     // With Cache Components, all routes support it. Without it, only fully
     // static pages do, because their per-segment prefetch responses are
     // generated during static generation (build or ISR).
-    S:
-      workStore.executionMode === 'prerender' || ctx.renderOpts.cacheComponents,
+    S: ctx.renderCapabilities.supportsPerSegmentPrefetching,
     h: getMetadataVaryParamsAccumulator(),
     r: getRootParamsVaryParamsAccumulator() ?? undefined,
     s: staleTimeIterable,
@@ -2257,7 +2268,6 @@ async function getErrorRSCPayload(
     query,
     componentMod: { createMetadataComponents, createElement, Fragment },
     url,
-    workStore,
   } = ctx
 
   let Viewport: ComponentType | null = null
@@ -2348,9 +2358,7 @@ async function getErrorRSCPayload(
     ctx
   )
 
-  const isPossiblyPartialHead =
-    workStore.executionMode === 'prerender' &&
-    ctx.renderOpts.experimental.isRoutePPREnabled === true
+  const isPossiblyPartialHead = ctx.renderCapabilities.isPossiblyPartialResponse
 
   return maybeAppendBuildIdToRSCPayload(ctx, {
     c: prepareInitialCanonicalUrl(url),
@@ -2370,8 +2378,7 @@ async function getErrorRSCPayload(
     // With Cache Components, all routes support it. Without it, only fully
     // static pages do, because their per-segment prefetch responses are
     // generated during static generation (build or ISR).
-    S:
-      workStore.executionMode === 'prerender' || ctx.renderOpts.cacheComponents,
+    S: ctx.renderCapabilities.supportsPerSegmentPrefetching,
     h: getMetadataVaryParamsAccumulator(),
     r: getRootParamsVaryParamsAccumulator() ?? undefined,
   } satisfies InitialRSCPayload)
@@ -2697,6 +2704,7 @@ async function renderToHTMLOrFlightImpl(
   stripInternalQueries(query)
 
   const isStaticGeneration = workStore.executionMode === 'prerender'
+  const isRoutePPREnabled = renderOpts.experimental.isRoutePPREnabled === true
 
   let requestId: string
   let htmlRequestId: string
@@ -2779,6 +2787,14 @@ async function renderToHTMLOrFlightImpl(
       isStaticGeneration,
       renderOpts.cacheComponents
     ),
+    // These are distinct rendering and protocol properties even though they
+    // are both determined by route-level PPR support today.
+    renderCapabilities: {
+      canPostpone: isStaticGeneration && isRoutePPREnabled,
+      isPossiblyPartialResponse: isStaticGeneration && isRoutePPREnabled,
+      supportsPerSegmentPrefetching:
+        isStaticGeneration || renderOpts.cacheComponents,
+    },
     parsedRequestHeaders,
     getDynamicParamFromSegment,
     interpolatedParams,
@@ -7974,6 +7990,12 @@ async function validateInstantConfigInBuildWithSample(
         false,
         outerCtx.renderOpts.cacheComponents
       ),
+      renderCapabilities: {
+        canPostpone: false,
+        isPossiblyPartialResponse: false,
+        supportsPerSegmentPrefetching:
+          outerCtx.renderCapabilities.supportsPerSegmentPrefetching,
+      },
       parsedRequestHeaders: outerCtx.parsedRequestHeaders,
       getDynamicParamFromSegment,
       interpolatedParams: sampleParams,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -133,8 +133,12 @@ async function createComponentTreeInternal(
     pagePath,
     getDynamicParamFromSegment,
     isPrefetch,
+    renderCapabilities,
     query,
   } = ctx
+
+  const { executionMode } = workStore
+  const { canPostpone, isPossiblyPartialResponse } = renderCapabilities
 
   const { page, conventionPath, segment, modules, parallelRoutes } =
     parseLoaderTree(tree)
@@ -273,10 +277,7 @@ async function createComponentTreeInternal(
       workStore.forceDynamic = true
 
       // TODO: (PPR) remove this bailout once PPR is the default
-      if (
-        workStore.executionMode === 'prerender' &&
-        !experimental.isRoutePPREnabled
-      ) {
+      if (executionMode === 'prerender' && !canPostpone) {
         // If the postpone API isn't available, we can't postpone the render and
         // therefore we can't use the dynamic API.
         const err = new DynamicServerError(
@@ -333,11 +334,11 @@ async function createComponentTreeInternal(
 
     if (
       !workStore.forceStatic &&
-      workStore.executionMode === 'prerender' &&
+      executionMode === 'prerender' &&
       defaultRevalidate === 0 &&
       // If the postpone API isn't available, we can't postpone the render and
       // therefore we can't use the dynamic API.
-      !experimental.isRoutePPREnabled
+      !canPostpone
     ) {
       const dynamicUsageDescription = `revalidate: 0 configured ${segment}`
       workStore.dynamicUsageDescription = dynamicUsageDescription
@@ -388,24 +389,6 @@ async function createComponentTreeInternal(
     }
   }
 
-  const isStaticGeneration = workStore.executionMode === 'prerender'
-
-  // Assume the segment we're rendering contains only partial data if PPR is
-  // enabled and this is a statically generated response. This is used by the
-  // client Segment Cache after a prefetch to determine if it can skip the
-  // second request to fill in the dynamic data.
-  //
-  // It's OK for this to be `true` when the data is actually fully static, but
-  // it's not OK for this to be `false` when the data possibly contains holes.
-  // Although the value here is overly pessimistic, for prefetches, it will be
-  // replaced by a more specific value when the data is later processed into
-  // per-segment responses (see collect-segment-data.tsx)
-  //
-  // For dynamic requests, this must always be `false` because dynamic responses
-  // are never partial.
-  const isPossiblyPartialResponse =
-    isStaticGeneration && experimental.isRoutePPREnabled === true
-
   const LayoutOrPage: ComponentType<any> | undefined = layoutOrPageMod
     ? interopDefault(layoutOrPageMod)
     : undefined
@@ -415,7 +398,7 @@ async function createComponentTreeInternal(
    */
   let MaybeComponent = LayoutOrPage
 
-  if (process.env.NODE_ENV === 'development' || isStaticGeneration) {
+  if (process.env.NODE_ENV === 'development' || executionMode === 'prerender') {
     const { isValidElementType } =
       require('next/dist/compiled/react-is') as typeof import('next/dist/compiled/react-is')
     if (
@@ -770,11 +753,7 @@ async function createComponentTreeInternal(
   // along the parent path of a force-dynamic segment will hit this condition effectively making the entire
   // render force-dynamic. We should refactor this function so that we can correctly track which segments
   // need to be dynamic
-  if (
-    workStore.executionMode === 'prerender' &&
-    workStore.forceDynamic &&
-    experimental.isRoutePPREnabled
-  ) {
+  if (canPostpone && workStore.forceDynamic) {
     return createSeedData(
       ctx,
       createElement(
@@ -829,7 +808,7 @@ async function createComponentTreeInternal(
           Component: PageComponent,
           serverProvidedParams: null,
         })
-      } else if (isStaticGeneration) {
+      } else if (executionMode === 'prerender') {
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
         const promiseOfSearchParams = createPrerenderSearchParamsForClientPage()
@@ -938,7 +917,7 @@ async function createComponentTreeInternal(
           slots: parallelRouteProps,
           serverProvidedParams: null,
         })
-      } else if (isStaticGeneration) {
+      } else if (executionMode === 'prerender') {
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
 


### PR DESCRIPTION
## Summary

`create-component-tree` currently combines `WorkStore.executionMode` with route-level PPR configuration at several leaf call sites to determine whether it can postpone dynamic subtrees and whether the resulting response may be partial.

This introduces `AppRenderCapabilities`, derived once at the App Render boundary, containing:

- `canPostpone`
- `isPossiblyPartialResponse`
- `supportsPerSegmentPrefetching`

Component tree construction consumes the explicit rendering capabilities instead of independently interpreting the PPR configuration. RSC payload generation likewise consumes `supportsPerSegmentPrefetching` instead of re-deriving the client `S` flag from execution mode and Cache Components, keeping the protocol decision consistent across dynamic, initial, and error payloads.