### PR TITLE
fix(next): expose unstable_doesProxyMatch

### DIFF
--- a/packages/next/src/experimental/testing/server/middleware-testing-utils.test.ts
+++ b/packages/next/src/experimental/testing/server/middleware-testing-utils.test.ts
@@ -1,12 +1,17 @@
 import {
   unstable_doesMiddlewareMatch,
-  type MiddlewareSourceConfig,
+  unstable_doesProxyMatch,
+  type ProxySourceConfig,
 } from './middleware-testing-utils'
 
-describe('unstable_doesMiddlewareMatch', () => {
+describe('unstable_doesProxyMatch', () => {
+  it('keeps unstable_doesMiddlewareMatch as a deprecated alias', () => {
+    expect(unstable_doesMiddlewareMatch).toBe(unstable_doesProxyMatch)
+  })
+
   it('matches everything when no matcher is provided', () => {
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config: {
           matcher: undefined,
         },
@@ -20,19 +25,19 @@ describe('unstable_doesMiddlewareMatch', () => {
       matcher: '/test',
     }
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/test',
       })
     ).toEqual(true)
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/test?q=1',
       })
     ).toEqual(true)
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/other-path',
       })
@@ -44,25 +49,25 @@ describe('unstable_doesMiddlewareMatch', () => {
       matcher: ['/test', '/test/(.*)', '/test2/:path+'],
     }
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/test',
       })
     ).toEqual(true)
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/test/slug',
       })
     ).toEqual(true)
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/test2/slug',
       })
     ).toEqual(true)
     expect(
-      unstable_doesMiddlewareMatch({
+      unstable_doesProxyMatch({
         config,
         url: '/test?q=1',
       })
@@ -72,7 +77,7 @@ describe('unstable_doesMiddlewareMatch', () => {
   describe('has condition', () => {
     describe('header', () => {
       it('matches only when the header is present', () => {
-        const config: MiddlewareSourceConfig = {
+        const config: ProxySourceConfig = {
           matcher: [
             {
               source: '/test',
@@ -87,13 +92,13 @@ describe('unstable_doesMiddlewareMatch', () => {
           ],
         }
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
           })
         ).toEqual(false)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
             headers: {
@@ -106,7 +111,7 @@ describe('unstable_doesMiddlewareMatch', () => {
 
     describe('cookies', () => {
       it('matches only when the cookie is present', () => {
-        const config: MiddlewareSourceConfig = {
+        const config: ProxySourceConfig = {
           matcher: [
             {
               source: '/test',
@@ -121,13 +126,13 @@ describe('unstable_doesMiddlewareMatch', () => {
           ],
         }
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
           })
         ).toEqual(false)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
             headers: {
@@ -136,7 +141,7 @@ describe('unstable_doesMiddlewareMatch', () => {
           })
         ).toEqual(false)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
             cookies: {
@@ -149,7 +154,7 @@ describe('unstable_doesMiddlewareMatch', () => {
 
     describe('query params', () => {
       it('matches only when the query parameter is present', () => {
-        const config: MiddlewareSourceConfig = {
+        const config: ProxySourceConfig = {
           matcher: [
             {
               source: '/test',
@@ -164,13 +169,13 @@ describe('unstable_doesMiddlewareMatch', () => {
           ],
         }
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
           })
         ).toEqual(false)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test?q=1',
           })
@@ -182,7 +187,7 @@ describe('unstable_doesMiddlewareMatch', () => {
   describe('missing condition', () => {
     describe('header', () => {
       it('matches only when the header is missing', () => {
-        const config: MiddlewareSourceConfig = {
+        const config: ProxySourceConfig = {
           matcher: [
             {
               source: '/test',
@@ -196,13 +201,13 @@ describe('unstable_doesMiddlewareMatch', () => {
           ],
         }
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
           })
         ).toEqual(true)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
             headers: {
@@ -215,7 +220,7 @@ describe('unstable_doesMiddlewareMatch', () => {
 
     describe('cookies', () => {
       it('matches only when the cookie is missing', () => {
-        const config: MiddlewareSourceConfig = {
+        const config: ProxySourceConfig = {
           matcher: [
             {
               source: '/test',
@@ -229,13 +234,13 @@ describe('unstable_doesMiddlewareMatch', () => {
           ],
         }
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
           })
         ).toEqual(true)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
             headers: {
@@ -244,7 +249,7 @@ describe('unstable_doesMiddlewareMatch', () => {
           })
         ).toEqual(true)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
             cookies: {
@@ -257,7 +262,7 @@ describe('unstable_doesMiddlewareMatch', () => {
 
     describe('query params', () => {
       it('matches only when the query parameter is missing', () => {
-        const config: MiddlewareSourceConfig = {
+        const config: ProxySourceConfig = {
           matcher: [
             {
               source: '/test',
@@ -271,13 +276,13 @@ describe('unstable_doesMiddlewareMatch', () => {
           ],
         }
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test',
           })
         ).toEqual(true)
         expect(
-          unstable_doesMiddlewareMatch({
+          unstable_doesProxyMatch({
             config,
             url: '/test?q=1',
           })
@@ -291,18 +296,18 @@ describe('unstable_doesMiddlewareMatch', () => {
       const nextConfig = {
         basePath: '/base',
       }
-      const config: MiddlewareSourceConfig = {
+      const config: ProxySourceConfig = {
         matcher: ['/test'],
       }
       expect(
-        unstable_doesMiddlewareMatch({
+        unstable_doesProxyMatch({
           config,
           url: '/test',
           nextConfig,
         })
       ).toEqual(false)
       expect(
-        unstable_doesMiddlewareMatch({
+        unstable_doesProxyMatch({
           config,
           url: '/base/test',
           nextConfig,

--- a/packages/next/src/experimental/testing/server/middleware-testing-utils.ts
+++ b/packages/next/src/experimental/testing/server/middleware-testing-utils.ts
@@ -6,24 +6,30 @@ import { parseUrl } from '../../../lib/url'
 import { constructRequest } from './utils'
 import type { MiddlewareConfigMatcherInput } from '../../../build/segment-config/middleware/middleware-config'
 
-export interface MiddlewareSourceConfig {
+export interface ProxySourceConfig {
   matcher?: MiddlewareConfigMatcherInput
 }
 
 /**
- * Checks whether the middleware config will match the provide URL and request
+ * @deprecated Use `ProxySourceConfig` instead. Middleware has been renamed to
+ * Proxy.
+ */
+export type MiddlewareSourceConfig = ProxySourceConfig
+
+/**
+ * Checks whether the proxy config will match the provided URL and request
  * information such as headers and cookies. This function is useful for
- * unit tests to assert that middleware is matching (and therefore executing)
+ * unit tests to assert that proxy is matching (and therefore executing)
  * only when it should be.
  */
-export function unstable_doesMiddlewareMatch({
+export function unstable_doesProxyMatch({
   config,
   url,
   headers,
   cookies,
   nextConfig,
 }: {
-  config: MiddlewareSourceConfig
+  config: ProxySourceConfig
   url: string
   headers?: IncomingHttpHeaders
   cookies?: Record<string, string>
@@ -38,3 +44,9 @@ export function unstable_doesMiddlewareMatch({
   const request = constructRequest({ url, headers, cookies })
   return routeMatchFn(pathname, request, Object.fromEntries(searchParams))
 }
+
+/**
+ * @deprecated Use `unstable_doesProxyMatch` instead. Middleware has been
+ * renamed to Proxy.
+ */
+export const unstable_doesMiddlewareMatch = unstable_doesProxyMatch


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Proxy testing utilities are still using the old middleware naming. I'm assuming this is not intentional since the [docs](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#unit-testing-experimental) do use the new proxy naming.

This PR renames that function and marks the old one as deprecated