### PR TITLE
Discard only cache entries that predate a tag revalidation

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6565,6 +6565,7 @@ function buildDevValidationWorkStore(
     cacheLifeProfiles: message.nextConfigSerializable.cacheLifeProfiles,
     buildId: message.buildId,
     deploymentId: message.deploymentId,
+    requestStartTime: message.request.requestStartTime,
     previouslyRevalidatedTags: [],
     refreshTagsByCacheKind: new Map(),
     runInCleanSnapshot: createSnapshot(),
@@ -8139,6 +8140,7 @@ async function validateInstantConfigInBuildWithSample(
   const workStore: WorkStore = {
     page: outerWorkStore.page,
     route: outerWorkStore.route,
+    requestStartTime: outerWorkStore.requestStartTime,
     incrementalCache: outerWorkStore.incrementalCache,
     cacheLifeProfiles: outerWorkStore.cacheLifeProfiles,
     useCacheTimeout: outerWorkStore.useCacheTimeout,

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -55,6 +55,7 @@ export interface DevValidationRequestSnapshot {
   isDraftMode: boolean
   isHmrRefresh: boolean
   hmrRefreshHash: string | undefined
+  requestStartTime: number
 }
 
 /**

--- a/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-snapshot.ts
@@ -75,6 +75,7 @@ export async function buildDevValidationSnapshot(
       isDraftMode: requestStore.draftMode.isEnabled,
       isHmrRefresh: requestStore.isHmrRefresh ?? false,
       hmrRefreshHash: requestStore.hmrRefreshHash,
+      requestStartTime: ctx.workStore.requestStartTime,
     },
     interpolatedParams: ctx.interpolatedParams,
     requestFallbackRouteParams: ctx.fallbackRouteParams,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -65,6 +65,14 @@ export interface WorkStore {
   pendingRevalidatedTags?: Array<{
     tag: string
     profile?: string | { stale?: number; revalidate?: number; expire?: number }
+    /**
+     * When the tag was revalidated, on the same clock as `CacheEntry.timestamp`
+     * (`performance.timeOrigin + performance.now()`). A cache entry created
+     * before this is stale; one created after it already reflects the
+     * revalidation and can still be served. Re-revalidating a tag moves this
+     * forward.
+     */
+    revalidatedAt: number
   }>
 
   /**
@@ -73,6 +81,15 @@ export interface WorkStore {
    * include any of these tags must be discarded.
    */
   readonly previouslyRevalidatedTags: readonly string[]
+
+  /**
+   * When this request started, on the same clock as `CacheEntry.timestamp`.
+   * `previouslyRevalidatedTags` carry no timestamp of their own, having been
+   * revalidated by an earlier request, so they are treated as revalidated at
+   * this instant: entries predating the request are discarded, while entries
+   * generated during it are not.
+   */
+  readonly requestStartTime: number
 
   /**
    * This map contains lazy results so that we can evaluate them when the first

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -139,6 +139,7 @@ function createWorkStoreImpl(
     cacheComponentsEnabled: renderOpts.cacheComponents,
     validationLevel: renderOpts.validationLevel,
     previouslyRevalidatedTags,
+    requestStartTime: performance.timeOrigin + performance.now(),
     refreshTagsByCacheKind: createRefreshTagsByCacheKind(),
     runInCleanSnapshot: createSnapshot(),
     shouldTrackFetchMetrics,

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -207,6 +207,7 @@ function buildProbeWorkStore(msg: ProbeMessage): WorkStore {
     cacheLifeProfiles: msg.nextConfigSerializable.cacheLifeProfiles,
     buildId: msg.buildId,
     deploymentId: msg.deploymentId,
+    requestStartTime: msg.request.requestStartTime,
     // Empty values for cache-handler / RDC bookkeeping. The `useCacheProbeMode`
     // branch in `cache()` returns before any code that reads or writes these
     // fields, so the values can never be observed.

--- a/packages/next/src/server/use-cache/use-cache-probe-globals.ts
+++ b/packages/next/src/server/use-cache/use-cache-probe-globals.ts
@@ -25,6 +25,7 @@ export type UseCacheProbeRequestSnapshot = {
   isDraftMode: boolean
   isHmrRefresh: boolean
   hmrRefreshHash: string | undefined
+  requestStartTime: number
 }
 
 /**

--- a/packages/next/src/server/use-cache/use-cache-probe-scheduler.ts
+++ b/packages/next/src/server/use-cache/use-cache-probe-scheduler.ts
@@ -116,6 +116,7 @@ export function setupProbeScheduler(
         isDraftMode: workStore.isDraftMode ?? false,
         isHmrRefresh: outerRequestStore.isHmrRefresh ?? false,
         hmrRefreshHash: outerRequestStore.hmrRefreshHash,
+        requestStartTime: workStore.requestStartTime,
       },
       timeoutMs: probeInternalTimeoutMs,
     }).then(

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2293,11 +2293,15 @@ export async function cache(
       // tags. When a server action calls updateTag(), the re-render should see
       // fresh data instead of stale RDC data.
       if (rdcResult !== undefined) {
+        const { timestamp } = rdcResult.entry
+
         if (
           rdcResult.entry.tags.some((tag) =>
-            isRecentlyRevalidatedTag(tag, workStore)
+            isRevalidatedAfter(tag, timestamp, workStore)
           ) ||
-          implicitTags.some((tag) => isRecentlyRevalidatedTag(tag, workStore))
+          implicitTags.some((tag) =>
+            isRevalidatedAfter(tag, timestamp, workStore)
+          )
         ) {
           debug?.(
             'discarding RDC entry due to recently revalidated tags',
@@ -3550,24 +3554,50 @@ function shouldDiscardCacheEntry(
 
   // If the cache entry contains revalidated tags that the cache handler might
   // not know about yet, we need to discard it.
-  if (entry.tags.some((tag) => isRecentlyRevalidatedTag(tag, workStore))) {
+  if (
+    entry.tags.some((tag) =>
+      isRevalidatedAfter(tag, entry.timestamp, workStore)
+    )
+  ) {
     return true
   }
 
   // Finally, if any of the implicit tags have been revalidated recently, we
   // also need to discard the cache entry.
-  if (implicitTags.some((tag) => isRecentlyRevalidatedTag(tag, workStore))) {
+  if (
+    implicitTags.some((tag) =>
+      isRevalidatedAfter(tag, entry.timestamp, workStore)
+    )
+  ) {
     return true
   }
 
   return false
 }
 
-function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
-  const { previouslyRevalidatedTags, pendingRevalidatedTags } = workStore
+/**
+ * Whether `tag` was revalidated after an entry created at `entryTimestamp`,
+ * which makes that entry stale. An entry produced after the revalidation
+ * already reflects it and is still usable.
+ */
+function isRevalidatedAfter(
+  tag: string,
+  entryTimestamp: number,
+  workStore: WorkStore
+): boolean {
+  const {
+    previouslyRevalidatedTags,
+    pendingRevalidatedTags,
+    requestStartTime,
+  } = workStore
 
   // Was the tag previously revalidated (e.g. by a redirecting server action)?
-  if (previouslyRevalidatedTags.includes(tag)) {
+  // That happened in an earlier request and carries no timestamp of its own, so
+  // it counts as having happened when this request started.
+  if (
+    entryTimestamp <= requestStartTime &&
+    previouslyRevalidatedTags.includes(tag)
+  ) {
     debug?.('tag', tag, 'was previously revalidated')
 
     return true
@@ -3577,7 +3607,11 @@ function isRecentlyRevalidatedTag(tag: string, workStore: WorkStore): boolean {
   // In this case the revalidation might not have been fully propagated by a
   // remote cache handler yet, so we read it from the pending tags in the work
   // store.
-  if (pendingRevalidatedTags?.some((item) => item.tag === tag)) {
+  if (
+    pendingRevalidatedTags?.some(
+      (item) => item.tag === tag && item.revalidatedAt > entryTimestamp
+    )
+  ) {
     debug?.('tag', tag, 'was just revalidated')
 
     return true

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -211,6 +211,8 @@ function revalidate(
     store.pendingRevalidatedTags = []
   }
 
+  const revalidatedAt = performance.timeOrigin + performance.now()
+
   for (const tag of tags) {
     const existingIndex = store.pendingRevalidatedTags.findIndex((item) => {
       if (item.tag !== tag) return false
@@ -227,7 +229,13 @@ function revalidate(
       store.pendingRevalidatedTags.push({
         tag,
         profile,
+        revalidatedAt,
       })
+    } else {
+      // Revalidating a tag again invalidates everything produced up to now, so
+      // the latest revalidation is the one that decides which entries are
+      // stale.
+      store.pendingRevalidatedTags[existingIndex].revalidatedAt = revalidatedAt
     }
   }
 

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/action-dedupe/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/action-dedupe/page.tsx
@@ -1,0 +1,58 @@
+import { cacheTag, updateTag } from 'next/cache'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+let invocations = 0
+
+async function getData(params: { id: number }) {
+  'use cache'
+  cacheTag('action-dedupe')
+  return `${params.id}:${++invocations}`
+}
+
+// Each call passes a fresh object literal so the React.cache memo misses on
+// reference equality, and the delay puts the second call outside the in-flight
+// dedupe window. Both calls therefore depend on a stored entry being reused.
+async function readTwice() {
+  const first = await getData({ id: 1 })
+  await setTimeout(100)
+  const second = await getData({ id: 1 })
+
+  return { first, second }
+}
+
+export default async function Page() {
+  await connection()
+
+  const { first, second } = await readTwice()
+
+  return (
+    <div>
+      <p className="first">{first}</p>
+      <p className="second">{second}</p>
+      <form>
+        <button
+          id="revalidate"
+          formAction={async () => {
+            'use server'
+            const { first: a1, second: a2 } = await readTwice()
+            console.log(`action-dedupe: revalidate action read ${a1} ${a2}`)
+            updateTag('action-dedupe')
+          }}
+        >
+          Read twice and revalidate
+        </button>{' '}
+        <button
+          id="no-revalidate"
+          formAction={async () => {
+            'use server'
+            const { first: a1, second: a2 } = await readTwice()
+            console.log(`action-dedupe: plain action read ${a1} ${a2}`)
+          }}
+        >
+          Read twice only
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1675,6 +1675,42 @@ describe('use-cache', () => {
     expect(first).toBe(second)
   })
 
+  it('should dedupe sequential calls in a server action and its subsequent render', async () => {
+    const browser = await next.browser('/action-dedupe')
+
+    const initial = await browser.elementByCss('.first').text()
+    expect(await browser.elementByCss('.second').text()).toBe(initial)
+
+    // With no revalidation, the action's two reads and the re-render's two
+    // reads all serve the entry that the initial render produced.
+    await browser.elementById('no-revalidate').click()
+
+    await retry(async () => {
+      expect(next.cliOutput).toContain(
+        `action-dedupe: plain action read ${initial} ${initial}`
+      )
+    })
+
+    expect(await browser.elementByCss('.first').text()).toBe(initial)
+    expect(await browser.elementByCss('.second').text()).toBe(initial)
+
+    // The action reads the still-valid entry twice, then revalidates the tag.
+    // The re-render must not reuse that entry, but its own two reads must share
+    // the entry the first of them regenerated.
+    await browser.elementById('revalidate').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('.first').text()).not.toBe(initial)
+    })
+
+    const revalidated = await browser.elementByCss('.first').text()
+    expect(await browser.elementByCss('.second').text()).toBe(revalidated)
+
+    expect(next.cliOutput).toContain(
+      `action-dedupe: revalidate action read ${initial} ${initial}`
+    )
+  })
+
   it('dedupes private caches across concurrent requests in dev but not in production', async () => {
     const [first$, second$] = await Promise.all([
       next.render$('/private-dedup-cross-request'),


### PR DESCRIPTION
Calling `updateTag()` in a server action made every later read of a cache carrying that tag regenerate for the remainder of the request, including reads of an entry that had just been generated after the invalidation and therefore already reflected it. Two sequential reads of the same cache function during the re-render produced two different values within a single render, and each one repeated the work.

`isRecentlyRevalidatedTag` only asked whether a tag appeared in `pendingRevalidatedTags`, with no notion of when the revalidation happened. That array lives for the whole `WorkStore`, which spans a server action and the render that follows it, so once a tag was in it every entry carrying that tag looked stale regardless of when it had been produced.

Each pending revalidated tag now records a `revalidatedAt` timestamp taken from the same clock as `CacheEntry.timestamp`, and the renamed `isRevalidatedAfter` reports an entry as stale only when the revalidation is newer than the entry. `CacheEntry.timestamp` is captured before a fill begins, so a fill straddling a revalidation is still discarded, which is the conservative answer for a body that may have read pre-invalidation data. Revalidating the same tag again moves the timestamp forward, since the later invalidation decides which entries are stale.

`previouslyRevalidatedTags` are forwarded from an earlier request by a redirecting server action and carry no timestamp of their own, so the work store now records when the request started and treats them as revalidated at that instant. Entries predating the request are still discarded while entries generated during it survive. The hang-detection probe worker and the dev validation worker take that value from the request they serve rather than reading the clock when they start, which would otherwise date every entry from the outer request as older than the request's own start.

The `action-dedupe` fixture covers this end to end: it reads a tagged cache twice inside a server action, revalidates the tag, then reads it twice again during the re-render, asserting that each pair shares a value and that the two pairs differ.