### PR TITLE
Warn when styled-jsx can't be deduplicated instead of failing silently

### DIFF
--- a/errors/styled-jsx-not-resolvable.mdx
+++ b/errors/styled-jsx-not-resolvable.mdx
@@ -1,0 +1,49 @@
+---
+title: '`styled-jsx` is not resolvable'
+---
+
+## Why This Error Occurred
+
+Next.js could not resolve its own copy of `styled-jsx`.
+
+`styled-jsx` is a dependency of `next`, and Next.js resolves it eagerly at startup to make sure that
+your code and the Pages Router renderer use the _same_ `styled-jsx` instance: the renderer creates
+the style registry and passes it to your components through a React context that belongs to that
+specific module instance.
+
+If two different copies end up being loaded, `<style jsx>` silently renders nothing on the server.
+The generated `jsx-*` class names are still there, but the CSS is only inserted after hydration - so
+the page briefly renders unstyled, without any error being reported. Next.js therefore fails here
+instead of continuing in that state.
+
+The most common causes are an incomplete or outdated installation (`node_modules` does not contain
+`next`'s own dependencies), or a setup that copies/bundles `next` without its nested dependencies.
+
+## Possible Ways to Fix It
+
+Reinstall your dependencies so that `next`'s own dependencies are present:
+
+```bash filename="Terminal"
+npm install
+# or
+yarn install
+# or
+pnpm install
+# or
+bun install
+```
+
+If your setup cannot resolve nested dependencies - for example a custom bundling, vendoring or
+deployment step that only keeps top-level packages - add `styled-jsx` to your app's dependencies so
+that it resolves to a single copy:
+
+```bash filename="Terminal"
+npm install styled-jsx
+```
+
+Make sure only one copy ends up installed. `npm ls styled-jsx` (or the equivalent for your package
+manager) should not list multiple different versions.
+
+## Useful Links
+
+- [styled-jsx](https://github.com/vercel/styled-jsx)

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1474,5 +1474,6 @@
   "1473": "Invariant: image cache entry \"%s\" is empty",
   "1474": "Invariant: cannot write an empty buffer to the image cache",
   "1475": "Invariant: no direct app page entry found for %s",
-  "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled."
+  "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled.",
+  "1477": "Next.js could not resolve its own copy of 'styled-jsx'. It is a dependency of 'next', so this usually means the installation is incomplete or 'node_modules' is out of date - reinstalling dependencies normally fixes it. If your setup can't resolve nested dependencies (for example a custom bundling or vendoring step), add 'styled-jsx' to your app dependencies so it resolves to a single copy.\nSee more info here: https://nextjs.org/docs/messages/styled-jsx-not-resolvable"
 }

--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -26,19 +26,21 @@ try {
     'styled-jsx/style.js': resolve('styled-jsx/style'),
   })
 } catch (cause) {
-  // Not being able to register these aliases is not fatal - an app that doesn't
-  // use styled-jsx doesn't care - but it silently breaks styled-jsx SSR when the
-  // app has its own copy of styled-jsx: user code and the Pages Router renderer
-  // then load two different styled-jsx instances, the style registry never
-  // receives anything and every style is missing from the server-rendered HTML
-  // (the `jsx-*` class names still render, so it only shows as a flash of
-  // unstyled content). Make that diagnosable instead of swallowing the error.
-  console.warn(
-    'Warning: Next.js could not resolve its own copy of `styled-jsx`, so ' +
-      '`styled-jsx` was not deduplicated. If this app uses styled-jsx in the ' +
-      'Pages Router, its styles will be missing from the server-rendered HTML ' +
-      'and only applied after hydration.' +
-      `\nReason: ${(cause as Error)?.message ?? cause}`
+  // These aliases make every `styled-jsx` request resolve to Next.js' own copy, which the Pages
+  // Router depends on: the renderer creates the styled-jsx style registry and hands it to user
+  // code through a React context owned by that module instance. Without the aliases, user code
+  // with its own copy of styled-jsx gets a second instance, `JSXStyle` finds no registry and
+  // silently renders nothing during SSR - the `jsx-*` class names are still emitted, but the CSS
+  // only arrives after hydration, i.e. a flash of unstyled content and no error anywhere. Failing
+  // loudly here is better than that.
+  throw new Error(
+    "Next.js could not resolve its own copy of 'styled-jsx'. It is a dependency of 'next', so " +
+      "this usually means the installation is incomplete or 'node_modules' is out of date - " +
+      "reinstalling dependencies normally fixes it. If your setup can't resolve nested " +
+      "dependencies (for example a custom bundling or vendoring step), add 'styled-jsx' to your " +
+      'app dependencies so it resolves to a single copy.\n' +
+      'See more info here: https://nextjs.org/docs/messages/styled-jsx-not-resolvable',
+    { cause }
   )
 }
 

--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -25,7 +25,22 @@ try {
     'styled-jsx/style': resolve('styled-jsx/style'),
     'styled-jsx/style.js': resolve('styled-jsx/style'),
   })
-} catch (_) {}
+} catch (cause) {
+  // Not being able to register these aliases is not fatal - an app that doesn't
+  // use styled-jsx doesn't care - but it silently breaks styled-jsx SSR when the
+  // app has its own copy of styled-jsx: user code and the Pages Router renderer
+  // then load two different styled-jsx instances, the style registry never
+  // receives anything and every style is missing from the server-rendered HTML
+  // (the `jsx-*` class names still render, so it only shows as a flash of
+  // unstyled content). Make that diagnosable instead of swallowing the error.
+  console.warn(
+    'Warning: Next.js could not resolve its own copy of `styled-jsx`, so ' +
+      '`styled-jsx` was not deduplicated. If this app uses styled-jsx in the ' +
+      'Pages Router, its styles will be missing from the server-rendered HTML ' +
+      'and only applied after hydration.' +
+      `\nReason: ${(cause as Error)?.message ?? cause}`
+  )
+}
 
 const toResolveMap = (map: Record<string, string>): [string, string][] => {
   const resolveMap: [string, string][] = []


### PR DESCRIPTION
### What?

`next/dist/server/require-hook` resolves `styled-jsx` requests to Next.js'
own copy so that the Pages Router renderer and user code share a single
`styled-jsx` module instance. If that resolution throws, the failure was
silently swallowed (`catch (_) {}`). This logs a warning with the underlying
error instead - the resolution still isn't fatal, it just isn't invisible
anymore.

### Why?

The renderer hands the styled-jsx style registry to user code through a
React context owned by that specific module instance - they have to share
one instance. If the aliases fail to register, user code loads its own
`styled-jsx` copy while the renderer loads a different one; `JSXStyle` then
finds no registry and silently renders nothing during SSR. The `jsx-*` class
names are still emitted, so the only symptom is a flash of unstyled content
on first load, with nothing in any log pointing at the cause.

### How?

Kept the `try/catch` non-fatal (an app that doesn't use styled-jsx doesn't
care if this fails), but log the caught error through `console.warn` so the
condition is diagnosable. Verified against a published Next.js install: the
normal (resolvable) case stays silent; an unresolvable case warns exactly
once with the real underlying error and does not throw.
