### PR TITLE
Fix checkCustomRoutes crashing on a basePath:false rewrite with a missing/non-string destination

### DIFF
--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -196,6 +196,7 @@ export function checkCustomRoutes(
     if (
       type === 'rewrite' &&
       (route as Rewrite).basePath === false &&
+      typeof (route as Rewrite).destination === 'string' &&
       !(
         (route as Rewrite).destination.startsWith('http://') ||
         (route as Rewrite).destination.startsWith('https://')

--- a/test/unit/check-custom-routes.test.ts
+++ b/test/unit/check-custom-routes.test.ts
@@ -1,0 +1,73 @@
+/* eslint-env jest */
+import { checkCustomRoutes } from 'next/dist/lib/load-custom-routes'
+
+describe('checkCustomRoutes', () => {
+  let errorSpy: jest.SpyInstance
+  let exitSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    }) as any
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
+  it('should report a validation error, not crash with a TypeError, when a rewrite has basePath: false and a missing destination', () => {
+    // Before the fix, this threw an uncaught
+    // `TypeError: Cannot read properties of undefined (reading 'startsWith')`
+    // instead of reaching the normal "destination is missing" validation path.
+    expect(() =>
+      checkCustomRoutes([{ source: '/foo', basePath: false } as any], 'rewrite')
+    ).toThrow('process.exit called')
+    expect(errorSpy.mock.calls.join('\n')).toContain('`destination` is missing')
+  })
+
+  it('should report a validation error, not crash with a TypeError, when a rewrite has basePath: false and a non-string destination', () => {
+    expect(() =>
+      checkCustomRoutes(
+        [{ source: '/foo', basePath: false, destination: 1234 } as any],
+        'rewrite'
+      )
+    ).toThrow('process.exit called')
+    expect(errorSpy.mock.calls.join('\n')).toContain(
+      '`destination` is not a string'
+    )
+  })
+
+  it('should still flag a rewrite with basePath: false and an internal destination as invalid', () => {
+    expect(() =>
+      checkCustomRoutes(
+        [
+          {
+            source: '/foo',
+            basePath: false,
+            destination: '/bar',
+          } as any,
+        ],
+        'rewrite'
+      )
+    ).toThrow('process.exit called')
+    expect(errorSpy.mock.calls.join('\n')).toContain(
+      'rewrites urls outside of the basePath'
+    )
+  })
+
+  it('should allow a rewrite with basePath: false and an external destination', () => {
+    checkCustomRoutes(
+      [
+        {
+          source: '/foo',
+          basePath: false,
+          destination: 'https://example.com/bar',
+        } as any,
+      ],
+      'rewrite'
+    )
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
checkCustomRoutes() called .startsWith() on route.destination for the basePath:false external-rewrite check before any check that destination is a string. A rewrite missing destination, or with a non-string destination, threw an uncaught TypeError instead of reaching the normal 'destination is missing'/'destination is not a string' validation path a few lines below.

### What?

`checkCustomRoutes()` in `packages/next/src/lib/load-custom-routes.ts` crashed with an uncaught `TypeError: Cannot read properties of undefined (reading 'startsWith')` when a `rewrites()` entry had `basePath: false` and a missing or non-string `destination`.

### Why?

The `basePath: false` branch calls `route.destination.startsWith(...)` before any check that `destination` is even defined or a string. Every other malformed-field case in this function (missing `source`, missing `destination`, non-string `destination`, etc.) is handled a few lines below with a clean, friendly validation error — this one bypassed that path entirely and crashed instead.

### How?

Added a `typeof (route as Rewrite).destination === 'string'` guard to the `basePath: false` condition. When `destination` is missing or not a string, the check now falls through to the existing validation logic below, which reports `` `destination` is missing `` or `` `destination` is not a string `` as intended, instead of throwing.

Added `test/unit/check-custom-routes.test.ts` with 4 cases. Confirmed 2 of them reproduce the exact `TypeError` on unpatched code and pass after the fix; the other 2 confirm the `basePath: false` external-rewrite validation still works correctly (still rejects an internal destination, still allows a valid external one).
