### PR TITLE
accidental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast-facade-core"
+version = "0.0.0"
+
+[[package]]
+name = "ast-facade-swc"
+version = "0.0.0"
+dependencies = [
+ "ast-facade-core",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+]
+
+[[package]]
 name = "ast_node"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10680,6 +10694,8 @@ name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ast-facade-core",
+ "ast-facade-swc",
  "async-trait",
  "bincode 2.0.1",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,8 @@ turbopack-test-utils = { path = "turbopack/crates/turbopack-test-utils" }
 turbopack-trace-server = { path = "turbopack/crates/turbopack-trace-server" }
 turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
+ast-facade-core = { path = "../../oxc-fascade/crates/ast-facade-core" }
+ast-facade-swc = { path = "../../oxc-fascade/crates/ast-facade-swc" }
 
 swc_ecma_react_compiler = "20.1.0"
 react_compiler = { version = "0.2", package = "forked_react_compiler" }

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -16,6 +16,8 @@ transform_emotion = []
 workspace = true
 
 [dependencies]
+ast-facade-core = { workspace = true }
+ast-facade-swc = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
@@ -44,4 +46,3 @@ swc_core = { workspace = true, features = [
 swc_plugin_backend_wasmtime = { workspace = true }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }
-

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/mod.rs
@@ -1,30 +1,74 @@
-use swc_core::ecma::ast::{Lit, Program};
+use ast_facade_core::{Backend, ExprRef, LitRef, ProgramItemRef, ProgramRef};
+use ast_facade_swc::Swc;
+use swc_core::ecma::ast::Program;
 
 pub mod client;
 pub mod client_disallowed;
 mod server_to_client_proxy;
 
-macro_rules! has_directive {
-    ($stmts:expr, $name:literal) => {
-        $stmts
-            .map(|item| {
-                if let Lit::Str(str) = item?.as_expr()?.expr.as_lit()? {
-                    Some(str)
-                } else {
-                    None
-                }
-            })
-            .take_while(Option::is_some)
-            .map(Option::unwrap)
-            .any(|s| &*s.value == $name)
-    };
+fn has_directive<B: Backend>(program: ProgramRef<'_, '_, B>, name: &str) -> bool {
+    program
+        .items()
+        .map_while(|item| {
+            let ProgramItemRef::ExprStmt(ExprRef::Lit(LitRef::String(value))) = item else {
+                return None;
+            };
+            value.value_utf8()
+        })
+        .any(|value| value == name)
 }
 
 fn is_client_module(program: &Program) -> bool {
-    match program {
-        Program::Module(m) => {
-            has_directive!(m.body.iter().map(|item| item.as_stmt()), "use client")
+    has_directive(ProgramRef::<Swc>::new(program), "use client")
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_core::{
+        common::DUMMY_SP,
+        ecma::ast::{EmptyStmt, Expr, ExprStmt, Lit, Script, Stmt, Str},
+    };
+
+    use super::is_client_module;
+
+    fn string_statement(value: &str) -> Stmt {
+        Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::new(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: value.into(),
+                raw: None,
+            }))),
+        })
+    }
+
+    #[test]
+    fn finds_client_directive_in_directive_prologue() {
+        let program = Script {
+            span: DUMMY_SP,
+            body: vec![
+                string_statement("use strict"),
+                string_statement("use client"),
+            ],
+            shebang: None,
         }
-        Program::Script(s) => has_directive!(s.body.iter().map(Some), "use client"),
+        .into();
+
+        assert!(is_client_module(&program));
+    }
+
+    #[test]
+    fn ignores_client_string_after_directive_prologue() {
+        let program = Script {
+            span: DUMMY_SP,
+            body: vec![
+                Stmt::Empty(EmptyStmt { span: DUMMY_SP }),
+                string_statement("use client"),
+            ],
+            shebang: None,
+        }
+        .into();
+
+        assert!(!is_client_module(&program));
     }
 }


### PR DESCRIPTION
## Summary

Use the AST facade abstraction when detecting directive prologues in Turbopack ECMAScript transforms. Add coverage for directives within and after the directive prologue.

## Verification

- `git diff --check`
- `cargo fmt -- --check`
- Not run: Rust tests (`../../oxc-fascade` is missing locally)

<!-- NEXT_JS_LLM -->