### PR TITLE
Remove App Page execution mode reads

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1465,5 +1465,6 @@
   "1464": "\\`experimental.turbopackChunkingHeuristics\\` has been renamed to \\`experimental.turbopackChunking\\`. Please update your next.config.js file accordingly.",
   "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead."
+  "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
+  "1468": "Missing workUnitStore in createComponentTree"
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -644,12 +644,6 @@ export async function handleAction({
     return handleUnrecognizedFetchAction(error)
   }
 
-  if (workStore.executionMode === 'prerender') {
-    throw new Error(
-      "Invariant: server actions can't be handled during static rendering"
-    )
-  }
-
   let temporaryReferences: TemporaryReferenceSet | undefined
 
   // When running actions the default is no-store, you can still `cache: 'force-cache'`

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -836,26 +836,52 @@ async function generateDynamicRSCPayload(
     baseResponse.p = options.runtimePrefetchStream
   }
 
-  // Include the per-page dynamic stale time from unstable_dynamicStaleTime, but only
-  // for dynamic renders (not prerenders/static generation). The client treats
-  // its presence as authoritative.
+  // Include the per-page dynamic stale time from unstable_dynamicStaleTime. This
+  // function only generates payloads for dynamic requests, and the client treats
+  // the field's presence as authoritative.
   // TODO: Move this to the prefetch hints file so we don't have to walk the
   // tree on every render.
-  if (workStore.executionMode !== 'prerender') {
-    const dynamicStaleTime = await getDynamicStaleTime(
-      ctx.componentMod.routeModule.userland.loaderTree
-    )
-    if (dynamicStaleTime !== null) {
-      baseResponse.d = dynamicStaleTime
-    }
+  const dynamicStaleTime = await getDynamicStaleTime(
+    ctx.componentMod.routeModule.userland.loaderTree
+  )
+  if (dynamicStaleTime !== null) {
+    baseResponse.d = dynamicStaleTime
   }
 
   return baseResponse
 }
 
-function createErrorContext(
+function createRequestErrorContext(
   ctx: AppRenderContext,
   renderSource: RequestErrorContext['renderSource']
+): RequestErrorContext {
+  return createErrorContext(
+    ctx,
+    renderSource,
+    getRevalidateReason({
+      isOnDemandRevalidate: ctx.workStore.isOnDemandRevalidate,
+    })
+  )
+}
+
+function createPrerenderErrorContext(
+  ctx: AppRenderContext,
+  renderSource: RequestErrorContext['renderSource']
+): RequestErrorContext {
+  return createErrorContext(
+    ctx,
+    renderSource,
+    getRevalidateReason({
+      isOnDemandRevalidate: ctx.workStore.isOnDemandRevalidate,
+      isStaticGeneration: true,
+    })
+  )
+}
+
+function createErrorContext(
+  ctx: AppRenderContext,
+  renderSource: RequestErrorContext['renderSource'],
+  revalidateReason: RequestErrorContext['revalidateReason']
 ): RequestErrorContext {
   return {
     routerKind: 'App Router',
@@ -863,10 +889,7 @@ function createErrorContext(
     // TODO: is this correct if `isPossibleServerAction` is a false positive?
     routeType: ctx.isPossibleServerAction ? 'action' : 'render',
     renderSource,
-    revalidateReason: getRevalidateReason({
-      isOnDemandRevalidate: ctx.workStore.isOnDemandRevalidate,
-      isStaticGeneration: ctx.workStore.executionMode === 'prerender',
-    }),
+    revalidateReason,
   }
 }
 
@@ -899,7 +922,7 @@ async function generateDynamicFlightRenderResult(
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'react-server-components-payload'),
+      createRequestErrorContext(ctx, 'react-server-components-payload'),
       silenceLog
     )
   }
@@ -1018,7 +1041,7 @@ async function generateStagedDynamicFlightRenderResultNode(
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'react-server-components-payload'),
+      createRequestErrorContext(ctx, 'react-server-components-payload'),
       silenceLog
     )
   }
@@ -1353,7 +1376,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'react-server-components-payload'),
+      createRequestErrorContext(ctx, 'react-server-components-payload'),
       silenceLog
     )
   }
@@ -1538,7 +1561,7 @@ async function generateRuntimePrefetchResult(
       err,
       req,
       // TODO(runtime-ppr): should we use a different value?
-      createErrorContext(ctx, 'react-server-components-payload'),
+      createRequestErrorContext(ctx, 'react-server-components-payload'),
       silenceLog
     )
   }
