### PR TITLE
[turbopack] Raise registration calls in hoisted modules to the top

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -61,7 +61,7 @@ use swc_core::{
     base::SwcComments,
     common::{
         BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Loc, Mark, SourceFile, SourceMap,
-        SourceMapper, Span, SpanSnippetError, SyntaxContext,
+        SourceMapper, Span, SpanSnippetError, Spanned, SyntaxContext,
         comments::{Comment, CommentKind, Comments},
         source_map::{FileLinesResult, Files, SourceMapLookupError},
         util::take::Take,
@@ -1235,6 +1235,41 @@ impl EcmascriptModuleContent {
     }
 }
 
+/// Comments delimiting the early hoisted statements, which [`merge_modules`] moves in front of the
+/// merged module so that a cyclic importer can't re-enter it before they ran.
+const EARLY_HOIST_START: &str = " TURBOPACK EARLY HOIST START";
+const EARLY_HOIST_END: &str = " TURBOPACK EARLY HOIST END";
+
+fn early_hoist_comment(text: &str) -> Comment {
+    Comment {
+        kind: CommentKind::Line,
+        span: DUMMY_SP,
+        text: text.into(),
+    }
+}
+
+/// Finds the statements delimited by [`EARLY_HOIST_START`] and [`EARLY_HOIST_END`], as an inclusive
+/// index range over `body` covering both delimiters. Must run before the spans are rewritten.
+fn early_hoist_range(
+    comments: &SwcComments,
+    body: impl Iterator<Item = Span>,
+) -> Option<(usize, usize)> {
+    let (mut start, mut end) = (None, None);
+    for (i, span) in body.enumerate() {
+        let Some(leading) = comments.get_leading(span.lo) else {
+            continue;
+        };
+        for comment in leading {
+            if comment.text == EARLY_HOIST_START {
+                start = Some(i);
+            } else if comment.text == EARLY_HOIST_END {
+                end = Some(i);
+            }
+        }
+    }
+    Some((start?, end?))
+}
+
 /// Merges multiple Ecmascript modules into a single AST, setting the syntax contexts correctly so
 /// that imports work.
 ///
@@ -1404,18 +1439,32 @@ async fn merge_modules(
         let mut unique_contexts_cache =
             FxHashMap::with_capacity_and_hasher(contents.len() * 5, Default::default());
 
+        let mut merged_prelude = Vec::new();
         let mut prepare_module =
             |module_count: usize,
              current_module_idx: usize,
              (module, content): &(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>, CodeGenResult),
              program: &mut Program,
+             merged_prelude: &mut Vec<ModuleItem>,
              lookup_table: &mut Vec<ModulePosition>| {
                 let _ = tracing::trace_span!("prepare module").entered();
                 if let CodeGenResult {
                     scope_hoisting_syntax_contexts: Some((module_contexts, _)),
+                    comments: CodeGenResultComments::Single { extra_comments, .. },
                     ..
                 } = content
                 {
+                    // The delimiter comments are keyed by the original spans, so this has to happen
+                    // before the visitor below rewrites them.
+                    let early_hoisted = match &*program {
+                        Program::Module(module) => {
+                            early_hoist_range(extra_comments, module.body.iter().map(|i| i.span()))
+                        }
+                        Program::Script(script) => {
+                            early_hoist_range(extra_comments, script.body.iter().map(|s| s.span()))
+                        }
+                    };
+
                     let modules_header_width = module_count.next_power_of_two().trailing_zeros();
                     GLOBALS.set(globals_merged, || {
                         let mut visitor = SetSyntaxContextVisitor {
@@ -1434,6 +1483,21 @@ async fn merge_modules(
                         program.visit_mut_with(&mut visitor);
                         visitor.error
                     })?;
+
+                    // Move the delimited statements out, dropping the two delimiters themselves.
+                    if let Some((start, end)) = early_hoisted {
+                        let mut hoisted: Vec<ModuleItem> = match program {
+                            Program::Module(module) => module.body.drain(start..=end).collect(),
+                            Program::Script(script) => script
+                                .body
+                                .drain(start..=end)
+                                .map(ModuleItem::Stmt)
+                                .collect(),
+                        };
+                        hoisted.pop();
+                        hoisted.remove(0);
+                        merged_prelude.extend(hoisted);
+                    }
 
                     Ok(match program.take() {
                         Program::Module(module) => Either::Left(module.body.into_iter()),
@@ -1465,6 +1529,7 @@ async fn merge_modules(
                     i,
                     &contents[i],
                     &mut programs[i],
+                    &mut merged_prelude,
                     &mut lookup_table,
                 )
                 .map_err(|err| (i, err))
@@ -1495,6 +1560,7 @@ async fn merge_modules(
                                         index,
                                         &contents[index],
                                         &mut programs[index],
+                                        &mut merged_prelude,
                                         &mut lookup_table,
                                     )
                                     .map_err(|err| (index, err))?
@@ -1547,7 +1613,7 @@ async fn merge_modules(
 
         let span = tracing::trace_span!("hygiene").entered();
         let mut merged_ast = Program::Module(swc_core::ecma::ast::Module {
-            body: result,
+            body: merged_prelude.into_iter().chain(result).collect(),
             span: DUMMY_SP,
             shebang: None,
         });
@@ -1844,7 +1910,8 @@ async fn process_parse_result(
                 trailing: Default::default(),
             };
 
-            process_content_with_code_gens(&mut program, globals, &mut code_gens);
+            let early_hoisted_count =
+                process_content_with_code_gens(&mut program, globals, &mut code_gens);
 
             for comments in code_gens.iter_mut().flat_map(|cg| cg.comments.as_mut()) {
                 let leading = Arc::unwrap_or_clone(take(&mut comments.leading));
@@ -1860,6 +1927,31 @@ async fn process_parse_result(
             }
 
             GLOBALS.set(globals, || {
+                // Delimit the early hoisted statements, which `merge_modules` moves in front of
+                // the merged module this module is part of.
+                if retain_syntax_context.is_some() && early_hoisted_count > 0 {
+                    let end = Span::dummy_with_cmt();
+                    extra_comments.add_leading(end.lo, early_hoist_comment(EARLY_HOIST_END));
+                    let start = Span::dummy_with_cmt();
+                    extra_comments.add_leading(start.lo, early_hoist_comment(EARLY_HOIST_START));
+                    let (end, start) = (
+                        Stmt::Empty(EmptyStmt { span: end }),
+                        Stmt::Empty(EmptyStmt { span: start }),
+                    );
+                    match &mut program {
+                        Program::Module(module) => {
+                            module
+                                .body
+                                .insert(early_hoisted_count, ModuleItem::Stmt(end));
+                            module.body.insert(0, ModuleItem::Stmt(start));
+                        }
+                        Program::Script(script) => {
+                            script.body.insert(early_hoisted_count, end);
+                            script.body.insert(0, start);
+                        }
+                    }
+                }
+
                 if let Some(prepend_ident_comment) = prepend_ident_comment {
                     let span = Span::dummy_with_cmt();
                     extra_comments.add_leading(span.lo, prepend_ident_comment);
@@ -2178,12 +2270,13 @@ async fn emit_content(
     .cell())
 }
 
+/// Applies the code generations, returning the number of early hoisted statements it prepended.
 #[instrument(level = Level::TRACE, skip_all, name = "apply code generation")]
 fn process_content_with_code_gens(
     program: &mut Program,
     globals: &Globals,
     code_gens: &mut Vec<CodeGeneration>,
-) {
+) -> usize {
     let mut visitors = Vec::new();
     let mut root_visitors = Vec::new();
     let mut early_hoisted_stmts = FxIndexMap::default();
@@ -2224,6 +2317,7 @@ fn process_content_with_code_gens(
         }
     });
 
+    let early_hoisted_count = early_hoisted_stmts.len();
     match program {
         Program::Module(ast::Module { body, .. }) => {
             body.splice(
@@ -2254,6 +2348,7 @@ fn process_content_with_code_gens(
             );
         }
     };
+    early_hoisted_count
 }
 
 /// Like `hygiene`, but only renames the Atoms without clearing all SyntaxContexts

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry1.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry1.js
@@ -1,0 +1,3 @@
+import './shared.js'
+
+export { instance, instanceFromClosure } from './library/index.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry2.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/entry2.js
@@ -1,0 +1,5 @@
+import { z } from './library/index.js'
+
+import './shared.js'
+
+z.any()

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/index.js
@@ -1,0 +1,7 @@
+it('should evaluate a merged module group only once', async () => {
+  const { instance, instanceFromClosure } = await import('./entry1.js')
+  await import('./entry2.js')
+
+  expect(globalThis.__evaluations).toBe(1)
+  expect(instanceFromClosure()).toBe(instance)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/index.js
@@ -1,0 +1,3 @@
+import * as z from './src/index.js'
+export { RealError, instance, instanceFromClosure } from './src/index.js'
+export { z }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/errors.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/errors.js
@@ -1,0 +1,1 @@
+export const RealError = 'RealError'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/index.js
@@ -1,0 +1,2 @@
+export { any, instance, instanceFromClosure } from './schemas.js'
+export { RealError } from './errors.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/iso.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/iso.js
@@ -1,0 +1,5 @@
+import * as schemas from './schemas.js'
+
+export function datetime() {
+  return schemas
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/schemas.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/library/src/schemas.js
@@ -1,0 +1,16 @@
+import * as iso from './iso.js'
+import { RealError } from './errors.js'
+
+globalThis.__evaluations = (globalThis.__evaluations ?? 0) + 1
+export const instance = { evaluation: globalThis.__evaluations }
+export function instanceFromClosure() {
+  return instance
+}
+
+RealError
+iso.datetime()
+
+export const anyBase = 1234
+export function any() {
+  return anyBase
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/shared.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/reentrant-group/input/shared.js
@@ -1,0 +1,5 @@
+import { RealError } from './library/index.js'
+import { z } from './library/index.js'
+
+z.any()
+RealError

--- a/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/output/0_9x_turbopack-tests_tests_snapshot_scope-hoisting_duplicate-imports_input_11zbkdc._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/output/0_9x_turbopack-tests_tests_snapshot_scope-hoisting_duplicate-imports_input_11zbkdc._.js
@@ -2,9 +2,9 @@
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
 "use strict";
 
+__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/index.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/index.js [test] (ecmascript)
 ;
-__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/index.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/c.js [test] (ecmascript)
 ;
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/duplicate-imports/input/b.js [test] (ecmascript)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/1jsg_tests_snapshot_scope-hoisting_split-shared_input_big_index_194gu9x.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/1jsg_tests_snapshot_scope-hoisting_split-shared_input_big_index_194gu9x.js
@@ -2,12 +2,12 @@
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js [test] (ecmascript)", ((__turbopack_context__) => {
 "use strict";
 
-// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js [test] (ecmascript)
-;
 __turbopack_context__.s([
     "default",
     ()=>__TURBOPACK__default__export__1
 ], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js [test] (ecmascript)");
+// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js [test] (ecmascript)
+;
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/other.js [test] (ecmascript)
 ;
 const __TURBOPACK__default__export__ = `

--- a/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/1jsg_tests_snapshot_scope-hoisting_split-shared_input_y_middle_1inkhp4.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/output/1jsg_tests_snapshot_scope-hoisting_split-shared_input_y_middle_1inkhp4.js
@@ -2,9 +2,9 @@
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/middle.js [test] (ecmascript)", ((__turbopack_context__) => {
 "use strict";
 
+__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/middle.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/middle.js [test] (ecmascript)
 ;
-__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/middle.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/y/inner.js [test] (ecmascript)
 ;
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$scope$2d$hoisting$2f$split$2d$shared$2f$input$2f$big$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/scope-hoisting/split-shared/input/big/index.js [test] (ecmascript)");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/1jsg_tests_snapshot_source_maps_input-source-map-merged_input_index_13tze6n.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/1jsg_tests_snapshot_source_maps_input-source-map-merged_input_index_13tze6n.js
@@ -2,9 +2,9 @@
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
 "use strict";
 
+__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js [test] (ecmascript)
 ;
-__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/index.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/input/sourcemapped.js [test] (ecmascript)
 ;
 function runExternalSourceMapped(fn) {

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/output/1do3_crates_turbopack-tests_tests_snapshot_source_maps_merged-unicode_input_1tq4mpj._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/output/1do3_crates_turbopack-tests_tests_snapshot_source_maps_merged-unicode_input_1tq4mpj._.js
@@ -2,9 +2,9 @@
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/entry-base.js [test] (ecmascript)", ((__turbopack_context__) => {
 "use strict";
 
+__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/entry-base.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/entry-base.js [test] (ecmascript)
 ;
-__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/entry-base.js [test] (ecmascript)");
 // MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/merged-unicode/input/params.js [test] (ecmascript)
 ;
 ;


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/96648, take a look at code like this:

<img width="1414" height="1336" alt="image" src="https://github.com/user-attachments/assets/7195f963-51a9-4331-be74-3e06be760422" />

Line 26 of scope-hoisting group A enters scope-hoisting group B, then on line 95 we re-enter scope-hoisting group A. Because our first execution of group A hadn't reached Line 29 yet to register schemas.js (which B depends on schemas.js).

On non-scope hoisted modules with cycles we already raise the module registration call to the start of the factory. But when we scope hoist, we lose that. This PR changes it so we do the registration at the start of the scope hoisted module

Before:

```javascript
"shared.js", "library/src/schemas.js", "library/src/index.js <export * as z>",
((__turbopack_context__) => {
"use strict";

// MERGED MODULE: shared.js
;
var …errors = __turbopack_context__.i("library/src/errors.js");
// MERGED MODULE: library/src/index.js <export * as z>
;
// MERGED MODULE: library/src/index.js
;
var …index_locals = __turbopack_context__.i("library/src/index.js <locals>");  // ← leaves the group
// MERGED MODULE: library/src/schemas.js
;
__turbopack_context__.s([                        // ← schemas registers HERE, too late
    "any", ()=>any,
    "anyBase", ()=>anyBase,
    "instance", ()=>instance,
    "instanceFromClosure", ()=>instanceFromClosure
], "library/src/schemas.js");
var …iso = __turbopack_context__.i("library/src/iso.js");
```

After:

```javascript
"shared.js", "library/src/schemas.js", "library/src/index.js <export * as z>",
((__turbopack_context__) => {
"use strict";

__turbopack_context__.s([                        // ← raised to the top of the merged module
    "any", ()=>any,
    "anyBase", ()=>anyBase,
    "instance", ()=>instance,
    "instanceFromClosure", ()=>instanceFromClosure
], "library/src/schemas.js");
// MERGED MODULE: shared.js
;
var …errors = __turbopack_context__.i("library/src/errors.js");
// MERGED MODULE: library/src/index.js <export * as z>
;
// MERGED MODULE: library/src/index.js
;
var …index_locals = __turbopack_context__.i("library/src/index.js <locals>");  // ← re-entry is safe
// MERGED MODULE: library/src/schemas.js
;
var …iso = __turbopack_context__.i("library/src/iso.js");
```