### PR TITLE
fix(next/image): preserve image response after optimization

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -99,6 +99,7 @@ export function getSharp(
         'VipsForeignLoadJpeg',
         'VipsForeignLoadNsgif',
         'VipsForeignLoadPng',
+        'VipsForeignLoadSvg',
         'VipsForeignLoadTiff',
         'VipsForeignLoadWebp',
       ],

--- a/test/e2e/og-api/app/app/pixel/[id]/route.js
+++ b/test/e2e/og-api/app/app/pixel/[id]/route.js
@@ -1,0 +1,12 @@
+const pixel = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+X8mN6QAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+export async function GET() {
+  return new Response(pixel, {
+    headers: {
+      'Content-Type': 'image/png',
+    },
+  })
+}

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -1,5 +1,6 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
+import { randomUUID } from 'crypto'
 import fs from 'fs-extra'
 import { join } from 'path'
 
@@ -32,12 +33,24 @@ describe('og-api', () => {
     expect(body.size).toBeGreaterThan(0)
   })
 
-  it('should work in app route in node runtime', async () => {
-    const res = await fetchViaHTTP(next.url, '/og-node')
-    expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toContain('image/png')
-    const body = await res.blob()
-    expect(body.size).toBeGreaterThan(0)
+  it('should work in app route in node runtime after image optimization', async () => {
+    const before = await fetchViaHTTP(next.url, '/og-node')
+    expect(before.status).toBe(200)
+    expect(before.headers.get('content-type')).toContain('image/png')
+    expect((await before.blob()).size).toBeGreaterThan(0)
+
+    const imageUrl = encodeURIComponent(`/pixel/${randomUUID()}`)
+    const optimized = await fetchViaHTTP(
+      next.url,
+      `/_next/image?url=${imageUrl}&w=640&q=75`
+    )
+    expect(optimized.status).toBe(200)
+    expect(optimized.headers.get('x-nextjs-cache')).toBe('MISS')
+
+    const after = await fetchViaHTTP(next.url, '/og-node')
+    expect(after.status).toBe(200)
+    expect(after.headers.get('content-type')).toContain('image/png')
+    expect((await after.blob()).size).toBeGreaterThan(0)
   })
 
   it('should work in middleware', async () => {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

An uncached next/image optimization globally blocked Sharp’s SVG loader, causing subsequent Node.js ImageResponse rendering to fail

This change restores the SVG loader required for ImageResponse and adds coverage for the exact same-process sequence.

This issue was introduced by #96301 

Fixes #96612