### PR TITLE
fix(dev-overlay): restore touch-action none on the draggable surface

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable.tsx
@@ -143,7 +143,12 @@ export function Draggable({
   }
 
   return (
-    <div {...props} {...drag} ref={ref}>
+    <div
+      {...props}
+      {...drag}
+      ref={ref}
+      style={{ touchAction: 'none', ...props.style }}
+    >
       {children}
     </div>
   )

--- a/test/unit/dev-overlay-draggable.test.tsx
+++ b/test/unit/dev-overlay-draggable.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Draggable } from '../../packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/draggable'
+
+describe('Draggable', () => {
+  it('opts the drag surface out of browser touch gestures', () => {
+    const { container } = render(
+      <Draggable padding={20} position="bottom-left" setPosition={() => {}}>
+        <div>child</div>
+      </Draggable>
+    )
+
+    const surface = container.firstElementChild as HTMLElement
+    expect(surface.style.touchAction).toBe('none')
+  })
+
+  it('keeps touch-action when a style prop is passed', () => {
+    const { container } = render(
+      <Draggable
+        padding={20}
+        position="bottom-left"
+        setPosition={() => {}}
+        style={{ zIndex: 1 }}
+      >
+        <div>child</div>
+      </Draggable>
+    )
+
+    const surface = container.firstElementChild as HTMLElement
+    expect(surface.style.touchAction).toBe('none')
+    expect(surface.style.zIndex).toBe('1')
+  })
+})


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/96634

On a touch device, a vertical or diagonal drag starting on the dev tools indicator makes the browser take the gesture over as a viewport scroll. That fires `pointercancel`, so the drag state machine never reaches `pointerup` and the indicator is left mid-drag with a stale `translate` until the page is reloaded.

#86816 moved `user-select` handling into the pointer handlers and dropped the whole inline style block from `<Draggable>`, which also took `touch-action: none` with it. That property is what kept the browser from claiming the gesture, so this puts it back and leaves the `user-select` change alone.