### PR TITLE
Next: expose edit transactions through the project binding

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -738,6 +738,74 @@ async fn benchmark_file_io(turbo_tasks: &NextTurboTasks, dir: &Path) -> Result<(
     Ok(())
 }
 
+#[turbo_tasks::function(operation, root)]
+fn project_fs_control_operation(container: ResolvedVc<ProjectContainer>) -> Vc<DiskFileSystem> {
+    container.project().project_fs()
+}
+
+/// Begin one acknowledged source edit. Returns no token when another edit transaction is active.
+#[napi]
+pub async fn project_begin_edit_transaction(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    changed_paths: Vec<String>,
+) -> napi::Result<Option<u32>> {
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+    let changed_paths = changed_paths.into_iter().map(PathBuf::from).collect();
+
+    ctx.turbo_tasks()
+        .run(async move {
+            project_fs_control_operation(container)
+                .read_strongly_consistent()
+                .await?
+                .begin_edit_transaction(changed_paths)
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
+#[napi]
+pub async fn project_renew_edit_transaction(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    token: u32,
+) -> napi::Result<bool> {
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+
+    ctx.turbo_tasks()
+        .run(async move {
+            project_fs_control_operation(container)
+                .read_strongly_consistent()
+                .await?
+                .renew_edit_transaction(token)
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
+/// End the matching source edit. A `true` result is acknowledged after invalidation is submitted.
+#[napi]
+pub async fn project_end_edit_transaction(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    token: u32,
+) -> napi::Result<bool> {
+    let ctx = &project.turbopack_ctx;
+    let container = project.container;
+
+    ctx.turbo_tasks()
+        .run(async move {
+            project_fs_control_operation(container)
+                .read_strongly_consistent()
+                .await?
+                .end_edit_transaction(token)
+                .await
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
 #[tracing::instrument(level = "info", name = "update project", skip_all)]
 #[napi]
 pub async fn project_update(

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -330,6 +330,20 @@ export declare function projectNew(
   turboEngineOptions: NapiTurboEngineOptions,
   napiCallbacks: NapiNextTurbopackCallbacksJsObject
 ): Promise<{ __napiType: 'Project' }>
+/** Begin one acknowledged source edit. Returns no token when another edit transaction is active. */
+export declare function projectBeginEditTransaction(
+  project: { __napiType: 'Project' },
+  changedPaths: Array<string>
+): Promise<number | null>
+export declare function projectRenewEditTransaction(
+  project: { __napiType: 'Project' },
+  token: number
+): Promise<boolean>
+/** End the matching source edit. A `true` result is acknowledged after invalidation is submitted. */
+export declare function projectEndEditTransaction(
+  project: { __napiType: 'Project' },
+  token: number
+): Promise<boolean>
 export declare function projectUpdate(
   project: { __napiType: 'Project' },
   options: NapiPartialProjectOptions

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -699,6 +699,21 @@ function bindingToApi(
       )
     }
 
+    beginEditTransaction(changedPaths: string[]): Promise<number | null> {
+      return binding.projectBeginEditTransaction(
+        this._nativeProject,
+        changedPaths
+      )
+    }
+
+    renewEditTransaction(token: number): Promise<boolean> {
+      return binding.projectRenewEditTransaction(this._nativeProject, token)
+    }
+
+    endEditTransaction(token: number): Promise<boolean> {
+      return binding.projectEndEditTransaction(this._nativeProject, token)
+    }
+
     async writeAnalyzeData(
       appDirOnly: boolean
     ): Promise<TurbopackResult<void>> {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -311,6 +311,18 @@ export interface UpdateInfo {
 export interface Project {
   update(options: Partial<ProjectOptions>): Promise<void>
 
+  /**
+   * Begin one source-edit transaction for the given filesystem-root-relative paths. Returns
+   * `null` when another edit transaction is active.
+   */
+  beginEditTransaction(changedPaths: string[]): Promise<number | null>
+
+  /** Renew the matching transaction's bounded lease. */
+  renewEditTransaction(token: number): Promise<boolean>
+
+  /** End the matching transaction, resolving after its invalidations have been submitted. */
+  endEditTransaction(token: number): Promise<boolean>
+
   writeAnalyzeData(appDirOnly: boolean): Promise<TurbopackResult<void>>
 
   getAllCompilationIssues(): Promise<TurbopackResult<void>>


### PR DESCRIPTION
## Summary

Expose the watcher edit-transaction primitive through the existing native
`Project` binding.

This PR is intentionally mechanical: four files, +109/−0, one signed commit
(`dd8c28a573`). It adds begin, renew, and end to the N-API project object and
the generated/manual TypeScript declarations. No MCP policy, path validation,
telemetry, watcher state machine, or v0 integration lives here.

## Contract

- begin returns the native token or `null` when another transaction is active;
- renew reports whether the exact native token was renewed;
- end reports whether the exact native token was flushed;
- unavailable/non-Turbopack projects use the existing unsupported result;
- all three methods await the watcher response, preserving the lower PR's
  acknowledgement and flush barriers.

## Files

- `crates/next-napi-bindings/src/next_api/project.rs`
- `packages/next/src/build/swc/generated-native.d.ts`
- `packages/next/src/build/swc/index.ts`
- `packages/next/src/build/swc/types.ts`

## Validation

Validated as part of the exact final source tree
`d5a230df5a15f9dfb752763035cb4e773e810a7f`:

- native unit tests: **128/128**;
- strict Clippy: passed;
- full uncached Next build: **16/16 tasks**;
- optimized native release build: passed;
- packaged Chromium E2E: **24/24**;
- default autoreview panel: **zero actionable findings**.

The full private-v0 measurements and graphs are in #96666. The packaged browser
proof is isolated in #96669.

<!-- STACK_LINKS_START -->
Review stack: #96666 → #96667 (this PR) → #96668 → #96669.
<!-- STACK_LINKS_END -->
