### PR TITLE
Use Tailwind Turbopack loader in create-next-app

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -72,7 +72,9 @@ export const installTemplate = async ({
   const copySource = ["**"];
   if (!eslint) copySource.push("!eslint.config.mjs");
   if (!biome) copySource.push("!biome.json");
-  if (!tailwind) copySource.push("!postcss.config.mjs");
+  if (!tailwind || bundler === Bundler.Turbopack) {
+    copySource.push("!postcss.config.mjs");
+  }
 
   await copy(copySource, root, {
     parents: true,
@@ -107,6 +109,30 @@ export const installTemplate = async ({
           "export default withRspack(nextConfig);",
         ),
     );
+  }
+
+  if (tailwind && bundler === Bundler.Turbopack) {
+    const nextConfigFile = path.join(
+      root,
+      mode === "js" ? "next.config.mjs" : "next.config.ts",
+    );
+    let configContent = await fs.readFile(nextConfigFile, "utf8");
+
+    configContent = configContent.replace(
+      "/* config options here */\n",
+      `/* config options here */
+  turbopack: {
+    rules: {
+      "*.css": {
+        loaders: ["@tailwindcss/turbopack"],
+        as: "*.css",
+      },
+    },
+  },
+`,
+    );
+
+    await fs.writeFile(nextConfigFile, configContent);
   }
 
   if (reactCompiler) {
@@ -278,9 +304,13 @@ export const installTemplate = async ({
 
   /* Add Tailwind CSS dependencies. */
   if (tailwind) {
+    const tailwindPlugin =
+      bundler === Bundler.Turbopack
+        ? "@tailwindcss/turbopack"
+        : "@tailwindcss/postcss";
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
-      "@tailwindcss/postcss": "^4",
+      [tailwindPlugin]: "^4",
       tailwindcss: "^4",
     };
   }

--- a/test/production/create-next-app/lib/specification.ts
+++ b/test/production/create-next-app/lib/specification.ts
@@ -19,6 +19,12 @@ export type ProjectSpecification = {
   }
 }
 
+const tailwindFiles = process.env.NEXT_RSPACK ? ['postcss.config.mjs'] : []
+const tailwindDevDeps = [
+  process.env.NEXT_RSPACK ? '@tailwindcss/postcss' : '@tailwindcss/turbopack',
+  'tailwindcss',
+]
+
 /**
  * Required files for a given project template and mode.
  */
@@ -95,10 +101,10 @@ export const projectSpecification: ProjectSpecification = {
         'pages/_app.js',
         'pages/api/hello.js',
         'pages/index.js',
-        'postcss.config.mjs',
+        ...tailwindFiles,
       ],
       deps: [],
-      devDeps: ['@tailwindcss/postcss', 'tailwindcss'],
+      devDeps: tailwindDevDeps,
     },
     ts: {
       files: [
@@ -106,7 +112,7 @@ export const projectSpecification: ProjectSpecification = {
         'pages/_app.tsx',
         'pages/api/hello.ts',
         'pages/index.tsx',
-        'postcss.config.mjs',
+        ...tailwindFiles,
         'tsconfig.json',
       ],
       deps: [],
@@ -114,8 +120,7 @@ export const projectSpecification: ProjectSpecification = {
         '@types/node',
         '@types/react-dom',
         '@types/react',
-        '@tailwindcss/postcss',
-        'tailwindcss',
+        ...tailwindDevDeps,
         'typescript',
       ],
     },
@@ -126,17 +131,17 @@ export const projectSpecification: ProjectSpecification = {
         'jsconfig.json',
         'pages/_app.js',
         'pages/index.js',
-        'postcss.config.mjs',
+        ...tailwindFiles,
       ],
       deps: [],
-      devDeps: ['@tailwindcss/postcss', 'tailwindcss'],
+      devDeps: tailwindDevDeps,
     },
     ts: {
       files: [
         'next-env.d.ts',
         'pages/_app.tsx',
         'pages/index.tsx',
-        'postcss.config.mjs',
+        ...tailwindFiles,
         'tsconfig.json',
       ],
       deps: [],
@@ -144,8 +149,7 @@ export const projectSpecification: ProjectSpecification = {
         '@types/node',
         '@types/react-dom',
         '@types/react',
-        '@tailwindcss/postcss',
-        'tailwindcss',
+        ...tailwindDevDeps,
         'typescript',
       ],
     },
@@ -214,12 +218,12 @@ export const projectSpecification: ProjectSpecification = {
   'app-tw': {
     js: {
       deps: [],
-      devDeps: ['@tailwindcss/postcss', 'tailwindcss'],
+      devDeps: tailwindDevDeps,
       files: [
         'app/layout.js',
         'app/page.js',
         'jsconfig.json',
-        'postcss.config.mjs',
+        ...tailwindFiles,
       ],
     },
     ts: {
@@ -228,15 +232,14 @@ export const projectSpecification: ProjectSpecification = {
         '@types/node',
         '@types/react-dom',
         '@types/react',
-        '@tailwindcss/postcss',
-        'tailwindcss',
+        ...tailwindDevDeps,
         'typescript',
       ],
       files: [
         'app/layout.tsx',
         'app/page.tsx',
         'next-env.d.ts',
-        'postcss.config.mjs',
+        ...tailwindFiles,
         'tsconfig.json',
       ],
     },
@@ -244,12 +247,12 @@ export const projectSpecification: ProjectSpecification = {
   'app-tw-empty': {
     js: {
       deps: [],
-      devDeps: ['@tailwindcss/postcss', 'tailwindcss'],
+      devDeps: tailwindDevDeps,
       files: [
         'app/layout.js',
         'app/page.js',
         'jsconfig.json',
-        'postcss.config.mjs',
+        ...tailwindFiles,
       ],
     },
     ts: {
@@ -258,15 +261,14 @@ export const projectSpecification: ProjectSpecification = {
         '@types/node',
         '@types/react-dom',
         '@types/react',
-        '@tailwindcss/postcss',
-        'tailwindcss',
+        ...tailwindDevDeps,
         'typescript',
       ],
       files: [
         'app/layout.tsx',
         'app/page.tsx',
         'next-env.d.ts',
-        'postcss.config.mjs',
+        ...tailwindFiles,
         'tsconfig.json',
       ],
     },

--- a/test/production/create-next-app/lib/utils.ts
+++ b/test/production/create-next-app/lib/utils.ts
@@ -5,7 +5,7 @@
  */
 
 import { execSync, spawn, SpawnOptions } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { join, resolve } from 'path'
 import glob from 'glob'
 import Conf from 'next/dist/compiled/conf'
@@ -143,18 +143,21 @@ export const shouldBeTemplateProject = ({
   mode,
   srcDir,
 }: CustomTemplateOptions) => {
+  const isTailwindTemplate = [
+    'app-tw',
+    'app-tw-empty',
+    'default-tw',
+    'default-tw-empty',
+  ].includes(template)
+
   projectFilesShouldExist({
     cwd,
     projectName,
     files: getProjectSetting({ template, mode, setting: 'files', srcDir }),
   })
 
-  // Tailwind templates share the same files (tailwind.config.mjs, postcss.config.mjs)
-  if (
-    !['app-tw', 'app-tw-empty', 'default-tw', 'default-tw-empty'].includes(
-      template
-    )
-  ) {
+  // Tailwind templates share the same files across JavaScript and TypeScript.
+  if (!isTailwindTemplate) {
     projectFilesShouldNotExist({
       cwd,
       projectName,
@@ -163,6 +166,23 @@ export const shouldBeTemplateProject = ({
         srcDir
       ),
     })
+  }
+
+  const projectRoot = resolve(cwd, projectName)
+  const nextConfig = readFileSync(
+    resolve(projectRoot, mode === 'js' ? 'next.config.mjs' : 'next.config.ts'),
+    'utf8'
+  )
+
+  if (isTailwindTemplate && !process.env.NEXT_RSPACK) {
+    expect(nextConfig).toContain('loaders: ["@tailwindcss/turbopack"]')
+    projectFilesShouldNotExist({
+      cwd,
+      projectName,
+      files: ['postcss.config.mjs'],
+    })
+  } else {
+    expect(nextConfig).not.toContain('@tailwindcss/turbopack')
   }
 
   projectDepsShouldBe({

--- a/test/production/create-next-app/prompts.test.ts
+++ b/test/production/create-next-app/prompts.test.ts
@@ -1,4 +1,5 @@
 import { retry } from 'next-test-utils'
+import { readFileSync } from 'fs'
 import { join } from 'path'
 import {
   createNextApp,
@@ -6,6 +7,19 @@ import {
   resolveNextTgzFilename,
   useTempDir,
 } from './utils'
+
+function expectTurbopackTailwindSetup(cwd: string, projectName: string) {
+  const projectRoot = join(cwd, projectName)
+  const pkg = require(join(projectRoot, 'package.json'))
+  expect(pkg.devDependencies).toMatchObject({
+    '@tailwindcss/turbopack': '^4',
+    tailwindcss: '^4',
+  })
+  expect(pkg.devDependencies).not.toHaveProperty('@tailwindcss/postcss')
+  expect(readFileSync(join(projectRoot, 'next.config.ts'), 'utf8')).toContain(
+    'loaders: ["@tailwindcss/turbopack"]'
+  )
+}
 
 describe('create-next-app prompts', () => {
   let nextTgzFilename: string
@@ -118,11 +132,13 @@ describe('create-next-app prompts', () => {
           projectFilesShouldExist({
             cwd,
             projectName,
-            files: ['postcss.config.mjs'],
+            files: ['next.config.ts'],
           })
           resolve()
         })
       })
+
+      expectTurbopackTailwindSetup(cwd, projectName)
     })
   })
 
@@ -185,7 +201,7 @@ describe('create-next-app prompts', () => {
             files: [
               'app',
               'package.json',
-              'postcss.config.mjs',
+              'next.config.ts',
               'tsconfig.json',
               'AGENTS.md',
               'CLAUDE.md',
@@ -197,6 +213,7 @@ describe('create-next-app prompts', () => {
 
       const pkg = require(join(cwd, projectName, 'package.json'))
       expect(pkg.name).toBe(projectName)
+      expectTurbopackTailwindSetup(cwd, projectName)
       const tsConfig = require(join(cwd, projectName, 'tsconfig.json'))
       expect(tsConfig.compilerOptions.paths).toMatchInlineSnapshot(`
         {
@@ -228,7 +245,7 @@ describe('create-next-app prompts', () => {
             files: [
               'app',
               'package.json',
-              'postcss.config.mjs', // tailwind
+              'next.config.ts', // tailwind
               'tsconfig.json', // typescript
               'AGENTS.md', // agent files
               'CLAUDE.md',
@@ -243,6 +260,7 @@ describe('create-next-app prompts', () => {
 
       const pkg = require(join(cwd, projectName, 'package.json'))
       expect(pkg.name).toBe(projectName)
+      expectTurbopackTailwindSetup(cwd, projectName)
     })
   })
 

--- a/test/production/create-next-app/templates/app.test.ts
+++ b/test/production/create-next-app/templates/app.test.ts
@@ -145,6 +145,7 @@ describe('create-next-app --app (App Router)', () => {
       await tryNextDev({
         cwd,
         projectName,
+        tailwind: true,
       })
     })
   })

--- a/test/production/create-next-app/templates/pages.test.ts
+++ b/test/production/create-next-app/templates/pages.test.ts
@@ -154,6 +154,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
         cwd,
         projectName,
         isApp: false,
+        tailwind: true,
       })
     })
   })

--- a/test/production/create-next-app/utils.ts
+++ b/test/production/create-next-app/utils.ts
@@ -1,9 +1,8 @@
 import execa from 'execa'
-import { readFileSync } from 'fs'
-import glob from 'glob'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { fetchViaHTTP, findPort, killApp } from 'next-test-utils'
+import webdriver from 'next-webdriver'
 import {
   resolveTestPkgPaths,
   serializeTestPkgPathsEnv,
@@ -116,16 +115,6 @@ export async function tryNextDev({
   })
   expect(buildResult.exitCode).toBe(0)
 
-  if (tailwind && !process.env.NEXT_RSPACK) {
-    const stylesheets = glob.sync('.next/static/**/*.css', { cwd: dir })
-    expect(stylesheets.length).toBeGreaterThan(0)
-
-    const css = stylesheets
-      .map((stylesheet) => readFileSync(join(dir, stylesheet), 'utf8'))
-      .join('\n')
-    expect(css).toMatch(/\.flex\s*\{[^}]*display:\s*flex(?:;|(?=\s*}))/)
-  }
-
   const port = await findPort()
   const server = spawn(
     'node',
@@ -142,6 +131,8 @@ export async function tryNextDev({
   // under webpack where the built output is larger. Give them generous
   // headroom so these tests aren't flaky on loaded CI machines.
   const startServerTimeout = 60_000
+
+  let browser: Awaited<ReturnType<typeof webdriver>> | undefined
 
   try {
     await new Promise<void>((resolve, reject) => {
@@ -178,6 +169,13 @@ export async function tryNextDev({
       })
     })
 
+    if (tailwind) {
+      browser = await webdriver(port, '/')
+      expect(await browser.elementByCss('main').getComputedCss('display')).toBe(
+        'flex'
+      )
+    }
+
     const res = await fetchViaHTTP(port, '/')
     if (isEmpty || isApi) {
       expect(await res.text()).toContain('Hello world!')
@@ -204,6 +202,7 @@ export async function tryNextDev({
       expect(apiRes.status).toBe(200)
     }
   } finally {
+    await browser?.close()
     await killApp(server).catch(() => {})
   }
 }

--- a/test/production/create-next-app/utils.ts
+++ b/test/production/create-next-app/utils.ts
@@ -1,4 +1,6 @@
 import execa from 'execa'
+import { readFileSync } from 'fs'
+import glob from 'glob'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { fetchViaHTTP, findPort, killApp } from 'next-test-utils'
@@ -84,12 +86,14 @@ export async function tryNextDev({
   isApp = true,
   isApi = false,
   isEmpty = false,
+  tailwind = false,
 }: {
   cwd: string
   projectName: string
   isApp?: boolean
   isApi?: boolean
   isEmpty?: boolean
+  tailwind?: boolean
 }) {
   // The caller wraps this in `useTempDir`, so `cwd` (and the CNA project
   // inside it) is already an isolated temp directory that gets removed
@@ -111,6 +115,16 @@ export async function tryNextDev({
     reject: false,
   })
   expect(buildResult.exitCode).toBe(0)
+
+  if (tailwind && !process.env.NEXT_RSPACK) {
+    const stylesheets = glob.sync('.next/static/**/*.css', { cwd: dir })
+    expect(stylesheets.length).toBeGreaterThan(0)
+
+    const css = stylesheets
+      .map((stylesheet) => readFileSync(join(dir, stylesheet), 'utf8'))
+      .join('\n')
+    expect(css).toMatch(/\.flex\s*\{[^}]*display:\s*flex(?:;|(?=\s*}))/)
+  }
 
   const port = await findPort()
   const server = spawn(

--- a/test/production/create-next-app/utils.ts
+++ b/test/production/create-next-app/utils.ts
@@ -169,7 +169,11 @@ export async function tryNextDev({
       })
     })
 
-    if (tailwind) {
+    // The webpack test matrix forces generated apps to build with webpack,
+    // but create-next-app only exposes Turbopack and Rspack as bundler choices.
+    // Only assert rendered Tailwind styles when the generated bundler matches
+    // the test bundler.
+    if (tailwind && !process.env.IS_WEBPACK_TEST) {
       browser = await webdriver(port, '/')
       expect(await browser.elementByCss('main').getComputedCss('display')).toBe(
         'flex'


### PR DESCRIPTION
## Summary

Use `@tailwindcss/turbopack` and a Turbopack CSS loader rule for Tailwind projects generated with Turbopack, avoiding the PostCSS setup in the default path.

Keep `@tailwindcss/postcss` and `postcss.config.mjs` for non-Turbopack bundlers, and update create-next-app production coverage to verify generated configuration, dependencies, and rendered Tailwind styles.

## Verification

- `pnpm test-start-turbo test/production/create-next-app/templates/app.test.ts -t "should create TailwindCSS project with --tailwind flag"`
- `pnpm test-start-rspack test/production/create-next-app/templates/app.test.ts -t "should create TailwindCSS project with --tailwind flag"`

<!-- NEXT_JS_LLM -->