### PR TITLE
fix: preserve repeated --require/--import flags when forking workers

### DIFF
--- a/packages/next/src/server/lib/utils.test.ts
+++ b/packages/next/src/server/lib/utils.test.ts
@@ -77,6 +77,19 @@ describe('formatNodeOptions', () => {
       ],
     })
   })
+
+  it('emits one flag per element for array values', () => {
+    const result = formatNodeOptions({
+      require: ['/path/a.cjs', '/path/b.cjs'],
+      import: '/path/c.mjs',
+    })
+
+    expect(result).toEqual({
+      execArgv: [],
+      nodeOptions:
+        '--require=/path/a.cjs --require=/path/b.cjs --import=/path/c.mjs',
+    })
+  })
 })
 
 describe('getMemoryRestartStats', () => {
@@ -191,5 +204,38 @@ describe('getFormattedNodeOptionsWithoutInspect', () => {
     const result = getFormattedNodeOptionsWithoutInspect()
 
     expect(result).toBe('--other --inspect-port=0.0.0.0:1234 --additional')
+  })
+
+  it('preserves repeated --require options', () => {
+    process.env.NODE_OPTIONS =
+      '--require=/path/a.cjs --require=/path/b.cjs --other'
+    const result = getFormattedNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--require=/path/a.cjs --require=/path/b.cjs --other')
+  })
+
+  it('preserves repeated --require options with space-separated values', () => {
+    process.env.NODE_OPTIONS = '--require /path/a.cjs --require /path/b.cjs'
+    const result = getFormattedNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--require=/path/a.cjs --require=/path/b.cjs')
+  })
+
+  it('preserves repeated --import options', () => {
+    process.env.NODE_OPTIONS =
+      '--import=/path/a.mjs --import=/path/b.mjs --other'
+    const result = getFormattedNodeOptionsWithoutInspect()
+
+    expect(result).toBe('--import=/path/a.mjs --import=/path/b.mjs --other')
+  })
+
+  it('preserves repeated --require with quoted values', () => {
+    process.env.NODE_OPTIONS =
+      '--require "./a with spaces.js" --require "./b with spaces.js"'
+    const result = getFormattedNodeOptionsWithoutInspect()
+
+    expect(result).toBe(
+      '--require="./a with spaces.js" --require="./b with spaces.js"'
+    )
   })
 })

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -11,10 +11,32 @@ export function printAndExit(message: string, code = 1) {
   return process.exit(code)
 }
 
-export type NodeOptions = Record<string, string | boolean | undefined>
+export type NodeOptions = Record<
+  string,
+  string | string[] | boolean | undefined
+>
+
+/**
+ * Node.js CLI flags that can be repeated. Node runs every occurrence of these
+ * flags, so they need to be preserved individually rather than collapsed into
+ * a single value keyed by option name.
+ * https://nodejs.org/api/cli.html#--requiremodule
+ * https://nodejs.org/api/cli.html#--importmodule
+ */
+const REPEATABLE_OPTIONS: Record<string, { type: 'string'; multiple: true }> = {
+  require: { type: 'string', multiple: true },
+  import: { type: 'string', multiple: true },
+}
 
 const parseNodeArgs = (args: string[]): NodeOptions => {
-  const { values, tokens } = parseArgs({ args, strict: false, tokens: true })
+  const parsed = parseArgs({
+    args,
+    strict: false,
+    tokens: true,
+    options: REPEATABLE_OPTIONS,
+  })
+  const values: NodeOptions = parsed.values
+  const tokens = parsed.tokens
 
   // For the `NODE_OPTIONS`, we support arguments with values without the `=`
   // sign. We need to parse them manually.
@@ -46,12 +68,27 @@ const parseNodeArgs = (args: string[]): NodeOptions => {
       continue
     }
 
+    const name = orphan.name
+
+    // If the option is repeatable, accumulate each occurrence instead of
+    // collapsing them into a single value.
+    if (name in REPEATABLE_OPTIONS) {
+      if (Array.isArray(values[name])) {
+        values[name].push(token.value)
+      } else if (typeof values[name] === 'string') {
+        values[name] = [values[name], token.value]
+      } else {
+        values[name] = token.value
+      }
+      continue
+    }
+
     // If the token is a positional one, and it has a value, so add it to the
     // values object. If it already exists, append it with a space.
-    if (orphan.name in values && typeof values[orphan.name] === 'string') {
-      values[orphan.name] += ` ${token.value}`
+    if (name in values && typeof values[name] === 'string') {
+      values[name] += ` ${token.value}`
     } else {
-      values[orphan.name] = token.value
+      values[name] = token.value
     }
   }
 
@@ -150,7 +187,7 @@ export const formatDebugAddress = ({ host, port }: DebugAddress): string => {
  * @returns An object with the host and port of the debug address.
  */
 export const getParsedDebugAddress = (
-  address: string | boolean | undefined
+  address: string | string[] | boolean | undefined
 ): DebugAddress => {
   if (!address || typeof address !== 'string') {
     return { host: undefined, port: 9229 }
@@ -183,10 +220,21 @@ const EXEC_ARGV_ONLY_OPTIONS = new Set([
 
 function formatArg(
   key: string,
-  value: string | boolean | undefined
+  value: string | string[] | boolean | undefined
 ): string | null {
   if (value === true) {
     return `--${key}`
+  }
+
+  if (Array.isArray(value)) {
+    const formatted: string[] = []
+    for (const item of value) {
+      const formattedItem = formatArg(key, item)
+      if (formattedItem !== null) {
+        formatted.push(formattedItem)
+      }
+    }
+    return formatted.length > 0 ? formatted.join(' ') : null
   }
 
   if (value) {
@@ -210,9 +258,10 @@ function formatArg(
  * @param args The arguments to be stringified.
  * @returns An object with `nodeOptions` string and `execArgv` array.
  */
-export function formatNodeOptions(
-  args: Record<string, string | boolean | undefined>
-): { nodeOptions: string; execArgv: string[] } {
+export function formatNodeOptions(args: NodeOptions): {
+  nodeOptions: string
+  execArgv: string[]
+} {
   const nodeOptionsParts: string[] = []
   const execArgv: string[] = []
 
@@ -230,10 +279,7 @@ export function formatNodeOptions(
   return { nodeOptions: nodeOptionsParts.join(' '), execArgv }
 }
 
-export function getParsedNodeOptions(): Record<
-  string,
-  string | boolean | undefined
-> {
+export function getParsedNodeOptions(): NodeOptions {
   const args = [...process.execArgv, ...getNodeOptionsArgs()]
   if (args.length === 0) return {}
 


### PR DESCRIPTION
Repeated --require/--import flags in NODE_OPTIONS are corrupted when Next.js reparses and reformats the options for forked workers.

## What changed

- Declare `require` and `import` as repeatable options in `parseNodeArgs` so `parseArgs` accumulates every occurrence into an array instead of keeping only the last value (equals form) or joining the space form into one bogus specifier.
- Emit one flag per array element in `formatArg`/round-trip.
- Widened `NodeOptions` and `getParsedDebugAddress` to accept `string[]`.

## Why

Two preloads in `NODE_OPTIONS` (e.g. an APM agent plus an env loader) silently lose one in forked workers (`--require=a --require=b`), or crash the build (`--require a --require b`, joining paths into a single MODULE_NOT_FOUND). Node itself runs every occurrence; the round-trip through Next must preserve them.

Fixes #96582

## Validation

- Unit tests in `packages/next/src/server/lib/utils.test.ts` cover both spellings, repeated `--import`, quoted values, and array formatting (22 passing).
- `pnpm --filter=next types` clean.