### PR TITLE
Don't report a client-aborted RSC stream as a render error

### DIFF
--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -48,6 +48,7 @@ import {
   atLeastOneTask,
   waitAtLeastOneReactRenderTask,
 } from '../../lib/scheduler'
+import { ResponseAborted } from '../web/spec-extension/adapters/next-request'
 import type {
   FlightPayload,
   FlightClientModules,
@@ -562,6 +563,17 @@ export function renderToNodeFlightStream(
     clientModules,
     renderOptions
   )
+
+  // If the destination is destroyed before the render ended, React aborts with a
+  // generic "The destination stream closed early." error that `onError` can't
+  // tell apart from a real render error. Abort first with the reason we already
+  // know; the listener is registered before piping so it runs before React's.
+  pt.once('close', () => {
+    if (!pt.writableEnded) {
+      pipeable.abort(new ResponseAborted())
+    }
+  })
+
   pipeable.pipe(pt)
 
   if (signal) {

--- a/test/e2e/on-request-error/client-abort/app/error/page.js
+++ b/test/e2e/on-request-error/client-abort/app/error/page.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  throw new Error('server-side-error')
+}

--- a/test/e2e/on-request-error/client-abort/app/error/page.js
+++ b/test/e2e/on-request-error/client-abort/app/error/page.js
@@ -1,5 +1,15 @@
-export const dynamic = 'force-dynamic'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function Boom() {
+  await connection()
+  throw new Error('server-side-error')
+}
 
 export default function Page() {
-  throw new Error('server-side-error')
+  return (
+    <Suspense fallback={<p>error-pending</p>}>
+      <Boom />
+    </Suspense>
+  )
 }

--- a/test/e2e/on-request-error/client-abort/app/hang/page.js
+++ b/test/e2e/on-request-error/client-abort/app/hang/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+
+export const dynamic = 'force-dynamic'
+
+async function Hang() {
+  await new Promise(() => {})
+  return null
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>stream-started</p>}>
+      <Hang />
+    </Suspense>
+  )
+}

--- a/test/e2e/on-request-error/client-abort/app/hang/page.js
+++ b/test/e2e/on-request-error/client-abort/app/hang/page.js
@@ -1,8 +1,8 @@
+import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const dynamic = 'force-dynamic'
-
 async function Hang() {
+  await connection()
   await new Promise(() => {})
   return null
 }

--- a/test/e2e/on-request-error/client-abort/app/layout.js
+++ b/test/e2e/on-request-error/client-abort/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/on-request-error/client-abort/client-abort.test.ts
+++ b/test/e2e/on-request-error/client-abort/client-abort.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('on-request-error - client-abort', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should not report an aborted RSC stream but still report render errors', async () => {
+    const controller = new AbortController()
+    const res = await next.fetch('/hang', {
+      headers: { RSC: '1' },
+      signal: controller.signal,
+    })
+    expect(res.status).toBe(200)
+
+    const decoder = new TextDecoder()
+    for await (const rawChunk of res.body) {
+      const chunk =
+        typeof rawChunk === 'string' ? rawChunk : decoder.decode(rawChunk)
+      // the fallback is flushed as soon as the stream opens, so nothing else
+      // arrives until we abort
+      if (chunk.includes('stream-started')) {
+        break
+      }
+    }
+    controller.abort()
+
+    await next.fetch('/error')
+
+    await retry(async () => {
+      expect(next.cliOutput).toContain(
+        '[instrumentation]:error server-side-error'
+      )
+    })
+    expect(next.cliOutput).not.toContain('The destination stream closed early')
+  })
+})

--- a/test/e2e/on-request-error/client-abort/instrumentation.js
+++ b/test/e2e/on-request-error/client-abort/instrumentation.js
@@ -1,0 +1,3 @@
+export function onRequestError(err) {
+  console.log('[instrumentation]:error', err.message)
+}

--- a/test/e2e/on-request-error/client-abort/next.config.js
+++ b/test/e2e/on-request-error/client-abort/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
When a client disconnects mid-stream, `pipeNodeReadableToNodeResponse` destroys the readable React is piping into. React sees its destination close before the render ended and aborts with a generic `Error("The destination stream closed early.")`, which `onError` has no way to distinguish from a real render error, so it ends up in `onRequestError` as a server render error.

The Web streams path doesn't have this problem: cancelling the readable passes the `ResponseAborted` reason straight through to React. This does the same for the Node path by aborting the pipeable with that reason as soon as the passthrough is destroyed early, before React's own close handler runs. Genuine render errors still go through untouched.

Fixes #96704