### PR TITLE
Fix DevTools requests with basePath

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -33,6 +33,8 @@ import {
 } from './cache'
 import type { FetchStrategy } from './types'
 
+const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+
 type InstantNavCookieState = 'empty' | 'pending' | 'mpa' | 'spa'
 
 function parseCookieValue(raw: string): InstantNavCookieState {
@@ -367,8 +369,8 @@ export function resetNavigationLockToPending(): void {
 /**
  * Returns true if the request targets a dev-server endpoint — one of the
  * hot-reloader middleware routes (error overlay, source maps, launch-editor,
- * devtools). They all share the `/__nextjs_` path prefix and are always
- * requested root-relative on the same origin.
+ * devtools). They all share the `/__nextjs_` path prefix and are requested on
+ * the same origin, either root-relative or prefixed with the configured basePath.
  */
 function isDevServerRequest(input: RequestInfo | URL): boolean {
   let url: URL
@@ -386,7 +388,8 @@ function isDevServerRequest(input: RequestInfo | URL): boolean {
   }
   return (
     url.origin === window.location.origin &&
-    url.pathname.startsWith('/__nextjs_')
+    (url.pathname.startsWith('/__nextjs_') ||
+      (basePath !== '' && url.pathname.startsWith(`${basePath}/__nextjs_`)))
   )
 }
 

--- a/packages/next/src/next-devtools/dev-overlay/font/font-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/font/font-styles.tsx
@@ -1,6 +1,8 @@
 import { css } from '../utils/css'
 import { useInsertionEffect } from 'react'
 
+const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+
 export const FontStyles = () => {
   useInsertionEffect(() => {
     const style = document.createElement('style')
@@ -11,7 +13,8 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(/__nextjs_font/geist-latin-ext.woff2) format('woff2');
+        src: url(${basePath}/__nextjs_font/geist-latin-ext.woff2)
+          format('woff2');
         unicode-range:
           U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
           U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
@@ -23,7 +26,8 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(/__nextjs_font/geist-mono-latin-ext.woff2) format('woff2');
+        src: url(${basePath}/__nextjs_font/geist-mono-latin-ext.woff2)
+          format('woff2');
         unicode-range:
           U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
           U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
@@ -35,7 +39,7 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(/__nextjs_font/geist-latin.woff2) format('woff2');
+        src: url(${basePath}/__nextjs_font/geist-latin.woff2) format('woff2');
         unicode-range:
           U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
           U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
@@ -47,7 +51,8 @@ export const FontStyles = () => {
         font-style: normal;
         font-weight: 400 600;
         font-display: swap;
-        src: url(/__nextjs_font/geist-mono-latin.woff2) format('woff2');
+        src: url(${basePath}/__nextjs_font/geist-mono-latin.woff2)
+          format('woff2');
         unicode-range:
           U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
           U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,

--- a/packages/next/src/next-devtools/shared/stack-frame.ts
+++ b/packages/next/src/next-devtools/shared/stack-frame.ts
@@ -11,6 +11,8 @@ import {
 
 export type { StackFrame }
 
+const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+
 interface ResolvedOriginalStackFrame extends OriginalStackFrameResponse {
   error: false
   reason: null
@@ -94,7 +96,7 @@ export async function getOriginalStackFrames(
   let res: Response | undefined = undefined
   let reason: string | undefined = undefined
   try {
-    res = await fetch('/__nextjs_original-stack-frames', {
+    res = await fetch(`${basePath}/__nextjs_original-stack-frames`, {
       method: 'POST',
       body: JSON.stringify(req),
     })

--- a/test/development/app-dir/devtools-base-path/app/browser/uncaught/page.tsx
+++ b/test/development/app-dir/devtools-base-path/app/browser/uncaught/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Page() {
+  const [shouldThrow, setShouldThrow] = useState(false)
+
+  if (shouldThrow) {
+    throw new Error('devtools basePath test error')
+  }
+
+  return <button onClick={() => setShouldThrow(true)}>Trigger error</button>
+}

--- a/test/development/app-dir/devtools-base-path/app/layout.tsx
+++ b/test/development/app-dir/devtools-base-path/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/devtools-base-path/devtools-base-path.test.ts
+++ b/test/development/app-dir/devtools-base-path/devtools-base-path.test.ts
@@ -1,0 +1,114 @@
+import { nextTestSetup } from 'e2e-utils'
+import { instant } from '@next/playwright'
+import { getRedboxSource, retry, waitForRedbox } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+
+describe('devtools basePath', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('prefixes error overlay requests with basePath', async () => {
+    const devtoolsRequestPaths = new Set<string>()
+    const devtoolsResponses: Array<{
+      pathname: string
+      method: string
+      status: number
+      contentType: string | undefined
+    }> = []
+    const browser = await next.browser('/base/browser/uncaught', {
+      beforePageLoad(page) {
+        page.on('request', (request) => {
+          const pathname = new URL(request.url()).pathname
+
+          if (
+            pathname.includes('/__nextjs_font/') ||
+            pathname.endsWith('/__nextjs_original-stack-frames')
+          ) {
+            devtoolsRequestPaths.add(pathname)
+          }
+        })
+        page.on('response', (response) => {
+          const request = response.request()
+          const pathname = new URL(response.url()).pathname
+
+          if (
+            pathname.includes('/__nextjs_font/') ||
+            pathname.endsWith('/__nextjs_original-stack-frames')
+          ) {
+            devtoolsResponses.push({
+              pathname,
+              method: request.method(),
+              status: response.status(),
+              contentType: response.headers()['content-type'],
+            })
+          }
+        })
+      },
+    })
+
+    await browser.elementByCss('button').click()
+    await waitForRedbox(browser)
+    await browser.waitForIdleNetwork()
+
+    await retry(() => {
+      expect([...devtoolsRequestPaths]).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^\/base\/__nextjs_font\/.+\.woff2$/),
+          '/base/__nextjs_original-stack-frames',
+        ])
+      )
+      expect(devtoolsResponses).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            pathname: expect.stringMatching(
+              /^\/base\/__nextjs_font\/.+\.woff2$/
+            ),
+            method: 'GET',
+            status: 200,
+            contentType: 'font/woff2',
+          }),
+          {
+            pathname: '/base/__nextjs_original-stack-frames',
+            method: 'POST',
+            status: 200,
+            contentType: 'application/json',
+          },
+        ])
+      )
+    }, 10_000)
+
+    expect(devtoolsRequestPaths.has('/__nextjs_original-stack-frames')).toBe(
+      false
+    )
+    expect(
+      [...devtoolsRequestPaths].some((pathname) =>
+        pathname.startsWith('/__nextjs_font/')
+      )
+    ).toBe(false)
+  })
+
+  it('resolves stack frames during an instant scope', async () => {
+    let page: Playwright.Page | undefined
+    const browser = await next.browser('/base/browser/uncaught', {
+      beforePageLoad(currentPage) {
+        page = currentPage
+      },
+    })
+
+    if (!page) {
+      throw new Error('Expected the browser page to be initialized')
+    }
+
+    await instant(page, async () => {
+      await browser.elementByCss('button').click()
+      await waitForRedbox(browser)
+
+      await retry(async () => {
+        expect(await getRedboxSource(browser)).toContain(
+          "throw new Error('devtools basePath test error')"
+        )
+      }, 10_000)
+    })
+  })
+})

--- a/test/development/app-dir/devtools-base-path/next.config.js
+++ b/test/development/app-dir/devtools-base-path/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  basePath: '/base',
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

With `basePath` configured in development, the Error Overlay requested its fonts and original stack frames from the origin root instead of under the configured base path.

The URLs were hard-coded in `font-styles.tsx` and `stack-frame.ts`, and the Instant Navigation fetch lock only recognized DevTools paths at the root.

This change applies the existing `basePath` value to those requests and the lock matching, while preserving the current behavior when no `basePath` is configured.

## Verification

Added browser coverage for the prefixed request paths, their responses, and code frame rendering. The tests pass with both Webpack and Turbopack, along with the Next.js build.

Fixes #85428