### PR TITLE
fix(devtools): optically align devtools panel close button

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
@@ -60,6 +60,12 @@ export function DevToolsHeader({
           justifyContent: 'center',
           borderRadius: '4px',
           color: 'var(--color-gray-900)',
+          // The 4px padding above is hit area, not spacing. Without this
+          // compensation the button's *box* sits flush against the header's
+          // 20px padding, leaving the visible X 24px from the panel's edge
+          // while the title's text starts at 20px. Pull it back so the icon
+          // optically aligns with the title and the panel content below it.
+          marginRight: '-4px',
         }}
       >
         <XIcon />


### PR DESCRIPTION
Reported internally against the Navigation Inspector panel: "the close button is misaligned."

### Cause

`DevToolsHeader` lays the title and close button out in a flex row with `padding: 8px 20px`. The close button carries its own `padding: 4px` as hit area, so the button's **box** sits flush against the header's 20px padding while the **visible X** ends up 24px from the panel's edge — 4px further in than everything else in the panel.

Measured on the Navigation Inspector (panel width 460, devtools scale 1):

| element | inset from panel edge |
| --- | --- |
| header title text | 20px left |
| "Debugger paused" info icon | 20px left |
| body title / description | 20px left |
| "Resume" button box | 20px right |
| **close X glyph** | **24px right** |

Small enough to read as "slightly off" rather than obviously broken, which is why it survived.

### Fix

`margin-right: -4px` on the button, cancelling the padding for layout purposes only. The 4px stays as hit area, so the button remains 30x30.

After the change the X glyph's right inset is 20px, matching the title's 20px left inset — the header is now optically symmetric, independent of whatever body content a given panel renders.

### Verification

Reproduced the panel chrome (`.panel-content-container` + `DevToolsHeader` + the instant-navs body and CSS) at devtools scale 1 and measured `getBoundingClientRect()` before and after:

| metric | before | after |
| --- | --- | --- |
| X glyph right inset | 24px | **20px** |
| title left inset | 20px | 20px |
| "Resume" right inset | 20px | 20px |
| button hit area | 30x30 | 30x30 |
| header height | 46px | 46px |
| button/title center Y | equal | equal |

Vertical centering was already correct (`align-items: center`) and is unchanged; header height is unchanged, so no panel's layout shifts.

`DevToolsHeader` is shared by the Preferences, Route Info, Navigation Inspector, Request Insights, Static/Dynamic Route, Cache disabled and Cold cache panels. All of them render the same close button with the same 20px header padding, so all of them get the same correction — which is the intent, rather than patching the Navigation Inspector alone.