### PR TITLE
Fix: Nav inspector causes request loop

### DIFF
--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -69,10 +69,11 @@ describe('instant-nav-panel', () => {
     })
   }
 
-  async function clickLink(browser: Playwright, href: string) {
-    await browser.eval((page) => {
-      document.querySelector<HTMLAnchorElement>(`[href="${page}"]`)!.click()
-    }, href)
+  async function clickLink(browser: Playwright, href: string, id?: string) {
+    const selector = id ? `#${id}` : `[href="${href}"]`
+    await browser.eval((selector) => {
+      document.querySelector<HTMLAnchorElement>(selector)!.click()
+    }, selector)
   }
 
   function getInstantNavPanel(browser: Playwright) {
@@ -698,16 +699,44 @@ describe('instant-nav-panel', () => {
 
       await openInstantNavPanel(browser)
       await clickStartCapturing(browser)
-      // The prefetch link shares its href with #link-to-target, so select it
-      // by id rather than by href.
-      await browser.eval(() => {
-        document
-          .querySelector<HTMLAnchorElement>('#link-to-target-prefetch')!
-          .click()
-      })
+      await clickLink(
+        browser,
+        '/target-page/my-post?search=foo',
+        'link-to-target-prefetch'
+      )
       await expectSpaPanel(browser)
 
       await expectTargetPageSpaShellWithRuntimeData(browser)
+    })
+
+    it('works for repeat clicks to links with prefetch={true} (regression)', async () => {
+      const browser = await openHomeWithTargetPageWarmup()
+
+      // 1. Enable the Nav Inspector and click the link
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(
+        browser,
+        '/target-page/my-post?search=foo',
+        'link-to-target-prefetch'
+      )
+      await expectSpaPanel(browser)
+
+      // 2. Close the Nav Inspector and navigate home
+      await closePanelViaHeader(browser)
+      await clickLink(browser, '/')
+      await browser.waitForElementByCss('[data-testid="home-title"]')
+
+      // 3. Enable the inspector and click the link again
+      await openInstantNavPanel(browser)
+      await clickStartCapturing(browser)
+      await clickLink(
+        browser,
+        '/target-page/my-post?search=foo',
+        'link-to-target-prefetch'
+      )
+      await expectSpaPanel(browser)
+      // 🔴 The app gets stuck in a compiling/pending state, and starts firing requests in a loop
     })
 
     it('should restart capture and return to awaiting navigation after resuming from SPA state', async () => {


### PR DESCRIPTION
Failing test for a bug that shows up when you 

- Enable the Nav Inspector and click a `<Link prefetch>`
- Close the Nav Inspector and click a link back home
- Enable the Inspector again and click the same link

The second time locks the app in a Compiling... state, and gets stuck firing off requests in a loop.

https://github.com/user-attachments/assets/d3dc2ec1-56c5-46a9-a7c5-a018cf0e7b22