### PR TITLE
Derive foreground cache revalidation from the consumer

### DIFF
--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -342,11 +342,11 @@ export type StaticPrerenderStore = Exclude<
 export interface CommonCacheStore
   extends Omit<CommonWorkUnitStore, 'implicitTags'> {
   /**
-   * Whether a stale cache entry must be revalidated before the outer work unit
-   * can continue. This is copied from the outer work unit because entering a
-   * cache scope intentionally hides that store.
+   * Whether this work unit will persist the results it consumes in a server
+   * cache. This only describes the immediate consumer; it is not inherited
+   * from outer scopes.
    */
-  readonly shouldRevalidateStaleCacheEntryInForeground: boolean
+  readonly consumerWillServerCache: boolean
   /**
    * A cache work unit store might not always have an outer work unit store,
    * from which implicit tags could be inherited.
@@ -445,7 +445,7 @@ export type WorkUnitStore =
   | PrerenderStore
   | GenerateStaticParamsStore
 
-export function shouldRevalidateStaleCacheEntryInForeground(
+export function willConsumerServerCache(
   workUnitStore: WorkUnitStore | undefined
 ): boolean {
   if (!workUnitStore) {
@@ -456,7 +456,7 @@ export function shouldRevalidateStaleCacheEntryInForeground(
     case 'cache':
     case 'private-cache':
     case 'unstable-cache':
-      return workUnitStore.shouldRevalidateStaleCacheEntryInForeground
+      return workUnitStore.consumerWillServerCache
     case 'prerender':
     case 'prerender-client':
     case 'prerender-ppr':

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -22,10 +22,10 @@ import type { FetchMetric } from '../base-http'
 import { createDedupeFetch } from './dedupe-fetch'
 import {
   getCacheSignal,
-  shouldRevalidateStaleCacheEntryInForeground,
   type RevalidateStore,
   type WorkUnitAsyncStorage,
   type WorkUnitStore,
+  willConsumerServerCache,
 } from '../app-render/work-unit-async-storage.external'
 import {
   CachedRouteKind,
@@ -1120,12 +1120,9 @@ export function createPatchedFetcher(
             }
 
             if (entry?.value && entry.value.kind === CachedRouteKind.FETCH) {
-              // when stale and is revalidating we wait for fresh data
-              // so the revalidated entry has the updated data
-              if (
-                shouldRevalidateStaleCacheEntryInForeground(workUnitStore) &&
-                entry.isStale
-              ) {
+              // If the consumer will persist this result in a server cache,
+              // wait for fresh data so it doesn't persist a stale value.
+              if (willConsumerServerCache(workUnitStore) && entry.isStale) {
                 isForegroundRevalidate = true
               } else {
                 if (entry.isStale) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -34,7 +34,7 @@ import {
   getCacheSignal,
   isHmrRefresh,
   getServerComponentsHmrCache,
-  shouldRevalidateStaleCacheEntryInForeground,
+  willConsumerServerCache,
 } from '../app-render/work-unit-async-storage.external'
 
 import {
@@ -753,8 +753,7 @@ function createUseCacheStore(
     return {
       type: 'private-cache',
       phase: 'render',
-      shouldRevalidateStaleCacheEntryInForeground:
-        shouldRevalidateStaleCacheEntryInForeground(outerWorkUnitStore),
+      consumerWillServerCache: true,
       implicitTags: outerWorkUnitStore?.implicitTags,
       revalidate: defaultCacheLife.revalidate,
       expire: defaultCacheLife.expire,
@@ -804,8 +803,7 @@ function createUseCacheStore(
     return {
       type: 'cache',
       phase: 'render',
-      shouldRevalidateStaleCacheEntryInForeground:
-        shouldRevalidateStaleCacheEntryInForeground(outerWorkUnitStore),
+      consumerWillServerCache: true,
       implicitTags: outerWorkUnitStore.implicitTags,
       revalidate: defaultCacheLife.revalidate,
       expire: defaultCacheLife.expire,
@@ -3255,15 +3253,14 @@ export async function cache(
                 ? Math.max(entry.expire, MIN_PRERENDERABLE_EXPIRE)
                 : entry.expire) *
                 1000 ||
-          (shouldRevalidateStaleCacheEntryInForeground(workUnitStore) &&
+          (willConsumerServerCache(workUnitStore) &&
             currentTime > entry.timestamp + entry.revalidate * 1000)
         ) {
           // Miss. Generate a new result.
 
-          // If the cache entry is stale and the outer work unit requires
-          // foreground revalidation, don't use the stale entry since it would
-          // unnecessarily shorten the lifetime of the generated result. We're
-          // not time constrained here, so regenerate it now.
+          // If the cache entry is stale and its consumer will persist the
+          // result in a server cache, don't persist the stale entry into a new
+          // cache. We're not time constrained here, so regenerate it now.
 
           // We need to run this inside a clean AsyncLocalStorage snapshot so
           // that the cache generation cannot read anything from the context
@@ -3279,7 +3276,7 @@ export async function cache(
             }
 
             if (
-              shouldRevalidateStaleCacheEntryInForeground(workUnitStore) &&
+              willConsumerServerCache(workUnitStore) &&
               currentTime > entry.timestamp + entry.revalidate * 1000
             ) {
               debug?.(

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -9,7 +9,7 @@ import {
 import {
   getCacheSignal,
   getDraftModeProviderForCacheScope,
-  shouldRevalidateStaleCacheEntryInForeground,
+  willConsumerServerCache,
   workUnitAsyncStorage,
 } from '../../app-render/work-unit-async-storage.external'
 import {
@@ -147,8 +147,7 @@ export function unstable_cache<T extends Callback>(
       const innerCacheStore: UnstableCacheStore = {
         type: 'unstable-cache',
         phase: 'render',
-        shouldRevalidateStaleCacheEntryInForeground:
-          shouldRevalidateStaleCacheEntryInForeground(workUnitStore),
+        consumerWillServerCache: true,
         implicitTags,
         draftMode:
           workUnitStore &&
@@ -283,9 +282,7 @@ export function unstable_cache<T extends Callback>(
 
                   // Attach the empty catch here so we don't get a "unhandled promise
                   // rejection" warning. (Behavior is matched with patch-fetch)
-                  if (
-                    shouldRevalidateStaleCacheEntryInForeground(workUnitStore)
-                  ) {
+                  if (willConsumerServerCache(workUnitStore)) {
                     revalidationPromise.catch(() => {})
                   }
 
@@ -294,15 +291,14 @@ export function unstable_cache<T extends Callback>(
                 }
 
                 // Check if we need to do foreground revalidation
-                if (
-                  shouldRevalidateStaleCacheEntryInForeground(workUnitStore)
-                ) {
-                  // When the page is revalidating and the cache entry is stale,
-                  // we need to wait for fresh data (blocking revalidate). The
-                  // `await` here keeps `cacheSignal.endRead` (in the outer
-                  // `finally`) suspended until the recompute + cacheNewResult
-                  // actually complete, so the prospective prerender's
-                  // `cacheSignal` doesn't resolve `cacheReady` prematurely.
+                if (willConsumerServerCache(workUnitStore)) {
+                  // When the consumer will persist this result in a server
+                  // cache, wait for fresh data so it doesn't persist a stale
+                  // value. The `await` here also keeps `cacheSignal.endRead` (in
+                  // the outer `finally`) suspended until the recompute +
+                  // cacheNewResult actually complete, so a prospective
+                  // prerender's `cacheSignal` doesn't resolve `cacheReady`
+                  // prematurely.
                   return await workStore.pendingRevalidates[invocationKey]
                 }
                 // Otherwise, we're doing background revalidation - return stale immediately

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/cache-consumer-foreground-revalidate/[key]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/cache-consumer-foreground-revalidate/[key]/page.tsx
@@ -1,0 +1,34 @@
+import { cacheLife, unstable_cache } from 'next/cache'
+import { connection } from 'next/server'
+
+const getInnerValue = unstable_cache(
+  async () => Date.now(),
+  ['cache-consumer-foreground-revalidate-inner'],
+  {
+    revalidate: false,
+    tags: ['cache-consumer-foreground-revalidate-inner'],
+  }
+)
+
+async function getOuterValue(key: string) {
+  'use cache'
+  cacheLife({ revalidate: 60, expire: 300 })
+
+  return {
+    key,
+    innerValue: await getInnerValue(),
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ key: string }>
+}) {
+  await connection()
+
+  const { key } = await params
+  const value = await getOuterValue(key)
+
+  return <p id="inner-value">{value.innerValue}</p>
+}

--- a/test/e2e/app-dir/use-cache/app/api/revalidate-cache-consumer/route.ts
+++ b/test/e2e/app-dir/use-cache/app/api/revalidate-cache-consumer/route.ts
@@ -1,0 +1,7 @@
+import { revalidateTag } from 'next/cache'
+
+export async function POST() {
+  revalidateTag('cache-consumer-foreground-revalidate-inner', 'max')
+
+  return new Response(null, { status: 204 })
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -433,6 +433,31 @@ describe('use-cache', () => {
     })
   })
 
+  it('should refresh a stale cache before storing it in an outer cache', async () => {
+    const browser = await next.browser(
+      '/cache-consumer-foreground-revalidate/first'
+    )
+    const firstValue = await browser.elementById('inner-value').text()
+
+    const response = await next.fetch('/api/revalidate-cache-consumer', {
+      method: 'POST',
+    })
+    expect(response.status).toBe(204)
+
+    // Use a different outer key to force a cache miss. Because that outer
+    // scope will cache what it consumes, it must wait for the stale inner
+    // entry to revalidate instead of persisting the stale value.
+    await browser.loadPage(
+      new URL(
+        '/cache-consumer-foreground-revalidate/second',
+        next.url
+      ).toString()
+    )
+    const secondValue = await browser.elementById('inner-value').text()
+
+    expect(secondValue).not.toBe(firstValue)
+  })
+
   it('should revalidate caches during on-demand revalidation', async () => {
     const browser = await next.browser('/on-demand-revalidate')
     const initial = await browser.elementById('value').text()


### PR DESCRIPTION
## Summary

Foreground revalidation is necessary when a stale result will be persisted by another server cache, not only when the request is prerendering. Otherwise, a cache created during a dynamic request can consume a stale inner value and extend its lifetime.

- derive foreground revalidation from whether the immediate work-unit consumer will persist the result in a server cache
- model that capability as willConsumerServerCache rather than inheriting it through the full outer scope chain
- treat server cache and static prerender work units as server-caching consumers, while runtime prerenders are not
- add regression coverage for an outer "use cache" scope consuming a stale unstable_cache entry

<!-- NEXT_JS_LLM -->