### PR TITLE
Turbopack: scale down idle Node.js process pools

### DIFF
--- a/turbopack/crates/turbopack-node/src/process_pool/heap_queue.rs
+++ b/turbopack/crates/turbopack-node/src/process_pool/heap_queue.rs
@@ -46,12 +46,16 @@ impl<T: Ord> HeapQueue<T> {
         Ok(item)
     }
 
-    pub fn reduce_to_one(&self) {
+    pub fn has_multiple(&self) -> bool {
+        self.semaphore.available_permits() > 1
+    }
+
+    pub fn reduce_to_one(&self) -> usize {
         // Drain the semaphore permits
         let mut n = self.semaphore.forget_permits(usize::MAX);
         if n <= 1 {
             self.semaphore.add_permits(n);
-            return;
+            return 0;
         }
         let mut heap: parking_lot::lock_api::MutexGuard<'_, parking_lot::RawMutex, BinaryHeap<T>> =
             self.heap.lock();
@@ -63,6 +67,7 @@ impl<T: Ord> HeapQueue<T> {
         }
         heap.push(top);
         self.semaphore.add_permits(1);
+        n
     }
 
     pub fn reduce_to_zero(self: &Arc<Self>, active_queues: &Mutex<Vec<Arc<Self>>>) {

--- a/turbopack/crates/turbopack-node/src/process_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/process_pool/mod.rs
@@ -23,6 +23,7 @@ use tokio::{
     process::{Child, ChildStderr, ChildStdout, Command},
     select,
     sync::Semaphore,
+    task::JoinHandle,
     time::{sleep, timeout},
 };
 use turbo_rcstr::{RcStr, rcstr};
@@ -84,6 +85,7 @@ impl PartialEq for NodeJsPoolProcess {
 }
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const IDLE_PROCESS_SCALE_DOWN_DELAY: Duration = Duration::from_secs(2);
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct OutputEntry {
@@ -627,6 +629,8 @@ pub struct ChildProcessPool {
     pub project_dir: FileSystemPath,
     #[turbo_tasks(trace_ignore, debug_ignore)]
     idle_processes: Arc<HeapQueue<NodeJsPoolProcess>>,
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    idle_scale_down_task: Arc<Mutex<Option<JoinHandle<()>>>>,
     /// Semaphore to limit the number of concurrent operations in general
     #[turbo_tasks(trace_ignore, debug_ignore)]
     concurrency_semaphore: Arc<Semaphore>,
@@ -671,6 +675,7 @@ impl ChildProcessPool {
                 })),
                 bootup_semaphore: Arc::new(Semaphore::new(1)),
                 idle_processes: Arc::new(HeapQueue::new()),
+                idle_scale_down_task: Default::default(),
                 shared_stdout: Arc::new(Mutex::new(FxIndexSet::default())),
                 shared_stderr: Arc::new(Mutex::new(FxIndexSet::default())),
                 debug,
@@ -737,14 +742,22 @@ impl NodeBackend for ChildProcessesBackend {
 impl EvaluateOperation for ChildProcessPool {
     async fn operation(&self) -> Result<Box<dyn Operation>> {
         // Acquire a running process (handles concurrency limits, boots up the process)
-
         let operation = {
             let _guard = duration_span!("Node.js operation");
             let (process, permits) = self.acquire_process().await?;
+
+            // Keep the expanded pool alive while operations are still arriving. Only
+            // cancel after acquisition succeeds so errors or cancellation cannot
+            // leave the pool without a pending scale down.
+            if let Some(task) = self.idle_scale_down_task.lock().take() {
+                task.abort();
+            }
+
             ChildProcessOperation {
                 process: Some(process),
                 permits,
                 idle_processes: self.idle_processes.clone(),
+                idle_scale_down_task: self.idle_scale_down_task.clone(),
                 start: Instant::now(),
                 stats: self.stats.clone(),
                 allow_process_reuse: true,
@@ -877,6 +890,7 @@ pub struct ChildProcessOperation {
     #[allow(dead_code)]
     permits: AcquiredPermits,
     idle_processes: Arc<HeapQueue<NodeJsPoolProcess>>,
+    idle_scale_down_task: Arc<Mutex<Option<JoinHandle<()>>>>,
     start: Instant,
     stats: Arc<Mutex<NodeJsPoolStats>>,
     allow_process_reuse: bool,
@@ -975,6 +989,23 @@ impl Drop for ChildProcessOperation {
                 process.cpu_time_invested += elapsed;
                 self.idle_processes.push(process, &ACTIVE_POOLS);
             }
+        }
+
+        let mut scale_down_task = self.idle_scale_down_task.lock();
+        if let Some(task) = scale_down_task.take() {
+            task.abort();
+        }
+        if self.idle_processes.has_multiple() {
+            let idle_processes = self.idle_processes.clone();
+            let stats = self.stats.clone();
+            *scale_down_task = Some(tokio::spawn(async move {
+                sleep(IDLE_PROCESS_SCALE_DOWN_DELAY).await;
+                let removed = idle_processes.reduce_to_one();
+                let mut stats = stats.lock();
+                for _ in 0..removed {
+                    stats.remove_worker();
+                }
+            }));
         }
     }
 }

--- a/turbopack/crates/turbopack-node/tests/pool.rs
+++ b/turbopack/crates/turbopack-node/tests/pool.rs
@@ -2,7 +2,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -257,6 +257,129 @@ async fn test_pool_concurrent_operations() {
             stats.warm_operation_count, 2,
             "both concurrent ops should be warm"
         );
+    })
+    .await;
+}
+
+#[cfg(all(feature = "process_pool", not(feature = "worker_pool")))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_pool_scales_down_after_idle() {
+    run_once_without_cache_check(&REGISTRATION, async {
+        let pool = create_test_pool(3).await.unwrap();
+        let mut op1 = pool.operation().await.unwrap();
+        let mut op2 = pool.operation().await.unwrap();
+        let mut op3 = pool.operation().await.unwrap();
+
+        let pid1 = send_recv(&mut op1, serde_json::json!({"worker": 1}))
+            .await
+            .pid;
+        let pid2 = send_recv(&mut op2, serde_json::json!({"worker": 2}))
+            .await
+            .pid;
+        let pid3 = send_recv(&mut op3, serde_json::json!({"worker": 3}))
+            .await
+            .pid;
+        drop((op1, op2, op3));
+
+        assert_eq!(pool.stats().workers, 3);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while pool.stats().workers != 1 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "idle process pool did not scale down within timeout"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        let mut op = pool.operation().await.unwrap();
+        let reused_pid = send_recv(&mut op, serde_json::json!({"after_idle": true}))
+            .await
+            .pid;
+        assert!(
+            [pid1, pid2, pid3].contains(&reused_pid),
+            "scale down should retain one warm process"
+        );
+        assert_eq!(pool.stats().bootup_count, 3);
+    })
+    .await;
+}
+
+#[cfg(all(feature = "process_pool", not(feature = "worker_pool")))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_pool_scales_down_after_non_reusable_operation() {
+    run_once_without_cache_check(&REGISTRATION, async {
+        let pool = create_test_pool(3).await.unwrap();
+        let mut operations = vec![
+            pool.operation().await.unwrap(),
+            pool.operation().await.unwrap(),
+            pool.operation().await.unwrap(),
+        ];
+
+        for (index, operation) in operations.iter_mut().enumerate() {
+            send_recv(operation, serde_json::json!({ "worker": index })).await;
+        }
+        drop(operations);
+        assert_eq!(pool.stats().workers, 3);
+
+        let mut failed_operation = pool.operation().await.unwrap();
+        failed_operation.disallow_reuse();
+        drop(failed_operation);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while pool.stats().workers != 1 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "pool did not scale down after a non-reusable operation"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert_eq!(pool.stats().bootup_count, 3);
+    })
+    .await;
+}
+
+#[cfg(all(feature = "process_pool", not(feature = "worker_pool")))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_pool_does_not_scale_down_during_an_operation() {
+    run_once_without_cache_check(&REGISTRATION, async {
+        let pool = create_test_pool(3).await.unwrap();
+        let mut operations = vec![
+            pool.operation().await.unwrap(),
+            pool.operation().await.unwrap(),
+            pool.operation().await.unwrap(),
+        ];
+
+        for (index, operation) in operations.iter_mut().enumerate() {
+            send_recv(operation, serde_json::json!({ "worker": index })).await;
+        }
+        drop(operations);
+        assert_eq!(pool.stats().workers, 3);
+
+        let mut active_operation = pool.operation().await.unwrap();
+        send_recv(
+            &mut active_operation,
+            serde_json::json!({ "while_active": true }),
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(2500)).await;
+        assert_eq!(
+            pool.stats().workers,
+            3,
+            "starting an operation should cancel the pending scale down"
+        );
+
+        drop(active_operation);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while pool.stats().workers != 1 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "pool did not scale down after the active operation completed"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert_eq!(pool.stats().bootup_count, 3);
     })
     .await;
 }