@@ -2106,7 +2129,6 @@ async function getRSCPayload(
     appUsingSizeAdjustment,
     componentMod: { createMetadataComponents, createElement, Fragment },
     url,
-    workStore,
   } = ctx
 
   const hints = ctx.renderOpts.prefetchHints?.[ctx.pagePath] ?? null
@@ -2238,7 +2260,7 @@ async function getRSCPayload(
     // TODO: Move this to the prefetch hints file so we don't have to walk
     // the tree on every render.
     d:
-      workStore.executionMode !== 'prerender'
+      workUnitAsyncStorage.getStore()?.type === 'request'
         ? ((await getDynamicStaleTime(tree)) ?? undefined)
         : undefined,
   } satisfies InitialRSCPayload & { P: ReactNode })
@@ -3616,7 +3638,7 @@ async function renderToStream(
       return onInstrumentationRequestError?.(
         err,
         req,
-        createErrorContext(ctx, 'react-server-components'),
+        createRequestErrorContext(ctx, 'react-server-components'),
         silenceLog
       )
     }
@@ -3635,7 +3657,7 @@ async function renderToStream(
       return onInstrumentationRequestError?.(
         err,
         req,
-        createErrorContext(ctx, 'server-rendering'),
+        createRequestErrorContext(ctx, 'server-rendering'),
         silenceLog
       )
     }
@@ -8557,7 +8579,7 @@ async function prerenderToStream(
       return onInstrumentationRequestError?.(
         err,
         req,
-        createErrorContext(ctx, 'react-server-components'),
+        createPrerenderErrorContext(ctx, 'react-server-components'),
         silenceLog
       )
     }
