### PR TITLE
Separate App Page render and prerender pipelines

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -18,7 +18,6 @@ import type { Readable } from 'node:stream'
 import {
   workAsyncStorage,
   type WorkStore,
-  type WorkStoreExecutionMode,
 } from '../app-render/work-async-storage.external'
 import type {
   InstantValidationSamples,
@@ -2508,7 +2507,7 @@ export type BinaryStreamOf<T> = AnyStream
 
 /**
  * Extracted to a separate function to prevent V8 from retaining the entire
- * `renderToHTMLOrFlightImpl` closure scope through globalThis.__next_require__.
+ * `prepareAppPageRender` closure scope through globalThis.__next_require__.
  * V8 shares a single Context object per scope for all closures; by creating
  * these closures in their own function scope, the globalThis references only
  * retain `instrumented` and `cacheComponents`, not request-specific data like
@@ -2580,7 +2579,32 @@ function installGlobalModuleLoadingHandlers(
   }
 }
 
-async function renderToHTMLOrFlightImpl(
+type PreparedAppPageRender = {
+  req: BaseNextRequest
+  ctx: AppRenderContext
+  metadata: AppPageRenderResultMetadata
+  loaderTree: LoaderTree
+}
+
+type GenerateRequestId = (req: BaseNextRequest) => string | Promise<string>
+
+const generateRenderRequestId: GenerateRequestId = () => {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    return crypto.randomUUID()
+  } else {
+    return (
+      require('next/dist/compiled/nanoid') as typeof import('next/dist/compiled/nanoid')
+    ).nanoid()
+  }
+}
+
+const generatePrerenderRequestId: GenerateRequestId = async (req) => {
+  return Buffer.from(
+    await crypto.subtle.digest('SHA-1', Buffer.from(req.url))
+  ).toString('hex')
+}
+
+async function prepareAppPageRender(
   req: BaseNextRequest,
   res: BaseNextResponse,
   url: ReturnType<typeof parseRelativeUrl>,
@@ -2589,12 +2613,12 @@ async function renderToHTMLOrFlightImpl(
   renderOpts: RenderOpts,
   workStore: WorkStore,
   parsedRequestHeaders: ParsedRequestHeaders,
-  postponedState: PostponedState | null,
-  serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
   sharedContext: AppSharedContext,
   interpolatedParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  isPrerendering: boolean
+  generateRequestId: GenerateRequestId,
+  missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
+  renderCapabilities: AppRenderCapabilities
 ) {
   const isNotFoundPath = pagePath === '/404'
   if (isNotFoundPath) {
@@ -2610,14 +2634,11 @@ async function renderToHTMLOrFlightImpl(
   const {
     ComponentMod,
     nextFontManifest,
-    serverActions,
     assetPrefix = '',
     enableTainting,
     cacheComponents,
     setIsrStatus,
   } = renderOpts
-
-  const { cachedNavigations } = renderOpts.experimental
 
   // We need to expose the bundled `require` API globally for
   // react-server-dom-webpack. This is a hack until we find a better way.
@@ -2705,23 +2726,13 @@ async function renderToHTMLOrFlightImpl(
   query = { ...query }
   stripInternalQueries(query)
 
-  const isRoutePPREnabled = renderOpts.experimental.isRoutePPREnabled === true
-
   let requestId: string
   let htmlRequestId: string
   const requestInsightsIdentity = process.env.__NEXT_REQUEST_INSIGHTS
     ? getRequestInsightsIdentity()
     : undefined
 
-  const {
-    flightRouterState,
-    isPrefetchRequest,
-    isRuntimePrefetchRequest,
-    isAppShellPrefetchRequest,
-    isRSCRequest,
-    isHmrRefresh,
-    nonce,
-  } = parsedRequestHeaders
+  const { flightRouterState, isPrefetchRequest, nonce } = parsedRequestHeaders
 
   if (parsedRequestHeaders.requestId) {
     // If the client has provided a request ID (in development mode), we use it.
@@ -2732,17 +2743,7 @@ async function renderToHTMLOrFlightImpl(
     requestId = requestInsightsIdentity.requestId
   } else {
     // Otherwise we generate a new request ID.
-    if (isPrerendering) {
-      requestId = Buffer.from(
-        await crypto.subtle.digest('SHA-1', Buffer.from(req.url))
-      ).toString('hex')
-    } else if (process.env.NEXT_RUNTIME === 'edge') {
-      requestId = crypto.randomUUID()
-    } else {
-      requestId = (
-        require('next/dist/compiled/nanoid') as typeof import('next/dist/compiled/nanoid')
-      ).nanoid()
-    }
+    requestId = await generateRequestId(req)
   }
 
   // If the client has provided an HTML request ID, we use it to associate the
@@ -2783,19 +2784,8 @@ async function renderToHTMLOrFlightImpl(
     url,
     renderOpts,
     workStore,
-    missingPrefetchHintPolicy: getMissingPrefetchHintPolicy(
-      renderOpts.isBuildTimePrerendering ?? false,
-      isPrerendering,
-      renderOpts.cacheComponents
-    ),
-    // These are distinct rendering and protocol properties even though they
-    // are both determined by route-level PPR support today.
-    renderCapabilities: {
-      canPostpone: isPrerendering && isRoutePPREnabled,
-      isPossiblyPartialResponse: isPrerendering && isRoutePPREnabled,
-      supportsPerSegmentPrefetching:
-        isPrerendering || renderOpts.cacheComponents,
-    },
+    missingPrefetchHintPolicy,
+    renderCapabilities,
     parsedRequestHeaders,
     getDynamicParamFromSegment,
     interpolatedParams,
@@ -2819,307 +2809,431 @@ async function renderToHTMLOrFlightImpl(
 
   getTracer().setRootSpanAttribute('next.route', pagePath)
 
-  if (isPrerendering) {
-    // We're either building or revalidating. In either case we need to
-    // prerender our page rather than render it.
-    const prerenderToStreamWithTracing = getTracer().wrap(
-      AppRenderSpan.getBodyResult,
-      {
-        spanName: `prerender route (app) ${pagePath}`,
-        attributes: {
-          'next.route': pagePath,
-        },
+  return {
+    req,
+    ctx,
+    metadata,
+    loaderTree,
+  }
+}
+
+async function prerenderAppPage({
+  req,
+  ctx,
+  metadata,
+  loaderTree,
+}: PreparedAppPageRender) {
+  const { res, pagePath, renderOpts, workStore, url, fallbackRouteParams } = ctx
+
+  // We're either building or revalidating. In either case we need to
+  // prerender our page rather than render it.
+  const prerenderToStreamWithTracing = getTracer().wrap(
+    AppRenderSpan.getBodyResult,
+    {
+      spanName: `prerender route (app) ${pagePath}`,
+      attributes: {
+        'next.route': pagePath,
       },
-      prerenderToStream
-    )
+    },
+    prerenderToStream
+  )
 
-    const response = await prerenderToStreamWithTracing(
-      req,
-      res,
+  const response = await prerenderToStreamWithTracing(
+    req,
+    res,
+    ctx,
+    metadata,
+    loaderTree,
+    fallbackRouteParams
+  )
+
+  // If we're debugging partial prerendering, print all the dynamic API accesses
+  // that occurred during the render.
+  // @TODO move into renderToStream function
+  if (
+    response.dynamicAccess &&
+    accessedDynamicData(response.dynamicAccess) &&
+    renderOpts.isDebugDynamicAccesses
+  ) {
+    warn('The following dynamic usage was detected:')
+    for (const access of formatDynamicAPIAccesses(response.dynamicAccess)) {
+      warn(access)
+    }
+  }
+
+  // If we encountered any unexpected errors during build we fail the
+  // prerendering phase and the build.
+  if (workStore.invalidDynamicUsageError) {
+    logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
+    throw new StaticGenBailoutError()
+  }
+  if (response.digestErrorsMap.size) {
+    const buildFailingError = response.digestErrorsMap.values().next().value
+    if (buildFailingError) throw buildFailingError
+  }
+  // Pick first userland SSR error, which is also not a RSC error.
+  if (response.ssrErrors.length) {
+    const buildFailingError = response.ssrErrors.find((err) =>
+      isUserLandError(err)
+    )
+    if (buildFailingError) throw buildFailingError
+  }
+
+  const options: RenderResultOptions = {
+    metadata,
+    contentType: HTML_CONTENT_TYPE_HEADER,
+  }
+
+  // If we have pending revalidates, wait until they are all resolved.
+  const maybeRevalidatesPromise = executeRevalidates(workStore)
+  if (maybeRevalidatesPromise !== false) {
+    const revalidatesPromise = maybeRevalidatesPromise.finally(() => {
+      if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
+        console.log('pending revalidates promise finished for:', url.href)
+      }
+    })
+    if (renderOpts.waitUntil) {
+      renderOpts.waitUntil(revalidatesPromise)
+    } else {
+      options.waitUntil = revalidatesPromise
+    }
+  }
+
+  applyMetadataFromPrerenderResult(response, metadata, workStore)
+
+  if (response.renderResumeDataCache) {
+    metadata.renderResumeDataCache = response.renderResumeDataCache
+  }
+
+  const streamString = await streamToString(response.stream)
+  const result = new RenderResult(streamString, options)
+
+  // Run build-time instant validation if the page has instant configs
+  // TODO(instant-validation-build): This is not a great place to wire this in.
+  if (
+    workStore.cacheComponentsEnabled &&
+    workStore.isBuildTimePrerendering &&
+    renderOpts.runInstantValidation &&
+    (await anySegmentNeedsInstantValidationInBuild(loaderTree))
+  ) {
+    // Throws StaticGenBailoutError if validation failed.
+    await validateInstantConfigsInBuild(
       ctx,
-      metadata,
-      loaderTree,
-      fallbackRouteParams
+      response.renderResumeDataCache ?? null
     )
+  }
 
-    // If we're debugging partial prerendering, print all the dynamic API accesses
-    // that occurred during the render.
-    // @TODO move into renderToStream function
-    if (
-      response.dynamicAccess &&
-      accessedDynamicData(response.dynamicAccess) &&
-      renderOpts.isDebugDynamicAccesses
-    ) {
-      warn('The following dynamic usage was detected:')
-      for (const access of formatDynamicAPIAccesses(response.dynamicAccess)) {
-        warn(access)
-      }
-    }
+  return result
+}
 
-    // If we encountered any unexpected errors during build we fail the
-    // prerendering phase and the build.
-    if (workStore.invalidDynamicUsageError) {
-      logDisallowedDynamicError(workStore, workStore.invalidDynamicUsageError)
-      throw new StaticGenBailoutError()
-    }
-    if (response.digestErrorsMap.size) {
-      const buildFailingError = response.digestErrorsMap.values().next().value
-      if (buildFailingError) throw buildFailingError
-    }
-    // Pick first userland SSR error, which is also not a RSC error.
-    if (response.ssrErrors.length) {
-      const buildFailingError = response.ssrErrors.find((err) =>
-        isUserLandError(err)
-      )
-      if (buildFailingError) throw buildFailingError
-    }
+async function renderAppPage(
+  { req, ctx, metadata, loaderTree }: PreparedAppPageRender,
+  postponedState: PostponedState | null,
+  serverComponentsHmrCache: ServerComponentsHmrCache | undefined
+) {
+  const {
+    res,
+    url,
+    renderOpts,
+    workStore,
+    parsedRequestHeaders,
+    componentMod: ComponentMod,
+    implicitTags,
+  } = ctx
+  const { cacheComponents, setIsrStatus, serverActions } = renderOpts
+  const { cachedNavigations } = renderOpts.experimental
+  const {
+    isHmrRefresh,
+    isRSCRequest,
+    isRuntimePrefetchRequest,
+    isAppShellPrefetchRequest,
+  } = parsedRequestHeaders
+  const isPossibleActionRequest = ctx.isPossibleServerAction
 
-    const options: RenderResultOptions = {
-      metadata,
-      contentType: HTML_CONTENT_TYPE_HEADER,
-    }
+  // We're rendering dynamically
+  const renderResumeDataCache =
+    renderOpts.renderResumeDataCache ??
+    postponedState?.renderResumeDataCache ??
+    null
 
-    // If we have pending revalidates, wait until they are all resolved.
-    const maybeRevalidatesPromise = executeRevalidates(workStore)
-    if (maybeRevalidatesPromise !== false) {
-      const revalidatesPromise = maybeRevalidatesPromise.finally(() => {
-        if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
-          console.log('pending revalidates promise finished for:', url.href)
-        }
-      })
-      if (renderOpts.waitUntil) {
-        renderOpts.waitUntil(revalidatesPromise)
-      } else {
-        options.waitUntil = revalidatesPromise
-      }
-    }
+  const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
+  const fallbackParams = getRequestMeta(req, 'fallbackParams') || null
+  const hmrRefreshHash = getRequestMeta(req, 'hmrRefreshHash')
 
-    applyMetadataFromPrerenderResult(response, metadata, workStore)
+  const createRequestStore = createRequestStoreForRender.bind(
+    null,
+    req,
+    res,
+    url,
+    rootParams,
+    implicitTags,
+    renderOpts.onUpdateCookies,
+    renderOpts.previewProps,
+    isHmrRefresh,
+    serverComponentsHmrCache,
+    renderResumeDataCache,
+    fallbackParams,
+    hmrRefreshHash
+  )
+  const requestStore = createRequestStore()
 
-    if (response.renderResumeDataCache) {
-      metadata.renderResumeDataCache = response.renderResumeDataCache
-    }
+  if (
+    process.env.__NEXT_DEV_SERVER &&
+    setIsrStatus &&
+    !cacheComponents &&
+    // Only pages using the Node runtime can use ISR, so we only need to
+    // update the status for those.
+    // The type check here ensures that `req` is correctly typed, and the
+    // environment variable check provides dead code elimination.
+    process.env.NEXT_RUNTIME !== 'edge' &&
+    isNodeNextRequest(req)
+  ) {
+    req.originalRequest.on('end', () => {
+      const { pathname } = new URL(req.url || '/', 'http://n')
+      const isStatic = !requestStore.usedDynamic && !workStore.forceDynamic
+      setIsrStatus(pathname, isStatic)
+    })
+  }
 
-    const streamString = await streamToString(response.stream)
-    const result = new RenderResult(streamString, options)
-
-    // Run build-time instant validation if the page has instant configs
-    // TODO(instant-validation-build): This is not a great place to wire this in.
-    if (
-      workStore.cacheComponentsEnabled &&
-      workStore.isBuildTimePrerendering &&
-      renderOpts.runInstantValidation &&
-      (await anySegmentNeedsInstantValidationInBuild(loaderTree))
-    ) {
-      // Throws StaticGenBailoutError if validation failed.
-      await validateInstantConfigsInBuild(
+  // MARK: RSC request
+  if (isRSCRequest) {
+    if (isRuntimePrefetchRequest) {
+      // MARK: RSC runtimePrefetch
+      return generateRuntimePrefetchResult(
+        req,
         ctx,
-        response.renderResumeDataCache ?? null
+        requestStore,
+        isAppShellPrefetchRequest
       )
-    }
-
-    return result
-  } else {
-    // We're rendering dynamically
-    const renderResumeDataCache =
-      renderOpts.renderResumeDataCache ??
-      postponedState?.renderResumeDataCache ??
-      null
-
-    const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
-    const fallbackParams = getRequestMeta(req, 'fallbackParams') || null
-    const hmrRefreshHash = getRequestMeta(req, 'hmrRefreshHash')
-
-    const createRequestStore = createRequestStoreForRender.bind(
-      null,
-      req,
-      res,
-      url,
-      rootParams,
-      implicitTags,
-      renderOpts.onUpdateCookies,
-      renderOpts.previewProps,
-      isHmrRefresh,
-      serverComponentsHmrCache,
-      renderResumeDataCache,
-      fallbackParams,
-      hmrRefreshHash
-    )
-    const requestStore = createRequestStore()
-
-    if (
-      process.env.__NEXT_DEV_SERVER &&
-      setIsrStatus &&
-      !cacheComponents &&
-      // Only pages using the Node runtime can use ISR, so we only need to
-      // update the status for those.
-      // The type check here ensures that `req` is correctly typed, and the
-      // environment variable check provides dead code elimination.
-      process.env.NEXT_RUNTIME !== 'edge' &&
-      isNodeNextRequest(req)
-    ) {
-      req.originalRequest.on('end', () => {
-        const { pathname } = new URL(req.url || '/', 'http://n')
-        const isStatic = !requestStore.usedDynamic && !workStore.forceDynamic
-        setIsrStatus(pathname, isStatic)
-      })
-    }
-
-    // MARK: RSC request
-    if (isRSCRequest) {
-      if (isRuntimePrefetchRequest) {
-        // MARK: RSC runtimePrefetch
-        return generateRuntimePrefetchResult(
+    } else {
+      if (
+        process.env.__NEXT_DEV_SERVER &&
+        process.env.NEXT_RUNTIME !== 'edge' &&
+        cacheComponents
+      ) {
+        // MARK: RSC devCacheComponents
+        return generateDynamicFlightRenderResultWithStagesInDev(
           req,
           ctx,
           requestStore,
-          isAppShellPrefetchRequest
+          createRequestStore,
+          fallbackParams
+        )
+      } else if (cacheComponents && cachedNavigations) {
+        // MARK: RSC cacheComponents
+        return generateStagedDynamicFlightRenderResultNode(
+          req,
+          ctx,
+          requestStore
         )
       } else {
-        if (
-          process.env.__NEXT_DEV_SERVER &&
-          process.env.NEXT_RUNTIME !== 'edge' &&
-          cacheComponents
-        ) {
-          // MARK: RSC devCacheComponents
-          return generateDynamicFlightRenderResultWithStagesInDev(
-            req,
-            ctx,
-            requestStore,
-            createRequestStore,
-            fallbackParams
-          )
-        } else if (cacheComponents && cachedNavigations) {
-          // MARK: RSC cacheComponents
-          return generateStagedDynamicFlightRenderResultNode(
-            req,
-            ctx,
-            requestStore
-          )
-        } else {
-          // MARK: RSC dynamic
-          return generateDynamicFlightRenderResult(req, ctx, requestStore)
-        }
+        // MARK: RSC dynamic
+        return generateDynamicFlightRenderResult(req, ctx, requestStore)
       }
     }
+  }
 
-    let didExecuteServerAction = false
-    let formState: null | any = null
-    if (isPossibleActionRequest) {
-      // For action requests, we handle them differently with a special render result.
-      const actionRequestResult = await handleAction({
-        req,
-        res,
-        ComponentMod,
-        generateFlight: generateDynamicFlightRenderResult,
-        workStore,
-        requestStore,
-        serverActions,
-        ctx,
-        metadata,
-      })
-
-      if (actionRequestResult) {
-        if (actionRequestResult.type === 'not-found') {
-          const notFoundLoaderTree = createNotFoundLoaderTree(loaderTree)
-          res.statusCode = 404
-          metadata.statusCode = 404
-          const stream = await renderToStream(
-            requestStore,
-            req,
-            res,
-            ctx,
-            notFoundLoaderTree,
-            formState,
-            postponedState,
-            metadata,
-            undefined, // Prevent restartable-render behavior in dev + Cache Components mode
-            fallbackParams
-          )
-
-          return new RenderResult(stream, {
-            metadata,
-            contentType: HTML_CONTENT_TYPE_HEADER,
-          })
-        } else if (actionRequestResult.type === 'done') {
-          if (actionRequestResult.result) {
-            actionRequestResult.result.assignMetadata(metadata)
-            return actionRequestResult.result
-          } else if (actionRequestResult.formState) {
-            formState = actionRequestResult.formState
-          }
-        }
-      }
-
-      didExecuteServerAction = true
-    }
-
-    const options: RenderResultOptions = {
-      metadata,
-      contentType: HTML_CONTENT_TYPE_HEADER,
-    }
-
-    const stream = await renderToStream(
-      // NOTE: in Cache Components (dev), if the render is restarted, it will use a different requestStore
-      // than the one that we're passing in here.
-      requestStore,
+  let didExecuteServerAction = false
+  let formState: null | any = null
+  if (isPossibleActionRequest) {
+    // For action requests, we handle them differently with a special render result.
+    const actionRequestResult = await handleAction({
       req,
       res,
+      ComponentMod,
+      generateFlight: generateDynamicFlightRenderResult,
+      workStore,
+      requestStore,
+      serverActions,
       ctx,
-      loaderTree,
-      formState,
-      postponedState,
       metadata,
-      // If we're rendering HTML after an action, we don't want restartable-render behavior
-      // because the result should be dynamic, like it is in prod.
-      // Also, the request store might have been mutated by the action (e.g. enabling draftMode)
-      // and we currently we don't copy changes over when creating a new store,
-      // so the restarted render wouldn't be correct.
-      didExecuteServerAction ? undefined : createRequestStore,
-      fallbackParams
-    )
+    })
 
-    // Forward an invalid-dynamic-usage error recorded by `'use cache'` only
-    // when userland caught it (try/catch around the cache call). If userland
-    // didn't catch, the rejection propagated into the React render, and React's
-    // `serverComponentsErrorHandler` already stamped a digest on the error and
-    // emitted it as a Flight error chunk — surfacing it again here would
-    // duplicate the entry in the dev overlay.
-    //
-    // The cacheComponents paths forward this themselves via
-    // `runValidationInDev` and the validation-skipped fallback in
-    // `generateDynamicFlightRenderResultWithStagesInDev`. Here we cover the
-    // non-cacheComponents dev path where neither runs.
-    if (
-      process.env.__NEXT_DEV_SERVER &&
-      !cacheComponents &&
-      workStore.invalidDynamicUsageError &&
-      !(workStore.invalidDynamicUsageError as { digest?: unknown }).digest
-    ) {
-      void logMessagesAndSendErrorsToBrowser(
-        [workStore.invalidDynamicUsageError],
-        ctx
-      )
-    }
+    if (actionRequestResult) {
+      if (actionRequestResult.type === 'not-found') {
+        const notFoundLoaderTree = createNotFoundLoaderTree(loaderTree)
+        res.statusCode = 404
+        metadata.statusCode = 404
+        const stream = await renderToStream(
+          requestStore,
+          req,
+          res,
+          ctx,
+          notFoundLoaderTree,
+          formState,
+          postponedState,
+          metadata,
+          undefined, // Prevent restartable-render behavior in dev + Cache Components mode
+          fallbackParams
+        )
 
-    // If we have pending revalidates, wait until they are all resolved.
-    const maybeRevalidatesPromise = executeRevalidates(workStore)
-    if (maybeRevalidatesPromise !== false) {
-      const revalidatesPromise = maybeRevalidatesPromise.finally(() => {
-        if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
-          console.log('pending revalidates promise finished for:', url.href)
+        return new RenderResult(stream, {
+          metadata,
+          contentType: HTML_CONTENT_TYPE_HEADER,
+        })
+      } else if (actionRequestResult.type === 'done') {
+        if (actionRequestResult.result) {
+          actionRequestResult.result.assignMetadata(metadata)
+          return actionRequestResult.result
+        } else if (actionRequestResult.formState) {
+          formState = actionRequestResult.formState
         }
-      })
-      if (renderOpts.waitUntil) {
-        renderOpts.waitUntil(revalidatesPromise)
-      } else {
-        options.waitUntil = revalidatesPromise
       }
     }
 
-    // Create the new render result for the response.
-    return new RenderResult(stream, options)
+    didExecuteServerAction = true
   }
+
+  const options: RenderResultOptions = {
+    metadata,
+    contentType: HTML_CONTENT_TYPE_HEADER,
+  }
+
+  const stream = await renderToStream(
+    // NOTE: in Cache Components (dev), if the render is restarted, it will use a different requestStore
+    // than the one that we're passing in here.
+    requestStore,
+    req,
+    res,
+    ctx,
+    loaderTree,
+    formState,
+    postponedState,
+    metadata,
+    // If we're rendering HTML after an action, we don't want restartable-render behavior
+    // because the result should be dynamic, like it is in prod.
+    // Also, the request store might have been mutated by the action (e.g. enabling draftMode)
+    // and we currently we don't copy changes over when creating a new store,
+    // so the restarted render wouldn't be correct.
+    didExecuteServerAction ? undefined : createRequestStore,
+    fallbackParams
+  )
+
+  // Forward an invalid-dynamic-usage error recorded by `'use cache'` only
+  // when userland caught it (try/catch around the cache call). If userland
+  // didn't catch, the rejection propagated into the React render, and React's
+  // `serverComponentsErrorHandler` already stamped a digest on the error and
+  // emitted it as a Flight error chunk — surfacing it again here would
+  // duplicate the entry in the dev overlay.
+  //
+  // The cacheComponents paths forward this themselves via
+  // `runValidationInDev` and the validation-skipped fallback in
+  // `generateDynamicFlightRenderResultWithStagesInDev`. Here we cover the
+  // non-cacheComponents dev path where neither runs.
+  if (
+    process.env.__NEXT_DEV_SERVER &&
+    !cacheComponents &&
+    workStore.invalidDynamicUsageError &&
+    !(workStore.invalidDynamicUsageError as { digest?: unknown }).digest
+  ) {
+    void logMessagesAndSendErrorsToBrowser(
+      [workStore.invalidDynamicUsageError],
+      ctx
+    )
+  }
+
+  // If we have pending revalidates, wait until they are all resolved.
+  const maybeRevalidatesPromise = executeRevalidates(workStore)
+  if (maybeRevalidatesPromise !== false) {
+    const revalidatesPromise = maybeRevalidatesPromise.finally(() => {
+      if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
+        console.log('pending revalidates promise finished for:', url.href)
+      }
+    })
+    if (renderOpts.waitUntil) {
+      renderOpts.waitUntil(revalidatesPromise)
+    } else {
+      options.waitUntil = revalidatesPromise
+    }
+  }
+
+  // Create the new render result for the response.
+  return new RenderResult(stream, options)
+}
+
+async function renderToHTMLOrFlightImpl(
+  req: BaseNextRequest,
+  res: BaseNextResponse,
+  url: ReturnType<typeof parseRelativeUrl>,
+  pagePath: string,
+  query: NextParsedUrlQuery,
+  renderOpts: RenderOpts,
+  workStore: WorkStore,
+  parsedRequestHeaders: ParsedRequestHeaders,
+  postponedState: PostponedState | null,
+  serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
+  sharedContext: AppSharedContext,
+  interpolatedParams: Params,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
+) {
+  const prepared = await prepareAppPageRender(
+    req,
+    res,
+    url,
+    pagePath,
+    query,
+    renderOpts,
+    workStore,
+    parsedRequestHeaders,
+    sharedContext,
+    interpolatedParams,
+    fallbackRouteParams,
+    generateRenderRequestId,
+    getMissingPrefetchHintPolicy(
+      renderOpts.isBuildTimePrerendering ?? false,
+      false,
+      renderOpts.cacheComponents
+    ),
+    {
+      canPostpone: false,
+      isPossiblyPartialResponse: false,
+      supportsPerSegmentPrefetching: renderOpts.cacheComponents,
+    }
+  )
+  return renderAppPage(prepared, postponedState, serverComponentsHmrCache)
+}
+
+async function prerenderToHTMLOrFlightImpl(
+  req: BaseNextRequest,
+  res: BaseNextResponse,
+  url: ReturnType<typeof parseRelativeUrl>,
+  pagePath: string,
+  query: NextParsedUrlQuery,
+  renderOpts: RenderOpts,
+  workStore: WorkStore,
+  parsedRequestHeaders: ParsedRequestHeaders,
+  sharedContext: AppSharedContext,
+  interpolatedParams: Params,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
+) {
+  const isRoutePPREnabled = renderOpts.experimental.isRoutePPREnabled === true
+  const prepared = await prepareAppPageRender(
+    req,
+    res,
+    url,
+    pagePath,
+    query,
+    renderOpts,
+    workStore,
+    parsedRequestHeaders,
+    sharedContext,
+    interpolatedParams,
+    fallbackRouteParams,
+    generatePrerenderRequestId,
+    getMissingPrefetchHintPolicy(
+      renderOpts.isBuildTimePrerendering ?? false,
+      true,
+      renderOpts.cacheComponents
+    ),
+    {
+      // These are distinct rendering and protocol properties even though they
+      // are both determined by route-level PPR support today.
+      canPostpone: isRoutePPREnabled,
+      isPossiblyPartialResponse: isRoutePPREnabled,
+      supportsPerSegmentPrefetching: true,
+    }
+  )
+  return prerenderAppPage(prepared)
 }
 
 export type AppPageRender = (
@@ -3133,29 +3247,19 @@ export type AppPageRender = (
   sharedContext: AppSharedContext
 ) => Promise<RenderResult<AppPageRenderResultMetadata>>
 
-type AppPageRenderWithExecutionMode = (
-  req: BaseNextRequest,
-  res: BaseNextResponse,
-  pagePath: string,
-  query: NextParsedUrlQuery,
-  fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  executionMode: WorkStoreExecutionMode,
-  renderOpts: RenderOpts,
-  serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
-  sharedContext: AppSharedContext
-) => Promise<RenderResult<AppPageRenderResultMetadata>>
+type AppPagePreparation = {
+  url: ReturnType<typeof parseRelativeUrl>
+  parsedRequestHeaders: ParsedRequestHeaders
+  interpolatedParams: Params
+  postponedState: PostponedState | null
+}
 
-const renderAppPage: AppPageRenderWithExecutionMode = (
-  req,
-  res,
-  pagePath,
-  query,
-  fallbackRouteParams,
-  executionMode,
-  renderOpts,
-  serverComponentsHmrCache,
-  sharedContext
-) => {
+function prepareAppPage(
+  req: BaseNextRequest,
+  pagePath: string,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null,
+  renderOpts: RenderOpts
+): AppPagePreparation {
   if (!req.url) {
     throw new Error('Invalid URL')
   }
@@ -3169,14 +3273,16 @@ const renderAppPage: AppPageRenderWithExecutionMode = (
     previewModeId: renderOpts.previewProps?.previewModeId,
   })
 
-  const { isPrefetchRequest, previouslyRevalidatedTags, nonce } =
-    parsedRequestHeaders
-
-  let interpolatedParams: Params
-  let postponedState: PostponedState | null = null
+  const interpolatedParams = interpolateParallelRouteParams(
+    renderOpts.ComponentMod.routeModule.userland.loaderTree,
+    renderOpts.params ?? {},
+    pagePath,
+    fallbackRouteParams
+  )
 
   // If provided, the postpone state should be parsed so it can be provided to
   // React.
+  let postponedState: PostponedState | null = null
   if (typeof renderOpts.postponed === 'string') {
     if (fallbackRouteParams) {
       throw new InvariantError(
@@ -3184,24 +3290,10 @@ const renderAppPage: AppPageRenderWithExecutionMode = (
       )
     }
 
-    interpolatedParams = interpolateParallelRouteParams(
-      renderOpts.ComponentMod.routeModule.userland.loaderTree,
-      renderOpts.params ?? {},
-      pagePath,
-      fallbackRouteParams
-    )
-
     postponedState = parsePostponedState(
       renderOpts.postponed,
       interpolatedParams,
       renderOpts.experimental.maxPostponedStateSizeBytes
-    )
-  } else {
-    interpolatedParams = interpolateParallelRouteParams(
-      renderOpts.ComponentMod.routeModule.userland.loaderTree,
-      renderOpts.params ?? {},
-      pagePath,
-      fallbackRouteParams
     )
   }
 
@@ -3214,9 +3306,31 @@ const renderAppPage: AppPageRenderWithExecutionMode = (
     )
   }
 
+  return {
+    url,
+    parsedRequestHeaders,
+    interpolatedParams,
+    postponedState,
+  }
+}
+
+export const renderToHTMLOrFlight: AppPageRender = (
+  req,
+  res,
+  pagePath,
+  query,
+  fallbackRouteParams,
+  renderOpts,
+  serverComponentsHmrCache,
+  sharedContext
+) => {
+  const { url, parsedRequestHeaders, interpolatedParams, postponedState } =
+    prepareAppPage(req, pagePath, fallbackRouteParams, renderOpts)
+  const { isPrefetchRequest, previouslyRevalidatedTags, nonce } =
+    parsedRequestHeaders
   const workStore = createWorkStore({
     page: renderOpts.routeModule.definition.page,
-    executionMode,
+    executionMode: 'request',
     renderOpts,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,
@@ -3228,9 +3342,7 @@ const renderAppPage: AppPageRenderWithExecutionMode = (
 
   return workAsyncStorage.run(
     workStore,
-    // The function to run
     renderToHTMLOrFlightImpl,
-    // all of it's args
     req,
     res,
     url,
@@ -3243,32 +3355,9 @@ const renderAppPage: AppPageRenderWithExecutionMode = (
     serverComponentsHmrCache,
     sharedContext,
     interpolatedParams,
-    fallbackRouteParams,
-    executionMode === 'prerender'
+    fallbackRouteParams
   )
 }
-
-export const renderToHTMLOrFlight: AppPageRender = (
-  req,
-  res,
-  pagePath,
-  query,
-  fallbackRouteParams,
-  renderOpts,
-  serverComponentsHmrCache,
-  sharedContext
-) =>
-  renderAppPage(
-    req,
-    res,
-    pagePath,
-    query,
-    fallbackRouteParams,
-    'request',
-    renderOpts,
-    serverComponentsHmrCache,
-    sharedContext
-  )
 
 export const prerenderToHTMLOrFlight: AppPageRender = (
   req,
@@ -3277,20 +3366,45 @@ export const prerenderToHTMLOrFlight: AppPageRender = (
   query,
   fallbackRouteParams,
   renderOpts,
-  serverComponentsHmrCache,
+  _serverComponentsHmrCache,
   sharedContext
-) =>
-  renderAppPage(
+) => {
+  const { url, parsedRequestHeaders, interpolatedParams } = prepareAppPage(
+    req,
+    pagePath,
+    fallbackRouteParams,
+    renderOpts
+  )
+  const { isPrefetchRequest, previouslyRevalidatedTags, nonce } =
+    parsedRequestHeaders
+  const workStore = createWorkStore({
+    page: renderOpts.routeModule.definition.page,
+    executionMode: 'prerender',
+    renderOpts,
+    // @TODO move to workUnitStore of type Request
+    isPrefetchRequest,
+    buildId: sharedContext.buildId,
+    deploymentId: sharedContext.deploymentId,
+    previouslyRevalidatedTags,
+    nonce,
+  })
+
+  return workAsyncStorage.run(
+    workStore,
+    prerenderToHTMLOrFlightImpl,
     req,
     res,
+    url,
     pagePath,
     query,
-    fallbackRouteParams,
-    'prerender',
     renderOpts,
-    serverComponentsHmrCache,
-    sharedContext
+    workStore,
+    parsedRequestHeaders,
+    sharedContext,
+    interpolatedParams,
+    fallbackRouteParams
   )
+}
 
 function applyMetadataFromPrerenderResult(
   response: Pick<


### PR DESCRIPTION
## Summary

App Page rendering currently shares a single implementation that uses the Work Store execution mode to choose between the request and prerender pipelines.

This change:

- Extracts mode-neutral App Page preparation into a shared step.
- Gives request rendering and prerendering separate top-level implementations.
- Moves Work Store creation into the corresponding entrypoint.
- Makes each path call `renderToStream` or `prerenderToStream` directly, removing the execution-mode dispatch between them.

This moves the rendering decision to the App Page boundary and creates a clearer path toward removing execution mode from the Work Store entirely.