### PR TITLE
[16.x] fix(next/image): preserve image response after optimization

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -99,6 +99,7 @@ export function getSharp(
         'VipsForeignLoadJpeg',
         'VipsForeignLoadNsgif',
         'VipsForeignLoadPng',
+        'VipsForeignLoadSvg',
         'VipsForeignLoadTiff',
         'VipsForeignLoadWebp',
       ],

--- a/test/e2e/og-api/app/app/pixel/[id]/route.js
+++ b/test/e2e/og-api/app/app/pixel/[id]/route.js
@@ -1,0 +1,12 @@
+const pixel = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+X8mN6QAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+export async function GET() {
+  return new Response(pixel, {
+    headers: {
+      'Content-Type': 'image/png',
+    },
+  })
+}

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -1,5 +1,6 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
+import { randomUUID } from 'crypto'
 import fs from 'fs-extra'
 import { join } from 'path'
 
@@ -32,12 +33,27 @@ describe('og-api', () => {
     expect(body.size).toBeGreaterThan(0)
   })
 
-  it('should work in app route in node runtime', async () => {
-    const res = await fetchViaHTTP(next.url, '/og-node')
-    expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toContain('image/png')
-    const body = await res.blob()
-    expect(body.size).toBeGreaterThan(0)
+  it('should work in app route in node runtime after image optimization', async () => {
+    const before = await fetchViaHTTP(next.url, '/og-node')
+    expect(before.status).toBe(200)
+    expect(before.headers.get('content-type')).toContain('image/png')
+    expect((await before.blob()).size).toBeGreaterThan(0)
+
+    const imageUrl = encodeURIComponent(`/pixel/${randomUUID()}`)
+    const optimized = await fetchViaHTTP(
+      next.url,
+      `/_next/image?url=${imageUrl}&w=640&q=75`
+    )
+    expect(optimized.status).toBe(200)
+    expect(
+      optimized.headers.get('x-vercel-cache') ||
+        optimized.headers.get('x-nextjs-cache')
+    ).toBe('MISS')
+
+    const after = await fetchViaHTTP(next.url, '/og-node')
+    expect(after.status).toBe(200)
+    expect(after.headers.get('content-type')).toContain('image/png')
+    expect((await after.blob()).size).toBeGreaterThan(0)
   })
 
   it('should work in middleware', async () => {


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/96681 to `next-16-3` which is itself a copy of https://github.com/vercel/next.js/pull/96621

Clean cherry-pick of 806fbd43676b1012091a94f0462ae793b000adc6 (`git cherry-pick -x`), no conflicts. The squashed commit includes the formatting fix from `test: format image cache assertion`, so the lint issue from the recreated PR is not carried over.

## Verification

- `pnpm test-start-turbo test/e2e/og-api/index.test.ts` — 5/5 pass on this branch.
- Confirmed the bug is present in `next-16-3` and that this commit is what fixes it: reverting the one-line `VipsForeignLoadSvg` addition and rebuilding makes `should work in app route in node runtime after image optimization` fail with `socket hang up` / `Input buffer contains unsupported image format`.
- `npx prettier --check` and `npx eslint` clean on the three touched files.

> [!NOTE]
> Opened from a fork because branch creation in `vercel/next.js` is restricted for the agent token that prepared this backport, so the `when deployed` job will not run here. Reopen as a branch PR if deploy coverage is needed before merging.

<!-- NEXT_JS_LLM -->