### PR TITLE
fix: Use per-segment prefetching for prefetch={true} in output: export mode

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -344,7 +344,7 @@ export type SegmentBundle = {
   parent: SegmentBundle | null
 }
 
-const isOutputExportMode =
+export const isOutputExportMode =
   process.env.NODE_ENV === 'production' &&
   process.env.__NEXT_CONFIG_OUTPUT === 'export'
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -856,10 +856,11 @@ function pingRootRouteTree(
         fetchStrategy = FetchStrategy.PPR
       } else if (isOutputExportMode) {
         // Static export can only serve the per-segment files the exporter wrote
-        // to disk. Any other strategy would issue a dynamic request, which in
-        // this mode reads the page's HTML document and fails to decode, wasting
-        // the download and leaving nothing prefetched. All data is static here,
-        // so PPR is equivalent to a full prefetch anyway.
+        // to disk. Any other strategy issues a dynamic request, which here
+        // returns the page's HTML document; the Flight client never finishes
+        // decoding it, so the prefetch hangs and the link is permanently dead.
+        // All data is static in this mode, so PPR is equivalent to a full
+        // prefetch anyway.
         fetchStrategy = FetchStrategy.PPR
       } else if (task.fetchStrategy === FetchStrategy.PPR) {
         fetchStrategy = route.supportsPerSegmentPrefetching

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -29,6 +29,7 @@ import {
   canNewFetchStrategyProvideMoreContent,
   attemptToFulfillDynamicSegmentFromBFCache,
   attemptToUpgradeSegmentFromBFCache,
+  isOutputExportMode,
 } from './cache'
 import type { RouteCacheKey } from './cache-key'
 import { createCacheKey } from './cache-key'
@@ -852,6 +853,13 @@ function pingRootRouteTree(
         // the `cacheComponents` flag is to support incremental adoption.
         // `prefetch={true}` will continue to work until you opt into
         // Partial Prefetching.
+        fetchStrategy = FetchStrategy.PPR
+      } else if (isOutputExportMode) {
+        // Static export can only serve the per-segment files the exporter wrote
+        // to disk. Any other strategy would issue a dynamic request, which in
+        // this mode reads the page's HTML document and fails to decode, wasting
+        // the download and leaving nothing prefetched. All data is static here,
+        // so PPR is equivalent to a full prefetch anyway.
         fetchStrategy = FetchStrategy.PPR
       } else if (task.fetchStrategy === FetchStrategy.PPR) {
         fetchStrategy = route.supportsPerSegmentPrefetching

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -254,6 +254,7 @@
       "test/e2e/app-dir/segment-cache/client-only-opt-in/client-only-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts",
       "test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts",
+      "test/e2e/app-dir/segment-cache/export-spa-fallback/segment-cache-output-export-spa-fallback.test.ts",
       "test/e2e/app-dir/segment-cache/export-trailing-slash/segment-cache-output-export-trailing-slash.test.ts",
       "test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts",
       "test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts",

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -254,6 +254,7 @@
       "test/e2e/app-dir/segment-cache/client-only-opt-in/client-only-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts",
       "test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts",
+      "test/e2e/app-dir/segment-cache/export-trailing-slash/segment-cache-output-export-trailing-slash.test.ts",
       "test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts",
       "test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",

--- a/test/e2e/app-dir/segment-cache/export-spa-fallback/segment-cache-output-export-spa-fallback.test.ts
+++ b/test/e2e/app-dir/segment-cache/export-spa-fallback/segment-cache-output-export-spa-fallback.test.ts
@@ -1,0 +1,65 @@
+import type { Server } from 'http'
+import { findPort, retry } from 'next-test-utils'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import { createSpaFallbackServer } from '../export/server.mjs'
+
+// Static hosts commonly answer a missing file with the index document and a
+// 200 instead of a 404. In `output: "export"` mode the router skips its
+// content-type check, so a prefetch can be handed an HTML document; the Flight
+// client is invoked with `allowPartialStream: true`, which never rejects on
+// input it cannot parse. The prefetch promise never settles, and the link goes
+// permanently dead.
+describe('segment cache (output: "export", SPA fallback host)', () => {
+  if (!isNextStart) {
+    test('build test should not run during dev test run', () => {})
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: join(__dirname, '../export'),
+    skipStart: true,
+    disableAutoSkewProtection: true,
+  })
+
+  let port: number
+  let server: Server
+
+  beforeAll(async () => {
+    await next.build()
+    port = await findPort()
+    server = createSpaFallbackServer(join(next.testDir, 'out'))
+    server.listen(port)
+  })
+
+  afterAll(() => {
+    server?.close()
+  })
+
+  // Skipped: this fails today. Swapping `createSpaFallbackServer` for
+  // `createExportServer` makes it pass, which pins the cause to the 200 rather
+  // than to anything about the route: the router recovers from a 404 and wedges
+  // on an HTML document. Fixing it means either rejecting `text/html` in the
+  // `isOutputExportMode` branch of `fetchPrefetchResponse`, or not passing
+  // `allowPartialStream` in this mode. Both are outside the scope of the
+  // prefetch strategy change this suite was added alongside.
+  it.skip('does not wedge on a link whose segment files were never exported', async () => {
+    const browser = await next.browser('/', { baseUrl: port })
+
+    const checkbox = await browser.elementByCss(
+      '[data-link-accordion="dynamic-missing-eager"]'
+    )
+    await checkbox.click()
+
+    const link = await browser.elementByCss('a[href="/dynamic/second"]')
+    await link.click()
+
+    // The prefetch cannot succeed here, and it does not have to. What it has to
+    // do is fail, so that the click falls back to a plain navigation. Under the
+    // bug the click does nothing at all: no soft navigation, no hard
+    // navigation, no error.
+    await retry(async () => {
+      expect(new URL(await browser.url()).pathname).toBe('/dynamic/second')
+    })
+  })
+})

--- a/test/e2e/app-dir/segment-cache/export-trailing-slash/segment-cache-output-export-trailing-slash.test.ts
+++ b/test/e2e/app-dir/segment-cache/export-trailing-slash/segment-cache-output-export-trailing-slash.test.ts
@@ -1,0 +1,129 @@
+import type * as Playwright from 'playwright'
+import type { Server } from 'http'
+import { createRouterAct } from 'router-act'
+import { findPort } from 'next-test-utils'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import { createExportServer } from '../export/server.mjs'
+
+// The prefetch and the navigation paths encode static export URLs separately:
+// prefetching appends the per-segment filename to the route directory, while
+// navigation appends `.txt` (or `index.txt`). `trailingSlash` is where the two
+// encodings are most likely to drift apart, so this reuses the `export` fixture
+// with only the config changed.
+describe('segment cache (output: "export", trailingSlash: true)', () => {
+  if (!isNextStart) {
+    test('build test should not run during dev test run', () => {})
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: join(__dirname, '../export'),
+    overrideFiles: {
+      'next.config.js': `module.exports = { output: 'export', trailingSlash: true }\n`,
+    },
+    skipStart: true,
+    disableAutoSkewProtection: true,
+  })
+
+  let port: number
+  let server: Server
+
+  beforeAll(async () => {
+    await next.build()
+    port = await findPort()
+    server = createExportServer(join(next.testDir, 'out'))
+    server.listen(port)
+  })
+
+  afterAll(() => {
+    server?.close()
+  })
+
+  it('basic prefetch with a trailing slash', async () => {
+    let act
+    const browser = await next.browser('/', {
+      baseUrl: port,
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="/target-page"]'
+        )
+        await checkbox.click()
+      },
+      {
+        includes: 'Target page',
+      }
+    )
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss('a[href="/target-page/"]')
+        await link.click()
+
+        const div = await browser.elementById('target-page')
+        expect(await div.text()).toBe('Target page')
+
+        await browser.elementByCss('a[href="/"]')
+      },
+      {
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
+
+  it('prefetch a link with prefetch={true} with a trailing slash', async () => {
+    let act
+    const fetched: string[] = []
+    const browser = await next.browser('/', {
+      baseUrl: port,
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+        p.on('response', (response) => {
+          const { pathname } = new URL(response.url())
+          if (
+            response.request().method() === 'GET' &&
+            !pathname.startsWith('/_next/static/')
+          ) {
+            fetched.push(pathname)
+          }
+        })
+      },
+    })
+
+    await act(async () => {
+      const checkbox = await browser.elementByCss(
+        '[data-link-accordion="target-page-eager"]'
+      )
+      await checkbox.click()
+    })
+
+    // This pins the exact filename on purpose: it is the one assertion that
+    // catches the prefetch and navigation encodings drifting apart under
+    // `trailingSlash`, which is the reason this suite exists. The trailing slash
+    // is dropped before the filename is appended, so the request goes to the
+    // same file as it would without `trailingSlash`.
+    expect(fetched).toContain('/target-page/__next.target-page.__PAGE__.txt')
+    expect(fetched).not.toContain('/target-page/')
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss('a[href="/target-page/"]')
+        await link.click()
+
+        const div = await browser.elementById('target-page')
+        expect(await div.text()).toBe('Target page')
+
+        await browser.elementByCss('a[href="/"]')
+      },
+      {
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
+})

--- a/test/e2e/app-dir/segment-cache/export-trailing-slash/segment-cache-output-export-trailing-slash.test.ts
+++ b/test/e2e/app-dir/segment-cache/export-trailing-slash/segment-cache-output-export-trailing-slash.test.ts
@@ -96,12 +96,15 @@ describe('segment cache (output: "export", trailingSlash: true)', () => {
       },
     })
 
