### PR TITLE
Move App Router execution intent to entrypoints

### DIFF
--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -897,11 +897,11 @@ export async function buildAppStaticPaths({
 
   const store = createWorkStore({
     page,
+    executionMode: 'request',
     renderOpts: {
       incrementalCache,
       cacheLifeProfiles,
       staticPageGenerationTimeout,
-      supportsDynamicResponse: true,
       cacheComponents,
       // generateStaticParams evaluation doesn't render pages, so instant
       // validation never runs here. The level value is irrelevant.

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -481,6 +481,8 @@ export function createAppPageEntrypoint({
       isDebugStaticShell && routeModule.isDev === true
 
     const isDebugFallbackShell = hasDebugFallbackShellQuery && isRoutePPREnabled
+    const isDebugPrerender =
+      isDebugStaticShell || isDebugDynamicAccesses || isDebugFallbackShell
 
     // If we're in minimal mode, then try to get the postponed information from
     // the request metadata. If available, use it for resuming the postponed
@@ -818,7 +820,7 @@ export function createAppPageEntrypoint({
         span,
         postponed,
         fallbackRouteParams,
-        forceStaticRender,
+        executionMode,
         allowEmptyStaticShell,
       }: {
         span?: Span
@@ -835,14 +837,7 @@ export function createAppPageEntrypoint({
          */
         fallbackRouteParams: OpaqueFallbackRouteParams | null
 
-        /**
-         * When true, this indicates that the response generator is being called
-         * in a context where the response must be generated statically.
-         *
-         * CRITICAL: This should only currently be used when revalidating due to a
-         * dynamic RSC request.
-         */
-        forceStaticRender: boolean
+        executionMode: AppPageRouteHandlerContext['executionMode']
       }): Promise<ResponseCacheEntry> => {
         const context: AppPageRouteHandlerContext = {
           query,
@@ -858,6 +853,7 @@ export function createAppPageEntrypoint({
             'serverComponentsHmrCache'
           ),
           fallbackRouteParams,
+          executionMode,
           renderOpts: {
             App: () => null,
             Document: () => null,
@@ -872,7 +868,8 @@ export function createAppPageEntrypoint({
             allowEmptyStaticShell,
             serveStreamingMetadata,
             supportsDynamicResponse:
-              typeof postponed === 'string' || supportsDynamicResponse,
+              executionMode === 'request' &&
+              (typeof postponed === 'string' || supportsDynamicResponse),
             buildManifest,
             nextFontManifest,
             reactLoadableManifest,
@@ -920,7 +917,6 @@ export function createAppPageEntrypoint({
             isDebugFallbackShell
               ? {
                   isBuildTimePrerendering: true,
-                  supportsDynamicResponse: false,
                   isDebugDynamicAccesses: isDebugDynamicAccesses,
                 }
               : {}),
@@ -987,12 +983,6 @@ export function createAppPageEntrypoint({
               ),
             err: getRequestMeta(req, 'invokeError'),
           },
-        }
-
-        // When we're revalidating in the background, we should not allow dynamic
-        // responses.
-        if (forceStaticRender) {
-          context.renderOpts.supportsDynamicResponse = false
         }
 
         const result = await invokeRouteModule(span, context)
@@ -1267,7 +1257,7 @@ export function createAppPageEntrypoint({
                     // the background path below will complete the shell into a
                     // more specific cache entry for later requests.
                     fallbackRouteParams,
-                    forceStaticRender: true,
+                    executionMode: 'prerender',
                     allowEmptyStaticShell: isInstantNavigationTest || undefined,
                   }),
                 waitUntil: ctx.waitUntil,
@@ -1325,7 +1315,7 @@ export function createAppPageEntrypoint({
                                     remainingFallbackRouteParams
                                   )
                                 : null,
-                            forceStaticRender: true,
+                            executionMode: 'prerender',
                           })
                         },
                         // We don't have a prior entry for this param-specific shell.
@@ -1571,12 +1561,19 @@ export function createAppPageEntrypoint({
             }
           }
 
+          // Forced static and debug renders are prerenders even when the
+          // surrounding request otherwise supports dynamic rendering.
+          const isRequestSpecificRender =
+            !forceStaticRender &&
+            !isDebugPrerender &&
+            (supportsDynamicResponse || isPossibleServerAction)
+
           // Perform the render.
           return doRender({
             span,
             postponed,
             fallbackRouteParams,
-            forceStaticRender,
+            executionMode: isRequestSpecificRender ? 'request' : 'prerender',
             allowEmptyStaticShell: isInstantNavigationTest || undefined,
           })
         } catch (err) {
@@ -2119,7 +2116,7 @@ export function createAppPageEntrypoint({
           // This is a resume render, not a fallback render. Fallback params
           // (for cacheComponents routes) are plumbed via request meta above.
           fallbackRouteParams: null,
-          forceStaticRender: false,
+          executionMode: 'request',
         })
           .then(async (result) => {
             if (!result) {

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1,6 +1,7 @@
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { FallbackRouteParam } from '../static-paths/types'
+import type { WorkStoreExecutionMode } from '../../server/app-render/work-async-storage.external'
 
 import {
   AppPageRouteModule,
@@ -741,12 +742,18 @@ export function createAppPageEntrypoint({
       let parentSpan: Span | undefined
       const invokeRouteModule = async (
         span: Span | undefined,
-        context: AppPageRouteHandlerContext
+        context: AppPageRouteHandlerContext,
+        executionMode: WorkStoreExecutionMode
       ) => {
         const nextReq = new NodeNextRequest(req)
         const nextRes = new NodeNextResponse(res)
 
-        return routeModule.render(nextReq, nextRes, context).finally(() => {
+        const result =
+          executionMode === 'prerender'
+            ? routeModule.prerender(nextReq, nextRes, context)
+            : routeModule.render(nextReq, nextRes, context)
+
+        return result.finally(() => {
           if (!span) return
 
           span.setAttributes({
@@ -837,7 +844,7 @@ export function createAppPageEntrypoint({
          */
         fallbackRouteParams: OpaqueFallbackRouteParams | null
 
-        executionMode: AppPageRouteHandlerContext['executionMode']
+        executionMode: WorkStoreExecutionMode
       }): Promise<ResponseCacheEntry> => {
         const context: AppPageRouteHandlerContext = {
           query,
@@ -853,7 +860,6 @@ export function createAppPageEntrypoint({
             'serverComponentsHmrCache'
           ),
           fallbackRouteParams,
-          executionMode,
           renderOpts: {
             App: () => null,
             Document: () => null,
@@ -985,7 +991,7 @@ export function createAppPageEntrypoint({
           },
         }
 
-        const result = await invokeRouteModule(span, context)
+        const result = await invokeRouteModule(span, context, executionMode)
 
         const { metadata } = result
 

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -197,18 +197,7 @@ export async function handler(
     cacheKey = cacheKey === '/index' ? '/' : cacheKey
   }
 
-  const supportsDynamicResponse: boolean =
-    // If we're in development, we always support dynamic HTML
-    routeModule.isDev === true ||
-    // If this is not SSG or does not have static paths, then it supports
-    // dynamic HTML.
-    !isIsr
-
-  // This is a revalidation request if the request is for a static
-  // page and it is not being resumed from a postponed render and
-  // it is not a dynamic RSC request then it is a revalidation
-  // request.
-  const isStaticGeneration = isIsr && !supportsDynamicResponse
+  const executionMode = cacheKey !== null ? 'prerender' : 'request'
 
   // Before rendering (which initializes component tree modules), we have to
   // set the reference manifests to our global store so Server Action's
@@ -244,6 +233,7 @@ export async function handler(
   const context: AppRouteRouteHandlerContext = {
     params,
     previewProps: prerenderManifest.preview,
+    executionMode,
     renderOpts: {
       experimental: {
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
@@ -251,7 +241,7 @@ export async function handler(
       },
       cacheComponents: Boolean(nextConfig.cacheComponents),
       validationLevel: nextConfig.experimental.instantInsights.validationLevel,
-      supportsDynamicResponse,
+      isDraftMode,
       incrementalCache,
       hmrRefreshHash: getRequestMeta(req, 'hmrRefreshHash'),
       cacheLifeProfiles: nextConfig.cacheLife,
@@ -388,7 +378,7 @@ export async function handler(
             routePath: srcPage,
             routeType: 'route',
             revalidateReason: getRevalidateReason({
-              isStaticGeneration,
+              isStaticGeneration: executionMode === 'prerender',
               isOnDemandRevalidate,
             }),
           },
@@ -492,7 +482,7 @@ export async function handler(
             routePath: normalizedSrcPage,
             routeType: 'route',
             revalidateReason: getRevalidateReason({
-              isStaticGeneration,
+              isStaticGeneration: executionMode === 'prerender',
               isOnDemandRevalidate,
             }),
           },

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -118,6 +118,7 @@ async function requestHandler(
       clientAssetToken,
     },
     fallbackRouteParams: null,
+    executionMode: 'request',
 
     renderOpts: {
       App: () => null,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -118,7 +118,6 @@ async function requestHandler(
       clientAssetToken,
     },
     fallbackRouteParams: null,
-    executionMode: 'request',
 
     renderOpts: {
       App: () => null,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -81,6 +81,7 @@ export async function exportAppPage(
       pathname,
       query,
       fallbackRouteParams,
+      'prerender',
       renderOpts,
       undefined,
       sharedContext

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -17,7 +17,7 @@ import {
   RSC_SEGMENT_SUFFIX,
 } from '../../lib/constants'
 import { hasNextSupport } from '../../server/ci-info'
-import { lazyRenderAppPage } from '../../server/route-modules/app-page/module.render'
+import { lazyPrerenderAppPage } from '../../server/route-modules/app-page/module.render'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 import { NEXT_IS_PRERENDER_HEADER } from '../../client/components/app-router-headers'
@@ -75,13 +75,12 @@ export async function exportAppPage(
   }
 
   try {
-    const result = await lazyRenderAppPage(
+    const result = await lazyPrerenderAppPage(
       new NodeNextRequest(req),
       new NodeNextResponse(res),
       pathname,
       query,
       fallbackRouteParams,
-      'prerender',
       renderOpts,
       undefined,
       sharedContext

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -71,6 +71,7 @@ export async function exportAppRoute(
       previewModeId: '',
       previewModeSigningKey: '',
     },
+    executionMode: 'prerender',
     renderOpts: {
       cacheComponents,
       // app-route handlers don't run instant validation, so the level
@@ -79,7 +80,6 @@ export async function exportAppRoute(
       validationLevel: 'warning',
       experimental,
       isBuildTimePrerendering: true,
-      supportsDynamicResponse: false,
       incrementalCache,
       waitUntil: afterRunner.context.waitUntil,
       onClose: afterRunner.context.onClose,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -18,6 +18,7 @@ import type { Readable } from 'node:stream'
 import {
   workAsyncStorage,
   type WorkStore,
+  type WorkStoreExecutionMode,
 } from '../app-render/work-async-storage.external'
 import type {
   InstantValidationSamples,
@@ -3127,6 +3128,7 @@ export type AppPageRender = (
   pagePath: string,
   query: NextParsedUrlQuery,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  executionMode: WorkStoreExecutionMode,
   renderOpts: RenderOpts,
   serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
   sharedContext: AppSharedContext
@@ -3138,6 +3140,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
   pagePath,
   query,
   fallbackRouteParams,
+  executionMode,
   renderOpts,
   serverComponentsHmrCache,
   sharedContext
@@ -3202,6 +3205,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
 
   const workStore = createWorkStore({
     page: renderOpts.routeModule.definition.page,
+    executionMode,
     renderOpts,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2593,7 +2593,8 @@ async function renderToHTMLOrFlightImpl(
   serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
   sharedContext: AppSharedContext,
   interpolatedParams: Params,
-  fallbackRouteParams: OpaqueFallbackRouteParams | null
+  fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  isPrerendering: boolean
 ) {
   const isNotFoundPath = pagePath === '/404'
   if (isNotFoundPath) {
@@ -2704,7 +2705,6 @@ async function renderToHTMLOrFlightImpl(
   query = { ...query }
   stripInternalQueries(query)
 
-  const isStaticGeneration = workStore.executionMode === 'prerender'
   const isRoutePPREnabled = renderOpts.experimental.isRoutePPREnabled === true
 
   let requestId: string
@@ -2732,7 +2732,7 @@ async function renderToHTMLOrFlightImpl(
     requestId = requestInsightsIdentity.requestId
   } else {
     // Otherwise we generate a new request ID.
-    if (isStaticGeneration) {
+    if (isPrerendering) {
       requestId = Buffer.from(
         await crypto.subtle.digest('SHA-1', Buffer.from(req.url))
       ).toString('hex')
@@ -2785,16 +2785,16 @@ async function renderToHTMLOrFlightImpl(
     workStore,
     missingPrefetchHintPolicy: getMissingPrefetchHintPolicy(
       renderOpts.isBuildTimePrerendering ?? false,
-      isStaticGeneration,
+      isPrerendering,
       renderOpts.cacheComponents
     ),
     // These are distinct rendering and protocol properties even though they
     // are both determined by route-level PPR support today.
     renderCapabilities: {
-      canPostpone: isStaticGeneration && isRoutePPREnabled,
-      isPossiblyPartialResponse: isStaticGeneration && isRoutePPREnabled,
+      canPostpone: isPrerendering && isRoutePPREnabled,
+      isPossiblyPartialResponse: isPrerendering && isRoutePPREnabled,
       supportsPerSegmentPrefetching:
-        isStaticGeneration || renderOpts.cacheComponents,
+        isPrerendering || renderOpts.cacheComponents,
     },
     parsedRequestHeaders,
     getDynamicParamFromSegment,
@@ -2819,7 +2819,7 @@ async function renderToHTMLOrFlightImpl(
 
   getTracer().setRootSpanAttribute('next.route', pagePath)
 
-  if (isStaticGeneration) {
+  if (isPrerendering) {
     // We're either building or revalidating. In either case we need to
     // prerender our page rather than render it.
     const prerenderToStreamWithTracing = getTracer().wrap(
@@ -3128,13 +3128,24 @@ export type AppPageRender = (
   pagePath: string,
   query: NextParsedUrlQuery,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  renderOpts: RenderOpts,
+  serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
+  sharedContext: AppSharedContext
+) => Promise<RenderResult<AppPageRenderResultMetadata>>
+
+type AppPageRenderWithExecutionMode = (
+  req: BaseNextRequest,
+  res: BaseNextResponse,
+  pagePath: string,
+  query: NextParsedUrlQuery,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null,
   executionMode: WorkStoreExecutionMode,
   renderOpts: RenderOpts,
   serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
   sharedContext: AppSharedContext
 ) => Promise<RenderResult<AppPageRenderResultMetadata>>
 
-export const renderToHTMLOrFlight: AppPageRender = (
+const renderAppPage: AppPageRenderWithExecutionMode = (
   req,
   res,
   pagePath,
@@ -3232,9 +3243,54 @@ export const renderToHTMLOrFlight: AppPageRender = (
     serverComponentsHmrCache,
     sharedContext,
     interpolatedParams,
-    fallbackRouteParams
+    fallbackRouteParams,
+    executionMode === 'prerender'
   )
 }
+
+export const renderToHTMLOrFlight: AppPageRender = (
+  req,
+  res,
+  pagePath,
+  query,
+  fallbackRouteParams,
+  renderOpts,
+  serverComponentsHmrCache,
+  sharedContext
+) =>
+  renderAppPage(
+    req,
+    res,
+    pagePath,
+    query,
+    fallbackRouteParams,
+    'request',
+    renderOpts,
+    serverComponentsHmrCache,
+    sharedContext
+  )
+
+export const prerenderToHTMLOrFlight: AppPageRender = (
+  req,
+  res,
+  pagePath,
+  query,
+  fallbackRouteParams,
+  renderOpts,
+  serverComponentsHmrCache,
+  sharedContext
+) =>
+  renderAppPage(
+    req,
+    res,
+    pagePath,
+    query,
+    fallbackRouteParams,
+    'prerender',
+    renderOpts,
+    serverComponentsHmrCache,
+    sharedContext
+  )
 
 function applyMetadataFromPrerenderResult(
   response: Pick<

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -14,13 +14,15 @@ import type { LazyResult } from '../lib/lazy-result'
 import type { DigestedError } from './create-error-handler'
 import type { ActionRevalidationKind } from '../../shared/lib/action-revalidation-kind'
 
+export type WorkStoreExecutionMode = 'prerender' | 'request'
+
 export interface WorkStore {
   /**
    * Whether this invocation produces reusable prerender output or renders a
    * response for the current request. Prerendering includes both build-time
    * generation and runtime revalidation.
    */
-  readonly executionMode: 'prerender' | 'request'
+  readonly executionMode: WorkStoreExecutionMode
 
   /**
    * The page that is being rendered. This relates to the path to the page file.

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -1,4 +1,7 @@
-import type { WorkStore } from '../app-render/work-async-storage.external'
+import type {
+  WorkStore,
+  WorkStoreExecutionMode,
+} from '../app-render/work-async-storage.external'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { RenderOpts } from '../app-render/types'
 import type { FetchMetric } from '../base-http'
@@ -22,6 +25,12 @@ export type WorkStoreContext = {
    */
   page: string
 
+  /**
+   * Whether this invocation produces reusable prerender output or renders a
+   * response for the current request.
+   */
+  executionMode: WorkStoreExecutionMode
+
   isPrefetchRequest?: boolean
   nonce?: string
   renderOpts: {
@@ -38,7 +47,6 @@ export type WorkStoreContext = {
     cacheComponents: boolean
     validationLevel: ValidationLevel
     fetchCache?: AppSegmentConfig['fetchCache']
-    isPossibleServerAction?: boolean
     pendingWaitUntil?: Promise<any>
     experimental: Pick<
       RenderOpts['experimental'],
@@ -64,7 +72,6 @@ export type WorkStoreContext = {
     // mirrored.
     RenderOpts,
     | 'assetPrefix'
-    | 'supportsDynamicResponse'
     | 'isBuildTimePrerendering'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
@@ -89,6 +96,7 @@ export type WorkStoreContext = {
 
 export function createWorkStore({
   page,
+  executionMode,
   renderOpts,
   isPrefetchRequest,
   buildId,
@@ -96,30 +104,6 @@ export function createWorkStore({
   previouslyRevalidatedTags,
   nonce,
 }: WorkStoreContext): WorkStore {
-  /**
-   * Rules of Static & Dynamic HTML:
-   *
-   *    1.) We must generate static HTML unless the caller explicitly opts
-   *        in to dynamic HTML support.
-   *
-   *    2.) If dynamic HTML support is requested, we must honor that request
-   *        or throw an error. It is the sole responsibility of the caller to
-   *        ensure they aren't e.g. requesting dynamic HTML for a static page.
-   *
-   *    3.) If the request is in draft mode, we must generate dynamic HTML.
-   *
-   *    4.) If the request is a server action, we must generate dynamic HTML.
-   *
-   * These rules help ensure that other existing features like request caching,
-   * coalescing, and ISR continue working as intended.
-   */
-  const executionMode =
-    !renderOpts.supportsDynamicResponse &&
-    !renderOpts.isDraftMode &&
-    !renderOpts.isPossibleServerAction
-      ? 'prerender'
-      : 'request'
-
   const shouldTrackFetchMetrics =
     !!process.env.__NEXT_DEV_SERVER ||
     // The only times we want to track fetch metrics outside of development is

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -651,6 +651,11 @@ export default class NextNodeServer extends BaseServer<
           // This code path does not service revalidations for unknown param
           // shells. As a result, we don't need to pass in the unknown params.
           null,
+          !renderOpts.supportsDynamicResponse &&
+            !renderOpts.isDraftMode &&
+            !renderOpts.isPossibleServerAction
+            ? 'prerender'
+            : 'request',
           renderOpts as LoadedRenderOpts<AppPageModule>,
           this.getServerComponentsHmrCache(),
           {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -105,7 +105,10 @@ import { createRequestResponseMocks } from './lib/mock-request'
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
 import { signalFromNodeResponse } from './web/spec-extension/adapters/next-request'
 import { loadManifest } from './load-manifest.external'
-import { lazyRenderAppPage } from './route-modules/app-page/module.render'
+import {
+  lazyPrerenderAppPage,
+  lazyRenderAppPage,
+} from './route-modules/app-page/module.render'
 import { lazyRenderPagesPage } from './route-modules/pages/module.render'
 import { interopDefault } from '../lib/interop-default'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
@@ -643,7 +646,14 @@ export default class NextNodeServer extends BaseServer<
       renderOpts.nextFontManifest = this.nextFontManifest
 
       if (this.enabledDirectories.app && renderOpts.isAppPath) {
-        return lazyRenderAppPage(
+        const renderAppPage =
+          !renderOpts.supportsDynamicResponse &&
+          !renderOpts.isDraftMode &&
+          !renderOpts.isPossibleServerAction
+            ? lazyPrerenderAppPage
+            : lazyRenderAppPage
+
+        return renderAppPage(
           req,
           res,
           pathname,
@@ -651,11 +661,6 @@ export default class NextNodeServer extends BaseServer<
           // This code path does not service revalidations for unknown param
           // shells. As a result, we don't need to pass in the unknown params.
           null,
-          !renderOpts.supportsDynamicResponse &&
-            !renderOpts.isDraftMode &&
-            !renderOpts.isPossibleServerAction
-            ? 'prerender'
-            : 'request',
           renderOpts as LoadedRenderOpts<AppPageModule>,
           this.getServerComponentsHmrCache(),
           {

--- a/packages/next/src/server/route-modules/app-page/module.render.ts
+++ b/packages/next/src/server/route-modules/app-page/module.render.ts
@@ -1,25 +1,19 @@
 import type { AppPageRender } from '../../app-render/app-render'
 
-export const lazyRenderAppPage: AppPageRender = (...args) => {
+function getAppPageModule(): typeof import('./module.compiled') {
   if (process.env.NEXT_MINIMAL) {
     throw new Error("Can't use lazyRenderAppPage in minimal mode")
   } else {
-    const render: AppPageRender = (
-      require('./module.compiled') as typeof import('./module.compiled')
-    ).renderToHTMLOrFlight
-
-    return render(...args)
+    return require('./module.compiled') as typeof import('./module.compiled')
   }
 }
 
-export const lazyPrerenderAppPage: AppPageRender = (...args) => {
-  if (process.env.NEXT_MINIMAL) {
-    throw new Error("Can't use lazyPrerenderAppPage in minimal mode")
-  } else {
-    const prerender: AppPageRender = (
-      require('./module.compiled') as typeof import('./module.compiled')
-    ).prerenderToHTMLOrFlight
+export const lazyRenderAppPage: AppPageRender = (...args) => {
+  const render: AppPageRender = getAppPageModule().renderToHTMLOrFlight
+  return render(...args)
+}
 
-    return prerender(...args)
-  }
+export const lazyPrerenderAppPage: AppPageRender = (...args) => {
+  const prerender: AppPageRender = getAppPageModule().prerenderToHTMLOrFlight
+  return prerender(...args)
 }

--- a/packages/next/src/server/route-modules/app-page/module.render.ts
+++ b/packages/next/src/server/route-modules/app-page/module.render.ts
@@ -11,3 +11,15 @@ export const lazyRenderAppPage: AppPageRender = (...args) => {
     return render(...args)
   }
 }
+
+export const lazyPrerenderAppPage: AppPageRender = (...args) => {
+  if (process.env.NEXT_MINIMAL) {
+    throw new Error("Can't use lazyPrerenderAppPage in minimal mode")
+  } else {
+    const prerender: AppPageRender = (
+      require('./module.compiled') as typeof import('./module.compiled')
+    ).prerenderToHTMLOrFlight
+
+    return prerender(...args)
+  }
+}

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -6,6 +6,7 @@ import type { LoaderTree } from '../../lib/app-dir-module'
 import type { PrerenderManifest } from '../../../build'
 
 import {
+  prerenderToHTMLOrFlight,
   renderToHTMLOrFlight,
   runValidationInDevFromSnapshot,
   type AppSharedContext,
@@ -22,7 +23,6 @@ import type { ServerComponentsHmrCache } from '../../response-cache'
 import type { OpaqueFallbackRouteParams } from '../../request/fallback-params'
 import { PrerenderManifestMatcher } from './helpers/prerender-manifest-matcher'
 import type { DeepReadonly } from '../../../shared/lib/deep-readonly'
-import type { WorkStoreExecutionMode } from '../../app-render/work-async-storage.external'
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -75,7 +75,6 @@ export interface AppPageRouteHandlerContext extends RouteModuleHandleContext {
   page: string
   query: NextParsedUrlQuery
   fallbackRouteParams: OpaqueFallbackRouteParams | null
-  executionMode: WorkStoreExecutionMode
   renderOpts: RenderOpts
   serverComponentsHmrCache?: ServerComponentsHmrCache
   sharedContext: AppSharedContext
@@ -167,7 +166,23 @@ export class AppPageRouteModule extends RouteModule<
       context.page,
       context.query,
       context.fallbackRouteParams,
-      context.executionMode,
+      context.renderOpts,
+      context.serverComponentsHmrCache,
+      context.sharedContext
+    )
+  }
+
+  public prerender(
+    req: BaseNextRequest,
+    res: BaseNextResponse,
+    context: AppPageRouteHandlerContext
+  ): Promise<RenderResult> {
+    return prerenderToHTMLOrFlight(
+      req,
+      res,
+      context.page,
+      context.query,
+      context.fallbackRouteParams,
       context.renderOpts,
       context.serverComponentsHmrCache,
       context.sharedContext
@@ -230,6 +245,6 @@ const vendored = {
   contexts: vendoredContexts,
 }
 
-export { renderToHTMLOrFlight, vendored }
+export { prerenderToHTMLOrFlight, renderToHTMLOrFlight, vendored }
 
 export default AppPageRouteModule

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -22,6 +22,7 @@ import type { ServerComponentsHmrCache } from '../../response-cache'
 import type { OpaqueFallbackRouteParams } from '../../request/fallback-params'
 import { PrerenderManifestMatcher } from './helpers/prerender-manifest-matcher'
 import type { DeepReadonly } from '../../../shared/lib/deep-readonly'
+import type { WorkStoreExecutionMode } from '../../app-render/work-async-storage.external'
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -74,6 +75,7 @@ export interface AppPageRouteHandlerContext extends RouteModuleHandleContext {
   page: string
   query: NextParsedUrlQuery
   fallbackRouteParams: OpaqueFallbackRouteParams | null
+  executionMode: WorkStoreExecutionMode
   renderOpts: RenderOpts
   serverComponentsHmrCache?: ServerComponentsHmrCache
   sharedContext: AppSharedContext
@@ -165,6 +167,7 @@ export class AppPageRouteModule extends RouteModule<
       context.page,
       context.query,
       context.fallbackRouteParams,
+      context.executionMode,
       context.renderOpts,
       context.serverComponentsHmrCache,
       context.sharedContext

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -42,6 +42,7 @@ import { DynamicServerError } from '../../../client/components/hooks-server-cont
 import {
   workAsyncStorage,
   type WorkStore,
+  type WorkStoreExecutionMode,
 } from '../../app-render/work-async-storage.external'
 import {
   workUnitAsyncStorage,
@@ -113,6 +114,7 @@ export type AppRouteSharedContext = {
  * handler for app routes.
  */
 export interface AppRouteRouteHandlerContext extends RouteModuleHandleContext {
+  executionMode: WorkStoreExecutionMode
   renderOpts: WorkStoreContext['renderOpts'] &
     Pick<RenderOptsPartial, 'onInstrumentationRequestError'> &
     CollectedCacheInfo
@@ -778,9 +780,9 @@ export class AppRouteRouteModule extends RouteModule<
       ? this.resolveHandlerFromUserland(req.method, liveUserland)
       : this.resolveHandler(req.method)
 
-    // Get the context for the static generation.
-    const staticGenerationContext: WorkStoreContext = {
+    const workStoreContext: WorkStoreContext = {
       page: this.definition.page,
+      executionMode: context.executionMode,
       renderOpts: context.renderOpts,
       buildId: context.sharedContext.buildId,
       deploymentId: context.sharedContext.deploymentId,
@@ -792,7 +794,7 @@ export class AppRouteRouteModule extends RouteModule<
     const userland = liveUserland ?? this.userland
 
     // Add the fetchCache option to the renderOpts.
-    staticGenerationContext.renderOpts.fetchCache = userland.fetchCache
+    workStoreContext.renderOpts.fetchCache = userland.fetchCache
 
     const actionStore: ActionStore = {
       isAppRoute: true,
@@ -815,7 +817,7 @@ export class AppRouteRouteModule extends RouteModule<
       context.renderOpts.hmrRefreshHash
     )
 
-    const workStore = createWorkStore(staticGenerationContext)
+    const workStore = createWorkStore(workStoreContext)
 
     // Run the handler with the request AsyncLocalStorage to inject the helper
     // support. We set this to `unknown` because the type is not known until

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -321,6 +321,7 @@ export async function adapter(
 
             const workStore = createWorkStore({
               page,
+              executionMode: 'request',
               renderOpts: {
                 cacheLifeProfiles: proxyCacheLifeProfiles,
                 // Proxy doesn't do static generation, so this value does not
@@ -343,7 +344,6 @@ export async function adapter(
                   // bug.
                   useCacheTimeout: 0,
                 },
-                supportsDynamicResponse: true,
                 waitUntil,
                 onClose: closeController.onClose.bind(closeController),
                 onAfterTaskError: undefined,

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -118,8 +118,8 @@ export class EdgeRouteModuleWrapper {
     const context: AppRouteRouteHandlerContext = {
       params,
       previewProps,
+      executionMode: 'request',
       renderOpts: {
-        supportsDynamicResponse: true,
         waitUntil,
         onClose: closeController.onClose.bind(closeController),
         onAfterTaskError: undefined,

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/revalidate-tag-form-data-no-refresh/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/revalidate-tag-form-data-no-refresh/page.tsx
@@ -1,0 +1,32 @@
+import { revalidateTag, cacheTag, cacheLife } from 'next/cache'
+
+async function getCachedRandomNumber() {
+  'use cache'
+  cacheTag('revalidate-tag-form-data-test')
+  cacheLife('max')
+
+  return Math.random().toString()
+}
+
+export default async function Page() {
+  const randomNumber = await getCachedRandomNumber()
+
+  return (
+    <div>
+      <p id="random">{randomNumber}</p>
+      <form>
+        <input type="hidden" name="value" value="new" />
+        <button
+          id="revalidate-tag-with-profile"
+          formAction={async (formData: FormData) => {
+            'use server'
+            void formData.get('value')
+            revalidateTag('revalidate-tag-form-data-test', 'max')
+          }}
+        >
+          Revalidate Tag (background)
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -563,6 +563,7 @@ describe('use-cache', () => {
           '/react-cache',
           '/referential-equality',
           '/revalidate-and-redirect/redirect',
+          '/revalidate-tag-form-data-no-refresh',
           '/revalidate-tag-no-refresh',
           '/rsc-payload',
           '/static-class-method',
@@ -810,6 +811,26 @@ describe('use-cache', () => {
       // The key assertion: after 3 clicks, the value should still be the same
       // This proves revalidateTag with profile does NOT cause read-your-own-writes
       // (Unlike the bug where click 3 would show a different stale value)
+    })
+
+    it('should return successful responses for repeated FormData actions after revalidateTag with profile', async () => {
+      const browser = await next.browser('/revalidate-tag-form-data-no-refresh')
+      const initial = await browser.elementByCss('#random').text()
+      const actionStatuses: number[] = []
+
+      browser.on('response', (response) => {
+        if (response.request().method() === 'POST') {
+          actionStatuses.push(response.status())
+        }
+      })
+
+      for (let click = 1; click <= 3; click++) {
+        await browser.elementByCss('#revalidate-tag-with-profile').click()
+        await retry(() => expect(actionStatuses).toHaveLength(click))
+        expect(await browser.elementByCss('#random').text()).toBe(initial)
+      }
+
+      expect(actionStatuses).toEqual([200, 200, 200])
     })
   }
 


### PR DESCRIPTION
## Summary

App Router execution intent was previously inferred during WorkStore construction from response capabilities and request state. App Page also carried that intent through its handler context and lazy render API before selecting the rendering operation inside app-render.

This change moves those decisions to entrypoints where the work is known:

- Reusable output, including build-time generation, fallback shells, and runtime revalidation, selects prerendering.
- Request-specific and resumed rendering selects request rendering.
- App Page exposes distinct render and prerender operations, so execution mode no longer travels through `AppPageRouteHandlerContext` or the lazy render API.
- App Route execution derives its intent from whether the response has an ISR cache key.

WorkStore still consumes the explicit mode internally as a transitional seam. Follow-up work can migrate downstream behavior to the active WorkUnitStore and remove the mode from WorkStore entirely.

Fixes #96519

## Verification

- `pnpm --filter=next types`
- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/static-shell-vary-params-regression/static-shell-vary-params-regression.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/segment-cache/static-shell-vary-params-regression/static-shell-vary-params-regression.test.ts`

<!-- NEXT_JS_LLM -->