### PR TITLE
Bugfix: don't seed route cache with hash from initial URL

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -113,7 +113,11 @@ export function createInitialRouterState({
       initialRouteTree,
       metadataVaryPath,
       initialCouldBeIntercepted,
-      canonicalUrl,
+      // Store a hashless canonical URL: the entry is shared across hashes, and
+      // a later same-route hash nav appends `url.hash` to it. Must match the
+      // navigation call site — seeding with location.hash poisons later
+      // replace/push that intentionally clear the hash (e.g. closing a #modal).
+      createHrefFromUrl(location, false),
       initialSupportsPerSegmentPrefetching,
       false // hasDynamicRewrite
     )

--- a/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/app/p/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/app/p/[id]/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+
+export default function ProductPage() {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  return (
+    <>
+      <h1 id="product-page">Product {pathname}</h1>
+      <button
+        id="replace-without-hash"
+        onClick={() => router.replace(pathname, { scroll: false })}
+      >
+        router.replace(pathname)
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <>
+      <h1 id="home">Home</h1>
+      <Link id="link-to-product" href="/p/123#modal">
+        Open product with hash
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/next.config.js
+++ b/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/next.config.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    // Disabling prefetch inlining avoids the `InliningHintsStale` marker
+    // that would otherwise immediately expire the initial-state route
+    // cache entry. The bug under test depends on that entry sticking
+    // around long enough to be read by `router.replace(pathname)`.
+    prefetchInlining: false,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/stale-hash-on-replace-regression.test.ts
+++ b/test/e2e/app-dir/segment-cache/stale-hash-on-replace-regression/stale-hash-on-replace-regression.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('segment cache - stale hash on replace regression', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    test('skipped in dev mode', () => {})
+    return
+  }
+
+  // Regression test for https://github.com/vercel/next.js/issues/96714.
+  //
+  // Reproduction is taken from the user's report and minimal repro at
+  // https://github.com/FelixK-Witt/next-hash-restore-repro:
+  //
+  // 1. Build and start the application.
+  // 2. Open `/p/123#modal` directly in the browser (full page load on a
+  //    dynamic param route).
+  // 3. Click the button that calls `router.replace(pathname)` with no hash.
+  //
+  // Expected: URL is `/p/123` with no hash.
+  // Buggy:   URL stays `/p/123#modal` — the hash from the initial page load
+  //          is restored from the route cache entry's canonicalUrl.
+
+  it('router.replace without a hash clears the hash from the initial page load on a dynamic route', async () => {
+    const browser = await next.browser('/p/123#modal')
+    await browser.waitForElementByCss('#product-page')
+
+    await retry(async () => {
+      const url = new URL(await browser.url())
+      expect(url.pathname).toBe('/p/123')
+      expect(url.hash).toBe('#modal')
+    })
+
+    await browser.elementById('replace-without-hash').click()
+
+    await retry(async () => {
+      const url = new URL(await browser.url())
+      expect(url.pathname).toBe('/p/123')
+      expect(url.hash).toBe('')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- On direct entry to a dynamic route with a hash (e.g. `/p/123#modal`), the initial `discoverKnownRoute` call stored a hash-ful `canonicalUrl` on the segment-cache route entry.
- Same-route navigations rebuild the address as `route.canonicalUrl + url.hash`. With an empty `url.hash` (e.g. `router.replace(pathname)` to close a hash modal), the stale `#modal` was restored.
- Seed the route cache with `createHrefFromUrl(location, false)`, matching the navigation call site. Router state still keeps the full URL (including hash) for history/scroll.

Fixes #96714

## Test plan

- [x] Reproduced with https://github.com/FelixK-Witt/next-hash-restore-repro on `next@16.3.1-canary.3`: `/p/123#modal` → `router.replace(pathname)` kept `#modal`.
- [x] After the fix (patched client bundle): same steps clear the hash to `/p/123`.
- [x] Control case `/#modal` still drops the hash.
- [ ] `stale-hash-on-replace-regression` e2e (production only; `prefetchInlining: false`, same pattern as #94144).