### PR TITLE
fix(next/image): don't block the svg loader used by next/og

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -99,6 +99,7 @@ export function getSharp(
         'VipsForeignLoadJpeg',
         'VipsForeignLoadNsgif',
         'VipsForeignLoadPng',
+        'VipsForeignLoadSvg', // blocking is process-wide and next/og renders svg
         'VipsForeignLoadTiff',
         'VipsForeignLoadWebp',
       ],

--- a/test/unit/image-optimizer/get-sharp.test.ts
+++ b/test/unit/image-optimizer/get-sharp.test.ts
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+import { detectContentType, getSharp } from 'next/dist/server/image-optimizer'
+
+const svg = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="red"/></svg>'
+)
+
+describe('getSharp', () => {
+  it('should leave the svg loader available to next/og', async () => {
+    const sharp = getSharp(null, null)
+    const png = await sharp(svg).png().toBuffer()
+
+    expect(await detectContentType(png)).toBe('image/png')
+  })
+})


### PR DESCRIPTION
On `next start`, `ImageResponse` stops working after the first uncached `/_next/image` request. The route returns an empty response and the server logs `Input buffer contains unsupported image format`.

`getSharp()` blocks every libvips loader and then unblocks the six raster formats next/image can optimize. That block is process-wide, and next/og renders by handing the SVG satori produced to the same sharp module, so it loses the only loader it needs. The image optimizer never passes SVG to sharp itself since SVG is a bypass type, so unblocking the loader does not widen what next/image will decode.

Fixes #96612
