### PR TITLE
Next: add MCP edit transaction tools

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1465,5 +1465,17 @@
   "1464": "\\`experimental.turbopackChunkingHeuristics\\` has been renamed to \\`experimental.turbopackChunking\\`. Please update your next.config.js file accordingly.",
   "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead."
+  "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
+  "1468": "Changed paths exceed %s characters",
+  "1469": "Turbopack project is not available. This tool requires the Turbopack bundler.",
+  "1470": "Changed path leaves the Turbopack filesystem root: %s",
+  "1471": "Changed path is watched outside the Turbopack source transaction: %s",
+  "1472": "Changed path must be project-relative: %s",
+  "1473": "Edit transaction acknowledgement timed out; retry",
+  "1474": "Changed path leaves the project root: %s",
+  "1475": "Too many active edit transactions (limit %s)",
+  "1476": "Changed path traverses a symbolic link: %s",
+  "1477": "Changed path must identify a file, not a directory: %s",
+  "1478": "Changed path would activate TypeScript through an independent dev-server watcher: %s",
+  "1479": "Changed path must not contain parent-directory segments: %s"
 }

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -6,6 +6,7 @@ import { registerGetLogsTool } from './tools/get-logs'
 import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
+import { registerEditTransactionTools } from './tools/edit-transaction'
 import { registerCompileRouteTool } from './tools/compile-route'
 import { registerGetRequestInsightsTool } from './tools/get-request-insights'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
