### PR TITLE
[turbopack] Don't scope hoist partial strongly connected components

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -71,6 +71,70 @@ impl MergedModuleInfo {
     }
 }
 
+/// Drops modules from merged groups if there's a strongly connected component that
+/// is split between two groups. For example, if a module (A) that is scope-hoisted
+/// depends on (B) and (B) depends on another module that is scope-hoisted with (A).
+/// This leads to double-execution of these modules.
+#[allow(clippy::type_complexity)]
+fn drop_split_cycles(
+    module_graph: &ModuleGraph,
+    lists: FxHashSet<Vec<ResolvedVc<Box<dyn MergeableModule>>>>,
+) -> Result<FxHashSet<Vec<ResolvedVc<Box<dyn MergeableModule>>>>> {
+    let mut lists = lists.into_iter().collect::<Vec<_>>();
+    loop {
+        let mut group_of: FxHashMap<ResolvedVc<Box<dyn Module>>, usize> = FxHashMap::default();
+        for (group, list) in lists.iter().enumerate() {
+            for module in list {
+                group_of.insert(ResolvedVc::upcast(*module), group);
+            }
+        }
+
+        let mut modules_to_drop: FxHashSet<ResolvedVc<Box<dyn Module>>> = FxHashSet::default();
+        module_graph.traverse_cycles(
+            |ref_data| {
+                matches!(
+                    ref_data.chunking_type,
+                    ChunkingType::Parallel { .. } | ChunkingType::Shared { .. }
+                )
+            },
+            |scc| {
+                let mut groups = scc.iter().map(|m| group_of.get(&**m).copied());
+                // An SCC always has a member; `None` means that member is not merged at all.
+                let first_group = groups.next().unwrap();
+                if first_group.is_none() || groups.any(|group| group != first_group) {
+                    modules_to_drop
+                        .extend(scc.iter().map(|m| **m).filter(|m| group_of.contains_key(m)));
+                }
+                Ok(())
+            },
+        )?;
+
+        if modules_to_drop.is_empty() {
+            return Ok(lists.into_iter().collect());
+        }
+
+        // Dropping a module splits its group in two; previously, a SCC that was contained
+        // to just one group could be split between groups.
+        let mut remaining = Vec::with_capacity(lists.len());
+        for list in lists {
+            let mut part = Vec::new();
+            for module in list {
+                if modules_to_drop.contains(&ResolvedVc::upcast(module)) {
+                    if !part.is_empty() {
+                        remaining.push(std::mem::take(&mut part));
+                    }
+                } else {
+                    part.push(module);
+                }
+            }
+            if !part.is_empty() {
+                remaining.push(part);
+            }
+        }
+        lists = remaining;
+    }
+}
+
 /// Determine which modules can be merged together:
 /// - if all chunks execute a sequence of modules in the same order, they can be merged together and
 ///   treated as one.
@@ -700,6 +764,10 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         let lists = lists.into_iter().flatten().collect::<FxHashSet<_>>();
 
         drop(inner_span);
+        let inner_span = tracing::info_span!("drop split cycles").entered();
+        let lists = drop_split_cycles(&module_graph, lists)?;
+        drop(inner_span);
+
         let inner_span = tracing::info_span!("merging");
         // Call MergeableModule impl to merge the modules.
         let result = lists

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry1.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry1.js
@@ -1,0 +1,3 @@
+import './shared.js'
+
+export { instance, instanceFromClosure } from './library/index.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry2.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry2.js
@@ -1,0 +1,5 @@
+import { z } from './library/index.js'
+
+import './shared.js'
+
+z.any()

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/index.js
@@ -1,0 +1,7 @@
+it('should evaluate a merged module group only once', async () => {
+  const { instance, instanceFromClosure } = await import('./entry1.js')
+  await import('./entry2.js')
+
+  expect(globalThis.__evaluations).toBe(1)
+  expect(instanceFromClosure()).toBe(instance)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/index.js
@@ -1,0 +1,3 @@
+import * as z from './src/index.js'
+export { RealError, instance, instanceFromClosure } from './src/index.js'
+export { z }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/errors.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/errors.js
@@ -1,0 +1,1 @@
+export const RealError = 'RealError'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/index.js
@@ -1,0 +1,2 @@
+export { any, instance, instanceFromClosure } from './schemas.js'
+export { RealError } from './errors.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/iso.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/iso.js
@@ -1,0 +1,5 @@
+import * as schemas from './schemas.js'
+
+export function datetime() {
+  return schemas
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/schemas.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/schemas.js
@@ -1,0 +1,16 @@
+import * as iso from './iso.js'
+import { RealError } from './errors.js'
+
+globalThis.__evaluations = (globalThis.__evaluations ?? 0) + 1
+export const instance = { evaluation: globalThis.__evaluations }
+export function instanceFromClosure() {
+  return instance
+}
+
+RealError
+iso.datetime()
+
+export const anyBase = 1234
+export function any() {
+  return anyBase
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/shared.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/shared.js
@@ -1,0 +1,5 @@
+import { RealError } from './library/index.js'
+import { z } from './library/index.js'
+
+z.any()
+RealError


### PR DESCRIPTION
Take this example: 

<img width="707" height="668" alt="Screenshot 2026-08-04 at 3 23 36 pm" src="https://github.com/user-attachments/assets/c754cddd-522d-46f2-92bd-7d7b3030f224" />

Line 26 of scope-hoisting group A enters scope-hoisting group B, then on line 95 we re-enter scope-hoisting group A. Because our first execution of group A hadn't reached Line 29 yet to register `schemas.js` (which B depends on `schemas.js`)

This can cause bugs like https://github.com/vercel/next.js/issues/96648. 

This PR does not scope-hoist if this is the case.