### PR TITLE
Preserve per-segment prefetching after dynamic navigation

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -787,6 +787,10 @@ async function generateDynamicRSCPayload(
       f: flightData,
       q: getRenderedSearch(query),
       i: !!couldBeIntercepted,
+      // Tells the client whether this route supports per-segment prefetching.
+      // With Cache Components, all routes support it. Without it, only fully
+      // static pages do, because their per-segment prefetch responses are
+      // generated during static generation (build or ISR).
       S: workStore.isStaticGeneration || ctx.renderOpts.cacheComponents,
       h: getMetadataVaryParamsAccumulator(),
       r: getRootParamsVaryParamsAccumulator() ?? undefined,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -787,7 +787,7 @@ async function generateDynamicRSCPayload(
       f: flightData,
       q: getRenderedSearch(query),
       i: !!couldBeIntercepted,
-      S: workStore.isStaticGeneration,
+      S: workStore.isStaticGeneration || ctx.renderOpts.cacheComponents,
       h: getMetadataVaryParamsAccumulator(),
       r: getRootParamsVaryParamsAccumulator() ?? undefined,
     }

--- a/test/e2e/app-dir/segment-cache/basic/app/partially-static/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/partially-static/target-page/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
+import { RouterPrefetchButton } from '../../../components/router-buttons'
 
 async function Content() {
   await connection()
@@ -8,10 +9,13 @@ async function Content() {
 
 export default function DynamicPage() {
   return (
-    <div id="dynamic-page">
-      <Suspense fallback="Loading...">
-        <Content />
-      </Suspense>
-    </div>
+    <>
+      <div id="dynamic-page">
+        <Suspense fallback="Loading...">
+          <Content />
+        </Suspense>
+      </div>
+      <RouterPrefetchButton href="/partially-static/target-page?query=1" />
+    </>
   )
 }

--- a/test/e2e/app-dir/segment-cache/basic/app/same-page-nav/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/same-page-nav/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { connection } from 'next/server'
+import { RouterPushButton } from '../../components/router-buttons'
 
 export default async function SamePageNav() {
   // Treat the page as dynamic so we can detect when it's refreshed
@@ -22,6 +23,9 @@ export default async function SamePageNav() {
         </span>
       </p>
       <ul>
+        <li>
+          <RouterPushButton href="/partially-static/target-page" />
+        </li>
         <li>
           <Link href="/same-page-nav">Link to current page</Link>
         </li>

--- a/test/e2e/app-dir/segment-cache/basic/components/router-buttons.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/components/router-buttons.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function RouterPushButton({ href }: { href: string }) {
+  const router = useRouter()
+  return (
+    <button data-router-push={href} onClick={() => router.push(href)}>
+      Navigate without prefetching
+    </button>
+  )
+}
+
+export function RouterPrefetchButton({ href }: { href: string }) {
+  const router = useRouter()
+  return (
+    <button data-router-prefetch={href} onClick={() => router.prefetch(href)}>
+      Prefetch
+    </button>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+++ b/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
@@ -11,6 +11,29 @@ describe('segment cache (basic tests)', () => {
     return
   }
 
+  it('preserves per-segment prefetching after a dynamic navigation', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/same-page-nav', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    const navigationButton = await browser.elementByCss(
+      'button[data-router-push="/partially-static/target-page"]'
+    )
+    await act(async () => navigationButton.click(), {
+      includes: 'Dynamic page',
+    })
+
+    // The target does not read search params, so this should reuse the cached
+    // segments instead of issuing a loading-boundary prefetch.
+    const prefetchButton = await browser.elementByCss(
+      'button[data-router-prefetch="/partially-static/target-page?query=1"]'
+    )
+    await act(async () => prefetchButton.click(), 'no-requests')
+  })
+
   it('navigate before any data has loaded into the prefetch cache', async () => {
     let act: ReturnType<typeof createRouterAct>
     const browser = await next.browser('/', {


### PR DESCRIPTION
## Summary

Cache Components routes support per-segment prefetching, but dynamic Flight responses only advertised this capability during static generation. This could cause a subsequent `router.prefetch()` call to fall back to loading-boundary prefetching and issue an unnecessary request.

In other words, this logic was correctly determined [here](https://github.com/vercel/next.js/blob/0db9e5f994ddf144bef72640d5be9bb17d77fe30/packages/next/src/server/app-render/app-render.tsx#L2204) but not in the initial payload.

## Verification

- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts`