### PR TITLE
Fix Navigation Inspector infinite RuntimeShell requests after Resume with prefetch={true}

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -903,6 +903,7 @@ export function readOrCreateSegmentCacheEntry(
   // Navigation Testing API only; always null in production). See below.
   navigationLockPrefetch: NavigationLockPrefetch | null
 ): SegmentCacheEntry {
+  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
   const existingEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
     if (
@@ -941,6 +942,34 @@ export function readOrCreateSegmentCacheEntry(
         }
         return existingEntry
       }
+
+      // The concrete-path match predates this lock (or is otherwise unowned).
+      // Shell strategies (StaticShell / RuntimeShell) store entries at the
+      // shell vary path, which is less specific than `tree.varyPath`. A
+      // leftover pre-lock concrete entry therefore shadows the owned shell
+      // entry on every `readSegmentCacheEntry(tree.varyPath)` — so without
+      // this second lookup we would keep creating a new Empty at the shell
+      // path, spawning RuntimeShell forever (Navigation Inspector +
+      // prefetch={true} after Resume). Prefer an already-owned entry at the
+      // request vary path when one exists.
+      if (lock !== null && varyPathForRequest !== tree.varyPath) {
+        const ownedRequestPathEntry = readSegmentCacheEntry(
+          now,
+          varyPathForRequest
+        )
+        if (
+          ownedRequestPathEntry !== null &&
+          lock.ownedEntries.has(ownedRequestPathEntry)
+        ) {
+          if (ownedRequestPathEntry.status === EntryStatus.Pending) {
+            trackNavigationLockPrefetchEntry(
+              navigationLockPrefetch,
+              ownedRequestPathEntry
+            )
+          }
+          return ownedRequestPathEntry
+        }
+      }
     } else {
       return existingEntry
     }
@@ -949,7 +978,6 @@ export function readOrCreateSegmentCacheEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = false
   setInCacheMap(

--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -710,6 +710,74 @@ describe('instant-nav-panel', () => {
       await expectTargetPageSpaShellWithRuntimeData(browser)
     })
 
+    // Regression for https://github.com/vercel/next.js/issues/96611:
+    // after Resume re-arms the lock, a second <Link prefetch={true}> click
+    // must not loop forever on RuntimeShell (next-router-prefetch: 3) requests.
+    it('should capture a second prefetch={true} navigation after resume without looping shell requests', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+
+      await browser.eval(() => {
+        document
+          .querySelector<HTMLAnchorElement>('#link-to-target-prefetch')!
+          .click()
+      })
+      await expectSpaPanel(browser)
+      await expectTargetPageSpaShellWithRuntimeData(browser)
+
+      await clickLink(browser, '/')
+      await expectSpaPanel(browser)
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+
+      await clickResume(browser)
+      await expectPendingPanel(browser)
+      await waitForInstantModeCookie(browser)
+
+      await browser.eval(() => {
+        const w = window as Window & {
+          __nextShellPrefetchCount?: number
+        }
+        w.__nextShellPrefetchCount = 0
+        const originalFetch = window.fetch.bind(window)
+        window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+          const headers = new Headers(
+            input instanceof Request ? input.headers : init?.headers
+          )
+          if (headers.get('next-router-prefetch') === '3') {
+            w.__nextShellPrefetchCount = (w.__nextShellPrefetchCount ?? 0) + 1
+          }
+          return originalFetch(input, init)
+        }
+      })
+
+      await browser.eval(() => {
+        document
+          .querySelector<HTMLAnchorElement>('#link-to-target-prefetch')!
+          .click()
+      })
+
+      // The bug left the URL on `/` and flooded RuntimeShell requests. Assert
+      // the navigation commits and the shell-request count stays bounded; do
+      // not require a pristine suspended shell — prior locked navigations may
+      // have already streamed dynamic holes into reused cache nodes.
+      await expectSpaPanel(browser)
+      await retry(async () => {
+        expect(await browser.url()).toContain('/target-page/my-post')
+      }, 10000)
+
+      const shellCount = await browser.eval(() => {
+        return (
+          (window as Window & { __nextShellPrefetchCount?: number })
+            .__nextShellPrefetchCount ?? 0
+        )
+      })
+      // A healthy second capture issues a small number of App Shell runtime
+      // requests. The bug flooded dozens per second without ever committing.
+      expect(shellCount).toBeLessThan(20)
+    })
+
     it('should restart capture and return to awaiting navigation after resuming from SPA state', async () => {
       const browser = await openHomeWithTargetPageWarmup()
 


### PR DESCRIPTION
## What

After Navigation Inspector Resume, a second click on `<Link prefetch={true}>` could spam `next-router-prefetch: 3` (RuntimeShell) requests and never commit the navigation (URL stuck on `/`).

## Why

Locked Instant Navigation ignores segment-cache entries that aren’t in the current lock’s `ownedEntries`. Soft refresh after Resume leaves older **concrete** vary-path entries in the cache. Shell strategies store at the **shell** vary path, so those leftover concrete entries shadowed the owned shell entry. Each scheduler pass treated that as a miss, created a new Empty at the shell path, and spawned another RuntimeShell forever.

## How

In `readOrCreateSegmentCacheEntry`, when a concrete-path hit isn’t owned and the request uses a different (shell) vary path, reuse an already-owned entry at the request/shell path instead of creating another Empty.

## Test plan

- [x] `HEADLESS=true NEXT_SKIP_ISOLATE=1 pnpm test-dev-turbo test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts -t "SPA captures"`
- [ ] Manual: `cacheComponents` + `partialPrefetching`, Navigation Inspector pause → `prefetch={true}` nav → home → Resume → second `prefetch={true}` click → navigates once, no request flood

Fixes #96611