### PR TITLE
next-build: fix terminal spinner rendering in narrow windows

### DIFF
--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -17,7 +17,7 @@ export default function createSpinner(
 
   if (process.stdout.isTTY) {
     spinner = ora({
-      text: undefined,
+      text: '',
       prefixText,
       spinner: dotsSpinner,
       stream: process.stdout,


### PR DESCRIPTION
@timneutkens spotted this bug with his eagle eyes.

On certain terminal widths, `next build` erases 1-2 lines of text when rendering a spinner.

The trigger is that we pass `undefined` to the `ora` spinner text, but the field is a string. So undefined -> `'undefined'` which causes the spinner to think the line is 9 characters longer than it actually is. If you're within 9 characters of the right side of the terminal, it thinks it needs to erase a line, when in fact that's not necessary.

Changing to empty string (`''`) fixes this. This bug is nearly 3 years old, it just appears in very rare configurations!

## Confirmation:

next@16.3.0
```
> next build

▲ Next.js 16.3.0-preview.10 (Turbopack)
✓ Running next.config.ts took 754ms

  Creating an optimized production build ...
  Collecting page data using 6 workers in 250ms   ✓ Collecting page data using 6 workers in 250ms
✓ Generating static pages using 6 workers (5/5) in 201ms
✓ Finalizing page optimization in 7ms

Route (app)
┌ ○ /
├ ○ /_not-found
└ ƒ /api/hello


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```

With this commit:
```
> next build

▲ Next.js 16.3.0-canary.97 (Turbopack)
✓ Running next.config.ts took 1333ms

  Creating an optimized production build ...
✓ Compiled successfully in 2.6s
✓ Finished TypeScript in 897ms
  Collecting page data using 6 workers in 343ms   ✓ Collecting page data using 6 workers in 343ms
✓ Generating static pages using 6 workers (5/5) in 229ms
✓ Finalizing page optimization in 10ms

Route (app)
┌ ○ /
├ ○ /_not-found
└ ƒ /api/hello


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```