### PR TITLE
Keep loaded env when a forced .env reload reads nothing

### DIFF
--- a/packages/next-env/index.ts
+++ b/packages/next-env/index.ts
@@ -139,9 +139,6 @@ export function loadEnvConfig(
   if (combinedEnv && !forceReload) {
     return { combinedEnv, parsedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
   }
-  replaceProcessEnv(initialEnv)
-  previousLoadedEnvFiles = cachedLoadedEnvFiles
-  cachedLoadedEnvFiles = []
 
   const isTest = process.env.NODE_ENV === 'test'
   const mode = isTest ? 'test' : dev ? 'development' : 'production'
@@ -155,6 +152,7 @@ export function loadEnvConfig(
     '.env',
   ].filter(Boolean) as string[]
 
+  const newLoadedEnvFiles: LoadedEnvFiles = []
   for (const envFile of dotenvFiles) {
     // only load .env if the user provided has an env config file
     const dotEnvPath = path.join(dir, envFile)
@@ -168,7 +166,7 @@ export function loadEnvConfig(
       }
 
       const contents = fs.readFileSync(dotEnvPath, 'utf8')
-      cachedLoadedEnvFiles.push({
+      newLoadedEnvFiles.push({
         path: envFile,
         contents,
         env: {}, // This will be populated in processEnv
@@ -179,6 +177,22 @@ export function loadEnvConfig(
       }
     }
   }
+
+  // A FIFO-mounted `.env` (used by secret managers) can only be consumed once,
+  // so a forced reload re-reads it as empty. When a reload finds no content but
+  // a previous load did, keep the already-loaded env instead of wiping it.
+  if (
+    forceReload &&
+    combinedEnv &&
+    newLoadedEnvFiles.every((envFile) => envFile.contents.trim() === '') &&
+    cachedLoadedEnvFiles.some((envFile) => envFile.contents.trim() !== '')
+  ) {
+    return { combinedEnv, parsedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
+  }
+
+  replaceProcessEnv(initialEnv)
+  previousLoadedEnvFiles = cachedLoadedEnvFiles
+  cachedLoadedEnvFiles = newLoadedEnvFiles
   ;[combinedEnv, parsedEnv] = processEnv(
     cachedLoadedEnvFiles,
     dir,

--- a/test/unit/next-env-fifo-reload.test.ts
+++ b/test/unit/next-env-fifo-reload.test.ts
@@ -1,0 +1,44 @@
+import { execFileSync, spawn, type ChildProcess } from 'child_process'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { loadEnvConfig } from '../../packages/next-env/'
+
+const silent = { info() {}, error() {} }
+
+describe('loadEnvConfig with a FIFO-mounted .env', () => {
+  let dir: string
+  let writer: ChildProcess | undefined
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'next-env-fifo-'))
+    delete process.env.SECRET
+  })
+
+  afterEach(() => {
+    writer?.kill()
+    writer = undefined
+    delete process.env.SECRET
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('keeps the previously-loaded env when a forced reload reads nothing', () => {
+    // FIFOs are POSIX-only.
+    if (process.platform === 'win32') return
+
+    const fifo = path.join(dir, '.env')
+    execFileSync('mkfifo', [fifo])
+    // Serve the secret once, then empty on later opens, as a drained pipe does.
+    // Each redirect blocks until a reader opens the pipe, so it self-synchronises.
+    writer = spawn('sh', [
+      '-c',
+      `printf 'SECRET=from-secret-manager\\n' > "${fifo}"; : > "${fifo}"`,
+    ])
+
+    loadEnvConfig(dir, true, silent)
+    expect(process.env.SECRET).toBe('from-secret-manager')
+
+    loadEnvConfig(dir, true, silent, true)
+    expect(process.env.SECRET).toBe('from-secret-manager')
+  }, 20000)
+})


### PR DESCRIPTION
On the dev server's forced env reload, `loadEnvConfig` calls `replaceProcessEnv(initialEnv)` before it reads the `.env` files, and read failures are swallowed. A FIFO-mounted `.env` (used by secret managers such as 1Password and Doppler) can only be read once, so the first watcher-triggered reload wipes `process.env` and then re-reads nothing, losing those values for the rest of the dev session.

This reads the env files first and, when a forced reload finds no content but a previous load did, keeps the already-loaded environment instead of replacing it.

Fixes #96547