### PR TITLE
Allow overriding projects, reporter, webServer, and testMatch in testmode Playwright defineConfig

### DIFF
--- a/packages/next/src/experimental/testmode/playwright/index.test.ts
+++ b/packages/next/src/experimental/testmode/playwright/index.test.ts
@@ -1,0 +1,37 @@
+import { defineConfig, defaultPlaywrightConfig } from './index'
+
+describe('next/experimental/testmode/playwright', () => {
+  describe('defineConfig', () => {
+    it('it should preserve default values when empty user config is passed', () => {
+      const config = defineConfig({})
+      expect(config.projects?.length).toBe(defaultPlaywrightConfig.projects.length)
+      expect(config.webServer).toEqual([defaultPlaywrightConfig.webServer])
+      expect(config.reporter).toEqual(defaultPlaywrightConfig.reporter)
+      expect(config.testMatch).toEqual(defaultPlaywrightConfig.testMatch)
+    })
+
+    it('it should override projects when projects array is provided by user', () => {
+      const customProjects = [{ name: 'chromium' }]
+      const config = defineConfig({ projects: customProjects })
+      expect(config.projects).toEqual(customProjects)
+    })
+
+    it('it should override webServer when webServer config is provided by user', () => {
+      const customWebServer = { command: 'pnpm dev', port: 3000 }
+      const config = defineConfig({ webServer: customWebServer })
+      expect(config.webServer).toEqual([customWebServer])
+    })
+
+    it('it should override reporter when reporter config is provided by user', () => {
+      const customReporter: any = [['json', { outputFile: 'results.json' }]]
+      const config = defineConfig({ reporter: customReporter })
+      expect(config.reporter).toEqual(customReporter)
+    })
+
+    it('it should override testMatch when testMatch pattern is provided by user', () => {
+      const customTestMatch = '**/*.test.ts'
+      const config = defineConfig({ testMatch: customTestMatch })
+      expect(config.testMatch).toEqual(customTestMatch)
+    })
+  })
+})

--- a/packages/next/src/experimental/testmode/playwright/index.ts
+++ b/packages/next/src/experimental/testmode/playwright/index.ts
@@ -17,17 +17,26 @@ export function defineConfig<T extends NextOptionsConfig, W>(
 export function defineConfig<T extends NextOptionsConfig = NextOptionsConfig>(
   config: base.PlaywrightTestConfig<T>
 ): base.PlaywrightTestConfig<T> {
-  if (config.webServer !== undefined) {
-    // Playwright doesn't merge the `webServer` field as we'd expect, so remove our default if the user specifies one.
-    const { webServer, ...partialDefaultPlaywrightConfig } =
-      defaultPlaywrightConfig as base.PlaywrightTestConfig<T>
-    return base.defineConfig<T>(partialDefaultPlaywrightConfig, config)
-  } else {
-    return base.defineConfig<T>(
-      defaultPlaywrightConfig as base.PlaywrightTestConfig<T>,
-      config
-    )
+  // Playwright doesn't merge certain fields (such as `webServer`, `projects`, `reporter`, `testMatch`)
+  // as expected when using `base.defineConfig`, so remove our defaults if the user specifies their own.
+  const partialDefaultPlaywrightConfig = {
+    ...(defaultPlaywrightConfig as base.PlaywrightTestConfig<T>),
   }
+
+  if (config.webServer !== undefined) {
+    delete partialDefaultPlaywrightConfig.webServer
+  }
+  if (config.projects !== undefined) {
+    delete partialDefaultPlaywrightConfig.projects
+  }
+  if (config.reporter !== undefined) {
+    delete partialDefaultPlaywrightConfig.reporter
+  }
+  if (config.testMatch !== undefined) {
+    delete partialDefaultPlaywrightConfig.testMatch
+  }
+
+  return base.defineConfig<T>(partialDefaultPlaywrightConfig, config)
 }
 
 export type { NextFixture, NextOptions }


### PR DESCRIPTION
#### Why do we need this change:
`defineConfig` in `next/experimental/testmode/playwright` wraps Playwright's `base.defineConfig(defaultPlaywrightConfig, userConfig)`. Playwright concatenates array fields (`projects`, `reporter`) and merges object fields (`webServer`).

Previously, Next.js only checked for `config.webServer` to remove it from `defaultPlaywrightConfig`. As a result, when users specified custom `projects`, `reporter`, or `testMatch`, default values (`chromium`, `firefox`, `webkit`, `list`/`html` reporters, default spec glob) were concatenated or retained alongside user options instead of being replaced.

#### What problem does it solve:
This change ensures that when users specify custom `projects`, `reporter`, `webServer`, or `testMatch` in their Playwright configuration, Next.js's defaults for those specific fields are removed prior to merging. This prevents default browsers and reporters from being force-included when custom options are provided.

Fixes #96555.