### PR TITLE
turbo-tasks-backend: let a GC pass wind down when it is blocking an operation

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -284,7 +284,6 @@ impl TurboTasksBackend {
 
         stats.gc_roots = roots.len();
         stats.aged_out_roots = aged_out_count;
-        // No budget means an uninterruptible pass, which by construction never interrupts.
         stats.interrupted = budget
             .as_ref()
             .is_some_and(|budget| budget.was_interrupted());
@@ -385,9 +384,7 @@ impl TurboTasksBackend {
         );
         let _serialize = self.snapshot_in_progress.lock();
         let phase = self.snapshot_coord.begin_snapshot();
-        // Uninterruptible: the exact-count tests this hook exists for need a full pass, and an
-        // interrupted one would silently collect less than they assert.
-        let (stats, roots) = self.gc_collect(turbo_tasks, &phase, false);
+        let (stats, roots) = self.gc_collect(turbo_tasks, &phase, /* interruptible= */ false);
 
         // Persist the roots map this pass produced. Some tests query the roots set and GC itself
         // does as well, this ensures it is available to the next cycle.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -122,26 +122,6 @@ pub(crate) struct GcStats {
     pub interrupted: bool,
 }
 
-/// Test-only snapshot of the most recent [`GcStats`]. Production reads these off the `gc` span; a
-/// unit test can't, so [`TurboTasksBackend`] stashes this after each pass. Kept as a small `Copy`
-/// struct so it can be cloned out from behind the mutex cheaply.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct LastGcStats {
-    /// Tasks collected this pass (soft-deleted). See [`GcStats::collected`].
-    pub collected: usize,
-    /// Whether the pass was interrupted by a waiting operation. See [`GcStats::interrupted`].
-    pub interrupted: bool,
-}
-
-impl From<&GcStats> for LastGcStats {
-    fn from(stats: &GcStats) -> Self {
-        Self {
-            collected: stats.collected,
-            interrupted: stats.interrupted,
-        }
-    }
-}
-
 impl Display for GcStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -408,11 +388,6 @@ impl TurboTasksBackend {
         // Uninterruptible: the exact-count tests this hook exists for need a full pass, and an
         // interrupted one would silently collect less than they assert.
         let (stats, roots) = self.gc_collect(turbo_tasks, &phase, false);
-
-        // Record the pass stats so the test-only hook (`last_gc_stats_for_testing`) reflects this
-        // direct pass too — production records these in `snapshot_and_persist`, which this hook
-        // bypasses.
-        *self.last_gc_stats.lock() = Some((&stats).into());
 
         // Persist the roots map this pass produced. Some tests query the roots set and GC itself
         // does as well, this ensures it is available to the next cycle.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -118,10 +118,7 @@ pub(crate) struct GcStats {
     pub aged_out_roots: usize,
     /// Persisted roots that this pass collected, to be dropped from the roots map.
     pub deleted_roots: Vec<TaskId>,
-    /// Whether the pass wound down early because an operation was waiting on the exclusion (see
-    /// [`GcBudget`]). An interrupted pass is not an error — the work it skipped is re-derived by
-    /// the next pass — but a dev session where this is always true means GC is never finishing and
-    /// the floor may need raising.
+    /// The gc loop was interrupted by competing work.
     pub interrupted: bool,
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -19,7 +19,8 @@
 use std::{
     fmt::Display,
     ops::ControlFlow,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use bincode::{Decode, Encode};
@@ -28,12 +29,12 @@ use turbo_tasks::{TaskId, TurboTasks, scope_unbounded::scope_unbounded_with};
 
 use crate::{
     backend::{
-        AnyOperation, TurboTasksBackend,
+        AnyOperation, GC_MIN_PROGRESS, TurboTasksBackend,
         operation::{
             AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
             TaskGuard, capture_all_outgoing_edges,
         },
-        snapshot_coordinator::SnapshotPhase,
+        snapshot_coordinator::{SnapshotCoordinator, SnapshotPhase},
         storage::{SpecificTaskDataCategory, TaskDataCategory},
         storage_schema::TaskStorageAccessors,
     },
@@ -70,6 +71,37 @@ enum GcJob {
     Collect(TaskId),
 }
 
+/// Decides when a GC pass should stop early because it is delaying real work.
+struct GcBudget<'a> {
+    coord: &'a SnapshotCoordinator<AnyOperation>,
+    started: Instant,
+    min_progress: Duration,
+    /// Latched on the first trip. Re-polling per job would let a waiter that arrives and leaves
+    /// produce a ragged pass that stops and starts; once we have decided to wind down, we commit.
+    /// Also reports whether the pass was interrupted, for [`GcStats`].
+    stopped: AtomicBool,
+}
+
+impl GcBudget<'_> {
+    fn should_stop(&self) -> bool {
+        if self.stopped.load(Ordering::Relaxed) {
+            return true;
+        }
+        if self.started.elapsed() < self.min_progress {
+            return false;
+        }
+        if !self.coord.operations_waiting() {
+            return false;
+        }
+        self.stopped.store(true, Ordering::Relaxed);
+        true
+    }
+
+    fn was_interrupted(&self) -> bool {
+        self.stopped.load(Ordering::Relaxed)
+    }
+}
+
 /// Observability counters for one [`TurboTasksBackend::gc_collect`] pass.
 #[derive(Default, Debug)]
 pub(crate) struct GcStats {
@@ -83,6 +115,38 @@ pub(crate) struct GcStats {
     pub aged_out_roots: usize,
     /// Persisted roots that this pass collected, to be dropped from the roots map.
     pub deleted_roots: Vec<TaskId>,
+    /// Whether the pass wound down early because an operation was waiting on the exclusion (see
+    /// [`GcBudget`]). An interrupted pass is not an error — the work it skipped is re-derived by
+    /// the next pass — but a dev session where this is always true means GC is never finishing and
+    /// the floor may need raising.
+    pub interrupted: bool,
+    /// Jobs dropped by the interrupt: queued work the pass chose not to start. Distinct from jobs
+    /// skipped because the task was no longer collectible, which is ordinary concurrent
+    /// re-validation rather than lost progress.
+    pub abandoned: usize,
+}
+
+/// Test-only snapshot of the most recent [`GcStats`]. Production reads these off the `gc` span; a
+/// unit test can't, so [`TurboTasksBackend`] stashes this after each pass. Kept as a small `Copy`
+/// struct so it can be cloned out from behind the mutex cheaply.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LastGcStats {
+    /// Tasks collected this pass (soft-deleted). See [`GcStats::collected`].
+    pub collected: usize,
+    /// Queued work the pass abandoned when it wound down early. See [`GcStats::abandoned`].
+    pub abandoned: usize,
+    /// Whether the pass was interrupted by a waiting operation. See [`GcStats::interrupted`].
+    pub interrupted: bool,
+}
+
+impl From<&GcStats> for LastGcStats {
+    fn from(stats: &GcStats) -> Self {
+        Self {
+            collected: stats.collected,
+            abandoned: stats.abandoned,
+            interrupted: stats.interrupted,
+        }
+    }
 }
 
 impl Display for GcStats {
@@ -90,11 +154,14 @@ impl Display for GcStats {
         write!(
             f,
             "gc_roots = {gc_roots}, collected: {collected}, edges_deleted: {edges_deleted}, \
-             aged_out_roots = {aged_out_roots}",
+             aged_out_roots = {aged_out_roots}, interrupted = {interrupted}, abandoned = \
+             {abandoned}",
             gc_roots = self.gc_roots,
             collected = self.collected,
             edges_deleted = self.edges_deleted,
-            aged_out_roots = self.aged_out_roots
+            aged_out_roots = self.aged_out_roots,
+            interrupted = self.interrupted,
+            abandoned = self.abandoned
         )
     }
 }
@@ -113,6 +180,7 @@ impl GcStats {
         } else {
             self.deleted_roots.append(&mut other.deleted_roots);
         }
+        self.abandoned += other.abandoned;
         self
     }
 }
