### PR TITLE
Add Request Insights controls and request details

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.test.ts
@@ -1,0 +1,60 @@
+import { getFetchUrlPresentation, truncateMiddle } from './fetch-label'
+
+describe('request insight fetch labels', () => {
+  it('classifies same-origin and external fetches by full web origin', () => {
+    expect(
+      getFetchUrlPresentation('/api/items?token=redacted', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'https://app.test/api/items?token=redacted',
+      path: '/api/items?token=redacted',
+      originKind: 'same-origin',
+      originLabel: 'Same origin',
+    })
+    expect(
+      getFetchUrlPresentation('https://api.test:445/items', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'https://api.test:445/items',
+      path: '/items',
+      originKind: 'external',
+      originLabel: 'External origin · api.test:445',
+    })
+    expect(
+      getFetchUrlPresentation('http://app.test/items', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'http://app.test/items',
+      path: '/items',
+      originKind: 'external',
+      originLabel: 'External origin · http://app.test',
+    })
+  })
+
+  it('does not guess origin semantics without a usable browser origin', () => {
+    expect(
+      getFetchUrlPresentation('https://api.test/items', undefined)
+    ).toEqual({
+      fullUrl: 'https://api.test/items',
+      path: '/items',
+      originKind: 'unknown',
+      originLabel: 'https://api.test',
+    })
+    expect(getFetchUrlPresentation('/api/items', undefined)).toEqual({
+      fullUrl: '/api/items',
+      path: '/api/items',
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    })
+  })
+
+  it('middle-truncates labels while retaining their distinguishing suffix', () => {
+    const value = '/api/a/very/long/path/to/tail-marker?token=redacted'
+    const truncated = truncateMiddle(value, 28)
+
+    expect(truncated).toHaveLength(28)
+    expect(truncated).toContain('…')
+    expect(truncated).toMatch(/token=redacted$/)
+
+    expect(truncateMiddle('😀abc', 3)).toBe('😀…c')
+    expect(truncateMiddle('secret', 1)).toBe('…')
+    expect(truncateMiddle('secret', 0)).toBe('')
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.ts
@@ -1,0 +1,111 @@
+export type FetchOriginKind = 'same-origin' | 'external' | 'unknown'
+
+export type FetchUrlPresentation = {
+  fullUrl: string
+  path: string
+  originKind: FetchOriginKind
+  originLabel: string
+}
+
+const DEFAULT_PATH_LENGTH = 48
+const DEFAULT_ORIGIN_LENGTH = 36
+
+export function getFetchUrlPresentation(
+  url: string | undefined,
+  currentOrigin: string | undefined,
+  pathLength = DEFAULT_PATH_LENGTH,
+  originLength = DEFAULT_ORIGIN_LENGTH
+): FetchUrlPresentation {
+  if (!url) {
+    return {
+      fullUrl: 'Unknown URL',
+      path: 'Unknown URL',
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    }
+  }
+
+  const baseUrl = parseHttpUrl(currentOrigin)
+
+  try {
+    const parsedUrl = baseUrl ? new URL(url, baseUrl) : new URL(url)
+    if (!isHttpUrl(parsedUrl)) {
+      return {
+        fullUrl: url,
+        path: truncateMiddle(url, pathLength),
+        originKind: 'unknown',
+        originLabel: 'Origin unavailable',
+      }
+    }
+
+    const sameOrigin = baseUrl?.origin === parsedUrl.origin
+    const originKind = baseUrl
+      ? sameOrigin
+        ? 'same-origin'
+        : 'external'
+      : 'unknown'
+    const compactOrigin =
+      baseUrl?.protocol === parsedUrl.protocol
+        ? parsedUrl.host
+        : parsedUrl.origin
+
+    return {
+      fullUrl: parsedUrl.href,
+      path: truncateMiddle(
+        `${parsedUrl.pathname}${parsedUrl.search}`,
+        pathLength
+      ),
+      originKind,
+      originLabel:
+        originKind === 'same-origin'
+          ? 'Same origin'
+          : originKind === 'external'
+            ? `External origin · ${truncateMiddle(compactOrigin, originLength)}`
+            : truncateMiddle(parsedUrl.origin, originLength),
+    }
+  } catch {
+    return {
+      fullUrl: url,
+      path: truncateMiddle(url, pathLength),
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    }
+  }
+}
+
+export function truncateMiddle(value: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return ''
+  }
+  const characters = Array.from(value)
+  if (characters.length <= maxLength) {
+    return value
+  }
+  if (maxLength === 1) {
+    return '…'
+  }
+
+  const availableLength = maxLength - 1
+  const prefixLength = Math.floor(availableLength / 2)
+  const suffixLength = availableLength - prefixLength
+  return `${characters.slice(0, prefixLength).join('')}…${characters
+    .slice(-suffixLength)
+    .join('')}`
+}
+
+function parseHttpUrl(value: string | undefined): URL | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(value)
+    return isHttpUrl(url) ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:'
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -1,0 +1,285 @@
+import {
+  getRequestInsightKind,
+  getRequestInsightSource,
+  type RequestInsight,
+} from '../../../shared/request-insights'
+import {
+  getRequestInsightRepresentation,
+  getRequestInsightRouterActivity,
+  getRequestInsightStatusCode,
+  hasRequestInsightProxyActivity,
+} from './request-list'
+
+export type RequestInsightFilter =
+  | 'source:page'
+  | 'source:action'
+  | 'source:api'
+  | 'source:image'
+  | 'source:asset'
+  | 'source:unknown'
+  | 'representation:html'
+  | 'representation:rsc'
+  | 'representation:unknown'
+  | 'activity:proxy'
+  | 'activity:instant-insights'
+  | 'activity:prefetch'
+  | 'activity:segment-prefetch'
+  | 'activity:hmr-refresh'
+  | 'status:error'
+  | 'status:http-4xx'
+  | 'status:http-5xx'
+  | 'fetches:present'
+  | 'fetches:none'
+  | 'cache:hit'
+  | 'cache:miss'
+  | 'cache:skip'
+  | 'cache:none'
+
+export type RequestInsightFilterGroup = Readonly<{
+  label: string
+  options: ReadonlyArray<{
+    value: RequestInsightFilter
+    label: string
+  }>
+}>
+
+export const REQUEST_INSIGHT_FILTER_GROUPS: readonly RequestInsightFilterGroup[] =
+  [
+    {
+      label: 'Request type',
+      options: [
+        { value: 'source:page', label: 'Page or navigation' },
+        { value: 'source:action', label: 'Server Action' },
+        { value: 'source:api', label: 'API' },
+        { value: 'source:image', label: 'Image optimization' },
+        { value: 'source:asset', label: 'Static asset' },
+        { value: 'source:unknown', label: 'Unknown type' },
+      ],
+    },
+    {
+      label: 'Page response',
+      options: [
+        { value: 'representation:html', label: 'HTML' },
+        { value: 'representation:rsc', label: 'RSC' },
+        { value: 'representation:unknown', label: 'Unavailable' },
+      ],
+    },
+    {
+      label: 'Activity',
+      options: [
+        { value: 'activity:proxy', label: 'Matched proxy' },
+        { value: 'activity:prefetch', label: 'App Router prefetch' },
+        { value: 'activity:segment-prefetch', label: 'Segment prefetch' },
+        { value: 'activity:hmr-refresh', label: 'HMR refresh' },
+        { value: 'activity:instant-insights', label: 'Instant Insights' },
+      ],
+    },
+    {
+      label: 'Status',
+      options: [
+        { value: 'status:error', label: 'Recorded error' },
+        { value: 'status:http-4xx', label: 'HTTP 4xx' },
+        { value: 'status:http-5xx', label: 'HTTP 5xx' },
+      ],
+    },
+    {
+      label: 'Fetches',
+      options: [
+        { value: 'fetches:present', label: 'Has fetches' },
+        { value: 'fetches:none', label: 'No fetches' },
+      ],
+    },
+    {
+      label: 'Fetch cache',
+      options: [
+        { value: 'cache:hit', label: 'Hit' },
+        { value: 'cache:miss', label: 'Miss' },
+        { value: 'cache:skip', label: 'Skip' },
+        { value: 'cache:none', label: 'No cache activity' },
+      ],
+    },
+  ]
+
+const ALL_FILTERS = REQUEST_INSIGHT_FILTER_GROUPS.flatMap((group) =>
+  group.options.map((option) => option.value)
+)
+
+type RequestInsightFilterResult = Readonly<{
+  requests: RequestInsight[]
+  matchingRequestCount: number
+  totalRequestCount: number
+  optionCounts: Readonly<Record<RequestInsightFilter, number>>
+}>
+
+export function getRequestInsightFilterResult(
+  requests: readonly RequestInsight[],
+  activeFilters: readonly RequestInsightFilter[],
+  showInternal = false
+): RequestInsightFilterResult {
+  const revealInternal =
+    showInternal || activeFilters.includes('activity:instant-insights')
+  const visibleRequests = requests.filter(
+    (request) => getRequestInsightKind(request) === 'request' || revealInternal
+  )
+  const activeFiltersByFacet = groupFiltersByFacet(activeFilters)
+  const optionCounts = Object.fromEntries(
+    ALL_FILTERS.map((filter) => [filter, 0])
+  ) as Record<RequestInsightFilter, number>
+
+  for (const request of requests) {
+    const tags = getRequestInsightTags(request)
+    if (getRequestInsightKind(request) === 'request' || showInternal) {
+      for (const tag of tags) {
+        optionCounts[tag] += 1
+      }
+    } else if (tags.has('activity:instant-insights')) {
+      optionCounts['activity:instant-insights'] += 1
+    }
+  }
+
+  const matchingRequests = visibleRequests.filter((request) =>
+    matchesActiveFilters(getRequestInsightTags(request), activeFiltersByFacet)
+  )
+
+  return {
+    requests: matchingRequests,
+    matchingRequestCount: matchingRequests.length,
+    totalRequestCount: visibleRequests.length,
+    optionCounts,
+  }
+}
+
+export function toggleRequestInsightFilter(
+  activeFilters: readonly RequestInsightFilter[],
+  filter: RequestInsightFilter
+): RequestInsightFilter[] {
+  return activeFilters.includes(filter)
+    ? activeFilters.filter((activeFilter) => activeFilter !== filter)
+    : [...activeFilters, filter]
+}
+
+function getRequestInsightTags(
+  request: RequestInsight
+): Set<RequestInsightFilter> {
+  const tags = new Set<RequestInsightFilter>()
+  const source = getRequestSourceFilter(request)
+  if (source) {
+    tags.add(source)
+  }
+
+  switch (getRequestInsightRepresentation(request)) {
+    case 'html':
+      tags.add('representation:html')
+      break
+    case 'rsc':
+      tags.add('representation:rsc')
+      break
+    case 'unknown':
+      tags.add('representation:unknown')
+      break
+    case 'not-applicable':
+      break
+  }
+
+  if (hasRequestInsightProxyActivity(request)) {
+    tags.add('activity:proxy')
+  }
+  const routerActivity = getRequestInsightRouterActivity(request)
+  if (routerActivity) {
+    tags.add(`activity:${routerActivity}`)
+  }
+  if (getRequestInsightKind(request) === 'instant-insights') {
+    tags.add('activity:instant-insights')
+  }
+
+  if (
+    request.status === 'error' ||
+    request.spans.some((span) => span.status === 'error' || span.error)
+  ) {
+    tags.add('status:error')
+  }
+  const statusCode = getRequestInsightStatusCode(request)
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+    tags.add('status:http-4xx')
+  } else if (
+    statusCode !== undefined &&
+    statusCode >= 500 &&
+    statusCode < 600
+  ) {
+    tags.add('status:http-5xx')
+  }
+
+  if (request.fetches.length === 0) {
+    tags.add('fetches:none')
+    tags.add('cache:none')
+  } else {
+    tags.add('fetches:present')
+    for (const fetch of request.fetches) {
+      if (
+        fetch.cacheStatus === 'hit' ||
+        fetch.cacheStatus === 'miss' ||
+        fetch.cacheStatus === 'skip'
+      ) {
+        tags.add(`cache:${fetch.cacheStatus}`)
+      }
+    }
+  }
+
+  return tags
+}
+
+function getRequestSourceFilter(
+  request: RequestInsight
+): RequestInsightFilter | undefined {
+  const source = getRequestInsightSource(request)
+  if (source === 'page' && request.serverAction) {
+    return 'source:action'
+  }
+
+  switch (source) {
+    case 'page':
+      return 'source:page'
+    case 'app-route':
+    case 'pages-api':
+      return 'source:api'
+    case 'image':
+      return 'source:image'
+    case 'asset':
+      return 'source:asset'
+    case 'proxy':
+    case 'instant-insights':
+      return undefined
+    case 'unknown':
+      return 'source:unknown'
+  }
+}
+
+function groupFiltersByFacet(
+  filters: readonly RequestInsightFilter[]
+): Map<string, RequestInsightFilter[]> {
+  const filtersByFacet = new Map<string, RequestInsightFilter[]>()
+
+  for (const filter of filters) {
+    const facet = filter.slice(0, filter.indexOf(':'))
+    const facetFilters = filtersByFacet.get(facet)
+    if (facetFilters) {
+      facetFilters.push(filter)
+    } else {
+      filtersByFacet.set(facet, [filter])
+    }
+  }
+
+  return filtersByFacet
+}
+
+function matchesActiveFilters(
+  tags: ReadonlySet<RequestInsightFilter>,
+  activeFiltersByFacet: ReadonlyMap<string, RequestInsightFilter[]>
+): boolean {
+  for (const facetFilters of activeFiltersByFacet.values()) {
+    if (!facetFilters.some((filter) => tags.has(filter))) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -8,6 +8,7 @@ import {
   getRequestInsightRouterActivity,
   getRequestInsightStatusCode,
   hasRequestInsightProxyActivity,
+  type RequestListEntry,
 } from './request-list'
 
 export type RequestInsightFilter =
@@ -105,46 +106,37 @@ const ALL_FILTERS = REQUEST_INSIGHT_FILTER_GROUPS.flatMap((group) =>
 )
 
 type RequestInsightFilterResult = Readonly<{
-  requests: RequestInsight[]
+  entries: RequestListEntry[]
   matchingRequestCount: number
   totalRequestCount: number
   optionCounts: Readonly<Record<RequestInsightFilter, number>>
 }>
 
 export function getRequestInsightFilterResult(
-  requests: readonly RequestInsight[],
-  activeFilters: readonly RequestInsightFilter[],
-  showInternal = false
+  entries: readonly RequestListEntry[],
+  activeFilters: readonly RequestInsightFilter[]
 ): RequestInsightFilterResult {
-  const revealInternal =
-    showInternal || activeFilters.includes('activity:instant-insights')
-  const visibleRequests = requests.filter(
-    (request) => getRequestInsightKind(request) === 'request' || revealInternal
-  )
   const activeFiltersByFacet = groupFiltersByFacet(activeFilters)
   const optionCounts = Object.fromEntries(
     ALL_FILTERS.map((filter) => [filter, 0])
   ) as Record<RequestInsightFilter, number>
 
-  for (const request of requests) {
-    const tags = getRequestInsightTags(request)
-    if (getRequestInsightKind(request) === 'request' || showInternal) {
-      for (const tag of tags) {
-        optionCounts[tag] += 1
-      }
-    } else if (tags.has('activity:instant-insights')) {
-      optionCounts['activity:instant-insights'] += 1
+  for (const entry of entries) {
+    const tags = getRequestInsightTags(entry)
+    for (const tag of tags) {
+      optionCounts[tag] += 1
     }
   }
 
-  const matchingRequests = visibleRequests.filter((request) =>
-    matchesActiveFilters(getRequestInsightTags(request), activeFiltersByFacet)
-  )
+  const matchingEntries = entries.filter((entry) => {
+    const tags = getRequestInsightTags(entry)
+    return matchesActiveFilters(tags, activeFiltersByFacet)
+  })
 
   return {
-    requests: matchingRequests,
-    matchingRequestCount: matchingRequests.length,
-    totalRequestCount: visibleRequests.length,
+    entries: matchingEntries,
+    matchingRequestCount: matchingEntries.length,
+    totalRequestCount: entries.length,
     optionCounts,
   }
 }
@@ -159,8 +151,9 @@ export function toggleRequestInsightFilter(
 }
 
 function getRequestInsightTags(
-  request: RequestInsight
+  entry: RequestListEntry
 ): Set<RequestInsightFilter> {
+  const { request } = entry
   const tags = new Set<RequestInsightFilter>()
   const source = getRequestSourceFilter(request)
   if (source) {
@@ -188,13 +181,19 @@ function getRequestInsightTags(
   if (routerActivity) {
     tags.add(`activity:${routerActivity}`)
   }
-  if (getRequestInsightKind(request) === 'instant-insights') {
+  if (
+    entry.instantInsights.length > 0 ||
+    getRequestInsightKind(request) === 'instant-insights'
+  ) {
     tags.add('activity:instant-insights')
   }
 
   if (
-    request.status === 'error' ||
-    request.spans.some((span) => span.status === 'error' || span.error)
+    [request, ...entry.instantInsights].some(
+      (item) =>
+        item.status === 'error' ||
+        item.spans.some((span) => span.status === 'error' || span.error)
+    )
   ) {
     tags.add('status:error')
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -1,3 +1,9 @@
+.request-insights-panel-container {
+  container-type: inline-size;
+  height: 100%;
+  min-height: 0;
+}
+
 .request-insights-panel {
   display: grid;
   grid-template-columns: minmax(210px, 320px) minmax(420px, 1fr);
@@ -462,13 +468,61 @@
 }
 
 .request-insights-overview span {
+  overflow: hidden;
+  max-width: 100%;
   min-width: 0;
   border: 1px solid var(--color-gray-400);
   border-radius: 4px;
   padding: 2px 6px;
   color: var(--color-gray-900);
   font-size: var(--size-12);
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-overview .request-insights-route-template {
+  border-style: dashed;
+  font-family: var(--font-mono);
+}
+
+.request-insights-params-trigger {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: help;
+  font: inherit;
+}
+
+.request-insights-params-trigger:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.request-insights-params-tooltip,
+.request-insights-fetch-tooltip,
+.request-insights-trace-tooltip {
+  --tooltip-background: var(--color-background-100);
+
+  border: 1px solid var(--color-gray-alpha-400);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 16%);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-params-tooltip {
+  max-width: min(420px, calc(100vw - 32px));
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.request-insights-fetch-tooltip,
+.request-insights-trace-tooltip {
+  max-width: min(640px, calc(100vw - 32px));
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .request-insights-error {
@@ -596,9 +650,18 @@
   flex-direction: column;
 }
 
+.request-insights-trace-rows:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -1px;
+}
+
 .request-insights-span-row {
   min-height: 28px;
   border-bottom: 1px solid var(--color-gray-300);
+}
+
+.request-insights-span-row[data-active='true'] {
+  background: var(--color-gray-200);
 }
 
 .request-insights-span-row:last-child {
@@ -642,7 +705,6 @@
   background: var(--color-red-800);
 }
 
-.request-insights-fetch-host,
 .request-insights-cache-reason {
   min-width: 0;
   overflow: hidden;
@@ -720,7 +782,52 @@
   gap: 8px;
 }
 
-@media (max-width: 900px) {
+.request-insights-fetch-url-trigger {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  cursor: help;
+}
+
+.request-insights-fetch-path,
+.request-insights-fetch-origin {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.request-insights-fetch-path {
+  color: var(--color-gray-1000);
+  text-overflow: ellipsis;
+}
+
+.request-insights-fetch-origin {
+  max-width: 240px;
+  flex-shrink: 0;
+  border: 1px solid var(--color-gray-400);
+  border-radius: 999px;
+  padding: 0 5px;
+  color: var(--color-gray-800);
+  font-family: inherit;
+  font-size: var(--size-10);
+  text-overflow: ellipsis;
+}
+
+.request-insights-fetch-origin[data-origin='external'] {
+  border-color: var(--color-purple-500);
+  color: var(--color-purple-900);
+}
+
+@media (forced-colors: active) {
+  .request-insights-trace-rows:focus-visible,
+  .request-insights-span-row[data-active='true'] {
+    outline: 1px solid Highlight;
+    outline-offset: -1px;
+  }
+}
+
+@container (width <= 900px) {
   .request-insights-summary {
     align-items: flex-start;
   }
@@ -730,7 +837,7 @@
   }
 }
 
-@media (max-width: 700px) {
+@container (width < 630px) {
   .request-insights-panel {
     grid-template-columns: 1fr;
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -28,6 +28,7 @@
 .request-insights-list {
   border-right: 1px solid var(--color-gray-400);
   overflow: auto;
+  overscroll-behavior: contain;
   min-width: 0;
 }
 
@@ -54,8 +55,50 @@
   gap: 6px;
 }
 
+.request-insights-scope-switcher {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--color-gray-400);
+  background: var(--color-background-100);
+}
+
+.request-insights-scope-switcher button {
+  min-height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-gray-900);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--size-11);
+}
+
+.request-insights-scope-switcher button:focus-visible,
+.request-insights-row:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.request-insights-scope-switcher button:hover:not(:disabled) {
+  background: var(--color-gray-200);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-scope-switcher button[aria-pressed='true'] {
+  background: var(--color-gray-300);
+  color: var(--color-gray-1000);
+  font-weight: 500;
+}
+
+.request-insights-scope-switcher button:disabled {
+  color: var(--color-gray-600);
+  cursor: default;
+}
+
 .request-insights-update-status {
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-11);
   white-space: nowrap;
 }
@@ -95,7 +138,7 @@
   border-radius: 999px;
   padding: 0 4px;
   background: var(--color-blue-800);
-  color: var(--color-background-100);
+  color: white;
   font-size: var(--size-10);
   line-height: 16px;
   text-align: center;
@@ -121,7 +164,7 @@
 
 .request-insights-filter-group-label {
   padding: 8px 8px 3px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-10);
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -157,7 +200,7 @@
 
 .request-insights-filter-option-count {
   min-width: 20px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-family: var(--font-mono);
   font-size: var(--size-11);
   text-align: right;
@@ -393,6 +436,20 @@
   color: var(--color-gray-800);
 }
 
+.request-insights-request-error {
+  flex-shrink: 0;
+  color: var(--color-red-900);
+  font-size: var(--size-11);
+}
+
+.request-insights-request-activity[data-activity='instant-insights'] {
+  color: var(--color-blue-900);
+}
+
+.request-insights-request-activity[data-activity='instant-insights'][data-status='error'] {
+  color: var(--color-red-900);
+}
+
 .request-insights-duration,
 .request-insights-meta {
   color: var(--color-gray-900);
@@ -418,6 +475,69 @@
   min-width: 0;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.request-insights-instant-section {
+  border-top: 1px solid var(--color-gray-400);
+}
+
+.request-insights-instant-section > summary {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  font-size: var(--size-12);
+  font-weight: 600;
+  list-style: none;
+}
+
+.request-insights-instant-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+.request-insights-instant-section > summary::before {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  content: '';
+  transform-origin: 2px 50%;
+}
+
+.request-insights-instant-section[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.request-insights-instant-section > summary > :first-child {
+  flex: 1;
+}
+
+.request-insights-instant-section > summary:hover {
+  background: var(--color-gray-100);
+}
+
+.request-insights-instant-section > summary:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.request-insights-instant-record {
+  border-top: 1px solid var(--color-gray-400);
+}
+
+.request-insights-instant-record-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
 }
 
 .request-insights-summary {
@@ -565,7 +685,7 @@
 }
 
 .request-insights-section-note {
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-11);
 }
 
@@ -747,6 +867,8 @@
 .request-insights-fetch-table {
   display: flex;
   flex-direction: column;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
   border-top: 1px solid var(--color-gray-400);
 }
 
@@ -760,6 +882,7 @@
   color: var(--color-gray-900);
   font-family: var(--font-mono);
   font-size: var(--size-12);
+  min-width: 640px;
 }
 
 .request-insights-fetch-header {
@@ -808,7 +931,7 @@
   border: 1px solid var(--color-gray-400);
   border-radius: 999px;
   padding: 0 5px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-family: inherit;
   font-size: var(--size-10);
   text-overflow: ellipsis;
@@ -846,13 +969,5 @@
     max-height: 180px;
     border-right: 0;
     border-bottom: 1px solid var(--color-gray-400);
-  }
-
-  .request-insights-fetch {
-    grid-template-columns: 44px minmax(0, 1fr) 56px;
-  }
-
-  .request-insights-fetch > span:nth-child(n + 4) {
-    display: none;
   }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -40,6 +40,162 @@
   font-size: var(--size-12);
 }
 
+.request-insights-list-controls,
+.request-insights-update-status {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.request-insights-update-status {
+  color: var(--color-gray-800);
+  font-size: var(--size-11);
+  white-space: nowrap;
+}
+
+.request-insights-paused-state::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 4px;
+  border-radius: 999px;
+  background: var(--color-amber-800);
+  content: '';
+}
+
+.request-insights-filter-trigger {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--color-gray-400);
+  border-radius: 4px;
+  padding: 2px 6px;
+  background: transparent;
+  color: var(--color-gray-900);
+  cursor: pointer;
+  font: inherit;
+}
+
+.request-insights-filter-trigger:hover,
+.request-insights-filter-trigger[aria-expanded='true'] {
+  background: var(--color-gray-200);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-filter-active-count {
+  min-width: 16px;
+  border-radius: 999px;
+  padding: 0 4px;
+  background: var(--color-blue-800);
+  color: var(--color-background-100);
+  font-size: var(--size-10);
+  line-height: 16px;
+  text-align: center;
+}
+
+.request-insights-filter-positioner {
+  z-index: var(--top-z-index);
+}
+
+.request-insights-filter-menu {
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  width: min(280px, calc(100vw - 24px));
+  max-height: min(560px, calc(100vh - 48px));
+  border: 1px solid var(--color-gray-400);
+  border-radius: 8px;
+  background: var(--color-background-100);
+  box-shadow: 0px 4px 8px -4px
+    color-mix(in srgb, var(--color-gray-900) 4%, transparent);
+  padding: 4px;
+  user-select: none;
+}
+
+.request-insights-filter-group-label {
+  padding: 8px 8px 3px;
+  color: var(--color-gray-800);
+  font-size: var(--size-10);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.request-insights-filter-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  font-size: var(--size-12);
+}
+
+.request-insights-filter-item[data-highlighted] {
+  background: var(--color-gray-200);
+}
+
+.request-insights-filter-item[data-disabled] {
+  color: var(--color-gray-700);
+  cursor: default;
+}
+
+.request-insights-filter-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.request-insights-filter-option-count {
+  min-width: 20px;
+  color: var(--color-gray-800);
+  font-family: var(--font-mono);
+  font-size: var(--size-11);
+  text-align: right;
+}
+
+.request-insights-filter-reset {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  margin-top: 4px;
+  border-top: 1px solid var(--color-gray-400);
+  padding: 6px 8px 2px;
+  color: var(--color-blue-900);
+  cursor: pointer;
+  font-size: var(--size-12);
+}
+
+.request-insights-filter-reset[data-disabled] {
+  color: var(--color-gray-700);
+  cursor: default;
+}
+
+.request-insights-filter-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--color-gray-400);
+  background: var(--color-gray-100);
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
+}
+
+.request-insights-filter-status button,
+.request-insights-list-empty button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-blue-900);
+  cursor: pointer;
+  font: inherit;
+}
+
 .request-insights-settings {
   position: relative;
   display: inline-flex;
@@ -186,48 +342,49 @@
   font-weight: 400;
 }
 
-.request-insights-row[data-nested='true'] .request-insights-route {
-  padding-left: 18px;
-}
-
-.request-insights-nested-arrow {
-  flex-shrink: 0;
-  color: var(--color-gray-700);
-}
-
-.request-insights-internal-badge {
-  flex-shrink: 0;
-  margin-right: 6px;
-  border: 1px solid var(--color-gray-500);
-  border-radius: 999px;
-  padding: 1px 6px;
-  color: var(--color-gray-800);
-  font-size: var(--size-10);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.request-insights-page-load {
-  flex-shrink: 0;
-  border-radius: 999px;
-  padding: 1px 5px;
-  background: var(--color-blue-100);
-  color: var(--color-blue-900);
-  font-size: var(--size-10);
-  font-weight: 600;
-  line-height: 16px;
-  white-space: nowrap;
-}
-
-.request-insights-item-context {
+.request-insights-row-metadata {
+  display: flex;
   min-width: 0;
   overflow: hidden;
+  align-items: center;
+  gap: 5px;
+  grid-column: 2;
+  grid-row: 2;
+  text-overflow: ellipsis;
+}
+
+.request-insights-request-type,
+.request-insights-request-activity {
+  flex-shrink: 0;
   color: var(--color-gray-900);
   font-size: var(--size-11);
-  font-weight: 400;
-  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-request-type[data-type='page-load'],
+.request-insights-request-type[data-type='rsc'],
+.request-insights-request-type[data-type='prefetch'],
+.request-insights-request-type[data-type='segment-prefetch'],
+.request-insights-request-type[data-type='hmr-refresh'] {
+  color: var(--color-blue-900);
+}
+
+.request-insights-request-type[data-type='action'] {
+  color: var(--color-amber-900);
+}
+
+.request-insights-request-type[data-type='api'] {
+  color: var(--color-purple-900);
+}
+
+.request-insights-request-type[data-type='image'],
+.request-insights-request-type[data-type='asset'],
+.request-insights-request-type[data-type='proxy'] {
+  color: var(--color-green-900);
+}
+
+.request-insights-request-activity {
+  color: var(--color-gray-800);
 }
 
 .request-insights-duration,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -13,7 +13,16 @@ import { CopyButton } from '../copy-button'
 import GearIcon from '../../icons/gear-icon'
 import { formatDuration } from './format-duration'
 import {
+  getRequestInsightFilterResult,
+  REQUEST_INSIGHT_FILTER_GROUPS,
+  toggleRequestInsightFilter,
+  type RequestInsightFilter,
+} from './request-filters'
+import {
   getActiveRequestKey,
+  getRequestInsightRowType,
+  getRequestInsightStatusCode,
+  getRequestInsightSummaryTypeLabel,
   getRequestListEntries,
   isInternalRequestInsight,
   isPageLoadRequest,
@@ -30,10 +39,18 @@ const TRACE_TICK_COUNT = 5
 
 export function RequestInsightsPanel() {
   const { dispatch, state, shadowRoot } = useDevOverlayContext()
+  const [activeFilters, setActiveFilters] = useState<
+    readonly RequestInsightFilter[]
+  >([])
+  const [pausedRequests, setPausedRequests] = useState<
+    readonly RequestInsight[] | null
+  >(null)
+  const displayedRequests = pausedRequests ?? state.requestInsights
   const requests = useMemo(
-    () => [...state.requestInsights].reverse(),
-    [state.requestInsights]
+    () => [...displayedRequests].reverse(),
+    [displayedRequests]
   )
+  const isPaused = pausedRequests !== null
   const { showInternal, verbose } = state.requestInsightsConfig
   const setRequestInsightsConfig = (patch: {
     showInternal?: boolean
@@ -45,9 +62,15 @@ export function RequestInsightsPanel() {
     })
     saveDevToolsConfig({ requestInsights: patch })
   }
+  const filterResult = useMemo(
+    () => getRequestInsightFilterResult(requests, activeFilters, showInternal),
+    [activeFilters, requests, showInternal]
+  )
+  const showInternalInList =
+    showInternal || activeFilters.includes('activity:instant-insights')
   const listEntries = useMemo(
-    () => getRequestListEntries(requests, showInternal),
-    [requests, showInternal]
+    () => getRequestListEntries(filterResult.requests, showInternalInList),
+    [filterResult.requests, showInternalInList]
   )
   const visibleRequests = useMemo(
     () => listEntries.map((entry) => entry.request),
@@ -76,7 +99,7 @@ export function RequestInsightsPanel() {
   // internal activity to reveal.
   const showInternalToggle = internalRequests.length > 0
 
-  if (requests.length === 0) {
+  if (displayedRequests.length === 0) {
     return (
       <div className="request-insights-empty">
         Request insights will appear after the next App Router request.
@@ -89,81 +112,143 @@ export function RequestInsightsPanel() {
       <div className="request-insights-list">
         <div className="request-insights-list-toolbar">
           <strong>Requests</strong>
-          <div className="request-insights-settings">
-            {hiddenInternalErrorCount > 0 ? (
-              <span
-                aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
-                className="request-insights-settings-dot"
-                role="img"
-              />
-            ) : null}
-            <Menu.Root delay={0} modal={false}>
-              <Menu.Trigger
-                aria-label="Request list settings"
-                className="request-insights-settings-trigger"
+          <div className="request-insights-list-controls">
+            {isPaused ? (
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                className="request-insights-update-status"
+                role="status"
               >
-                <GearIcon />
-              </Menu.Trigger>
-              <Menu.Portal container={shadowRoot}>
-                <Menu.Positioner
-                  align="end"
-                  className="request-insights-settings-positioner"
-                  side="bottom"
-                  sideOffset={4}
+                <span className="request-insights-paused-state">Paused</span>
+              </div>
+            ) : null}
+            <RequestFiltersMenu
+              activeFilters={activeFilters}
+              onReset={() => setActiveFilters([])}
+              onToggle={(filter) =>
+                setActiveFilters((filters) =>
+                  toggleRequestInsightFilter(filters, filter)
+                )
+              }
+              optionCounts={filterResult.optionCounts}
+              shadowRoot={shadowRoot}
+            />
+            <div className="request-insights-settings">
+              {hiddenInternalErrorCount > 0 ? (
+                <span
+                  aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
+                  className="request-insights-settings-dot"
+                  role="img"
+                />
+              ) : null}
+              <Menu.Root delay={0} modal={false}>
+                <Menu.Trigger
+                  aria-label="Request list settings"
+                  className="request-insights-settings-trigger"
                 >
-                  <Menu.Popup className="request-insights-settings-menu">
-                    {showInternalToggle ? (
+                  <GearIcon />
+                </Menu.Trigger>
+                <Menu.Portal container={shadowRoot}>
+                  <Menu.Positioner
+                    align="end"
+                    className="request-insights-settings-positioner"
+                    side="bottom"
+                    sideOffset={4}
+                  >
+                    <Menu.Popup className="request-insights-settings-menu">
                       <Menu.CheckboxItem
-                        checked={showInternal}
+                        checked={isPaused}
                         className="request-insights-settings-item"
                         closeOnClick={false}
                         onCheckedChange={(checked) =>
-                          setRequestInsightsConfig({ showInternal: checked })
+                          setPausedRequests(
+                            checked ? [...state.requestInsights] : null
+                          )
                         }
                       >
                         <span
                           className="request-insights-settings-checkbox"
-                          data-checked={showInternal || undefined}
+                          data-checked={isPaused || undefined}
                         >
-                          {showInternal ? <CheckIcon /> : null}
+                          {isPaused ? <CheckIcon /> : null}
                         </span>
-                        Internal activity
+                        Pause updates
                       </Menu.CheckboxItem>
-                    ) : null}
-                    <Menu.CheckboxItem
-                      checked={verbose}
-                      className="request-insights-settings-item"
-                      closeOnClick={false}
-                      onCheckedChange={(checked) =>
-                        setRequestInsightsConfig({ verbose: checked })
-                      }
-                    >
-                      <span
-                        className="request-insights-settings-checkbox"
-                        data-checked={verbose || undefined}
+                      {showInternalToggle ? (
+                        <Menu.CheckboxItem
+                          checked={showInternal}
+                          className="request-insights-settings-item"
+                          closeOnClick={false}
+                          onCheckedChange={(checked) =>
+                            setRequestInsightsConfig({ showInternal: checked })
+                          }
+                        >
+                          <span
+                            className="request-insights-settings-checkbox"
+                            data-checked={showInternal || undefined}
+                          >
+                            {showInternal ? <CheckIcon /> : null}
+                          </span>
+                          Internal activity
+                        </Menu.CheckboxItem>
+                      ) : null}
+                      <Menu.CheckboxItem
+                        checked={verbose}
+                        className="request-insights-settings-item"
+                        closeOnClick={false}
+                        onCheckedChange={(checked) =>
+                          setRequestInsightsConfig({ verbose: checked })
+                        }
                       >
-                        {verbose ? <CheckIcon /> : null}
-                      </span>
-                      Verbose traces
-                    </Menu.CheckboxItem>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
+                        <span
+                          className="request-insights-settings-checkbox"
+                          data-checked={verbose || undefined}
+                        >
+                          {verbose ? <CheckIcon /> : null}
+                        </span>
+                        Verbose traces
+                      </Menu.CheckboxItem>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            </div>
           </div>
         </div>
+        {activeFilters.length > 0 ? (
+          <div className="request-insights-filter-status">
+            <span>
+              {filterResult.matchingRequestCount} of{' '}
+              {filterResult.totalRequestCount} requests
+            </span>
+            <button onClick={() => setActiveFilters([])} type="button">
+              Reset
+            </button>
+          </div>
+        ) : null}
         {listEntries.length === 0 ? (
           <div className="request-insights-list-empty">
-            Only internal activity has been captured. Enable “Internal activity”
-            to view it.
+            {activeFilters.length > 0 ? (
+              <>
+                No requests match the active filters.{' '}
+                <button onClick={() => setActiveFilters([])} type="button">
+                  Reset filters
+                </button>
+              </>
+            ) : (
+              <>
+                Only internal activity has been captured. Enable “Internal
+                activity” to view it.
+              </>
+            )}
           </div>
         ) : (
-          listEntries.map(({ request, nested }) => {
+          listEntries.map(({ request }) => {
             const requestKey = getRequestInsightKey(request)
             return (
               <RequestRow
                 key={requestKey}
-                nested={nested}
                 request={request}
                 pageLoad={isPageLoadRequest(request, initialRequestId)}
                 selected={requestKey === activeRequestKey}
@@ -181,15 +266,99 @@ export function RequestInsightsPanel() {
   )
 }
 
+function RequestFiltersMenu({
+  activeFilters,
+  onReset,
+  onToggle,
+  optionCounts,
+  shadowRoot,
+}: {
+  activeFilters: readonly RequestInsightFilter[]
+  onReset: () => void
+  onToggle: (filter: RequestInsightFilter) => void
+  optionCounts: Readonly<Record<RequestInsightFilter, number>>
+  shadowRoot: ShadowRoot
+}) {
+  return (
+    <Menu.Root delay={0} modal={false}>
+      <Menu.Trigger
+        aria-label={`Filter requests${activeFilters.length > 0 ? `, ${activeFilters.length} active` : ''}`}
+        className="request-insights-filter-trigger"
+      >
+        Filter
+        {activeFilters.length > 0 ? (
+          <span className="request-insights-filter-active-count">
+            {activeFilters.length}
+          </span>
+        ) : null}
+      </Menu.Trigger>
+      <Menu.Portal container={shadowRoot}>
+        <Menu.Positioner
+          align="end"
+          className="request-insights-filter-positioner"
+          side="bottom"
+          sideOffset={4}
+        >
+          <Menu.Popup
+            aria-label="Request filters"
+            className="request-insights-filter-menu"
+          >
+            {REQUEST_INSIGHT_FILTER_GROUPS.map((group) => (
+              <Menu.Group key={group.label}>
+                <Menu.GroupLabel className="request-insights-filter-group-label">
+                  {group.label}
+                </Menu.GroupLabel>
+                {group.options.map((option) => {
+                  const checked = activeFilters.includes(option.value)
+                  const count = optionCounts[option.value]
+                  return (
+                    <Menu.CheckboxItem
+                      key={option.value}
+                      checked={checked}
+                      className="request-insights-filter-item"
+                      closeOnClick={false}
+                      data-filter-value={option.value}
+                      disabled={!checked && count === 0}
+                      onCheckedChange={() => onToggle(option.value)}
+                    >
+                      <span
+                        className="request-insights-settings-checkbox"
+                        data-checked={checked || undefined}
+                      >
+                        {checked ? <CheckIcon /> : null}
+                      </span>
+                      <span className="request-insights-filter-option-label">
+                        {option.label}
+                      </span>
+                      <span className="request-insights-filter-option-count">
+                        {count}
+                      </span>
+                    </Menu.CheckboxItem>
+                  )
+                })}
+              </Menu.Group>
+            ))}
+            <Menu.Item
+              className="request-insights-filter-reset"
+              disabled={activeFilters.length === 0}
+              onClick={onReset}
+            >
+              Reset filters
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  )
+}
+
 function RequestRow({
   request,
-  nested,
   pageLoad,
   selected,
   onSelect,
 }: {
   request: RequestInsight
-  nested: boolean
   pageLoad: boolean
   selected: boolean
   onSelect: () => void
@@ -197,12 +366,15 @@ function RequestRow({
   const isInstantInsights =
     getRequestInsightKind(request) === 'instant-insights'
   const route = request.route ?? request.url ?? 'Unknown route'
+  const requestType = getRequestInsightRowType(request, pageLoad)
+  const clockTime = formatClockTime(request.startTime)
+  const bypassesProxy = request.proxyStatus === 'bypassed'
 
   return (
     <button
+      aria-label={`${isInstantInsights ? `Instant Insights for ${route}` : route}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
-      data-nested={nested || undefined}
       data-page-load={pageLoad}
       data-selected={selected}
       onClick={onSelect}
@@ -210,24 +382,30 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        {nested ? <NestedArrowIcon /> : null}
-        {isInstantInsights && !nested ? (
-          <span className="request-insights-internal-badge">Internal</span>
-        ) : null}
         <span className="request-insights-route-label">
           {isInstantInsights ? 'Instant Insights' : route}
         </span>
-        {isInstantInsights && !nested ? (
-          <span className="request-insights-item-context">{route}</span>
-        ) : pageLoad ? (
-          <span className="request-insights-page-load">Page load</span>
-        ) : null}
       </span>
       <span className="request-insights-duration">
         {formatDuration(request.durationMs)}
       </span>
-      <span className="request-insights-meta">
-        {formatClockTime(request.startTime)}
+      <span className="request-insights-meta request-insights-row-metadata">
+        <span
+          className="request-insights-request-type"
+          data-type={requestType.type}
+          title={requestType.accessibleLabel}
+        >
+          {requestType.label}
+        </span>
+        {bypassesProxy ? (
+          <span
+            className="request-insights-request-activity"
+            title="This request did not match the configured proxy"
+          >
+            No proxy
+          </span>
+        ) : null}
+        <span>{clockTime}</span>
       </span>
       <span className="request-insights-meta request-insights-fetch-summary">
         {request.fetches.length
@@ -235,25 +413,6 @@ function RequestRow({
           : 'No fetches'}
       </span>
     </button>
-  )
-}
-
-function NestedArrowIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      className="request-insights-nested-arrow"
-      fill="none"
-      height="12"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.5"
-      viewBox="0 0 16 16"
-      width="12"
-    >
-      <path d="M4 3v5.5A2.5 2.5 0 0 0 6.5 11H12M12 11l-3-3m3 3-3 3" />
-    </svg>
   )
 }
 
@@ -492,8 +651,7 @@ function getRequestOverview(request: RequestInsight) {
     : (getFirstStringAttribute(request, 'http.method') ??
       getMethodFromName(request.spans[0]?.name) ??
       'GET')
-  const statusCode = getFirstNumberAttribute(request, 'http.status_code')
-  const isRsc = getFirstBooleanAttribute(request, 'next.rsc')
+  const statusCode = getRequestInsightStatusCode(request)
   const erroredSpan = request.spans.find(
     (span) => span.status === 'error' || span.error
   )
@@ -516,11 +674,7 @@ function getRequestOverview(request: RequestInsight) {
     method,
     statusCode,
     statusLabel: statusCode ?? request.status,
-    kind: isInstantInsights
-      ? 'Instant Insights'
-      : isRsc
-        ? 'RSC request'
-        : 'HTML request',
+    kind: getRequestInsightSummaryTypeLabel(request),
     fetchSummary: request.fetches.length
       ? `${request.fetches.length} fetch${request.fetches.length === 1 ? '' : 'es'}`
       : 'No fetches',
@@ -592,30 +746,6 @@ function getFirstStringAttribute(
   for (const span of request.spans) {
     const value = span.attributes?.[key]
     if (typeof value === 'string') {
-      return value
-    }
-  }
-}
-
-function getFirstNumberAttribute(
-  request: RequestInsight,
-  key: string
-): number | undefined {
-  for (const span of request.spans) {
-    const value = span.attributes?.[key]
-    if (typeof value === 'number') {
-      return value
-    }
-  }
-}
-
-function getFirstBooleanAttribute(
-  request: RequestInsight,
-  key: string
-): boolean | undefined {
-  for (const span of request.spans) {
-    const value = span.attributes?.[key]
-    if (typeof value === 'boolean') {
       return value
     }
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -41,6 +41,7 @@ import {
   getRequestInsightStatusCode,
   getRequestInsightSummaryTypeLabel,
   getRequestListEntries,
+  getRequestListEntriesForPage,
   isInternalRequestInsight,
   isPageLoadRequest,
 } from './request-list'
@@ -54,6 +55,7 @@ import {
 import './request-insights-panel.css'
 
 const TRACE_TICK_COUNT = 5
+type RequestScope = 'all' | 'page'
 
 export function RequestInsightsPanel() {
   const { dispatch, state, shadowRoot } = useDevOverlayContext()
@@ -63,11 +65,13 @@ export function RequestInsightsPanel() {
   const [pausedRequests, setPausedRequests] = useState<
     readonly RequestInsight[] | null
   >(null)
+  const [requestScope, setRequestScope] = useState<RequestScope>('all')
   const displayedRequests = pausedRequests ?? state.requestInsights
   const requests = useMemo(
     () => [...displayedRequests].reverse(),
     [displayedRequests]
   )
+  const initialRequestId = self.__next_r
   const isPaused = pausedRequests !== null
   const { showInternal, verbose } = state.requestInsightsConfig
   const setRequestInsightsConfig = (patch: {
@@ -80,16 +84,30 @@ export function RequestInsightsPanel() {
     })
     saveDevToolsConfig({ requestInsights: patch })
   }
+  const retainedEntries = useMemo(
+    () => getRequestListEntries(requests, true),
+    [requests]
+  )
+  const allListEntries = useMemo(
+    () =>
+      showInternal
+        ? retainedEntries
+        : retainedEntries.filter(
+            ({ request }) => !isInternalRequestInsight(request)
+          ),
+    [retainedEntries, showInternal]
+  )
+  const currentPageEntries = useMemo(
+    () => getRequestListEntriesForPage(allListEntries, initialRequestId),
+    [allListEntries, initialRequestId]
+  )
+  const scopedEntries =
+    requestScope === 'page' ? currentPageEntries : allListEntries
   const filterResult = useMemo(
-    () => getRequestInsightFilterResult(requests, activeFilters, showInternal),
-    [activeFilters, requests, showInternal]
+    () => getRequestInsightFilterResult(scopedEntries, activeFilters),
+    [activeFilters, scopedEntries]
   )
-  const showInternalInList =
-    showInternal || activeFilters.includes('activity:instant-insights')
-  const listEntries = useMemo(
-    () => getRequestListEntries(filterResult.requests, showInternalInList),
-    [filterResult.requests, showInternalInList]
-  )
+  const listEntries = filterResult.entries
   const visibleRequests = useMemo(
     () => listEntries.map((entry) => entry.request),
     [listEntries]
@@ -101,21 +119,23 @@ export function RequestInsightsPanel() {
     visibleRequests,
     selectedRequestKey
   )
-  const selectedRequest =
-    visibleRequests.find(
-      (request) => getRequestInsightKey(request) === activeRequestKey
+  const selectedEntry =
+    listEntries.find(
+      ({ request }) => getRequestInsightKey(request) === activeRequestKey
     ) ?? null
-  const initialRequestId = self.__next_r
-  const internalRequests = useMemo(
-    () => requests.filter((request) => isInternalRequestInsight(request)),
-    [requests]
+  const selectedRequest = selectedEntry?.request ?? null
+  const orphanedInternalRequests = useMemo(
+    () =>
+      retainedEntries
+        .filter(({ request }) => isInternalRequestInsight(request))
+        .map(({ request }) => request),
+    [retainedEntries]
   )
   const hiddenInternalErrorCount = showInternal
     ? 0
-    : internalRequests.filter((request) => request.status === 'error').length
-  // Only offer the internal-activity toggle once the session has captured
-  // internal activity to reveal.
-  const showInternalToggle = internalRequests.length > 0
+    : orphanedInternalRequests.filter((request) => request.status === 'error')
+        .length
+  const showInternalToggle = orphanedInternalRequests.length > 0
 
   if (displayedRequests.length === 0) {
     return (
@@ -236,6 +256,28 @@ export function RequestInsightsPanel() {
             </div>
           </div>
         </div>
+        <div
+          aria-label="Request scope"
+          className="request-insights-scope-switcher"
+          role="group"
+        >
+          <button
+            aria-pressed={requestScope === 'all'}
+            onClick={() => setRequestScope('all')}
+            type="button"
+          >
+            All
+          </button>
+          <button
+            aria-pressed={requestScope === 'page'}
+            disabled={currentPageEntries.length === 0}
+            onClick={() => setRequestScope('page')}
+            title="Show requests correlated to this browser document"
+            type="button"
+          >
+            This page
+          </button>
+        </div>
         {activeFilters.length > 0 ? (
           <div className="request-insights-filter-status">
             <span>
@@ -256,6 +298,8 @@ export function RequestInsightsPanel() {
                   Reset filters
                 </button>
               </>
+            ) : requestScope === 'page' ? (
+              <>No requests are correlated to this browser document.</>
             ) : (
               <>
                 Only internal activity has been captured. Enable “Internal
@@ -264,10 +308,11 @@ export function RequestInsightsPanel() {
             )}
           </div>
         ) : (
-          listEntries.map(({ request }) => {
+          listEntries.map(({ request, instantInsights }) => {
             const requestKey = getRequestInsightKey(request)
             return (
               <RequestRow
+                instantInsights={instantInsights}
                 key={requestKey}
                 request={request}
                 pageLoad={isPageLoadRequest(request, initialRequestId)}
@@ -280,7 +325,11 @@ export function RequestInsightsPanel() {
       </div>
 
       {selectedRequest && (
-        <RequestDetails request={selectedRequest} verbose={verbose} />
+        <RequestDetails
+          instantInsights={selectedEntry?.instantInsights ?? []}
+          request={selectedRequest}
+          verbose={verbose}
+        />
       )}
     </div>
   )
@@ -373,11 +422,13 @@ function RequestFiltersMenu({
 }
 
 function RequestRow({
+  instantInsights,
   request,
   pageLoad,
   selected,
   onSelect,
 }: {
+  instantInsights: readonly RequestInsight[]
   request: RequestInsight
   pageLoad: boolean
   selected: boolean
@@ -392,10 +443,21 @@ function RequestRow({
   )
   const clockTime = formatClockTime(request.startTime)
   const bypassesProxy = request.proxyStatus === 'bypassed'
+  const hasInstantInsightsError = instantInsights.some(
+    (item) =>
+      item.status === 'error' ||
+      item.spans.some((span) => span.status === 'error' || span.error)
+  )
+  const hasRequestError =
+    request.status === 'error' ||
+    request.spans.some((span) => span.status === 'error' || span.error)
+  const hasVisibleError = hasRequestError || hasInstantInsightsError
+  const statusLabel = getRequestInsightStatusCode(request) ?? request.status
 
   return (
     <button
-      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, Status ${statusLabel}, ${instantInsights.length > 0 ? `Includes Instant Insights${hasInstantInsightsError ? ' with errors' : ''}, ` : ''}${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-pressed={selected}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
       data-page-load={pageLoad}
@@ -405,7 +467,7 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        <span className="request-insights-route-label">
+        <span className="request-insights-route-label" title={requestUrl}>
           {isInstantInsights ? 'Instant Insights' : requestUrl}
         </span>
       </span>
@@ -420,6 +482,16 @@ function RequestRow({
         >
           {requestType.label}
         </span>
+        {instantInsights.length > 0 ? (
+          <span
+            className="request-insights-request-activity"
+            data-activity="instant-insights"
+            data-status={hasInstantInsightsError ? 'error' : 'ok'}
+            title={`${instantInsights.length} Instant Insights record${instantInsights.length === 1 ? '' : 's'}${hasInstantInsightsError ? ' with errors' : ''}`}
+          >
+            Instant
+          </span>
+        ) : null}
         {bypassesProxy ? (
           <span
             className="request-insights-request-activity"
@@ -427,6 +499,9 @@ function RequestRow({
           >
             No proxy
           </span>
+        ) : null}
+        {hasVisibleError ? (
+          <span className="request-insights-request-error">Error</span>
         ) : null}
         <span>{clockTime}</span>
       </span>
@@ -454,9 +529,11 @@ function CheckIcon() {
 }
 
 function RequestDetails({
+  instantInsights,
   request,
   verbose,
 }: {
+  instantInsights: readonly RequestInsight[]
   request: RequestInsight
   verbose: boolean
 }) {
@@ -478,7 +555,7 @@ function RequestDetails({
       <div className="request-insights-summary">
         <div className="request-insights-heading">
           <div className="request-insights-title-row">
-            <div className="request-insights-title">
+            <div className="request-insights-title" title={requestUrl}>
               {getRequestInsightKind(request) === 'instant-insights'
                 ? `Instant Insights · ${requestUrl}`
                 : requestUrl}
@@ -508,6 +585,65 @@ function RequestDetails({
         request={request}
       />
 
+      <FetchTable fetches={request.fetches} />
+
+      {instantInsights.length > 0 ? (
+        <InstantInsightsSection requests={instantInsights} verbose={verbose} />
+      ) : null}
+    </div>
+  )
+}
+
+function InstantInsightsSection({
+  requests,
+  verbose,
+}: {
+  requests: readonly RequestInsight[]
+  verbose: boolean
+}) {
+  return (
+    <details className="request-insights-instant-section">
+      <summary>
+        <span>Instant Insights</span>
+        <span className="request-insights-section-note">
+          {requests.length} record{requests.length === 1 ? '' : 's'}
+        </span>
+      </summary>
+      {requests.map((request) => (
+        <InstantInsightsRecord
+          key={getRequestInsightKey(request)}
+          request={request}
+          verbose={verbose}
+        />
+      ))}
+    </details>
+  )
+}
+
+function InstantInsightsRecord({
+  request,
+  verbose,
+}: {
+  request: RequestInsight
+  verbose: boolean
+}) {
+  const traceItems = useMemo(
+    () =>
+      getTraceItems(
+        request,
+        verbose,
+        typeof window === 'undefined' ? undefined : window.location.origin
+      ),
+    [request, verbose]
+  )
+
+  return (
+    <div className="request-insights-instant-record">
+      <div className="request-insights-instant-record-summary">
+        <span>Status {request.status}</span>
+        <span>{formatDuration(request.durationMs)}</span>
+      </div>
+      <Trace items={traceItems} request={request} />
       <FetchTable fetches={request.fetches} />
     </div>
   )
@@ -782,14 +918,17 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
           No server fetches captured.
         </div>
       ) : (
-        <div className="request-insights-fetch-table">
-          <div className="request-insights-fetch request-insights-fetch-header">
-            <span>Method</span>
-            <span>URL</span>
-            <span>Duration</span>
-            <span>Status</span>
-            <span>Cache</span>
-            <span>Reason</span>
+        <div className="request-insights-fetch-table" role="table">
+          <div
+            className="request-insights-fetch request-insights-fetch-header"
+            role="row"
+          >
+            <span role="columnheader">Method</span>
+            <span role="columnheader">URL</span>
+            <span role="columnheader">Duration</span>
+            <span role="columnheader">Status</span>
+            <span role="columnheader">Cache</span>
+            <span role="columnheader">Reason</span>
           </div>
           {fetches.map((fetch, index) => {
             const url = getFetchUrlPresentation(fetch.url, currentOrigin)
@@ -798,11 +937,12 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
                 className="request-insights-fetch"
                 data-origin={url.originKind}
                 key={index}
+                role="row"
               >
-                <span className="request-insights-method">
+                <span className="request-insights-method" role="cell">
                   {fetch.method ?? 'GET'}
                 </span>
-                <span className="request-insights-fetch-url">
+                <span className="request-insights-fetch-url" role="cell">
                   <Tooltip
                     className="request-insights-fetch-tooltip"
                     title={url.fullUrl}
@@ -820,10 +960,10 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
                     </span>
                   </Tooltip>
                 </span>
-                <span>{formatDuration(fetch.durationMs)}</span>
-                <span>{fetch.statusCode ?? '-'}</span>
-                <span>{fetch.cacheStatus ?? 'unknown'}</span>
-                <span className="request-insights-cache-reason">
+                <span role="cell">{formatDuration(fetch.durationMs)}</span>
+                <span role="cell">{fetch.statusCode ?? '-'}</span>
+                <span role="cell">{fetch.cacheStatus ?? 'unknown'}</span>
+                <span className="request-insights-cache-reason" role="cell">
                   {fetch.cacheReason ?? '-'}
                 </span>
               </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -1,4 +1,13 @@
-import { useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react'
 import { Menu } from '@base-ui-components/react/menu'
 import {
   getRequestInsightKey,
@@ -10,7 +19,9 @@ import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { ACTION_DEVTOOLS_CONFIG } from '../../shared'
 import { saveDevToolsConfig } from '../../utils/save-devtools-config'
 import { CopyButton } from '../copy-button'
+import { Tooltip } from '../tooltip/tooltip'
 import GearIcon from '../../icons/gear-icon'
+import { getFetchUrlPresentation } from './fetch-label'
 import { formatDuration } from './format-duration'
 import {
   getRequestInsightFilterResult,
@@ -18,6 +29,12 @@ import {
   toggleRequestInsightFilter,
   type RequestInsightFilter,
 } from './request-filters'
+import {
+  formatRequestRouteParams,
+  getRequestDisplayUrl,
+  getRequestListDisplayUrl,
+  getRequestRouteParams,
+} from './request-label'
 import {
   getActiveRequestKey,
   getRequestInsightRowType,
@@ -29,6 +46,7 @@ import {
 } from './request-list'
 import {
   getTraceItems,
+  getTraceNavigationIndex,
   getTracePosition,
   getTraceRange,
   type TraceItem,
@@ -181,7 +199,9 @@ export function RequestInsightsPanel() {
                           className="request-insights-settings-item"
                           closeOnClick={false}
                           onCheckedChange={(checked) =>
-                            setRequestInsightsConfig({ showInternal: checked })
+                            setRequestInsightsConfig({
+                              showInternal: checked,
+                            })
                           }
                         >
                           <span
@@ -365,14 +385,17 @@ function RequestRow({
 }) {
   const isInstantInsights =
     getRequestInsightKind(request) === 'instant-insights'
-  const route = request.route ?? request.url ?? 'Unknown route'
   const requestType = getRequestInsightRowType(request, pageLoad)
+  const requestUrl = getRequestListDisplayUrl(
+    request,
+    requestType.type === 'rsc'
+  )
   const clockTime = formatClockTime(request.startTime)
   const bypassesProxy = request.proxyStatus === 'bypassed'
 
   return (
     <button
-      aria-label={`${isInstantInsights ? `Instant Insights for ${route}` : route}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
       data-page-load={pageLoad}
@@ -383,7 +406,7 @@ function RequestRow({
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
         <span className="request-insights-route-label">
-          {isInstantInsights ? 'Instant Insights' : route}
+          {isInstantInsights ? 'Instant Insights' : requestUrl}
         </span>
       </span>
       <span className="request-insights-duration">
@@ -438,11 +461,17 @@ function RequestDetails({
   verbose: boolean
 }) {
   const traceItems = useMemo(
-    () => getTraceItems(request, verbose),
+    () =>
+      getTraceItems(
+        request,
+        verbose,
+        typeof window === 'undefined' ? undefined : window.location.origin
+      ),
     [request, verbose]
   )
   const overview = useMemo(() => getRequestOverview(request), [request])
   const diagnosis = getDiagnosis(request, traceItems)
+  const requestUrl = getRequestDisplayUrl(request)
 
   return (
     <div className="request-insights-details">
@@ -451,8 +480,8 @@ function RequestDetails({
           <div className="request-insights-title-row">
             <div className="request-insights-title">
               {getRequestInsightKind(request) === 'instant-insights'
-                ? `Instant Insights · ${request.route ?? request.url ?? request.requestId}`
-                : (request.route ?? request.url ?? request.requestId)}
+                ? `Instant Insights · ${requestUrl}`
+                : requestUrl}
             </div>
             <CopyButton
               actionLabel="Copy request JSON"
@@ -473,7 +502,11 @@ function RequestDetails({
       ) : null}
       <div className="request-insights-diagnosis">{diagnosis}</div>
 
-      <Trace items={traceItems} request={request} />
+      <Trace
+        items={traceItems}
+        key={getRequestInsightKey(request)}
+        request={request}
+      />
 
       <FetchTable fetches={request.fetches} />
     </div>
@@ -493,6 +526,27 @@ function RequestOverview({
       <span>{overview.fetchSummary}</span>
       <span>{overview.cacheSummary}</span>
       <span>{overview.spanSummary}</span>
+      {overview.route ? (
+        <span className="request-insights-route-template">
+          Route {overview.route}
+        </span>
+      ) : null}
+      {overview.routeParams?.length ? (
+        <Tooltip
+          className="request-insights-params-tooltip"
+          title={formatRequestRouteParams(overview.routeParams)}
+        >
+          <button
+            aria-label={`Route parameters: ${overview.routeParams
+              .map(({ name }) => name)
+              .join(', ')}`}
+            className="request-insights-params-trigger"
+            type="button"
+          >
+            Params {overview.routeParams.map(({ name }) => name).join(', ')}
+          </button>
+        </Tooltip>
+      ) : null}
     </div>
   )
 }
@@ -504,7 +558,41 @@ function Trace({
   request: RequestInsight
   items: TraceItem[]
 }) {
+  const [activeItemId, setActiveItemId] = useState<string | null>(
+    items[0]?.id ?? null
+  )
+  const [activeTraceRow, setActiveTraceRow] = useState<HTMLElement | null>(null)
+  const traceRowsRef = useRef<HTMLDivElement>(null)
+  const shouldScrollActiveItemIntoViewRef = useRef(false)
+  const traceId = useId()
   const range = getTraceRange(request)
+  const activeItemIndex = items.findIndex((item) => item.id === activeItemId)
+  const safeActiveItemIndex =
+    items.length === 0 ? -1 : Math.max(activeItemIndex, 0)
+  const activeItem = items[safeActiveItemIndex]
+  const activeItemDescription = activeItem
+    ? getTraceItemDescription(activeItem, range)
+    : null
+
+  useEffect(() => {
+    if (
+      !shouldScrollActiveItemIntoViewRef.current ||
+      safeActiveItemIndex === -1
+    ) {
+      return
+    }
+
+    shouldScrollActiveItemIntoViewRef.current = false
+    const activeOption =
+      traceRowsRef.current?.children.item(safeActiveItemIndex)
+    if (activeOption instanceof HTMLElement) {
+      activeOption.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      })
+    }
+  }, [safeActiveItemIndex])
+
   const ticks = Array.from({ length: TRACE_TICK_COUNT }, (_, index) => {
     const position = index / (TRACE_TICK_COUNT - 1)
     return {
@@ -512,6 +600,52 @@ function Trace({
       position: position * 100,
     }
   })
+  const handleTraceKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return
+      }
+
+      const nextIndex = getTraceNavigationIndex(
+        activeItemIndex,
+        items.length,
+        event.key
+      )
+      if (nextIndex === undefined) {
+        return
+      }
+
+      event.preventDefault()
+      shouldScrollActiveItemIntoViewRef.current = true
+      setActiveItemId(items[nextIndex]?.id ?? null)
+    },
+    [activeItemIndex, items]
+  )
+  const handleTracePointerOver = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      const row = target.closest<HTMLElement>('[data-trace-index]')
+      if (row === null || !event.currentTarget.contains(row)) {
+        return
+      }
+
+      const index = Number(row.dataset.traceIndex)
+      if (Number.isSafeInteger(index)) {
+        shouldScrollActiveItemIntoViewRef.current = false
+        const itemId = items[index]?.id
+        if (itemId !== undefined) {
+          setActiveItemId((currentItemId) =>
+            currentItemId === itemId ? currentItemId : itemId
+          )
+        }
+      }
+    },
+    [items]
+  )
 
   return (
     <div className="request-insights-section">
@@ -548,54 +682,98 @@ function Trace({
               Duration
             </span>
           </div>
-          <div className="request-insights-trace-rows">
-            {items.map((item) => {
-              const position = getTracePosition(item, range)
+          <Tooltip
+            anchor={activeTraceRow}
+            asChild
+            className="request-insights-trace-tooltip"
+            direction="top"
+            title={activeItemDescription}
+          >
+            <div
+              aria-activedescendant={
+                safeActiveItemIndex === -1
+                  ? undefined
+                  : `${traceId}-item-${safeActiveItemIndex}`
+              }
+              aria-label={`Trace spans, ${items.length} item${items.length === 1 ? '' : 's'}. Use arrow keys to inspect timing.`}
+              className="request-insights-trace-rows"
+              onKeyDown={handleTraceKeyDown}
+              onPointerOver={handleTracePointerOver}
+              ref={traceRowsRef}
+              role="listbox"
+              tabIndex={items.length === 0 ? undefined : 0}
+            >
+              {items.map((item, index) => {
+                const position = getTracePosition(item, range)
+                const description = getTraceItemDescription(item, range)
 
-              return (
-                <div
-                  className="request-insights-span-row"
-                  data-kind={item.kind}
-                  key={item.id}
-                  title={`${item.label} · +${formatDuration(position.offsetMs)} · ${formatDuration(item.durationMs)}`}
-                >
-                  <span
-                    className="request-insights-span-name"
-                    style={{ paddingLeft: `${item.depth * 14 + 4}px` }}
+                return (
+                  <div
+                    aria-label={description}
+                    aria-selected={index === safeActiveItemIndex}
+                    className="request-insights-span-row"
+                    data-active={index === safeActiveItemIndex || undefined}
+                    data-kind={item.kind}
+                    data-trace-item-id={item.id}
+                    data-trace-index={index}
+                    id={`${traceId}-item-${index}`}
+                    key={item.id}
+                    ref={
+                      index === safeActiveItemIndex
+                        ? setActiveTraceRow
+                        : undefined
+                    }
+                    role="option"
                   >
-                    <span className="request-insights-span-label">
-                      <span
-                        className="request-insights-span-marker"
-                        data-kind={item.kind}
-                        data-status={item.status}
-                      />
-                      <span>{item.label}</span>
-                    </span>
-                  </span>
-                  <span className="request-insights-span-track">
                     <span
-                      className="request-insights-span-bar"
-                      data-status={item.status}
-                      style={{
-                        left: `${position.left}%`,
-                        width: `${position.width}%`,
-                      }}
-                    />
-                  </span>
-                  <span className="request-insights-span-duration">
-                    {formatDuration(item.durationMs)}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
+                      className="request-insights-span-name"
+                      style={{ paddingLeft: `${item.depth * 14 + 4}px` }}
+                    >
+                      <span className="request-insights-span-label">
+                        <span
+                          className="request-insights-span-marker"
+                          data-kind={item.kind}
+                          data-status={item.status}
+                        />
+                        <span>{item.label}</span>
+                      </span>
+                    </span>
+                    <span className="request-insights-span-track">
+                      <span
+                        className="request-insights-span-bar"
+                        data-status={item.status}
+                        style={{
+                          left: `${position.left}%`,
+                          width: `${position.width}%`,
+                        }}
+                      />
+                    </span>
+                    <span className="request-insights-span-duration">
+                      {formatDuration(item.durationMs)}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </Tooltip>
         </div>
       </div>
     </div>
   )
 }
 
+function getTraceItemDescription(
+  item: TraceItem,
+  range: ReturnType<typeof getTraceRange>
+): string {
+  const position = getTracePosition(item, range)
+  return `${item.fullLabel ?? item.label} · +${formatDuration(position.offsetMs)} · ${formatDuration(item.durationMs)}`
+}
+
 function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
+  const currentOrigin =
+    typeof window === 'undefined' ? undefined : window.location.origin
+
   return (
     <div className="request-insights-section">
       <div className="request-insights-section-title">Fetches</div>
@@ -614,19 +792,33 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
             <span>Reason</span>
           </div>
           {fetches.map((fetch, index) => {
-            const urlParts = formatUrl(fetch.url)
+            const url = getFetchUrlPresentation(fetch.url, currentOrigin)
             return (
-              <div className="request-insights-fetch" key={index}>
+              <div
+                className="request-insights-fetch"
+                data-origin={url.originKind}
+                key={index}
+              >
                 <span className="request-insights-method">
                   {fetch.method ?? 'GET'}
                 </span>
                 <span className="request-insights-fetch-url">
-                  <span>{urlParts.path}</span>
-                  {urlParts.host ? (
-                    <span className="request-insights-fetch-host">
-                      {urlParts.host}
+                  <Tooltip
+                    className="request-insights-fetch-tooltip"
+                    title={url.fullUrl}
+                  >
+                    <span className="request-insights-fetch-url-trigger">
+                      <span className="request-insights-fetch-path">
+                        {url.path}
+                      </span>
+                      <span
+                        className="request-insights-fetch-origin"
+                        data-origin={url.originKind}
+                      >
+                        {url.originLabel}
+                      </span>
                     </span>
-                  ) : null}
+                  </Tooltip>
                 </span>
                 <span>{formatDuration(fetch.durationMs)}</span>
                 <span>{fetch.statusCode ?? '-'}</span>
@@ -687,6 +879,8 @@ function getRequestOverview(request: RequestInsight) {
               cacheCounts.unknown ? `, ${cacheCounts.unknown} unknown` : ''
             }`,
     spanSummary: `${request.spans.length} span${request.spans.length === 1 ? '' : 's'}`,
+    route: request.route,
+    routeParams: getRequestRouteParams(request),
     errorSummary,
   }
 }
@@ -719,8 +913,11 @@ function getDiagnosis(
     (!criticalItem ||
       (slowestFetch.durationMs ?? 0) >= (criticalItem.durationMs ?? 0))
   ) {
-    const urlParts = formatUrl(slowestFetch.url)
-    return `Slowest recorded operation: ${urlParts.path} · ${formatDuration(slowestFetch.durationMs)}${getCacheSummary(slowestFetch)}.`
+    const url = getFetchUrlPresentation(
+      slowestFetch.url,
+      typeof window === 'undefined' ? undefined : window.location.origin
+    )
+    return `Slowest recorded operation: ${url.path} · ${formatDuration(slowestFetch.durationMs)}${getCacheSummary(slowestFetch)}.`
   }
 
   if (criticalItem) {
@@ -756,24 +953,6 @@ function getMethodFromName(name: string | undefined): string | undefined {
     /^(?:RSC )?(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)\b/
   )
   return match?.[1]
-}
-
-function formatUrl(url: string | undefined): { path: string; host?: string } {
-  if (!url) {
-    return { path: 'Unknown URL' }
-  }
-
-  try {
-    const parsedUrl = new URL(url, window.location.origin)
-    const path = `${parsedUrl.pathname}${parsedUrl.search}`
-    const sameHost = parsedUrl.host === window.location.host
-    return {
-      path,
-      host: sameHost ? undefined : parsedUrl.host,
-    }
-  } catch {
-    return { path: url }
-  }
 }
 
 function formatClockTime(timestamp: number): string {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -698,6 +698,8 @@ function Trace({
     items[0]?.id ?? null
   )
   const [activeTraceRow, setActiveTraceRow] = useState<HTMLElement | null>(null)
+  const [isTraceFocused, setIsTraceFocused] = useState(false)
+  const [isTraceTooltipOpen, setIsTraceTooltipOpen] = useState(false)
   const traceRowsRef = useRef<HTMLDivElement>(null)
   const shouldScrollActiveItemIntoViewRef = useRef(false)
   const traceId = useId()
@@ -757,7 +759,7 @@ function Trace({
     },
     [activeItemIndex, items]
   )
-  const handleTracePointerOver = useCallback(
+  const handleTracePointerMove = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
       const target = event.target
       if (!(target instanceof Element)) {
@@ -793,7 +795,10 @@ function Trace({
         </div>
       </div>
       <div className="request-insights-trace-viewport">
-        <div className="request-insights-trace">
+        <div
+          className="request-insights-trace"
+          onPointerMove={handleTracePointerMove}
+        >
           <div className="request-insights-trace-header">
             <span>Span</span>
             <span className="request-insights-trace-axis">
@@ -823,6 +828,8 @@ function Trace({
             asChild
             className="request-insights-trace-tooltip"
             direction="top"
+            onOpenChange={setIsTraceTooltipOpen}
+            open={isTraceFocused || isTraceTooltipOpen}
             title={activeItemDescription}
           >
             <div
@@ -833,8 +840,9 @@ function Trace({
               }
               aria-label={`Trace spans, ${items.length} item${items.length === 1 ? '' : 's'}. Use arrow keys to inspect timing.`}
               className="request-insights-trace-rows"
+              onBlur={() => setIsTraceFocused(false)}
+              onFocus={() => setIsTraceFocused(true)}
               onKeyDown={handleTraceKeyDown}
-              onPointerOver={handleTracePointerOver}
               ref={traceRowsRef}
               role="listbox"
               tabIndex={items.length === 0 ? undefined : 0}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.test.ts
@@ -1,0 +1,87 @@
+import {
+  formatRequestRouteParams,
+  getRequestDisplayUrl,
+  getRequestListDisplayUrl,
+  getRequestRouteParams,
+} from './request-label'
+
+describe('request insight request labels', () => {
+  it('prefers the concrete URL and hides the transport-only RSC query', () => {
+    const request = {
+      requestId: 'request-1',
+      route: '/products/[id]',
+      url: '/products/blue?tab=details&_rsc=redacted#summary',
+    }
+
+    expect(getRequestDisplayUrl(request)).toBe(
+      '/products/blue?tab=details&_rsc=redacted#summary'
+    )
+    expect(getRequestListDisplayUrl(request, true)).toBe(
+      '/products/blue?tab=details#summary'
+    )
+    expect(getRequestListDisplayUrl(request, false)).toBe(
+      '/products/blue?tab=details&_rsc=redacted#summary'
+    )
+    expect(
+      getRequestListDisplayUrl(
+        {
+          requestId: 'request-2',
+          route: '/products/[id]',
+          url: '//example.test/products/blue?_rsc=redacted',
+        },
+        true
+      )
+    ).toBe('//example.test/products/blue')
+  })
+
+  it('extracts dynamic, catch-all, and optional catch-all parameters', () => {
+    expect(
+      getRequestRouteParams({
+        route: '/products/[category]/[...slug]',
+        url: '/products/widgets/blue/large?sort=redacted',
+      })
+    ).toEqual([
+      { name: 'category', value: 'widgets' },
+      { name: 'slug', value: ['blue', 'large'] },
+    ])
+    expect(
+      getRequestRouteParams({
+        route: '/docs/[[...slug]]',
+        url: '/docs',
+      })
+    ).toEqual([{ name: 'slug', value: [] }])
+  })
+
+  it('handles base paths and encoded route values', () => {
+    const params = getRequestRouteParams(
+      {
+        route: '/products/[category]/[...slug]',
+        url: '/shop/products/home%20goods/blue%2Flarge',
+      },
+      '/shop'
+    )
+
+    expect(params).toEqual([
+      { name: 'category', value: 'home goods' },
+      { name: 'slug', value: ['blue/large'] },
+    ])
+    expect(formatRequestRouteParams(params!)).toBe(
+      '{\n  "category": "home goods",\n  "slug": [\n    "blue/large"\n  ]\n}'
+    )
+  })
+
+  it('does not guess parameters from malformed or mismatched routes', () => {
+    expect(
+      getRequestRouteParams({ route: '/products/[id]', url: '/users/1' })
+    ).toBeUndefined()
+    expect(
+      getRequestRouteParams({ route: '/products/[id]', url: '/products/%zz' })
+    ).toBeUndefined()
+    expect(
+      getRequestRouteParams({
+        route: '/products/[id]/[id]',
+        url: '/products/one/two',
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.ts
@@ -1,0 +1,180 @@
+import type { RequestInsight } from '../../../shared/request-insights'
+import { removePathPrefix } from '../../../../shared/lib/router/utils/remove-path-prefix'
+
+type RequestIdentity = Pick<RequestInsight, 'requestId' | 'route' | 'url'>
+
+export type RequestRouteParam = {
+  name: string
+  value: string | string[]
+}
+
+export function getRequestDisplayUrl(request: RequestIdentity): string {
+  return request.url ?? request.route ?? request.requestId
+}
+
+export function getRequestListDisplayUrl(
+  request: RequestIdentity,
+  rscRequest: boolean
+): string {
+  const displayUrl = getRequestDisplayUrl(request)
+  if (!rscRequest) {
+    return displayUrl
+  }
+
+  try {
+    const protocolRelative = displayUrl.startsWith('//')
+    const rootRelative = !protocolRelative && displayUrl.startsWith('/')
+    const parsed = new URL(displayUrl, 'http://next.local')
+    if (!parsed.searchParams.has('_rsc')) {
+      return displayUrl
+    }
+
+    parsed.searchParams.delete('_rsc')
+    return protocolRelative
+      ? `//${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`
+      : rootRelative
+        ? `${parsed.pathname}${parsed.search}${parsed.hash}`
+        : parsed.toString()
+  } catch {
+    return displayUrl
+  }
+}
+
+export function getRequestRouteParams(
+  request: Pick<RequestIdentity, 'route' | 'url'>,
+  basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+): RequestRouteParam[] | undefined {
+  if (!request.route || !request.url) {
+    return undefined
+  }
+
+  const pathname = getPathname(request.url)
+  if (!pathname) {
+    return undefined
+  }
+
+  const routeSegments = splitPathname(request.route)
+  const pathnameSegments = splitPathname(removePathPrefix(pathname, basePath))
+  if (!routeSegments || !pathnameSegments) {
+    return undefined
+  }
+
+  const params: RequestRouteParam[] = []
+  const names = new Set<string>()
+  let pathnameIndex = 0
+
+  for (const routeSegment of routeSegments) {
+    const dynamicSegment = parseDynamicSegment(routeSegment)
+
+    if (!dynamicSegment) {
+      if (
+        routeSegment.includes('[') ||
+        routeSegment.includes(']') ||
+        pathnameSegments[pathnameIndex] !== routeSegment
+      ) {
+        return undefined
+      }
+      pathnameIndex += 1
+      continue
+    }
+
+    if (names.has(dynamicSegment.name)) {
+      return undefined
+    }
+    names.add(dynamicSegment.name)
+
+    if (dynamicSegment.catchAll) {
+      const value = pathnameSegments.slice(pathnameIndex)
+      if (value.length === 0 && !dynamicSegment.optional) {
+        return undefined
+      }
+      params.push({ name: dynamicSegment.name, value })
+      pathnameIndex = pathnameSegments.length
+      continue
+    }
+
+    const value = pathnameSegments[pathnameIndex]
+    if (value === undefined) {
+      return undefined
+    }
+    params.push({ name: dynamicSegment.name, value })
+    pathnameIndex += 1
+  }
+
+  return pathnameIndex === pathnameSegments.length ? params : undefined
+}
+
+export function formatRequestRouteParams(params: RequestRouteParam[]): string {
+  return JSON.stringify(
+    Object.fromEntries(params.map(({ name, value }) => [name, value])),
+    null,
+    2
+  )
+}
+
+function getPathname(url: string): string | undefined {
+  try {
+    if (url.startsWith('/')) {
+      return new URL(url, 'http://next.local').pathname
+    }
+
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.pathname
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function splitPathname(pathname: string): string[] | undefined {
+  if (!pathname.startsWith('/')) {
+    return undefined
+  }
+
+  const segments = pathname.split('/').slice(1)
+  if (segments.at(-1) === '') {
+    segments.pop()
+  }
+
+  const decoded: string[] = []
+  for (const segment of segments) {
+    const value = decodeSegment(segment)
+    if (value === undefined) {
+      return undefined
+    }
+    decoded.push(value)
+  }
+  return decoded
+}
+
+function decodeSegment(segment: string): string | undefined {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return undefined
+  }
+}
+
+function parseDynamicSegment(segment: string):
+  | {
+      name: string
+      catchAll: boolean
+      optional: boolean
+    }
+  | undefined {
+  const optionalCatchAll = segment.match(/^\[\[\.\.\.([^[/\]]+)\]\]$/)
+  const catchAll = segment.match(/^\[\.\.\.([^[/\]]+)\]$/)
+  const dynamic = segment.match(/^\[([^[/\]]+)\]$/)
+  const match = optionalCatchAll ?? catchAll ?? dynamic
+
+  if (!match) {
+    return undefined
+  }
+
+  return {
+    name: match[1],
+    catchAll: optionalCatchAll !== null || catchAll !== null,
+    optional: optionalCatchAll !== null,
+  }
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -1,7 +1,11 @@
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsight,
+  type RequestInsightSpan,
 } from '../../../shared/request-insights'
 
 export function getActiveRequestKey(
@@ -30,65 +34,291 @@ export function isInternalRequestInsight(
 
 export type RequestListEntry = {
   request: RequestInsight
-  nested: boolean
 }
 
 export function getRequestListEntries(
   requests: readonly RequestInsight[],
   showInternal: boolean
 ): RequestListEntry[] {
-  if (!showInternal) {
-    return requests
-      .filter((request) => !isInternalRequestInsight(request))
-      .map((request) => ({ request, nested: false }))
-  }
+  return requests
+    .filter((request) => showInternal || !isInternalRequestInsight(request))
+    .map((request) => ({ request }))
+}
 
-  // Group internal records by the request they belong to, and record which
-  // request ids have a parent (non-internal) record present, both in one pass.
-  const internalByRequestId = new Map<string, RequestInsight[]>()
-  const parentRequestIds = new Set<string>()
-  for (const request of requests) {
-    if (isInternalRequestInsight(request)) {
-      const group = internalByRequestId.get(request.requestId)
-      if (group) {
-        group.push(request)
-      } else {
-        internalByRequestId.set(request.requestId, [request])
+export type RequestInsightRowType =
+  | 'page'
+  | 'page-load'
+  | 'rsc'
+  | 'action'
+  | 'prefetch'
+  | 'segment-prefetch'
+  | 'hmr-refresh'
+  | 'api'
+  | 'image'
+  | 'asset'
+  | 'proxy'
+  | 'instant-insights'
+  | 'unknown'
+
+export type RequestInsightRowTypePresentation = Readonly<{
+  type: RequestInsightRowType
+  label: string
+  accessibleLabel: string
+}>
+
+const REQUEST_INSIGHT_ROW_TYPES: Readonly<
+  Record<RequestInsightRowType, RequestInsightRowTypePresentation>
+> = {
+  page: { type: 'page', label: 'Page', accessibleLabel: 'Page request' },
+  'page-load': {
+    type: 'page-load',
+    label: 'Page load',
+    accessibleLabel: 'Page load',
+  },
+  rsc: {
+    type: 'rsc',
+    label: 'RSC',
+    accessibleLabel: 'React Server Component request',
+  },
+  action: {
+    type: 'action',
+    label: 'Action',
+    accessibleLabel: 'Server Action request',
+  },
+  prefetch: {
+    type: 'prefetch',
+    label: 'Prefetch',
+    accessibleLabel: 'App Router prefetch request',
+  },
+  'segment-prefetch': {
+    type: 'segment-prefetch',
+    label: 'Segment',
+    accessibleLabel: 'App Router segment prefetch request',
+  },
+  'hmr-refresh': {
+    type: 'hmr-refresh',
+    label: 'HMR',
+    accessibleLabel: 'Hot Module Replacement refresh request',
+  },
+  api: { type: 'api', label: 'API', accessibleLabel: 'API request' },
+  image: {
+    type: 'image',
+    label: 'Image',
+    accessibleLabel: 'Image optimization request',
+  },
+  asset: {
+    type: 'asset',
+    label: 'Asset',
+    accessibleLabel: 'Static asset request',
+  },
+  proxy: { type: 'proxy', label: 'Proxy', accessibleLabel: 'Proxy request' },
+  'instant-insights': {
+    type: 'instant-insights',
+    label: 'Instant',
+    accessibleLabel: 'Instant Insights activity',
+  },
+  unknown: {
+    type: 'unknown',
+    label: 'Unknown',
+    accessibleLabel: 'Unclassified request',
+  },
+}
+
+export function getRequestInsightRowType(
+  request: RequestInsight,
+  pageLoad = false
+): RequestInsightRowTypePresentation {
+  switch (getRequestInsightSource(request)) {
+    case 'page': {
+      if (request.serverAction) {
+        return REQUEST_INSIGHT_ROW_TYPES.action
       }
-    } else {
-      parentRequestIds.add(request.requestId)
+      const routerActivity = getRequestInsightRouterActivity(request)
+      if (routerActivity) {
+        return REQUEST_INSIGHT_ROW_TYPES[routerActivity]
+      }
+      if (getRequestInsightIsRsc(request) === true) {
+        return REQUEST_INSIGHT_ROW_TYPES.rsc
+      }
+      return REQUEST_INSIGHT_ROW_TYPES[pageLoad ? 'page-load' : 'page']
     }
+    case 'app-route':
+    case 'pages-api':
+      return REQUEST_INSIGHT_ROW_TYPES.api
+    case 'image':
+      return REQUEST_INSIGHT_ROW_TYPES.image
+    case 'asset':
+      return REQUEST_INSIGHT_ROW_TYPES.asset
+    case 'proxy':
+      return REQUEST_INSIGHT_ROW_TYPES.proxy
+    case 'instant-insights':
+      return REQUEST_INSIGHT_ROW_TYPES['instant-insights']
+    case 'unknown':
+      return REQUEST_INSIGHT_ROW_TYPES.unknown
   }
+}
 
-  const entries: RequestListEntry[] = []
-  for (const request of requests) {
-    if (isInternalRequestInsight(request)) {
-      // Orphans (no parent request in the list) remain top-level and preserve
-      // their ordering relative to other top-level records. Nested internal
-      // records are emitted under their request below.
-      if (!parentRequestIds.has(request.requestId)) {
-        entries.push({ request, nested: false })
-      }
+export function hasRequestInsightProxyActivity(
+  request: RequestInsight
+): boolean {
+  return (
+    getRequestInsightSource(request) === 'proxy' ||
+    request.proxyStatus === 'matched' ||
+    request.spans.some(
+      (span) =>
+        span.attributes?.['next.span_type'] === REQUEST_INSIGHT_PROXY_SPAN_TYPE
+    )
+  )
+}
+
+export function getCanonicalRequestSpan(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): RequestInsightSpan | undefined {
+  let latestRequestSpan: RequestInsightSpan | undefined
+  let latestMatchedRouteSpan: RequestInsightSpan | undefined
+
+  for (const span of request.spans) {
+    if (
+      span.attributes?.['next.span_type'] !== REQUEST_INSIGHT_REQUEST_SPAN_TYPE
+    ) {
       continue
     }
-
-    entries.push({ request, nested: false })
-    const nested = internalByRequestId.get(request.requestId)
-    if (nested) {
-      for (const internalRequest of nested) {
-        entries.push({ request: internalRequest, nested: true })
-      }
+    if (!latestRequestSpan || span.startTime >= latestRequestSpan.startTime) {
+      latestRequestSpan = span
+    }
+    if (
+      request.route &&
+      span.attributes?.['next.route'] === request.route &&
+      (!latestMatchedRouteSpan ||
+        span.startTime >= latestMatchedRouteSpan.startTime)
+    ) {
+      latestMatchedRouteSpan = span
     }
   }
-  return entries
+
+  return latestMatchedRouteSpan ?? latestRequestSpan
+}
+
+export function getRequestInsightStatusCode(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): number | undefined {
+  return getCanonicalThenAnySpanAttribute(
+    request,
+    'http.status_code',
+    (value): value is number => typeof value === 'number'
+  )
+}
+
+export function getRequestInsightIsRsc(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): boolean | undefined {
+  return getCanonicalThenAnySpanAttribute(
+    request,
+    'next.rsc',
+    (value): value is boolean => typeof value === 'boolean'
+  )
+}
+
+export type RequestInsightRepresentation =
+  | 'html'
+  | 'rsc'
+  | 'not-applicable'
+  | 'unknown'
+
+export function getRequestInsightRepresentation(
+  request: Pick<
+    RequestInsight,
+    'kind' | 'source' | 'serverAction' | 'route' | 'spans'
+  >
+): RequestInsightRepresentation {
+  if (request.serverAction) {
+    return 'not-applicable'
+  }
+
+  switch (getRequestInsightSource(request)) {
+    case 'page': {
+      const isRsc = getRequestInsightIsRsc(request)
+      return isRsc === true ? 'rsc' : isRsc === false ? 'html' : 'unknown'
+    }
+    case 'unknown':
+      return 'unknown'
+    case 'app-route':
+    case 'pages-api':
+    case 'image':
+    case 'asset':
+    case 'proxy':
+    case 'instant-insights':
+      return 'not-applicable'
+  }
+}
+
+export function getRequestInsightRouterActivity(
+  request: Pick<RequestInsight, 'routerActivity'>
+): RequestInsight['routerActivity'] {
+  switch (request.routerActivity) {
+    case 'prefetch':
+    case 'segment-prefetch':
+    case 'hmr-refresh':
+      return request.routerActivity
+    case undefined:
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+export function getRequestInsightSummaryTypeLabel(
+  request: RequestInsight
+): string {
+  const rowType = getRequestInsightRowType(request)
+  if (
+    rowType.type === 'instant-insights' ||
+    rowType.type === 'action' ||
+    rowType.type === 'prefetch' ||
+    rowType.type === 'segment-prefetch' ||
+    rowType.type === 'hmr-refresh'
+  ) {
+    return rowType.accessibleLabel
+  }
+
+  switch (getRequestInsightRepresentation(request)) {
+    case 'html':
+      return 'HTML request'
+    case 'rsc':
+      return 'RSC request'
+    case 'not-applicable':
+    case 'unknown':
+      return rowType.accessibleLabel
+  }
+}
+
+function getCanonicalThenAnySpanAttribute<T>(
+  request: Pick<RequestInsight, 'route' | 'spans'>,
+  key: string,
+  isValue: (value: unknown) => value is T
+): T | undefined {
+  const canonicalValue = getCanonicalRequestSpan(request)?.attributes?.[key]
+  if (isValue(canonicalValue)) {
+    return canonicalValue
+  }
+
+  for (const span of request.spans) {
+    const value = span.attributes?.[key]
+    if (isValue(value)) {
+      return value
+    }
+  }
 }
 
 export function isPageLoadRequest(
-  request: Pick<RequestInsight, 'requestId' | 'kind'>,
+  request: RequestInsight,
   initialRequestId: string | undefined
 ): boolean {
   return (
     getRequestInsightKind(request) === 'request' &&
-    request.requestId === initialRequestId
+    getRequestInsightSource(request) === 'page' &&
+    !request.serverAction &&
+    getRequestInsightIsRsc(request) === false &&
+    request.htmlRequestId === initialRequestId
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -32,17 +32,60 @@ export function isInternalRequestInsight(
   return getRequestInsightKind(request) !== 'request'
 }
 
-export type RequestListEntry = {
+export type RequestListEntry = Readonly<{
   request: RequestInsight
-}
+  instantInsights: readonly RequestInsight[]
+}>
 
 export function getRequestListEntries(
   requests: readonly RequestInsight[],
   showInternal: boolean
 ): RequestListEntry[] {
-  return requests
-    .filter((request) => showInternal || !isInternalRequestInsight(request))
-    .map((request) => ({ request }))
+  const requestIds = new Set(
+    requests
+      .filter((request) => !isInternalRequestInsight(request))
+      .map((request) => request.requestId)
+  )
+  const instantInsightsByOwner = new Map<string, RequestInsight[]>()
+  for (const request of requests) {
+    if (getRequestInsightKind(request) !== 'instant-insights') {
+      continue
+    }
+    const owned = instantInsightsByOwner.get(request.requestId)
+    if (owned) {
+      owned.push(request)
+    } else {
+      instantInsightsByOwner.set(request.requestId, [request])
+    }
+  }
+
+  return requests.flatMap((request) => {
+    if (isInternalRequestInsight(request)) {
+      return showInternal && !requestIds.has(request.requestId)
+        ? [{ request, instantInsights: [] }]
+        : []
+    }
+
+    return [
+      {
+        request,
+        instantInsights: instantInsightsByOwner.get(request.requestId) ?? [],
+      },
+    ]
+  })
+}
+
+export function getRequestListEntriesForPage(
+  entries: readonly RequestListEntry[],
+  htmlRequestId: string | undefined
+): RequestListEntry[] {
+  if (!htmlRequestId) {
+    return []
+  }
+
+  return entries.filter(
+    (entry) => entry.request.htmlRequestId === htmlRequestId
+  )
 }
 
 export type RequestInsightRowType =

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -9,7 +9,12 @@ import {
   getRequestListEntries,
   isPageLoadRequest,
 } from './request-list'
-import { getTraceItems, getTracePosition, getTraceRange } from './trace-viewer'
+import {
+  getTraceItems,
+  getTraceNavigationIndex,
+  getTracePosition,
+  getTraceRange,
+} from './trace-viewer'
 
 function createRequest(
   overrides: Partial<RequestInsight> = {}
@@ -28,6 +33,18 @@ function createRequest(
 }
 
 describe('request insights trace viewer', () => {
+  it('moves the active trace row without leaving the listbox', () => {
+    expect(getTraceNavigationIndex(0, 3, 'ArrowDown')).toBe(1)
+    expect(getTraceNavigationIndex(2, 3, 'ArrowDown')).toBe(2)
+    expect(getTraceNavigationIndex(2, 3, 'ArrowUp')).toBe(1)
+    expect(getTraceNavigationIndex(1, 3, 'Home')).toBe(0)
+    expect(getTraceNavigationIndex(1, 3, 'End')).toBe(2)
+    expect(getTraceNavigationIndex(1, 3, 'ArrowRight')).toBeUndefined()
+    expect(getTraceNavigationIndex(1, 3, 'ArrowLeft')).toBeUndefined()
+    expect(getTraceNavigationIndex(0, 0, 'ArrowDown')).toBeUndefined()
+    expect(getTraceNavigationIndex(0, 3, 'Enter')).toBeUndefined()
+  })
+
   it('keeps the active request selected when newer requests arrive', () => {
     const selectedRequest = createRequest({ requestId: 'selected' })
     const newerRequest = createRequest({ requestId: 'newer' })
@@ -272,6 +289,40 @@ describe('request insights trace viewer', () => {
         }),
       })
     )
+  })
+
+  it('distinguishes same-origin and external fetches in the trace', () => {
+    const request = createRequest({
+      fetches: [
+        {
+          method: 'GET',
+          url: 'https://app.test/api/data?token=%3Credacted%3E',
+          startTime: 110,
+          durationMs: 10,
+        },
+        {
+          method: 'POST',
+          url: 'https://api.example.test/api/data',
+          startTime: 120,
+          durationMs: 20,
+        },
+      ],
+    })
+
+    expect(
+      getTraceItems(request, true, 'https://app.test').map(
+        ({ label, fullLabel }) => ({ label, fullLabel })
+      )
+    ).toEqual([
+      {
+        label: 'GET /api/data?token=%3Credacted%3E · Same origin',
+        fullLabel: 'GET https://app.test/api/data?token=%3Credacted%3E',
+      },
+      {
+        label: 'POST /api/data · External origin · api.example.test',
+        fullLabel: 'POST https://api.example.test/api/data',
+      },
+    ])
   })
 
   it('orders spans by their recorded parent-child hierarchy', () => {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -7,6 +7,7 @@ import {
   getActiveRequestKey,
   getRequestInsightRowType,
   getRequestListEntries,
+  getRequestListEntriesForPage,
   isPageLoadRequest,
 } from './request-list'
 import {
@@ -80,11 +81,12 @@ describe('request insights trace viewer', () => {
     })
 
     expect(getRequestListEntries([instantInsights, request], false)).toEqual([
-      { request },
+      { request, instantInsights: [instantInsights] },
     ])
+    expect(getRequestListEntries([instantInsights], false)).toEqual([])
   })
 
-  it('keeps internal records flat and in capture order', () => {
+  it('keeps owned internal activity off the list and reveals only orphans', () => {
     const newerRequest = createRequest({ requestId: 'newer' })
     const olderRequest = createRequest({ requestId: 'older' })
     const newerInstantInsights = createRequest({
@@ -95,6 +97,10 @@ describe('request insights trace viewer', () => {
       requestId: 'older',
       kind: 'instant-insights',
     })
+    const orphanedInstantInsights = createRequest({
+      requestId: 'orphaned',
+      kind: 'instant-insights',
+    })
 
     expect(
       getRequestListEntries(
@@ -103,15 +109,51 @@ describe('request insights trace viewer', () => {
           newerRequest,
           olderInstantInsights,
           olderRequest,
+          orphanedInstantInsights,
         ],
         true
       )
     ).toEqual([
-      { request: newerInstantInsights },
-      { request: newerRequest },
-      { request: olderInstantInsights },
-      { request: olderRequest },
+      { request: newerRequest, instantInsights: [newerInstantInsights] },
+      { request: olderRequest, instantInsights: [olderInstantInsights] },
+      { request: orphanedInstantInsights, instantInsights: [] },
     ])
+  })
+
+  it('scopes requests to an exact document identity', () => {
+    const currentPage = createRequest({
+      requestId: 'current-page',
+      htmlRequestId: 'current-document',
+    })
+    const currentNavigation = createRequest({
+      requestId: 'current-navigation',
+      htmlRequestId: 'current-document',
+    })
+    const earlierPage = createRequest({
+      requestId: 'earlier-page',
+      htmlRequestId: 'earlier-document',
+    })
+    const currentPageInstantInsights = createRequest({
+      requestId: 'current-page',
+      kind: 'instant-insights',
+      htmlRequestId: 'different-correlation-metadata',
+    })
+    const entries = getRequestListEntries(
+      [currentNavigation, earlierPage, currentPageInstantInsights, currentPage],
+      true
+    )
+
+    expect(getRequestListEntriesForPage(entries, 'current-document')).toEqual([
+      { request: currentNavigation, instantInsights: [] },
+      {
+        request: currentPage,
+        instantInsights: [currentPageInstantInsights],
+      },
+    ])
+    expect(getRequestListEntriesForPage(entries, 'missing-document')).toEqual(
+      []
+    )
+    expect(getRequestListEntriesForPage(entries, undefined)).toEqual([])
   })
 
   it('labels and filters normalized request activity', () => {
@@ -142,6 +184,29 @@ describe('request insights trace viewer', () => {
     })
     const api = createRequest({ requestId: 'api', source: 'app-route' })
     const asset = createRequest({ requestId: 'asset', source: 'asset' })
+    const instantInsights = createRequest({
+      requestId: 'page',
+      kind: 'instant-insights',
+      source: 'instant-insights',
+      status: 'error',
+    })
+    const entries = getRequestListEntries(
+      [page, instantInsights, rsc, action, api, asset],
+      false
+    )
+    const orphanedInstantInsights = createRequest({
+      requestId: 'orphaned',
+      kind: 'instant-insights',
+      source: 'instant-insights',
+    })
+    const entriesWithOrphan = getRequestListEntries(
+      [page, instantInsights, orphanedInstantInsights, rsc, action, api, asset],
+      true
+    )
+    const entriesWithHiddenOrphan = getRequestListEntries(
+      [page, instantInsights, orphanedInstantInsights, rsc, action, api, asset],
+      false
+    )
 
     expect(getRequestInsightRowType(page, true).label).toBe('Page load')
     expect(getRequestInsightRowType(rsc).label).toBe('RSC')
@@ -149,23 +214,37 @@ describe('request insights trace viewer', () => {
     expect(getRequestInsightRowType(api).label).toBe('API')
     expect(getRequestInsightRowType(asset).label).toBe('Asset')
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api],
-        ['source:page', 'cache:miss']
-      ).requests
+      getRequestInsightFilterResult(entries, [
+        'source:page',
+        'cache:miss',
+      ]).entries.map(({ request }) => request)
     ).toEqual([page])
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api, asset],
-        ['source:action', 'source:api']
-      ).requests
+      getRequestInsightFilterResult(entries, [
+        'source:action',
+        'source:api',
+      ]).entries.map(({ request }) => request)
     ).toEqual([action, api])
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api, asset],
-        ['source:asset']
-      ).requests
+      getRequestInsightFilterResult(entries, ['source:asset']).entries.map(
+        ({ request }) => request
+      )
     ).toEqual([asset])
+    expect(
+      getRequestInsightFilterResult(entriesWithHiddenOrphan, [
+        'activity:instant-insights',
+      ]).entries.map(({ request }) => request)
+    ).toEqual([page])
+    expect(
+      getRequestInsightFilterResult(entriesWithOrphan, [
+        'activity:instant-insights',
+      ]).entries.map(({ request }) => request)
+    ).toEqual([page, orphanedInstantInsights])
+    expect(
+      getRequestInsightFilterResult(entries, ['status:error']).entries.map(
+        ({ request }) => request
+      )
+    ).toEqual([page])
   })
 
   it('only marks the exact initial document request as the page load', () => {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -1,6 +1,11 @@
-import type { RequestInsight } from '../../../shared/request-insights'
+import {
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  type RequestInsight,
+} from '../../../shared/request-insights'
+import { getRequestInsightFilterResult } from './request-filters'
 import {
   getActiveRequestKey,
+  getRequestInsightRowType,
   getRequestListEntries,
   isPageLoadRequest,
 } from './request-list'
@@ -58,11 +63,11 @@ describe('request insights trace viewer', () => {
     })
 
     expect(getRequestListEntries([instantInsights, request], false)).toEqual([
-      { request, nested: false },
+      { request },
     ])
   })
 
-  it('nests internal records directly after their request row', () => {
+  it('keeps internal records flat and in capture order', () => {
     const newerRequest = createRequest({ requestId: 'newer' })
     const olderRequest = createRequest({ requestId: 'older' })
     const newerInstantInsights = createRequest({
@@ -85,49 +90,89 @@ describe('request insights trace viewer', () => {
         true
       )
     ).toEqual([
-      { request: newerRequest, nested: false },
-      { request: newerInstantInsights, nested: true },
-      { request: olderRequest, nested: false },
-      { request: olderInstantInsights, nested: true },
+      { request: newerInstantInsights },
+      { request: newerRequest },
+      { request: olderInstantInsights },
+      { request: olderRequest },
     ])
   })
 
-  it('keeps orphaned internal records top-level and in root ordering', () => {
-    const request = createRequest({ requestId: 'present' })
-    const presentInstantInsights = createRequest({
-      requestId: 'present',
-      kind: 'instant-insights',
+  it('labels and filters normalized request activity', () => {
+    const requestSpan = (rsc: boolean) => ({
+      name: 'GET',
+      startTime: 100,
+      attributes: {
+        'next.span_type': REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+        'next.rsc': rsc,
+      },
     })
-    const orphanInstantInsights = createRequest({
-      requestId: 'evicted',
-      kind: 'instant-insights',
+    const page = createRequest({
+      requestId: 'page',
+      source: 'page',
+      spans: [requestSpan(false)],
+      fetches: [{ cacheStatus: 'miss' }],
     })
+    const rsc = createRequest({
+      requestId: 'rsc',
+      source: 'page',
+      spans: [requestSpan(true)],
+    })
+    const action = createRequest({
+      requestId: 'action',
+      source: 'page',
+      serverAction: true,
+      spans: [requestSpan(true)],
+    })
+    const api = createRequest({ requestId: 'api', source: 'app-route' })
+    const asset = createRequest({ requestId: 'asset', source: 'asset' })
 
-    const entries = getRequestListEntries(
-      [presentInstantInsights, orphanInstantInsights, request],
-      true
-    )
-
-    expect(entries).toEqual([
-      { request: orphanInstantInsights, nested: false },
-      { request, nested: false },
-      { request: presentInstantInsights, nested: true },
-    ])
-    // Every record appears exactly once.
-    expect(new Set(entries.map((entry) => entry.request)).size).toBe(
-      entries.length
-    )
-    expect(entries).toHaveLength(3)
+    expect(getRequestInsightRowType(page, true).label).toBe('Page load')
+    expect(getRequestInsightRowType(rsc).label).toBe('RSC')
+    expect(getRequestInsightRowType(action).label).toBe('Action')
+    expect(getRequestInsightRowType(api).label).toBe('API')
+    expect(getRequestInsightRowType(asset).label).toBe('Asset')
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api],
+        ['source:page', 'cache:miss']
+      ).requests
+    ).toEqual([page])
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api, asset],
+        ['source:action', 'source:api']
+      ).requests
+    ).toEqual([action, api])
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api, asset],
+        ['source:asset']
+      ).requests
+    ).toEqual([asset])
   })
 
   it('only marks the exact initial document request as the page load', () => {
     const initialRequestId = 'document-request'
+    const htmlSpan = {
+      name: 'GET',
+      startTime: 100,
+      attributes: {
+        'next.span_type': REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+        'next.rsc': false,
+      },
+    }
+    const rscSpan = {
+      ...htmlSpan,
+      attributes: { ...htmlSpan.attributes, 'next.rsc': true },
+    }
 
     expect(
       isPageLoadRequest(
         createRequest({
-          requestId: initialRequestId,
+          requestId: 'server-owned-request',
+          source: 'page',
           htmlRequestId: initialRequestId,
+          spans: [htmlSpan],
         }),
         initialRequestId
       )
@@ -136,7 +181,9 @@ describe('request insights trace viewer', () => {
       isPageLoadRequest(
         createRequest({
           requestId: 'related-rsc-request',
+          source: 'page',
           htmlRequestId: initialRequestId,
+          spans: [rscSpan],
         }),
         initialRequestId
       )
@@ -145,7 +192,9 @@ describe('request insights trace viewer', () => {
       isPageLoadRequest(
         createRequest({
           requestId: initialRequestId,
+          source: 'instant-insights',
           kind: 'instant-insights',
+          spans: [htmlSpan],
         }),
         initialRequestId
       )

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -3,6 +3,7 @@ import type {
   RequestInsightFetch,
   RequestInsightSpan,
 } from '../../../shared/request-insights'
+import { getFetchUrlPresentation } from './fetch-label'
 
 export type TraceItem = {
   id: string
@@ -11,6 +12,7 @@ export type TraceItem = {
   spanType?: string
   category: 'nextjs' | 'application'
   label: string
+  fullLabel?: string
   startTime: number
   durationMs?: number
   status: 'ok' | 'error' | 'pending'
@@ -21,6 +23,32 @@ export type TraceItem = {
 export type TraceRange = {
   startTime: number
   durationMs: number
+}
+
+export function getTraceNavigationIndex(
+  currentIndex: number,
+  itemCount: number,
+  key: string
+): number | undefined {
+  if (itemCount <= 0) {
+    return undefined
+  }
+
+  const lastIndex = itemCount - 1
+  const safeCurrentIndex = Math.min(Math.max(currentIndex, 0), lastIndex)
+
+  switch (key) {
+    case 'ArrowDown':
+      return Math.min(safeCurrentIndex + 1, lastIndex)
+    case 'ArrowUp':
+      return Math.max(safeCurrentIndex - 1, 0)
+    case 'Home':
+      return 0
+    case 'End':
+      return lastIndex
+    default:
+      return undefined
+  }
 }
 
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
@@ -76,7 +104,8 @@ const SPAN_WORD_CASE: Record<string, string> = {
 
 export function getTraceItems(
   request: RequestInsight,
-  verbose: boolean
+  verbose: boolean,
+  currentOrigin?: string
 ): TraceItem[] {
   const fetchSpansByIndex = new Map<number, RequestInsightSpan>()
 
@@ -110,7 +139,7 @@ export function getTraceItems(
   request.fetches.forEach((fetch, index) => {
     const matchingSpan =
       fetch.index === undefined ? undefined : fetchSpansByIndex.get(fetch.index)
-    const item = getFetchTraceItem(fetch, index, matchingSpan)
+    const item = getFetchTraceItem(fetch, index, matchingSpan, currentOrigin)
     if (item) {
       items.push(item)
     }
@@ -173,12 +202,16 @@ function getSpanTraceItem(
 function getFetchTraceItem(
   fetch: RequestInsightFetch,
   index: number,
-  matchingSpan: RequestInsightSpan | undefined
+  matchingSpan: RequestInsightSpan | undefined,
+  currentOrigin: string | undefined
 ): UnnestedTraceItem | null {
   const startTime = fetch.startTime ?? matchingSpan?.startTime
   if (startTime === undefined) {
     return null
   }
+
+  const method = fetch.method ?? 'GET'
+  const url = getFetchUrlPresentation(fetch.url, currentOrigin)
 
   return {
     id: `fetch:${matchingSpan?.spanId ?? fetch.index ?? index}:${startTime}`,
@@ -186,7 +219,8 @@ function getFetchTraceItem(
     parentSpanId: matchingSpan?.parentSpanId,
     spanType: FETCH_SPAN_TYPE,
     category: matchingSpan ? getSpanCategory(matchingSpan) : 'application',
-    label: `${fetch.method ?? 'GET'} ${getUrlPath(fetch.url)}`,
+    label: `${method} ${url.path}${currentOrigin ? ` · ${url.originLabel}` : ''}`,
+    fullLabel: `${method} ${url.fullUrl}`,
     startTime,
     durationMs: fetch.durationMs ?? matchingSpan?.durationMs,
     status:
@@ -393,17 +427,4 @@ function getSpanLabel(span: RequestInsightSpan): string {
   }
 
   return words.join(' ')
-}
-
-function getUrlPath(url: string | undefined): string {
-  if (!url) {
-    return 'Unknown URL'
-  }
-
-  try {
-    const parsedUrl = new URL(url, 'http://localhost')
-    return `${parsedUrl.pathname}${parsedUrl.search}`
-  } catch {
-    return url
-  }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.css
@@ -5,6 +5,8 @@
 }
 
 .tooltip {
+  --tooltip-background: var(--color-gray-1000);
+
   position: relative;
   padding: 6px 12px;
   border-radius: 8px;
@@ -12,7 +14,7 @@
   line-height: 1.4;
   pointer-events: none;
   color: var(--color-gray-100);
-  background-color: var(--color-gray-1000);
+  background-color: var(--tooltip-background);
 }
 
 .tooltip-arrow {
@@ -27,7 +29,7 @@
 .tooltip-arrow--top {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px) 0
     var(--arrow-size, 6px);
-  border-top-color: var(--color-gray-1000);
+  border-top-color: var(--tooltip-background);
   bottom: 0;
   transform: translateY(100%);
 }
@@ -35,7 +37,7 @@
 .tooltip-arrow--bottom {
   border-width: 0 var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-bottom-color: var(--color-gray-1000);
+  border-bottom-color: var(--tooltip-background);
   top: 0;
   transform: translateY(-100%);
 }
@@ -43,7 +45,7 @@
 .tooltip-arrow--left {
   border-width: var(--arrow-size, 6px) 0 var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-left-color: var(--color-gray-1000);
+  border-left-color: var(--tooltip-background);
   right: 0;
   transform: translateX(100%);
 }
@@ -51,7 +53,7 @@
 .tooltip-arrow--right {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px) 0;
-  border-right-color: var(--color-gray-1000);
+  border-right-color: var(--tooltip-background);
   left: 0;
   transform: translateX(-100%);
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
@@ -9,6 +9,8 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
 interface TooltipProps {
   children: React.ReactNode
   title: string | null
+  open?: React.ComponentProps<typeof BaseTooltip.Root>['open']
+  onOpenChange?: React.ComponentProps<typeof BaseTooltip.Root>['onOpenChange']
   anchor?: React.ComponentProps<typeof BaseTooltip.Positioner>['anchor']
   asChild?: boolean
   direction?: TooltipDirection
@@ -22,6 +24,8 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(function Tooltip(
     className,
     children,
     title,
+    open,
+    onOpenChange,
     anchor,
     asChild = false,
     direction = 'top',
@@ -36,7 +40,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(function Tooltip(
   }
   return (
     <BaseTooltip.Provider>
-      <BaseTooltip.Root delay={400}>
+      <BaseTooltip.Root delay={400} onOpenChange={onOpenChange} open={open}>
         <BaseTooltip.Trigger
           ref={ref}
           render={

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, isValidElement } from 'react'
 import { Tooltip as BaseTooltip } from '@base-ui-components/react/tooltip'
 import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { cx } from '../../utils/cx'
@@ -9,72 +9,80 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
 interface TooltipProps {
   children: React.ReactNode
   title: string | null
+  anchor?: React.ComponentProps<typeof BaseTooltip.Positioner>['anchor']
+  asChild?: boolean
   direction?: TooltipDirection
   arrowSize?: number
   offset?: number
   className?: string
 }
 
-export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
-  function Tooltip(
-    {
-      className,
-      children,
-      title,
-      direction = 'top',
-      arrowSize = 6,
-      offset = 8,
-    },
-    ref
-  ) {
-    const { shadowRoot } = useDevOverlayContext()
-    if (!title) {
-      return children
-    }
-    return (
-      <BaseTooltip.Provider>
-        <BaseTooltip.Root delay={400}>
-          <BaseTooltip.Trigger
-            ref={ref}
-            render={(triggerProps) => {
-              return <span {...triggerProps}>{children}</span>
-            }}
-          />
+export const Tooltip = forwardRef<HTMLElement, TooltipProps>(function Tooltip(
+  {
+    className,
+    children,
+    title,
+    anchor,
+    asChild = false,
+    direction = 'top',
+    arrowSize = 6,
+    offset = 8,
+  },
+  ref
+) {
+  const { shadowRoot } = useDevOverlayContext()
+  if (!title) {
+    return children
+  }
+  return (
+    <BaseTooltip.Provider>
+      <BaseTooltip.Root delay={400}>
+        <BaseTooltip.Trigger
+          ref={ref}
+          render={
+            asChild && isValidElement<Record<string, unknown>>(children)
+              ? children
+              : (triggerProps) => {
+                  return <span {...triggerProps}>{children}</span>
+                }
+          }
+        />
 
-          <BaseTooltip.Portal container={shadowRoot}>
-            <BaseTooltip.Positioner
-              side={direction}
-              sideOffset={offset + arrowSize}
-              className="tooltip-positioner"
+        <BaseTooltip.Portal container={shadowRoot}>
+          <BaseTooltip.Positioner
+            anchor={anchor}
+            positionMethod={anchor ? 'fixed' : undefined}
+            side={direction}
+            sideOffset={offset + arrowSize}
+            className="tooltip-positioner"
+            style={
+              {
+                '--anchor-width': `${arrowSize}px`,
+                '--anchor-height': `${arrowSize}px`,
+              } as React.CSSProperties
+            }
+          >
+            <BaseTooltip.Popup
+              className={cx('tooltip', className)}
               style={
                 {
-                  '--anchor-width': `${arrowSize}px`,
-                  '--anchor-height': `${arrowSize}px`,
+                  '--arrow-size': `${arrowSize}px`,
                 } as React.CSSProperties
               }
             >
-              <BaseTooltip.Popup
-                className={cx('tooltip', className)}
+              {title}
+              <BaseTooltip.Arrow
+                className={cx('tooltip-arrow', `tooltip-arrow--${direction}`)}
                 style={
                   {
                     '--arrow-size': `${arrowSize}px`,
                   } as React.CSSProperties
                 }
-              >
-                {title}
-                <BaseTooltip.Arrow
-                  className={cx('tooltip-arrow', `tooltip-arrow--${direction}`)}
-                  style={
-                    {
-                      '--arrow-size': `${arrowSize}px`,
-                    } as React.CSSProperties
-                  }
-                />
-              </BaseTooltip.Popup>
-            </BaseTooltip.Positioner>
-          </BaseTooltip.Portal>
-        </BaseTooltip.Root>
-      </BaseTooltip.Provider>
-    )
-  }
-)
+              />
+            </BaseTooltip.Popup>
+          </BaseTooltip.Positioner>
+        </BaseTooltip.Portal>
+      </BaseTooltip.Root>
+    </BaseTooltip.Provider>
+  )
+})

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -374,6 +374,7 @@ export const PanelRouter = () => {
       {isAppRouter && !!process.env.__NEXT_REQUEST_INSIGHTS && (
         <PanelRoute name="request-insights">
           <DynamicPanel
+            containerProps={{ className: 'request-insights-panel-container' }}
             sharePanelSizeGlobally={false}
             sharePanelPositionGlobally={false}
             draggable

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -9,6 +9,8 @@ export {
   getRequestInsightKey,
   getRequestInsightKind,
   getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsightIdentity,
   type RequestInsightKind,
   type RequestInsightProxyStatus,

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -538,17 +538,18 @@ describe('request insights', () => {
   it('redacts sensitive request insight payload fields', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
+    const secret = 'Q2_SECRET_SENTINEL'
     recordSpan({
-      name: 'fetch GET https://example.vercel.sh/api',
+      name: `fetch GET https://example.vercel.sh/api?token=${secret}`,
       startTime: 100,
       durationMs: 10,
       requestId: 'req_4',
       route: '/account',
       attributes: {
         'next.span_type': 'AppRender.fetch',
-        'http.url':
-          'https://user:pass@example.vercel.sh/api?access_token=abc&delay=1&signature=sig',
+        'http.url': `https://user:pass@example.vercel.sh/api?access_token=${secret}&delay=1&signature=sig`,
         'http.method': 'GET',
+        'next.span_name': `fetch GET https://user:pass@example.vercel.sh/api?access_token=${secret}`,
         'custom.secret': 'should not be exposed',
       },
       events: [
@@ -588,11 +589,13 @@ describe('request insights', () => {
       expect.objectContaining({
         spans: [
           expect.objectContaining({
+            name: 'fetch GET https://example.vercel.sh/api?query=redacted',
             attributes: {
               'next.span_type': 'AppRender.fetch',
-              'http.url':
-                'https://example.vercel.sh/api?access_token=redacted&delay=1&signature=redacted',
+              'http.url': 'https://example.vercel.sh/api?query=redacted',
               'http.method': 'GET',
+              'next.span_name':
+                'fetch GET https://example.vercel.sh/api?query=redacted',
             },
             events: [
               {
@@ -614,13 +617,95 @@ describe('request insights', () => {
         ],
         fetches: [
           expect.objectContaining({
-            url: 'https://example.vercel.sh/api?access_token=redacted&delay=1&signature=redacted',
+            url: 'https://example.vercel.sh/api?query=redacted',
           }),
           expect.objectContaining({
-            url: 'https://example.vercel.sh/api?token=redacted&keep=1',
+            url: 'https://example.vercel.sh/api?query=redacted',
           }),
         ],
       })
     )
+    expect(JSON.stringify(getRequestInsightsSnapshot())).not.toContain(secret)
+  })
+
+  it('only exposes bounded URLs without query payloads', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const cases = [
+      {
+        requestId: 'relative',
+        input: '/products/blue?sort=price#details',
+        expected: '/products/blue?query=redacted',
+      },
+      {
+        requestId: 'protocol-relative',
+        input: '//example.com/items?cursor=secret',
+        expected: '//example.com/items?query=redacted',
+      },
+      {
+        requestId: 'absolute',
+        input: 'https://user:password@example.com/items?visible=value#details',
+        expected: 'https://example.com/items?query=redacted',
+      },
+      {
+        requestId: 'opaque',
+        input: 'data:text/plain,secret',
+        expected: 'data:redacted',
+      },
+      {
+        requestId: 'untrusted-relative',
+        input: 'items?token=secret',
+        expected: undefined,
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      recordRequestInsightFetch(
+        { requestId: testCase.requestId },
+        { url: testCase.input, startTime: 100, durationMs: 1 }
+      )
+    }
+
+    const requests = new Map(
+      getRequestInsightsSnapshot().requests.map((request) => [
+        request.requestId,
+        request,
+      ])
+    )
+    for (const testCase of cases) {
+      expect(requests.get(testCase.requestId)?.fetches[0]?.url).toBe(
+        testCase.expected
+      )
+    }
+
+    recordRequestInsightFetch(
+      { requestId: 'oversized' },
+      {
+        url: `https://example.com/${'x'.repeat(64 * 1024)}`,
+        startTime: 100,
+        durationMs: 1,
+      }
+    )
+    expect(
+      getRequestInsightsSnapshot().requests.find(
+        (request) => request.requestId === 'oversized'
+      )?.fetches[0]?.url
+    ).toBeUndefined()
+
+    recordRequestInsightFetch(
+      { requestId: 'query-name' },
+      {
+        url: 'https://example.com/items?sk_live_SENTINEL',
+        startTime: 100,
+        durationMs: 1,
+      }
+    )
+    expect(
+      JSON.stringify(
+        getRequestInsightsSnapshot().requests.find(
+          (request) => request.requestId === 'query-name'
+        )
+      )
+    ).not.toContain('sk_live_SENTINEL')
   })
 })

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -19,6 +19,8 @@ import type { SpanStoreRecord } from './span-store'
 export { isRequestInsightsEnabled } from './span-store'
 
 const MAX_REQUEST_INSIGHTS = 100
+const MAX_REQUEST_INSIGHT_URL_LENGTH = 2048
+const MAX_REQUEST_INSIGHT_RAW_URL_LENGTH = 64 * 1024
 const REQUEST_INSIGHTS_STORE_KEY = Symbol.for('@next/request-insights-store')
 const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
   'NextNodeServer.clientComponentLoading'
@@ -55,9 +57,6 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.span_name',
   'next.span_type',
 ])
-const SENSITIVE_PARAM_NAME_RE =
-  /(?:^|[_-])(?:access[_-]?token|api[_-]?key|auth|authorization|code|cookie|credential|id[_-]?token|jwt|key|password|secret|session|signature|sig|token)(?:$|[_-])/i
-
 class InMemoryRequestInsightsStore {
   private readonly requests = new Map<string, RequestInsight>()
   private readonly requestTimings = new Map<
@@ -116,7 +115,7 @@ class InMemoryRequestInsightsStore {
           : insight.status
 
     insight.spans.push({
-      name: span.name,
+      name: sanitizeSpanName(span),
       startTime: spanStartTime,
       durationMs: span.durationMs,
       status: span.status,
@@ -462,15 +461,43 @@ function sanitizeSpanAttributes(
   }
 
   const sanitized: NonNullable<SpanStoreRecord['attributes']> = {}
+  const sanitizedFetchSpanName =
+    attributes['next.span_type'] === 'AppRender.fetch'
+      ? getSanitizedFetchSpanName(attributes)
+      : undefined
   for (const [key, value] of Object.entries(attributes)) {
     if (!SAFE_SPAN_ATTRIBUTE_KEYS.has(key)) {
       continue
     }
 
-    sanitized[key] = key === 'http.url' ? sanitizeUrlAttribute(value) : value
+    sanitized[key] =
+      key === 'http.url'
+        ? sanitizeUrlAttribute(value)
+        : key === 'next.span_name' && sanitizedFetchSpanName
+          ? sanitizedFetchSpanName
+          : value
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+function sanitizeSpanName(span: SpanStoreRecord): string {
+  if (span.attributes?.['next.span_type'] !== 'AppRender.fetch') {
+    return span.name
+  }
+
+  return getSanitizedFetchSpanName(span.attributes, span.url)
+}
+
+function getSanitizedFetchSpanName(
+  attributes: NonNullable<SpanStoreRecord['attributes']>,
+  fallbackUrl?: string
+): string {
+  const method = getStringAttribute(attributes['http.method'])
+  const url = sanitizeUrl(
+    getStringAttribute(attributes['http.url']) ?? fallbackUrl
+  )
+  return ['fetch', method, url].filter(Boolean).join(' ')
 }
 
 function sanitizeSpanEvents(
@@ -500,24 +527,67 @@ function sanitizeUrl(value: string | undefined): string | undefined {
     return value
   }
 
-  const isRelativeUrl = value.startsWith('/')
+  if (value.length > MAX_REQUEST_INSIGHT_RAW_URL_LENGTH) {
+    return undefined
+  }
+
+  const isProtocolRelativeUrl = value.startsWith('//')
+  const isRootRelativeUrl = !isProtocolRelativeUrl && value.startsWith('/')
+  const hasProtocol = /^[a-z][a-z\d+.-]*:/i.test(value)
+
+  if (!isProtocolRelativeUrl && !isRootRelativeUrl && !hasProtocol) {
+    return undefined
+  }
 
   try {
-    const url = isRelativeUrl ? new URL(value, 'http://n') : new URL(value)
+    const url =
+      isProtocolRelativeUrl || isRootRelativeUrl
+        ? new URL(value, 'http://n')
+        : new URL(value)
+
+    if (
+      url.protocol !== 'http:' &&
+      url.protocol !== 'https:' &&
+      !isProtocolRelativeUrl &&
+      !isRootRelativeUrl
+    ) {
+      return `${url.protocol}${REDACTED_VALUE}`
+    }
 
     url.username = ''
     url.password = ''
+    url.hash = ''
 
-    for (const name of Array.from(url.searchParams.keys())) {
-      if (SENSITIVE_PARAM_NAME_RE.test(name)) {
-        url.searchParams.set(name, REDACTED_VALUE)
-      }
-    }
+    const hasApplicationQuery = Array.from(url.searchParams.keys()).some(
+      (name) => name !== '_rsc'
+    )
+    url.search = hasApplicationQuery ? `?query=${REDACTED_VALUE}` : ''
 
-    return isRelativeUrl ? `${url.pathname}${url.search}${url.hash}` : url.href
+    const sanitizedUrl = isProtocolRelativeUrl
+      ? `//${url.host}${url.pathname}${url.search}`
+      : isRootRelativeUrl
+        ? `${url.pathname}${url.search}`
+        : url.href
+
+    return truncateText(sanitizedUrl, MAX_REQUEST_INSIGHT_URL_LENGTH)
   } catch {
+    return undefined
+  }
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
     return value
   }
+
+  let end = Math.max(0, maxLength - 1)
+  if (end > 0) {
+    const lastCharCode = value.charCodeAt(end - 1)
+    if (lastCharCode >= 0xd800 && lastCharCode <= 0xdbff) {
+      end--
+    }
+  }
+  return `${value.slice(0, end)}…`
 }
 
 function getStringAttribute(value: AttributeValue | undefined) {

--- a/test/development/app-dir/request-insights/app/instant-insights/page.tsx
+++ b/test/development/app-dir/request-insights/app/instant-insights/page.tsx
@@ -1,3 +1,5 @@
+import { EmitRequestInsightsSnapshot } from './snapshot-button'
+
 export const instant = { level: 'experimental-error' }
 
 async function fillCache() {
@@ -13,5 +15,10 @@ export default async function Page() {
 
   await fillCache()
 
-  return <p>{message}</p>
+  return (
+    <>
+      <p>{message}</p>
+      <EmitRequestInsightsSnapshot />
+    </>
+  )
 }

--- a/test/development/app-dir/request-insights/app/instant-insights/snapshot-button.tsx
+++ b/test/development/app-dir/request-insights/app/instant-insights/snapshot-button.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { dispatcher } from 'next/dist/compiled/next-devtools'
+
+export function EmitRequestInsightsSnapshot() {
+  return (
+    <button
+      id="emit-request-insights-snapshot"
+      onClick={() => {
+        const startTime = Date.now()
+        dispatcher.onRequestInsightsSnapshot({
+          requests: [
+            ...Array.from({ length: 40 }, (_, index) => ({
+              requestId: `synthetic-request-${index}`,
+              kind: 'request' as const,
+              source: 'page' as const,
+              htmlRequestId: `synthetic-document-${index}`,
+              route: `/synthetic-${index}`,
+              url: `/synthetic-${index}`,
+              startTime: startTime + index,
+              durationMs: index + 1,
+              status: 'ok' as const,
+              spans: [],
+              fetches: [],
+            })),
+            {
+              requestId: 'synthetic-internal-request',
+              kind: 'instant-insights',
+              source: 'instant-insights',
+              htmlRequestId: 'synthetic-internal-document',
+              route: '/synthetic-internal',
+              url: '/synthetic-internal',
+              startTime: startTime + 40,
+              durationMs: 1,
+              status: 'ok',
+              spans: [],
+              fetches: [],
+            },
+          ],
+        })
+      }}
+      type="button"
+    >
+      Emit Request Insights snapshot
+    </button>
+  )
+}

--- a/test/development/app-dir/request-insights/app/products/[id]/page.tsx
+++ b/test/development/app-dir/request-insights/app/products/[id]/page.tsx
@@ -1,0 +1,23 @@
+import { headers } from 'next/headers'
+import { connection } from 'next/server'
+
+export const instant = false
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  await connection()
+  const { id } = await params
+  const host = (await headers()).get('host')
+  if (!host) {
+    throw new Error('Missing request host')
+  }
+
+  await fetch(`http://${host}/api/source?token=Q2_SECRET_SENTINEL`, {
+    cache: 'no-store',
+  })
+
+  return <p id="product-id">{id}</p>
+}

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -712,6 +712,103 @@ describe('request insights', () => {
     })
   })
 
+  it('restores Internal activity across an overlay reload', async () => {
+    const browser = await next.browser('/instant-insights')
+    shouldResetRequestInsightsConfig = true
+
+    await patchRequestInsightsConfig({ showInternal: true })
+    await retry(async () => {
+      const config = JSON.parse(
+        await next.readFile('build/dev/cache/next-devtools-config.json')
+      )
+      expect(config.requestInsights?.showInternal).toBe(true)
+    })
+
+    await browser.refresh()
+    await browser.elementById('emit-request-insights-snapshot').click()
+    await openRequestInsightsPanel(browser)
+    await browser.elementByCss('.request-insights-settings-trigger').click()
+
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const item = Array.from(
+          root?.querySelectorAll('.request-insights-settings-item') ?? []
+        ).find((candidate) =>
+          candidate.textContent?.includes('Internal activity')
+        )
+        return {
+          checked:
+            item
+              ?.querySelector('.request-insights-settings-checkbox')
+              ?.getAttribute('data-checked') ?? null,
+          syntheticInternalVisible: Array.from(
+            root?.querySelectorAll(
+              '.request-insights-row[data-internal="true"]'
+            ) ?? []
+          ).some((row) =>
+            row.getAttribute('aria-label')?.includes('/synthetic-internal')
+          ),
+        }
+      })
+
+      expect(state).toEqual({
+        checked: 'true',
+        syntheticInternalVisible: true,
+      })
+    })
+  })
+
+  it('contains Request Insights scrolling inside the overlay panes', async () => {
+    const browser = await next.browser('/instant-insights')
+
+    await browser.elementById('emit-request-insights-snapshot').click()
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        document.body.style.minHeight = '300vh'
+        window.scrollTo(0, 200)
+
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const list = root?.querySelector<HTMLElement>('.request-insights-list')
+        const details = root?.querySelector<HTMLElement>(
+          '.request-insights-details'
+        )
+        const pageScrollBefore = window.scrollY
+
+        if (list) {
+          list.scrollTop = list.scrollHeight
+          list.scrollBy({ top: 100 })
+        }
+
+        return {
+          detailsOverscroll: details
+            ? getComputedStyle(details).overscrollBehaviorY
+            : null,
+          listOverflow: list ? getComputedStyle(list).overflowY : null,
+          listOverscroll: list
+            ? getComputedStyle(list).overscrollBehaviorY
+            : null,
+          listScrollable: list
+            ? list.scrollHeight > list.clientHeight && list.scrollTop > 0
+            : false,
+          pageScrollBefore,
+          pageScrollAfter: window.scrollY,
+        }
+      })
+
+      expect(state).toEqual({
+        detailsOverscroll: 'contain',
+        listOverflow: 'auto',
+        listOverscroll: 'contain',
+        listScrollable: true,
+        pageScrollBefore: 200,
+        pageScrollAfter: 200,
+      })
+    })
+  })
+
   it('relates owned Instant Insights to the foreground request', async () => {
     const browser = await next.browser('/instant-insights')
     shouldResetRequestInsightsConfig = true

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -561,12 +561,12 @@ describe('request insights', () => {
       expect(instantInsights?.htmlRequestId).toBe(request?.htmlRequestId)
       expect(request?.fetches).toEqual([
         expect.objectContaining({
-          url: 'data:text/plain,instant insights',
+          url: 'data:redacted',
         }),
       ])
       expect(instantInsights?.fetches).toEqual([
         expect.objectContaining({
-          url: 'data:text/plain,instant insights',
+          url: 'data:redacted',
         }),
       ])
       const rootSpans = instantInsights?.spans.filter(

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -712,113 +712,118 @@ describe('request insights', () => {
     })
   })
 
-  it('hides internal activity behind the settings menu', async () => {
+  it('relates owned Instant Insights to the foreground request', async () => {
     const browser = await next.browser('/instant-insights')
     shouldResetRequestInsightsConfig = true
 
-    function getSettingsMenuItems(): Promise<
-      Array<{ label: string | undefined; checked: string | null }>
-    > {
-      return browser.eval(() => {
-        const root = document.querySelector('nextjs-portal')?.shadowRoot
-        return Array.from(
-          root?.querySelectorAll('.request-insights-settings-item') ?? []
-        ).map((item) => ({
-          label: item.textContent?.trim(),
-          checked:
-            item
-              .querySelector('.request-insights-settings-checkbox')
-              ?.getAttribute('data-checked') ?? null,
-        }))
-      })
-    }
-
     await openRequestInsightsPanel(browser)
 
+    let allRequestCount = 0
     await retry(async () => {
       const state = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
         const rows = Array.from(
           root?.querySelectorAll('.request-insights-row') ?? []
         )
+        const owner = rows.find(
+          (row) =>
+            row.querySelector('.request-insights-route-label')?.textContent ===
+            '/instant-insights'
+        )
         return {
           rowCount: rows.length,
-          hasInstantInsightsRow: rows.some((row) =>
-            row.textContent?.includes('Instant Insights')
-          ),
+          internalRowCount: rows.filter(
+            (row) => row.getAttribute('data-internal') === 'true'
+          ).length,
+          ownerInstantLabel: owner
+            ?.querySelector('[data-activity="instant-insights"]')
+            ?.textContent?.trim(),
         }
       })
 
+      allRequestCount = state.rowCount
       expect(state.rowCount).toBeGreaterThan(0)
-      expect(state.hasInstantInsightsRow).toBe(false)
+      expect(state.internalRowCount).toBe(0)
+      expect(state.ownerInstantLabel).toBe('Instant')
     })
 
-    await browser.elementByCss('.request-insights-settings-trigger').click()
     await retry(async () => {
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: null },
-        { label: 'Verbose traces', checked: null },
-      ])
-    })
-
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Internal activity")'
-      )
-      .click()
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Verbose traces")'
-      )
-      .click()
-
-    await retry(async () => {
-      const internalRows = await browser.eval(() => {
+      const selected = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
-        return Array.from(
-          root?.querySelectorAll(
-            '.request-insights-row[data-internal="true"]'
-          ) ?? []
-        ).map((row) => ({
-          nested: row.hasAttribute('data-nested'),
-          label: row.textContent ?? '',
-        }))
+        const owner = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find(
+          (row) =>
+            row.querySelector('.request-insights-route-label')?.textContent ===
+            '/instant-insights'
+        )
+        owner?.click()
+        return owner !== undefined
       })
-
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: 'true' },
-        { label: 'Verbose traces', checked: 'true' },
-      ])
-      expect(internalRows.length).toBeGreaterThan(0)
-      for (const row of internalRows) {
-        expect(row.nested).toBe(false)
-        expect(row.label).toContain('Instant Insights')
-      }
+      expect(selected).toBe(true)
     })
 
     await retry(async () => {
-      const config = JSON.parse(
-        await next.readFile('build/dev/cache/next-devtools-config.json')
+      const instantSection = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const section = root?.querySelector<HTMLDetailsElement>(
+          '.request-insights-instant-section'
+        )
+        return {
+          exists: section !== null,
+          open: section?.open ?? null,
+          title: section
+            ?.querySelector('summary > span:first-child')
+            ?.textContent?.trim(),
+        }
+      })
+      expect(instantSection.exists).toBe(true)
+      expect(instantSection.open).toBe(false)
+      expect(instantSection.title).toBe('Instant Insights')
+    })
+
+    await browser
+      .elementByCss('.request-insights-instant-section > summary')
+      .click()
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const section = root?.querySelector<HTMLDetailsElement>(
+          '.request-insights-instant-section'
+        )
+        return {
+          open: section?.open ?? false,
+          traceRows:
+            section?.querySelectorAll('.request-insights-span-row').length ?? 0,
+        }
+      })
+      expect(state.open).toBe(true)
+      expect(state.traceRows).toBeGreaterThan(0)
+    })
+
+    await browser
+      .elementByCss(
+        '.request-insights-scope-switcher button:has-text("This page")'
       )
-      expect(config.requestInsights).toEqual({
-        showInternal: true,
-        verbose: true,
-      })
-    })
-
-    await browser.elementByCss('.request-insights-details').click()
-    await browser.refresh()
-    await openRequestInsightsPanel(browser)
-    await browser.elementByCss('.request-insights-settings-trigger').click()
-
+      .click()
     await retry(async () => {
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: 'true' },
-        { label: 'Verbose traces', checked: 'true' },
-      ])
+      const pageScope = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const button = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>(
+            '.request-insights-scope-switcher button'
+          ) ?? []
+        ).find((item) => item.textContent?.trim() === 'This page')
+        return {
+          pressed: button?.getAttribute('aria-pressed'),
+          requestCount:
+            root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(pageScope.pressed).toBe('true')
+      expect(pageScope.requestCount).toBeGreaterThan(0)
+      expect(pageScope.requestCount).toBeLessThan(allRequestCount)
     })
   })
 
@@ -946,6 +951,9 @@ describe('request insights', () => {
     const browser = await next.browser('/products/blue?tab=details')
     await openRequestInsightsPanel(browser)
 
+    const foregroundTraceSelector =
+      '.request-insights-details > .request-insights-section .request-insights-trace-rows'
+
     await retry(async () => {
       const selected = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
@@ -956,15 +964,17 @@ describe('request insights', () => {
           candidate.textContent?.includes('/products/blue?query=redacted')
         )
         row?.click()
-        return row !== undefined
+        return row?.dataset.selected === 'true'
       })
       expect(selected).toBe(true)
     })
 
     await browser
-      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .locator(
+        `nextjs-portal ${foregroundTraceSelector} .request-insights-span-row[data-active="true"]`
+      )
       .hover()
-    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+    await browser.locator(`nextjs-portal ${foregroundTraceSelector}`).focus()
 
     const readTraceState = () =>
       browser.eval(() => {
@@ -973,7 +983,7 @@ describe('request insights', () => {
           '.request-insights-panel-container'
         )
         const listbox = root?.querySelector<HTMLElement>(
-          '.request-insights-trace-rows'
+          '.request-insights-details > .request-insights-section .request-insights-trace-rows'
         )
         const activeDescendant = listbox?.getAttribute('aria-activedescendant')
         const activeRow = listbox?.querySelector<HTMLElement>(
@@ -990,11 +1000,19 @@ describe('request insights', () => {
         const tooltipRect = tooltip?.getBoundingClientRect()
 
         return {
+          activeRowCount:
+            listbox?.querySelectorAll(
+              '.request-insights-span-row[data-active="true"]'
+            ).length ?? 0,
           activeDescendant,
           activeRowId: activeRow?.id ?? null,
           activeTraceItemId: activeRow?.dataset.traceItemId ?? null,
           firstRowId: firstRow?.id ?? null,
           activeLabel: activeRow?.getAttribute('aria-label') ?? null,
+          requestTitle:
+            root
+              ?.querySelector('.request-insights-title')
+              ?.textContent?.trim() ?? null,
           focused: root?.activeElement === listbox,
           horizontalOverlap:
             !!rowRect &&
@@ -1022,6 +1040,7 @@ describe('request insights', () => {
     const expectAnchoredTrace = async (expectedTraceItemId?: string | null) =>
       retry(async () => {
         const state = await readTraceState()
+        expect(state.activeRowCount).toBe(1)
         expect(state.activeDescendant).toEqual(expect.any(String))
         if (expectedTraceItemId !== undefined) {
           expect(state.activeTraceItemId).toBe(expectedTraceItemId)
@@ -1040,7 +1059,9 @@ describe('request insights', () => {
     await browser.eval(() => {
       const root = document.querySelector('nextjs-portal')?.shadowRoot
       root
-        ?.querySelector<HTMLElement>('.request-insights-trace-rows')
+        ?.querySelector<HTMLElement>(
+          '.request-insights-details > .request-insights-section .request-insights-trace-rows'
+        )
         ?.dispatchEvent(
           new KeyboardEvent('keydown', {
             altKey: true,
@@ -1119,10 +1140,19 @@ describe('request insights', () => {
       expect(selection.activeRowId).toBe(selection.firstRowId)
     })
 
+    await retry(async () => {
+      const state = await readTraceState()
+      expect(state.activeRowCount).toBe(1)
+      expect(state.requestTitle).toBe('/api/source?query=redacted')
+      expect(state.activeTraceItemId).not.toBe(nextState.activeTraceItemId)
+    })
+
     await browser
-      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .locator(
+        `nextjs-portal ${foregroundTraceSelector} .request-insights-span-row:first-child`
+      )
       .hover()
-    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+    await browser.locator(`nextjs-portal ${foregroundTraceSelector}`).focus()
 
     const switchedState = await expectAnchoredTrace()
     expect(switchedState.activeDescendant).toBe(switchedState.firstRowId)

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -888,6 +888,246 @@ describe('request insights', () => {
     })
   })
 
+  it('shows concrete request URLs, route params, and fetch origins', async () => {
+    const browser = await next.browser('/products/blue?tab=details')
+
+    await retry(async () => {
+      expect(await browser.elementById('product-id').text()).toBe('blue')
+    })
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/products/blue?query=redacted')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+
+    await retry(async () => {
+      const details = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const panel = root?.querySelector('.request-insights-details')
+        return {
+          text: panel?.textContent ?? '',
+          paramsLabel:
+            panel?.querySelector('.request-insights-params-trigger')
+              ?.textContent ?? '',
+          fetchOrigins: Array.from(
+            panel?.querySelectorAll('.request-insights-fetch-origin') ?? []
+          ).map((element) => element.textContent ?? ''),
+          fetchTraceLabels: Array.from(
+            panel?.querySelectorAll(
+              '.request-insights-span-row[data-kind="fetch"] .request-insights-span-label'
+            ) ?? []
+          ).map((element) => element.textContent ?? ''),
+        }
+      })
+
+      expect(details.text).toContain('/products/blue?query=redacted')
+      expect(details.text).toContain('Route /products/[id]')
+      expect(details.paramsLabel).toBe('Params id')
+      expect(details.fetchOrigins).toContain('Same origin')
+      expect(
+        details.fetchTraceLabels.some((label) => label.includes('Same origin'))
+      ).toBe(true)
+      expect(details.text).not.toContain('Q2_SECRET_SENTINEL')
+    })
+  })
+
+  it('keeps trace inspection anchored while the panel is resized', async () => {
+    const browser = await next.browser('/products/blue?tab=details')
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/products/blue?query=redacted')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+
+    await browser
+      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .hover()
+    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+
+    const readTraceState = () =>
+      browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const panel = root?.querySelector<HTMLElement>(
+          '.request-insights-panel-container'
+        )
+        const listbox = root?.querySelector<HTMLElement>(
+          '.request-insights-trace-rows'
+        )
+        const activeDescendant = listbox?.getAttribute('aria-activedescendant')
+        const activeRow = listbox?.querySelector<HTMLElement>(
+          '.request-insights-span-row[data-active="true"]'
+        )
+        const firstRow = listbox?.querySelector<HTMLElement>(
+          '.request-insights-span-row'
+        )
+        const tooltip = root?.querySelector<HTMLElement>(
+          '.request-insights-trace-tooltip'
+        )
+        const panelRect = panel?.getBoundingClientRect()
+        const rowRect = activeRow?.getBoundingClientRect()
+        const tooltipRect = tooltip?.getBoundingClientRect()
+
+        return {
+          activeDescendant,
+          activeRowId: activeRow?.id ?? null,
+          activeTraceItemId: activeRow?.dataset.traceItemId ?? null,
+          firstRowId: firstRow?.id ?? null,
+          activeLabel: activeRow?.getAttribute('aria-label') ?? null,
+          focused: root?.activeElement === listbox,
+          horizontalOverlap:
+            !!rowRect &&
+            !!tooltipRect &&
+            tooltipRect.right >= rowRect.left &&
+            tooltipRect.left <= rowRect.right,
+          tooltipLabel: tooltip?.textContent?.trim() ?? null,
+          tooltipNearPanel:
+            !!panelRect &&
+            !!tooltipRect &&
+            tooltipRect.right >= panelRect.left - 100 &&
+            tooltipRect.left <= panelRect.right + 100 &&
+            tooltipRect.bottom >= panelRect.top - 100 &&
+            tooltipRect.top <= panelRect.bottom + 100,
+          verticalGap:
+            rowRect && tooltipRect
+              ? Math.min(
+                  Math.abs(tooltipRect.bottom - rowRect.top),
+                  Math.abs(tooltipRect.top - rowRect.bottom)
+                )
+              : Number.POSITIVE_INFINITY,
+        }
+      })
+
+    const expectAnchoredTrace = async (expectedTraceItemId?: string | null) =>
+      retry(async () => {
+        const state = await readTraceState()
+        expect(state.activeDescendant).toEqual(expect.any(String))
+        if (expectedTraceItemId !== undefined) {
+          expect(state.activeTraceItemId).toBe(expectedTraceItemId)
+        }
+        expect(state.activeRowId).toBe(state.activeDescendant)
+        expect(state.activeLabel).toBe(state.tooltipLabel)
+        expect(state.focused).toBe(true)
+        expect(state.horizontalOverlap).toBe(true)
+        expect(state.tooltipNearPanel).toBe(true)
+        expect(state.verticalGap).toBeLessThan(160)
+        return state
+      })
+
+    const initialState = await expectAnchoredTrace()
+
+    await browser.eval(() => {
+      const root = document.querySelector('nextjs-portal')?.shadowRoot
+      root
+        ?.querySelector<HTMLElement>('.request-insights-trace-rows')
+        ?.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            altKey: true,
+            bubbles: true,
+            key: 'ArrowDown',
+          })
+        )
+    })
+    expect((await readTraceState()).activeTraceItemId).toBe(
+      initialState.activeTraceItemId
+    )
+
+    await browser.keydown('ArrowDown')
+    await browser.keyup('ArrowDown')
+
+    const nextState = await retry(async () => {
+      const state = await readTraceState()
+      expect(state.activeTraceItemId).not.toBe(initialState.activeTraceItemId)
+      return state
+    })
+    await expectAnchoredTrace(nextState.activeTraceItemId)
+
+    const columnCountAtPanelWidth = async (width: number): Promise<number> => {
+      return await browser.eval(`(() => {
+        const root = document.querySelector('nextjs-portal').shadowRoot
+        const panelContainer = root.querySelector('.dynamic-panel-container')
+        panelContainer.style.width = '${width}px'
+        const panel = root.querySelector('.request-insights-panel')
+        return getComputedStyle(panel).gridTemplateColumns.split(' ').length
+      })()`)
+    }
+
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(760)).toBe(2)
+    })
+    await expectAnchoredTrace()
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(560)).toBe(1)
+    })
+    await expectAnchoredTrace()
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(760)).toBe(2)
+    })
+    await expectAnchoredTrace()
+
+    await browser
+      .locator('nextjs-portal .request-insights-row[aria-label^="/api/source"]')
+      .first()
+      .click()
+
+    await retry(async () => {
+      const selection = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) => candidate.textContent?.includes('/api/source'))
+        return {
+          found: row !== undefined,
+          selected: row?.dataset.selected,
+          title: root
+            ?.querySelector<HTMLElement>('.request-insights-title')
+            ?.textContent?.trim(),
+          activeRowId: root?.querySelector<HTMLElement>(
+            '.request-insights-span-row[data-active="true"]'
+          )?.id,
+          firstRowId: root?.querySelector<HTMLElement>(
+            '.request-insights-span-row'
+          )?.id,
+        }
+      })
+      expect(selection.found).toBe(true)
+      expect(selection.selected).toBe('true')
+      expect(selection.title).toBe('/api/source?query=redacted')
+      expect(selection.firstRowId).toEqual(expect.any(String))
+      expect(selection.activeRowId).toBe(selection.firstRowId)
+    })
+
+    await browser
+      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .hover()
+    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+
+    const switchedState = await expectAnchoredTrace()
+    expect(switchedState.activeDescendant).toBe(switchedState.firstRowId)
+  })
+
   it('classifies framework-owned request activity without retaining action IDs', async () => {
     const existingRequestIds = new Set(
       (
@@ -1009,8 +1249,18 @@ describe('request insights', () => {
   })
 
   it('classifies an App Route before its handler completes', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
     const waitKey = `active-${Date.now()}`
     const requestPath = `/api/app-stream-lifecycle?wait=${waitKey}`
+    const recordedRequestPath = '/api/app-stream-lifecycle?query=redacted'
     const responsePromise = next.fetch(requestPath)
 
     try {
@@ -1021,7 +1271,10 @@ describe('request insights', () => {
           requests: RequestInsight[]
         }
         const matchingRequests = snapshot.requests.filter(
-          (request) => request.url === requestPath
+          (request) =>
+            !existingRequestIds.has(request.requestId) &&
+            request.url === recordedRequestPath &&
+            request.kind !== 'instant-insights'
         )
 
         expect(matchingRequests).toHaveLength(1)
@@ -1052,7 +1305,12 @@ describe('request insights', () => {
       }
       const matchingRequests = snapshot.requests.filter(
         (request) =>
-          request.url === requestPath && request.kind !== 'instant-insights'
+          !existingRequestIds.has(request.requestId) &&
+          request.url === recordedRequestPath &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'GET'
+          )
       )
 
       expect(matchingRequests).toHaveLength(1)
@@ -1071,7 +1329,17 @@ describe('request insights', () => {
   })
 
   it('classifies a Page after proxy completes', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
     const requestPath = `/api/proxied-page?run=${Date.now()}`
+    const recordedRequestPath = '/api/proxied-page?query=redacted'
     const response = await next.fetch(requestPath)
     expect(response.status).toBe(200)
     expect(await response.text()).toContain('proxied page')
@@ -1084,7 +1352,9 @@ describe('request insights', () => {
       }
       const matchingRequests = snapshot.requests.filter(
         (request) =>
-          request.url === requestPath && request.kind !== 'instant-insights'
+          !existingRequestIds.has(request.requestId) &&
+          request.url === recordedRequestPath &&
+          request.kind !== 'instant-insights'
       )
 
       expect(matchingRequests).toHaveLength(1)

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -756,6 +756,7 @@ describe('request insights', () => {
     await browser.elementByCss('.request-insights-settings-trigger').click()
     await retry(async () => {
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: null },
         { label: 'Verbose traces', checked: null },
       ])
@@ -773,26 +774,26 @@ describe('request insights', () => {
       .click()
 
     await retry(async () => {
-      const nestedRows = await browser.eval(() => {
+      const internalRows = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
         return Array.from(
-          root?.querySelectorAll('.request-insights-row[data-nested="true"]') ??
-            []
+          root?.querySelectorAll(
+            '.request-insights-row[data-internal="true"]'
+          ) ?? []
         ).map((row) => ({
-          internal: row.getAttribute('data-internal'),
-          hasArrow: !!row.querySelector('.request-insights-nested-arrow'),
+          nested: row.hasAttribute('data-nested'),
           label: row.textContent ?? '',
         }))
       })
 
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
-      expect(nestedRows.length).toBeGreaterThan(0)
-      for (const row of nestedRows) {
-        expect(row.internal).toBe('true')
-        expect(row.hasArrow).toBe(true)
+      expect(internalRows.length).toBeGreaterThan(0)
+      for (const row of internalRows) {
+        expect(row.nested).toBe(false)
         expect(row.label).toContain('Instant Insights')
       }
     })
@@ -814,9 +815,76 @@ describe('request insights', () => {
 
     await retry(async () => {
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
+    })
+  })
+
+  it('filters typed request rows and pauses live updates', async () => {
+    const browser = await next.browser('/instant-insights')
+    expect((await next.fetch('/api/source?before=pause')).status).toBe(200)
+
+    await openRequestInsightsPanel(browser)
+    await browser.elementByCss('.request-insights-filter-trigger').click()
+    await browser
+      .elementByCss(
+        '.request-insights-filter-item[data-filter-value="source:api"]'
+      )
+      .click()
+
+    await retry(async () => {
+      const rowTypes = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-request-type') ?? []
+        ).map((type) => type.textContent?.trim())
+      })
+      expect(rowTypes.length).toBeGreaterThan(0)
+      expect(new Set(rowTypes)).toEqual(new Set(['API']))
+    })
+
+    await browser.elementByCss('.request-insights-details').click()
+    await browser.elementByCss('.request-insights-settings-trigger').click()
+    await browser
+      .elementByCss('.request-insights-settings-item:has-text("Pause updates")')
+      .click()
+
+    const pausedRowCount = await browser.eval(() => {
+      const root = document.querySelector('nextjs-portal')?.shadowRoot
+      return root?.querySelectorAll('.request-insights-row').length ?? 0
+    })
+    expect((await next.fetch('/api/source?while=paused')).status).toBe(200)
+
+    await retry(async () => {
+      const pausedState = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return {
+          paused: root?.querySelector('.request-insights-paused-state')
+            ?.textContent,
+          rowCount: root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(pausedState).toEqual({
+        paused: 'Paused',
+        rowCount: pausedRowCount,
+      })
+    })
+
+    await browser
+      .elementByCss('.request-insights-settings-item:has-text("Pause updates")')
+      .click()
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return {
+          paused: root?.querySelector('.request-insights-paused-state'),
+          rowCount: root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(state.paused).toBeNull()
+      expect(state.rowCount).toBeGreaterThan(pausedRowCount)
     })
   })
 


### PR DESCRIPTION
## Summary

This PR turns the trusted classification foundation into a usable, stable Request Insights exploration experience while keeping capture and viewing concerns separate.

- `Add Request Insights filters and pause controls`
  - adds typed filters for request type, representation, framework activity, response status, fetch presence, and cache state
  - shows live option counts and disables impossible selections
  - adds a viewer-only pause snapshot; server capture continues and an authoritative resync replaces the snapshot on resume
  - keeps Pause inside the settings control instead of spending permanent header space
- `Improve Request Insights request and fetch details`
  - uses the sanitized concrete URL as the selected request title while retaining the matched route pattern separately
  - parses validated dynamic, catch-all, and optional parameters and refuses malformed route patterns
  - shows same-origin versus external fetch context, bounded middle truncation, and the full safe origin in an accessible tooltip
  - redacts credential-bearing, data, and other unsafe URL forms
- `Relate Request Insights activity`
  - attaches framework-owned Instant Insights records to the exact foreground request that caused them
  - keeps truly orphaned internal activity separately filterable
  - avoids representing causal server requests as an unbounded nested tree; they remain distinct logical roots
- `Keep Request Insights trace focus stable`
  - preserves keyboard and pointer focus when the panel resizes or trace rows rerender
  - anchors responsive tooltips to the focused row instead of placing them at the bottom of the viewport
- `Test Request Insights overlay persistence and scrolling`
  - verifies Internal activity restoration on first overlay load
  - contains request-list, detail, settings, and trace scrolling so the underlying application does not move
  - covers keyboard trace navigation and selection fallback when filters hide or retention evicts a row
- `Expect sanitized Request Insights fetch URLs`
  - pins the safe `data:redacted` representation and prevents raw data URLs from appearing in tests or UI

## Verification

- exact layer head passes `pnpm --filter=next types`
- focused request/fetch labeling, route-parameter parsing, filters, terminal-safe serialization, trace focus, tooltip, persistence, and scroll-containment tests
- Request Insights suite verifies pause/resume, authoritative resync, typed filters, concrete URLs and parameters, internal/external origins, owned Instant activity, resizing, keyboard focus, and contained scrolling in Turbopack and Webpack
- accessibility coverage includes listbox semantics, active-descendant selection, rich request-row labels, focus-visible states, live regions, and progress semantics
- final Fable 5 corrected-stack review: `SHIP`, zero blockers
