### PR TITLE
Do not restore the initial hash on same-route navigations

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -113,7 +113,11 @@ export function createInitialRouterState({
       initialRouteTree,
       metadataVaryPath,
       initialCouldBeIntercepted,
-      canonicalUrl,
+      // Store a hashless canonical URL: the entry is shared across hashes, and
+      // a later same-route hash nav appends `url.hash` to it. `canonicalUrl`
+      // is derived from `location` above and keeps the hash, which would
+      // otherwise be restored by a subsequent hashless navigation.
+      createHrefFromUrl(location, false),
       initialSupportsPerSegmentPrefetching,
       false // hasDynamicRewrite
     )

--- a/test/e2e/app-dir/navigation/app/hash-replace/[id]/page.js
+++ b/test/e2e/app-dir/navigation/app/hash-replace/[id]/page.js
@@ -1,0 +1,12 @@
+import { ReplaceButton } from '../replace-button'
+
+export default async function Page({ params }) {
+  const { id } = await params
+
+  return (
+    <div id="hash-replace-dynamic">
+      <div id="id">{id}</div>
+      <ReplaceButton />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/hash-replace/page.js
+++ b/test/e2e/app-dir/navigation/app/hash-replace/page.js
@@ -1,0 +1,9 @@
+import { ReplaceButton } from './replace-button'
+
+export default function Page() {
+  return (
+    <div id="hash-replace-index">
+      <ReplaceButton />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/hash-replace/replace-button.js
+++ b/test/e2e/app-dir/navigation/app/hash-replace/replace-button.js
@@ -1,0 +1,17 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+
+export function ReplaceButton() {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  return (
+    <button
+      id="replace-without-hash"
+      onClick={() => router.replace(pathname, { scroll: false })}
+    >
+      Replace with the current pathname
+    </button>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -223,6 +223,38 @@ describe('app dir - navigation', () => {
     })
   })
 
+  describe('hash-replace', () => {
+    // The route cache entry is shared across hashes, so a same-route
+    // navigation appends the incoming `url.hash` to the stored canonical URL.
+    // Seeding that entry with a hash-ful URL on initial load made a later
+    // hashless `router.replace` restore the hash it was meant to remove.
+    it('should not restore the initial hash when replacing on a dynamic route', async () => {
+      const browser = await next.browser('/hash-replace/123#modal')
+      await browser.waitForElementByCss('#hash-replace-dynamic')
+
+      await browser.elementById('replace-without-hash').click()
+
+      await retry(async () => {
+        const url = new URL(await browser.url())
+        expect(url.pathname).toBe('/hash-replace/123')
+        expect(url.hash).toBe('')
+      })
+    })
+
+    it('should not restore the initial hash when replacing on a non-dynamic route', async () => {
+      const browser = await next.browser('/hash-replace#modal')
+      await browser.waitForElementByCss('#hash-replace-index')
+
+      await browser.elementById('replace-without-hash').click()
+
+      await retry(async () => {
+        const url = new URL(await browser.url())
+        expect(url.pathname).toBe('/hash-replace')
+        expect(url.hash).toBe('')
+      })
+    })
+  })
+
   describe('hash-with-scroll-offset', () => {
     it('should scroll to the specified hash', async () => {
       const browser = await next.browser('/hash-with-scroll-offset')


### PR DESCRIPTION
### What?

Entering a page directly on a URL that has a hash, then calling `router.replace(pathname)` with no hash, leaves the hash in the address bar. The router itself calls `history.replaceState(..., "/p/123#modal")` even though the app passed `/p/123`.

The practical effect: a modal opened via `#hash` and closed with `router.replace(pathnameWithoutHash)` can never be closed when the page was opened from a deep link.

### Why?

Route cache entries are shared across hashes, so a same-route navigation appends the incoming `url.hash` to the entry's stored canonical URL:

```ts
// segment-cache/navigation.ts
const canonicalUrl = route.canonicalUrl + url.hash
```

That makes "the stored canonical URL is hashless" an invariant every writer has to hold up. The navigation writer does, and documents it:

```ts
// segment-cache/navigation.ts
// Store a hashless canonical URL: the entry is shared across hashes, and
// a later same-route hash nav appends `url.hash` to it.
createHrefFromUrl(canonicalUrl, false),
```

The initial-load writer in `create-initial-router-state.ts` did not. It passed `canonicalUrl`, which is `createHrefFromUrl(location)`, and `createHrefFromUrl` includes the hash unless told otherwise.

So opening `/p/123#modal` directly seeds the entry with `/p/123#modal`. A later `router.replace('/p/123')` has an empty `url.hash`, the concatenation is a no-op, and the stale hash is handed back to `history.replaceState`.

This only shows up on routes that aren't prefetched before the replace. A statically prerendered route gets its entry overwritten by a prefetch (with a correctly hashless URL) and hides the bug, which is why it looked specific to dynamic param routes.

### How?

Pass a hashless canonical URL at the initial-load call site, matching what the navigation call site already does. The router state's own `canonicalUrl` still keeps the hash, only the route cache seed changes.

Added two e2e cases under `test/e2e/app-dir/navigation`, covering a dynamic param route and a non-dynamic route. Both fail on `canary` (`Expected: "" / Received: "#modal"`) and pass with the change. The suite's seven existing hash fixtures still pass in both dev and start mode.

Fixes #96714
