### PR TITLE
Move the dev dynamic route builder into its own function

### DIFF
--- a/packages/next/src/server/lib/router-utils/build-dev-dynamic-routes.ts
+++ b/packages/next/src/server/lib/router-utils/build-dev-dynamic-routes.ts
@@ -1,0 +1,56 @@
+import type { FilesystemDynamicRoute } from './filesystem'
+import type { NextConfigComplete } from '../../config-shared'
+import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
+import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
+import { buildDataRoute } from './build-data-route'
+
+/**
+ * Builds the route list the dev router matches a request against once an exact
+ * path lookup missed. The `/_next/data` routes come first so a data request
+ * doesn't match the page route it shadows.
+ */
+export function buildDevDynamicRoutes(
+  sortedRoutes: string[],
+  i18n: NextConfigComplete['i18n']
+): FilesystemDynamicRoute[] {
+  const pageRoutes = sortedRoutes.map((page): FilesystemDynamicRoute => {
+    const regex = getNamedRouteRegex(page, {
+      prefixRouteKeys: true,
+    })
+    return {
+      regex: regex.re.toString(),
+      namedRegex: regex.namedRegex,
+      routeKeys: regex.routeKeys,
+      match: getRouteMatcher(regex),
+      page,
+    }
+  })
+
+  const dataRoutes = sortedRoutes.map((page): FilesystemDynamicRoute => {
+    const route = buildDataRoute(page, 'development')
+    const routeRegex = getNamedRouteRegex(route.page, {
+      prefixRouteKeys: true,
+    })
+    return {
+      ...route,
+      regex: routeRegex.re.toString(),
+      namedRegex: routeRegex.namedRegex,
+      routeKeys: routeRegex.routeKeys,
+      match: getRouteMatcher({
+        // TODO: fix this in the manifest itself, must also be fixed in
+        // upstream builder that relies on this
+        re: i18n
+          ? new RegExp(
+              route.dataRouteRegex.replace(
+                `/development/`,
+                `/development/(?<nextLocale>[^/]+?)/`
+              )
+            )
+          : new RegExp(route.dataRouteRegex),
+        groups: routeRegex.groups,
+      }),
+    }
+  })
+
+  return [...dataRoutes, ...pageRoutes]
+}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1,5 +1,4 @@
 import type { NextConfigComplete } from '../../config-shared'
-import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
@@ -28,9 +27,7 @@ import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import { sortByPageExts } from '../../../build/sort-by-page-exts'
 import { verifyAndRunTypeScript } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
-import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
-import { buildDataRoute } from './build-data-route'
-import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
+import { buildDevDynamicRoutes } from './build-dev-dynamic-routes'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { createClientRouterFilter } from '../../../lib/create-client-router-filter'
 import { absolutePathToPage } from '../../../shared/lib/page-path/absolute-path-to-page'
@@ -1036,49 +1033,10 @@ async function startWatcher(
         // before it has been built and is populated in the _buildManifest
         const sortedRoutes = getSortedRoutes(routedPages)
 
-        opts.fsChecker.dynamicRoutes = sortedRoutes.map(
-          (page): FilesystemDynamicRoute => {
-            const regex = getNamedRouteRegex(page, {
-              prefixRouteKeys: true,
-            })
-            return {
-              regex: regex.re.toString(),
-              namedRegex: regex.namedRegex,
-              routeKeys: regex.routeKeys,
-              match: getRouteMatcher(regex),
-              page,
-            }
-          }
+        opts.fsChecker.dynamicRoutes = buildDevDynamicRoutes(
+          sortedRoutes,
+          opts.nextConfig.i18n
         )
-
-        const dataRoutes: typeof opts.fsChecker.dynamicRoutes = []
-
-        for (const page of sortedRoutes) {
-          const route = buildDataRoute(page, 'development')
-          const routeRegex = getNamedRouteRegex(route.page, {
-            prefixRouteKeys: true,
-          })
-          dataRoutes.push({
-            ...route,
-            regex: routeRegex.re.toString(),
-            namedRegex: routeRegex.namedRegex,
-            routeKeys: routeRegex.routeKeys,
-            match: getRouteMatcher({
-              // TODO: fix this in the manifest itself, must also be fixed in
-              // upstream builder that relies on this
-              re: opts.nextConfig.i18n
-                ? new RegExp(
-                    route.dataRouteRegex.replace(
-                      `/development/`,
-                      `/development/(?<nextLocale>[^/]+?)/`
-                    )
-                  )
-                : new RegExp(route.dataRouteRegex),
-              groups: routeRegex.groups,
-            }),
-          })
-        }
-        opts.fsChecker.dynamicRoutes.unshift(...dataRoutes)
 
         // For Turbopack ADDED_PAGE and REMOVED_PAGE are implemented in hot-reloader-turbopack.ts
         // in order to avoid a race condition where ADDED_PAGE and REMOVED_PAGE are sent before Turbopack picked up the file change.


### PR DESCRIPTION
In dev the router matches a request against a list of dynamic routes once an exact path lookup misses. That list is built inline in the watchpack handler in `setup-dev-bundler.ts`, in the middle of a long function that does a lot of other things.

This moves it out into `buildDevDynamicRoutes`. No behavior change: the data routes still come first, so a data request doesn't match the page route it shadows, and the caller now passes in the sorted routes it already computed instead of the function sorting them a second time.

A PR stacked on top of this one builds the same list from the routes Turbopack reports, so it needs a second caller. Moving it on its own keeps that PR's diff down to the logic that's actually new.

## Test Plan

There's no new behavior to test. The moved code is the same apart from three mechanical changes: it takes `i18n` as an argument instead of reading `opts.nextConfig.i18n`, the loop that pushed the data routes into an array is now a `.map`, and the `unshift` that put them in front is now a spread in the return.

Dev suites that exercise this list pass on both bundlers, 6 suites and 35 tests each: `i18n-data-route`, `dynamic-route-rename`, `app-aspath`, `gssp-notfound`, `filesystempublicroutes`, `link-with-encoding`. `i18n-data-route` is what covers the locale splice in the data route regex, which is the subtlest thing in here. `filesystempublicroutes` is the only coverage of `useFileSystemPublicRoutes: false`.
