### PR TITLE
[16.x] [turbopack] Add `turbopack_ecmascript` and `turbopack_wasm`'s embeded FS to `internal_assets_conditions`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5052,6 +5052,7 @@ dependencies = [
  "turbopack-resolve",
  "turbopack-static",
  "turbopack-trace-utils",
+ "turbopack-wasm",
 ]
 
 [[package]]

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -86,6 +86,7 @@ turbopack-nodejs = { workspace = true }
 turbopack-resolve = { workspace = true }
 turbopack-static = { workspace = true }
 turbopack-trace-utils = { workspace = true }
+turbopack-wasm = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -316,6 +316,13 @@ pub async fn internal_assets_conditions() -> Result<ContextCondition> {
                 .await?,
         ),
         ContextCondition::InPath(turbopack_node::embed_js::embed_fs().root().owned().await?),
+        ContextCondition::InPath(
+            turbopack_ecmascript::embed_js::embed_fs()
+                .root()
+                .owned()
+                .await?,
+        ),
+        ContextCondition::InPath(turbopack_wasm::embed::embed_fs().root().owned().await?),
     ]))
 }
 

--- a/test/e2e/app-dir/worker-relay-compiler/app/layout.tsx
+++ b/test/e2e/app-dir/worker-relay-compiler/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/worker-relay-compiler/app/page.tsx
+++ b/test/e2e/app-dir/worker-relay-compiler/app/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function Page() {
+  const [state, setState] = useState('default')
+
+  useEffect(() => {
+    const worker = new Worker(new URL('./worker', import.meta.url))
+    worker.addEventListener('message', (event) => setState(event.data))
+    return () => worker.terminate()
+  }, [])
+
+  return <p id="worker-state">{state}</p>
+}

--- a/test/e2e/app-dir/worker-relay-compiler/app/worker.ts
+++ b/test/e2e/app-dir/worker-relay-compiler/app/worker.ts
@@ -1,0 +1,1 @@
+self.postMessage('hello from worker')

--- a/test/e2e/app-dir/worker-relay-compiler/next.config.js
+++ b/test/e2e/app-dir/worker-relay-compiler/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  compiler: {
+    relay: {
+      src: './',
+      language: 'typescript',
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/worker-relay-compiler/worker-relay-compiler.test.ts
+++ b/test/e2e/app-dir/worker-relay-compiler/worker-relay-compiler.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// Regression test for https://github.com/vercel/next.js/issues/96597
+describe('worker-relay-compiler', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should compile a web worker while the relay transform is enabled', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () =>
+      expect(await browser.elementByCss('#worker-state').text()).toBe(
+        'hello from worker'
+      )
+    )
+  })
+})

--- a/turbopack/crates/turbopack-wasm/src/embed.rs
+++ b/turbopack/crates/turbopack-wasm/src/embed.rs
@@ -2,6 +2,6 @@ use turbo_tasks::Vc;
 use turbo_tasks_fs::{FileSystem, embed_directory};
 
 #[turbo_tasks::function]
-pub(crate) fn embed_fs() -> Vc<Box<dyn FileSystem>> {
+pub fn embed_fs() -> Vc<Box<dyn FileSystem>> {
     embed_directory!("turbopack-wasm", "$CARGO_MANIFEST_DIR/js/src")
 }

--- a/turbopack/crates/turbopack-wasm/src/lib.rs
+++ b/turbopack/crates/turbopack-wasm/src/lib.rs
@@ -16,7 +16,7 @@ use turbo_tasks_hash::HashAlgorithm;
 use turbopack_core::asset::{Asset, no_hash_salt};
 
 pub(crate) mod analysis;
-pub(crate) mod embed;
+pub mod embed;
 pub(crate) mod loader;
 pub mod module_asset;
 pub(crate) mod output_asset;


### PR DESCRIPTION
Backports #96600 ([turbopack] Add `turbopack_ecmascript` and `turbopack_wasm`'s embeded FS to `internal_assets_conditions`) to `next-16-3`.


<!-- NEXT_JS_LLM -->