### PR TITLE
Avoid reporting client-aborted RSC streams as request errors

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -887,20 +887,13 @@ async function generateDynamicFlightRenderResult(
     onFlightDataRenderError
   )
 
-  // With Server Components HMR cancellation enabled, a superseded HMR refresh
-  // aborts its own client fetch, which closes this response. We use that
-  // response-close to abort the discarded render. This is the
-  // non-Cache-Components dev RSC path; unlike the Cache Components staged path
-  // it has no detached validation, so the render is the only work to cancel.
-  const requestAbortSignal =
-    process.env.__NEXT_DEV_SERVER &&
-    renderOpts.experimental.serverComponentsHmrCancellation === true &&
-    requestStore.isHmrRefresh === true &&
-    isNodeNextResponse(ctx.res)
+  if (process.env.__NEXT_USE_NODE_STREAMS) {
+    // Abort the React render before response piping destroys its destination.
+    // This preserves the ResponseAborted reason when a client disconnects.
+    const requestAbortSignal = isNodeNextResponse(ctx.res)
       ? signalFromNodeResponse(ctx.res.originalResponse)
       : undefined
 
-  if (process.env.__NEXT_USE_NODE_STREAMS) {
     const debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
     if (debugChannel) {
@@ -937,6 +930,17 @@ async function generateDynamicFlightRenderResult(
       options?.waitUntil
     )
   } else {
+    // With Server Components HMR cancellation enabled, a superseded HMR refresh
+    // aborts its own client fetch, which closes this response. We use that
+    // response-close to abort the discarded render.
+    const requestAbortSignal =
+      process.env.__NEXT_DEV_SERVER &&
+      renderOpts.experimental.serverComponentsHmrCancellation === true &&
+      requestStore.isHmrRefresh === true &&
+      isNodeNextResponse(ctx.res)
+        ? signalFromNodeResponse(ctx.res.originalResponse)
+        : undefined
+
     const debugChannel = setReactDebugChannel && createWebDebugChannel()
 
     if (debugChannel) {
@@ -1475,6 +1479,12 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
 
     debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
+    // This stream is piped directly to the response, unlike the replayable
+    // staged render above, so abort it when the response closes.
+    const requestAbortSignal = isNodeNextResponse(ctx.res)
+      ? signalFromNodeResponse(ctx.res.originalResponse)
+      : undefined
+
     stream = await stagedRenderWithoutCachesInDevNode(
       ctx,
       initialRequestStore,
@@ -1483,6 +1493,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
         onError: onError,
         filterStackFrame,
         debugChannel: debugChannel?.serverSide,
+        signal: requestAbortSignal,
       }
     )
   }

--- a/test/e2e/on-request-error/basic/app/rsc-client-abort/page.js
+++ b/test/e2e/on-request-error/basic/app/rsc-client-abort/page.js
@@ -1,0 +1,17 @@
+import { after, connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  await connection()
+  after(() => console.log('[rsc-client-abort] response closed'))
+
+  return (
+    <Suspense fallback="rsc-client-abort-fallback">
+      <NeverFinishes />
+    </Suspense>
+  )
+}
+
+async function NeverFinishes() {
+  await new Promise(() => {})
+}

--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -1,6 +1,33 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup, type NextInstance } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
+
+async function expectClientAbortNotReported(
+  next: NextInstance,
+  headers: Record<string, string> = {}
+) {
+  const getOutput = next.getCliOutputFromHere()
+  const abortController = new AbortController()
+  const response = await next.fetch('/rsc-client-abort', {
+    headers: { rsc: '1', ...headers },
+    signal: abortController.signal,
+  })
+
+  expect(response.status).toBe(200)
+
+  const iterator = response.body[Symbol.asyncIterator]()
+  const firstChunk = await iterator.next()
+  expect(firstChunk.done).toBe(false)
+
+  abortController.abort()
+
+  await retry(() => {
+    expect(getOutput()).toContain('[rsc-client-abort] response closed')
+  })
+  expect(getOutput()).not.toContain(
+    '[instrumentation] onRequestError:/rsc-client-abort'
+  )
+}
 
 describe('on-request-error - basic', () => {
   const { next, skipped } = nextTestSetup({
@@ -72,6 +99,10 @@ describe('on-request-error - basic', () => {
         url: '/server-page/edge',
         renderSource: 'react-server-components',
       })
+    })
+
+    it('should not report a client-aborted RSC stream', async () => {
+      await expectClientAbortNotReported(next)
     })
 
     it('should catch client component page error in node runtime', async () => {
@@ -162,3 +193,25 @@ describe('on-request-error - basic', () => {
     })
   })
 })
+
+if (isNextDev) {
+  describe('on-request-error - Cache Components client abort', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      overrideFiles: {
+        'next.config.js': 'module.exports = { cacheComponents: true }',
+      },
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    it('should not report a client-aborted RSC stream while bypassing caches', async () => {
+      await expectClientAbortNotReported(next, {
+        'cache-control': 'no-cache',
+      })
+    })
+  })
+}

--- a/test/e2e/on-request-error/basic/instrumentation.ts
+++ b/test/e2e/on-request-error/basic/instrumentation.ts
@@ -5,6 +5,8 @@ export const onRequestError: Instrumentation.onRequestError = (
   request,
   context
 ) => {
+  console.log(`[instrumentation] onRequestError:${request.path}`)
+
   fetch(`http://localhost:${process.env.PORT}/write-log`, {
     method: 'POST',
     body: JSON.stringify({


### PR DESCRIPTION
### What?

- Pass the response-backed abort signal to native Node RSC renders.
- Apply the same behavior to the Cache Components development cache-bypass path.
- Add regression coverage for client-aborted RSC responses.

### Why?

- A client disconnect currently destroys the destination stream before React receives the expected `ResponseAborted` reason.
- React consequently reports `"The destination stream closed early."` through `onRequestError`.
- Client cancellation is expected request lifecycle behavior, not a server rendering failure.

### How?

- Abort the React render when the underlying Node response closes.
- Verify that cancelling after the first RSC chunk does not invoke `onRequestError`.
- Cover development and production with Turbopack and Webpack.

Fixes #96704

### Validation

- `pnpm test-dev-turbo test/e2e/on-request-error/basic/basic.test.ts`
- `pnpm test-dev-webpack test/e2e/on-request-error/basic/basic.test.ts`
- `pnpm test-start-turbo test/e2e/on-request-error/basic/basic.test.ts`
- `pnpm test-start-webpack test/e2e/on-request-error/basic/basic.test.ts`
- `pnpm --filter=next build`
