### PR TITLE
[ci] Fix create_release_branch for new repo permissions

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -42,7 +42,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
-          permission-environments: write
           permission-workflows: write
 
       - name: Get GitHub App user ID

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -6,15 +6,51 @@ const {
   configureGitHubAuth,
   getGitHubToken,
   getGitHubTokenMissingMessage,
-  verifyGitHubApiAccess,
 } = require('./release-github-auth')
 const {
+  githubRequest,
   createSignedCommit,
   upsertBranchRef,
 } = require('./github-utils/signed-commit')
 
 const REPO_OWNER = 'vercel'
 const REPO_NAME = 'next.js'
+
+/**
+ * Fail fast, before any file mutation, if the branch already exists.
+ *
+ * This doubles as the API preflight: it exercises the same git-data path the
+ * script later writes to (blobs/trees/commits/refs), so a token missing those
+ * grants fails here rather than midway through creating objects. A plain
+ * repository GET would succeed with any valid installation token and so could
+ * never catch that.
+ */
+async function verifyBranchIsAvailable(token, branch) {
+  let existing
+
+  try {
+    existing = await githubRequest(
+      token,
+      'GET',
+      `/repos/${REPO_OWNER}/${REPO_NAME}/git/ref/heads/${branch}`
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    // A 404 is the expected, successful outcome: the branch is available.
+    if (message.includes('failed (404)')) {
+      console.log(`Verified GitHub API access; branch ${branch} is available`)
+      return
+    }
+
+    throw error
+  }
+
+  throw new Error(
+    `Branch ${branch} already exists (at ${existing.object?.sha}). ` +
+      `Delete it or choose a different branch name before re-running.`
+  )
+}
 
 async function main() {
   const args = process.argv
@@ -37,23 +73,16 @@ async function main() {
   }
 
   await configureGitHubAuth(githubToken)
-  await verifyGitHubApiAccess(
-    githubToken,
-    `/repos/${REPO_OWNER}/${REPO_NAME}`,
-    'repository access'
-  )
+  await verifyBranchIsAvailable(githubToken, branchName)
 
-  await execa(`git checkout -b "${branchName}"`, {
+  await execa('git', ['checkout', '-b', branchName], {
     stdio: 'inherit',
-    shell: true,
   })
-  await execa(`git fetch origin ${tagName} --tags`, {
+  await execa('git', ['fetch', 'origin', tagName, '--tags'], {
     stdio: 'inherit',
-    shell: true,
   })
-  await execa(`git reset --hard ${tagName}`, {
+  await execa('git', ['reset', '--hard', tagName], {
     stdio: 'inherit',
-    shell: true,
   })
   const lernaPath = path.join(__dirname, '..', 'lerna.json')
   const existingLerna = JSON.parse(
@@ -98,13 +127,11 @@ async function main() {
 
   const commitMessage = 'setup release branch'
 
-  await execa(`git add .`, {
+  await execa('git', ['add', '.'], {
     stdio: 'inherit',
-    shell: true,
   })
-  await execa(`git commit -m "${commitMessage}"`, {
+  await execa('git', ['commit', '-m', commitMessage], {
     stdio: 'inherit',
-    shell: true,
   })
 
   // Branch protection requires signed commits, so create the commit on the

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -8,6 +8,13 @@ const {
   getGitHubTokenMissingMessage,
   verifyGitHubApiAccess,
 } = require('./release-github-auth')
+const {
+  createSignedCommit,
+  upsertBranchRef,
+} = require('./github-utils/signed-commit')
+
+const REPO_OWNER = 'vercel'
+const REPO_NAME = 'next.js'
 
 async function main() {
   const args = process.argv
@@ -32,8 +39,8 @@ async function main() {
   await configureGitHubAuth(githubToken)
   await verifyGitHubApiAccess(
     githubToken,
-    '/repos/vercel/next.js/environments/release-stable/deployment-branch-policies?per_page=1',
-    'release-stable deployment branch policies'
+    `/repos/${REPO_OWNER}/${REPO_NAME}`,
+    'repository access'
   )
 
   await execa(`git checkout -b "${branchName}"`, {
@@ -89,44 +96,49 @@ async function main() {
 
   await fs.promises.writeFile(buildAndTestPath, buildAndTest)
 
+  const commitMessage = 'setup release branch'
+
   await execa(`git add .`, {
     stdio: 'inherit',
     shell: true,
   })
-  await execa(`git commit -m "setup release branch"`, {
+  await execa(`git commit -m "${commitMessage}"`, {
     stdio: 'inherit',
     shell: true,
   })
 
-  await execa(`git push origin "${branchName}"`, {
-    stdio: 'inherit',
-    shell: true,
+  // Branch protection requires signed commits, so create the commit on the
+  // remote as a GitHub-signed commit via the REST API instead of running
+  // `git push` (which would push the unsigned local commit).
+  //
+  // Release tags are annotated tag objects, so dereference to the underlying
+  // commit -- the tag object's SHA is not valid as a commit parent.
+  const { stdout: baseSha } = await execa('git', [
+    'rev-parse',
+    `${tagName}^{commit}`,
+  ])
+  const { stdout: localCommitSha } = await execa('git', ['rev-parse', 'HEAD'])
+
+  const signedCommit = await createSignedCommit({
+    token: githubToken,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    baseSha: baseSha.trim(),
+    localCommitSha: localCommitSha.trim(),
+    message: commitMessage,
   })
 
-  console.log(`Waiting 5s before updating branch rules`)
-  await new Promise((resolve) => setTimeout(resolve, 5_000))
+  await upsertBranchRef({
+    token: githubToken,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    branch: branchName,
+    sha: signedCommit.sha,
+  })
 
-  const updateEnvironmentRes = await fetch(
-    'https://api.github.com/repos/vercel/next.js/environments/release-stable/deployment-branch-policies',
-    {
-      method: 'POST',
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${githubToken}`,
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      body: JSON.stringify({ name: branchName }),
-    }
+  console.log(
+    `Created branch ${branchName} at signed commit ${signedCommit.sha}`
   )
-
-  if (!updateEnvironmentRes.ok) {
-    console.error(
-      { status: updateEnvironmentRes.status },
-      await updateEnvironmentRes.text()
-    )
-    throw new Error(`Failed to update environment branch rules`)
-  }
-  console.log(`Successfully updated deployment environment branch rules`)
 }
 
 main()


### PR DESCRIPTION
### What

Fixes the **Create Release Branch** workflow, which currently fails on every run.

1. Drop `permission-environments: write` from the token request.
   - We can no longer request it, and due to repo policies we no longer need to mutate the environment
2. Drop the runtime `deployment-branch-policies` API call from `scripts/create-release-branch.js`.
   - No longer needed: the `release-stable` environment now statically allows branches conforming to `next-NN` / `next-NN-*`. This is what the permission above existed for.
3. Create the setup commit as a GitHub-signed commit via `scripts/github-utils/signed-commit.js` instead of `git push`.
   - Branch protection requires signed commits

### Why

The most recent run ([30923742579](https://github.com/vercel/next.js/actions/runs/30923742579/job/92040655448)) dies at the first step, `Create GitHub App token`, with a 422 — so the job never even clones the repo.
