### PR TITLE
Remove cache revalidation execution mode reads

### DIFF
--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -342,6 +342,12 @@ export type StaticPrerenderStore = Exclude<
 export interface CommonCacheStore
   extends Omit<CommonWorkUnitStore, 'implicitTags'> {
   /**
+   * Whether a stale cache entry must be revalidated before the outer work unit
+   * can continue. This is copied from the outer work unit because entering a
+   * cache scope intentionally hides that store.
+   */
+  readonly shouldRevalidateStaleCacheEntryInForeground: boolean
+  /**
    * A cache work unit store might not always have an outer work unit store,
    * from which implicit tags could be inherited.
    */
@@ -438,6 +444,33 @@ export type WorkUnitStore =
   | CacheStore
   | PrerenderStore
   | GenerateStaticParamsStore
+
+export function shouldRevalidateStaleCacheEntryInForeground(
+  workUnitStore: WorkUnitStore | undefined
+): boolean {
+  if (!workUnitStore) {
+    return false
+  }
+
+  switch (workUnitStore.type) {
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+      return workUnitStore.shouldRevalidateStaleCacheEntryInForeground
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+      return true
+    case 'request':
+    case 'prerender-runtime':
+    case 'validation-client':
+    case 'generate-static-params':
+      return false
+    default:
+      return workUnitStore satisfies never
+  }
+}
 
 export type WorkUnitAsyncStorage = AsyncLocalStorage<WorkUnitStore>
 

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -22,6 +22,7 @@ import type { FetchMetric } from '../base-http'
 import { createDedupeFetch } from './dedupe-fetch'
 import {
   getCacheSignal,
+  shouldRevalidateStaleCacheEntryInForeground,
   type RevalidateStore,
   type WorkUnitAsyncStorage,
 } from '../app-render/work-unit-async-storage.external'
@@ -1082,7 +1083,10 @@ export function createPatchedFetcher(
             if (entry?.value && entry.value.kind === CachedRouteKind.FETCH) {
               // when stale and is revalidating we wait for fresh data
               // so the revalidated entry has the updated data
-              if (workStore.executionMode === 'prerender' && entry.isStale) {
+              if (
+                shouldRevalidateStaleCacheEntryInForeground(workUnitStore) &&
+                entry.isStale
+              ) {
                 isForegroundRevalidate = true
               } else {
                 if (entry.isStale) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -34,6 +34,7 @@ import {
   getCacheSignal,
   isHmrRefresh,
   getServerComponentsHmrCache,
+  shouldRevalidateStaleCacheEntryInForeground,
 } from '../app-render/work-unit-async-storage.external'
 
 import {
@@ -670,6 +671,8 @@ function createUseCacheStore(
     return {
       type: 'private-cache',
       phase: 'render',
+      shouldRevalidateStaleCacheEntryInForeground:
+        shouldRevalidateStaleCacheEntryInForeground(outerWorkUnitStore),
       implicitTags: outerWorkUnitStore?.implicitTags,
       revalidate: defaultCacheLife.revalidate,
       expire: defaultCacheLife.expire,
@@ -719,6 +722,8 @@ function createUseCacheStore(
     return {
       type: 'cache',
       phase: 'render',
+      shouldRevalidateStaleCacheEntryInForeground:
+        shouldRevalidateStaleCacheEntryInForeground(outerWorkUnitStore),
       implicitTags: outerWorkUnitStore.implicitTags,
       revalidate: defaultCacheLife.revalidate,
       expire: defaultCacheLife.expire,
@@ -3120,15 +3125,15 @@ export async function cache(
                 ? Math.max(entry.expire, MIN_PRERENDERABLE_EXPIRE)
                 : entry.expire) *
                 1000 ||
-          (workStore.executionMode === 'prerender' &&
+          (shouldRevalidateStaleCacheEntryInForeground(workUnitStore) &&
             currentTime > entry.timestamp + entry.revalidate * 1000)
         ) {
           // Miss. Generate a new result.
 
-          // If the cache entry is stale and we're prerendering, we don't want
-          // to use the stale entry since it would unnecessarily need to shorten
-          // the lifetime of the prerender. We're not time constrained here so
-          // we can re-generated it now.
+          // If the cache entry is stale and the outer work unit requires
+          // foreground revalidation, don't use the stale entry since it would
+          // unnecessarily shorten the lifetime of the generated result. We're
+          // not time constrained here, so regenerate it now.
 
           // We need to run this inside a clean AsyncLocalStorage snapshot so
           // that the cache generation cannot read anything from the context
@@ -3144,10 +3149,13 @@ export async function cache(
             }
 
             if (
-              workStore.executionMode === 'prerender' &&
+              shouldRevalidateStaleCacheEntryInForeground(workUnitStore) &&
               currentTime > entry.timestamp + entry.revalidate * 1000
             ) {
-              debug?.('static generation, entry is stale', cacheHandlerKey)
+              debug?.(
+                'foreground revalidation, entry is stale',
+                cacheHandlerKey
+              )
             }
           }
 

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -9,6 +9,7 @@ import {
 import {
   getCacheSignal,
   getDraftModeProviderForCacheScope,
+  shouldRevalidateStaleCacheEntryInForeground,
   workUnitAsyncStorage,
 } from '../../app-render/work-unit-async-storage.external'
 import {
@@ -146,6 +147,8 @@ export function unstable_cache<T extends Callback>(
       const innerCacheStore: UnstableCacheStore = {
         type: 'unstable-cache',
         phase: 'render',
+        shouldRevalidateStaleCacheEntryInForeground:
+          shouldRevalidateStaleCacheEntryInForeground(workUnitStore),
         implicitTags,
         draftMode:
           workUnitStore &&
@@ -280,7 +283,9 @@ export function unstable_cache<T extends Callback>(
 
                   // Attach the empty catch here so we don't get a "unhandled promise
                   // rejection" warning. (Behavior is matched with patch-fetch)
-                  if (workStore.executionMode === 'prerender') {
+                  if (
+                    shouldRevalidateStaleCacheEntryInForeground(workUnitStore)
+                  ) {
                     revalidationPromise.catch(() => {})
                   }
 
@@ -289,7 +294,9 @@ export function unstable_cache<T extends Callback>(
                 }
 
                 // Check if we need to do foreground revalidation
-                if (workStore.executionMode === 'prerender') {
+                if (
+                  shouldRevalidateStaleCacheEntryInForeground(workUnitStore)
+                ) {
                   // When the page is revalidating and the cache entry is stale,
                   // we need to wait for fresh data (blocking revalidate). The
                   // `await` here keeps `cacheSignal.endRead` (in the outer

--- a/test/production/app-dir/unstable-cache-foreground-revalidate/app/isr-10-nested/page.js
+++ b/test/production/app-dir/unstable-cache-foreground-revalidate/app/isr-10-nested/page.js
@@ -1,0 +1,37 @@
+import { unstable_cache } from 'next/cache'
+
+export const revalidate = 10
+
+const getCachedData = unstable_cache(
+  async () => {
+    const generatedAt = Date.now()
+
+    console.log(
+      '[NESTED TEST] unstable_cache callback executed at:',
+      generatedAt
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    return { generatedAt }
+  },
+  ['nested-inner-cached-data'],
+  { revalidate: 5 }
+)
+
+const getNestedCachedData = unstable_cache(
+  async () => getCachedData(),
+  ['nested-outer-cached-data'],
+  { revalidate: 5 }
+)
+
+export default async function Page() {
+  const cachedData = await getNestedCachedData()
+
+  console.log(
+    '[NESTED TEST] Page render completed with cache data from:',
+    cachedData.generatedAt
+  )
+
+  return <div id="cache-generated-at">{cachedData.generatedAt}</div>
+}

--- a/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts
+++ b/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts
@@ -70,4 +70,42 @@ describe('unstable-cache-foreground-revalidate', () => {
     // - ISR uses stale data, so timestamps will be far apart (> 10000ms)
     expect(timeDiff).toBeLessThan(1000)
   })
+
+  it('should propagate foreground revalidation through nested unstable_cache scopes', async () => {
+    await next.render('/isr-10-nested')
+
+    const initialLogLength = next.cliOutput.length
+
+    await new Promise((resolve) => setTimeout(resolve, 11000))
+
+    await next.render('/isr-10-nested')
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const logs = next.cliOutput.substring(initialLogLength)
+    const cacheExecutions = [
+      ...logs.matchAll(
+        /\[NESTED TEST\] unstable_cache callback executed at: (\d+)/g
+      ),
+    ]
+    const completions = [
+      ...logs.matchAll(
+        /\[NESTED TEST\] Page render completed with cache data from: (\d+)/g
+      ),
+    ]
+
+    const lastCacheExecution = cacheExecutions.at(-1)
+    const lastCompletion = completions.at(-1)
+
+    if (!lastCacheExecution || !lastCompletion) {
+      throw new Error(
+        `Expected nested cache execution and page completion during ISR revalidation. ` +
+          `Cache executions: ${cacheExecutions.length}, Page completions: ${completions.length}`
+      )
+    }
+
+    const cacheExecutedAt = parseInt(lastCacheExecution[1])
+    const cacheDataFrom = parseInt(lastCompletion[1])
+
+    expect(Math.abs(cacheExecutedAt - cacheDataFrom)).toBeLessThan(1000)
+  })
 })


### PR DESCRIPTION
## Summary

- derive foreground stale-cache revalidation from Work Unit state instead of `WorkStore.executionMode`
- propagate that specific policy through `"use cache"` and `unstable_cache` scopes so nested cache and fetch calls preserve their outer behavior
- add coverage for foreground ISR revalidation through nested `unstable_cache` scopes

This is intended to be a behavior-preserving refactor.