### PR TITLE
docs: remove experimental note from runtime prefetching

### DIFF
--- a/docs/01-app/02-guides/runtime-prefetching.mdx
+++ b/docs/01-app/02-guides/runtime-prefetching.mdx
@@ -2,7 +2,6 @@
 title: Runtime prefetching
 description: Prefetch URL data alongside the App Shell using the prefetch segment config and per-session caching directives.
 nav_title: Runtime prefetching
-version: experimental
 related:
   title: Learn more
   description: Validate your structure and review the caching primitives.


### PR DESCRIPTION
Runtime prefetching no longer needs this label.