### PR DESCRIPTION
<!-- NEXT_JS_LLM -->

## What

Scale each Turbopack Node.js child-process pool back to one warm process after two seconds of inactivity.

- active operations still use the configured concurrency;
- the hottest process stays warm for the next edit;
- a new successfully acquired operation cancels pending cleanup;
- normal, failed, non-reusable, killed, and cancelled operation paths all re-evaluate idle cleanup;
- per-pool worker statistics are decremented for removed idle processes.

## Why

Incremental HMR can expand webpack-loader/PostCSS evaluation pools to machine parallelism, but those expensive Node.js children remain in the idle heap afterward. The existing global scale-down hook runs after a whole-application graph operation and does not reliably cover incremental loader work.

On a large real application this makes the development-server working set history-dependent: identical warmed sessions retained 3-13 loader children, and a 12-file edit burst could add about 3.2 GB to the process tree. This directly contributes to development sessions crossing Next.js's memory threshold and restarting after repeated saves.

## Real-application benchmark

I tested optimized native binaries from the same base commit in the same 16-vCPU/32-GB Vercel environment against a real v0 `/projects` route. The paired matrix covers 1, 2, 4, 8, 12, and 24 distinct files plus 12-file bursts with 0, 5, 20, 50, 100, and 150 ms write gaps. Chromium had to observe the exact final server-rendered revision; the harness also verified RSC requests, renders, errors, source/config restoration, and the loaded native binary hash.