-    await act(async () => {
-      const checkbox = await browser.elementByCss(
-        '[data-link-accordion="target-page-eager"]'
-      )
-      await checkbox.click()
-    })
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="target-page-eager"]'
+        )
+        await checkbox.click()
+      },
+      { includes: 'Target page', kind: 'static' }
+    )
 
     // This pins the exact filename on purpose: it is the one assertion that
     // catches the prefetch and navigation encodings drifting apart under

--- a/test/e2e/app-dir/segment-cache/export/app/dynamic/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/dynamic/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }]
+}
+
+export default async function DynamicPage({ params }) {
+  const { slug } = await params
+  return (
+    <>
+      {/* One interpolated string rather than `Dynamic page: {slug}`, so the text
+          survives into the Flight payload as a single string a test can match
+          on. Separate JSX children arrive as separate strings. */}
+      <div id="dynamic-page">{`Dynamic page: ${slug}`}</div>
+      {/* Not prefetched, so that a test can assert that navigating here costs
+          no network requests at all. */}
+      <Link href="/" prefetch={false}>
+        Back to home
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/export/app/nested/inner/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/nested/inner/layout.tsx
@@ -1,0 +1,12 @@
+export default function InnerLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div id="inner-layout">
+      <h3>Inner layout</h3>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/export/app/nested/inner/page.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/nested/inner/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function NestedInnerPage() {
+  return (
+    <>
+      <div id="nested-inner-page">Nested inner page</div>
+      {/* Not prefetched, so that a test can assert that navigating here costs
+          no network requests at all. */}
+      <Link href="/" prefetch={false}>
+        Back to home
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/export/app/nested/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/nested/layout.tsx
@@ -1,0 +1,12 @@
+export default function NestedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div id="nested-layout">
+      <h2>Nested layout</h2>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/export/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/page.tsx
@@ -11,9 +11,14 @@ export default function OutputExport() {
         <li>
           <LinkAccordion href="/target-page">Target</LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/target-page" prefetch name="target-page-eager">
+            Target (prefetch=true)
+          </LinkAccordion>
+        </li>
       </ul>
       <p>
-        The following link is rewritten on the server to the same page as the
+        The following links are rewritten on the server to the same page as the
         link above:
       </p>
       <ul>
@@ -22,15 +27,49 @@ export default function OutputExport() {
             Rewrite to target page
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion
+            href="/rewrite-to-target-page"
+            prefetch
+            name="rewrite-eager"
+          >
+            Rewrite to target page (prefetch=true)
+          </LinkAccordion>
+        </li>
       </ul>
       <p>
-        The following link is redirected on the server to the same page as the
+        The following links are redirected on the server to the same page as the
         link above:
       </p>
       <ul>
         <li>
           <LinkAccordion href="/redirect-to-target-page">
             Redirect to target page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion
+            href="/redirect-to-target-page"
+            prefetch
+            name="redirect-eager"
+          >
+            Redirect to target page (prefetch=true)
+          </LinkAccordion>
+        </li>
+      </ul>
+      <p>The following link points at a route with a dynamic param:</p>
+      <ul>
+        <li>
+          <LinkAccordion href="/dynamic/first" prefetch name="dynamic-eager">
+            Dynamic page
+          </LinkAccordion>
+        </li>
+      </ul>
+      <p>The following link points at a page below two nested layouts:</p>
+      <ul>
+        <li>
+          <LinkAccordion href="/nested/inner" prefetch name="nested-eager">
+            Nested inner page
           </LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/export/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/page.tsx
@@ -65,6 +65,21 @@ export default function OutputExport() {
           </LinkAccordion>
         </li>
       </ul>
+      <p>
+        The following link points at a dynamic param that was not exported, so
+        none of its segment files exist on disk:
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion
+            href="/dynamic/second"
+            prefetch
+            name="dynamic-missing-eager"
+          >
+            Missing dynamic page
+          </LinkAccordion>
+        </li>
+      </ul>
       <p>The following link points at a page below two nested layouts:</p>
       <ul>
         <li>

--- a/test/e2e/app-dir/segment-cache/export/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/export/components/link-accordion.tsx
@@ -3,7 +3,12 @@
 import Link from 'next/link'
 import { useState } from 'react'
 
-export function LinkAccordion({ href, children }) {
+export function LinkAccordion({
+  href,
+  children,
+  prefetch = undefined,
+  name = href,
+}) {
   const [isVisible, setIsVisible] = useState(false)
   return (
     <>
@@ -11,10 +16,12 @@ export function LinkAccordion({ href, children }) {
         type="checkbox"
         checked={isVisible}
         onChange={() => setIsVisible(!isVisible)}
-        data-link-accordion={href}
+        data-link-accordion={name}
       />
       {isVisible ? (
-        <Link href={href}>{children}</Link>
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
       ) : (
         `${children} (link is hidden)`
       )}

--- a/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
+++ b/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
@@ -150,7 +150,7 @@ describe('segment cache (output: "export")', () => {
         )
         await checkbox.click()
       },
-      { includes: 'Dynamic page: first' }
+      { includes: 'Dynamic page: first', kind: 'static' }
     )
 
     expect(fetched).not.toContain('/dynamic/first')
@@ -178,7 +178,7 @@ describe('segment cache (output: "export")', () => {
         )
         await checkbox.click()
       },
-      { includes: 'Nested inner page' }
+      { includes: 'Nested inner page', kind: 'static' }
     )
 
     // Whatever the router decides to request, at any depth, it has to be a file

--- a/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
+++ b/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
@@ -39,6 +39,33 @@ describe('segment cache (output: "export")', () => {
     server?.close()
   })
 
+  // A static export can only serve the files the exporter wrote, so every
+  // prefetch has to read the per-segment files rather than the page itself.
+  // Tests that assert on this open the home page through this helper, which
+  // records the pathname of every request the router makes.
+  async function loadHomeAndRecordFetches() {
+    let act: ReturnType<typeof createRouterAct>
+    const fetched: string[] = []
+    const browser = await next.browser('/', {
+      baseUrl: port,
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+        p.on('response', (response) => {
+          // Prefetching sends a HEAD request to the page to resolve redirects,
+          // so only the GETs describe what the router reads.
+          const { pathname } = new URL(response.url())
+          if (
+            response.request().method() === 'GET' &&
+            !pathname.startsWith('/_next/static/')
+          ) {
+            fetched.push(pathname)
+          }
+        })
+      },
+    })
+    return { browser, act: act!, fetched }
+  }
+
   it('basic prefetch in output: "export" mode', async () => {
     let act
     const browser = await next.browser('/', {
@@ -74,6 +101,110 @@ describe('segment cache (output: "export")', () => {
         includes: 'Demonstrates that per-segment prefetching works',
       }
     )
+  })
+
+  it('prefetch a link with prefetch={true}', async () => {
+    const { browser, act, fetched } = await loadHomeAndRecordFetches()
+
+    // `kind: 'static'` is the assertion that this fetched per-segment files
+    // rather than issuing a dynamic request. A dynamic request would be served
+    // the page's HTML document, which happens to contain the same text, so
+    // matching on content alone would not tell the two apart.
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="target-page-eager"]'
+        )
+        await checkbox.click()
+      },
+      { includes: 'Target page', kind: 'static' }
+    )
+
+    // Requesting the page would return its HTML document, which cannot be
+    // decoded as Flight.
+    expect(fetched).not.toContain('/target-page')
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss('a[href="/target-page"]')
+        await link.click()
+
+        const div = await browser.elementById('target-page')
+        expect(await div.text()).toBe('Target page')
+
+        await browser.elementByCss('a[href="/"]')
+      },
+      {
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
+
+  it('prefetch a link with prefetch={true} to a route with a dynamic param', async () => {
+    const { browser, act, fetched } = await loadHomeAndRecordFetches()
+
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="dynamic-eager"]'
+        )
+        await checkbox.click()
+      },
+      { includes: 'Dynamic page: first' }
+    )
+
+    expect(fetched).not.toContain('/dynamic/first')
+
+    // The payoff of a prefetch is that the navigation needs no network. This is
+    // what makes the assertion above meaningful: a prefetch that fetched the
+    // wrong thing would leave the click to fetch the page itself.
+    await act(async () => {
+      const link = await browser.elementByCss('a[href="/dynamic/first"]')
+      await link.click()
+
+      const div = await browser.elementById('dynamic-page')
+      expect(await div.text()).toBe('Dynamic page: first')
+      expect(new URL(await browser.url()).pathname).toBe('/dynamic/first')
+    }, 'no-requests')
+  })
+
+  it('prefetch a link with prefetch={true} to a page below nested layouts', async () => {
+    const { browser, act, fetched } = await loadHomeAndRecordFetches()
+
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="nested-eager"]'
+        )
+        await checkbox.click()
+      },
+      { includes: 'Nested inner page' }
+    )
+
+    // Whatever the router decides to request, at any depth, it has to be a file
+    // the exporter wrote. Reading a route path would return an HTML document.
+    expect(fetched).not.toContain('/nested/inner')
+    expect(fetched).not.toContain('/nested')
+    expect(
+      fetched.filter(
+        (pathname) => pathname !== '/' && !pathname.endsWith('.txt')
+      )
+    ).toEqual([])
+
+    await act(async () => {
+      const link = await browser.elementByCss('a[href="/nested/inner"]')
+      await link.click()
+
+      const div = await browser.elementById('nested-inner-page')
+      expect(await div.text()).toBe('Nested inner page')
+      expect(await browser.elementById('nested-layout').text()).toContain(
+        'Nested layout'
+      )
+      expect(await browser.elementById('inner-layout').text()).toContain(
+        'Inner layout'
+      )
+      expect(new URL(await browser.url()).pathname).toBe('/nested/inner')
+    }, 'no-requests')
   })
 
   it('prefetch a link to a page that is rewritten server side', async () => {
@@ -115,6 +246,41 @@ describe('segment cache (output: "export")', () => {
     )
   })
 
+  it('prefetch a link with prefetch={true} to a page that is rewritten server side', async () => {
+    const { browser, act, fetched } = await loadHomeAndRecordFetches()
+
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="rewrite-eager"]'
+        )
+        await checkbox.click()
+      },
+      { includes: 'Target page', kind: 'static' }
+    )
+
+    // The router does not know about the rewrite, so it asks for segment files
+    // under the link's own path and lets the server map them over.
+    expect(fetched).not.toContain('/rewrite-to-target-page')
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/rewrite-to-target-page"]'
+        )
+        await link.click()
+
+        const div = await browser.elementById('target-page')
+        expect(await div.text()).toBe('Target page')
+
+        await browser.elementByCss('a[href="/"]')
+      },
+      {
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
+
   it('prefetch a link to a page that is redirected server side', async () => {
     let act
     const browser = await next.browser('/', {
@@ -135,6 +301,42 @@ describe('segment cache (output: "export")', () => {
         includes: 'Target page',
       }
     )
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/redirect-to-target-page"]'
+        )
+        await link.click()
+
+        const div = await browser.elementById('target-page')
+        expect(await div.text()).toBe('Target page')
+
+        await browser.elementByCss('a[href="/"]')
+      },
+      {
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
+
+  it('prefetch a link with prefetch={true} to a page that is redirected server side', async () => {
+    const { browser, act, fetched } = await loadHomeAndRecordFetches()
+
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-link-accordion="redirect-eager"]'
+        )
+        await checkbox.click()
+      },
+      { includes: 'Target page', kind: 'static' }
+    )
+
+    // The HEAD probe resolves the redirect first, so the segment files are read
+    // from the destination rather than from the link's own path.
+    expect(fetched).not.toContain('/redirect-to-target-page')
+    expect(fetched).not.toContain('/target-page')
 
     await act(
       async () => {

--- a/test/e2e/app-dir/segment-cache/export/server.mjs
+++ b/test/e2e/app-dir/segment-cache/export/server.mjs
@@ -2,6 +2,7 @@
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'node:http'
+import { existsSync } from 'node:fs'
 
 // output: "export" mode was originally designed to work seamlessly with the
 // "serve" package, which uses "server-handler" internally. It has built-in
@@ -36,6 +37,22 @@ export function createExportServer(outDir = DEFAULT_OUT_DIR) {
       request.url = newUrl
     }
 
+    return handler(request, response, {
+      public: outDir,
+    })
+  })
+}
+
+// Mimics a static host with an SPA fallback: Netlify's `200.html`, an S3
+// error-document, or Cloudflare Pages. Anything not on disk is answered with
+// the index document and a 200 rather than a 404. Only applied to the
+// per-segment `.txt` files, which is the surface the router prefetches.
+export function createSpaFallbackServer(outDir = DEFAULT_OUT_DIR) {
+  return createServer((request, response) => {
+    const { pathname } = new URL(request.url, 'http://n')
+    if (pathname.endsWith('.txt') && !existsSync(join(outDir, pathname))) {
+      request.url = '/index.html'
+    }
     return handler(request, response, {
       public: outDir,
     })


### PR DESCRIPTION
Fixes: #92341

Inert navigations with `<Link prefetch={true}>` and `output: 'export'`.

Segment cache export support (#75671) only wired up the per-segment static path. `prefetch={true}` goes through another one: it resolves to `FetchStrategy.Full`, which requests the page URL rather than the `__next.*.txt` files we write for export mode, so a static host hands it the HTML document.

> Observed in a plain create-next-app only after v16, once the segment cache became the default

Having a branch that does `FetchStrategy.PPR` for export mode fixes it, otherwise every other branch **_in that switch_** ends in a dynamic request. It's also fine, because a static export has no dynamic data, so there is nothing a full prefetch would fetch that the per-segment files do not already contain.

---

The Flight client is invoked with `allowPartialStream: true`, so it does not reject on input it cannot parse; it simply never finishes. The segment entries the navigation waits on stay pending forever, and the click has nothing to resolve against.

As far as I understand, we could also reject the HTML response, or pass `allowPartialStream: false`. Either would make the prefetch reject rather than hang, and the navigation would then fetch `.txt` on its own — on click. I haven't looked too deep into those, and they'd defeat the purpose of the prefetch.
