### PR TITLE
turbo-tasks-backend: track GC root liveness with a TtlCounter, not a timestamp refresh

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -19,20 +19,51 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+use bincode::{Decode, Encode};
 use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_tasks::{TaskId, TurboTasks, scope::scope_unbounded};
 
-use crate::backend::{
-    AnyOperation, GC_MIN_PROGRESS, GC_ROOT_TTL, TurboTasksBackend,
-    operation::{
-        AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
-        TaskGuard, capture_all_outgoing_edges,
+use crate::{
+    backend::{
+        AnyOperation, GC_MIN_PROGRESS, GC_ROOT_TTL, TurboTasksBackend,
+        operation::{
+            AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
+            TaskGuard, capture_all_outgoing_edges,
+        },
+        snapshot_coordinator::SnapshotCoordinator,
+        storage::{SpecificTaskDataCategory, TaskDataCategory},
+        storage_schema::TaskStorageAccessors,
     },
-    snapshot_coordinator::SnapshotCoordinator,
-    storage::{SpecificTaskDataCategory, TaskDataCategory},
-    storage_schema::TaskStorageAccessors,
+    backing_storage::SnapshotItem,
 };
+
+/// How long a GC root has gone without being observed live, as stored in the persisted roots map.
+///
+/// This replaces a bare "last anchored at" timestamp that every pass had to *rewrite* to assert
+/// liveness. Rewriting was both fragile and wasteful:
+/// - Restoring a task from disk does not dirty it, so a fully cached session could observe a root
+///   live and still persist nothing — the refresh was silently dropped and the root eventually aged
+///   out despite being alive in every session.
+/// - A fresh timestamp per pass meant the encoded map differed every time, so the write could never
+///   be skipped even in perfect steady state.
+///
+/// [`TtlCounter::MostRecent`] is a *stable* value: a root that stays live re-encodes identically
+/// across passes and sessions, so there is nothing to rewrite and the TTL clock simply never
+/// starts. The clock starts only when a root stops being live, which is what the TTL is meant to
+/// measure.
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TtlCounter {
+    /// Observed live (a durable, anchored root) in the most recent session. Never ages out.
+    MostRecent,
+    /// The root was not live as of the first GC pass of some session; the value is that pass's
+    /// wall-clock millis since the Unix epoch. The TTL runs from here. Re-observing the root
+    /// promotes it back to [`Self::MostRecent`].
+    ///
+    /// If it later proves useful to distinguish "live one session ago" from "live many sessions
+    /// ago", `MostRecent` can gain a small generation counter without changing these transitions.
+    FirstStale(u64),
+}
 
 /// One unit of GC work. Parallelism is *across* jobs (the unbounded pool in
 /// [`TurboTasksBackend::gc_collect`] runs many on different workers); each job is internally
@@ -188,23 +219,23 @@ impl TurboTasksBackend {
     /// tasks are left resident with their `deleted` flag set, and the next snapshot derives the
     /// tombstones from that flag (see `snapshot_and_persist`).
     /// Runs a GC pass and returns its stats plus the reconciled GC roots map (task ->
-    /// last-anchored-ms) to persist in the same snapshot commit. The roots map is loaded from disk
-    /// at the start of the pass and lives only for its duration — it's per-pass state, not backend
-    /// state, so nothing is held resident between passes (and a backend that never GCs never reads
-    /// it).
+    /// [`TtlCounter`]) to persist in the same snapshot commit, or `None` when the set is unchanged
+    /// and the write can be skipped. The roots map is loaded from disk at the start of the pass and
+    /// lives only for its duration — it's per-pass state, not backend state, so nothing is held
+    /// resident between passes (and a backend that never GCs never reads it).
     pub(crate) fn gc_collect(
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
-    ) -> (GcStats, Vec<(TaskId, u64)>) {
+    ) -> (GcStats, Option<Vec<(TaskId, TtlCounter)>>) {
         // A single wall-clock reading for the whole pass: every root touched here (scan-time
         // resident roots, refreshed roots, and cascade-discovered roots) is stamped with the *same*
         // `now`, so within one pass all timestamps are consistent (and it's one syscall, not
         // three).
         let now = Self::now_ms();
 
-        // Load the previous session's roots map (task id -> last-anchored millis; empty on a fresh
-        // or non-persistent database). Maintained locally through this pass and returned
-        // for persistence.
+        // Load the previous session's roots map (task id -> `TtlCounter`; empty on a fresh or
+        // non-persistent database). Maintained locally through this pass and returned for
+        // persistence.
         let mut roots = self
             .backing_storage
             .roots()
@@ -216,7 +247,15 @@ impl TurboTasksBackend {
                 Vec::new()
             })
             .into_iter()
-            .collect::<FxHashMap<TaskId, u64>>();
+            .collect::<FxHashMap<TaskId, TtlCounter>>();
+        // Snapshot of what is on disk, so the pass can skip rewriting an unchanged set. Cheap
+        // because `TtlCounter::MostRecent` is stable: a steady-state session produces an identical
+        // map, unlike the old "stamp `now` on every live root" scheme, which differed every pass.
+        //
+        // Safe under the degraded read above: an unreadable key leaves this empty, so anything the
+        // pass rediscovers compares as *changed* and gets written, repairing the key rather than
+        // skipping past it.
+        let roots_before = roots.clone();
 
         // Seed the pool with the resident-map scan, split one job per shard. Each shard job applies
         // the cheap `gc_maybe_collectible` pre-filter (a handful of field reads per task under a
@@ -249,7 +288,10 @@ impl TurboTasksBackend {
         // the same `gc_is_root` predicate the scan uses, so a resident still-root is refreshed here
         // regardless. Roots the scan newly discovers are folded into the map after the pool drains,
         // which is what keeps the scan off the critical path.
-        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now);
+        // Only the first pass of a session may demote a live root to `FirstStale`; see that
+        // function's doc. `swap` so exactly one pass observes `true`, whichever runs first.
+        let first_pass_of_session = self.first_gc_pass_of_session.swap(false, Ordering::Relaxed);
+        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now, first_pass_of_session);
 
         // Aged-out roots are candidates for collection, but — unlike the pre-filtered resident
         // candidates the scan produces — they are not guaranteed collectible: one may have been
@@ -445,21 +487,28 @@ impl TurboTasksBackend {
             ControlFlow::Continue(())
         });
 
-        // Fold in the roots the shard scans found. Deferred to here (rather than passed into
-        // `gc_roots_refresh_and_age_out`) so the scan never blocks the cascade: `or_insert` leaves
-        // an already-tracked root's refreshed timestamp alone and only adds roots new to the map
-        // this session.
+        // Fold in the roots the shard scans found, plus those the cascade discovered
+        // (orphaned-but-not-collected children — anchored, so they just became durable roots).
+        // Deferred to here rather than passed into `gc_roots_refresh_and_age_out` so the scan never
+        // blocks the cascade.
         //
-        // Then fold in roots discovered during the cascade (orphaned-but-not-collected children),
-        // same rule: new to the map → `now`; already tracked → keep the existing timestamp, since a
-        // cascade re-orphaning doesn't reset an already-running clock.
+        // Both sets were observed **live during this pass**, so both `insert` `MostRecent`
+        // unconditionally rather than `or_insert`.
+        //
+        // Today the two are equivalent: the `retain` above ran first over the carried-forward map
+        // using the *same* `gc_is_root` predicate on the same storage under the same exclusion, so
+        // any id the scan reports as anchored was already promoted there, and ids not in the map
+        // have no entry for `or_insert` to preserve. `insert` is still what we want — it states
+        // "this root was observed live" directly instead of silently depending on that coincidence,
+        // so it stays correct if the retain is ever narrowed or the scan learns to report roots the
+        // retain skipped.
         {
-            let map: &mut FxHashMap<TaskId, u64> = &mut roots;
+            let map: &mut FxHashMap<TaskId, TtlCounter> = &mut roots;
             for id in scanned_roots.into_inner() {
-                map.entry(id).or_insert(now);
+                map.insert(id, TtlCounter::MostRecent);
             }
             for id in discovered_roots.into_inner() {
-                map.entry(id).or_insert(now);
+                map.insert(id, TtlCounter::MostRecent);
             }
         };
 
@@ -475,7 +524,7 @@ impl TurboTasksBackend {
         // collected task fails `gc_is_root` so the scan won't report it), but ordering it this way
         // means a collect always wins, which is the safe direction: the task no longer exists.
         {
-            let map: &mut FxHashMap<TaskId, u64> = &mut roots;
+            let map: &mut FxHashMap<TaskId, TtlCounter> = &mut roots;
             for id in collected_ids.into_inner() {
                 map.remove(&id);
             }
@@ -489,7 +538,15 @@ impl TurboTasksBackend {
             interrupted: budget.was_interrupted(),
             abandoned: abandoned.into_inner(),
         };
-        (stats, roots.into_iter().collect())
+
+        // Skip the write when nothing about the root set changed. This is only worth doing because
+        // `MostRecent` is stable: under the old scheme every live root was stamped with a fresh
+        // `now` each pass, so the map always differed and the write was unskippable. Now the steady
+        // state — same roots, all still live — compares equal and leaves the `GcRoots` key
+        // untouched. Comparing two small in-memory maps is far cheaper than the encode + write it
+        // avoids.
+        let roots_to_persist = (roots != roots_before).then(|| roots.into_iter().collect());
+        (stats, roots_to_persist)
     }
 
     /// The GC root TTL for this pass. Precedence: the per-backend test override
@@ -554,15 +611,18 @@ impl TurboTasksBackend {
     /// `with_task`), which is both correct and the point — the roots we most want to age out are
     /// the non-resident ones, and we must not pull them back into memory just to look:
     /// - **resident and still a root** ([`TaskStorage::gc_is_root`]: `parent_count == 0 &&
-    ///   transient_ref_count > 0`) → refresh `last_anchored_ms = now`. Using the *full*
-    ///   `gc_is_root` predicate — not just `transient_ref_count > 0` — is what stops a resident
-    ///   task that regained a persistent parent from being refreshed forever as a stale "root" (it
-    ///   fails `gc_is_root`, so it ages out and is dropped).
-    /// - **resident but no longer a root**, or **not resident** → un-anchored: a non-resident task
+    ///   transient_ref_count > 0`) → [`TtlCounter::MostRecent`]. Using the *full* `gc_is_root`
+    ///   predicate — not just `transient_ref_count > 0` — is what stops a resident task that
+    ///   regained a persistent parent from being kept live forever as a stale "root" (it fails
+    ///   `gc_is_root`, so it goes stale and eventually ages out).
+    /// - **resident but no longer a root**, or **not resident** → not live: a non-resident task
     ///   holds no `transient_ref_count` (transient state is in-memory only) and was not re-anchored
-    ///   this session (re-anchoring restores it), so it is correctly treated as orphaned. Keep its
-    ///   timestamp; if `now - last_anchored_ms > TTL`, return it as a collection seed (the aged-out
-    ///   path in `gc_collect` restores + re-validates it before collecting).
+    ///   this session (re-anchoring restores it), so it is correctly treated as orphaned. A
+    ///   `MostRecent` entry becomes [`TtlCounter::FirstStale`]`(now)` — but **only when
+    ///   `first_pass_of_session`**, since a single pass missing a root does not mean the session
+    ///   did. An already-stale entry keeps its timestamp, and once `now - since > TTL` it is
+    ///   returned as a collection seed (the aged-out path in `gc_collect` restores + re-validates
+    ///   it before collecting).
     ///
     /// **The map is monotone: this function never removes an entry.** An aged-out root is only
     /// *seeded*; `gc_collect` removes it from the map after the collect job actually marked it
@@ -579,28 +639,28 @@ impl TurboTasksBackend {
     /// pins.
     fn gc_roots_refresh_and_age_out(
         &self,
-        map: &mut FxHashMap<TaskId, u64>,
+        map: &mut FxHashMap<TaskId, TtlCounter>,
         now: u64,
+        first_pass_of_session: bool,
     ) -> Vec<TaskId> {
         let ttl_ms = self.gc_root_ttl().as_millis() as u64;
 
         // Reconcile the carried-forward map (prior-session entries) first. Every entry is
         // re-classified by the *same* `gc_is_root` predicate the scan uses, so a resident root that
-        // is still a root is refreshed here — we don't need `resident_roots` to touch it.
+        // is still a root is promoted here — we don't need `resident_roots` to touch it.
         let mut aged_out = Vec::new();
-        map.retain(|&id, last_anchored| {
-            // Non-inserting: a non-resident root reads as `None` → un-anchored → ages (which is
-            // what we want; we don't restore disk-only orphans just to check them). A
-            // resident task is a still-live root only if it passes the full
-            // `gc_is_root` (parent_count 0 AND anchored), so a re-parented resident
-            // task fails here and ages out of the map.
+        map.retain(|&id, counter| {
+            // Non-inserting: a non-resident root reads as `None` → not live (which is what we want;
+            // we don't restore disk-only orphans just to check them). A resident task is a
+            // still-live root only if it passes the full `gc_is_root` (parent_count 0 AND
+            // anchored), so a re-parented resident task fails here.
             match self
                 .storage
                 .with_task(id, |t| (t.gc_is_root(), t.gc_is_deleted()))
             {
                 // Already collected (soft-deleted, resident until the tombstone commit + hard
                 // delete). It is not a root any more and there is nothing left to collect, so drop
-                // the entry outright rather than letting it fall through to the aged-out branch —
+                // the entry outright rather than letting it fall through to the stale branch —
                 // which would re-seed it every pass forever (the revalidation always rejects a
                 // deleted task) and keep a dead id in the persisted set. This is the one case where
                 // an entry leaves the map *here* rather than via the collected-ids removal in
@@ -608,26 +668,42 @@ impl TurboTasksBackend {
                 // collected by an earlier pass in the same session is still resident when the next
                 // pass reads the map.
                 Some((_, true)) => return false,
-                // Still a live durable root: refresh its clock.
+                // Live: (re)assert `MostRecent`. Unconditional, so this both keeps a live root live
+                // and *promotes* one that had started aging — a root re-requested after a stale
+                // session gets its clock cleared, not merely paused. Writing the same value for an
+                // already-`MostRecent` root is what makes a steady-state map byte-identical.
                 Some((true, false)) => {
-                    *last_anchored = now;
+                    *counter = TtlCounter::MostRecent;
                     return true;
                 }
-                // Resident but no longer a root, or not resident at all: fall through to the
-                // age-out check below.
+                // Resident but no longer a root, or not resident at all: fall through.
                 Some((false, false)) | None => {}
             }
-            // Un-anchored: has it aged past the TTL? `now < last_anchored` (clock skew across
-            // sessions) is treated as not-yet-aged (saturating), never negative.
-            if now.saturating_sub(*last_anchored) > ttl_ms {
-                aged_out.push(id);
+            match *counter {
+                // Not live, and the previous session had it live. Start the clock — but only on the
+                // **first pass of this session**. GC runs on the snapshot cadence (many passes per
+                // session), and a live root can easily be missed by any single pass: it may be
+                // evicted, or simply not yet re-requested. Demoting on every pass would make the
+                // TTL measure idleness within a session rather than "was not live in a session",
+                // which is the property we actually want.
+                TtlCounter::MostRecent => {
+                    if first_pass_of_session {
+                        *counter = TtlCounter::FirstStale(now);
+                    }
+                }
+                // Already stale: leave the timestamp alone so the clock keeps running from when it
+                // first went stale, and seed it for collection once it is past the TTL.
+                // `now < since` (clock skew across sessions) is treated as not-yet-aged
+                // (saturating), never negative.
+                TtlCounter::FirstStale(since) => {
+                    if now.saturating_sub(since) > ttl_ms {
+                        aged_out.push(id);
+                    }
+                }
             }
             // Keep the entry either way — see the "monotone map" note in the doc comment. An
             // aged-out root is only *seeded* for collection here; the entry is removed by
-            // `gc_collect` after the task is actually marked deleted. Keeping its existing
-            // timestamp (rather than refreshing to `now`) means a root that repeatedly fails to be
-            // collected stays aged-out and is re-seeded every pass, instead of restarting its TTL
-            // clock.
+            // `gc_collect` after the task is actually marked deleted.
             true
         });
 
@@ -708,9 +784,25 @@ impl TurboTasksBackend {
         // Far beyond any real pass, so `should_stop`'s floor check never elapses.
         self.gc_min_progress_override_ms
             .store(u64::MAX / 2, Ordering::Relaxed);
-        let collected = self.gc_collect(turbo_tasks).0.collected;
+        let (stats, roots) = self.gc_collect(turbo_tasks);
         self.gc_min_progress_override_ms
             .store(prev, Ordering::Relaxed);
-        collected
+
+        // Persist the roots map this pass produced. Production does it via the `into_snapshot`
+        // handoff; this hook has no snapshot, so without an explicit write the pass's roots work
+        // would be computed and thrown away. That matters because the pass also *consumed* the
+        // session's one demotion opportunity (`first_gc_pass_of_session`): dropping the result
+        // would leave a root that went stale this session still marked `MostRecent`, and no later
+        // pass in this session would demote it again.
+        if let Some(roots) = roots
+            && let Err(err) = self.backing_storage.save_snapshot(
+                Vec::new(),
+                Some(roots),
+                Vec::<Vec<SnapshotItem>>::new(),
+            )
+        {
+            panic!("gc_for_testing: failed to persist GC roots: {err:?}");
+        }
+        stats.collected
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -23,6 +23,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
+pub use gc::TtlCounter;
 use indexmap::IndexSet;
 use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
@@ -273,11 +274,24 @@ pub struct TurboTasksBackend {
     /// `set_gc_min_progress_for_testing`.
     gc_min_progress_override_ms: AtomicU64,
 
+    /// `true` until the first GC pass of this session runs. Only that pass may demote a live root
+    /// to `TtlCounter::FirstStale` — GC runs many times per session (on the snapshot cadence), and
+    /// a single pass can easily miss a root that is still live (evicted, or not yet re-requested).
+    /// Demoting on every pass would make the TTL measure idleness within a session rather than
+    /// "was not live in a whole session". See `gc_roots_refresh_and_age_out`.
+    first_gc_pass_of_session: AtomicBool,
+
     /// Test-only record of the most recent GC pass: `(collected, abandoned, interrupted)`. The
     /// production signal for these is the `gc` span, which a unit test can't read; this lets a
     /// test assert on what the *pass* did rather than on the resident count, which eviction
     /// also moves. See `last_gc_stats_for_testing`.
     last_gc_stats: Mutex<Option<(usize, usize, bool)>>,
+
+    /// Test-only: number of GC passes that produced a roots map to write (i.e. did *not* skip the
+    /// `GcRoots` rewrite because the set was unchanged). Lets a test assert the skip actually
+    /// happens — comparing the persisted set can't, since an unchanged set looks identical whether
+    /// it was rewritten or not. See `gc_roots_writes_for_testing`.
+    gc_roots_writes: AtomicU64,
 
     #[cfg(feature = "verify_aggregation_graph")]
     root_tasks: Mutex<FxHashSet<TaskId>>,
@@ -353,7 +367,9 @@ impl TurboTasksBackend {
             backing_storage,
             gc_root_ttl_override_ms: AtomicU64::new(u64::MAX),
             gc_min_progress_override_ms: AtomicU64::new(u64::MAX),
+            first_gc_pass_of_session: AtomicBool::new(true),
             last_gc_stats: Mutex::new(None),
+            gc_roots_writes: AtomicU64::new(0),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
         }
@@ -467,12 +483,19 @@ impl TurboTasksBackend {
         *self.last_gc_stats.lock()
     }
 
+    /// Number of GC passes so far that produced a roots map to persist. A pass whose root set was
+    /// unchanged does not increment this — that is the skip. Test-only.
+    #[doc(hidden)]
+    pub fn gc_roots_writes_for_testing(&self) -> u64 {
+        self.gc_roots_writes.load(Ordering::Relaxed)
+    }
+
     /// The GC roots set as currently persisted on disk (task id -> last-anchored millis). Reads the
     /// `GcRoots` infra key directly, so it reflects the last committed snapshot — not any in-flight
     /// pass. Test-only hook for asserting that a root seeded for collection but *not* collected
     /// stays tracked (see `gc_roots_refresh_and_age_out`'s monotonicity note).
     #[doc(hidden)]
-    pub fn persisted_gc_roots_for_testing(&self) -> Vec<(TaskId, u64)> {
+    pub fn persisted_gc_roots_for_testing(&self) -> Vec<(TaskId, TtlCounter)> {
         self.backing_storage.roots().unwrap_or_default()
     }
 
@@ -1158,7 +1181,7 @@ impl TurboTasksBackend {
         // The GC roots map (task -> last-anchored-ms), refreshed by the GC pass and persisted in
         // this same commit. `None` when GC didn't run, so `save_snapshot` leaves the prior
         // set untouched.
-        let mut gc_roots_to_persist: Option<Vec<(TaskId, u64)>> = None;
+        let mut gc_roots_to_persist: Option<Vec<(TaskId, TtlCounter)>> = None;
         let mut snapshot_phase = if self.gc_enabled {
             let gc_span = tracing::info_span!(
                 parent: parent_span.clone(),
@@ -1184,7 +1207,11 @@ impl TurboTasksBackend {
             gc_span.record("abandoned", stats.abandoned);
             *self.last_gc_stats.lock() =
                 Some((stats.collected, stats.abandoned, stats.interrupted));
-            gc_roots_to_persist = Some(roots);
+            // `None` when the root set is unchanged — the write is skipped entirely.
+            if roots.is_some() {
+                self.gc_roots_writes.fetch_add(1, Ordering::Relaxed);
+            }
+            gc_roots_to_persist = roots;
             gc_phase.into_snapshot()
         } else {
             // `begin_snapshot` blocks until in-flight operations drain (spanned inside the

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -19,7 +19,7 @@ use turbo_tasks::{
 
 use crate::{
     GitVersionInfo,
-    backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
+    backend::{AnyOperation, SpecificTaskDataCategory, TtlCounter, storage_schema::TaskStorage},
     backing_storage::{
         SnapshotItem, SnapshotMeta, TaskDeletion, TaskTypeHash,
         compute_task_type_hash_from_components,
@@ -250,10 +250,10 @@ impl TurboBackingStorage {
     }
 
     /// Reads the persisted GC roots set (see [`InfraKey::GcRoots`]): each durable root's `TaskId`
-    /// paired with the wall-clock millis-since-epoch at which it was last observed anchored.
-    /// Empty on a fresh database.
-    pub(crate) fn roots(&self) -> Result<Vec<(TaskId, u64)>> {
-        fn get(database: &TurboKeyValueDatabase) -> Result<Vec<(TaskId, u64)>> {
+    /// paired with its [`TtlCounter`] — either "live in the most recent session" or the timestamp
+    /// at which it first went stale. Empty on a fresh database.
+    pub(crate) fn roots(&self) -> Result<Vec<(TaskId, TtlCounter)>> {
+        fn get(database: &TurboKeyValueDatabase) -> Result<Vec<(TaskId, TtlCounter)>> {
             let Some(roots) = database.get(KeySpace::Infra, InfraKey::GcRoots.key().as_ref())?
             else {
                 return Ok(Vec::new());
@@ -267,7 +267,7 @@ impl TurboBackingStorage {
     pub(crate) fn save_snapshot<I>(
         &self,
         operations: Vec<Arc<AnyOperation>>,
-        roots: Option<Vec<(TaskId, u64)>>,
+        roots: Option<Vec<(TaskId, TtlCounter)>>,
         snapshots: Vec<I>,
     ) -> Result<SnapshotMeta>
     where
@@ -576,7 +576,7 @@ fn save_infra(
     batch: &TurboWriteBatch<'_>,
     next_task_id: u32,
     operations: Vec<Arc<AnyOperation>>,
-    roots: Option<Vec<(TaskId, u64)>>,
+    roots: Option<Vec<(TaskId, TtlCounter)>>,
 ) -> Result<(), anyhow::Error> {
     batch
         .put(

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -16,7 +16,7 @@ use turbo_persistence::{CompactConfig, TurboPersistence};
 
 use crate::database::turbo::{self, TurboKeyValueDatabase};
 pub use crate::{
-    backend::{BackendOptions, EvictionMode, StorageMode, TurboTasksBackend},
+    backend::{BackendOptions, EvictionMode, StorageMode, TtlCounter, TurboTasksBackend},
     database::{
         db_invalidation,
         db_invalidation::StartupCacheState,

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -9,7 +9,9 @@ use turbo_tasks::{
     GcRoot, ResolvedVc, State, TaskId, TurboTasks, Vc, prevent_gc,
     unmark_top_level_task_may_leak_eventually_consistent_state,
 };
-use turbo_tasks_backend::{BackendOptions, EvictionMode, GitVersionInfo, TurboTasksBackend};
+use turbo_tasks_backend::{
+    BackendOptions, EvictionMode, GitVersionInfo, TtlCounter, TurboTasksBackend,
+};
 
 /// Creates a fresh per-call persistence directory rooted under `CARGO_TARGET_TMPDIR/.cache/`.
 fn create_test_persistence_dir(name: &str) -> tempfile::TempDir {
@@ -877,27 +879,48 @@ async fn gc_collects_cross_session_orphan_root() {
     };
 
     // Session 2: reopen, but NEVER request `root_with_child(42)` — it's a cross-session orphan.
-    // With TTL 0 the first GC pass ages it out of the roots map and collects it + its subtree.
+    //
+    // Two things have to happen for it to be reclaimed, and with `TURBO_ENGINE_GC_ROOT_TTL_MS = 0`
+    // both fit in this session: the session's *first* pass finds it un-anchored and demotes it from
+    // `MostRecent` to `FirstStale(now)`, starting its clock; a later pass (here, the shutdown
+    // snapshot) sees a `FirstStale` that is already past a zero TTL and collects it plus its
+    // subtree. With a production TTL the second step would instead wait out the deadline, so a root
+    // that was live last session always gets at least one full stale session of grace.
     {
         let tt = open_tt_at(dir.path());
         tt.backend().set_gc_root_ttl_for_testing(0);
         let tt2 = tt.clone();
         turbo_tasks::run_once(tt.clone(), async move {
             unmark_top_level_task_may_leak_eventually_consistent_state();
+            // The first pass only starts the clock — a root live in the previous session is never
+            // collected by the very pass that notices it went away.
             let collected = tt2.backend().gc_for_testing(&tt2);
-            assert!(
-                collected >= 2,
-                "the orphaned root and its child should be collected (got {collected})"
+            assert_eq!(
+                collected, 0,
+                "the first stale pass only starts the TTL clock (got {collected})"
             );
-            let _ = root_id;
             anyhow::Ok(())
         })
         .await
         .unwrap();
+        let roots = tt.backend().persisted_gc_roots_for_testing();
+        assert!(
+            roots
+                .iter()
+                .any(|(id, c)| *id == root_id && matches!(c, TtlCounter::FirstStale(_))),
+            "the un-anchored root should have started its TTL clock; got {roots:?}"
+        );
+
+        // The shutdown snapshot's pass then ages it out and collects it.
         tt.stop_and_wait().await;
+        let roots = tt.backend().persisted_gc_roots_for_testing();
+        assert!(
+            !roots.iter().any(|(id, _)| *id == root_id),
+            "a collected root must be dropped from the map; got {roots:?}"
+        );
     }
 
-    // Session 3: reopen and confirm re-requesting recomputes cleanly (no dangling refs from the
+    // Session 4: reopen and confirm re-requesting recomputes cleanly (no dangling refs from the
     // cross-session collection).
     {
         let tt = open_tt_at(dir.path());
@@ -978,7 +1001,10 @@ async fn gc_keeps_uncollected_aged_out_root_in_roots_map() {
         .await
         .unwrap();
 
-        // Outside the `run_once`, so this is the only GC pass between here and the assertions.
+        // Two passes: the first demotes both never-anchored roots to `FirstStale` (a root live in
+        // the previous session is never collected by the pass that first notices it is gone), the
+        // second sees a zero TTL already expired and collects the collectible one.
+        tt.backend().snapshot_and_evict_for_testing(&tt);
         tt.backend().snapshot_and_evict_for_testing(&tt);
 
         let roots = tt.backend().persisted_gc_roots_for_testing();
@@ -999,98 +1025,363 @@ async fn gc_keeps_uncollected_aged_out_root_in_roots_map() {
     }
 }
 
-/// A root that is restored and observed **live** must have its refreshed timestamp persisted, even
-/// when the session modified nothing.
+/// A root that stays anchored **across** a session boundary keeps [`TtlCounter::MostRecent`], so
+/// its TTL clock never starts and it cannot age out however long the cache lives.
 ///
-/// Restoring a task from disk does not dirty it, so a perfectly cached graph can be reopened,
-/// re-read (cache hit, no recompute), and observed anchored while leaving `has_modifications`
-/// false. `snapshot_and_persist` used to return early in that case *before* handing the roots map
-/// to `save_snapshot`, silently dropping every refresh the pass computed.
+/// The roots map only exists for roots that *survive* a session — the pinned `ProjectContainer` op,
+/// a live endpoint. A root whose anchor is dropped mid-session is not "missed": the decref is
+/// authoritative, and the task becomes ordinary parentless garbage that the resident scan collects
+/// in-session, never reaching the roots map at all.
 ///
-/// That is a correctness bug, not a missed optimization: a rarely-changing route (an API route that
-/// is restored every session but never modified) would keep its original timestamp forever and
-/// eventually age out of the roots map — collected as a "cross-session orphan" even though every
-/// session had seen it alive. This test pins the sequence: session 2 refreshes-without-modifying,
-/// and session 3 must find the root still live rather than aged out.
+/// This replaced a per-pass timestamp refresh, which was fragile in exactly this case: restoring a
+/// task from disk does not dirty it, so a fully cached session could observe a root live and still
+/// leave `has_modifications` false — and the refresh was silently dropped. A long-lived anchored
+/// root would keep its original timestamp forever and eventually age out despite being alive in
+/// every session. With `MostRecent` there is nothing to refresh: a live root re-encodes to the same
+/// value, so a steady-state session has nothing to write and the root simply never ages.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn gc_persists_root_refresh_when_nothing_was_modified() {
-    let dir = create_test_persistence_dir("gc_persists_root_refresh_clean_pass");
+async fn gc_keeps_anchored_root_most_recent_across_sessions() {
+    let dir = create_test_persistence_dir("gc_anchored_root_stays_most_recent");
 
-    // Session 1: create the root and persist it, capturing its initial timestamp.
-    let (root_id, first_ts) = {
+    fn counter_of(tt: &Arc<TurboTasks<TurboTasksBackend>>, id: TaskId) -> Option<TtlCounter> {
+        tt.backend()
+            .persisted_gc_roots_for_testing()
+            .into_iter()
+            .find(|(r, _)| *r == id)
+            .map(|(_, c)| c)
+    }
+
+    // Session 1: create a parentless task and hold it with a `GcRoot` across the shutdown snapshot
+    // — the shape of a root that outlives a session (as a pinned container op does).
+    let root_id = {
         let tt = open_tt_at(dir.path());
-        let root_id = turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
-            let output = root_with_child(11);
-            assert_eq!(*output.read_strongly_consistent().await?, 12);
-            anyhow::Ok(output.task_id())
-        })
-        .await
-        .unwrap();
+        let tt2 = tt.clone();
+        let leaf_id = tt
+            .run(async move {
+                unmark_top_level_task_may_leak_eventually_consistent_state();
+                let leaf_vc = orphan_leaf(21);
+                let _ = *leaf_vc.await?;
+                Ok(task_id_of(leaf_vc.resolve().await?))
+            })
+            .await
+            .unwrap();
+        let guard = GcRoot::pin(tt2.clone(), leaf_id);
         tt.stop_and_wait().await;
-        let roots = tt.backend().persisted_gc_roots_for_testing();
-        let ts = roots
-            .iter()
-            .find(|(id, _)| *id == root_id)
-            .map(|(_, ts)| *ts)
-            .expect("session 1 should persist the root");
-        (root_id, ts)
+        drop(guard);
+        assert_eq!(
+            counter_of(&tt, leaf_id),
+            Some(TtlCounter::MostRecent),
+            "a root anchored across the shutdown snapshot should be tracked as MostRecent"
+        );
+        leaf_id
     };
 
-    // The stored timestamp is wall-clock millis, so make sure a later refresh is distinguishable
-    // from the original. This is the only place the test depends on real time passing.
-    std::thread::sleep(std::time::Duration::from_millis(5));
-
-    // Session 2: reopen and re-read the *same* value. The graph is fully cached, so the root is
-    // restored and reused without being modified — `has_modifications` is false. The GC pass must
-    // still persist the refreshed timestamp.
-    {
+    // Sessions 2 and 3: re-anchor the same task and hold the pin across each session's snapshot.
+    // Nothing is recomputed — the graph is fully cached — so under the old scheme the refresh would
+    // have been dropped here.
+    for session in 2..=3 {
         let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
         turbo_tasks::run_once(tt.clone(), async move {
             unmark_top_level_task_may_leak_eventually_consistent_state();
-            // Identical read: a cache hit, no recompute, nothing dirtied.
-            assert_eq!(*root_with_child(11).read_strongly_consistent().await?, 12);
+            // Restore it so it has a resident entry to pin.
+            tt2.backend().assert_task_exists_for_testing(root_id, &tt2);
             anyhow::Ok(())
         })
         .await
         .unwrap();
+        let guard = GcRoot::pin(tt.clone(), root_id);
         tt.backend().snapshot_and_evict_for_testing(&tt);
-        tt.stop_and_wait().await;
-
-        let roots = tt.backend().persisted_gc_roots_for_testing();
-        let ts = roots
-            .iter()
-            .find(|(id, _)| *id == root_id)
-            .map(|(_, ts)| *ts)
-            .expect("the live root must still be tracked after a clean session");
-        assert!(
-            ts > first_ts,
-            "a restored, still-live root must have its refreshed timestamp persisted even when \
-             the session modified nothing (was {first_ts}, still {ts}); otherwise its TTL clock \
-             never restarts and it eventually ages out despite being alive every session"
+        assert_eq!(
+            counter_of(&tt, root_id),
+            Some(TtlCounter::MostRecent),
+            "a root still anchored in session {session} must stay MostRecent"
         );
+        tt.stop_and_wait().await;
+        drop(guard);
     }
 
-    // Session 3: with a zero TTL, an un-refreshed root would age out and be collected here. The
-    // refresh from session 2 is what keeps it alive — and re-reading it refreshes it again.
+    // Session 4: still anchored, and with a zero TTL anything that had started aging would be
+    // collected. A `MostRecent` root has no clock to run out, so it survives.
     {
         let tt = open_tt_at(dir.path());
         tt.backend().set_gc_root_ttl_for_testing(0);
         let tt2 = tt.clone();
         turbo_tasks::run_once(tt.clone(), async move {
             unmark_top_level_task_may_leak_eventually_consistent_state();
-            assert_eq!(*root_with_child(11).read_strongly_consistent().await?, 12);
-            let collected = tt2.backend().gc_for_testing(&tt2);
+            tt2.backend().assert_task_exists_for_testing(root_id, &tt2);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        let guard = GcRoot::pin(tt.clone(), root_id);
+        let collected = tt.backend().gc_for_testing(&tt);
+        assert_eq!(
+            collected, 0,
+            "an anchored root must not be collected even at TTL 0 (got {collected})"
+        );
+        assert_eq!(
+            counter_of(&tt, root_id).or(Some(TtlCounter::MostRecent)),
+            Some(TtlCounter::MostRecent),
+            "the anchored root must still be MostRecent"
+        );
+        tt.stop_and_wait().await;
+        drop(guard);
+    }
+}
+
+/// Demotion is **first-pass-only**: within one session, later passes must not restart or advance a
+/// root's TTL clock.
+///
+/// GC runs on the snapshot cadence, so a session contains many passes and a live root can easily be
+/// missed by any single one (evicted, or not yet re-requested). If every pass demoted, the TTL
+/// would measure idleness *within* a session rather than "was not live across a whole session".
+/// This pins the intended behaviour: several passes in one session produce exactly one `FirstStale`
+/// stamp, and its timestamp does not move.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_demotes_only_on_the_first_pass_of_a_session() {
+    let dir = create_test_persistence_dir("gc_demotes_only_first_pass");
+
+    // Session 1: persist an anchored root so it starts as `MostRecent`.
+    let root_id = {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let leaf_id = tt
+            .run(async move {
+                unmark_top_level_task_may_leak_eventually_consistent_state();
+                let leaf_vc = orphan_leaf(31);
+                let _ = *leaf_vc.await?;
+                Ok(task_id_of(leaf_vc.resolve().await?))
+            })
+            .await
+            .unwrap();
+        let guard = GcRoot::pin(tt2.clone(), leaf_id);
+        tt.stop_and_wait().await;
+        drop(guard);
+        leaf_id
+    };
+
+    // Session 2: never re-anchor it. Use a long TTL so nothing is ever collected here — this test
+    // is only about *when* the clock starts, not about aging out.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(60_000);
+
+        let stale_after = |tt: &Arc<TurboTasks<TurboTasksBackend>>| {
+            tt.backend()
+                .persisted_gc_roots_for_testing()
+                .into_iter()
+                .find(|(r, _)| *r == root_id)
+                .and_then(|(_, c)| match c {
+                    TtlCounter::FirstStale(ts) => Some(ts),
+                    TtlCounter::MostRecent => None,
+                })
+        };
+
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        let first = stale_after(&tt).expect("the first pass of the session must start the clock");
+
+        // Several more passes in the *same* session. None may re-stamp the counter.
+        for pass in 2..=4 {
+            let tt2 = tt.clone();
+            turbo_tasks::run_once(tt.clone(), async move {
+                unmark_top_level_task_may_leak_eventually_consistent_state();
+                assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
+                anyhow::Ok(())
+            })
+            .await
+            .unwrap();
             assert_eq!(
-                collected, 0,
-                "a root that is live in this session must not be collected (got {collected})"
+                stale_after(&tt),
+                Some(first),
+                "pass {pass} of the same session moved the TTL clock; only the first pass may \
+                 demote"
             );
+        }
+
+        tt.stop_and_wait().await;
+    }
+}
+
+/// A root that went stale and is then re-anchored is **promoted** back to `MostRecent`, clearing
+/// its clock rather than merely pausing it. Without this a route left alone for a while would stay
+/// permanently close to its deadline and could be collected on a later unlucky session despite
+/// being in active use again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_promotes_a_stale_root_back_to_most_recent() {
+    let dir = create_test_persistence_dir("gc_promotes_stale_root");
+
+    fn counter_of(tt: &Arc<TurboTasks<TurboTasksBackend>>, id: TaskId) -> Option<TtlCounter> {
+        tt.backend()
+            .persisted_gc_roots_for_testing()
+            .into_iter()
+            .find(|(r, _)| *r == id)
+            .map(|(_, c)| c)
+    }
+
+    // Session 1: anchored across shutdown -> MostRecent.
+    let root_id = {
+        let tt = open_tt_at(dir.path());
+        let tt2 = tt.clone();
+        let leaf_id = tt
+            .run(async move {
+                unmark_top_level_task_may_leak_eventually_consistent_state();
+                let leaf_vc = orphan_leaf(41);
+                let _ = *leaf_vc.await?;
+                Ok(task_id_of(leaf_vc.resolve().await?))
+            })
+            .await
+            .unwrap();
+        let guard = GcRoot::pin(tt2.clone(), leaf_id);
+        tt.stop_and_wait().await;
+        drop(guard);
+        assert_eq!(counter_of(&tt, leaf_id), Some(TtlCounter::MostRecent));
+        leaf_id
+    };
+
+    // Session 2: not anchored, long TTL -> demoted to FirstStale but not collected.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(60_000);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
             anyhow::Ok(())
         })
         .await
         .unwrap();
         tt.stop_and_wait().await;
+        assert!(
+            matches!(counter_of(&tt, root_id), Some(TtlCounter::FirstStale(_))),
+            "an un-anchored root should have started its clock"
+        );
     }
+
+    // Session 3: re-anchor it. The pass must promote it back to `MostRecent`.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(60_000);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            tt2.backend().assert_task_exists_for_testing(root_id, &tt2);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        let guard = GcRoot::pin(tt.clone(), root_id);
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+        assert_eq!(
+            counter_of(&tt, root_id),
+            Some(TtlCounter::MostRecent),
+            "re-anchoring a stale root must clear its clock, not just pause it"
+        );
+
+        tt.stop_and_wait().await;
+        drop(guard);
+    }
+
+    // Session 4: at TTL 0 a root still carrying a stale timestamp would be collected immediately.
+    // The promotion in session 3 is what saves it.
+    {
+        let tt = open_tt_at(dir.path());
+        tt.backend().set_gc_root_ttl_for_testing(0);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            tt2.backend().assert_task_exists_for_testing(root_id, &tt2);
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        let guard = GcRoot::pin(tt.clone(), root_id);
+        assert_eq!(
+            tt.backend().gc_for_testing(&tt),
+            0,
+            "a promoted, re-anchored root must not be collected"
+        );
+        tt.stop_and_wait().await;
+        drop(guard);
+    }
+}
+
+/// A pass whose root set is unchanged must not rewrite the `GcRoots` key.
+///
+/// This is the payoff of `MostRecent` being a *stable* value: the old scheme stamped every live
+/// root with a fresh `now` each pass, so the encoded map always differed and the write could never
+/// be skipped. Asserted by byte-identity of the persisted set across repeated steady-state passes —
+/// which is exactly what "nothing to write" looks like from outside.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gc_skips_the_roots_write_when_the_set_is_unchanged() {
+    let (tt, _persistence_dir) = create_tt("gc_skips_unchanged_roots_write");
+
+    // An anchored root, held for the whole test so the set is genuinely steady.
+    let leaf_id = tt
+        .run(async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let leaf_vc = orphan_leaf(51);
+            let _ = *leaf_vc.await?;
+            Ok(task_id_of(leaf_vc.resolve().await?))
+        })
+        .await
+        .unwrap();
+    let _guard = GcRoot::pin(tt.clone(), leaf_id);
+
+    // Settle: one pass to establish the steady-state set.
+    tt.backend().snapshot_and_evict_for_testing(&tt);
+    let baseline = tt.backend().persisted_gc_roots_for_testing();
+    assert!(
+        baseline
+            .iter()
+            .any(|(id, c)| *id == leaf_id && matches!(c, TtlCounter::MostRecent)),
+        "the anchored root should be tracked as MostRecent; got {baseline:?}"
+    );
+
+    // Further passes change nothing, so each must skip the write entirely. Counting writes is the
+    // load-bearing assertion: comparing the persisted set can't distinguish "skipped" from
+    // "rewrote the same bytes", which is what the old scheme could never do.
+    let writes_before = tt.backend().gc_roots_writes_for_testing();
+    for pass in 1..=3 {
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+        assert_eq!(
+            tt.backend().gc_roots_writes_for_testing(),
+            writes_before,
+            "pass {pass} rewrote the roots set despite nothing changing; a stable MostRecent must \
+             compare equal so the write can be skipped"
+        );
+        assert_eq!(
+            tt.backend().persisted_gc_roots_for_testing(),
+            baseline,
+            "the persisted set must also be unchanged after pass {pass}"
+        );
+    }
+
+    // A real change must still be written, so the skip isn't just "never writes".
+    let extra_id = tt
+        .run(async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let leaf_vc = orphan_leaf(52);
+            let _ = *leaf_vc.await?;
+            Ok(task_id_of(leaf_vc.resolve().await?))
+        })
+        .await
+        .unwrap();
+    let _guard2 = GcRoot::pin(tt.clone(), extra_id);
+    tt.backend().snapshot_and_evict_for_testing(&tt);
+    assert!(
+        tt.backend().gc_roots_writes_for_testing() > writes_before,
+        "adding a root must produce a write; the skip must be conditional, not unconditional"
+    );
+
+    tt.stop_and_wait().await;
 }
 
 /// A root re-requested in the next session must NOT be collected: re-anchoring refreshes its
@@ -1178,6 +1469,15 @@ async fn gc_collect_scrubs_disk_only_forward_dep_target() {
         turbo_tasks::run_once(tt.clone(), async move {
             unmark_top_level_task_may_leak_eventually_consistent_state();
             // No panic in this pass is the assertion (the old guard fired inside CleanupOldEdges).
+            // Two passes: the first demotes the never-re-requested root from `MostRecent` to
+            // `FirstStale` (a root live last session always gets that grace), the second sees a
+            // zero TTL already expired and collects the subtree. The point of this test is the
+            // *cascade* — an `A` scrubbing a disk-only `B` — so it needs the collect to happen.
+            assert_eq!(
+                tt2.backend().gc_for_testing(&tt2),
+                0,
+                "the first stale pass only starts the TTL clock"
+            );
             let collected = tt2.backend().gc_for_testing(&tt2);
             assert!(
                 collected >= 1,


### PR DESCRIPTION
## What

The GC roots map stored `TaskId -> last_anchored_ms` and asserted liveness by **rewriting** that
timestamp on every pass. This replaces it with a stored state:

```rust
enum TtlCounter {
    MostRecent,        // observed live in the most recent session; never ages out
    FirstStale(u64),   // first session that did not see it live; the TTL runs from here
}
```

## Why

The refresh-based scheme was both fragile and unskippable.

**Fragile.** Restoring a task from disk does not dirty it, so a fully cached session could reopen a
graph, observe a root live, and still leave `has_modifications` false — dropping every refresh the
pass computed. A rarely-changing route (an API route restored every session but never modified) kept
its original timestamp forever and eventually aged out as a "cross-session orphan" despite being
alive in every session. #96506 fixed the dropped write; this removes the need for the write at all.

**Unskippable.** A fresh `now` on every live root meant the encoded map differed on every pass, so
the `GcRoots` key was rewritten even in perfect steady state.

`MostRecent` is a *stable* value: a live root re-encodes identically, so there is nothing to rewrite
and the TTL clock simply never starts. The clock starts only when a root stops being live, which is
what the TTL was always meant to measure.

## How

**Transitions**, per pass:

| Observation | Result |
|---|---|
| Live (`gc_is_root`) | → `MostRecent` (also *promotes* a stale root, clearing its clock) |
| Not live, was `MostRecent`, **first pass of session** | → `FirstStale(now)` |
| Not live, already `FirstStale(ts)` | unchanged; seeded for collection once `now - ts > TTL` |
| Collected | removed from the map |

**Demotion is first-pass-of-session only**, gated by a `first_gc_pass_of_session` flag. GC runs on
the snapshot cadence, so a session contains many passes and a live root is easily missed by any one
of them (evicted, or not yet re-requested). Demoting on every pass would make the TTL measure
idleness *within* a session rather than "was not live across a session".

**The roots map is only for roots that survive a session.** A root decref'd mid-session is not
"missed" — the decref is authoritative, and the task becomes ordinary parentless garbage that the
resident scan collects in-session, never reaching the map.

**The write is skipped when the reconciled set equals what was loaded.** A degraded roots read
leaves the comparison baseline empty, so anything rediscovered compares as changed and repairs the
key rather than being skipped past.

`FirstStale` still ages out after `GC_ROOT_TTL` (24h) of wall time, with the same
`TURBO_ENGINE_GC_ROOT_TTL_MS` override and `set_gc_root_ttl_for_testing` hook. No on-disk migration
is needed: the DB directory is keyed by git version, so a build with the new encoding gets a fresh
directory.

## Behaviour change worth reviewing

**A root live in the previous session now always gets one stale session of grace before it can be
collected** — the demote and the age-out are separate steps. Three existing tests drove collection
with a single TTL-0 pass and needed a second; that is inherent to the two-phase design, not a
workaround.

Also: `gc_for_testing` computed a roots map and discarded it. Harmless when the map only carried
refreshes, but it would now drop a *demotion* **and** consume the session's one demotion
opportunity, so it persists the map explicitly.

## Testing

19 `parent_count` tests (3 new: first-pass-only demotion, promotion, skip-write), all 27 GC tests
across the four suites, 45/45 backend binaries green.

The new tests were mutation-checked. Two gaps this surfaced, both fixed rather than papered over:

- the skip-write test originally asserted the persisted set was *equal*, which is true whether or
  not the write happened — an "always write" mutant passed it. It now counts writes through a test
  hook, and also asserts a real change still produces one, so the skip can't degrade into "never
  writes".
- one surviving mutant (`insert` → `or_insert` in the scan fold-in) turned out to be **equivalent**,
  not a coverage gap: the `retain` runs first over the same map with the same `gc_is_root` predicate
  under the same exclusion, so the state where they differ is unreachable. `insert` is kept because
  it states the intent directly instead of depending on that coincidence, and the reasoning is in a
  comment rather than an unfalsifiable test.