After five seconds idle, across 11 paired scenarios:

| Metric | Baseline | Candidate | Change | Paired bootstrap 95% CI |
|---|---:|---:|---:|---:|
| Process-tree RSS | 7.649 GB | 4.468 GB | **-3.181 GB / -41.6%** | -45.2% to -37.5% |
| Process-tree PSS | 6.850 GB | 4.336 GB | **-2.514 GB / -36.7%** | -40.8% to -31.9% |
| Private memory | 6.803 GB | 4.299 GB | **-2.505 GB / -36.8%** | -40.9% to -32.1% |
| Idle pool children | 12.64 | 1.00 | **-92.1%** | -92.6% to -91.5% |
| Browser-visible update | 1,164 ms | 1,137 ms | -27 ms / -2.3% | -8.2% to +2.9% |

Candidate memory was lower in all 11 pairs. The latency interval crosses zero, so the result is no measurable HMR latency regression. A separate 20-burst endurance run reduced mean RSS from 7.209 GB to 4.358 GB and maximum RSS from 8.461 GB to 5.167 GB. A second real route reduced post-idle RSS from 8.620 GB to 4.031 GB.

This is independent of #96433: that PR coalesces invalidations during acknowledged edit transactions; this PR releases expanded loader processes after work becomes idle and requires no controller protocol.

## Validation

- `cargo test -p turbopack-node --test pool --features process_pool` (8/8)
- `cargo clippy -p turbopack-node --tests --features process_pool -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm --dir packages/next-swc build-native-release`
- `pnpm build-all` (18/18)
- `git diff --check`

The new tests cover ordinary idle shrink/reuse, a non-reusable operation, and ensuring an active operation is never scaled down.

## Scope

This intentionally changes only the process-pool backend. It does not cap active parallelism or scale to zero. The pre-existing global `ChildProcessPool::scale_down()` statistics path is unchanged and can be corrected separately with a broader pool-registry redesign.
