### PR TITLE
[react-sync] Open pull requests as the bot that authors the commits

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -19,6 +19,11 @@ env:
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest
+    permissions:
+      # The built-in token is only used to read the facebook/react compare API
+      # for the changelog. Everything that writes to this repository
+      # authenticates as the release app instead.
+      contents: read
     steps:
       - name: Create GitHub App token
         id: release-app-token
@@ -29,6 +34,10 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          # To open the Pull Request, request reviewers, and apply labels and
+          # assignees. `actions/create-github-app-token` narrows the token to
+          # exactly the permissions requested here.
+          permission-pull-requests: write
 
       - name: Get GitHub App user ID
         id: release-app-user
@@ -67,7 +76,10 @@ jobs:
         shell: bash
         run: pnpm sync-react --actor "${{ github.actor }}" --commit --create-pull --version "${{ inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          # Only used to authenticate the facebook/react compare API request
+          # that builds the changelog, so it doesn't hit anonymous rate limits.
+          # The commits, branch, and Pull Request all use the app token below.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -309,7 +309,7 @@ async function main() {
     .options('actor', {
       type: 'string',
       description:
-        'Required with `--create-pull`. The actor (GitHub username) that runs this script. Will be used for notifications but not commit attribution.',
+        'Required with `--create-pull`. The actor (GitHub username) that runs this script. Will be assigned to the Pull Request for notifications, but neither the commits nor the Pull Request are attributed to them.',
     })
     .options('create-pull', {
       default: false,
@@ -356,12 +356,6 @@ async function main() {
         'Pass an actor via `--actor "some-actor"`.'
     )
   }
-  const githubToken = process.env.GITHUB_TOKEN
-  if (createPull && !githubToken) {
-    throw new Error(
-      `Environment variable 'GITHUB_TOKEN' not specified but required when --create-pull is specified.`
-    )
-  }
   const releaseGithubToken = process.env.RELEASE_GITHUB_TOKEN
   const releaseAppSlug = process.env.RELEASE_GITHUB_APP_SLUG
   const releaseAppUserId = process.env.RELEASE_GITHUB_APP_USER_ID
@@ -382,7 +376,8 @@ async function main() {
     // succeed even on CI runners that don't have a default git identity.
     // The values themselves are discarded by the GitHub REST API: the
     // GPG-signed commits on the remote are attributed to the app token's
-    // identity regardless of local git config.
+    // identity regardless of local git config. The same app token opens the
+    // Pull Request, so the PR author matches the commit author.
     const botUserName = `${releaseAppSlug}[bot]`
     const botUserEmail = `${releaseAppUserId}+${releaseAppSlug}[bot]@users.noreply.github.com`
     await execa('git', ['config', 'user.name', botUserName])
@@ -664,7 +659,9 @@ Or run this command again without the --no-install flag to do both automatically
   }
 
   if (createPull) {
-    const octokit = new Octokit({ auth: githubToken })
+    // Authenticate as the release app so the Pull Request is opened by the
+    // same identity that authors the signed commits pushed below.
+    const octokit = new Octokit({ auth: releaseGithubToken })
     const prTitle = `Upgrade React from \`${baseSha}-${baseDateString}\` to \`${newSha}-${newDateString}\``
 
     await execa('git', ['checkout', '-b', branchName])


### PR DESCRIPTION
Noticed when auto-merge didn't work. `vercel-release-bot` isn't in the exemption list (for good reason).

Since `vercel-release-bot` still uses a static token, it's time to use the app fully.

The rest of the usage I'll do in a follow-up.

## test plan

It'll fail for now when enabling auto-merge. Everything else works though. I'll fix the perms for auto-merge in a follow-up.

- [x] [sync from this branch](https://github.com/vercel/next.js/actions/runs/30954178134/job/92143210455) -> https://github.com/vercel/next.js/pull/96688