### PR TITLE
fix(app-render): add nonce to loading/template/error segment script tags

### DIFF
--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -37,6 +37,7 @@ export async function createComponentStylesAndScripts({
         src: `${ctx.assetPrefix}/_next/${encodeURIPath(href)}${getAssetQueryString(ctx, true)}`,
         async: true,
         key: `script-${scriptIndex}`,
+        nonce: ctx.nonce,
       })
     )
     scriptIndex++


### PR DESCRIPTION
### What?

Add `nonce: ctx.nonce` to the `<script>` tags `createComponentStylesAndScripts` builds for the `template` / `error` / `loading` segments.

### Why?

Its sibling `get-layer-assets.tsx` — which builds the same kind of tag for the `layout` / `page` segments — already passes `nonce: ctx.nonce`:

```js
createElement('script', {
  src: fullSrc,
  async: true,
  key: `script-${scriptIndex}`,
  nonce: ctx.nonce,   // <-- present here
})
```

`create-component-styles-and-scripts.tsx` does not. One has it, the other doesn't, and both are reached from the same tree walk in `create-component-tree.tsx` — this reads as an omission rather than an intentional difference.

Under a nonce-based CSP with `'strict-dynamic'`, host-source allowlisting is disabled, so a parser-inserted `<script src>` with no nonce is blocked outright:

```
Loading the script '…_app_loading_tsx_….js' violates the following Content Security
Policy directive: "script-src 'self' 'nonce-…' 'strict-dynamic' 'unsafe-eval'".
Note that 'strict-dynamic' is present, so host-based allowlisting is disabled.
```

On the app where I hit this (Next 16.2.7, Turbopack, nonce + `'strict-dynamic'` generated in `proxy`/`middleware` and mirrored on both the request and response headers, per the CSP guide), 58 of the 62 `<script>` tags on the page carry the nonce; the only executable one that does not is the `loading` segment's chunk. The other 3 are `application/ld+json` data blocks, which aren't subject to `script-src`.

With this change applied locally (via `pnpm patch` on the compiled runtime), the same page goes to 62/62 with no other change, and a production build of the same app stays clean on every route I checked.

### Why it is rarely seen

Whether the missing nonce actually surfaces depends on whether that chunk *also* gets registered somewhere else with a nonce:

- If the segment's chunks are already in `injectedJS`, nothing is emitted at all.
- If the chunk belongs to a client reference, React's Fizz hoistable-script dedup by `src` keeps whichever registration lands first — and the nonce-carrying `preinit` from the flight client usually wins, masking it.
- It reliably fires when the segment owns a chunk that is **not** a client reference — e.g. the per-file chunk Turbopack emits in dev for a `loading.tsx` that is itself a Server Component.

That last condition is why I could not distill a small reproduction: on a fresh app Turbopack merges the whole app into one chunk and the code path never produces an element. I tried 7 variants on a clean `next@16.3.0` app (bare `loading.tsx`; loading-only server module; loading-only client component; padding the graph to ~1 MB of client modules; nested route with root `loading.tsx`; `turbopack.root` above the app dir) — all 0 violations.

Production is affected by the same code path, it's just usually masked. I instrumented the compiled prod runtime to check: in a production build the path *does* run and *does* produce a nonce-less element for `loading.tsx` / `error.tsx` / `not-found.tsx`; React's dedup is what hides it. That leaves a production app one chunk-splitting change away from the same breakage — a broken loading skeleton or error boundary shown to real users.

### How

One line. No behavior change when no CSP nonce is present: `ctx.nonce` is `undefined` there, and React omits the attribute — which is exactly what `get-layer-assets.tsx` already relies on.

The same call site also serves `template.tsx` and `error.tsx`. `not-found` / `forbidden` / `unauthorized` discard the returned scripts at the destructuring site, so they are unaffected in practice.

### Verifying on an installed copy

The compiled runtime is what executes (editing `dist/server/...` has no effect):

```bash
# before this change — one hit: the missing-nonce site
grep -o 'key:`script-${[a-z]*}`}' \
  node_modules/next/dist/compiled/next-server/app-page-turbo.runtime.dev.js

# the sibling that already does it correctly
grep -o 'key:`script-${[a-z]*}`,nonce:' \
  node_modules/next/dist/compiled/next-server/app-page-turbo.runtime.dev.js
```

Both hit on 16.2.7 and 16.3.0 (`.prod.js` too).

I did not add a test: the failure needs a module graph large enough for Turbopack to give the segment its own non-client-reference chunk, which I could not construct in a fixture. Happy to add one if you can point me at the right harness for asserting rendered `<script>` attributes for a segment.

Closes #96605
