### PR TITLE
docs: add TruoCloud to the example loader configurations

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
@@ -66,6 +66,7 @@ To learn more about configuring the behavior of the built-in [Image Optimization
 - [Sirv](#sirv)
 - [Supabase](#supabase)
 - [Thumbor](#thumbor)
+- [TruoCloud](#truocloud)
 - [Imagekit](#imagekitio)
 - [Nitrogen AIO](#nitrogen-aio)
 
@@ -240,6 +241,22 @@ export default function supabaseLoader({ src, width, quality }) {
 export default function thumborLoader({ src, width, quality }) {
   const params = [`${width}x0`, `filters:quality(${quality || 75})`]
   return `https://example.com${params.join('/')}${src}`
+}
+```
+
+### TruoCloud
+
+```js
+// Docs: https://docs.truo.cloud/images
+// Parameters are set in alphabetical order on purpose: TruoCloud treats the
+// sorted form as canonical, so two orderings of the same request would be two
+// CDN cache entries for one image.
+export default function truoCloudLoader({ src, width, quality }) {
+  const params = new URLSearchParams()
+  params.set('f', 'auto')
+  if (quality) params.set('q', quality.toString())
+  params.set('w', width.toString())
+  return `https://img.truo.cloud/i/<pid>/${src.replace(/^\//, '')}?${params}`
 }
 ```
 


### PR DESCRIPTION
Adds [TruoCloud](https://docs.truo.cloud/images) to the list of example loader
configurations in `images.mdx`, in the same shape as the entries around it: one
bullet in the index and one code block.

Docs-only, 12 lines added, nothing removed.

The one thing worth a comment in the snippet — and it is in there — is that the
parameters are set in alphabetical order deliberately. TruoCloud treats the
sorted form as canonical, so an unsorted loader would produce a second CDN cache
entry for every image without changing what is served.

There is also a published loader package, `@truocloud/img-next`, which adds
per-segment RFC 3986 encoding of the source path and optional URL signing. I
kept the example self-contained to match the other entries.