### PR TITLE
Serialize prerender manifest updates in dev

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -25,6 +25,7 @@ import type { PagesManifest } from '../../build/webpack/plugins/pages-manifest-p
 import * as React from 'react'
 import fs from 'fs'
 import { Worker } from 'next/dist/compiled/jest-worker'
+import writeFileAtomic from 'next/dist/compiled/write-file-atomic'
 import { installUseCacheProbe } from './use-cache-probe-pool'
 import { installDevValidationWorker } from './dev-validation-worker-pool'
 import { join as pathJoin } from 'path'
@@ -146,6 +147,7 @@ export default class DevServer extends Server {
   private staticPathsCache: LRUCache<
     UnwrapPromise<ReturnType<DevServer['getStaticPaths']>>
   >
+  private prerenderManifestUpdate: Promise<void> = Promise.resolve()
   private startServerSpan: Span
   private readonly serverComponentsHmrCache:
     | ServerComponentsHmrCache
@@ -928,53 +930,46 @@ export default class DevServer extends Server {
           // This matches the hasGenerateStaticParams logic we do during build.
           (!isAppPath || (prerenderedRoutes && prerenderedRoutes.length > 0))
         ) {
+          const fallbackField = fallbackModeToFallbackField(
+            res.value.fallbackMode,
+            page
+          )
+
           // we write the static paths to partial manifest for
           // fallback handling inside of entry handler's
-          const rawExistingManifest = await fs.promises.readFile(
-            pathJoin(this.distDir, PRERENDER_MANIFEST),
-            'utf8'
-          )
-          const existingManifest: PrerenderManifest =
-            JSON.parse(rawExistingManifest)
-          for (const staticPath of value.staticPaths || []) {
-            existingManifest.routes[staticPath] = {} as any
-          }
+          await this.updatePrerenderManifest((existingManifest) => {
+            for (const staticPath of value.staticPaths || []) {
+              existingManifest.routes[staticPath] = {} as any
+            }
 
-          // Find the fallback route from the prerendered routes. This is
-          // the route whose pathname matches the page pattern (e.g.
-          // /dynamic-params/[slug]) and has fallback route params describing
-          // which params are unknown at build time.
-          const fallbackPrerenderedRoute = prerenderedRoutes?.find(
-            (route) => route.pathname === pathname
-          )
-
-          existingManifest.dynamicRoutes[pathname] = {
-            dataRoute: null,
-            dataRouteRegex: null,
-            fallback: fallbackModeToFallbackField(res.value.fallbackMode, page),
-            fallbackRevalidate: false,
-            fallbackExpire: undefined,
-            fallbackHeaders: undefined,
-            fallbackStatus: undefined,
-            fallbackRootParams: fallbackPrerenderedRoute?.fallbackRootParams,
-            fallbackRouteParams: fallbackPrerenderedRoute?.fallbackRouteParams,
-            fallbackSourceRoute: pathname,
-            prefetchDataRoute: undefined,
-            prefetchDataRouteRegex: undefined,
-            routeRegex: getRouteRegex(pathname).re.source,
-            experimentalPPR: undefined,
-            renderingMode: undefined,
-            allowHeader: [],
-          }
-
-          const updatedManifest = JSON.stringify(existingManifest)
-
-          if (updatedManifest !== rawExistingManifest) {
-            await fs.promises.writeFile(
-              pathJoin(this.distDir, PRERENDER_MANIFEST),
-              updatedManifest
+            // Find the fallback route from the prerendered routes. This is
+            // the route whose pathname matches the page pattern (e.g.
+            // /dynamic-params/[slug]) and has fallback route params describing
+            // which params are unknown at build time.
+            const fallbackPrerenderedRoute = prerenderedRoutes?.find(
+              (route) => route.pathname === pathname
             )
-          }
+
+            existingManifest.dynamicRoutes[pathname] = {
+              dataRoute: null,
+              dataRouteRegex: null,
+              fallback: fallbackField,
+              fallbackRevalidate: false,
+              fallbackExpire: undefined,
+              fallbackHeaders: undefined,
+              fallbackStatus: undefined,
+              fallbackRootParams: fallbackPrerenderedRoute?.fallbackRootParams,
+              fallbackRouteParams:
+                fallbackPrerenderedRoute?.fallbackRouteParams,
+              fallbackSourceRoute: pathname,
+              prefetchDataRoute: undefined,
+              prefetchDataRouteRegex: undefined,
+              routeRegex: getRouteRegex(pathname).re.source,
+              experimentalPPR: undefined,
+              renderingMode: undefined,
+              allowHeader: [],
+            }
+          })
         }
         this.staticPathsCache.set(pathname, value)
 
@@ -1011,6 +1006,35 @@ export default class DevServer extends Server {
       return result
     }
     return nextInvoke as NonNullable<typeof result>
+  }
+
+  private updatePrerenderManifest(
+    update: (manifest: PrerenderManifest) => void
+  ): Promise<void> {
+    // Several routes can resolve their static paths at the same time, so the
+    // read-modify-write is queued and the write is atomic to keep concurrent
+    // updates from tearing the manifest or dropping each other's entries.
+    const pending = this.prerenderManifestUpdate.then(async () => {
+      const manifestPath = pathJoin(this.distDir, PRERENDER_MANIFEST)
+      const rawExistingManifest = await fs.promises.readFile(
+        manifestPath,
+        'utf8'
+      )
+      const existingManifest: PrerenderManifest =
+        JSON.parse(rawExistingManifest)
+
+      update(existingManifest)
+
+      const updatedManifest = JSON.stringify(existingManifest)
+
+      if (updatedManifest !== rawExistingManifest) {
+        await writeFileAtomic(manifestPath, updatedManifest)
+      }
+    })
+
+    this.prerenderManifestUpdate = pending.catch(() => {})
+
+    return pending
   }
 
   protected async ensurePage(opts: {

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -798,13 +798,17 @@ declare module 'next/dist/compiled/web-vitals' {
 declare module 'next/dist/compiled/web-vitals-attribution' {}
 
 declare module 'next/dist/compiled/write-file-atomic' {
-  function writeFileAtomicSync(
+  function writeFileAtomic(
+    filename: string,
+    data: string | Buffer,
+    options?: { mode?: number; chown?: { uid: number; gid: number } }
+  ): Promise<void>
+  export function sync(
     filename: string,
     data: string | Buffer,
     options?: { mode?: number; chown?: { uid: number; gid: number } }
   ): void
-  export const sync: typeof writeFileAtomicSync
-  export default writeFileAtomicSync
+  export default writeFileAtomic
 }
 
 declare module 'next/dist/compiled/ws' {

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/app/four/[slug]/page.tsx
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/app/four/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'a' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>four {slug}</p>
+}

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/app/layout.tsx
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/app/one/[slug]/page.tsx
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/app/one/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'a' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>one {slug}</p>
+}

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/app/three/[slug]/page.tsx
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/app/three/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'a' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>three {slug}</p>
+}

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/app/two/[slug]/page.tsx
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/app/two/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'a' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>two {slug}</p>
+}

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/next.config.js
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/prerender-manifest-concurrent-static-params/prerender-manifest-concurrent-static-params.test.ts
+++ b/test/development/app-dir/prerender-manifest-concurrent-static-params/prerender-manifest-concurrent-static-params.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('prerender-manifest-concurrent-static-params', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('keeps every route in the manifest when static params resolve concurrently', async () => {
+    const routes = ['/four/a', '/one/a', '/three/a', '/two/a']
+
+    const responses = await Promise.all(
+      routes.map((route) => next.fetch(route))
+    )
+
+    for (const response of responses) {
+      expect(response.status).toBe(200)
+    }
+
+    await retry(async () => {
+      const manifest = await next.readJSON('.next/dev/prerender-manifest.json')
+
+      expect(Object.keys(manifest.dynamicRoutes).sort()).toEqual([
+        '/four/[slug]',
+        '/one/[slug]',
+        '/three/[slug]',
+        '/two/[slug]',
+      ])
+      expect(Object.keys(manifest.routes).sort()).toEqual(routes)
+    })
+  })
+})


### PR DESCRIPTION
Concurrent first requests to several `generateStaticParams` routes can corrupt `.next/dev/prerender-manifest.json`. `loadStaticPaths` reads the manifest, merges one route's entries, and writes the whole file back, and nothing serializes those read-modify-writes. When two writers truncate before either finishes, a short document lands on top of a long one. Every render after that throws `SyntaxError: Unexpected non-whitespace character after JSON`, so the dev server returns 500 for every route until it restarts. Even when the file stays parseable, routes that read the same base drop each other's entries.

This queues the updates behind a single promise chain and writes through `write-file-atomic`, so each update sees the previous one's result and readers never catch a half-written file.

Fixes #96664
