### PR TITLE
test: fix missing await in css-chunking test

### DIFF
--- a/test/e2e/app-dir/css-chunking/css-chunking.test.ts
+++ b/test/e2e/app-dir/css-chunking/css-chunking.test.ts
@@ -12,14 +12,14 @@ describe('css-chunking', () => {
     async () => {
       const $ = await next.render$('/')
       const stylesheets = $('link[rel="stylesheet"]')
-      stylesheets.each(async (_, element) => {
+      for (const element of stylesheets.get() as CheerioElement[]) {
         const href = element.attribs.href
         const result = await next.fetch(href)
         const css = await result.text()
 
         // eslint-disable-next-line jest/no-standalone-expect
         expect(css).not.toContain('.otherPage')
-      })
+      }
     }
   )
 })


### PR DESCRIPTION
`cheerio.each()` does not handle async things, so this was effectively just a race