### PR TITLE
[ci] Open automated update pull requests with `nextjs-bot`

### DIFF
--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -22,6 +22,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Get GitHub App user ID
         id: release-app-user
@@ -62,7 +63,6 @@ jobs:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
-          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
           # We need to use `--override` for rspack (but not for turbopack).
           # We don't currently have any CI running on every PR, so it's quite
@@ -85,6 +85,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Get GitHub App user ID
         id: release-app-user
@@ -125,7 +126,6 @@ jobs:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
-          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
           SCRIPT: test/update-bundler-manifest.js --bundler rspack --test-suite build --override
           PR_TITLE: Update Rspack production test manifest

--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -22,6 +22,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Get GitHub App user ID
         id: release-app-user
@@ -62,7 +63,6 @@ jobs:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
-          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: turbopack-manifest
           SCRIPT: test/update-bundler-manifest.js --bundler turbopack --test-suite dev
           PR_TITLE: Update Turbopack development test manifest
@@ -81,6 +81,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Get GitHub App user ID
         id: release-app-user
@@ -121,7 +122,6 @@ jobs:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
-          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: turbopack-manifest
           SCRIPT: test/update-bundler-manifest.js --bundler turbopack --test-suite build
           PR_TITLE: Update Turbopack production test manifest

--- a/.github/workflows/update_fonts_data.yml
+++ b/.github/workflows/update_fonts_data.yml
@@ -21,6 +21,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Get GitHub App user ID
         id: release-app-user
@@ -61,7 +62,6 @@ jobs:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
-          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: fonts-data
           SCRIPT: scripts/update-google-fonts.js
           PR_TITLE: Update font data

--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -34,9 +34,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: next.js
           permission-contents: write
-          # To open the Pull Request, request reviewers, and apply labels and
-          # assignees. `actions/create-github-app-token` narrows the token to
-          # exactly the permissions requested here.
           permission-pull-requests: write
 
       - name: Get GitHub App user ID

--- a/scripts/automated-update-workflow.js
+++ b/scripts/automated-update-workflow.js
@@ -11,7 +11,6 @@ const exec = promisify(execOriginal)
 
 const {
   RELEASE_GITHUB_TOKEN = '',
-  PR_GITHUB_TOKEN = '',
   RELEASE_GITHUB_APP_SLUG = '',
   RELEASE_GITHUB_APP_USER_ID = '',
   SCRIPT = '',
@@ -22,10 +21,6 @@ const {
 
 if (!RELEASE_GITHUB_TOKEN) {
   console.log('missing RELEASE_GITHUB_TOKEN env')
-  process.exit(1)
-}
-if (!PR_GITHUB_TOKEN) {
-  console.log('missing PR_GITHUB_TOKEN env')
   process.exit(1)
 }
 if (!RELEASE_GITHUB_APP_SLUG) {
@@ -45,7 +40,7 @@ const REPO_OWNER = 'vercel'
 const REPO_NAME = 'next.js'
 
 async function main() {
-  const octokit = new Octokit({ auth: PR_GITHUB_TOKEN })
+  const octokit = new Octokit({ auth: RELEASE_GITHUB_TOKEN })
   const branchName = `update/${BRANCH_NAME}-${Date.now()}`
   const botUserName = `${RELEASE_GITHUB_APP_SLUG}[bot]`
   const botUserEmail = `${RELEASE_GITHUB_APP_USER_ID}+${RELEASE_GITHUB_APP_SLUG}[bot]@users.noreply.github.com`

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -659,8 +659,6 @@ Or run this command again without the --no-install flag to do both automatically
   }
 
   if (createPull) {
-    // Authenticate as the release app so the Pull Request is opened by the
-    // same identity that authors the signed commits pushed below.
     const octokit = new Octokit({ auth: releaseGithubToken })
     const prTitle = `Upgrade React from \`${baseSha}-${baseDateString}\` to \`${newSha}-${newDateString}\``
 


### PR DESCRIPTION
Gets rid of of all usages of the static `GH_TOKEN_PULL_REQUESTS` token that was issued for `vercel-release-bot`. 

We already create commits with `nextjs-bot`. `nextjs-bot` already had permissions to open PRs which is already being used by React sync.