@@ -8577,7 +8599,7 @@ async function prerenderToStream(
       return onInstrumentationRequestError?.(
         err,
         req,
-        createErrorContext(ctx, 'server-rendering'),
+        createPrerenderErrorContext(ctx, 'server-rendering'),
         silenceLog
       )
     }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2100,6 +2100,7 @@ async function getRSCPayload(
   ctx: AppRenderContext,
   options: {
     is404: boolean
+    isPrerendering: boolean
     staleTimeIterable?: AsyncIterable<number>
     staticStageByteLengthPromise?: Promise<number>
     shellByteLengthPromise?: Promise<number | null>
@@ -2108,6 +2109,7 @@ async function getRSCPayload(
 ): Promise<InitialRSCPayload & { P: ReactNode }> {
   const {
     is404,
+    isPrerendering,
     staleTimeIterable,
     staticStageByteLengthPromise,
     shellByteLengthPromise,
@@ -2178,6 +2180,7 @@ async function getRSCPayload(
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
     MetadataOutlet,
+    isPrerendering,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -2259,10 +2262,9 @@ async function getRSCPayload(
     // authoritative.
     // TODO: Move this to the prefetch hints file so we don't have to walk
     // the tree on every render.
-    d:
-      workUnitAsyncStorage.getStore()?.type === 'request'
-        ? ((await getDynamicStaleTime(tree)) ?? undefined)
-        : undefined,
+    d: !isPrerendering
+      ? ((await getDynamicStaleTime(tree)) ?? undefined)
+      : undefined,
   } satisfies InitialRSCPayload & { P: ReactNode })
 }
 
@@ -3697,7 +3699,7 @@ async function renderToStream(
               getRSCPayload,
               tree,
               ctx,
-              { is404: res.statusCode === 404 }
+              { is404: res.statusCode === 404, isPrerendering: false }
             )
 
           if (isBypassingCachesInDev(requestStore, workStore)) {
@@ -3881,6 +3883,7 @@ async function renderToStream(
           ctx,
           {
             is404: res.statusCode === 404,
+            isPrerendering: false,
             staleTimeIterable,
             shellByteLengthPromise: shellByteLengthDeferred.promise,
             staticStageByteLengthPromise: staticStageByteLengthDeferred.promise,
@@ -3950,7 +3953,7 @@ async function renderToStream(
               getRSCPayload,
               tree,
               ctx,
-              { is404: res.statusCode === 404 }
+              { is404: res.statusCode === 404, isPrerendering: false }
             )
 
           const debugChannel = setReactDebugChannel && createNodeDebugChannel()
@@ -3992,7 +3995,7 @@ async function renderToStream(
               getRSCPayload,
               tree,
               ctx,
-              { is404: res.statusCode === 404 }
+              { is404: res.statusCode === 404, isPrerendering: false }
             )
 
           const debugChannel = setReactDebugChannel && createWebDebugChannel()
@@ -8284,7 +8287,7 @@ async function validateInstantConfigInBuildWithSample(
           getRSCPayload,
           loaderTree,
           validationCtx,
-          { is404: false }
+          { is404: false, isPrerendering: true }
         ),
       (signal) =>
         function onError(err) {
@@ -8734,7 +8737,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        { is404: res.statusCode === 404 }
+        { is404: res.statusCode === 404, isPrerendering: true }
       )
 
       const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
@@ -9048,6 +9051,7 @@ async function prerenderToStream(
         ctx,
         {
           is404: res.statusCode === 404,
+          isPrerendering: true,
           shellByteLengthPromise: shellByteLengthDeferred.promise,
         }
       )
@@ -9556,7 +9560,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        { is404: res.statusCode === 404 }
+        { is404: res.statusCode === 404, isPrerendering: true }
       )
       let reactServerResult: ReactServerPrerenderResult
       reactServerResult = reactServerPrerenderResult =
@@ -9794,7 +9798,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        { is404: res.statusCode === 404 }
+        { is404: res.statusCode === 404, isPrerendering: true }
       )
 
       let reactServerResult: ReactServerPrerenderResult

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -22,7 +22,10 @@ import { getTracer } from '../lib/trace/tracer'
 import { NextNodeServerSpan } from '../lib/trace/constants'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import type { Params } from '../request/params'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  type WorkUnitStore,
+} from './work-unit-async-storage.external'
 import {
   createVaryParamsAccumulator,
   emptyVaryParamsAccumulator,
@@ -60,12 +63,14 @@ export function createComponentTree(props: {
   authInterrupts: boolean
   MetadataOutlet: ComponentType
 }): Promise<CacheNodeSeedData> {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
     {
       spanName: 'build component tree',
     },
-    () => createComponentTreeInternal(props, true)
+    () => createComponentTreeInternal(props, true, workUnitStore)
   )
 }
 
@@ -80,6 +85,33 @@ function errorMissingDefaultExport(
 }
 
 const cacheNodeKey = 'c'
+
+function isPrerenderWorkUnit(
+  workUnitStore: WorkUnitStore | undefined
+): boolean {
+  if (!workUnitStore) {
+    return false
+  }
+
+  switch (workUnitStore.type) {
+    case 'prerender':
+    case 'prerender-runtime':
+    case 'prerender-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+      return true
+    case 'request':
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      return false
+    default:
+      workUnitStore satisfies never
+      return false
+  }
+}
 
 async function createComponentTreeInternal(
   {
@@ -109,7 +141,8 @@ async function createComponentTreeInternal(
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
   },
-  isRoot: boolean
+  isRoot: boolean,
+  workUnitStore: WorkUnitStore | undefined
 ): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental, cacheComponents },
@@ -137,7 +170,9 @@ async function createComponentTreeInternal(
     query,
   } = ctx
 
-  const { executionMode } = workStore
+  // A WorkStore can span several request and prerender work units during
+  // staged rendering, so component-tree behavior follows the active work unit.
+  const isPrerendering = isPrerenderWorkUnit(workUnitStore)
   const { canPostpone, isPossiblyPartialResponse } = renderCapabilities
 
   const { page, conventionPath, segment, modules, parallelRoutes } =
@@ -277,7 +312,7 @@ async function createComponentTreeInternal(
       workStore.forceDynamic = true
 
       // TODO: (PPR) remove this bailout once PPR is the default
-      if (executionMode === 'prerender' && !canPostpone) {
+      if (isPrerendering && !canPostpone) {
         // If the postpone API isn't available, we can't postpone the render and
         // therefore we can't use the dynamic API.
         const err = new DynamicServerError(
@@ -303,8 +338,6 @@ async function createComponentTreeInternal(
 
   if (typeof layoutOrPageMod?.revalidate === 'number') {
     const defaultRevalidate = layoutOrPageMod.revalidate as number
-
-    const workUnitStore = workUnitAsyncStorage.getStore()
 
     if (workUnitStore) {
       switch (workUnitStore.type) {
@@ -334,7 +367,7 @@ async function createComponentTreeInternal(
 
     if (
       !workStore.forceStatic &&
-      executionMode === 'prerender' &&
+      isPrerendering &&
       defaultRevalidate === 0 &&
       // If the postpone API isn't available, we can't postpone the render and
       // therefore we can't use the dynamic API.
@@ -355,8 +388,6 @@ async function createComponentTreeInternal(
     typeof layoutOrPageMod?.unstable_dynamicStaleTime === 'number'
   ) {
     const pageStaleTime = layoutOrPageMod.unstable_dynamicStaleTime
-    const workUnitStore = workUnitAsyncStorage.getStore()
-
     if (workUnitStore) {
       switch (workUnitStore.type) {
         case 'prerender':
@@ -398,7 +429,7 @@ async function createComponentTreeInternal(
    */
   let MaybeComponent = LayoutOrPage
 
-  if (process.env.NODE_ENV === 'development' || executionMode === 'prerender') {
+  if (process.env.NODE_ENV === 'development' || isPrerendering) {
     const { isValidElementType } =
       require('next/dist/compiled/react-is') as typeof import('next/dist/compiled/react-is')
     if (
@@ -586,7 +617,8 @@ async function createComponentTreeInternal(
                 // but we only want to throw on the first one.
                 MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
               },
-              false
+              false,
+              workUnitStore
             )
 
             childCacheNodeSeedData = seedData
@@ -808,7 +840,7 @@ async function createComponentTreeInternal(
           Component: PageComponent,
           serverProvidedParams: null,
         })
-      } else if (executionMode === 'prerender') {
+      } else if (isPrerendering) {
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
         const promiseOfSearchParams = createPrerenderSearchParamsForClientPage()
@@ -917,7 +949,7 @@ async function createComponentTreeInternal(
           slots: parallelRouteProps,
           serverProvidedParams: null,
         })
-      } else if (executionMode === 'prerender') {
+      } else if (isPrerendering) {
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -26,6 +26,7 @@ import {
   workUnitAsyncStorage,
   type WorkUnitStore,
 } from './work-unit-async-storage.external'
+import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   createVaryParamsAccumulator,
   emptyVaryParamsAccumulator,
@@ -62,8 +63,12 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   MetadataOutlet: ComponentType
+  isPrerendering: boolean
 }): Promise<CacheNodeSeedData> {
   const workUnitStore = workUnitAsyncStorage.getStore()
+  if (!workUnitStore) {
+    throw new InvariantError('Missing workUnitStore in createComponentTree')
+  }
 
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -86,33 +91,6 @@ function errorMissingDefaultExport(
 
 const cacheNodeKey = 'c'
 
-function isPrerenderWorkUnit(
-  workUnitStore: WorkUnitStore | undefined
-): boolean {
-  if (!workUnitStore) {
-    return false
-  }
-
-  switch (workUnitStore.type) {
-    case 'prerender':
-    case 'prerender-runtime':
-    case 'prerender-client':
-    case 'prerender-ppr':
-    case 'prerender-legacy':
-      return true
-    case 'request':
-    case 'validation-client':
-    case 'cache':
-    case 'private-cache':
-    case 'unstable-cache':
-    case 'generate-static-params':
-      return false
-    default:
-      workUnitStore satisfies never
-      return false
-  }
-}
-
 async function createComponentTreeInternal(
   {
     loaderTree: tree,
@@ -127,6 +105,7 @@ async function createComponentTreeInternal(
     preloadCallbacks,
     authInterrupts,
     MetadataOutlet,
+    isPrerendering,
   }: {
     loaderTree: LoaderTree
     parentParams: Params
@@ -140,9 +119,10 @@ async function createComponentTreeInternal(
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
+    isPrerendering: boolean
   },
   isRoot: boolean,
-  workUnitStore: WorkUnitStore | undefined
+  workUnitStore: WorkUnitStore
 ): Promise<CacheNodeSeedData> {
   const {
     renderOpts: { nextConfigOutput, experimental, cacheComponents },
@@ -170,9 +150,6 @@ async function createComponentTreeInternal(
     query,
   } = ctx
 
-  // A WorkStore can span several request and prerender work units during
-  // staged rendering, so component-tree behavior follows the active work unit.
-  const isPrerendering = isPrerenderWorkUnit(workUnitStore)
   const { canPostpone, isPossiblyPartialResponse } = renderCapabilities
 
   const { page, conventionPath, segment, modules, parallelRoutes } =
@@ -339,30 +316,28 @@ async function createComponentTreeInternal(
   if (typeof layoutOrPageMod?.revalidate === 'number') {
     const defaultRevalidate = layoutOrPageMod.revalidate as number
 
-    if (workUnitStore) {
-      switch (workUnitStore.type) {
-        case 'prerender':
-        case 'prerender-runtime':
-        case 'prerender-legacy':
-        case 'prerender-ppr':
-          if (workUnitStore.revalidate > defaultRevalidate) {
-            workUnitStore.revalidate = defaultRevalidate
-          }
-          break
-        case 'request':
-          // A request store doesn't have a revalidate property.
-          break
-        // createComponentTree is not called for these stores:
-        case 'cache':
-        case 'private-cache':
-        case 'prerender-client':
-        case 'validation-client':
-        case 'unstable-cache':
-        case 'generate-static-params':
-          break
-        default:
-          workUnitStore satisfies never
-      }
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-runtime':
+      case 'prerender-legacy':
+      case 'prerender-ppr':
+        if (workUnitStore.revalidate > defaultRevalidate) {
+          workUnitStore.revalidate = defaultRevalidate
+        }
+        break
+      case 'request':
+        // A request store doesn't have a revalidate property.
+        break
+      // createComponentTree is not called for these stores:
+      case 'cache':
+      case 'private-cache':
+      case 'prerender-client':
+      case 'validation-client':
+      case 'unstable-cache':
+      case 'generate-static-params':
+        break
+      default:
+        workUnitStore satisfies never
     }
 
     if (
@@ -388,35 +363,33 @@ async function createComponentTreeInternal(
     typeof layoutOrPageMod?.unstable_dynamicStaleTime === 'number'
   ) {
     const pageStaleTime = layoutOrPageMod.unstable_dynamicStaleTime
-    if (workUnitStore) {
-      switch (workUnitStore.type) {
-        case 'prerender':
-        case 'prerender-runtime':
-        case 'prerender-legacy':
-        case 'prerender-ppr':
-          if (workUnitStore.stale > pageStaleTime) {
-            workUnitStore.stale = pageStaleTime
-          }
-          break
-        case 'request':
-          if (
-            workUnitStore.stale === undefined ||
-            workUnitStore.stale > pageStaleTime
-          ) {
-            workUnitStore.stale = pageStaleTime
-          }
-          break
-        // createComponentTree is not called for these stores:
-        case 'cache':
-        case 'private-cache':
-        case 'prerender-client':
-        case 'validation-client':
-        case 'unstable-cache':
-        case 'generate-static-params':
-          break
-        default:
-          workUnitStore satisfies never
-      }
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-runtime':
+      case 'prerender-legacy':
+      case 'prerender-ppr':
+        if (workUnitStore.stale > pageStaleTime) {
+          workUnitStore.stale = pageStaleTime
+        }
+        break
+      case 'request':
+        if (
+          workUnitStore.stale === undefined ||
+          workUnitStore.stale > pageStaleTime
+        ) {
+          workUnitStore.stale = pageStaleTime
+        }
+        break
+      // createComponentTree is not called for these stores:
+      case 'cache':
+      case 'private-cache':
+      case 'prerender-client':
+      case 'validation-client':
+      case 'unstable-cache':
+      case 'generate-static-params':
+        break
+      default:
+        workUnitStore satisfies never
     }
   }
 
@@ -616,6 +589,7 @@ async function createComponentTreeInternal(
                 // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
                 // but we only want to throw on the first one.
                 MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
+                isPrerendering,
               },
               false,
               workUnitStore

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -262,6 +262,7 @@ export async function walkTreeWithFlightRouterState({
         preloadCallbacks,
         authInterrupts: experimental.authInterrupts,
         MetadataOutlet,
+        isPrerendering: false,
       }
     )
 
@@ -389,6 +390,7 @@ export async function createFullTreeFlightDataForNavigation({
     preloadCallbacks,
     authInterrupts: experimental.authInterrupts,
     MetadataOutlet,
+    isPrerendering: false,
   })
 
   return [


### PR DESCRIPTION
## Summary

App Page leaf logic still reads the Work Store execution mode after request rendering and prerendering have already been separated at the entrypoint.

This change removes those remaining reads by:

- Deriving component-tree behavior from the active Work Unit type.
- Relying on request-only boundaries for dynamic Flight payloads and Server Actions.
- Selecting request or prerender instrumentation context from the corresponding render pipeline.

After this change, App Page only supplies `executionMode` when constructing a Work Store; none of its downstream behavior reads it. Removing the field itself remains a follow-up once App Route and cache consumers have been migrated.