### PR TITLE
Fix playwright config merging for projects property

### DIFF
--- a/packages/next/src/experimental/testmode/playwright/index.ts
+++ b/packages/next/src/experimental/testmode/playwright/index.ts
@@ -17,17 +17,17 @@ export function defineConfig<T extends NextOptionsConfig, W>(
 export function defineConfig<T extends NextOptionsConfig = NextOptionsConfig>(
   config: base.PlaywrightTestConfig<T>
 ): base.PlaywrightTestConfig<T> {
-  if (config.webServer !== undefined) {
-    // Playwright doesn't merge the `webServer` field as we'd expect, so remove our default if the user specifies one.
-    const { webServer, ...partialDefaultPlaywrightConfig } =
-      defaultPlaywrightConfig as base.PlaywrightTestConfig<T>
-    return base.defineConfig<T>(partialDefaultPlaywrightConfig, config)
-  } else {
-    return base.defineConfig<T>(
-      defaultPlaywrightConfig as base.PlaywrightTestConfig<T>,
-      config
-    )
-  }
+  // Playwright doesn't replace the `webServer` and `projects` fields as we'd expect, so remove our defaults if the user specifies their own.
+  const { webServer, projects, ...partialDefaultPlaywrightConfig } =
+    defaultPlaywrightConfig as base.PlaywrightTestConfig<T>
+  return base.defineConfig<T>(
+    {
+      ...partialDefaultPlaywrightConfig,
+      ...(config.webServer === undefined ? { webServer } : undefined),
+      ...(config.projects === undefined ? { projects } : undefined),
+    },
+    config
+  )
 }
 
 export type { NextFixture, NextOptions }


### PR DESCRIPTION
`defineConfig` from `next/experimental/testmode/playwright` spreads the default `projects` array into Playwright's `base.defineConfig`. Playwright merges project arrays instead of replacing them, so a user's own `projects` are appended after the three default browsers rather than replacing them. This applies the same treatment already used for `webServer`: drop the default `projects` when the user provides their own.

Fixes #96555