### PR TITLE
Remove WorkStore execution mode

### DIFF
--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -897,7 +897,6 @@ export async function buildAppStaticPaths({
 
   const store = createWorkStore({
     page,
-    executionMode: 'request',
     renderOpts: {
       incrementalCache,
       cacheLifeProfiles,

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1,7 +1,6 @@
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { FallbackRouteParam } from '../static-paths/types'
-import type { WorkStoreExecutionMode } from '../../server/app-render/work-async-storage.external'
 
 import {
   AppPageRouteModule,
@@ -93,6 +92,8 @@ import { InvariantError } from '../../shared/lib/invariant-error' with { 'turbop
 import { scheduleOnNextTick } from '../../lib/scheduler' with { 'turbopack-transition': 'next-server-utility' }
 import { isInterceptionRouteAppPath } from '../../shared/lib/router/utils/interception-routes' with { 'turbopack-transition': 'next-server-utility' }
 import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param' with { 'turbopack-transition': 'next-server-utility' }
+
+type AppPageRenderOperation = 'render' | 'prerender'
 
 /**
  * Builds the cache key for the most complete prerenderable shell we can derive
@@ -743,13 +744,13 @@ export function createAppPageEntrypoint({
       const invokeRouteModule = async (
         span: Span | undefined,
         context: AppPageRouteHandlerContext,
-        executionMode: WorkStoreExecutionMode
+        renderOperation: AppPageRenderOperation
       ) => {
         const nextReq = new NodeNextRequest(req)
         const nextRes = new NodeNextResponse(res)
 
         const result =
-          executionMode === 'prerender'
+          renderOperation === 'prerender'
             ? routeModule.prerender(nextReq, nextRes, context)
             : routeModule.render(nextReq, nextRes, context)
 
@@ -827,7 +828,7 @@ export function createAppPageEntrypoint({
         span,
         postponed,
         fallbackRouteParams,
-        executionMode,
+        renderOperation,
         allowEmptyStaticShell,
       }: {
         span?: Span
@@ -844,7 +845,7 @@ export function createAppPageEntrypoint({
          */
         fallbackRouteParams: OpaqueFallbackRouteParams | null
 
-        executionMode: WorkStoreExecutionMode
+        renderOperation: AppPageRenderOperation
       }): Promise<ResponseCacheEntry> => {
         const context: AppPageRouteHandlerContext = {
           query,
@@ -874,7 +875,7 @@ export function createAppPageEntrypoint({
             allowEmptyStaticShell,
             serveStreamingMetadata,
             supportsDynamicResponse:
-              executionMode === 'request' &&
+              renderOperation === 'render' &&
               (typeof postponed === 'string' || supportsDynamicResponse),
             buildManifest,
             nextFontManifest,
@@ -991,7 +992,7 @@ export function createAppPageEntrypoint({
           },
         }
 
-        const result = await invokeRouteModule(span, context, executionMode)
+        const result = await invokeRouteModule(span, context, renderOperation)
 
         const { metadata } = result
 
@@ -1263,7 +1264,7 @@ export function createAppPageEntrypoint({
                     // the background path below will complete the shell into a
                     // more specific cache entry for later requests.
                     fallbackRouteParams,
-                    executionMode: 'prerender',
+                    renderOperation: 'prerender',
                     allowEmptyStaticShell: isInstantNavigationTest || undefined,
                   }),
                 waitUntil: ctx.waitUntil,
@@ -1321,7 +1322,7 @@ export function createAppPageEntrypoint({
                                     remainingFallbackRouteParams
                                   )
                                 : null,
-                            executionMode: 'prerender',
+                            renderOperation: 'prerender',
                           })
                         },
                         // We don't have a prior entry for this param-specific shell.
@@ -1579,7 +1580,7 @@ export function createAppPageEntrypoint({
             span,
             postponed,
             fallbackRouteParams,
-            executionMode: isRequestSpecificRender ? 'request' : 'prerender',
+            renderOperation: isRequestSpecificRender ? 'render' : 'prerender',
             allowEmptyStaticShell: isInstantNavigationTest || undefined,
           })
         } catch (err) {
@@ -2122,7 +2123,7 @@ export function createAppPageEntrypoint({
           // This is a resume render, not a fallback render. Fallback params
           // (for cacheComponents routes) are plumbed via request meta above.
           fallbackRouteParams: null,
-          executionMode: 'request',
+          renderOperation: 'render',
         })
           .then(async (result) => {
             if (!result) {

--- a/packages/next/src/client/components/handle-isr-error.tsx
+++ b/packages/next/src/client/components/handle-isr-error.tsx
@@ -1,16 +1,33 @@
-import { workAsyncStorage } from './server-async-storage'
+import { workUnitAsyncStorage } from './server-async-storage'
 
 // if we are revalidating we want to re-throw the error so the
 // function crashes so we can maintain our previous cache
 // instead of caching the error page
 export function handleISRError({ error }: { error: any }) {
-  if (workAsyncStorage) {
-    const store = workAsyncStorage.getStore()
-    if (store?.executionMode === 'prerender') {
+  if (!workUnitAsyncStorage) {
+    return
+  }
+
+  const store = workUnitAsyncStorage.getStore()
+  switch (store?.type) {
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
       if (error) {
         console.error(error)
       }
       throw error
-    }
+    case 'request':
+    case 'prerender-runtime':
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+    case undefined:
+      return
+    default:
+      store satisfies never
   }
 }

--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -706,7 +706,6 @@ const createMockWorkStore = (afterContext: AfterContext): WorkStore => {
     forceStatic: false,
     forceDynamic: false,
     dynamicShouldError: false,
-    executionMode: 'request',
     pendingRevalidatedTags: [],
     pendingRevalidates: undefined,
     pendingRevalidateWrites: undefined,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -87,7 +87,10 @@ import {
   createRequestStoreForRender,
 } from '../async-storage/request-store'
 import { isRSCRequestHeader } from '../lib/is-rsc-request'
-import { createWorkStore } from '../async-storage/work-store'
+import {
+  createPrerenderWorkStore,
+  createWorkStore,
+} from '../async-storage/work-store'
 import { formatValidationEvent } from './dev-validation-events'
 import { createSnapshot } from './async-local-storage'
 import {
@@ -3354,7 +3357,6 @@ export const renderToHTMLOrFlight: AppPageRender = (
     parsedRequestHeaders
   const workStore = createWorkStore({
     page: renderOpts.routeModule.definition.page,
-    executionMode: 'request',
     renderOpts,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,
@@ -3401,9 +3403,8 @@ export const prerenderToHTMLOrFlight: AppPageRender = (
   )
   const { isPrefetchRequest, previouslyRevalidatedTags, nonce } =
     parsedRequestHeaders
-  const workStore = createWorkStore({
+  const workStore = createPrerenderWorkStore({
     page: renderOpts.routeModule.definition.page,
-    executionMode: 'prerender',
     renderOpts,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,
@@ -6554,7 +6555,6 @@ function buildDevValidationWorkStore(
   })
 
   return {
-    executionMode: 'request',
     page: message.page,
     route: message.route,
     forceStatic: message.forceStatic,
@@ -8137,7 +8137,6 @@ async function validateInstantConfigInBuildWithSample(
 
   // NOTE: Matching the field order in `createWorkStore` to avoid deopting.
   const workStore: WorkStore = {
-    executionMode: 'request',
     page: outerWorkStore.page,
     route: outerWorkStore.route,
     incrementalCache: outerWorkStore.incrementalCache,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -14,16 +14,7 @@ import type { LazyResult } from '../lib/lazy-result'
 import type { DigestedError } from './create-error-handler'
 import type { ActionRevalidationKind } from '../../shared/lib/action-revalidation-kind'
 
-export type WorkStoreExecutionMode = 'prerender' | 'request'
-
 export interface WorkStore {
-  /**
-   * Whether this invocation produces reusable prerender output or renders a
-   * response for the current request. Prerendering includes both build-time
-   * generation and runtime revalidation.
-   */
-  readonly executionMode: WorkStoreExecutionMode
-
   /**
    * The page that is being rendered. This relates to the path to the page file.
    */

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -1,7 +1,4 @@
-import type {
-  WorkStore,
-  WorkStoreExecutionMode,
-} from '../app-render/work-async-storage.external'
+import type { WorkStore } from '../app-render/work-async-storage.external'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { RenderOpts } from '../app-render/types'
 import type { FetchMetric } from '../base-http'
@@ -24,12 +21,6 @@ export type WorkStoreContext = {
    * The page that is being rendered. This relates to the path to the page file.
    */
   page: string
-
-  /**
-   * Whether this invocation produces reusable prerender output or renders a
-   * response for the current request.
-   */
-  executionMode: WorkStoreExecutionMode
 
   isPrefetchRequest?: boolean
   nonce?: string
@@ -94,27 +85,32 @@ export type WorkStoreContext = {
   previouslyRevalidatedTags: string[]
 }
 
-export function createWorkStore({
-  page,
-  executionMode,
-  renderOpts,
-  isPrefetchRequest,
-  buildId,
-  deploymentId,
-  previouslyRevalidatedTags,
-  nonce,
-}: WorkStoreContext): WorkStore {
-  const shouldTrackFetchMetrics =
-    !!process.env.__NEXT_DEV_SERVER ||
-    // The only times we want to track fetch metrics outside of development is
-    // when we are performing a static generation and we either are in debug
-    // mode, or tracking fetch metrics was specifically opted into.
-    (executionMode === 'prerender' &&
-      (!!process.env.NEXT_DEBUG_BUILD ||
-        process.env.NEXT_SSG_FETCH_METRICS === '1'))
+export function createWorkStore(context: WorkStoreContext): WorkStore {
+  return createWorkStoreImpl(context, !!process.env.__NEXT_DEV_SERVER)
+}
 
+export function createPrerenderWorkStore(context: WorkStoreContext): WorkStore {
+  return createWorkStoreImpl(
+    context,
+    !!process.env.__NEXT_DEV_SERVER ||
+      !!process.env.NEXT_DEBUG_BUILD ||
+      process.env.NEXT_SSG_FETCH_METRICS === '1'
+  )
+}
+
+function createWorkStoreImpl(
+  {
+    page,
+    renderOpts,
+    isPrefetchRequest,
+    buildId,
+    deploymentId,
+    previouslyRevalidatedTags,
+    nonce,
+  }: WorkStoreContext,
+  shouldTrackFetchMetrics: boolean
+): WorkStore {
   const store: WorkStore = {
-    executionMode,
     page,
     route: normalizeAppPath(page),
     incrementalCache:

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -197,7 +197,6 @@ function buildProbeWorkStore(msg: ProbeMessage): WorkStore {
   })
 
   return {
-    executionMode: 'request',
     page: msg.page,
     route: msg.route,
     useCacheProbeMode: { timeoutMs: msg.timeoutMs },

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -25,6 +25,7 @@ import {
   shouldRevalidateStaleCacheEntryInForeground,
   type RevalidateStore,
   type WorkUnitAsyncStorage,
+  type WorkUnitStore,
 } from '../app-render/work-unit-async-storage.external'
 import {
   CachedRouteKind,
@@ -40,6 +41,44 @@ import { encodeCacheTag } from './encode-cache-tag'
 import type { Span } from './trace/tracer'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
+
+/**
+ * Whether fetch cache configuration needs to be processed for the current work
+ * unit before an origin fetch. Static prerender stores use it for dynamic
+ * access tracking. Cache scopes apply it to their own cache policy, regardless
+ * of which outer work unit created them. Development staged renders additionally
+ * coordinate dynamic fetches with the dynamic render stage.
+ */
+function shouldProcessFetchConfigForWorkUnit(
+  workUnitStore: WorkUnitStore | undefined
+): boolean {
+  if (!workUnitStore) {
+    return false
+  }
+
+  switch (workUnitStore.type) {
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+      return true
+    case 'request':
+      return Boolean(
+        process.env.NODE_ENV === 'development' &&
+          process.env.__NEXT_CACHE_COMPONENTS &&
+          workUnitStore.stagedRendering
+      )
+    case 'prerender-runtime':
+    case 'validation-client':
+    case 'generate-static-params':
+      return false
+    default:
+      return workUnitStore satisfies never
+  }
+}
 
 type Fetcher = typeof fetch
 
@@ -1147,15 +1186,9 @@ export function createPatchedFetcher(
         }
 
         if (
-          (workStore.executionMode === 'prerender' ||
-            (process.env.NODE_ENV === 'development' &&
-              process.env.__NEXT_CACHE_COMPONENTS &&
-              workUnitStore &&
-              // eslint-disable-next-line no-restricted-syntax
-              workUnitStore.type === 'request' &&
-              workUnitStore.stagedRendering)) &&
           init &&
-          typeof init === 'object'
+          typeof init === 'object' &&
+          shouldProcessFetchConfigForWorkUnit(workUnitStore)
         ) {
           const { cache } = init
 

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -703,7 +703,6 @@ describe('local span recording', () => {
           require('./tracer') as typeof import('./tracer')
 
         const workStore = {
-          executionMode: 'request',
           page: '/products/[id]/page',
           route: '/products/[id]',
           cacheComponentsEnabled: true,

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -14,6 +14,7 @@ import {
 } from '../route-module'
 import { createRequestStoreForAPI } from '../../async-storage/request-store'
 import {
+  createPrerenderWorkStore,
   createWorkStore,
   type WorkStoreContext,
 } from '../../async-storage/work-store'
@@ -1074,7 +1075,6 @@ export class AppRouteRouteModule extends RouteModule<
     const prepared = await this.prepareExecution(req, context)
     const workStore = createWorkStore({
       page: this.definition.page,
-      executionMode: 'request',
       renderOpts: context.renderOpts,
       buildId: context.sharedContext.buildId,
       deploymentId: context.sharedContext.deploymentId,
@@ -1089,9 +1089,8 @@ export class AppRouteRouteModule extends RouteModule<
     context: AppRouteRouteHandlerContext
   ): Promise<Response> {
     const prepared = await this.prepareExecution(req, context)
-    const workStore = createWorkStore({
+    const workStore = createPrerenderWorkStore({
       page: this.definition.page,
-      executionMode: 'prerender',
       renderOpts: context.renderOpts,
       buildId: context.sharedContext.buildId,
       deploymentId: context.sharedContext.deploymentId,

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -321,7 +321,6 @@ export async function adapter(
 
             const workStore = createWorkStore({
               page,
-              executionMode: 'request',
               renderOpts: {
                 cacheLifeProfiles: proxyCacheLifeProfiles,
                 // Proxy doesn't do static generation, so this value does not


### PR DESCRIPTION
## Summary

This removes the intermediate `executionMode` from `WorkStore` now that App Page and App Route select their render or prerender pipeline before constructing the store.

- Derive ISR error handling from the active `WorkUnitStore`
- Derive fetch configuration processing from the active `WorkUnitStore`, including treating cache scopes as owners of their cache policy regardless of the outer render operation
- Use explicit render and prerender WorkStore constructors where fetch-metric behavior differs
- Keep the App Page render/prerender operation local to the top-level route-module dispatch

This completes the migration away from global render-mode state on `WorkStore`, allowing downstream behavior to depend on the more precise work-unit scope instead.

<!-- NEXT_JS_LLM -->