@@ -68,6 +69,22 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
 
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)
+    if (process.env.__NEXT_EXPERIMENTAL_EDIT_TRANSACTIONS === 'true') {
+      registerEditTransactionTools(
+        mcpServer,
+        options.projectPath,
+        options.nextConfig.turbopack?.root ||
+          options.nextConfig.outputFileTracingRoot ||
+          options.projectPath,
+        {
+          appDir: options.appDir,
+          pagesDir: options.pagesDir,
+          pageExtensions: options.nextConfig.pageExtensions,
+          tsconfigPath: options.nextConfig.typescript.tsconfigPath,
+        },
+        options.getTurbopackProject
+      )
+    }
   }
 
   if (options.compileRoute) {

--- a/packages/next/src/server/mcp/tools/edit-transaction-paths.ts
+++ b/packages/next/src/server/mcp/tools/edit-transaction-paths.ts
@@ -1,0 +1,360 @@
+import { existsSync, lstatSync, realpathSync } from 'node:fs'
+import path from 'node:path'
+import type { PageExtensions } from '../../../build/page-extensions-type'
+import {
+  getPossibleInstrumentationHookFilenames,
+  getPossibleMiddlewareFilenames,
+} from '../../../build/utils'
+import { createValidFileMatcher } from '../../lib/find-page-file'
+
+export const MAX_CHANGED_PATHS = 2_048
+const MAX_CHANGED_PATH_CHARACTERS = 1_048_576
+
+export type RouteWatcherOptions = {
+  appDir: string | undefined
+  pagesDir: string | undefined
+  pageExtensions: PageExtensions
+  tsconfigPath: string | undefined
+}
+
+function pathIsInside(directory: string, candidate: string) {
+  const relative = path.relative(directory, candidate)
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  )
+}
+
+function isCaseInsensitiveFileSystem(directory: string) {
+  let current = realpathSync.native(directory)
+  for (;;) {
+    const parent = path.dirname(current)
+    const name = path.basename(current)
+    const alternateName = name.replace(/[A-Za-z]/, (character) =>
+      character === character.toLowerCase()
+        ? character.toUpperCase()
+        : character.toLowerCase()
+    )
+    if (alternateName !== name) {
+      try {
+        return realpathSync.native(path.join(parent, alternateName)) === current
+      } catch (error) {
+        if (
+          error !== null &&
+          typeof error === 'object' &&
+          'code' in error &&
+          (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+        ) {
+          return false
+        }
+        throw error
+      }
+    }
+    if (parent === current) return process.platform === 'win32'
+    current = parent
+  }
+}
+
+function createRouteWatcherPathMatcher(
+  projectPath: string,
+  { appDir, pagesDir, pageExtensions }: RouteWatcherOptions,
+  caseInsensitive: boolean
+) {
+  const pathKey = (value: string) =>
+    caseInsensitive ? value.toLowerCase() : value
+  const matcherPageExtensions = pageExtensions.map(pathKey)
+  const pagesRoots = new Set(
+    [
+      pagesDir,
+      path.join(projectPath, 'pages'),
+      path.join(projectPath, 'src', 'pages'),
+    ]
+      .filter((directory): directory is string => directory !== undefined)
+      .map((directory) => pathKey(path.resolve(directory)))
+  )
+  const appRoots = new Set(
+    [
+      appDir,
+      path.join(projectPath, 'app'),
+      path.join(projectPath, 'src', 'app'),
+    ]
+      .filter((directory): directory is string => directory !== undefined)
+      .map((directory) => pathKey(path.resolve(directory)))
+  )
+  const pagesFileMatcher = createValidFileMatcher(
+    matcherPageExtensions,
+    undefined
+  )
+  const appFileMatchers = [...appRoots].map(
+    (directory) =>
+      [
+        directory,
+        createValidFileMatcher(matcherPageExtensions, directory),
+      ] as const
+  )
+  const rootConventionFiles = new Set(
+    [
+      ...getPossibleMiddlewareFilenames(projectPath, matcherPageExtensions),
+      ...getPossibleMiddlewareFilenames(
+        path.join(projectPath, 'src'),
+        matcherPageExtensions
+      ),
+      ...getPossibleInstrumentationHookFilenames(
+        projectPath,
+        matcherPageExtensions
+      ),
+      ...getPossibleInstrumentationHookFilenames(
+        path.join(projectPath, 'src'),
+        matcherPageExtensions
+      ),
+    ].map((file) => pathKey(path.resolve(file)))
+  )
+
+  return (absolute: string) => {
+    const candidate = pathKey(absolute)
+    if (rootConventionFiles.has(candidate)) return true
+    if (
+      [...pagesRoots].some((directory) => pathIsInside(directory, candidate)) &&
+      pagesFileMatcher.isPageFile(candidate)
+    ) {
+      return true
+    }
+    return appFileMatchers.some(
+      ([directory, matcher]) =>
+        pathIsInside(directory, candidate) &&
+        (matcher.isAppRouterPage(candidate) ||
+          matcher.isAppLayoutPage(candidate) ||
+          matcher.isAppDefaultPage(candidate) ||
+          matcher.isRootNotFound(candidate))
+    )
+  }
+}
+
+/**
+ * Resolve every existing segment to its filesystem spelling while rejecting symbolic links.
+ * Missing suffixes are appended to the last canonical existing ancestor because agents commonly
+ * declare files before creating them.
+ */
+function resolveCanonicalChangedPath(
+  projectRoot: string,
+  canonicalProjectRoot: string,
+  projectRelative: string,
+  changedPath: string
+) {
+  const segments = projectRelative.split(path.sep)
+  let lexicalCurrent = projectRoot
+  let canonicalCurrent = canonicalProjectRoot
+  for (let index = 0; index < segments.length; index++) {
+    lexicalCurrent = path.join(lexicalCurrent, segments[index])
+    try {
+      if (lstatSync(lexicalCurrent).isSymbolicLink()) {
+        throw new Error(
+          `Changed path traverses a symbolic link: ${changedPath}`
+        )
+      }
+      canonicalCurrent = realpathSync.native(lexicalCurrent)
+    } catch (error) {
+      if (
+        error !== null &&
+        typeof error === 'object' &&
+        'code' in error &&
+        (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+      ) {
+        return path.join(canonicalCurrent, ...segments.slice(index))
+      }
+      throw error
+    }
+  }
+  return canonicalCurrent
+}
+
+function resolveCanonicalConfiguredPath(
+  projectRoot: string,
+  canonicalProjectRoot: string,
+  configuredPath: string
+) {
+  try {
+    return realpathSync.native(configuredPath)
+  } catch (error) {
+    if (
+      error !== null &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+    ) {
+      return path.resolve(
+        canonicalProjectRoot,
+        path.relative(projectRoot, configuredPath)
+      )
+    }
+    throw error
+  }
+}
+
+export function resolveEditTransactionPaths(
+  projectPath: string,
+  turbopackRootPath: string,
+  routeWatcherOptions: RouteWatcherOptions,
+  changedPaths: string[]
+) {
+  const requestedPathCharacters = changedPaths.reduce(
+    (total, changedPath) => total + changedPath.length,
+    0
+  )
+  if (requestedPathCharacters > MAX_CHANGED_PATH_CHARACTERS) {
+    throw new Error(
+      `Changed paths exceed ${MAX_CHANGED_PATH_CHARACTERS} characters`
+    )
+  }
+  const projectRoot = path.resolve(projectPath)
+  const turbopackRoot = path.resolve(turbopackRootPath)
+  const canonicalProjectRoot = realpathSync.native(projectRoot)
+  const canonicalTurbopackRoot = realpathSync.native(turbopackRoot)
+  const caseInsensitive = isCaseInsensitiveFileSystem(canonicalProjectRoot)
+  const pathKey = (value: string) =>
+    caseInsensitive ? value.toLowerCase() : value
+  const configuredTsconfig = resolveCanonicalConfiguredPath(
+    projectRoot,
+    canonicalProjectRoot,
+    path.resolve(
+      projectRoot,
+      routeWatcherOptions.tsconfigPath ?? 'tsconfig.json'
+    )
+  )
+  const canonicalAppDir = routeWatcherOptions.appDir
+    ? resolveCanonicalConfiguredPath(
+        projectRoot,
+        canonicalProjectRoot,
+        routeWatcherOptions.appDir
+      )
+    : undefined
+  const canonicalPagesDir = routeWatcherOptions.pagesDir
+    ? resolveCanonicalConfiguredPath(
+        projectRoot,
+        canonicalProjectRoot,
+        routeWatcherOptions.pagesDir
+      )
+    : undefined
+  const isRouteWatcherPath = createRouteWatcherPathMatcher(
+    canonicalProjectRoot,
+    {
+      ...routeWatcherOptions,
+      appDir: canonicalAppDir,
+      pagesDir: canonicalPagesDir,
+    },
+    caseInsensitive
+  )
+  const hasTypeScriptConfiguration = existsSync(configuredTsconfig)
+  const typeScriptActivationRoots = [canonicalAppDir, canonicalPagesDir].filter(
+    (directory): directory is string => directory !== undefined
+  )
+  const resolved = new Set<string>()
+
+  for (const changedPath of new Set(changedPaths)) {
+    if (path.isAbsolute(changedPath)) {
+      throw new Error(`Changed path must be project-relative: ${changedPath}`)
+    }
+    const absolute = path.resolve(projectRoot, changedPath)
+    const projectRelative = path.relative(projectRoot, absolute)
+    if (
+      projectRelative === '' ||
+      projectRelative === '..' ||
+      projectRelative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(projectRelative)
+    ) {
+      throw new Error(`Changed path leaves the project root: ${changedPath}`)
+    }
+    if (changedPath.split(/[\\/]+/).includes('..')) {
+      throw new Error(
+        `Changed path must not contain parent-directory segments: ${changedPath}`
+      )
+    }
+
+    const canonicalAbsolute = resolveCanonicalChangedPath(
+      projectRoot,
+      canonicalProjectRoot,
+      projectRelative,
+      changedPath
+    )
+    try {
+      if (lstatSync(canonicalAbsolute).isDirectory()) {
+        throw new Error(
+          `Changed path must identify a file, not a directory: ${changedPath}`
+        )
+      }
+    } catch (error) {
+      if (
+        !(
+          error !== null &&
+          typeof error === 'object' &&
+          'code' in error &&
+          (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+        )
+      ) {
+        throw error
+      }
+    }
+    const canonicalProjectRelative = path.relative(
+      canonicalProjectRoot,
+      canonicalAbsolute
+    )
+
+    const normalizedProjectRelative = canonicalProjectRelative
+      .split(path.sep)
+      .join('/')
+    const reservedPath = pathKey(normalizedProjectRelative)
+    if (
+      /^\.env(?:\..+)?$/.test(reservedPath) ||
+      reservedPath === 'tsconfig.json' ||
+      reservedPath === 'jsconfig.json' ||
+      pathKey(canonicalAbsolute) === pathKey(configuredTsconfig) ||
+      /^next\.config\.(?:js|mjs|cjs|ts|mts|cts)$/.test(reservedPath) ||
+      isRouteWatcherPath(canonicalAbsolute)
+    ) {
+      throw new Error(
+        `Changed path is watched outside the Turbopack source transaction: ${changedPath}`
+      )
+    }
+    if (
+      !hasTypeScriptConfiguration &&
+      /\.tsx?$/.test(reservedPath) &&
+      typeScriptActivationRoots.some((directory) =>
+        pathIsInside(pathKey(directory), pathKey(canonicalAbsolute))
+      )
+    ) {
+      throw new Error(
+        `Changed path would activate TypeScript through an independent dev-server watcher: ${changedPath}`
+      )
+    }
+
+    const turbopackRelative = path.relative(
+      canonicalTurbopackRoot,
+      canonicalAbsolute
+    )
+    if (
+      turbopackRelative === '' ||
+      turbopackRelative === '..' ||
+      turbopackRelative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(turbopackRelative)
+    ) {
+      throw new Error(
+        `Changed path leaves the Turbopack filesystem root: ${changedPath}`
+      )
+    }
+    resolved.add(turbopackRelative)
+  }
+
+  const result = [...resolved]
+  const pathCharacters = result.reduce(
+    (total, changedPath) => total + changedPath.length,
+    0
+  )
+  if (pathCharacters > MAX_CHANGED_PATH_CHARACTERS) {
+    throw new Error(
+      `Changed paths exceed ${MAX_CHANGED_PATH_CHARACTERS} characters`
+    )
+  }
+  return result
+}

--- a/packages/next/src/server/mcp/tools/edit-transaction.test.ts
+++ b/packages/next/src/server/mcp/tools/edit-transaction.test.ts
@@ -1,0 +1,542 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import type { Project } from '../../../build/swc/types'
+import { registerEditTransactionTools } from './edit-transaction'
+
+type ToolResult = {
+  isError?: boolean
+  content: Array<{ type: 'text'; text: string }>
+}
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>
+
+const temporaryRoots: string[] = []
+
+function setup({
+  app = true,
+  pages = true,
+  pageExtensions = ['js', 'jsx', 'ts', 'tsx'],
+}: {
+  app?: boolean
+  pages?: boolean
+  pageExtensions?: string[]
+} = {}) {
+  const turbopackRoot = mkdtempSync(join(tmpdir(), 'next-edit-transaction-'))
+  temporaryRoots.push(turbopackRoot)
+  const projectPath = join(turbopackRoot, 'project')
+  mkdirSync(projectPath)
+  const appDir = app ? join(projectPath, 'app') : undefined
+  const pagesDir = pages ? join(projectPath, 'pages') : undefined
+  if (appDir) mkdirSync(appDir)
+  if (pagesDir) mkdirSync(pagesDir)
+  const handlers = new Map<string, ToolHandler>()
+  const server = {
+    registerTool(name: string, _definition: unknown, handler: ToolHandler) {
+      handlers.set(name, handler)
+    },
+  } as unknown as McpServer
+  let nextNativeToken = 1
+  let currentProject = {
+    beginEditTransaction: jest.fn(async () => nextNativeToken++),
+    renewEditTransaction: jest.fn(async () => true),
+    endEditTransaction: jest.fn(async () => true),
+  } as unknown as Project
+
+  registerEditTransactionTools(
+    server,
+    projectPath,
+    turbopackRoot,
+    {
+      appDir,
+      pagesDir,
+      pageExtensions,
+      tsconfigPath: 'tsconfig.app.json',
+    },
+    () => currentProject
+  )
+
+  const call = async (name: string, args: Record<string, unknown> = {}) => {
+    const result = await handlers.get(name)!(args)
+    return {
+      isError: result.isError === true,
+      value: JSON.parse(result.content[0].text),
+    }
+  }
+
+  return {
+    call,
+    projectPath,
+    turbopackRoot,
+    get project() {
+      return currentProject
+    },
+    setProject(project: Project) {
+      currentProject = project
+    },
+  }
+}
+
+describe('MCP edit transaction tools', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+    for (const root of temporaryRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('declares paths at begin and acknowledges the final flush', async () => {
+    jest.useFakeTimers()
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx', 'components/card.tsx'],
+    })
+
+    expect(started.value).toMatchObject({
+      status: 'started',
+      leaseMs: 4_000,
+      maximumDurationMs: 60_000,
+    })
+    expect(project.beginEditTransaction).toHaveBeenCalledWith([
+      join('project', 'components', 'card.tsx'),
+    ])
+
+    const ended = await call('end_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(ended.value.status).toBe('flushed')
+    expect(project.endEditTransaction).toHaveBeenCalledWith(1)
+  })
+
+  it('reports native contention without creating a public token', async () => {
+    const { call, project } = setup()
+    ;(project.beginEditTransaction as jest.Mock).mockResolvedValueOnce(null)
+
+    const result = await call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+    expect(result.value).toEqual({ status: 'busy', retryAfterMs: 25 })
+  })
+
+  it('renews the native lease and forgets rejected native tokens', async () => {
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+    expect(
+      (
+        await call('renew_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('renewed')
+    ;(project.renewEditTransaction as jest.Mock).mockResolvedValueOnce(false)
+    expect(
+      (
+        await call('renew_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('expired')
+    expect(
+      (
+        await call('end_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('unknown')
+  })
+
+  it('bounds abandoned JavaScript state while native owns crash recovery', async () => {
+    jest.useFakeTimers()
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+
+    jest.advanceTimersByTime(5_000)
+    expect(
+      (
+        await call('end_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('unknown')
+    expect(project.endEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('clamps renewal to the absolute native transaction deadline', async () => {
+    jest.useFakeTimers()
+    const { call } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+
+    for (let renewal = 0; renewal < 14; renewal++) {
+      jest.advanceTimersByTime(4_000)
+      expect(
+        (
+          await call('renew_edit_transaction', {
+            token: started.value.token,
+          })
+        ).value.status
+      ).toBe('renewed')
+    }
+    jest.advanceTimersByTime(3_000)
+    const finalRenewal = await call('renew_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(finalRenewal.value).toMatchObject({ status: 'renewed' })
+    expect(finalRenewal.value.leaseMs).toBeGreaterThan(0)
+    expect(finalRenewal.value.leaseMs).toBeLessThanOrEqual(1_000)
+
+    jest.advanceTimersByTime(1_000)
+    expect(
+      (
+        await call('end_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('unknown')
+  })
+
+  it('serializes an in-flight renewal before ending the transaction', async () => {
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+    let finishRenewal!: (renewed: boolean) => void
+    ;(project.renewEditTransaction as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishRenewal = resolve
+        })
+    )
+
+    const renewal = call('renew_edit_transaction', {
+      token: started.value.token,
+    })
+    await Promise.resolve()
+    const ending = call('end_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(project.endEditTransaction).not.toHaveBeenCalled()
+
+    finishRenewal(true)
+    expect((await renewal).value.status).toBe('renewed')
+    expect((await ending).value.status).toBe('flushed')
+    expect(
+      (
+        await call('end_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('unknown')
+  })
+
+  it('preserves the acknowledgement timeout when native cleanup fails', async () => {
+    jest.useFakeTimers()
+    const { call, project } = setup()
+    ;(project.beginEditTransaction as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          setTimeout(() => resolve(1), 4_000)
+        })
+    )
+    ;(project.endEditTransaction as jest.Mock).mockRejectedValueOnce(
+      new Error('watcher stopped')
+    )
+
+    const beginning = call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+    await jest.advanceTimersByTimeAsync(4_000)
+    const result = await beginning
+    expect(result.isError).toBe(true)
+    expect(result.value.error).toContain(
+      'Edit transaction acknowledgement timed out; retry'
+    )
+  })
+
+  it('retains the project instance that acknowledged the token', async () => {
+    const harness = setup()
+    const originalProject = harness.project
+    const started = await harness.call('begin_edit_transaction', {
+      changedPaths: ['components/card.tsx'],
+    })
+    const replacementProject = {
+      beginEditTransaction: jest.fn(),
+      renewEditTransaction: jest.fn(),
+      endEditTransaction: jest.fn(),
+    } as unknown as Project
+    harness.setProject(replacementProject)
+
+    await harness.call('end_edit_transaction', { token: started.value.token })
+    expect(originalProject.endEditTransaction).toHaveBeenCalledWith(1)
+    expect(replacementProject.endEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('keeps a token retryable when native end fails', async () => {
+    const { call, project } = setup()
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['generated.ts'],
+    })
+    ;(project.endEditTransaction as jest.Mock)
+      .mockRejectedValueOnce(new Error('flush failed'))
+      .mockResolvedValueOnce(true)
+
+    const failed = await call('end_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(failed.isError).toBe(true)
+    expect(failed.value.error).toBe('flush failed')
+
+    const retried = await call('end_edit_transaction', {
+      token: started.value.token,
+    })
+    expect(retried.value.status).toBe('flushed')
+    expect(project.endEditTransaction).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects paths handled by independent dev-server watchers', async () => {
+    const { call, project } = setup()
+    for (const changedPath of [
+      '.env.local',
+      'tsconfig.json',
+      'tsconfig.app.json',
+      'jsconfig.json',
+      'next.config.ts',
+      'app/page.tsx',
+      'app/api/route.ts',
+      'app/layout.tsx',
+      'app/icon.tsx',
+      'pages/index.tsx',
+      'middleware.ts',
+      'src/instrumentation.ts',
+    ]) {
+      const result = await call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(true)
+      expect(result.value.error).toContain(
+        'watched outside the Turbopack source transaction'
+      )
+    }
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('matches missing reserved files with filesystem case semantics', async () => {
+    const { call, turbopackRoot, project } = setup()
+    const caseInsensitive = existsSync(join(turbopackRoot, 'Project'))
+
+    for (const changedPath of [
+      '.ENV.LOCAL',
+      'TSCONFIG.APP.JSON',
+      'NEXT.CONFIG.TS',
+      'SRC/INSTRUMENTATION.TS',
+    ]) {
+      const result = await call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(caseInsensitive)
+      if (caseInsensitive) {
+        expect(result.value.error).toContain(
+          'watched outside the Turbopack source transaction'
+        )
+      } else {
+        expect(result.value.status).toBe('started')
+        expect(
+          (
+            await call('end_edit_transaction', {
+              token: result.value.token,
+            })
+          ).value.status
+        ).toBe('flushed')
+      }
+    }
+    expect(project.beginEditTransaction).toHaveBeenCalledTimes(
+      caseInsensitive ? 0 : 4
+    )
+
+    const missingRoutes = setup({ app: false, pages: false })
+    for (const changedPath of ['APP/PAGE.TSX', 'PAGES/INDEX.TSX']) {
+      const result = await missingRoutes.call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(caseInsensitive)
+      if (caseInsensitive) {
+        expect(result.value.error).toContain(
+          'watched outside the Turbopack source transaction'
+        )
+      } else {
+        expect(result.value.status).toBe('started')
+        expect(
+          (
+            await missingRoutes.call('end_edit_transaction', {
+              token: result.value.token,
+            })
+          ).value.status
+        ).toBe('flushed')
+      }
+    }
+  })
+
+  it('rejects the nested instrumentation hook watched in src layouts', async () => {
+    const { call, project } = setup()
+    const result = await call('begin_edit_transaction', {
+      changedPaths: ['src/src/instrumentation.ts'],
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.value.error).toContain(
+      'watched outside the Turbopack source transaction'
+    )
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects route files under router directories that do not exist yet', async () => {
+    const appOnly = setup({ pages: false })
+    for (const changedPath of ['pages/new.tsx', 'src/pages/new.tsx']) {
+      const result = await appOnly.call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(true)
+      expect(result.value.error).toContain(
+        'watched outside the Turbopack source transaction'
+      )
+    }
+
+    const pagesOnly = setup({ app: false })
+    for (const changedPath of ['app/new/page.tsx', 'src/app/new/layout.tsx']) {
+      const result = await pagesOnly.call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(true)
+      expect(result.value.error).toContain(
+        'watched outside the Turbopack source transaction'
+      )
+    }
+  })
+
+  it('matches case-folded routes with custom uppercase extensions', async () => {
+    const { call, project } = setup({
+      app: false,
+      pages: false,
+      pageExtensions: ['TSX'],
+    })
+
+    for (const changedPath of ['pages/new.TSX', 'app/new/page.TSX']) {
+      const result = await call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(result.isError).toBe(true)
+      expect(result.value.error).toContain(
+        'watched outside the Turbopack source transaction'
+      )
+    }
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects first-TypeScript activation with case-insensitive paths', async () => {
+    const { call, projectPath, turbopackRoot, project } = setup()
+    const nativeRealpath = realpathSync.native
+    const canonicalProjectPath = nativeRealpath(projectPath)
+    jest.spyOn(realpathSync, 'native').mockImplementation((candidate) => {
+      if (candidate === join(turbopackRoot, 'Project')) {
+        return canonicalProjectPath
+      }
+      return nativeRealpath(candidate)
+    })
+
+    for (const changedPath of [
+      'app/components/new.tsx',
+      'app/components/new.TSX',
+    ]) {
+      const rejected = await call('begin_edit_transaction', {
+        changedPaths: [changedPath],
+      })
+      expect(rejected.isError).toBe(true)
+      expect(rejected.value.error).toContain(
+        'activate TypeScript through an independent dev-server watcher'
+      )
+    }
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+
+    writeFileSync(join(projectPath, 'tsconfig.app.json'), '{}')
+    const started = await call('begin_edit_transaction', {
+      changedPaths: ['app/components/new.TSX'],
+    })
+    expect(started.value.status).toBe('started')
+    expect(project.beginEditTransaction).toHaveBeenCalledTimes(1)
+    expect(
+      (
+        await call('end_edit_transaction', {
+          token: started.value.token,
+        })
+      ).value.status
+    ).toBe('flushed')
+  })
+
+  it('rejects an existing directory before beginning', async () => {
+    const { call, projectPath, project } = setup()
+    mkdirSync(join(projectPath, 'components'))
+
+    const result = await call('begin_edit_transaction', {
+      changedPaths: ['components'],
+    })
+    expect(result.isError).toBe(true)
+    expect(result.value.error).toContain(
+      'must identify a file, not a directory'
+    )
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects paths that traverse a symbolic link', async () => {
+    const { call, projectPath, turbopackRoot, project } = setup()
+    const outsideProject = join(turbopackRoot, 'outside-project')
+    mkdirSync(outsideProject)
+    symlinkSync(
+      outsideProject,
+      join(projectPath, 'linked'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const result = await call('begin_edit_transaction', {
+      changedPaths: ['linked/card.tsx'],
+    })
+    expect(result.isError).toBe(true)
+    expect(result.value.error).toContain('traverses a symbolic link')
+
+    const parentSegmentResult = await call('begin_edit_transaction', {
+      changedPaths: ['linked/../victim.ts'],
+    })
+    expect(parentSegmentResult.isError).toBe(true)
+    expect(parentSegmentResult.value.error).toContain(
+      'must not contain parent-directory segments'
+    )
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects absolute paths and paths outside either root', async () => {
+    const { call, project } = setup()
+    for (const changedPath of ['/tmp/file.ts', '../file.ts', '.']) {
+      expect(
+        (
+          await call('begin_edit_transaction', {
+            changedPaths: [changedPath],
+          })
+        ).isError
+      ).toBe(true)
+    }
+    expect(project.beginEditTransaction).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/server/mcp/tools/edit-transaction.ts
+++ b/packages/next/src/server/mcp/tools/edit-transaction.ts
@@ -1,0 +1,275 @@
+/** Experimental MCP tools for publishing a multi-file agent edit as one Turbopack update. */
+import { randomUUID } from 'node:crypto'
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import z from 'next/dist/compiled/zod'
+import type { Project } from '../../../build/swc/types'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+import {
+  MAX_CHANGED_PATHS,
+  resolveEditTransactionPaths,
+  type RouteWatcherOptions,
+} from './edit-transaction-paths'
+
+const NATIVE_LEASE_MS = 5_000
+const CONTROLLER_LEASE_MS = 4_000
+const MAXIMUM_DURATION_MS = 60_000
+const MAX_ACTIVE_TRANSACTIONS = 32
+
+type EditTransaction = {
+  project: Project
+  nativeToken: number
+  maximumExpiration: number
+  nativeExpiration: number
+  operation: Promise<void>
+  pendingOperations: number
+}
+
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
+const errorResult = (error: unknown) => ({
+  isError: true,
+  content: [
+    {
+      type: 'text' as const,
+      text: JSON.stringify({
+        error: errorMessage(error),
+      }),
+    },
+  ],
+})
+
+const successResult = (value: object) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify(value) }],
+})
+
+export function registerEditTransactionTools(
+  server: McpServer,
+  projectPath: string,
+  turbopackRootPath: string,
+  routeWatcherOptions: RouteWatcherOptions,
+  getProject: () => Project | undefined
+) {
+  const activeTransactions = new Map<string, EditTransaction>()
+
+  function pruneExpiredTransactions(now = performance.now()) {
+    for (const [token, transaction] of activeTransactions) {
+      if (
+        transaction.pendingOperations === 0 &&
+        transaction.nativeExpiration <= now
+      ) {
+        activeTransactions.delete(token)
+      }
+    }
+  }
+
+  function getTransaction(token: string) {
+    const transaction = activeTransactions.get(token)
+    if (
+      transaction &&
+      transaction.pendingOperations === 0 &&
+      transaction.nativeExpiration <= performance.now()
+    ) {
+      activeTransactions.delete(token)
+      return undefined
+    }
+    return transaction
+  }
+
+  async function serializeTransaction<T>(
+    transaction: EditTransaction,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    transaction.pendingOperations++
+    const previousOperation = transaction.operation
+    let release!: () => void
+    transaction.operation = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previousOperation
+    try {
+      return await operation()
+    } finally {
+      transaction.pendingOperations--
+      release()
+    }
+  }
+
+  server.registerTool(
+    'begin_edit_transaction',
+    {
+      description:
+        'Begin one acknowledged Turbopack update before changing multiple files. ' +
+        'Declare every project-relative file path up front; directory declarations are rejected. Routing and configuration files are rejected ' +
+        'because independent dev-server watchers handle them. Adding the first TypeScript file to an app is also rejected until TypeScript setup completes. ' +
+        'Always end the returned token in a finally block.',
+      inputSchema: {
+        changedPaths: z
+          .array(z.string().min(1).max(4_096))
+          .min(1)
+          .max(MAX_CHANGED_PATHS),
+      },
+    },
+    async ({ changedPaths }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/begin_edit_transaction')
+      try {
+        pruneExpiredTransactions()
+        if (activeTransactions.size >= MAX_ACTIVE_TRANSACTIONS) {
+          throw new Error(
+            `Too many active edit transactions (limit ${MAX_ACTIVE_TRANSACTIONS})`
+          )
+        }
+        const project = getProject()
+        if (!project) {
+          throw new Error(
+            'Turbopack project is not available. This tool requires the Turbopack bundler.'
+          )
+        }
+        const resolvedPaths = resolveEditTransactionPaths(
+          projectPath,
+          turbopackRootPath,
+          routeWatcherOptions,
+          changedPaths
+        )
+        const startedAt = performance.now()
+        const nativeToken = await project.beginEditTransaction(resolvedPaths)
+        if (nativeToken === null) {
+          return successResult({ status: 'busy', retryAfterMs: 25 })
+        }
+        const acknowledgedAt = performance.now()
+        const maximumExpiration = startedAt + MAXIMUM_DURATION_MS
+        const leaseMs = Math.max(
+          0,
+          Math.min(startedAt + CONTROLLER_LEASE_MS, maximumExpiration) -
+            acknowledgedAt
+        )
+        if (leaseMs === 0) {
+          try {
+            await project.endEditTransaction(nativeToken)
+          } catch {
+            // The native lease remains the crash-safety fallback. Preserve the
+            // actionable controller timeout instead of masking it with cleanup.
+          }
+          throw new Error('Edit transaction acknowledgement timed out; retry')
+        }
+        const token = randomUUID()
+        activeTransactions.set(token, {
+          project,
+          nativeToken,
+          maximumExpiration,
+          nativeExpiration: Math.min(
+            startedAt + NATIVE_LEASE_MS,
+            maximumExpiration
+          ),
+          operation: Promise.resolve(),
+          pendingOperations: 0,
+        })
+        return successResult({
+          token,
+          status: 'started',
+          leaseMs,
+          maximumDurationMs: MAXIMUM_DURATION_MS,
+        })
+      } catch (error) {
+        return errorResult(error)
+      }
+    }
+  )
+
+  server.registerTool(
+    'renew_edit_transaction',
+    {
+      description:
+        'Renew the bounded lease for one active Turbopack edit transaction before leaseMs elapses.',
+      inputSchema: { token: z.string().uuid() },
+    },
+    async ({ token }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/renew_edit_transaction')
+      try {
+        const transaction = getTransaction(token)
+        if (!transaction) return successResult({ token, status: 'unknown' })
+        return await serializeTransaction(transaction, async () => {
+          if (activeTransactions.get(token) !== transaction) {
+            return successResult({ token, status: 'unknown' })
+          }
+          const startedAt = performance.now()
+          const renewed = await transaction.project.renewEditTransaction(
+            transaction.nativeToken
+          )
+          if (!renewed) {
+            activeTransactions.delete(token)
+            return successResult({ token, status: 'expired' })
+          }
+
+          transaction.nativeExpiration = Math.min(
+            startedAt + NATIVE_LEASE_MS,
+            transaction.maximumExpiration
+          )
+          const leaseMs = Math.max(
+            0,
+            Math.min(
+              startedAt + CONTROLLER_LEASE_MS,
+              transaction.maximumExpiration
+            ) - performance.now()
+          )
+          if (leaseMs === 0) {
+            activeTransactions.delete(token)
+            try {
+              await transaction.project.endEditTransaction(
+                transaction.nativeToken
+              )
+            } catch {
+              // Native expiration at the absolute deadline remains authoritative.
+            }
+            return successResult({ token, status: 'expired' })
+          }
+          return successResult({
+            token,
+            status: 'renewed',
+            leaseMs,
+          })
+        })
+      } catch (error) {
+        return errorResult(error)
+      }
+    }
+  )
+
+  server.registerTool(
+    'end_edit_transaction',
+    {
+      description:
+        'End one acknowledged Turbopack edit transaction after all declared writes complete. ' +
+        'A flushed result means invalidations were submitted before this call returned.',
+      inputSchema: { token: z.string().uuid() },
+    },
+    async ({ token }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/end_edit_transaction')
+      const transaction = getTransaction(token)
+      if (!transaction) return successResult({ token, status: 'unknown' })
+      try {
+        return await serializeTransaction(transaction, async () => {
+          if (activeTransactions.get(token) !== transaction) {
+            return successResult({ token, status: 'unknown' })
+          }
+          activeTransactions.delete(token)
+          let flushed: boolean
+          try {
+            flushed = await transaction.project.endEditTransaction(
+              transaction.nativeToken
+            )
+          } catch (error) {
+            activeTransactions.set(token, transaction)
+            throw error
+          }
+          return successResult({
+            token,
+            status: flushed ? 'flushed' : 'expired',
+          })
+        })
+      } catch (error) {
+        return errorResult(error)
+      }
+    }
+  )
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -283,6 +283,9 @@ export type McpToolName =
   | 'mcp/get_server_action_by_id'
   | 'mcp/get_compilation_issues'
   | 'mcp/compile_route'
+  | 'mcp/begin_edit_transaction'
+  | 'mcp/renew_edit_transaction'
+  | 'mcp/end_edit_transaction'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/packages/next/src/telemetry/events/mcp-telemetry.test.ts
+++ b/packages/next/src/telemetry/events/mcp-telemetry.test.ts
@@ -82,6 +82,9 @@ describe('MCP Telemetry Events', () => {
       'mcp/get_server_action_by_id',
       'mcp/get_compilation_issues',
       'mcp/compile_route',
+      'mcp/begin_edit_transaction',
+      'mcp/renew_edit_transaction',
+      'mcp/end_edit_transaction',
     ]
 
     const usages = allTools.map((tool, index) => ({
@@ -91,7 +94,7 @@ describe('MCP Telemetry Events', () => {
 
     const events = eventMcpToolUsage(usages)
 
-    expect(events).toHaveLength(9)
+    expect(events).toHaveLength(12)
 
     events.forEach((event, index) => {
       expect(event.eventName).toBe(EVENT_MCP_TOOL_USAGE)


### PR DESCRIPTION
## Summary

Add an opt-in Next development MCP adapter for one acknowledged, bounded edit
transaction.

This PR has three separately reviewable signed commits:

| Commit | Scope |
|---|---|
| `53eb363c48` | path ownership, canonicalization, containment |
| `ca2513c77c` | lifecycle, registration, generated metadata, telemetry |
| `5603b40ac9` | lifecycle/path regression tests |

The PR is seven files, +1,214/−2. Production policy and lifecycle are no longer
interleaved: `edit-transaction.ts` is **275 lines** (down from 663), while the
360-line path module can be reviewed independently. Focused tests are 542
lines.

## Tools

- `begin_edit_transaction`
- `renew_edit_transaction`
- `end_edit_transaction`

The adapter validates caller scope and translates one opaque UUID to one native
watcher token. The watcher remains the sole owner of invalidation batching and
flush safety.

## Deliberately narrow contract

- enabled only by `__NEXT_EXPERIMENTAL_EDIT_TRANSACTIONS=true`;
- one transaction per Turbopack project;
- 1–2,048 project-relative paths;
- at most 4,096 characters per path and 1 MiB total path text;
- conservative 4-second controller lease over the native 5-second lease;
- native non-extendable 60-second continuous maximum;
- begin: `started` or `busy`;
- renew: `renewed`, `expired`, or `unknown`;
- end: `flushed`, `expired`, or `unknown`;
- native end failure preserves the controller token for a safe retry.

Expiry is checked lazily at tool boundaries. A small `pendingOperations`
serialization guard preserves renew/end ordering without per-token timers or
rescheduling machinery.

## Path ownership and safety

The path module validates the project-root relationship and then performs
symlink-aware containment. Raw parent components are rejected before canonical
resolution can erase them. It rejects directories and paths owned by independent
Next dev-server watcher/control planes:

- `.env*`;
- `next.config.*`;
- `tsconfig.json` and `jsconfig.json`;
- Pages/App route convention files;
- root middleware, proxy, and instrumentation files.

The first TypeScript activation is rejected when no configured tsconfig exists.
The activation check uses the case-folded reserved path, so uppercase
`.TS`/`.TSX` cannot bypass the restriction on case-insensitive filesystems.
That fixes the Vercel Agent inline finding with a deterministic
`realpathSync.native` regression.

Post-flush advisory revalidation was removed in the simplification pass: it
could report only after the native commit and therefore did not provide an
enforceable correctness guarantee.

## Focused coverage

The 24-test MCP/telemetry set covers flag gating, busy/unknown/expired states,
renewal and cleanup, operation serialization, native-failure retry, binding,
path/count/byte bounds, traversal, symlinks, raw `..` after a symlink
component, directories, case renames, route/config rejection, first-TypeScript
activation (including uppercase extensions), and registration/telemetry.

## Real-v0 relevance

The complete A/B campaign and graphs are in #96666. At complaint-scale
(24 files, 150 ms gaps), the contract reduced:

- RSC waves: **11.625 → 1.000 (−91.4%)**;
- server renders: **12.563 → 1.000 (−92.0%)**;
- aborted RSC requests: **61 → 2 (−96.7%)**;
- summed RSC work: **21.94 s → 0.40 s (−98.2%)**;
- final-write-to-correct-preview: **1.98 s → 0.79 s (−60.3%)**.

After simplification, an exact-build private-v0 regression still produced one
RSC wave, one render, and zero visible intermediate revisions in all 12/12
measured edits across the realistic and stress workloads.

## Validation on the final source tree

Final tree: `d5a230df5a15f9dfb752763035cb4e773e810a7f`.

- focused MCP/telemetry Jest: **24/24**;
- native unit tests: **128/128**;
- strict Clippy: passed;
- full uncached Next build: **16/16 tasks**;
- optimized native release build: passed;
- packaged Chromium matrix: **24/24** across native, forced-recursive, and
  3-second polling modes;
- default autoreview panel (GPT-5.6 Sol xhigh + Claude Opus 5 xhigh):
  **zero actionable findings**.

<!-- STACK_LINKS_START -->
Review stack: #96666 → #96667 → #96668 (this PR) → #96669.
<!-- STACK_LINKS_END -->