@@ -147,6 +215,15 @@ impl TurboTasksBackend {
 
         let aged_out_count = aged_out.len();
         // TODO(perf): recycle the task ids of collected tasks.
+        let budget = GcBudget {
+            coord: &self.snapshot_coord,
+            started: Instant::now(),
+            min_progress: self.gc_min_progress(),
+            stopped: AtomicBool::new(false),
+        };
+
+        // Each job builds its own GC `ExecuteContext`; see the doc above for the concurrency
+        // argument. No root classification happens in here — that is the post-drain scan below.
         let mut stats: GcStats = scope_unbounded_with(
             // Start by scanning all shards and collecting the aged out roots from prior sessions
             (0..self.storage.shard_count())
@@ -154,6 +231,18 @@ impl TurboTasksBackend {
                 .chain(aged_out.into_iter().map(GcJob::Collect)),
             GcStats::default,
             |spawner, job, stats| {
+                // The **only** interrupt point: at job entry, before any mutation. Everything past
+                // here runs to completion, which is what makes a partial pass safe to hand to
+                // `into_snapshot` — every task we marked deleted also had its edges torn down and
+                // its children's `parent_count` decremented, so the graph the snapshot sees is
+                // consistent. Never check the budget between `set_deleted` and `CleanupOldEdges`.
+                //
+                // `Break` closes the queue: remaining jobs are discarded without being dispatched,
+                // and in-flight jobs cannot re-grow it as they finish.
+                if budget.should_stop() {
+                    stats.abandoned += 1;
+                    return ControlFlow::Break(());
+                }
                 let collector = |task_id| spawner.spawn(GcJob::Collect(task_id));
                 let task_id = match job {
                     GcJob::ScanShard(index) => {
@@ -224,11 +313,30 @@ impl TurboTasksBackend {
 
         stats.gc_roots = roots.len();
         stats.aged_out_roots = aged_out_count;
+        stats.interrupted = budget.was_interrupted();
 
         // Only persist the roots map if it actually changed
         let roots_to_persist: Option<Vec<_>> =
             (roots != roots_before).then(|| roots.into_iter().collect());
         (stats, roots_to_persist)
+    }
+
+    /// The min-progress floor for this pass — how long GC runs before it will honour an interrupt.
+    /// Same precedence chain as [`Self::gc_root_ttl`]: the per-backend test override
+    /// (`set_gc_min_progress_for_testing`, race-free across parallel tests) → the
+    /// `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env → [`GC_MIN_PROGRESS`].
+    fn gc_min_progress(&self) -> Duration {
+        let override_ms = self.gc_min_progress_override_ms.load(Ordering::Relaxed);
+        if override_ms != u64::MAX {
+            return Duration::from_millis(override_ms);
+        }
+        match std::env::var("TURBO_ENGINE_GC_MIN_PROGRESS_MS") {
+            Ok(v) => match v.parse::<u64>() {
+                Ok(ms) => Duration::from_millis(ms),
+                Err(_) => GC_MIN_PROGRESS,
+            },
+            Err(_) => GC_MIN_PROGRESS,
+        }
     }
 
     /// Compute which persisted roots have expired their TTL
@@ -321,7 +429,20 @@ impl TurboTasksBackend {
         );
         let _serialize = self.snapshot_in_progress.lock();
         let phase = self.snapshot_coord.begin_snapshot();
+        // Save/restore rather than set-and-leave: the caller may run further passes and expect its
+        // own override (e.g. a TTL test) to still apply.
+        let prev = self.gc_min_progress_override_ms.load(Ordering::Relaxed);
+        // Far beyond any real pass, so `should_stop`'s floor check never elapses.
+        self.gc_min_progress_override_ms
+            .store(u64::MAX / 2, Ordering::Relaxed);
         let (stats, roots) = self.gc_collect(turbo_tasks, &phase);
+        self.gc_min_progress_override_ms
+            .store(prev, Ordering::Relaxed);
+
+        // Record the pass stats so the test-only hook (`last_gc_stats_for_testing`) reflects this
+        // direct pass too — production records these in `snapshot_and_persist`, which this hook
+        // bypasses.
+        *self.last_gc_stats.lock() = Some((&stats).into());
 
         // Persist the roots map this pass produced. Some tests query the roots set and GC itself
         // does as well, this ensures it is available to the next cycle.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -80,10 +80,16 @@ struct GcBudget<'a> {
     /// produce a ragged pass that stops and starts; once we have decided to wind down, we commit.
     /// Also reports whether the pass was interrupted, for [`GcStats`].
     stopped: AtomicBool,
+    /// When false the pass ignores waiters entirely and runs to completion. See
+    /// [`TurboTasksBackend::gc_collect`].
+    interruptible: bool,
 }
 
 impl GcBudget<'_> {
     fn should_stop(&self) -> bool {
+        if !self.interruptible {
+            return false;
+        }
         if self.stopped.load(Ordering::Relaxed) {
             return true;
         }
@@ -120,10 +126,6 @@ pub(crate) struct GcStats {
     /// the next pass — but a dev session where this is always true means GC is never finishing and
     /// the floor may need raising.
     pub interrupted: bool,
-    /// Jobs dropped by the interrupt: queued work the pass chose not to start. Distinct from jobs
-    /// skipped because the task was no longer collectible, which is ordinary concurrent
-    /// re-validation rather than lost progress.
-    pub abandoned: usize,
 }
 
 /// Test-only snapshot of the most recent [`GcStats`]. Production reads these off the `gc` span; a
@@ -133,8 +135,6 @@ pub(crate) struct GcStats {
 pub(crate) struct LastGcStats {
     /// Tasks collected this pass (soft-deleted). See [`GcStats::collected`].
     pub collected: usize,
-    /// Queued work the pass abandoned when it wound down early. See [`GcStats::abandoned`].
-    pub abandoned: usize,
     /// Whether the pass was interrupted by a waiting operation. See [`GcStats::interrupted`].
     pub interrupted: bool,
 }
@@ -143,7 +143,6 @@ impl From<&GcStats> for LastGcStats {
     fn from(stats: &GcStats) -> Self {
         Self {
             collected: stats.collected,
-            abandoned: stats.abandoned,
             interrupted: stats.interrupted,
         }
     }
@@ -154,14 +153,12 @@ impl Display for GcStats {
         write!(
             f,
             "gc_roots = {gc_roots}, collected: {collected}, edges_deleted: {edges_deleted}, \
-             aged_out_roots = {aged_out_roots}, interrupted = {interrupted}, abandoned = \
-             {abandoned}",
+             aged_out_roots = {aged_out_roots}, interrupted = {interrupted}",
             gc_roots = self.gc_roots,
             collected = self.collected,
             edges_deleted = self.edges_deleted,
             aged_out_roots = self.aged_out_roots,
-            interrupted = self.interrupted,
-            abandoned = self.abandoned
+            interrupted = self.interrupted
         )
     }
 }
@@ -180,7 +177,6 @@ impl GcStats {
         } else {
             self.deleted_roots.append(&mut other.deleted_roots);
         }
-        self.abandoned += other.abandoned;
         self
     }
 }
@@ -192,10 +188,13 @@ impl TurboTasksBackend {
     /// is what makes it safe to mutate the graph here.
     ///
     /// Returns [`GcStats`] for the pass.
+    /// `interruptible` false pins the pass to run to completion, ignoring waiters. Used for the
+    /// shutdown pass, which has no successor to finish what it skips.
     pub(crate) fn gc_collect(
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
         phase: &SnapshotPhase<'_, AnyOperation>,
+        interruptible: bool,
     ) -> (GcStats, Option<Vec<(TaskId, TtlCounter)>>) {
         // Record the time at the beginning of the loop to have a consistent timestamp for the roots
         let now = SystemTime::now()
@@ -220,6 +219,7 @@ impl TurboTasksBackend {
             started: Instant::now(),
             min_progress: self.gc_min_progress(),
             stopped: AtomicBool::new(false),
+            interruptible,
         };
 
         // Each job builds its own GC `ExecuteContext`; see the doc above for the concurrency
@@ -240,7 +240,6 @@ impl TurboTasksBackend {
                 // `Break` closes the queue: remaining jobs are discarded without being dispatched,
                 // and in-flight jobs cannot re-grow it as they finish.
                 if budget.should_stop() {
-                    stats.abandoned += 1;
                     return ControlFlow::Break(());
                 }
                 let collector = |task_id| spawner.spawn(GcJob::Collect(task_id));
@@ -429,15 +428,9 @@ impl TurboTasksBackend {
         );
         let _serialize = self.snapshot_in_progress.lock();
         let phase = self.snapshot_coord.begin_snapshot();
-        // Save/restore rather than set-and-leave: the caller may run further passes and expect its
-        // own override (e.g. a TTL test) to still apply.
-        let prev = self.gc_min_progress_override_ms.load(Ordering::Relaxed);
-        // Far beyond any real pass, so `should_stop`'s floor check never elapses.
-        self.gc_min_progress_override_ms
-            .store(u64::MAX / 2, Ordering::Relaxed);
-        let (stats, roots) = self.gc_collect(turbo_tasks, &phase);
-        self.gc_min_progress_override_ms
-            .store(prev, Ordering::Relaxed);
+        // Uninterruptible: the exact-count tests this hook exists for need a full pass, and an
+        // interrupted one would silently collect less than they assert.
+        let (stats, roots) = self.gc_collect(turbo_tasks, &phase, false);
 
         // Record the pass stats so the test-only hook (`last_gc_stats_for_testing`) reflects this
         // direct pass too — production records these in `snapshot_and_persist`, which this hook

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -34,7 +34,7 @@ use crate::{
             AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
             TaskGuard, capture_all_outgoing_edges,
         },
-        snapshot_coordinator::{SnapshotCoordinator, SnapshotPhase},
+        snapshot_coordinator::SnapshotPhase,
         storage::{SpecificTaskDataCategory, TaskDataCategory},
         storage_schema::TaskStorageAccessors,
     },
@@ -73,32 +73,29 @@ enum GcJob {
 
 /// Decides when a GC pass should stop early because it is delaying real work.
 struct GcBudget<'a> {
-    coord: &'a SnapshotCoordinator<AnyOperation>,
+    phase: &'a SnapshotPhase<'a, AnyOperation>,
     started: Instant,
+    /// The minimum quantum of work this pass does before any interrupt is honoured.
     min_progress: Duration,
     /// Latched on the first trip. Re-polling per job would let a waiter that arrives and leaves
     /// produce a ragged pass that stops and starts; once we have decided to wind down, we commit.
     /// Also reports whether the pass was interrupted, for [`GcStats`].
     stopped: AtomicBool,
-    /// When false the pass ignores waiters entirely and runs to completion. See
-    /// [`TurboTasksBackend::gc_collect`].
-    interruptible: bool,
 }
 
 impl GcBudget<'_> {
     fn should_stop(&self) -> bool {
-        if !self.interruptible {
-            return false;
-        }
         if self.stopped.load(Ordering::Relaxed) {
             return true;
         }
         if self.started.elapsed() < self.min_progress {
             return false;
         }
-        if !self.coord.operations_waiting() {
+        if !self.phase.operations_waiting() {
             return false;
         }
+        // If we get here then there is an operation waiting _and_ we have already executed for at
+        // least our min_progress duration
         self.stopped.store(true, Ordering::Relaxed);
         true
     }
@@ -187,9 +184,11 @@ impl TurboTasksBackend {
     /// `phase` is the held exclusion; it is the caller's proof that no operation is running, which
     /// is what makes it safe to mutate the graph here.
     ///
-    /// Returns [`GcStats`] for the pass.
-    /// `interruptible` false pins the pass to run to completion, ignoring waiters. Used for the
-    /// shutdown pass, which has no successor to finish what it skips.
+    /// `interruptible` controls whether we should abandon GC if other tasks are waiting to run.
+    /// Abandonment is controlled by [`GcBudget`] which ensures we can make a minimum amount of
+    /// progress even under load.
+    ///
+    /// Returns [`GcStats`] for the pass and the new roots to persist if any
     pub(crate) fn gc_collect(
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
@@ -214,16 +213,17 @@ impl TurboTasksBackend {
 
         let aged_out_count = aged_out.len();
         // TODO(perf): recycle the task ids of collected tasks.
-        let budget = GcBudget {
-            coord: &self.snapshot_coord,
-            started: Instant::now(),
-            min_progress: self.gc_min_progress,
-            stopped: AtomicBool::new(false),
-            interruptible,
+        let budget = if interruptible {
+            Some(GcBudget {
+                phase,
+                started: Instant::now(),
+                min_progress: self.gc_min_progress,
+                stopped: AtomicBool::new(false),
+            })
+        } else {
+            None
         };
 
-        // Each job builds its own GC `ExecuteContext`; see the doc above for the concurrency
-        // argument. No root classification happens in here — that is the post-drain scan below.
         let mut stats: GcStats = scope_unbounded_with(
             // Start by scanning all shards and collecting the aged out roots from prior sessions
             (0..self.storage.shard_count())
@@ -232,7 +232,9 @@ impl TurboTasksBackend {
             GcStats::default,
             |spawner, job, stats| {
                 // Abort the gc loop if we are interrupted
-                if budget.should_stop() {
+                if let Some(budget) = &budget
+                    && budget.should_stop()
+                {
                     return ControlFlow::Break(());
                 }
                 let collector = |task_id| spawner.spawn(GcJob::Collect(task_id));
@@ -305,7 +307,10 @@ impl TurboTasksBackend {
 
         stats.gc_roots = roots.len();
         stats.aged_out_roots = aged_out_count;
-        stats.interrupted = budget.was_interrupted();
+        // No budget means an uninterruptible pass, which by construction never interrupts.
+        stats.interrupted = budget
+            .as_ref()
+            .is_some_and(|budget| budget.was_interrupted());
 
         // Only persist the roots map if it actually changed
         let roots_to_persist: Option<Vec<_>> =

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -88,10 +88,10 @@ impl GcBudget<'_> {
         if self.stopped.load(Ordering::Relaxed) {
             return true;
         }
-        if self.started.elapsed() < self.min_progress {
+        if !self.phase.operations_waiting() {
             return false;
         }
-        if !self.phase.operations_waiting() {
+        if self.started.elapsed() < self.min_progress {
             return false;
         }
         // If we get here then there is an operation waiting _and_ we have already executed for at

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -29,7 +29,7 @@ use turbo_tasks::{TaskId, TurboTasks, scope_unbounded::scope_unbounded_with};
 
 use crate::{
     backend::{
-        AnyOperation, GC_MIN_PROGRESS, TurboTasksBackend,
+        AnyOperation, TurboTasksBackend,
         operation::{
             AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
             TaskGuard, capture_all_outgoing_edges,
@@ -217,7 +217,7 @@ impl TurboTasksBackend {
         let budget = GcBudget {
             coord: &self.snapshot_coord,
             started: Instant::now(),
-            min_progress: self.gc_min_progress(),
+            min_progress: self.gc_min_progress,
             stopped: AtomicBool::new(false),
             interruptible,
         };
@@ -231,14 +231,7 @@ impl TurboTasksBackend {
                 .chain(aged_out.into_iter().map(GcJob::Collect)),
             GcStats::default,
             |spawner, job, stats| {
-                // The **only** interrupt point: at job entry, before any mutation. Everything past
-                // here runs to completion, which is what makes a partial pass safe to hand to
-                // `into_snapshot` — every task we marked deleted also had its edges torn down and
-                // its children's `parent_count` decremented, so the graph the snapshot sees is
-                // consistent. Never check the budget between `set_deleted` and `CleanupOldEdges`.
-                //
-                // `Break` closes the queue: remaining jobs are discarded without being dispatched,
-                // and in-flight jobs cannot re-grow it as they finish.
+                // Abort the gc loop if we are interrupted
                 if budget.should_stop() {
                     return ControlFlow::Break(());
                 }
@@ -318,24 +311,6 @@ impl TurboTasksBackend {
         let roots_to_persist: Option<Vec<_>> =
             (roots != roots_before).then(|| roots.into_iter().collect());
         (stats, roots_to_persist)
-    }
-
-    /// The min-progress floor for this pass — how long GC runs before it will honour an interrupt.
-    /// Same precedence chain as [`Self::gc_root_ttl`]: the per-backend test override
-    /// (`set_gc_min_progress_for_testing`, race-free across parallel tests) → the
-    /// `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env → [`GC_MIN_PROGRESS`].
-    fn gc_min_progress(&self) -> Duration {
-        let override_ms = self.gc_min_progress_override_ms.load(Ordering::Relaxed);
-        if override_ms != u64::MAX {
-            return Duration::from_millis(override_ms);
-        }
-        match std::env::var("TURBO_ENGINE_GC_MIN_PROGRESS_MS") {
-            Ok(v) => match v.parse::<u64>() {
-                Ok(ms) => Duration::from_millis(ms),
-                Err(_) => GC_MIN_PROGRESS,
-            },
-            Err(_) => GC_MIN_PROGRESS,
-        }
     }
 
     /// Compute which persisted roots have expired their TTL

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -108,7 +108,7 @@ impl GcBudget<'_> {
 
 /// Observability counters for one [`TurboTasksBackend::gc_collect`] pass.
 #[derive(Default, Debug)]
-pub(crate) struct GcStats {
+pub struct GcStats {
     /// Number of roots detected by the pass
     pub gc_roots: usize,
     /// Tasks collected (marked soft-deleted).

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -77,14 +77,15 @@ struct GcBudget<'a> {
     started: Instant,
     /// The minimum quantum of work this pass does before any interrupt is honoured.
     min_progress: Duration,
-    /// Latched on the first trip. Re-polling per job would let a waiter that arrives and leaves
-    /// produce a ragged pass that stops and starts; once we have decided to wind down, we commit.
-    /// Also reports whether the pass was interrupted, for [`GcStats`].
+    /// Latched on the first trip.
     stopped: AtomicBool,
 }
 
 impl GcBudget<'_> {
     fn should_stop(&self) -> bool {
+        // We only stop if someone is waiting and we have already run for at least our
+        // `min_progress` To make querying the clock and phase cheaper we record it as a
+        // durable decision.
         if self.stopped.load(Ordering::Relaxed) {
             return true;
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -97,26 +97,8 @@ use crate::{
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
 
 /// The minimum useful quantum of GC work: how much a pass always does before it will honour an
-/// interrupt.
-///
-/// A GC pass holds total operation exclusion, so a waiting invalidation (an HMR edit) is stalled
-/// for its whole duration. An interruptible pass therefore watches
-/// [`SnapshotPhase::operations_waiting`](snapshot_coordinator::SnapshotPhase::operations_waiting)
-/// and winds down early when it is standing in someone's way — but not before this floor has
-/// elapsed. Without a floor, a dev server under sustained edits could interrupt every pass at its
-/// first job and never reclaim anything.
-///
-/// The floor is unconditional, so it also applies when a waiter is already present as the pass
-/// begins — an operation that suspended to let the exclusion start, or one that arrived in the
-/// race between deciding to run and acquiring it. Such a pass does exactly this much work and then
-/// yields. That is the intended trade: the alternative, bailing at zero cost when the race is
-/// lost, buys a little HMR latency at the price of passes that can accomplish nothing at all under
-/// steady contention.
-///
-/// A *time* floor rather than a task count because the property we want is a bound on the stall
-/// itself: whatever the graph looks like, the worst case an edit can wait behind GC is roughly this
-/// plus the longest single task teardown. Overridable in tests/debugging via
-/// `TURBO_ENGINE_GC_MIN_PROGRESS_MS`.
+/// interrupt.  GC holds an operation lock and so we can block concurrent operations.  Interruption
+/// ensures we are responsive and this ensures a minimum amount of progress.
 const GC_MIN_PROGRESS: Duration = Duration::from_millis(100);
 
 /// Priority used to re-schedule a task that became stale during execution.
@@ -184,14 +166,7 @@ pub struct BackendOptions {
     /// [`DEFAULT_GC_ROOT_TTL`].
     pub gc_root_ttl: Option<Duration>,
 
-    /// Overrides how long a GC pass runs before it will honour an interrupt. `None` (default)
-    /// derives it from the `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env var, falling back to
-    /// [`GC_MIN_PROGRESS`].
-    ///
-    /// Tests that assert on exact collected counts pin this beyond any plausible pass length so a
-    /// blocked operation can't shorten the pass under them; tests of the interrupt path itself pin
-    /// it to zero. Per-backend rather than relying on the env var, which every test in a binary
-    /// would share.
+    /// Overrides how long a GC pass runs before it will honour an interrupt.
     pub gc_min_progress: Option<Duration>,
 }
 
@@ -237,26 +212,6 @@ impl SnapshotReason {
     }
 
     /// Whether a GC pass run for this reason may wind down early when an operation is waiting.
-    ///
-    /// True for `IdleTimeout`, because it is the only *opportunistic* schedule: it fires on a bet
-    /// that the system is idle and the exclusion is therefore free. A waiter falsifies the bet —
-    /// either we lost a race (an operation arrived between the decision to run and
-    /// `begin_exclusion`) or one was already mid-flight and suspended to let us in — so the pass
-    /// should take its minimum quantum and yield. There is no deadline to miss; the next idle
-    /// window retries.
-    ///
-    /// The periodic reasons are not claiming the system is idle, only that a snapshot is due, so
-    /// a waiter is not evidence they should stand down — and interrupting them is expensive rather
-    /// than merely late. An interrupted pass leaves tasks unexamined, so its whole cycle is
-    /// skipped (see `snapshot_and_persist`), discarding the accumulated compilation time that the
-    /// `MIN_SNAPSHOT_ACTIVE_TIME` threshold had just judged worth persisting. `Stop` has no later
-    /// cycle at all.
-    ///
-    /// `Test` is not a schedule but a stand-in for one, so it follows whatever the caller is
-    /// exercising: it stays interruptible, which is what lets `gc_interrupt.rs` drive a
-    /// production-shaped interruptible pass. Tests needing a guaranteed full pass pin
-    /// `BackendOptions::gc_min_progress` high (or use `gc_for_testing`, which forces
-    /// `interruptible = false` outright).
     fn gc_is_interruptible(self) -> bool {
         matches!(self, SnapshotReason::IdleTimeout | SnapshotReason::Test)
     }
@@ -304,9 +259,7 @@ pub struct TurboTasksBackend {
     /// How long a GC root may go un-anchored before it ages out.
     gc_root_ttl: Duration,
 
-    /// How long a GC pass runs before it will honour an interrupt, resolved once at construction
-    /// from [`BackendOptions::gc_min_progress`] / the `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env /
-    /// [`GC_MIN_PROGRESS`].
+    /// How long a GC pass runs before it will honour an interrupt
     gc_min_progress: Duration,
 
     /// Test-only record of the most recent GC pass. The production signal for these fields is the
@@ -1231,8 +1184,6 @@ impl TurboTasksBackend {
                 stats = tracing::field::Empty,
             )
             .entered();
-            // Only the opportunistic idle pass yields to waiters; a due snapshot and shutdown run
-            // to completion. See `SnapshotReason::gc_is_interruptible`.
             let (stats, roots) =
                 self.gc_collect(turbo_tasks, &snapshot_phase, reason.gc_is_interruptible());
             let interrupted = stats.interrupted;
@@ -1248,15 +1199,7 @@ impl TurboTasksBackend {
                 reason.as_str()
             );
             if interrupted {
-                // Persisting now would write the tasks this pass never examined as live, and the
-                // eviction that follows would drop them from the resident map. `evictability` does
-                // not consult `parent_count`, so an unexamined orphan evicts like any other clean
-                // task — and once it is gone from memory, neither the resident shard scan nor
-                // `note_gc_collectible` can ever reach it again. It would leak for the lifetime of
-                // the cache. Skip the whole cycle instead; the next one retries from a clean slate.
-                // Release the exclusion without handing it to a snapshot: dropping the phase is
-                // what lets the operations parked behind this pass (the waiter that interrupted
-                // it) through.
+                // IF we were interrupted also abandon the persistence loop.
                 drop(snapshot_phase);
                 drop(gc_span);
                 return Ok((start, false));

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -220,6 +220,16 @@ impl SnapshotReason {
         }
     }
 
+    /// Whether a GC pass run for this reason may wind down early when an operation is waiting.
+    ///
+    /// False only for `Stop`. An interrupted pass leaves tasks unexamined and its cycle is
+    /// therefore skipped entirely (see `snapshot_and_persist`); at shutdown that would mean not
+    /// persisting at all, and there is no later cycle to retry. Nothing is waiting on a
+    /// shutting-down backend anyway, so running to completion costs nothing.
+    fn gc_is_interruptible(self) -> bool {
+        !matches!(self, SnapshotReason::Stop)
+    }
+
     /// True only for `Stop`: at shutdown the whole map is dropped right after, so each task
     /// entry can be drained from the map and freed as it is serialized instead of after the
     /// whole batch is written. This reduces peak memory during `next build` shutdown.
@@ -476,16 +486,16 @@ impl TurboTasksBackend {
             .store(min_progress_ms, Ordering::Relaxed);
     }
 
-    /// `(collected, abandoned, interrupted)` for the most recent GC pass run inside
+    /// `(collected, interrupted)` for the most recent GC pass run inside
     /// `snapshot_and_persist`, or `None` if none has run. Test-only: production reads these off the
     /// `gc` span. Lets a test assert on the pass itself rather than on the resident task count,
     /// which eviction also moves and which therefore can't distinguish "GC collected it" from "GC
     /// skipped it and eviction dropped it to disk".
     #[doc(hidden)]
-    pub fn last_gc_stats_for_testing(&self) -> Option<(usize, usize, bool)> {
+    pub fn last_gc_stats_for_testing(&self) -> Option<(usize, bool)> {
         self.last_gc_stats
             .lock()
-            .map(|s| (s.collected, s.abandoned, s.interrupted))
+            .map(|s| (s.collected, s.interrupted))
     }
 
     /// The GC roots set as currently persisted on disk (task id -> [`TtlCounter`]).
@@ -1186,9 +1196,35 @@ impl TurboTasksBackend {
                 stats = tracing::field::Empty,
             )
             .entered();
-            let (stats, roots) = self.gc_collect(turbo_tasks, &snapshot_phase);
+            // Shutdown is the last pass there will ever be, so a partial one has no successor to
+            // finish its work. Run it to completion regardless of contention.
+            let (stats, roots) =
+                self.gc_collect(turbo_tasks, &snapshot_phase, reason.gc_is_interruptible());
+            let interrupted = stats.interrupted;
             *self.last_gc_stats.lock() = Some((&stats).into());
             gc_span.record("stats", display(stats));
+            // `interruptible = false` makes this structurally impossible; the assert guards the
+            // wiring, not the runtime, so a future change that reintroduces a way to interrupt a
+            // shutdown pass fails loudly instead of silently skipping the final persist.
+            debug_assert!(
+                !(interrupted && !reason.gc_is_interruptible()),
+                "a shutdown GC pass must never be interrupted: it has no successor to finish its \
+                 work"
+            );
+            if interrupted {
+                // Persisting now would write the tasks this pass never examined as live, and the
+                // eviction that follows would drop them from the resident map. `evictability` does
+                // not consult `parent_count`, so an unexamined orphan evicts like any other clean
+                // task — and once it is gone from memory, neither the resident shard scan nor
+                // `note_gc_collectible` can ever reach it again. It would leak for the lifetime of
+                // the cache. Skip the whole cycle instead; the next one retries from a clean slate.
+                // Release the exclusion without handing it to a snapshot: dropping the phase is
+                // what lets the operations parked behind this pass (the waiter that interrupted
+                // it) through.
+                drop(snapshot_phase);
+                drop(gc_span);
+                return Ok((start, false));
+            }
             (Some(start.elapsed()), roots)
         } else {
             (None, None)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -18,10 +18,7 @@ use std::{
     hash::BuildHasherDefault,
     mem::take,
     pin::Pin,
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, LazyLock},
     time::SystemTime,
 };
 
@@ -178,6 +175,16 @@ pub struct BackendOptions {
     /// derives it from the `TURBO_ENGINE_GC_ROOT_TTL_MS` env var, falling back to
     /// [`DEFAULT_GC_ROOT_TTL`].
     pub gc_root_ttl: Option<Duration>,
+
+    /// Overrides how long a GC pass runs before it will honour an interrupt. `None` (default)
+    /// derives it from the `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env var, falling back to
+    /// [`GC_MIN_PROGRESS`].
+    ///
+    /// Tests that assert on exact collected counts pin this beyond any plausible pass length so a
+    /// blocked operation can't shorten the pass under them; tests of the interrupt path itself pin
+    /// it to zero. Per-backend rather than relying on the env var, which every test in a binary
+    /// would share.
+    pub gc_min_progress: Option<Duration>,
 }
 
 impl Default for BackendOptions {
@@ -191,6 +198,7 @@ impl Default for BackendOptions {
             eviction_mode: EvictionMode::Off,
             gc: None,
             gc_root_ttl: None,
+            gc_min_progress: None,
         }
     }
 }
@@ -273,13 +281,10 @@ pub struct TurboTasksBackend {
     /// How long a GC root may go un-anchored before it ages out.
     gc_root_ttl: Duration,
 
-    /// Test-only override of the GC min-progress floor, in milliseconds; `u64::MAX` means "unset"
-    /// (use [`GC_MIN_PROGRESS`] / the `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env). Per-backend for the
-    /// same reason as `gc_root_ttl_override_ms`: parallel tests must not race a process-global.
-    /// `0` makes a pass interruptible immediately; `u64::MAX / 2` effectively disables
-    /// interruption (used by `gc_for_testing`, whose contract is a full pass). See
-    /// `set_gc_min_progress_for_testing`.
-    gc_min_progress_override_ms: AtomicU64,
+    /// How long a GC pass runs before it will honour an interrupt, resolved once at construction
+    /// from [`BackendOptions::gc_min_progress`] / the `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env /
+    /// [`GC_MIN_PROGRESS`].
+    gc_min_progress: Duration,
 
     /// Test-only record of the most recent GC pass. The production signal for these fields is the
     /// `gc` span, which a unit test can't read; this lets a test assert on what the *pass* did
@@ -327,6 +332,22 @@ impl TurboTasksBackend {
             gc_enabled = false;
         }
 
+        let gc_min_progress = options.gc_min_progress.unwrap_or_else(|| {
+            match std::env::var("TURBO_ENGINE_GC_MIN_PROGRESS_MS") {
+                Ok(v) => match v.parse::<u64>() {
+                    Ok(ms) => Duration::from_millis(ms),
+                    Err(e) => {
+                        eprintln!(
+                            "warning: TURBO_ENGINE_GC_MIN_PROGRESS_MS set but is not parsable: \
+                             {e}. Using the default instead."
+                        );
+                        GC_MIN_PROGRESS
+                    }
+                },
+                Err(_) => GC_MIN_PROGRESS,
+            }
+        });
+
         let gc_root_ttl = options.gc_root_ttl.unwrap_or_else(|| {
             match std::env::var("TURBO_ENGINE_GC_ROOT_TTL_MS") {
                 Ok(v) => match v.parse::<u64>() {
@@ -367,7 +388,7 @@ impl TurboTasksBackend {
             task_statistics: TaskStatisticsApi::default(),
             backing_storage,
             gc_root_ttl,
-            gc_min_progress_override_ms: AtomicU64::new(u64::MAX),
+            gc_min_progress,
             last_gc_stats: Mutex::new(None),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
@@ -475,15 +496,6 @@ impl TurboTasksBackend {
         self.storage
             .with_task(task, |t| t.gc_transient_ref_count())
             .unwrap_or(0)
-    }
-
-    /// Override the GC min-progress floor for this backend (milliseconds). `0` makes a pass
-    /// honour an interrupt from its very first job, which is what a test that wants to observe a
-    /// partial pass needs. Per-backend, so parallel tests don't race the global env. Test-only.
-    #[doc(hidden)]
-    pub fn set_gc_min_progress_for_testing(&self, min_progress_ms: u64) {
-        self.gc_min_progress_override_ms
-            .store(min_progress_ms, Ordering::Relaxed);
     }
 
     /// `(collected, interrupted)` for the most recent GC pass run inside

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1209,17 +1209,9 @@ impl TurboTasksBackend {
             let (stats, roots) =
                 self.gc_collect(turbo_tasks, &snapshot_phase, reason.gc_is_interruptible());
             gc_span.record("stats", display(&stats));
-            // `interruptible = false` makes this structurally impossible; the assert guards the
-            // wiring, not the runtime, so a future change that reintroduces a way to interrupt an
-            // uninterruptible pass fails loudly instead of silently skipping the persist.
-            debug_assert!(
-                !(stats.interrupted && !reason.gc_is_interruptible()),
-                "GC pass for reason {} must never be interrupted: skipping its cycle would \
-                 discard the snapshot it was run to take",
-                reason.as_str()
-            );
             if stats.interrupted {
-                // IF we were interrupted also abandon the persistence loop.
+                // If we were interrupted also abandon the persistence loop.
+                // This ensures that we don't persist roots that were not completely validated.
                 drop(snapshot_phase);
                 drop(gc_span);
                 return Ok((start, false, Some(stats)));

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -18,14 +18,17 @@ use std::{
     hash::BuildHasherDefault,
     mem::take,
     pin::Pin,
-    sync::{Arc, LazyLock},
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::SystemTime,
 };
 
 use anyhow::{Context, Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
-use gc::DEFAULT_GC_ROOT_TTL;
 pub use gc::TtlCounter;
+use gc::{DEFAULT_GC_ROOT_TTL, LastGcStats};
 use hashbrown::hash_table::Entry;
 use indexmap::IndexSet;
 use parking_lot::{Mutex, RwLock};
@@ -95,6 +98,21 @@ use crate::{
 /// If the number of dependent tasks exceeds this threshold,
 /// the operation will be parallelized.
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
+
+/// How long a GC pass runs before it will honour an interrupt.
+///
+/// A GC pass holds total operation exclusion, so a waiting invalidation (an HMR edit) is stalled
+/// for its whole duration. The pass therefore watches
+/// [`SnapshotCoordinator::operations_waiting`](snapshot_coordinator::SnapshotCoordinator::operations_waiting)
+/// and winds down early when it is standing in someone's way — but not before this floor has
+/// elapsed. Without a floor, a dev server under sustained edits could interrupt every pass at its
+/// first job and never reclaim anything.
+///
+/// A *time* floor rather than a task count because the property we want is a bound on the stall
+/// itself: whatever the graph looks like, the worst case an edit can wait behind GC is roughly this
+/// plus the longest single task teardown. Overridable in tests/debugging via
+/// `TURBO_ENGINE_GC_MIN_PROGRESS_MS`.
+const GC_MIN_PROGRESS: Duration = Duration::from_millis(100);
 
 /// Priority used to re-schedule a task that became stale during execution.
 ///
@@ -245,6 +263,20 @@ pub struct TurboTasksBackend {
     /// How long a GC root may go un-anchored before it ages out.
     gc_root_ttl: Duration,
 
+    /// Test-only override of the GC min-progress floor, in milliseconds; `u64::MAX` means "unset"
+    /// (use [`GC_MIN_PROGRESS`] / the `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env). Per-backend for the
+    /// same reason as `gc_root_ttl_override_ms`: parallel tests must not race a process-global.
+    /// `0` makes a pass interruptible immediately; `u64::MAX / 2` effectively disables
+    /// interruption (used by `gc_for_testing`, whose contract is a full pass). See
+    /// `set_gc_min_progress_for_testing`.
+    gc_min_progress_override_ms: AtomicU64,
+
+    /// Test-only record of the most recent GC pass. The production signal for these fields is the
+    /// `gc` span, which a unit test can't read; this lets a test assert on what the *pass* did
+    /// rather than on the resident count, which eviction also moves. See
+    /// `last_gc_stats_for_testing`.
+    last_gc_stats: Mutex<Option<LastGcStats>>,
+
     #[cfg(feature = "verify_aggregation_graph")]
     root_tasks: Mutex<FxHashSet<TaskId>>,
 }
@@ -325,6 +357,8 @@ impl TurboTasksBackend {
             task_statistics: TaskStatisticsApi::default(),
             backing_storage,
             gc_root_ttl,
+            gc_min_progress_override_ms: AtomicU64::new(u64::MAX),
+            last_gc_stats: Mutex::new(None),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
         }
@@ -431,6 +465,27 @@ impl TurboTasksBackend {
         self.storage
             .with_task(task, |t| t.gc_transient_ref_count())
             .unwrap_or(0)
+    }
+
+    /// Override the GC min-progress floor for this backend (milliseconds). `0` makes a pass
+    /// honour an interrupt from its very first job, which is what a test that wants to observe a
+    /// partial pass needs. Per-backend, so parallel tests don't race the global env. Test-only.
+    #[doc(hidden)]
+    pub fn set_gc_min_progress_for_testing(&self, min_progress_ms: u64) {
+        self.gc_min_progress_override_ms
+            .store(min_progress_ms, Ordering::Relaxed);
+    }
+
+    /// `(collected, abandoned, interrupted)` for the most recent GC pass run inside
+    /// `snapshot_and_persist`, or `None` if none has run. Test-only: production reads these off the
+    /// `gc` span. Lets a test assert on the pass itself rather than on the resident task count,
+    /// which eviction also moves and which therefore can't distinguish "GC collected it" from "GC
+    /// skipped it and eviction dropped it to disk".
+    #[doc(hidden)]
+    pub fn last_gc_stats_for_testing(&self) -> Option<(usize, usize, bool)> {
+        self.last_gc_stats
+            .lock()
+            .map(|s| (s.collected, s.abandoned, s.interrupted))
     }
 
     /// The GC roots set as currently persisted on disk (task id -> [`TtlCounter`]).
@@ -1132,6 +1187,7 @@ impl TurboTasksBackend {
             )
             .entered();
             let (stats, roots) = self.gc_collect(turbo_tasks, &snapshot_phase);
+            *self.last_gc_stats.lock() = Some((&stats).into());
             gc_span.record("stats", display(stats));
             (Some(start.elapsed()), roots)
         } else {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -96,14 +96,22 @@ use crate::{
 /// the operation will be parallelized.
 const DEPENDENT_TASKS_DIRTY_PARALLELIZATION_THRESHOLD: usize = 10000;
 
-/// How long a GC pass runs before it will honour an interrupt.
+/// The minimum useful quantum of GC work: how much a pass always does before it will honour an
+/// interrupt.
 ///
 /// A GC pass holds total operation exclusion, so a waiting invalidation (an HMR edit) is stalled
-/// for its whole duration. The pass therefore watches
-/// [`SnapshotCoordinator::operations_waiting`](snapshot_coordinator::SnapshotCoordinator::operations_waiting)
+/// for its whole duration. An interruptible pass therefore watches
+/// [`SnapshotPhase::operations_waiting`](snapshot_coordinator::SnapshotPhase::operations_waiting)
 /// and winds down early when it is standing in someone's way — but not before this floor has
 /// elapsed. Without a floor, a dev server under sustained edits could interrupt every pass at its
 /// first job and never reclaim anything.
+///
+/// The floor is unconditional, so it also applies when a waiter is already present as the pass
+/// begins — an operation that suspended to let the exclusion start, or one that arrived in the
+/// race between deciding to run and acquiring it. Such a pass does exactly this much work and then
+/// yields. That is the intended trade: the alternative, bailing at zero cost when the race is
+/// lost, buys a little HMR latency at the price of passes that can accomplish nothing at all under
+/// steady contention.
 ///
 /// A *time* floor rather than a task count because the property we want is a bound on the stall
 /// itself: whatever the graph looks like, the worst case an edit can wait behind GC is roughly this
@@ -230,12 +238,27 @@ impl SnapshotReason {
 
     /// Whether a GC pass run for this reason may wind down early when an operation is waiting.
     ///
-    /// False only for `Stop`. An interrupted pass leaves tasks unexamined and its cycle is
-    /// therefore skipped entirely (see `snapshot_and_persist`); at shutdown that would mean not
-    /// persisting at all, and there is no later cycle to retry. Nothing is waiting on a
-    /// shutting-down backend anyway, so running to completion costs nothing.
+    /// True for `IdleTimeout`, because it is the only *opportunistic* schedule: it fires on a bet
+    /// that the system is idle and the exclusion is therefore free. A waiter falsifies the bet —
+    /// either we lost a race (an operation arrived between the decision to run and
+    /// `begin_exclusion`) or one was already mid-flight and suspended to let us in — so the pass
+    /// should take its minimum quantum and yield. There is no deadline to miss; the next idle
+    /// window retries.
+    ///
+    /// The periodic reasons are not claiming the system is idle, only that a snapshot is due, so
+    /// a waiter is not evidence they should stand down — and interrupting them is expensive rather
+    /// than merely late. An interrupted pass leaves tasks unexamined, so its whole cycle is
+    /// skipped (see `snapshot_and_persist`), discarding the accumulated compilation time that the
+    /// `MIN_SNAPSHOT_ACTIVE_TIME` threshold had just judged worth persisting. `Stop` has no later
+    /// cycle at all.
+    ///
+    /// `Test` is not a schedule but a stand-in for one, so it follows whatever the caller is
+    /// exercising: it stays interruptible, which is what lets `gc_interrupt.rs` drive a
+    /// production-shaped interruptible pass. Tests needing a guaranteed full pass pin
+    /// `BackendOptions::gc_min_progress` high (or use `gc_for_testing`, which forces
+    /// `interruptible = false` outright).
     fn gc_is_interruptible(self) -> bool {
-        !matches!(self, SnapshotReason::Stop)
+        matches!(self, SnapshotReason::IdleTimeout | SnapshotReason::Test)
     }
 
     /// True only for `Stop`: at shutdown the whole map is dropped right after, so each task
@@ -1208,20 +1231,21 @@ impl TurboTasksBackend {
                 stats = tracing::field::Empty,
             )
             .entered();
-            // Shutdown is the last pass there will ever be, so a partial one has no successor to
-            // finish its work. Run it to completion regardless of contention.
+            // Only the opportunistic idle pass yields to waiters; a due snapshot and shutdown run
+            // to completion. See `SnapshotReason::gc_is_interruptible`.
             let (stats, roots) =
                 self.gc_collect(turbo_tasks, &snapshot_phase, reason.gc_is_interruptible());
             let interrupted = stats.interrupted;
             *self.last_gc_stats.lock() = Some((&stats).into());
             gc_span.record("stats", display(stats));
             // `interruptible = false` makes this structurally impossible; the assert guards the
-            // wiring, not the runtime, so a future change that reintroduces a way to interrupt a
-            // shutdown pass fails loudly instead of silently skipping the final persist.
+            // wiring, not the runtime, so a future change that reintroduces a way to interrupt an
+            // uninterruptible pass fails loudly instead of silently skipping the persist.
             debug_assert!(
                 !(interrupted && !reason.gc_is_interruptible()),
-                "a shutdown GC pass must never be interrupted: it has no successor to finish its \
-                 work"
+                "GC pass for reason {} must never be interrupted: skipping its cycle would \
+                 discard the snapshot it was run to take",
+                reason.as_str()
             );
             if interrupted {
                 // Persisting now would write the tasks this pass never examined as live, and the

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -25,7 +25,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
 pub use gc::TtlCounter;
-use gc::{DEFAULT_GC_ROOT_TTL, LastGcStats};
+use gc::{DEFAULT_GC_ROOT_TTL, GcStats};
 use hashbrown::hash_table::Entry;
 use indexmap::IndexSet;
 use parking_lot::{Mutex, RwLock};
@@ -262,14 +262,36 @@ pub struct TurboTasksBackend {
     /// How long a GC pass runs before it will honour an interrupt
     gc_min_progress: Duration,
 
-    /// Test-only record of the most recent GC pass. The production signal for these fields is the
-    /// `gc` span, which a unit test can't read; this lets a test assert on what the *pass* did
-    /// rather than on the resident count, which eviction also moves. See
-    /// `last_gc_stats_for_testing`.
-    last_gc_stats: Mutex<Option<LastGcStats>>,
-
     #[cfg(feature = "verify_aggregation_graph")]
     root_tasks: Mutex<FxHashSet<TaskId>>,
+}
+
+/// What [`TurboTasksBackend::snapshot_and_evict_for_testing`] observed.
+#[doc(hidden)]
+#[derive(Debug, Default)]
+pub struct TestSnapshotOutcome {
+    /// Whether the snapshot found modifications to persist.
+    pub had_new_data: bool,
+    /// Tasks evicted from memory at each level.
+    pub eviction_counts: EvictionCounts,
+    /// `(collected, interrupted)` for the GC pass this snapshot ran, or `None` when GC is
+    /// disabled for the backend.
+    pub gc: Option<(usize, bool)>,
+}
+
+impl TestSnapshotOutcome {
+    /// `(collected, interrupted)` for the GC pass, panicking if GC is disabled. For tests whose
+    /// whole point is the pass, so a misconfigured backend fails loudly rather than silently
+    /// asserting nothing.
+    pub fn gc_stats(&self) -> (usize, bool) {
+        self.gc
+            .expect("no GC pass ran: the backend needs `BackendOptions::gc = Some(true)`")
+    }
+
+    /// Whether the GC pass wound down early. `false` when GC is disabled.
+    pub fn gc_interrupted(&self) -> bool {
+        self.gc.is_some_and(|(_, interrupted)| interrupted)
+    }
 }
 
 impl TurboTasksBackend {
@@ -365,7 +387,6 @@ impl TurboTasksBackend {
             backing_storage,
             gc_root_ttl,
             gc_min_progress,
-            last_gc_stats: Mutex::new(None),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
         }
@@ -425,28 +446,35 @@ impl TurboTasksBackend {
     /// This is exposed for integration tests that need to verify the
     /// snapshot → evict → restore cycle works correctly.
     ///
-    /// Returns `(snapshot_had_new_data, eviction_counts)`.
+    /// Returns [`TestSnapshotOutcome`], which carries the GC pass's own `(collected, interrupted)`
+    /// alongside the eviction counts. A test needs the pass's numbers because the resident task
+    /// count can't distinguish "GC collected it" from "GC skipped it and eviction dropped it to
+    /// disk".
     #[doc(hidden)]
     pub fn snapshot_and_evict_for_testing(
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> (bool, EvictionCounts) {
+    ) -> TestSnapshotOutcome {
         assert!(
             self.should_persist(),
             "snapshot_and_evict requires persistence"
         );
         let snapshot_result = self.snapshot_and_persist(None, SnapshotReason::Test, turbo_tasks);
-        let had_new_data = match snapshot_result {
-            Ok((_, new_data)) => new_data,
+        let (had_new_data, gc_stats) = match snapshot_result {
+            Ok((_, new_data, gc_stats)) => (new_data, gc_stats),
             Err(_) => {
                 // Snapshot/persist failed — skip eviction since the data may not
                 // be on disk yet. Evicting now could lose in-memory state that
                 // can't be restored.
-                return (false, EvictionCounts::default());
+                return TestSnapshotOutcome::default();
             }
         };
-        let counts = self.storage.evict_after_snapshot(None);
-        (had_new_data, counts)
+        let eviction_counts = self.storage.evict_after_snapshot(None);
+        TestSnapshotOutcome {
+            had_new_data,
+            eviction_counts,
+            gc: gc_stats.map(|s| (s.collected, s.interrupted)),
+        }
     }
 
     /// The number of persistent (non-transient) tasks resident in the map. Test-only hook; see
@@ -472,18 +500,6 @@ impl TurboTasksBackend {
         self.storage
             .with_task(task, |t| t.gc_transient_ref_count())
             .unwrap_or(0)
-    }
-
-    /// `(collected, interrupted)` for the most recent GC pass run inside
-    /// `snapshot_and_persist`, or `None` if none has run. Test-only: production reads these off the
-    /// `gc` span. Lets a test assert on the pass itself rather than on the resident task count,
-    /// which eviction also moves and which therefore can't distinguish "GC collected it" from "GC
-    /// skipped it and eviction dropped it to disk".
-    #[doc(hidden)]
-    pub fn last_gc_stats_for_testing(&self) -> Option<(usize, bool)> {
-        self.last_gc_stats
-            .lock()
-            .map(|s| (s.collected, s.interrupted))
     }
 
     /// The GC roots set as currently persisted on disk (task id -> [`TtlCounter`]).
@@ -1154,12 +1170,18 @@ impl TurboTasksBackend {
         (listener, true)
     }
 
+    /// Runs a GC pass (when enabled) and persists the result.
+    ///
+    /// Returns `(snapshot_start, had_new_data, gc_stats)`. `gc_stats` is `None` when GC is
+    /// disabled; it is returned rather than stashed on `self` so a test can inspect the pass it
+    /// just triggered without the backend carrying test-only state. Production reads the same
+    /// numbers off the `gc` span.
     fn snapshot_and_persist(
         &self,
         parent_span: Option<tracing::Id>,
         reason: SnapshotReason,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> Result<(Instant, bool), anyhow::Error> {
+    ) -> Result<(Instant, bool, Option<GcStats>), anyhow::Error> {
         let snapshot_span =
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason.as_str())
                 .entered();
@@ -1177,7 +1199,7 @@ impl TurboTasksBackend {
         // can't be used for cross-process trace correlation.
         let wall_start = SystemTime::now();
         let mut snapshot_phase = self.snapshot_coord.begin_snapshot();
-        let (gc_elapsed, gc_roots_to_persist) = if self.gc_enabled {
+        let (gc_elapsed, gc_roots_to_persist, gc_stats) = if self.gc_enabled {
             let gc_span = tracing::info_span!(
                 parent: parent_span.clone(),
                 "gc",
@@ -1186,27 +1208,25 @@ impl TurboTasksBackend {
             .entered();
             let (stats, roots) =
                 self.gc_collect(turbo_tasks, &snapshot_phase, reason.gc_is_interruptible());
-            let interrupted = stats.interrupted;
-            *self.last_gc_stats.lock() = Some((&stats).into());
-            gc_span.record("stats", display(stats));
+            gc_span.record("stats", display(&stats));
             // `interruptible = false` makes this structurally impossible; the assert guards the
             // wiring, not the runtime, so a future change that reintroduces a way to interrupt an
             // uninterruptible pass fails loudly instead of silently skipping the persist.
             debug_assert!(
-                !(interrupted && !reason.gc_is_interruptible()),
+                !(stats.interrupted && !reason.gc_is_interruptible()),
                 "GC pass for reason {} must never be interrupted: skipping its cycle would \
                  discard the snapshot it was run to take",
                 reason.as_str()
             );
-            if interrupted {
+            if stats.interrupted {
                 // IF we were interrupted also abandon the persistence loop.
                 drop(snapshot_phase);
                 drop(gc_span);
-                return Ok((start, false));
+                return Ok((start, false, Some(stats)));
             }
-            (Some(start.elapsed()), roots)
+            (Some(start.elapsed()), roots, Some(stats))
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         debug_assert!(self.should_persist());
@@ -1223,7 +1243,7 @@ impl TurboTasksBackend {
             // No tasks modified since the last snapshot — drop the guard (which
             // calls end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
-            return Ok((start, false));
+            return Ok((start, false, gc_stats));
         }
 
         #[cfg(feature = "print_cache_item_size")]
@@ -1518,7 +1538,7 @@ impl TurboTasksBackend {
             // was present, and every modification that increments the count also failed
             // during encoding.
             std::hint::cold_path();
-            return Ok((snapshot_time, false));
+            return Ok((snapshot_time, false, gc_stats));
         }
 
         let persist_start = Instant::now();
@@ -1662,7 +1682,7 @@ impl TurboTasksBackend {
             ]),
         )));
 
-        Ok((snapshot_time, true))
+        Ok((snapshot_time, true, gc_stats))
     }
 
     fn startup(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
@@ -3227,7 +3247,7 @@ impl TurboTasksBackend {
                                 Self::log_unrecoverable_persist_error();
                                 return;
                             }
-                            Ok((snapshot_start, new_data)) => {
+                            Ok((snapshot_start, new_data, _gc_stats)) => {
                                 // if we see 'new_data' then the next idle transition is 'fresh'
                                 fresh_idle = new_data;
                                 is_first = false;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -24,8 +24,8 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
-pub use gc::TtlCounter;
-use gc::{DEFAULT_GC_ROOT_TTL, GcStats};
+use gc::DEFAULT_GC_ROOT_TTL;
+pub use gc::{GcStats, TtlCounter};
 use hashbrown::hash_table::Entry;
 use indexmap::IndexSet;
 use parking_lot::{Mutex, RwLock};
@@ -274,23 +274,24 @@ pub struct TestSnapshotOutcome {
     pub had_new_data: bool,
     /// Tasks evicted from memory at each level.
     pub eviction_counts: EvictionCounts,
-    /// `(collected, interrupted)` for the GC pass this snapshot ran, or `None` when GC is
-    /// disabled for the backend.
-    pub gc: Option<(usize, bool)>,
+    /// The [`GcStats`] of the GC pass this snapshot ran, or `None` when GC is disabled for the
+    /// backend.
+    pub gc: Option<GcStats>,
 }
 
 impl TestSnapshotOutcome {
-    /// `(collected, interrupted)` for the GC pass, panicking if GC is disabled. For tests whose
-    /// whole point is the pass, so a misconfigured backend fails loudly rather than silently
-    /// asserting nothing.
-    pub fn gc_stats(&self) -> (usize, bool) {
+    /// The [`GcStats`] for the GC pass, panicking if GC is disabled. For tests whose whole point
+    /// is the pass, so a misconfigured backend fails loudly rather than silently asserting
+    /// nothing.
+    pub fn gc_stats(&self) -> &GcStats {
         self.gc
+            .as_ref()
             .expect("no GC pass ran: the backend needs `BackendOptions::gc = Some(true)`")
     }
 
     /// Whether the GC pass wound down early. `false` when GC is disabled.
     pub fn gc_interrupted(&self) -> bool {
-        self.gc.is_some_and(|(_, interrupted)| interrupted)
+        self.gc.as_ref().is_some_and(|stats| stats.interrupted)
     }
 }
 
@@ -446,10 +447,9 @@ impl TurboTasksBackend {
     /// This is exposed for integration tests that need to verify the
     /// snapshot → evict → restore cycle works correctly.
     ///
-    /// Returns [`TestSnapshotOutcome`], which carries the GC pass's own `(collected, interrupted)`
-    /// alongside the eviction counts. A test needs the pass's numbers because the resident task
-    /// count can't distinguish "GC collected it" from "GC skipped it and eviction dropped it to
-    /// disk".
+    /// Returns [`TestSnapshotOutcome`], which carries the GC pass's own [`GcStats`] alongside the
+    /// eviction counts. A test needs the pass's numbers because the resident task count can't
+    /// distinguish "GC collected it" from "GC skipped it and eviction dropped it to disk".
     #[doc(hidden)]
     pub fn snapshot_and_evict_for_testing(
         &self,
@@ -473,7 +473,7 @@ impl TurboTasksBackend {
         TestSnapshotOutcome {
             had_new_data,
             eviction_counts,
-            gc: gc_stats.map(|s| (s.collected, s.interrupted)),
+            gc: gc_stats,
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1170,7 +1170,7 @@ impl TurboTasksBackend {
         (listener, true)
     }
 
-    /// Runs a GC pass (when enabled) and persists the result.
+    /// Runs a persistence cycle
     ///
     /// Returns `(snapshot_start, had_new_data, gc_stats)`. `gc_stats` is `None` when GC is
     /// disabled; it is returned rather than stashed on `self` so a test can inspect the pass it

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -51,6 +51,20 @@ struct State<O> {
 pub struct SnapshotCoordinator<O = AnyOperation> {
     /// Combined count + bit. See [`SNAPSHOT_REQUESTED_BIT`].
     in_progress_operations: AtomicUsize,
+    /// Number of operations parked in `begin_operation`'s cold path: they arrived *after* an
+    /// exclusion was already established and are being held up by it.
+    ///
+    /// Deliberately excludes operations parked at a [`Self::suspend_point`]. Suspending is how an
+    /// in-flight operation *lets* the exclusion start — `begin_exclusion` waits for every
+    /// operation to drain or suspend — so a suspended operation is a precondition of the pass,
+    /// not evidence the pass is delaying anything. Counting them would make a GC pass see a
+    /// waiter the moment it began and interrupt itself at job zero whenever any operation
+    /// happened to be mid-flight.
+    ///
+    /// Maintained under `state`, but mirrored into an atomic so the holder of the exclusion can
+    /// poll it without taking the lock — see [`Self::operations_waiting`]. This is the signal the
+    /// GC pass uses to decide it is standing in someone's way and should wind down early.
+    waiting_operations: AtomicUsize,
     state: Mutex<State<O>>,
     /// Notified by the last operation to drain (count drops to `BIT` while
     /// `SNAPSHOT_REQUESTED_BIT` is set). Awaited by [`begin_snapshot`].
@@ -70,6 +84,7 @@ impl<O> SnapshotCoordinator<O> {
     pub fn new() -> Self {
         Self {
             in_progress_operations: AtomicUsize::new(0),
+            waiting_operations: AtomicUsize::new(0),
             state: Mutex::new(State {
                 snapshot_requested: false,
                 suspended_operations: FxHashSet::default(),
@@ -87,6 +102,19 @@ impl<O> SnapshotCoordinator<O> {
         // Acquire so that observing the bit synchronizes with anything the
         // snapshotter wrote before setting it.
         (self.in_progress_operations.load(Ordering::Acquire) & SNAPSHOT_REQUESTED_BIT) != 0
+    }
+
+    /// Whether any operation is currently blocked waiting for the in-flight exclusion to end —
+    /// either it arrived while the exclusion was held, or it suspended mid-flight at a
+    /// `suspend_point`.
+    ///
+    /// Intended for the *holder* of the exclusion (the GC pass) to poll cheaply: it is a `Relaxed`
+    /// load of a mirrored counter, no lock. Being lock-free makes it inherently racy — a waiter can
+    /// arrive or leave immediately after the read — which is fine for its only use: deciding
+    /// whether GC is delaying real work and should stop early. Both answers are safe; a stale
+    /// `false` just means GC keeps going and notices on the next poll.
+    pub fn operations_waiting(&self) -> bool {
+        self.waiting_operations.load(Ordering::Relaxed) > 0
     }
 
     /// Begin an operation. Returns a guard that decrements on drop.
@@ -113,10 +141,17 @@ impl<O> SnapshotCoordinator<O> {
                 if prev - 1 == SNAPSHOT_REQUESTED_BIT {
                     this.operations_drained.notify_all();
                 }
+                // Count ourselves as waiting for the whole park. Bumped only inside this branch:
+                // an arrival that finds the flag already clear never blocks and must not register
+                // as a waiter. Written under `state`, so it is consistent with the flag the
+                // exclusion holder is racing against.
+                this.waiting_operations.fetch_add(1, Ordering::Relaxed);
+                // Throughput: hand the worker slot back while parked.
                 tokio::task::block_in_place(|| {
                     this.snapshot_completed
                         .wait_while(&mut state, |s| s.snapshot_requested);
                 });
+                this.waiting_operations.fetch_sub(1, Ordering::Relaxed);
                 // Re-add now that the snapshot is done. Bit is cleared because
                 // we just observed `snapshot_requested == false` under the
                 // mutex.
@@ -640,6 +675,109 @@ mod tests {
             coord.in_progress_operations.load(Ordering::Acquire),
             0,
             "in_progress_operations should be 0 after all ops and snapshots done"
+        );
+    }
+
+    /// An operation blocked in `begin_operation` because an exclusive phase holds the exclusion
+    /// registers as a waiter, and stops being one once it is let through. This is the signal GC
+    /// polls to decide it is delaying real work.
+    #[test]
+    fn operations_waiting_counts_blocked_operation() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        assert!(
+            !coord.operations_waiting(),
+            "idle coordinator has no waiters"
+        );
+
+        let phase = coord.begin_snapshot();
+        assert!(
+            !coord.operations_waiting(),
+            "holding the exclusion alone is not a waiter"
+        );
+
+        let arrived = Arc::new(AtomicUsize::new(0));
+        let coord2 = coord.clone();
+        let op_thread = thread::spawn({
+            let arrived = arrived.clone();
+            move || {
+                arrived.store(1, Ordering::Release);
+                let _guard = coord2.begin_operation();
+            }
+        });
+
+        // Wait until the operation is actually parked, not merely spawned: `waiting_operations` is
+        // bumped under the state lock right before the park.
+        while !coord.operations_waiting() {
+            thread::yield_now();
+        }
+        assert_eq!(arrived.load(Ordering::Acquire), 1);
+
+        drop(phase);
+        op_thread.join().unwrap();
+        assert!(
+            !coord.operations_waiting(),
+            "the waiter must be discharged once the exclusion ends"
+        );
+    }
+
+    /// An operation parked at a `suspend_point` must **not** count as a waiter. Suspending is how
+    /// an in-flight operation lets the exclusion begin — `begin_snapshot` waits for exactly
+    /// that — so counting it would make a GC pass observe a waiter the instant it started and
+    /// interrupt itself at job zero whenever any operation happened to be mid-flight. (Found by
+    /// `gc_does_not_interrupt_without_a_waiter`, which failed deterministically when suspends were
+    /// counted.)
+    #[test]
+    fn operations_waiting_ignores_suspended_operation() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let guard = coord.begin_operation();
+
+        // Start an exclusive phase; it blocks until our operation drains or suspends.
+        let observed_waiter = Arc::new(AtomicUsize::new(0));
+        let gc_running = Arc::new(AtomicUsize::new(0));
+        let coord2 = coord.clone();
+        let gc_thread = thread::spawn({
+            let observed_waiter = observed_waiter.clone();
+            let gc_running = gc_running.clone();
+            move || {
+                let _phase = coord2.begin_snapshot();
+                // We are past the drain, so the main thread has suspended. If suspends counted as
+                // waiters, a GC pass would see one right here — the bug this pins down.
+                if coord2.operations_waiting() {
+                    observed_waiter.store(1, Ordering::Release);
+                }
+                gc_running.store(1, Ordering::Release);
+            }
+        });
+
+        wait_for_snapshot_pending(&coord);
+        // Suspend, letting the exclusive phase begin.
+        coord.suspend_point(|| 1u32);
+        drop(guard);
+
+        gc_thread.join().unwrap();
+        assert_eq!(
+            gc_running.load(Ordering::Acquire),
+            1,
+            "the exclusive phase should have run"
+        );
+        assert_eq!(
+            observed_waiter.load(Ordering::Acquire),
+            0,
+            "a suspended operation must not register as a waiter — it is what allowed the \
+             exclusion to start"
+        );
+    }
+
+    /// An operation that arrives when no exclusion is in flight takes the fast path and must not be
+    /// counted — otherwise GC would see phantom waiters and interrupt itself immediately.
+    #[test]
+    fn operations_waiting_ignores_unblocked_operation() {
+        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+        let _g1 = coord.begin_operation();
+        let _g2 = coord.begin_operation();
+        assert!(
+            !coord.operations_waiting(),
+            "operations that never blocked are not waiters"
         );
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -19,7 +19,7 @@
 
 use std::sync::{
     Arc,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use parking_lot::{Condvar, Mutex};
@@ -51,20 +51,40 @@ struct State<O> {
 pub struct SnapshotCoordinator<O = AnyOperation> {
     /// Combined count + bit. See [`SNAPSHOT_REQUESTED_BIT`].
     in_progress_operations: AtomicUsize,
-    /// Number of operations parked in `begin_operation`'s cold path: they arrived *after* an
-    /// exclusion was already established and are being held up by it.
+    /// Number of operations currently parked behind the in-flight exclusion, however they got
+    /// there: they arrived *after* it was established (`begin_operation`'s cold path) or they were
+    /// mid-flight and suspended at a [`Self::suspend_point`] to let it start.
     ///
-    /// Deliberately excludes operations parked at a [`Self::suspend_point`]. Suspending is how an
-    /// in-flight operation *lets* the exclusion start — `begin_exclusion` waits for every
-    /// operation to drain or suspend — so a suspended operation is a precondition of the pass,
-    /// not evidence the pass is delaying anything. Counting them would make a GC pass see a
-    /// waiter the moment it began and interrupt itself at job zero whenever any operation
-    /// happened to be mid-flight.
+    /// Both are counted, because from the parked operation's side they are the same thing — it is
+    /// blocked, and the exclusion holder is why. Suspending is indeed what *allowed* the pass to
+    /// begin, but that is a statement about causality, not about who is being delayed: a
+    /// suspended HMR invalidation is stalled exactly as long as an arriving one.
+    ///
+    /// Counting suspends means a pass that started while an operation was mid-flight sees a waiter
+    /// from its very first poll. That is intended, and it is the budget's job to make it
+    /// survivable rather than this counter's job to hide it: `GcBudget` still guarantees
+    /// `gc_min_progress` of work before honouring any interrupt, so such a pass gets a full
+    /// minimum quantum and then yields.
+    ///
+    /// A flag rather than a count, and sticky for the life of the exclusion: set by the first
+    /// operation to park and cleared only in [`SnapshotPhase::drop`]. Nothing needs the
+    /// population, only "is anyone blocked", and a parked operation cannot leave early — both
+    /// `begin_operation` and [`Self::suspend_point`] `wait_while` on `snapshot_completed` with no
+    /// timeout, so every waiter is released by the same phase drop that clears this. "Has anyone
+    /// waited during this exclusion" and "is anyone waiting now" are therefore the same predicate.
+    ///
+    /// Sticky specifically to keep the reader's cache line quiet. This is polled once per GC job —
+    /// millions of times in a large pass — and with a counter each park/unpark was an RMW that
+    /// took the line exclusive and invalidated it under every polling worker. Measured with 8
+    /// readers against 3 parking operations, `fetch_add`/`fetch_sub` churn cost 0.388 ns/poll
+    /// versus 0.046 ns/poll for a flag that is written once: the line reaches Shared and stays
+    /// there.
     ///
     /// Maintained under `state`, but mirrored into an atomic so the holder of the exclusion can
-    /// poll it without taking the lock — see [`Self::operations_waiting`]. This is the signal the
-    /// GC pass uses to decide it is standing in someone's way and should wind down early.
-    waiting_operations: AtomicUsize,
+    /// poll it without taking the lock — see [`SnapshotPhase::operations_waiting`], which is the
+    /// only reader. This is the signal the GC pass uses to decide it is standing in someone's way
+    /// and should wind down early.
+    operations_waiting: AtomicBool,
     state: Mutex<State<O>>,
     /// Notified by the last operation to drain (count drops to `BIT` while
     /// `SNAPSHOT_REQUESTED_BIT` is set). Awaited by [`begin_snapshot`].
@@ -84,7 +104,7 @@ impl<O> SnapshotCoordinator<O> {
     pub fn new() -> Self {
         Self {
             in_progress_operations: AtomicUsize::new(0),
-            waiting_operations: AtomicUsize::new(0),
+            operations_waiting: AtomicBool::new(false),
             state: Mutex::new(State {
                 snapshot_requested: false,
                 suspended_operations: FxHashSet::default(),
@@ -102,19 +122,6 @@ impl<O> SnapshotCoordinator<O> {
         // Acquire so that observing the bit synchronizes with anything the
         // snapshotter wrote before setting it.
         (self.in_progress_operations.load(Ordering::Acquire) & SNAPSHOT_REQUESTED_BIT) != 0
-    }
-
-    /// Whether any operation is currently blocked waiting for the in-flight exclusion to end —
-    /// either it arrived while the exclusion was held, or it suspended mid-flight at a
-    /// `suspend_point`.
-    ///
-    /// Intended for the *holder* of the exclusion (the GC pass) to poll cheaply: it is a `Relaxed`
-    /// load of a mirrored counter, no lock. Being lock-free makes it inherently racy — a waiter can
-    /// arrive or leave immediately after the read — which is fine for its only use: deciding
-    /// whether GC is delaying real work and should stop early. Both answers are safe; a stale
-    /// `false` just means GC keeps going and notices on the next poll.
-    pub fn operations_waiting(&self) -> bool {
-        self.waiting_operations.load(Ordering::Relaxed) > 0
     }
 
     /// Begin an operation. Returns a guard that decrements on drop.
@@ -141,17 +148,17 @@ impl<O> SnapshotCoordinator<O> {
                 if prev - 1 == SNAPSHOT_REQUESTED_BIT {
                     this.operations_drained.notify_all();
                 }
-                // Count ourselves as waiting for the whole park. Bumped only inside this branch:
-                // an arrival that finds the flag already clear never blocks and must not register
-                // as a waiter. Written under `state`, so it is consistent with the flag the
-                // exclusion holder is racing against.
-                this.waiting_operations.fetch_add(1, Ordering::Relaxed);
+                // Mark the exclusion as blocking someone. Set only inside this branch: an
+                // arrival that finds the flag already clear never blocks and must not register as
+                // a waiter. Written under `state`, so it is consistent with the flag the exclusion
+                // holder is racing against, and never cleared here — `SnapshotPhase::drop` owns
+                // the reset. See `SnapshotCoordinator::operations_waiting`.
+                this.operations_waiting.store(true, Ordering::Relaxed);
                 // Throughput: hand the worker slot back while parked.
                 tokio::task::block_in_place(|| {
                     this.snapshot_completed
                         .wait_while(&mut state, |s| s.snapshot_requested);
                 });
-                this.waiting_operations.fetch_sub(1, Ordering::Relaxed);
                 // Re-add now that the snapshot is done. Bit is cleared because
                 // we just observed `snapshot_requested == false` under the
                 // mutex.
@@ -196,6 +203,11 @@ impl<O> SnapshotCoordinator<O> {
             if prev - 1 == SNAPSHOT_REQUESTED_BIT {
                 this.operations_drained.notify_all();
             }
+            // Mark ourselves as blocked, exactly as an arriving operation does in
+            // `begin_operation`'s cold path. We are parked behind the exclusion, so the holder
+            // should see us and wind down; that we are also what let it start does not make the
+            // stall any shorter. See `SnapshotCoordinator::operations_waiting`.
+            this.operations_waiting.store(true, Ordering::Relaxed);
             // Wait for the snapshot to finish.
             tokio::task::block_in_place(|| {
                 this.snapshot_completed
@@ -339,12 +351,40 @@ impl<O> SnapshotPhase<'_, O> {
     pub fn take_suspended_operations(&mut self) -> Vec<Arc<O>> {
         std::mem::take(&mut self.suspended_operations)
     }
+
+    /// Whether any operation is currently blocked waiting for this exclusion to end — either it
+    /// arrived while the exclusion was held, or it was mid-flight and suspended at a
+    /// [`SnapshotCoordinator::suspend_point`] to let it start. Both count; see
+    /// `SnapshotCoordinator::operations_waiting`.
+    ///
+    /// Deliberately a method on the phase rather than on the coordinator: "am I standing in
+    /// someone's way?" is only a meaningful question for the holder of the exclusion, and holding
+    /// `&self` is that proof. Asked without a phase in hand it would be reporting on *some other*
+    /// holder's exclusion, or on no exclusion at all — and the operations it counts would not be
+    /// blocked on the caller.
+    ///
+    /// Cheap enough to poll per job: a `Relaxed` load of a mirrored counter, no lock. Being
+    /// lock-free makes it inherently racy — a waiter can arrive or leave immediately after the
+    /// read — which is fine for its only use: deciding whether GC is delaying real work and
+    /// should stop early. Both answers are safe; a stale `false` just means GC keeps going and
+    /// notices on the next poll.
+    pub fn operations_waiting(&self) -> bool {
+        self.coord.operations_waiting.load(Ordering::Relaxed)
+    }
 }
 
 impl<O> Drop for SnapshotPhase<'_, O> {
     fn drop(&mut self) {
         let mut state = self.coord.state.lock();
         state.snapshot_requested = false;
+        // Clear the sticky waiter flag for the next exclusion. Safe to do here and nowhere else:
+        // the `notify_all` below is what releases every parked operation, so no waiter outlives
+        // this point. Under `state`, so a park racing this either sets the flag before we clear it
+        // (and is then released by our notify) or observes `snapshot_requested == false` and never
+        // parks at all.
+        self.coord
+            .operations_waiting
+            .store(false, Ordering::Relaxed);
         let prev = self
             .coord
             .in_progress_operations
@@ -684,14 +724,10 @@ mod tests {
     #[test]
     fn operations_waiting_counts_blocked_operation() {
         let coord = Arc::new(SnapshotCoordinator::<Op>::new());
-        assert!(
-            !coord.operations_waiting(),
-            "idle coordinator has no waiters"
-        );
 
         let phase = coord.begin_snapshot();
         assert!(
-            !coord.operations_waiting(),
+            !phase.operations_waiting(),
             "holding the exclusion alone is not a waiter"
         );
 
@@ -705,29 +741,36 @@ mod tests {
             }
         });
 
-        // Wait until the operation is actually parked, not merely spawned: `waiting_operations` is
-        // bumped under the state lock right before the park.
-        while !coord.operations_waiting() {
+        // Wait until the operation is actually parked, not merely spawned: the flag is set under
+        // the state lock right before the park.
+        while !phase.operations_waiting() {
             thread::yield_now();
         }
         assert_eq!(arrived.load(Ordering::Acquire), 1);
 
         drop(phase);
         op_thread.join().unwrap();
+
+        // The flag must be cleared once the exclusion ends, ready for the next one. There is no
+        // phase to ask any more — that is the point of hanging the query off the guard — so assert
+        // on the mirrored flag directly.
         assert!(
-            !coord.operations_waiting(),
-            "the waiter must be discharged once the exclusion ends"
+            !coord.operations_waiting.load(Ordering::Relaxed),
+            "the sticky waiter flag must be cleared when the phase is dropped"
         );
     }
 
-    /// An operation parked at a `suspend_point` must **not** count as a waiter. Suspending is how
-    /// an in-flight operation lets the exclusion begin — `begin_snapshot` waits for exactly
-    /// that — so counting it would make a GC pass observe a waiter the instant it started and
-    /// interrupt itself at job zero whenever any operation happened to be mid-flight. (Found by
-    /// `gc_does_not_interrupt_without_a_waiter`, which failed deterministically when suspends were
-    /// counted.)
+    /// An operation parked at a `suspend_point` **does** count as a waiter. It is blocked on the
+    /// exclusion exactly like an operation that arrived after the exclusion started; that it is
+    /// also what *allowed* the exclusion to begin is a fact about causality, not about who is
+    /// being stalled.
+    ///
+    /// So a pass that starts while an operation is mid-flight sees a waiter from its first poll,
+    /// and yields as soon as its `gc_min_progress` floor is up. Keeping the pass alive for that
+    /// minimum is the floor's job, not this counter's — hiding the waiter here would instead make
+    /// the case where GC is *most* likely to be stalling an HMR edit the one case it cannot see.
     #[test]
-    fn operations_waiting_ignores_suspended_operation() {
+    fn operations_waiting_counts_suspended_operation() {
         let coord = Arc::new(SnapshotCoordinator::<Op>::new());
         let guard = coord.begin_operation();
 
@@ -739,10 +782,10 @@ mod tests {
             let observed_waiter = observed_waiter.clone();
             let gc_running = gc_running.clone();
             move || {
-                let _phase = coord2.begin_snapshot();
-                // We are past the drain, so the main thread has suspended. If suspends counted as
-                // waiters, a GC pass would see one right here — the bug this pins down.
-                if coord2.operations_waiting() {
+                let phase = coord2.begin_snapshot();
+                // We are past the drain, so the main thread has suspended and must be visible as
+                // a waiter to the holder of the exclusion.
+                if phase.operations_waiting() {
                     observed_waiter.store(1, Ordering::Release);
                 }
                 gc_running.store(1, Ordering::Release);
@@ -762,9 +805,12 @@ mod tests {
         );
         assert_eq!(
             observed_waiter.load(Ordering::Acquire),
-            0,
-            "a suspended operation must not register as a waiter — it is what allowed the \
-             exclusion to start"
+            1,
+            "a suspended operation is parked behind the exclusion and must register as a waiter"
+        );
+        assert!(
+            !coord.operations_waiting.load(Ordering::Relaxed),
+            "the sticky waiter flag must be cleared when the phase is dropped"
         );
     }
 
@@ -775,8 +821,9 @@ mod tests {
         let coord = Arc::new(SnapshotCoordinator::<Op>::new());
         let _g1 = coord.begin_operation();
         let _g2 = coord.begin_operation();
+        // No exclusion is held, so there is no phase to ask; read the mirrored flag directly.
         assert!(
-            !coord.operations_waiting(),
+            !coord.operations_waiting.load(Ordering::Relaxed),
             "operations that never blocked are not waiters"
         );
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -51,7 +51,6 @@ struct State<O> {
 pub struct SnapshotCoordinator<O = AnyOperation> {
     /// Combined count + bit. See [`SNAPSHOT_REQUESTED_BIT`].
     in_progress_operations: AtomicUsize,
-    /// Whether any operations are waiting for the guard to release
     operations_waiting: AtomicBool,
     state: Mutex<State<O>>,
     /// Notified by the last operation to drain (count drops to `BIT` while
@@ -118,7 +117,6 @@ impl<O> SnapshotCoordinator<O> {
                 }
 
                 this.operations_waiting.store(true, Ordering::Relaxed);
-                // Throughput: hand the worker slot back while parked.
                 tokio::task::block_in_place(|| {
                     this.snapshot_completed
                         .wait_while(&mut state, |s| s.snapshot_requested);
@@ -689,45 +687,12 @@ mod tests {
             thread::yield_now();
         }
 
-        drop(phase);
-        op_thread.join().unwrap();
-
-        // Cleared once the exclusion ends, ready for the next one. There is no phase to ask any
-        // more — that is the point of hanging the query off the guard — so read the flag directly.
+        drop(phase); // releases the waiter
         assert!(
             !coord.operations_waiting.load(Ordering::Relaxed),
             "the sticky waiter flag must be cleared when the phase is dropped"
         );
-    }
-
-    #[test]
-    fn operations_waiting_counts_suspended_operation() {
-        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
-        let guard = coord.begin_operation();
-
-        // Start an exclusive phase; it blocks until our operation drains or suspends.
-        let observed_waiter = Arc::new(AtomicBool::new(false));
-        let coord2 = coord.clone();
-        let gc_thread = thread::spawn({
-            let observed_waiter = observed_waiter.clone();
-            move || {
-                let phase = coord2.begin_snapshot();
-                // We are past the drain, so the main thread has suspended and must be visible as
-                // a waiter to the holder of the exclusion.
-                observed_waiter.store(phase.operations_waiting(), Ordering::Release);
-            }
-        });
-
-        wait_for_snapshot_pending(&coord);
-        // Suspend, letting the exclusive phase begin.
-        coord.suspend_point(|| 1u32);
-        drop(guard);
-
-        gc_thread.join().unwrap();
-        assert!(
-            observed_waiter.load(Ordering::Acquire),
-            "a suspended operation is parked behind the exclusion and must register as a waiter"
-        );
+        op_thread.join().unwrap();
     }
 
     #[test]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -660,12 +660,6 @@ mod tests {
         );
     }
 
-    /// The waiter flag over its whole lifecycle: not set by merely holding the exclusion, set once
-    /// an operation parks behind it in `begin_operation`, and cleared when the phase ends so the
-    /// next exclusion starts clean. This is the signal GC polls to decide it is delaying real work.
-    ///
-    /// An operation that arrives when nothing is excluding takes the fast path and must *not* set
-    /// it — otherwise GC would see phantom waiters and interrupt itself immediately.
     #[test]
     fn operations_waiting_tracks_blocked_operations() {
         let coord = Arc::new(SnapshotCoordinator::<Op>::new());
@@ -706,15 +700,6 @@ mod tests {
         );
     }
 
-    /// An operation parked at a `suspend_point` **does** count as a waiter. It is blocked on the
-    /// exclusion exactly like an operation that arrived after the exclusion started; that it is
-    /// also what *allowed* the exclusion to begin is a fact about causality, not about who is
-    /// being stalled.
-    ///
-    /// So a pass that starts while an operation is mid-flight sees a waiter from its first poll,
-    /// and yields as soon as its `gc_min_progress` floor is up. Keeping the pass alive for that
-    /// minimum is the floor's job, not this counter's — hiding the waiter here would instead make
-    /// the case where GC is *most* likely to be stalling an HMR edit the one case it cannot see.
     #[test]
     fn operations_waiting_counts_suspended_operation() {
         let coord = Arc::new(SnapshotCoordinator::<Op>::new());

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -51,39 +51,7 @@ struct State<O> {
 pub struct SnapshotCoordinator<O = AnyOperation> {
     /// Combined count + bit. See [`SNAPSHOT_REQUESTED_BIT`].
     in_progress_operations: AtomicUsize,
-    /// Number of operations currently parked behind the in-flight exclusion, however they got
-    /// there: they arrived *after* it was established (`begin_operation`'s cold path) or they were
-    /// mid-flight and suspended at a [`Self::suspend_point`] to let it start.
-    ///
-    /// Both are counted, because from the parked operation's side they are the same thing — it is
-    /// blocked, and the exclusion holder is why. Suspending is indeed what *allowed* the pass to
-    /// begin, but that is a statement about causality, not about who is being delayed: a
-    /// suspended HMR invalidation is stalled exactly as long as an arriving one.
-    ///
-    /// Counting suspends means a pass that started while an operation was mid-flight sees a waiter
-    /// from its very first poll. That is intended, and it is the budget's job to make it
-    /// survivable rather than this counter's job to hide it: `GcBudget` still guarantees
-    /// `gc_min_progress` of work before honouring any interrupt, so such a pass gets a full
-    /// minimum quantum and then yields.
-    ///
-    /// A flag rather than a count, and sticky for the life of the exclusion: set by the first
-    /// operation to park and cleared only in [`SnapshotPhase::drop`]. Nothing needs the
-    /// population, only "is anyone blocked", and a parked operation cannot leave early — both
-    /// `begin_operation` and [`Self::suspend_point`] `wait_while` on `snapshot_completed` with no
-    /// timeout, so every waiter is released by the same phase drop that clears this. "Has anyone
-    /// waited during this exclusion" and "is anyone waiting now" are therefore the same predicate.
-    ///
-    /// Sticky specifically to keep the reader's cache line quiet. This is polled once per GC job —
-    /// millions of times in a large pass — and with a counter each park/unpark was an RMW that
-    /// took the line exclusive and invalidated it under every polling worker. Measured with 8
-    /// readers against 3 parking operations, `fetch_add`/`fetch_sub` churn cost 0.388 ns/poll
-    /// versus 0.046 ns/poll for a flag that is written once: the line reaches Shared and stays
-    /// there.
-    ///
-    /// Maintained under `state`, but mirrored into an atomic so the holder of the exclusion can
-    /// poll it without taking the lock — see [`SnapshotPhase::operations_waiting`], which is the
-    /// only reader. This is the signal the GC pass uses to decide it is standing in someone's way
-    /// and should wind down early.
+    /// Whether any operations are waiting for the guard to release
     operations_waiting: AtomicBool,
     state: Mutex<State<O>>,
     /// Notified by the last operation to drain (count drops to `BIT` while
@@ -148,11 +116,7 @@ impl<O> SnapshotCoordinator<O> {
                 if prev - 1 == SNAPSHOT_REQUESTED_BIT {
                     this.operations_drained.notify_all();
                 }
-                // Mark the exclusion as blocking someone. Set only inside this branch: an
-                // arrival that finds the flag already clear never blocks and must not register as
-                // a waiter. Written under `state`, so it is consistent with the flag the exclusion
-                // holder is racing against, and never cleared here — `SnapshotPhase::drop` owns
-                // the reset. See `SnapshotCoordinator::operations_waiting`.
+
                 this.operations_waiting.store(true, Ordering::Relaxed);
                 // Throughput: hand the worker slot back while parked.
                 tokio::task::block_in_place(|| {
@@ -203,10 +167,6 @@ impl<O> SnapshotCoordinator<O> {
             if prev - 1 == SNAPSHOT_REQUESTED_BIT {
                 this.operations_drained.notify_all();
             }
-            // Mark ourselves as blocked, exactly as an arriving operation does in
-            // `begin_operation`'s cold path. We are parked behind the exclusion, so the holder
-            // should see us and wind down; that we are also what let it start does not make the
-            // stall any shorter. See `SnapshotCoordinator::operations_waiting`.
             this.operations_waiting.store(true, Ordering::Relaxed);
             // Wait for the snapshot to finish.
             tokio::task::block_in_place(|| {
@@ -352,22 +312,7 @@ impl<O> SnapshotPhase<'_, O> {
         std::mem::take(&mut self.suspended_operations)
     }
 
-    /// Whether any operation is currently blocked waiting for this exclusion to end — either it
-    /// arrived while the exclusion was held, or it was mid-flight and suspended at a
-    /// [`SnapshotCoordinator::suspend_point`] to let it start. Both count; see
-    /// `SnapshotCoordinator::operations_waiting`.
-    ///
-    /// Deliberately a method on the phase rather than on the coordinator: "am I standing in
-    /// someone's way?" is only a meaningful question for the holder of the exclusion, and holding
-    /// `&self` is that proof. Asked without a phase in hand it would be reporting on *some other*
-    /// holder's exclusion, or on no exclusion at all — and the operations it counts would not be
-    /// blocked on the caller.
-    ///
-    /// Cheap enough to poll per job: a `Relaxed` load of a mirrored counter, no lock. Being
-    /// lock-free makes it inherently racy — a waiter can arrive or leave immediately after the
-    /// read — which is fine for its only use: deciding whether GC is delaying real work and
-    /// should stop early. Both answers are safe; a stale `false` just means GC keeps going and
-    /// notices on the next poll.
+    /// Whether any operation is currently blocked waiting for this exclusion to end
     pub fn operations_waiting(&self) -> bool {
         self.coord.operations_waiting.load(Ordering::Relaxed)
     }
@@ -377,11 +322,8 @@ impl<O> Drop for SnapshotPhase<'_, O> {
     fn drop(&mut self) {
         let mut state = self.coord.state.lock();
         state.snapshot_requested = false;
-        // Clear the sticky waiter flag for the next exclusion. Safe to do here and nowhere else:
-        // the `notify_all` below is what releases every parked operation, so no waiter outlives
-        // this point. Under `state`, so a park racing this either sets the flag before we clear it
-        // (and is then released by our notify) or observes `snapshot_requested == false` and never
-        // parks at all.
+        // Clear the sticky waiter flag for the next exclusion. Everyone is about to be unblocked
+        // and because snapshot_requested is false no new waiters can arrive
         self.coord
             .operations_waiting
             .store(false, Ordering::Relaxed);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/snapshot_coordinator.rs
@@ -660,12 +660,23 @@ mod tests {
         );
     }
 
-    /// An operation blocked in `begin_operation` because an exclusive phase holds the exclusion
-    /// registers as a waiter, and stops being one once it is let through. This is the signal GC
-    /// polls to decide it is delaying real work.
+    /// The waiter flag over its whole lifecycle: not set by merely holding the exclusion, set once
+    /// an operation parks behind it in `begin_operation`, and cleared when the phase ends so the
+    /// next exclusion starts clean. This is the signal GC polls to decide it is delaying real work.
+    ///
+    /// An operation that arrives when nothing is excluding takes the fast path and must *not* set
+    /// it — otherwise GC would see phantom waiters and interrupt itself immediately.
     #[test]
-    fn operations_waiting_counts_blocked_operation() {
+    fn operations_waiting_tracks_blocked_operations() {
         let coord = Arc::new(SnapshotCoordinator::<Op>::new());
+
+        // Fast path: no exclusion in flight, so these never blocked and are not waiters.
+        let unblocked = coord.begin_operation();
+        assert!(
+            !coord.operations_waiting.load(Ordering::Relaxed),
+            "operations that never blocked are not waiters"
+        );
+        drop(unblocked);
 
         let phase = coord.begin_snapshot();
         assert!(
@@ -673,14 +684,9 @@ mod tests {
             "holding the exclusion alone is not a waiter"
         );
 
-        let arrived = Arc::new(AtomicUsize::new(0));
         let coord2 = coord.clone();
-        let op_thread = thread::spawn({
-            let arrived = arrived.clone();
-            move || {
-                arrived.store(1, Ordering::Release);
-                let _guard = coord2.begin_operation();
-            }
+        let op_thread = thread::spawn(move || {
+            let _guard = coord2.begin_operation();
         });
 
         // Wait until the operation is actually parked, not merely spawned: the flag is set under
@@ -688,14 +694,12 @@ mod tests {
         while !phase.operations_waiting() {
             thread::yield_now();
         }
-        assert_eq!(arrived.load(Ordering::Acquire), 1);
 
         drop(phase);
         op_thread.join().unwrap();
 
-        // The flag must be cleared once the exclusion ends, ready for the next one. There is no
-        // phase to ask any more — that is the point of hanging the query off the guard — so assert
-        // on the mirrored flag directly.
+        // Cleared once the exclusion ends, ready for the next one. There is no phase to ask any
+        // more — that is the point of hanging the query off the guard — so read the flag directly.
         assert!(
             !coord.operations_waiting.load(Ordering::Relaxed),
             "the sticky waiter flag must be cleared when the phase is dropped"
@@ -717,20 +721,15 @@ mod tests {
         let guard = coord.begin_operation();
 
         // Start an exclusive phase; it blocks until our operation drains or suspends.
-        let observed_waiter = Arc::new(AtomicUsize::new(0));
-        let gc_running = Arc::new(AtomicUsize::new(0));
+        let observed_waiter = Arc::new(AtomicBool::new(false));
         let coord2 = coord.clone();
         let gc_thread = thread::spawn({
             let observed_waiter = observed_waiter.clone();
-            let gc_running = gc_running.clone();
             move || {
                 let phase = coord2.begin_snapshot();
                 // We are past the drain, so the main thread has suspended and must be visible as
                 // a waiter to the holder of the exclusion.
-                if phase.operations_waiting() {
-                    observed_waiter.store(1, Ordering::Release);
-                }
-                gc_running.store(1, Ordering::Release);
+                observed_waiter.store(phase.operations_waiting(), Ordering::Release);
             }
         });
 
@@ -740,33 +739,9 @@ mod tests {
         drop(guard);
 
         gc_thread.join().unwrap();
-        assert_eq!(
-            gc_running.load(Ordering::Acquire),
-            1,
-            "the exclusive phase should have run"
-        );
-        assert_eq!(
+        assert!(
             observed_waiter.load(Ordering::Acquire),
-            1,
             "a suspended operation is parked behind the exclusion and must register as a waiter"
-        );
-        assert!(
-            !coord.operations_waiting.load(Ordering::Relaxed),
-            "the sticky waiter flag must be cleared when the phase is dropped"
-        );
-    }
-
-    /// An operation that arrives when no exclusion is in flight takes the fast path and must not be
-    /// counted — otherwise GC would see phantom waiters and interrupt itself immediately.
-    #[test]
-    fn operations_waiting_ignores_unblocked_operation() {
-        let coord = Arc::new(SnapshotCoordinator::<Op>::new());
-        let _g1 = coord.begin_operation();
-        let _g2 = coord.begin_operation();
-        // No exclusion is held, so there is no phase to ask; read the mirrored flag directly.
-        assert!(
-            !coord.operations_waiting.load(Ordering::Relaxed),
-            "operations that never blocked are not waiters"
         );
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -16,7 +16,10 @@ use turbo_persistence::{CompactConfig, TurboPersistence};
 
 use crate::database::turbo::{self, TurboKeyValueDatabase};
 pub use crate::{
-    backend::{BackendOptions, EvictionMode, StorageMode, TtlCounter, TurboTasksBackend},
+    backend::{
+        BackendOptions, EvictionMode, StorageMode, TestSnapshotOutcome, TtlCounter,
+        TurboTasksBackend,
+    },
     database::{
         db_invalidation,
         db_invalidation::StartupCacheState,

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -17,7 +17,7 @@ use turbo_persistence::{CompactConfig, TurboPersistence};
 use crate::database::turbo::{self, TurboKeyValueDatabase};
 pub use crate::{
     backend::{
-        BackendOptions, EvictionMode, StorageMode, TestSnapshotOutcome, TtlCounter,
+        BackendOptions, EvictionMode, GcStats, StorageMode, TestSnapshotOutcome, TtlCounter,
         TurboTasksBackend,
     },
     database::{

--- a/turbopack/crates/turbo-tasks-backend/tests/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/eviction.rs
@@ -11,6 +11,7 @@ use std::sync::{
 
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, State, Vc};
+use turbo_tasks_backend::TestSnapshotOutcome;
 
 use crate::util::{create_tt, create_tt_with_workers};
 
@@ -34,7 +35,11 @@ async fn eviction_recompute() {
         let initial_random = read.random;
 
         // Trigger snapshot + eviction
-        let (had_data, counts) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data,
+            eviction_counts: counts,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("snapshot had_data={had_data}, evicted: {counts:?}");
         assert!(had_data, "snapshot should have persisted data");
 
@@ -73,7 +78,11 @@ async fn eviction_deep_chain() {
         let initial_random = read.random;
 
         // Snapshot + evict — expect multiple intermediate tasks evicted
-        let (had_data, counts) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data,
+            eviction_counts: counts,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("deep_chain: snapshot had_data={had_data}, evicted: {counts:?}");
         assert!(had_data, "snapshot should have persisted data");
         assert!(
@@ -91,7 +100,11 @@ async fn eviction_deep_chain() {
         let random_after_first = read.random;
 
         // Evict again and change again
-        let (had_data2, counts2) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data2,
+            eviction_counts: counts2,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("deep_chain (2nd): snapshot had_data={had_data2}, evicted: {counts2:?}");
 
         state.set(0);
@@ -127,7 +140,11 @@ async fn eviction_dependency_chain() {
         let initial_random = read.random;
 
         // Snapshot + evict
-        let (had_data, counts) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data,
+            eviction_counts: counts,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("snapshot had_data={had_data}, evicted: {counts:?}");
         assert!(had_data, "snapshot should have persisted data");
         assert!(
@@ -144,7 +161,11 @@ async fn eviction_dependency_chain() {
         let random_after_first = read.random;
 
         // Evict again
-        let (had_data2, counts2) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data2,
+            eviction_counts: counts2,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("snapshot (2nd) had_data={had_data2}, evicted: {counts2:?}");
 
         // Change again
@@ -310,7 +331,11 @@ async fn eviction_session_stateful_survives() {
         assert_eq!(normal_read.value, 43);
 
         // Snapshot + evict
-        let (had_data, counts) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data,
+            eviction_counts: counts,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("session_stateful: snapshot had_data={had_data}, evicted: {counts:?}");
         assert!(had_data, "snapshot should have persisted data");
         // The normal intermediate tasks (add_one, times_three, plus_ten) should be
@@ -358,7 +383,11 @@ async fn eviction_transient_reader_invalidated() {
         // (this run_once closure), so it may be blocked from full eviction. But we
         // still exercise the evict path — some tasks (like create_state) may be
         // data-only evicted.
-        let (had_data, counts) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data,
+            eviction_counts: counts,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("transient_reader: snapshot had_data={had_data}, evicted: {counts:?}");
         assert!(had_data, "snapshot should have persisted data");
 
@@ -374,7 +403,10 @@ async fn eviction_transient_reader_invalidated() {
         );
 
         // Second eviction cycle
-        let (_, counts2) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let counts2 = tt2
+            .backend()
+            .snapshot_and_evict_for_testing(&tt2)
+            .eviction_counts;
         println!("transient_reader (2nd): evicted: {counts2:?}");
 
         state.set(0);
@@ -611,7 +643,11 @@ async fn eviction_persistable_never_preserves_live_cell() {
         // Snapshot + evict. `create_session_alive`'s `cell_data` should retain
         // the SessionAlive cell as residue (Evictability::Never), while
         // clearing `data_restored` and persisted data flag bits.
-        let (had_data, counts) = tt2.backend().snapshot_and_evict_for_testing(&tt2);
+        let TestSnapshotOutcome {
+            had_new_data: had_data,
+            eviction_counts: counts,
+            ..
+        } = tt2.backend().snapshot_and_evict_for_testing(&tt2);
         println!("persistable_never: snapshot had_data={had_data}, evicted: {counts:?}");
         assert!(had_data, "snapshot should have persisted data");
 

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_fixture.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_fixture.rs
@@ -60,3 +60,46 @@ pub async fn diamond_root(constant: ResolvedVc<Constant>, fanout: u32) -> Result
 pub async fn diamond_root_op(constant: ResolvedVc<Constant>, fanout: u32) -> Result<Vc<u32>> {
     Ok(diamond_root(*constant, fanout))
 }
+
+// --- Generation fixture ---
+//
+// A wide set of tasks keyed by a generation counter. Bumping the generation makes `wide_root` read
+// an entirely fresh set, disconnecting the whole previous generation (`2 * width` tasks) as garbage
+// in one shot. `width` is a task argument rather than a constant so callers can pick their own
+// scale while sharing these definitions.
+
+/// The generation counter. A `State` so a test can bump it without rebuilding the graph.
+#[turbo_tasks::value(transparent)]
+pub struct Generation(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+pub fn create_generation() -> Vc<Generation> {
+    Generation(State::new(0)).cell()
+}
+
+/// A leaf keyed by (generation, index). Bumping the generation makes `wide_root` read an entirely
+/// fresh set of these, disconnecting the whole previous generation.
+#[turbo_tasks::function]
+pub fn leaf(generation: u32, index: u32) -> Vc<u32> {
+    Vc::cell(generation.wrapping_mul(1000).wrapping_add(index))
+}
+
+/// A shared-dependency layer, so the disconnected garbage is a subtree (intermediate + leaf) and
+/// the tests exercise the cascade rather than single-node collection.
+#[turbo_tasks::function]
+pub async fn intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *leaf(generation, index).await?))
+}
+
+/// Reads `width` intermediates (each reading a leaf). Bumping the generation re-executes this and
+/// connects a fresh generation's worth of tasks, disconnecting the entire previous generation
+/// (`2 * width` tasks) as garbage.
+#[turbo_tasks::function(operation, root)]
+pub async fn wide_root(generation: ResolvedVc<Generation>, width: u32) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..width {
+        sum = sum.wrapping_add(*intermediate(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_fixture.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_fixture.rs
@@ -62,11 +62,6 @@ pub async fn diamond_root_op(constant: ResolvedVc<Constant>, fanout: u32) -> Res
 }
 
 // --- Generation fixture ---
-//
-// A wide set of tasks keyed by a generation counter. Bumping the generation makes `wide_root` read
-// an entirely fresh set, disconnecting the whole previous generation (`2 * width` tasks) as garbage
-// in one shot. `width` is a task argument rather than a constant so callers can pick their own
-// scale while sharing these definitions.
 
 /// The generation counter. A `State` so a test can bump it without rebuilding the graph.
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -1,0 +1,270 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+//! A GC pass holds total operation exclusion, so every invalidation blocks for its whole duration —
+//! in dev that is an HMR edit stalled behind the cascade. The pass therefore watches the
+//! coordinator's waiter count and winds down early once someone is blocked, but not before a
+//! min-progress floor has elapsed (so sustained edits can't starve GC entirely).
+//!
+//! These tests drive that machinery through `snapshot_and_evict_for_testing`, which runs a real
+//! production-shaped pass (`begin_gc` -> `gc_collect` -> `into_snapshot`). `gc_for_testing` is
+//! deliberately *not* used here: it forces an uninterruptible pass, because the exact-count
+//! regression tests depend on a full pass.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::{
+    BackendOptions, BackingStorageOptions, EvictionMode, GitVersionInfo, TurboTasksBackend,
+};
+
+fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
+    std::fs::create_dir_all(&parent).unwrap();
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir_in(&parent)
+        .unwrap()
+}
+
+fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_test_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            // Force GC on so `snapshot_and_evict_for_testing` runs a real pass.
+            gc: Some(true),
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            BackingStorageOptions {
+                is_short_session: true,
+                skip_compaction: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .0,
+    ));
+    (tt, dir)
+}
+
+#[turbo_tasks::value(transparent)]
+struct Generation(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+fn create_generation() -> Vc<Generation> {
+    Generation(State::new(0)).cell()
+}
+
+#[turbo_tasks::function]
+fn leaf(generation: u32, index: u32) -> Vc<u32> {
+    Vc::cell(generation.wrapping_mul(1000).wrapping_add(index))
+}
+
+#[turbo_tasks::function]
+async fn intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *leaf(generation, index).await?))
+}
+
+/// Wide enough that a pass has many jobs to abandon, so an interrupt is observable as a shortfall
+/// rather than lost in rounding.
+const WIDTH: u32 = 400;
+
+/// Reads `WIDTH` intermediates (each reading a leaf). Bumping the generation disconnects the whole
+/// previous generation — `2 * WIDTH` tasks of garbage in one shot.
+#[turbo_tasks::function(operation, root)]
+async fn wide_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
+    let generation = *generation.await?.get();
+    let mut sum = 0u32;
+    for index in 0..WIDTH {
+        sum = sum.wrapping_add(*intermediate(generation, index).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// Builds generation `gen_value`, disconnecting the previous generation's `2 * WIDTH` tasks.
+async fn build_generation(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u32) {
+    turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let generation_op = create_generation();
+        let generation_vc = generation_op.resolve().strongly_consistent().await?;
+        if gen_value > 0 {
+            let generation = generation_op.read_strongly_consistent().await?;
+            generation.set(gen_value);
+        }
+        wide_root(generation_vc).read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// A pass with the floor at 0 and nothing contending must **not** interrupt: the budget's trigger
+/// is real contention, not merely being interruptible. This is the control for the tests below —
+/// without it, "interrupted" could just mean "the budget fires unconditionally".
+///
+/// "Nothing contending" can't be *guaranteed* from the outside: the backend may take an operation
+/// guard for its own background work at any moment (a genuine waiter, correctly reported), and at a
+/// zero floor even one such arrival trips the budget. That is the mechanism working, not a bug —
+/// but it makes a single observation unreliable. So this runs several rounds and requires that at
+/// least one completes uninterrupted; an unconditional trip could never produce that.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_does_not_interrupt_without_a_waiter() {
+    let (tt, _persistence_dir) = create_tt("gc_no_interrupt_without_waiter");
+
+    // Interruptible from the first job — but nothing of ours is waiting.
+    tt.backend().set_gc_min_progress_for_testing(0);
+
+    const ROUNDS: u32 = 5;
+    let mut saw_uninterrupted = false;
+    for gen_value in 0..ROUNDS {
+        build_generation(&tt, gen_value).await;
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+
+        let (collected, abandoned, interrupted) = tt
+            .backend()
+            .last_gc_stats_for_testing()
+            .expect("a GC pass should have run");
+        println!(
+            "no-waiter round {gen_value}: collected={collected} abandoned={abandoned} \
+             interrupted={interrupted}"
+        );
+        if !interrupted {
+            assert_eq!(
+                abandoned, 0,
+                "an uninterrupted pass must abandon nothing (round {gen_value})"
+            );
+            saw_uninterrupted = true;
+        }
+    }
+
+    assert!(
+        saw_uninterrupted,
+        "every one of {ROUNDS} passes interrupted despite nothing of ours waiting — the budget is \
+         tripping unconditionally rather than on real contention"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// With the floor at its default and an operation blocked on the exclusion for the whole pass, the
+/// floor must win: the pass runs to completion rather than bailing at job zero. This is what stops
+/// a dev server under sustained edits from starving GC entirely.
+///
+/// The waiter is real, not simulated: a background task takes an operation guard while the GC phase
+/// is held, so it parks in `begin_operation`'s cold path — exactly what an HMR edit arriving
+/// mid-pass does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_min_progress_floor_beats_a_waiting_operation() {
+    let (tt, _persistence_dir) = create_tt("gc_min_progress_floor");
+
+    build_generation(&tt, 0).await;
+    build_generation(&tt, 1).await;
+
+    // A floor far longer than the pass: the interrupt must never be honoured.
+    tt.backend().set_gc_min_progress_for_testing(60_000);
+
+    let tt_waiter = tt.clone();
+    let waiter = tokio::spawn(async move {
+        turbo_tasks::run_once(tt_waiter.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let generation_op = create_generation();
+            let generation_vc = generation_op.resolve().strongly_consistent().await?;
+            wide_root(generation_vc).read_strongly_consistent().await?;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    });
+
+    tt.backend().snapshot_and_evict_for_testing(&tt);
+    waiter.await.unwrap();
+
+    let (collected, abandoned, interrupted) = tt
+        .backend()
+        .last_gc_stats_for_testing()
+        .expect("a GC pass should have run");
+    println!("floor: collected={collected} abandoned={abandoned} interrupted={interrupted}");
+    assert!(
+        !interrupted,
+        "the min-progress floor must suppress the interrupt (collected={collected}, \
+         abandoned={abandoned})"
+    );
+    assert_eq!(
+        abandoned, 0,
+        "a pass held by the floor abandons nothing, even with an operation waiting"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// An interrupted pass must be *self-healing*: whatever it abandons is re-derived and collected by
+/// a later pass, so garbage is never lost permanently. This is the property that makes abandoning
+/// work safe, and it holds regardless of whether any particular pass actually interrupted.
+///
+/// Asserted on GC's **own** collected counts, not the resident task count. Eviction moves tasks to
+/// disk after every snapshot, so the resident count falls to near zero whether GC collected the
+/// garbage or merely skipped it — it cannot tell the two apart, which is exactly the distinction
+/// this test exists to make.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gc_interrupt_is_self_healing() {
+    let (tt, _persistence_dir) = create_tt("gc_interrupt_is_self_healing");
+
+    // Interruptible from the first job for the whole test, so passes are free to abandon work.
+    tt.backend().set_gc_min_progress_for_testing(0);
+
+    build_generation(&tt, 0).await;
+
+    const ROUNDS: u32 = 10;
+    let mut total_collected = 0usize;
+    let mut interrupted_rounds = 0usize;
+    for gen_value in 1..=ROUNDS {
+        // Each round disconnects the previous generation: 2*WIDTH tasks of fresh garbage.
+        build_generation(&tt, gen_value).await;
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+        let (collected, abandoned, interrupted) = tt
+            .backend()
+            .last_gc_stats_for_testing()
+            .expect("a GC pass should have run");
+        println!(
+            "round {gen_value}: collected={collected} abandoned={abandoned} \
+             interrupted={interrupted}"
+        );
+        total_collected += collected;
+        if interrupted {
+            interrupted_rounds += 1;
+        }
+    }
+
+    // Each round produces 2*WIDTH garbage tasks, so ROUNDS rounds produce 2*WIDTH*ROUNDS. GC must
+    // have collected the bulk of that: an interrupted pass leaves work for the next one, but across
+    // ROUNDS rounds the totals have to add up. If interruption lost garbage permanently, this would
+    // fall short by roughly the amount abandoned.
+    let produced = (2 * WIDTH as usize) * (ROUNDS as usize);
+    let expected_min = produced / 2;
+    println!(
+        "self-healing: total_collected={total_collected} produced={produced} \
+         expected_min={expected_min} interrupted_rounds={interrupted_rounds}/{ROUNDS}"
+    );
+    assert!(
+        total_collected >= expected_min,
+        "GC collected only {total_collected} of ~{produced} garbage tasks across {ROUNDS} rounds \
+         ({interrupted_rounds} interrupted); interrupted passes are losing garbage instead of \
+         leaving it for the next pass"
+    );
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -134,19 +134,12 @@ async fn gc_does_not_interrupt_without_a_waiter() {
         build_generation(&tt, gen_value).await;
         tt.backend().snapshot_and_evict_for_testing(&tt);
 
-        let (collected, abandoned, interrupted) = tt
+        let (collected, interrupted) = tt
             .backend()
             .last_gc_stats_for_testing()
             .expect("a GC pass should have run");
-        println!(
-            "no-waiter round {gen_value}: collected={collected} abandoned={abandoned} \
-             interrupted={interrupted}"
-        );
+        println!("no-waiter round {gen_value}: collected={collected} interrupted={interrupted}");
         if !interrupted {
-            assert_eq!(
-                abandoned, 0,
-                "an uninterrupted pass must abandon nothing (round {gen_value})"
-            );
             saw_uninterrupted = true;
         }
     }
@@ -193,19 +186,14 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
     tt.backend().snapshot_and_evict_for_testing(&tt);
     waiter.await.unwrap();
 
-    let (collected, abandoned, interrupted) = tt
+    let (collected, interrupted) = tt
         .backend()
         .last_gc_stats_for_testing()
         .expect("a GC pass should have run");
-    println!("floor: collected={collected} abandoned={abandoned} interrupted={interrupted}");
+    println!("floor: collected={collected} interrupted={interrupted}");
     assert!(
         !interrupted,
-        "the min-progress floor must suppress the interrupt (collected={collected}, \
-         abandoned={abandoned})"
-    );
-    assert_eq!(
-        abandoned, 0,
-        "a pass held by the floor abandons nothing, even with an operation waiting"
+        "the min-progress floor must suppress the interrupt (collected={collected})"
     );
 
     tt.stop_and_wait().await;
@@ -235,14 +223,11 @@ async fn gc_interrupt_is_self_healing() {
         // Each round disconnects the previous generation: 2*WIDTH tasks of fresh garbage.
         build_generation(&tt, gen_value).await;
         tt.backend().snapshot_and_evict_for_testing(&tt);
-        let (collected, abandoned, interrupted) = tt
+        let (collected, interrupted) = tt
             .backend()
             .last_gc_stats_for_testing()
             .expect("a GC pass should have run");
-        println!(
-            "round {gen_value}: collected={collected} abandoned={abandoned} \
-             interrupted={interrupted}"
-        );
+        println!("round {gen_value}: collected={collected} interrupted={interrupted}");
         total_collected += collected;
         if interrupted {
             interrupted_rounds += 1;
@@ -250,9 +235,9 @@ async fn gc_interrupt_is_self_healing() {
     }
 
     // Each round produces 2*WIDTH garbage tasks, so ROUNDS rounds produce 2*WIDTH*ROUNDS. GC must
-    // have collected the bulk of that: an interrupted pass leaves work for the next one, but across
-    // ROUNDS rounds the totals have to add up. If interruption lost garbage permanently, this would
-    // fall short by roughly the amount abandoned.
+    // have collected the bulk of that: an interrupted pass's whole cycle is skipped and retried by
+    // the next one, but across ROUNDS rounds the totals have to add up. If interruption lost
+    // garbage permanently, this would fall short.
     let produced = (2 * WIDTH as usize) * (ROUNDS as usize);
     let expected_min = produced / 2;
     println!(

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -2,11 +2,7 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
-//! A GC pass holds total operation exclusion, so it winds down early once an operation blocks
-//! behind it — but not before `gc_min_progress` has elapsed, so sustained edits can't starve GC.
-//!
-//! `snapshot_and_evict_for_testing` runs an interruptible pass; `gc_for_testing` forces an
-//! uninterruptible one.
+//! Test the interruption mechanisms for GC
 
 mod gc_fixture;
 mod util;
@@ -44,9 +40,6 @@ async fn build_generation(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u3
 }
 
 /// A waiter blocked for the whole pass must not interrupt it while the floor is unmet.
-///
-/// The waiter is real rather than simulated: the spawned task takes an operation guard while the
-/// GC phase is held, so it parks in `begin_operation`'s cold path.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_min_progress_floor_beats_a_waiting_operation() {
     // A floor far longer than the pass: the interrupt must never be honoured.
@@ -86,9 +79,6 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
 ///
 /// A zero floor interrupts every pass deterministically, rather than a mid-range floor that might
 /// interrupt none of them and assert nothing.
-///
-/// Asserts on GC's own collected counts, not the resident count: eviction moves tasks to disk
-/// after every snapshot, so the resident count can't distinguish collected from skipped.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
     let (tt, _persistence_dir) =

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -12,7 +12,7 @@
 //! deliberately *not* used here: it forces an uninterruptible pass, because the exact-count
 //! regression tests depend on a full pass.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use turbo_tasks::{
@@ -31,7 +31,10 @@ fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
         .unwrap()
 }
 
-fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+fn create_tt(
+    name: &str,
+    gc_min_progress: Duration,
+) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
     let dir = create_test_persistence_dir(name);
     let tt = TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {
@@ -41,6 +44,7 @@ fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempD
             eviction_mode: EvictionMode::Full,
             // Force GC on so `snapshot_and_evict_for_testing` runs a real pass.
             gc: Some(true),
+            gc_min_progress: Some(gc_min_progress),
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(
@@ -123,10 +127,8 @@ async fn build_generation(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u3
 /// least one completes uninterrupted; an unconditional trip could never produce that.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_does_not_interrupt_without_a_waiter() {
-    let (tt, _persistence_dir) = create_tt("gc_no_interrupt_without_waiter");
-
     // Interruptible from the first job — but nothing of ours is waiting.
-    tt.backend().set_gc_min_progress_for_testing(0);
+    let (tt, _persistence_dir) = create_tt("gc_no_interrupt_without_waiter", Duration::ZERO);
 
     const ROUNDS: u32 = 5;
     let mut saw_uninterrupted = false;
@@ -162,13 +164,11 @@ async fn gc_does_not_interrupt_without_a_waiter() {
 /// mid-pass does.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_min_progress_floor_beats_a_waiting_operation() {
-    let (tt, _persistence_dir) = create_tt("gc_min_progress_floor");
+    // A floor far longer than the pass: the interrupt must never be honoured.
+    let (tt, _persistence_dir) = create_tt("gc_min_progress_floor", Duration::from_secs(60));
 
     build_generation(&tt, 0).await;
     build_generation(&tt, 1).await;
-
-    // A floor far longer than the pass: the interrupt must never be honoured.
-    tt.backend().set_gc_min_progress_for_testing(60_000);
 
     let tt_waiter = tt.clone();
     let waiter = tokio::spawn(async move {
@@ -209,10 +209,8 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
 /// this test exists to make.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
-    let (tt, _persistence_dir) = create_tt("gc_interrupt_is_self_healing");
-
     // Interruptible from the first job for the whole test, so passes are free to abandon work.
-    tt.backend().set_gc_min_progress_for_testing(0);
+    let (tt, _persistence_dir) = create_tt("gc_interrupt_is_self_healing", Duration::ZERO);
 
     build_generation(&tt, 0).await;
 

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -116,19 +116,21 @@ async fn build_generation(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u3
     .unwrap();
 }
 
-/// A pass with the floor at 0 and nothing contending must **not** interrupt: the budget's trigger
-/// is real contention, not merely being interruptible. This is the control for the tests below —
-/// without it, "interrupted" could just mean "the budget fires unconditionally".
+/// An interruptible pass that is not actually blocking anyone must **not** interrupt: the budget's
+/// trigger is real contention, not merely being interruptible. This is the control for the tests
+/// below — without it, "interrupted" could just mean "the budget fires unconditionally".
 ///
-/// "Nothing contending" can't be *guaranteed* from the outside: the backend may take an operation
-/// guard for its own background work at any moment (a genuine waiter, correctly reported), and at a
-/// zero floor even one such arrival trips the budget. That is the mechanism working, not a bug —
-/// but it makes a single observation unreliable. So this runs several rounds and requires that at
-/// least one completes uninterrupted; an unconditional trip could never produce that.
+/// The floor is deliberately non-zero, because "nothing contending" cannot be arranged from the
+/// outside. The backend takes operation guards for its own background work, and one that is
+/// mid-flight when the exclusion begins suspends to let it start — a real waiter, visible from the
+/// pass's first poll (see `SnapshotCoordinator::waiting_operations`). At a zero floor that alone
+/// trips the budget every time, which is the mechanism working correctly but leaves no room to
+/// observe an *uninterrupted* pass. A short floor lets a quiet pass finish while still being far
+/// too small to mask a budget that fires unconditionally.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_does_not_interrupt_without_a_waiter() {
-    // Interruptible from the first job — but nothing of ours is waiting.
-    let (tt, _persistence_dir) = create_tt("gc_no_interrupt_without_waiter", Duration::ZERO);
+    let (tt, _persistence_dir) =
+        create_tt("gc_no_interrupt_without_waiter", Duration::from_secs(5));
 
     const ROUNDS: u32 = 5;
     let mut saw_uninterrupted = false;
@@ -201,7 +203,18 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
 
 /// An interrupted pass must be *self-healing*: whatever it abandons is re-derived and collected by
 /// a later pass, so garbage is never lost permanently. This is the property that makes abandoning
-/// work safe, and it holds regardless of whether any particular pass actually interrupted.
+/// work safe.
+///
+/// Structured in two phases so that both halves are actually observed rather than assumed. A
+/// floor tuned to interrupt *sometimes* would be timing-dependent and could silently degrade into
+/// either "never interrupts" (proving nothing about healing) or "always collects nothing"
+/// (proving nothing about recovery), so neither half is left to chance:
+///
+/// 1. **Abandon.** A zero floor with backend background work in flight means a waiter is present
+///    from the pass's first poll, so every pass interrupts immediately and collects nothing. The
+///    garbage accumulates, unexamined.
+/// 2. **Heal.** One uninterruptible pass (`gc_for_testing`) must then find all of it. If an
+///    interrupted pass had *lost* garbage rather than left it, this pass would come up short.
 ///
 /// Asserted on GC's **own** collected counts, not the resident task count. Eviction moves tasks to
 /// disk after every snapshot, so the resident count falls to near zero whether GC collected the
@@ -209,13 +222,14 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
 /// this test exists to make.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
-    // Interruptible from the first job for the whole test, so passes are free to abandon work.
+    // Interruptible from the first job, so every pass in phase 1 abandons its work.
     let (tt, _persistence_dir) = create_tt("gc_interrupt_is_self_healing", Duration::ZERO);
 
     build_generation(&tt, 0).await;
 
+    // Phase 1: accumulate garbage under passes that keep interrupting.
     const ROUNDS: u32 = 10;
-    let mut total_collected = 0usize;
+    let mut collected_while_interrupting = 0usize;
     let mut interrupted_rounds = 0usize;
     for gen_value in 1..=ROUNDS {
         // Each round disconnects the previous generation: 2*WIDTH tasks of fresh garbage.
@@ -226,26 +240,40 @@ async fn gc_interrupt_is_self_healing() {
             .last_gc_stats_for_testing()
             .expect("a GC pass should have run");
         println!("round {gen_value}: collected={collected} interrupted={interrupted}");
-        total_collected += collected;
+        collected_while_interrupting += collected;
         if interrupted {
             interrupted_rounds += 1;
         }
     }
 
-    // Each round produces 2*WIDTH garbage tasks, so ROUNDS rounds produce 2*WIDTH*ROUNDS. GC must
-    // have collected the bulk of that: an interrupted pass's whole cycle is skipped and retried by
-    // the next one, but across ROUNDS rounds the totals have to add up. If interruption lost
-    // garbage permanently, this would fall short.
-    let produced = (2 * WIDTH as usize) * (ROUNDS as usize);
-    let expected_min = produced / 2;
-    println!(
-        "self-healing: total_collected={total_collected} produced={produced} \
-         expected_min={expected_min} interrupted_rounds={interrupted_rounds}/{ROUNDS}"
+    // The premise of phase 2: these passes really did abandon work. Without this the test could
+    // pass while never exercising interruption at all.
+    assert!(
+        interrupted_rounds > 0,
+        "no pass interrupted across {ROUNDS} rounds at a zero floor, so nothing was abandoned and \
+         this test cannot say anything about healing"
     );
+
+    // Phase 2: one pass that runs to completion must recover everything left behind.
+    let healed = tt.backend().gc_for_testing(&tt);
+
+    let produced = (2 * WIDTH as usize) * (ROUNDS as usize);
+    let total_collected = collected_while_interrupting + healed;
+    println!(
+        "self-healing: collected_while_interrupting={collected_while_interrupting} \
+         healed={healed} total_collected={total_collected} produced={produced} \
+         interrupted_rounds={interrupted_rounds}/{ROUNDS}"
+    );
+
+    // Every generation but the live one is garbage, so the completing pass has to account for the
+    // bulk of what was produced. Falling short here means interrupted passes dropped garbage on
+    // the floor instead of leaving it for a successor.
+    let expected_min = produced / 2;
     assert!(
         total_collected >= expected_min,
-        "GC collected only {total_collected} of ~{produced} garbage tasks across {ROUNDS} rounds \
-         ({interrupted_rounds} interrupted); interrupted passes are losing garbage instead of \
+        "GC collected only {total_collected} of ~{produced} garbage tasks \
+         ({collected_while_interrupting} during {interrupted_rounds} interrupting rounds, \
+         {healed} in the completing pass); interrupted passes are losing garbage instead of \
          leaving it for the next pass"
     );
 

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -2,172 +2,56 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
-//! A GC pass holds total operation exclusion, so every invalidation blocks for its whole duration —
-//! in dev that is an HMR edit stalled behind the cascade. The pass therefore watches the
-//! coordinator's waiter count and winds down early once someone is blocked, but not before a
-//! min-progress floor has elapsed (so sustained edits can't starve GC entirely).
+//! A GC pass holds total operation exclusion, so it winds down early once an operation blocks
+//! behind it — but not before `gc_min_progress` has elapsed, so sustained edits can't starve GC.
 //!
-//! These tests drive that machinery through `snapshot_and_evict_for_testing`, which runs a real
-//! production-shaped pass (`begin_gc` -> `gc_collect` -> `into_snapshot`). `gc_for_testing` is
-//! deliberately *not* used here: it forces an uninterruptible pass, because the exact-count
-//! regression tests depend on a full pass.
+//! `snapshot_and_evict_for_testing` runs an interruptible pass; `gc_for_testing` forces an
+//! uninterruptible one.
+
+mod gc_fixture;
+mod util;
 
 use std::{sync::Arc, time::Duration};
 
-use anyhow::Result;
-use turbo_tasks::{
-    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+use turbo_tasks::TurboTasks;
+use turbo_tasks_backend::TurboTasksBackend;
+
+use crate::{
+    gc_fixture::{create_generation, wide_root},
+    util::create_tt_with_gc_min_progress,
 };
-use turbo_tasks_backend::{
-    BackendOptions, BackingStorageOptions, EvictionMode, GitVersionInfo, TurboTasksBackend,
-};
 
-fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
-    let parent = std::path::PathBuf::from(format!("{}/.cache", env!("CARGO_TARGET_TMPDIR")));
-    std::fs::create_dir_all(&parent).unwrap();
-    tempfile::Builder::new()
-        .prefix(&format!("{name}-"))
-        .tempdir_in(&parent)
-        .unwrap()
-}
-
-fn create_tt(
-    name: &str,
-    gc_min_progress: Duration,
-) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
-    let dir = create_test_persistence_dir(name);
-    let tt = TurboTasks::new(TurboTasksBackend::new(
-        BackendOptions {
-            num_workers: Some(2),
-            small_preallocation: true,
-            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
-            eviction_mode: EvictionMode::Full,
-            // Force GC on so `snapshot_and_evict_for_testing` runs a real pass.
-            gc: Some(true),
-            gc_min_progress: Some(gc_min_progress),
-            ..Default::default()
-        },
-        turbo_tasks_backend::turbo_backing_storage(
-            dir.path(),
-            &GitVersionInfo {
-                describe: "test-unversioned",
-                dirty: false,
-            },
-            BackingStorageOptions {
-                is_short_session: true,
-                skip_compaction: true,
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .0,
-    ));
-    (tt, dir)
-}
-
-#[turbo_tasks::value(transparent)]
-struct Generation(State<u32>);
-
-#[turbo_tasks::function(operation, root)]
-fn create_generation() -> Vc<Generation> {
-    Generation(State::new(0)).cell()
-}
-
-#[turbo_tasks::function]
-fn leaf(generation: u32, index: u32) -> Vc<u32> {
-    Vc::cell(generation.wrapping_mul(1000).wrapping_add(index))
-}
-
-#[turbo_tasks::function]
-async fn intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
-    Ok(Vc::cell(1 + *leaf(generation, index).await?))
-}
-
-/// Wide enough that a pass has many jobs to abandon, so an interrupt is observable as a shortfall
-/// rather than lost in rounding.
+/// Wide enough that an interrupted pass leaves an observable shortfall rather than a rounding
+/// difference.
 const WIDTH: u32 = 400;
-
-/// Reads `WIDTH` intermediates (each reading a leaf). Bumping the generation disconnects the whole
-/// previous generation — `2 * WIDTH` tasks of garbage in one shot.
-#[turbo_tasks::function(operation, root)]
-async fn wide_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
-    let generation = *generation.await?.get();
-    let mut sum = 0u32;
-    for index in 0..WIDTH {
-        sum = sum.wrapping_add(*intermediate(generation, index).await?);
-    }
-    Ok(Vc::cell(sum))
-}
 
 /// Builds generation `gen_value`, disconnecting the previous generation's `2 * WIDTH` tasks.
 async fn build_generation(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u32) {
     turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
         let generation_op = create_generation();
         let generation_vc = generation_op.resolve().strongly_consistent().await?;
         if gen_value > 0 {
             let generation = generation_op.read_strongly_consistent().await?;
             generation.set(gen_value);
         }
-        wide_root(generation_vc).read_strongly_consistent().await?;
+        wide_root(generation_vc, WIDTH)
+            .read_strongly_consistent()
+            .await?;
         anyhow::Ok(())
     })
     .await
     .unwrap();
 }
 
-/// An interruptible pass that is not actually blocking anyone must **not** interrupt: the budget's
-/// trigger is real contention, not merely being interruptible. This is the control for the tests
-/// below — without it, "interrupted" could just mean "the budget fires unconditionally".
+/// A waiter blocked for the whole pass must not interrupt it while the floor is unmet.
 ///
-/// The floor is deliberately non-zero, because "nothing contending" cannot be arranged from the
-/// outside. The backend takes operation guards for its own background work, and one that is
-/// mid-flight when the exclusion begins suspends to let it start — a real waiter, visible from the
-/// pass's first poll (see `SnapshotCoordinator::waiting_operations`). At a zero floor that alone
-/// trips the budget every time, which is the mechanism working correctly but leaves no room to
-/// observe an *uninterrupted* pass. A short floor lets a quiet pass finish while still being far
-/// too small to mask a budget that fires unconditionally.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn gc_does_not_interrupt_without_a_waiter() {
-    let (tt, _persistence_dir) =
-        create_tt("gc_no_interrupt_without_waiter", Duration::from_secs(5));
-
-    const ROUNDS: u32 = 5;
-    let mut saw_uninterrupted = false;
-    for gen_value in 0..ROUNDS {
-        build_generation(&tt, gen_value).await;
-        tt.backend().snapshot_and_evict_for_testing(&tt);
-
-        let (collected, interrupted) = tt
-            .backend()
-            .last_gc_stats_for_testing()
-            .expect("a GC pass should have run");
-        println!("no-waiter round {gen_value}: collected={collected} interrupted={interrupted}");
-        if !interrupted {
-            saw_uninterrupted = true;
-        }
-    }
-
-    assert!(
-        saw_uninterrupted,
-        "every one of {ROUNDS} passes interrupted despite nothing of ours waiting — the budget is \
-         tripping unconditionally rather than on real contention"
-    );
-
-    tt.stop_and_wait().await;
-}
-
-/// With the floor at its default and an operation blocked on the exclusion for the whole pass, the
-/// floor must win: the pass runs to completion rather than bailing at job zero. This is what stops
-/// a dev server under sustained edits from starving GC entirely.
-///
-/// The waiter is real, not simulated: a background task takes an operation guard while the GC phase
-/// is held, so it parks in `begin_operation`'s cold path — exactly what an HMR edit arriving
-/// mid-pass does.
+/// The waiter is real rather than simulated: the spawned task takes an operation guard while the
+/// GC phase is held, so it parks in `begin_operation`'s cold path.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_min_progress_floor_beats_a_waiting_operation() {
     // A floor far longer than the pass: the interrupt must never be honoured.
-    let (tt, _persistence_dir) = create_tt("gc_min_progress_floor", Duration::from_secs(60));
+    let (tt, _persistence_dir) =
+        create_tt_with_gc_min_progress("gc_min_progress_floor", Duration::from_secs(60));
 
     build_generation(&tt, 0).await;
     build_generation(&tt, 1).await;
@@ -175,24 +59,21 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
     let tt_waiter = tt.clone();
     let waiter = tokio::spawn(async move {
         turbo_tasks::run_once(tt_waiter.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             let generation_op = create_generation();
             let generation_vc = generation_op.resolve().strongly_consistent().await?;
-            wide_root(generation_vc).read_strongly_consistent().await?;
+            wide_root(generation_vc, WIDTH)
+                .read_strongly_consistent()
+                .await?;
             anyhow::Ok(())
         })
         .await
         .unwrap();
     });
 
-    tt.backend().snapshot_and_evict_for_testing(&tt);
+    let outcome = tt.backend().snapshot_and_evict_for_testing(&tt);
     waiter.await.unwrap();
 
-    let (collected, interrupted) = tt
-        .backend()
-        .last_gc_stats_for_testing()
-        .expect("a GC pass should have run");
-    println!("floor: collected={collected} interrupted={interrupted}");
+    let (collected, interrupted) = outcome.gc_stats();
     assert!(
         !interrupted,
         "the min-progress floor must suppress the interrupt (collected={collected})"
@@ -201,29 +82,17 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
     tt.stop_and_wait().await;
 }
 
-/// An interrupted pass must be *self-healing*: whatever it abandons is re-derived and collected by
-/// a later pass, so garbage is never lost permanently. This is the property that makes abandoning
-/// work safe.
+/// What an interrupted pass abandons must still be collectible by a later pass.
 ///
-/// Structured in two phases so that both halves are actually observed rather than assumed. A
-/// floor tuned to interrupt *sometimes* would be timing-dependent and could silently degrade into
-/// either "never interrupts" (proving nothing about healing) or "always collects nothing"
-/// (proving nothing about recovery), so neither half is left to chance:
+/// A zero floor interrupts every pass deterministically, rather than a mid-range floor that might
+/// interrupt none of them and assert nothing.
 ///
-/// 1. **Abandon.** A zero floor with backend background work in flight means a waiter is present
-///    from the pass's first poll, so every pass interrupts immediately and collects nothing. The
-///    garbage accumulates, unexamined.
-/// 2. **Heal.** One uninterruptible pass (`gc_for_testing`) must then find all of it. If an
-///    interrupted pass had *lost* garbage rather than left it, this pass would come up short.
-///
-/// Asserted on GC's **own** collected counts, not the resident task count. Eviction moves tasks to
-/// disk after every snapshot, so the resident count falls to near zero whether GC collected the
-/// garbage or merely skipped it — it cannot tell the two apart, which is exactly the distinction
-/// this test exists to make.
+/// Asserts on GC's own collected counts, not the resident count: eviction moves tasks to disk
+/// after every snapshot, so the resident count can't distinguish collected from skipped.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
-    // Interruptible from the first job, so every pass in phase 1 abandons its work.
-    let (tt, _persistence_dir) = create_tt("gc_interrupt_is_self_healing", Duration::ZERO);
+    let (tt, _persistence_dir) =
+        create_tt_with_gc_min_progress("gc_interrupt_is_self_healing", Duration::ZERO);
 
     build_generation(&tt, 0).await;
 
@@ -232,29 +101,21 @@ async fn gc_interrupt_is_self_healing() {
     let mut collected_while_interrupting = 0usize;
     let mut interrupted_rounds = 0usize;
     for gen_value in 1..=ROUNDS {
-        // Each round disconnects the previous generation: 2*WIDTH tasks of fresh garbage.
         build_generation(&tt, gen_value).await;
-        tt.backend().snapshot_and_evict_for_testing(&tt);
-        let (collected, interrupted) = tt
-            .backend()
-            .last_gc_stats_for_testing()
-            .expect("a GC pass should have run");
+        let (collected, interrupted) = tt.backend().snapshot_and_evict_for_testing(&tt).gc_stats();
         println!("round {gen_value}: collected={collected} interrupted={interrupted}");
         collected_while_interrupting += collected;
-        if interrupted {
-            interrupted_rounds += 1;
-        }
+        interrupted_rounds += usize::from(interrupted);
     }
 
-    // The premise of phase 2: these passes really did abandon work. Without this the test could
-    // pass while never exercising interruption at all.
+    // The premise of phase 2: without an interrupt, nothing was abandoned to heal from.
     assert!(
         interrupted_rounds > 0,
-        "no pass interrupted across {ROUNDS} rounds at a zero floor, so nothing was abandoned and \
-         this test cannot say anything about healing"
+        "no pass interrupted across {ROUNDS} rounds at a zero floor: nothing was abandoned, so \
+         this test proves nothing"
     );
 
-    // Phase 2: one pass that runs to completion must recover everything left behind.
+    // Phase 2: a completing pass must recover what was left behind.
     let healed = tt.backend().gc_for_testing(&tt);
 
     let produced = (2 * WIDTH as usize) * (ROUNDS as usize);
@@ -265,16 +126,13 @@ async fn gc_interrupt_is_self_healing() {
          interrupted_rounds={interrupted_rounds}/{ROUNDS}"
     );
 
-    // Every generation but the live one is garbage, so the completing pass has to account for the
-    // bulk of what was produced. Falling short here means interrupted passes dropped garbage on
-    // the floor instead of leaving it for a successor.
+    // Every generation but the live one is garbage, so most of it must be accounted for.
     let expected_min = produced / 2;
     assert!(
         total_collected >= expected_min,
-        "GC collected only {total_collected} of ~{produced} garbage tasks \
-         ({collected_while_interrupting} during {interrupted_rounds} interrupting rounds, \
-         {healed} in the completing pass); interrupted passes are losing garbage instead of \
-         leaving it for the next pass"
+        "collected {total_collected} of ~{produced} garbage tasks ({collected_while_interrupting} \
+         across {interrupted_rounds} interrupted rounds, {healed} in the completing pass): \
+         interrupted passes are losing garbage rather than leaving it"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -40,6 +40,14 @@ async fn build_generation(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u3
 }
 
 /// A waiter blocked for the whole pass must not interrupt it while the floor is unmet.
+///
+/// This *provokes* the interleaving rather than forcing it: the spawned operation may park on the
+/// exclusion while the pass is running, or it may not be scheduled until the pass is already over,
+/// in which case `operations_waiting()` is never true and there was no interrupt to suppress.
+/// Forcing it would mean reaching into the coordinator from the test, which is a bigger intrusion
+/// than the coverage is worth. Both interleavings must produce a completing pass, so the
+/// assertions below hold either way — the floor is what makes the outcome independent of the
+/// scheduling.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_min_progress_floor_beats_a_waiting_operation() {
     // A floor far longer than the pass: the interrupt must never be honoured.
@@ -66,10 +74,19 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
     let outcome = tt.backend().snapshot_and_evict_for_testing(&tt);
     waiter.await.unwrap();
 
-    let (collected, interrupted) = outcome.gc_stats();
+    let stats = outcome.gc_stats();
     assert!(
-        !interrupted,
-        "the min-progress floor must suppress the interrupt (collected={collected})"
+        !stats.interrupted,
+        "the min-progress floor must suppress the interrupt (collected={})",
+        stats.collected
+    );
+    // Generation 0 is fully disconnected by generation 1, and an uninterrupted pass must take all
+    // of it: `2 * WIDTH` tasks (an `intermediate` and a `leaf` per index). The live generation and
+    // the transient `run_once` roots are not collectible, so this is an exact count, not a floor.
+    assert_eq!(
+        stats.collected,
+        2 * WIDTH as usize,
+        "a completing pass must collect the whole disconnected generation: {stats}"
     );
 
     tt.stop_and_wait().await;
@@ -77,8 +94,14 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
 
 /// What an interrupted pass abandons must still be collectible by a later pass.
 ///
-/// A zero floor interrupts every pass deterministically, rather than a mid-range floor that might
-/// interrupt none of them and assert nothing.
+/// The two phases are sequential, not concurrent: nothing here forces a pass to overlap with an
+/// operation. Phase 1 relies only on the zero `min_progress` floor, which makes *any* waiter
+/// observed by `GcBudget::should_stop` interrupt the pass immediately, so interrupts happen
+/// readily across the rounds instead of needing a mid-range floor that might interrupt none of
+/// them and assert nothing. Because that is still scheduling-dependent, the loop asserts only
+/// that at least one round interrupted — which is the premise phase 2 needs. Phase 2 then runs a
+/// deliberately *uninterruptible* pass (`gc_for_testing`) after phase 1 is fully over, and that
+/// pass is what must recover everything the interrupted rounds abandoned.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
     let (tt, _persistence_dir) =
@@ -92,10 +115,11 @@ async fn gc_interrupt_is_self_healing() {
     let mut interrupted_rounds = 0usize;
     for gen_value in 1..=ROUNDS {
         build_generation(&tt, gen_value).await;
-        let (collected, interrupted) = tt.backend().snapshot_and_evict_for_testing(&tt).gc_stats();
-        println!("round {gen_value}: collected={collected} interrupted={interrupted}");
-        collected_while_interrupting += collected;
-        interrupted_rounds += usize::from(interrupted);
+        let outcome = tt.backend().snapshot_and_evict_for_testing(&tt);
+        let stats = outcome.gc_stats();
+        println!("round {gen_value}: {stats}");
+        collected_while_interrupting += stats.collected;
+        interrupted_rounds += usize::from(stats.interrupted);
     }
 
     // The premise of phase 2: without an interrupt, nothing was abandoned to heal from.
@@ -116,11 +140,13 @@ async fn gc_interrupt_is_self_healing() {
          interrupted_rounds={interrupted_rounds}/{ROUNDS}"
     );
 
-    // Every generation but the live one is garbage, so most of it must be accounted for.
-    let expected_min = produced / 2;
-    assert!(
-        total_collected >= expected_min,
-        "collected {total_collected} of ~{produced} garbage tasks ({collected_while_interrupting} \
+    // Phase 2's pass is uninterruptible and runs once phase 1 is over, so nothing is left for a
+    // later pass to pick up: every generation but the live one is garbage, and all of it must be
+    // accounted for exactly. An interrupted pass that *lost* garbage rather than leaving it would
+    // show up here as a shortfall.
+    assert_eq!(
+        total_collected, produced,
+        "collected {total_collected} of {produced} garbage tasks ({collected_while_interrupting} \
          across {interrupted_rounds} interrupted rounds, {healed} in the completing pass): \
          interrupted passes are losing garbage rather than leaving it"
     );

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -57,11 +57,22 @@ async fn gc_re_rooting_stays_flat() {
     let (tt, _persistence_dir) = create_tt("gc_re_rooting_stays_flat");
     let tt2 = tt.clone();
 
+    // This test asserts on *how much* GC collects, so it must not race the interrupt heuristic.
+    // `gc_for_testing` already pins the floor for its own pass, but each round also runs
+    // `snapshot_and_evict_for_testing`, whose GC pass is fully interruptible: on a loaded machine
+    // it can wind down as soon as an operation blocks behind it, collecting less through no fault
+    // of GC. Pin the floor beyond any plausible pass so the counts are deterministic; the
+    // interrupt path has its own tests.
+    tt.backend().set_gc_min_progress_for_testing(u64::MAX / 2);
+
     const ROUNDS: u32 = 20;
 
     // Each round runs in its own `run_once` so the root's activeness is released before GC (a
     // `run_once` root keeps everything it touched active until it returns).
-    async fn round(tt: &Arc<TurboTasks<TurboTasksBackend>>, gen_value: u32) -> (usize, usize) {
+    async fn round(
+        tt: &Arc<TurboTasks<TurboTasksBackend>>,
+        gen_value: u32,
+    ) -> (usize, usize, bool) {
         let tt_inner = tt.clone();
         turbo_tasks::run_once(tt.clone(), async move {
             // `create_generation` is a cached root operation, so this returns the same task each
@@ -85,34 +96,48 @@ async fn gc_re_rooting_stays_flat() {
         // first would drop the garbage to disk-only where the in-memory GC can't collect or
         // tombstone it.
         let collected = tt.backend().gc_for_testing(tt);
+        // This runs a *second*, interruptible GC pass inside `snapshot_and_persist` (unlike
+        // `gc_for_testing`, which pins `min_progress` so high it can never trip). On a loaded
+        // machine that pass can wind down early, which shows up as a collection shortfall rather
+        // than a bug — so report it instead of letting it look like GC failing to collect.
         tt.backend().snapshot_and_evict_for_testing(tt);
+        let interrupted = tt
+            .backend()
+            .last_gc_stats_for_testing()
+            .is_some_and(|(_, _, interrupted)| interrupted);
         // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
         // roots (each round's `run_once`/Once task) are never collected and accumulate
         // independently of GC — including them would mask the real signal.
         (
             collected,
             tt.backend().resident_persistent_task_count_for_testing(),
+            interrupted,
         )
     }
 
     // Warm up: build generation 0, then measure the steady-state baseline after one full cycle.
-    let (_, baseline) = round(&tt2, 0).await;
+    let (_, baseline, _) = round(&tt2, 0).await;
     println!("baseline persistent resident after gen 0: {baseline}");
 
     // Churn: swap the whole dependency set many times.
     let mut max_resident = baseline;
     let mut total_collected = 0usize;
+    let mut interrupted_rounds = 0usize;
     for gen_value in 1..=ROUNDS {
-        let (collected, resident) = round(&tt2, gen_value).await;
-        println!("gen {gen_value}: collected={collected} persistent_resident={resident}");
+        let (collected, resident, interrupted) = round(&tt2, gen_value).await;
+        println!(
+            "gen {gen_value}: collected={collected} persistent_resident={resident} \
+             snapshot_gc_interrupted={interrupted}"
+        );
         max_resident = max_resident.max(resident);
         total_collected += collected;
+        interrupted_rounds += usize::from(interrupted);
     }
 
     let no_gc_growth = baseline + (2 * WIDTH as usize) * (ROUNDS as usize);
     println!(
         "baseline={baseline} max_resident={max_resident} total_collected={total_collected} \
-         no_gc_growth_would_be={no_gc_growth}"
+         interrupted_rounds={interrupted_rounds} no_gc_growth_would_be={no_gc_growth}"
     );
     // Without GC the persistent resident set would climb by ~2*WIDTH per round (each generation's
     // intermediates + leaves persisted forever), so a bound within a small constant of the baseline
@@ -129,7 +154,10 @@ async fn gc_re_rooting_stays_flat() {
     assert!(
         total_collected >= expected_min_collected,
         "GC collected too little ({total_collected}); expected >= {expected_min_collected} across \
-         {ROUNDS} re-rootings — GC is not doing the collection"
+         {ROUNDS} re-rootings — GC is not doing the collection. snapshot-pass interrupts: \
+         {interrupted_rounds}/{ROUNDS} (a non-zero count means the interruptible pass inside \
+         `snapshot_and_persist` wound down early under load, which is a flaky-environment signal \
+         rather than a GC defect)"
     );
 
     // The live graph must still compute correctly after all the churn.

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -104,7 +104,7 @@ async fn gc_re_rooting_stays_flat() {
         let interrupted = tt
             .backend()
             .last_gc_stats_for_testing()
-            .is_some_and(|(_, _, interrupted)| interrupted);
+            .is_some_and(|(_, interrupted)| interrupted);
         // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
         // roots (each round's `run_once`/Once task) are never collected and accumulate
         // independently of GC — including them would mask the real signal.

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -2,51 +2,20 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
+mod gc_fixture;
 mod util;
 
 use std::{sync::Arc, time::Duration};
 
-use anyhow::Result;
-use turbo_tasks::{ResolvedVc, State, TurboTasks, Vc};
+use turbo_tasks::TurboTasks;
 use turbo_tasks_backend::TurboTasksBackend;
 
-use crate::util::create_tt_with_gc_min_progress;
-
-#[turbo_tasks::value(transparent)]
-struct Generation(State<u32>);
-
-#[turbo_tasks::function(operation, root)]
-fn create_generation() -> Vc<Generation> {
-    Generation(State::new(0)).cell()
-}
-
-/// A leaf keyed by (generation, index). Bumping the generation makes `wide_root` read an entirely
-/// fresh set of these, disconnecting the whole previous generation.
-#[turbo_tasks::function]
-fn leaf(generation: u32, index: u32) -> Vc<u32> {
-    Vc::cell(generation.wrapping_mul(1000).wrapping_add(index))
-}
-
-/// A shared-dependency layer, so the disconnected garbage is a subtree (intermediate + leaf) and
-/// the test exercises the cascade rather than single-node collection.
-#[turbo_tasks::function]
-async fn intermediate(generation: u32, index: u32) -> Result<Vc<u32>> {
-    Ok(Vc::cell(1 + *leaf(generation, index).await?))
-}
+use crate::{
+    gc_fixture::{create_generation, wide_root},
+    util::create_tt_with_gc_min_progress,
+};
 
 const WIDTH: u32 = 24;
-
-/// Bumping the generation re-executes this and connects a fresh generation's worth of tasks,
-/// disconnecting the entire previous generation (2*WIDTH tasks) as garbage.
-#[turbo_tasks::function(operation, root)]
-async fn wide_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
-    let generation = *generation.await?.get();
-    let mut sum = 0u32;
-    for index in 0..WIDTH {
-        sum = sum.wrapping_add(*intermediate(generation, index).await?);
-    }
-    Ok(Vc::cell(sum))
-}
 
 /// Repeatedly swapping a wide set of common dependencies (as happens when a project is re-rooted or
 /// its dependencies churn) must NOT grow the resident task set monotonically. Each round bumps the
@@ -82,7 +51,7 @@ async fn gc_re_rooting_stays_flat() {
                 let generation = generation_op.read_strongly_consistent().await?;
                 generation.set(gen_value);
             }
-            let output = wide_root(generation_vc);
+            let output = wide_root(generation_vc, WIDTH);
             output.read_strongly_consistent().await?;
             let _ = &tt_inner;
             anyhow::Ok(())
@@ -99,11 +68,10 @@ async fn gc_re_rooting_stays_flat() {
         // `gc_for_testing`, which pins `min_progress` so high it can never trip). On a loaded
         // machine that pass can wind down early, which shows up as a collection shortfall rather
         // than a bug — so report it instead of letting it look like GC failing to collect.
-        tt.backend().snapshot_and_evict_for_testing(tt);
         let interrupted = tt
             .backend()
-            .last_gc_stats_for_testing()
-            .is_some_and(|(_, interrupted)| interrupted);
+            .snapshot_and_evict_for_testing(tt)
+            .gc_interrupted();
         // Measure the *persistent* resident count: GC only collects persistent tasks. Transient
         // roots (each round's `run_once`/Once task) are never collected and accumulate
         // independently of GC — including them would mask the real signal.
@@ -164,7 +132,7 @@ async fn gc_re_rooting_stays_flat() {
     let result = turbo_tasks::run_once(tt.clone(), async move {
         let generation_op = create_generation();
         let generation_vc = generation_op.resolve().strongly_consistent().await?;
-        let output = wide_root(generation_vc);
+        let output = wide_root(generation_vc, WIDTH);
         // generation is ROUNDS; sum = WIDTH intermediates each = 1 + leaf(ROUNDS, i).
         let expected: u32 = (0..WIDTH)
             .map(|i| 1 + (ROUNDS.wrapping_mul(1000).wrapping_add(i)))

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -23,12 +23,6 @@ const WIDTH: u32 = 24;
 /// evicts, and the resident count must return to a flat baseline.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gc_re_rooting_stays_flat() {
-    // This test asserts on *how much* GC collects, so it must not race the interrupt heuristic.
-    // `gc_for_testing` already pins the floor for its own pass, but each round also runs
-    // `snapshot_and_evict_for_testing`, whose GC pass is fully interruptible: on a loaded machine
-    // it can wind down as soon as an operation blocks behind it, collecting less through no fault
-    // of GC. Pin the floor beyond any plausible pass so the counts are deterministic; the
-    // interrupt path has its own tests.
     let (tt, _persistence_dir) =
         create_tt_with_gc_min_progress("gc_re_rooting_stays_flat", Duration::from_secs(60 * 60));
     let tt2 = tt.clone();
@@ -64,10 +58,7 @@ async fn gc_re_rooting_stays_flat() {
         // first would drop the garbage to disk-only where the in-memory GC can't collect or
         // tombstone it.
         let collected = tt.backend().gc_for_testing(tt);
-        // This runs a *second*, interruptible GC pass inside `snapshot_and_persist` (unlike
-        // `gc_for_testing`, which pins `min_progress` so high it can never trip). On a loaded
-        // machine that pass can wind down early, which shows up as a collection shortfall rather
-        // than a bug — so report it instead of letting it look like GC failing to collect.
+
         let interrupted = tt
             .backend()
             .snapshot_and_evict_for_testing(tt)

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_stress.rs
@@ -4,13 +4,13 @@
 
 mod util;
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, State, TurboTasks, Vc};
 use turbo_tasks_backend::TurboTasksBackend;
 
-use crate::util::create_tt;
+use crate::util::create_tt_with_gc_min_progress;
 
 #[turbo_tasks::value(transparent)]
 struct Generation(State<u32>);
@@ -54,16 +54,15 @@ async fn wide_root(generation: ResolvedVc<Generation>) -> Result<Vc<u32>> {
 /// evicts, and the resident count must return to a flat baseline.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gc_re_rooting_stays_flat() {
-    let (tt, _persistence_dir) = create_tt("gc_re_rooting_stays_flat");
-    let tt2 = tt.clone();
-
     // This test asserts on *how much* GC collects, so it must not race the interrupt heuristic.
     // `gc_for_testing` already pins the floor for its own pass, but each round also runs
     // `snapshot_and_evict_for_testing`, whose GC pass is fully interruptible: on a loaded machine
     // it can wind down as soon as an operation blocks behind it, collecting less through no fault
     // of GC. Pin the floor beyond any plausible pass so the counts are deterministic; the
     // interrupt path has its own tests.
-    tt.backend().set_gc_min_progress_for_testing(u64::MAX / 2);
+    let (tt, _persistence_dir) =
+        create_tt_with_gc_min_progress("gc_re_rooting_stays_flat", Duration::from_secs(60 * 60));
+    let tt2 = tt.clone();
 
     const ROUNDS: u32 = 20;
 

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -72,9 +72,11 @@ fn open_tt_at_with_gc(
 /// A persistence directory that outlives the backends opened on it, so a test can stop one backend
 /// and open another on the same path to simulate a restart.
 pub fn create_persistence_dir(name: &str) -> tempfile::TempDir {
+    let parent = Path::new(env!("CARGO_TARGET_TMPDIR")).join(".cache");
+    std::fs::create_dir_all(&parent).unwrap();
     tempfile::Builder::new()
         .prefix(&format!("{name}-"))
-        .tempdir()
+        .tempdir_in(&parent)
         .unwrap()
 }
 

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -23,7 +23,7 @@ use turbo_tasks_backend::{
 /// Reusing the same `path` (after the previous backend has been stopped) reopens the persisted
 /// database, which is how a test can assert that state survives a restart.
 fn open_tt_at(path: &Path, num_workers: usize) -> Arc<TurboTasks<TurboTasksBackend>> {
-    open_tt_at_with_gc(path, num_workers, Some(true), None)
+    open_tt_at_with_gc(path, num_workers, Some(true), None, None)
 }
 
 /// Like [`open_tt_at`], but forces the GC on or off for this backend instead of deriving it from
@@ -37,6 +37,7 @@ fn open_tt_at_with_gc(
     num_workers: usize,
     gc: Option<bool>,
     gc_root_ttl: Option<Duration>,
+    gc_min_progress: Option<Duration>,
 ) -> Arc<TurboTasks<TurboTasksBackend>> {
     TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {
@@ -48,6 +49,7 @@ fn open_tt_at_with_gc(
             eviction_mode: EvictionMode::Full,
             gc,
             gc_root_ttl,
+            gc_min_progress,
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(
@@ -80,7 +82,7 @@ pub fn create_persistence_dir(name: &str) -> tempfile::TempDir {
 /// [`open_tt_at_with_gc`]). The previous backend must already be stopped so its shutdown snapshot
 /// has been flushed.
 pub fn reopen_tt_with_gc(dir: &tempfile::TempDir) -> Arc<TurboTasks<TurboTasksBackend>> {
-    open_tt_at_with_gc(dir.path(), 2, Some(true), None)
+    open_tt_at_with_gc(dir.path(), 2, Some(true), None, None)
 }
 
 /// [`reopen_tt_with_gc`] with the GC root TTL pinned, so a test can age a root out inside the test
@@ -89,7 +91,7 @@ pub fn reopen_tt_with_gc_ttl(
     dir: &tempfile::TempDir,
     gc_root_ttl: Duration,
 ) -> Arc<TurboTasks<TurboTasksBackend>> {
-    open_tt_at_with_gc(dir.path(), 2, Some(true), Some(gc_root_ttl))
+    open_tt_at_with_gc(dir.path(), 2, Some(true), Some(gc_root_ttl), None)
 }
 
 /// A fresh persistent backend in its own temp directory, with `num_workers` workers.
@@ -105,4 +107,17 @@ pub fn create_tt_with_workers(
 /// A fresh persistent backend in its own temp directory, with the default worker count.
 pub fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
     create_tt_with_workers(name, 2)
+}
+
+/// [`create_tt`] with the GC min-progress floor pinned, so a test that asserts on exact collected
+/// counts can't have a pass shortened under it by an operation blocking behind GC. Set at
+/// construction, where the floor is resolved; per-backend, so it doesn't race the
+/// `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env var that every test in the binary would share.
+pub fn create_tt_with_gc_min_progress(
+    name: &str,
+    gc_min_progress: Duration,
+) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_persistence_dir(name);
+    let tt = open_tt_at_with_gc(dir.path(), 2, Some(true), None, Some(gc_min_progress));
+    (tt, dir)
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -111,10 +111,7 @@ pub fn create_tt(name: &str) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::T
     create_tt_with_workers(name, 2)
 }
 
-/// [`create_tt`] with the GC min-progress floor pinned, so a test that asserts on exact collected
-/// counts can't have a pass shortened under it by an operation blocking behind GC. Set at
-/// construction, where the floor is resolved; per-backend, so it doesn't race the
-/// `TURBO_ENGINE_GC_MIN_PROGRESS_MS` env var that every test in the binary would share.
+/// [`create_tt`] with a custom GC min-progress floor
 pub fn create_tt_with_gc_min_progress(
     name: &str,
     gc_min_progress: Duration,


### PR DESCRIPTION
A GC pass holds total operation exclusion, so every invalidation, cell update and child connect
blocks for its whole duration. In dev that is an HMR edit stalled behind the cascade, and the pass
had no way to notice or yield.

This makes a gc pass interruptible so we are guaranteed to not stall too much work.  To ensure progress we have a minimum guaranteed execution time `100ms` 
