### PR TITLE
[turbopack] Don't run Webpack tests on Turbopack-only changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,6 +43,17 @@ jobs:
           echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT;
           echo 'EOF' >> $GITHUB_OUTPUT
 
+      - name: check for turbopack only change
+        id: turbopack-change
+        run: |
+          set -euo pipefail
+          TURBOPACK_ONLY="$(node scripts/run-for-change.mjs --not --type turbopack --exec echo 'false')"
+          {
+            echo "TURBOPACK_ONLY<<EOF"
+            echo "$TURBOPACK_ONLY"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: check for release
         id: is-release
         run: |
@@ -56,6 +67,12 @@ jobs:
     outputs:
       docs-only: ${{ steps.docs-change.outputs.DOCS_ONLY != 'false' }}
       is-release: ${{ steps.is-release.outputs.IS_RELEASE == 'true' }}
+      # Pull requests only, so canary and release run all Webpack tests.
+      turbopack-only: >-
+        ${{
+          github.event_name == 'pull_request' &&
+          steps.turbopack-change.outputs.TURBOPACK_ONLY != 'false'
+        }}
       rspack: >-
         ${{
           steps.is-release.outputs.IS_RELEASE == 'true' || (
@@ -830,7 +847,7 @@ jobs:
         'build-next',
         'fetch-test-timings',
       ]
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.turbopack-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -943,7 +960,7 @@ jobs:
         'build-next',
         'fetch-test-timings',
       ]
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.turbopack-only == 'false' }}
 
     strategy:
       fail-fast: false

--- a/scripts/run-for-change.mjs
+++ b/scripts/run-for-change.mjs
@@ -55,6 +55,15 @@ const CHANGE_ITEM_GROUPS = {
     'test/production/create-next-app',
     'scripts/send-trace-to-jaeger',
   ],
+  // Changes confined to these paths cannot affect a webpack build.
+  turbopack: [
+    'turbopack/crates',
+    '!turbopack/crates/turbo-bincode',
+    '!turbopack/crates/turbo-rcstr', // also covers turbo-rcstr-macros
+    '!turbopack/crates/turbo-tasks-hash',
+    '!turbopack/crates/turbo-tasks-macros',
+    '!turbopack/crates/turbo-unix-path',
+  ],
 }
 
 async function main() {
@@ -106,6 +115,12 @@ async function main() {
       ).join(', ')}`
     )
   }
+  // an item prefixed with "!" excludes paths another item matched
+  const excludedItems = changeItems
+    .filter((item) => item.startsWith('!'))
+    .map((item) => item.slice(1))
+  const includedItems = changeItems.filter((item) => !item.startsWith('!'))
+
   let changedFilesCount = 0
   let changedDirectories = new Set()
 
@@ -124,13 +139,15 @@ async function main() {
       // if --not flag is provided we execute for any file changed
       // not included in the change items otherwise we only execute
       // if a change item is changed
-      const matchesItem = changeItems.some((item) => {
-        const found = file.startsWith(item)
-        if (found) {
-          changedDirectories.add(item)
-        }
-        return found
-      })
+      const matchesItem =
+        !excludedItems.some((item) => file.startsWith(item)) &&
+        includedItems.some((item) => {
+          const found = file.startsWith(item)
+          if (found) {
+            changedDirectories.add(item)
+          }
+          return found
+        })
 
       if (!matchesItem && isNegated) {
         hasMatchingChange = true


### PR DESCRIPTION
Hopefully this saves us money + makes it easier to merge Turbopack PRs due to flaky Webpack tests