### PR TITLE
Improve Request Insights request and fetch details

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.test.ts
@@ -1,0 +1,60 @@
+import { getFetchUrlPresentation, truncateMiddle } from './fetch-label'
+
+describe('request insight fetch labels', () => {
+  it('classifies same-origin and external fetches by full web origin', () => {
+    expect(
+      getFetchUrlPresentation('/api/items?token=redacted', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'https://app.test/api/items?token=redacted',
+      path: '/api/items?token=redacted',
+      originKind: 'same-origin',
+      originLabel: 'Same origin',
+    })
+    expect(
+      getFetchUrlPresentation('https://api.test:445/items', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'https://api.test:445/items',
+      path: '/items',
+      originKind: 'external',
+      originLabel: 'External origin · api.test:445',
+    })
+    expect(
+      getFetchUrlPresentation('http://app.test/items', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'http://app.test/items',
+      path: '/items',
+      originKind: 'external',
+      originLabel: 'External origin · http://app.test',
+    })
+  })
+
+  it('does not guess origin semantics without a usable browser origin', () => {
+    expect(
+      getFetchUrlPresentation('https://api.test/items', undefined)
+    ).toEqual({
+      fullUrl: 'https://api.test/items',
+      path: '/items',
+      originKind: 'unknown',
+      originLabel: 'https://api.test',
+    })
+    expect(getFetchUrlPresentation('/api/items', undefined)).toEqual({
+      fullUrl: '/api/items',
+      path: '/api/items',
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    })
+  })
+
+  it('middle-truncates labels while retaining their distinguishing suffix', () => {
+    const value = '/api/a/very/long/path/to/tail-marker?token=redacted'
+    const truncated = truncateMiddle(value, 28)
+
+    expect(truncated).toHaveLength(28)
+    expect(truncated).toContain('…')
+    expect(truncated).toMatch(/token=redacted$/)
+
+    expect(truncateMiddle('😀abc', 3)).toBe('😀…c')
+    expect(truncateMiddle('secret', 1)).toBe('…')
+    expect(truncateMiddle('secret', 0)).toBe('')
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.ts
@@ -1,0 +1,111 @@
+export type FetchOriginKind = 'same-origin' | 'external' | 'unknown'
+
+export type FetchUrlPresentation = {
+  fullUrl: string
+  path: string
+  originKind: FetchOriginKind
+  originLabel: string
+}
+
+const DEFAULT_PATH_LENGTH = 48
+const DEFAULT_ORIGIN_LENGTH = 36
+
+export function getFetchUrlPresentation(
+  url: string | undefined,
+  currentOrigin: string | undefined,
+  pathLength = DEFAULT_PATH_LENGTH,
+  originLength = DEFAULT_ORIGIN_LENGTH
+): FetchUrlPresentation {
+  if (!url) {
+    return {
+      fullUrl: 'Unknown URL',
+      path: 'Unknown URL',
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    }
+  }
+
+  const baseUrl = parseHttpUrl(currentOrigin)
+
+  try {
+    const parsedUrl = baseUrl ? new URL(url, baseUrl) : new URL(url)
+    if (!isHttpUrl(parsedUrl)) {
+      return {
+        fullUrl: url,
+        path: truncateMiddle(url, pathLength),
+        originKind: 'unknown',
+        originLabel: 'Origin unavailable',
+      }
+    }
+
+    const sameOrigin = baseUrl?.origin === parsedUrl.origin
+    const originKind = baseUrl
+      ? sameOrigin
+        ? 'same-origin'
+        : 'external'
+      : 'unknown'
+    const compactOrigin =
+      baseUrl?.protocol === parsedUrl.protocol
+        ? parsedUrl.host
+        : parsedUrl.origin
+
+    return {
+      fullUrl: parsedUrl.href,
+      path: truncateMiddle(
+        `${parsedUrl.pathname}${parsedUrl.search}`,
+        pathLength
+      ),
+      originKind,
+      originLabel:
+        originKind === 'same-origin'
+          ? 'Same origin'
+          : originKind === 'external'
+            ? `External origin · ${truncateMiddle(compactOrigin, originLength)}`
+            : truncateMiddle(parsedUrl.origin, originLength),
+    }
+  } catch {
+    return {
+      fullUrl: url,
+      path: truncateMiddle(url, pathLength),
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    }
+  }
+}
+
+export function truncateMiddle(value: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return ''
+  }
+  const characters = Array.from(value)
+  if (characters.length <= maxLength) {
+    return value
+  }
+  if (maxLength === 1) {
+    return '…'
+  }
+
+  const availableLength = maxLength - 1
+  const prefixLength = Math.floor(availableLength / 2)
+  const suffixLength = availableLength - prefixLength
+  return `${characters.slice(0, prefixLength).join('')}…${characters
+    .slice(-suffixLength)
+    .join('')}`
+}
+
+function parseHttpUrl(value: string | undefined): URL | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(value)
+    return isHttpUrl(url) ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:'
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -1,0 +1,285 @@
+import {
+  getRequestInsightKind,
+  getRequestInsightSource,
+  type RequestInsight,
+} from '../../../shared/request-insights'
+import {
+  getRequestInsightRepresentation,
+  getRequestInsightRouterActivity,
+  getRequestInsightStatusCode,
+  hasRequestInsightProxyActivity,
+} from './request-list'
+
+export type RequestInsightFilter =
+  | 'source:page'
+  | 'source:action'
+  | 'source:api'
+  | 'source:image'
+  | 'source:asset'
+  | 'source:unknown'
+  | 'representation:html'
+  | 'representation:rsc'
+  | 'representation:unknown'
+  | 'activity:proxy'
+  | 'activity:instant-insights'
+  | 'activity:prefetch'
+  | 'activity:segment-prefetch'
+  | 'activity:hmr-refresh'
+  | 'status:error'
+  | 'status:http-4xx'
+  | 'status:http-5xx'
+  | 'fetches:present'
+  | 'fetches:none'
+  | 'cache:hit'
+  | 'cache:miss'
+  | 'cache:skip'
+  | 'cache:none'
+
+export type RequestInsightFilterGroup = Readonly<{
+  label: string
+  options: ReadonlyArray<{
+    value: RequestInsightFilter
+    label: string
+  }>
+}>
+
+export const REQUEST_INSIGHT_FILTER_GROUPS: readonly RequestInsightFilterGroup[] =
+  [
+    {
+      label: 'Request type',
+      options: [
+        { value: 'source:page', label: 'Page or navigation' },
+        { value: 'source:action', label: 'Server Action' },
+        { value: 'source:api', label: 'API' },
+        { value: 'source:image', label: 'Image optimization' },
+        { value: 'source:asset', label: 'Static asset' },
+        { value: 'source:unknown', label: 'Unknown type' },
+      ],
+    },
+    {
+      label: 'Page response',
+      options: [
+        { value: 'representation:html', label: 'HTML' },
+        { value: 'representation:rsc', label: 'RSC' },
+        { value: 'representation:unknown', label: 'Unavailable' },
+      ],
+    },
+    {
+      label: 'Activity',
+      options: [
+        { value: 'activity:proxy', label: 'Matched proxy' },
+        { value: 'activity:prefetch', label: 'App Router prefetch' },
+        { value: 'activity:segment-prefetch', label: 'Segment prefetch' },
+        { value: 'activity:hmr-refresh', label: 'HMR refresh' },
+        { value: 'activity:instant-insights', label: 'Instant Insights' },
+      ],
+    },
+    {
+      label: 'Status',
+      options: [
+        { value: 'status:error', label: 'Recorded error' },
+        { value: 'status:http-4xx', label: 'HTTP 4xx' },
+        { value: 'status:http-5xx', label: 'HTTP 5xx' },
+      ],
+    },
+    {
+      label: 'Fetches',
+      options: [
+        { value: 'fetches:present', label: 'Has fetches' },
+        { value: 'fetches:none', label: 'No fetches' },
+      ],
+    },
+    {
+      label: 'Fetch cache',
+      options: [
+        { value: 'cache:hit', label: 'Hit' },
+        { value: 'cache:miss', label: 'Miss' },
+        { value: 'cache:skip', label: 'Skip' },
+        { value: 'cache:none', label: 'No cache activity' },
+      ],
+    },
+  ]
+
+const ALL_FILTERS = REQUEST_INSIGHT_FILTER_GROUPS.flatMap((group) =>
+  group.options.map((option) => option.value)
+)
+
+type RequestInsightFilterResult = Readonly<{
+  requests: RequestInsight[]
+  matchingRequestCount: number
+  totalRequestCount: number
+  optionCounts: Readonly<Record<RequestInsightFilter, number>>
+}>
+
+export function getRequestInsightFilterResult(
+  requests: readonly RequestInsight[],
+  activeFilters: readonly RequestInsightFilter[],
+  showInternal = false
+): RequestInsightFilterResult {
+  const revealInternal =
+    showInternal || activeFilters.includes('activity:instant-insights')
+  const visibleRequests = requests.filter(
+    (request) => getRequestInsightKind(request) === 'request' || revealInternal
+  )
+  const activeFiltersByFacet = groupFiltersByFacet(activeFilters)
+  const optionCounts = Object.fromEntries(
+    ALL_FILTERS.map((filter) => [filter, 0])
+  ) as Record<RequestInsightFilter, number>
+
+  for (const request of requests) {
+    const tags = getRequestInsightTags(request)
+    if (getRequestInsightKind(request) === 'request' || showInternal) {
+      for (const tag of tags) {
+        optionCounts[tag] += 1
+      }
+    } else if (tags.has('activity:instant-insights')) {
+      optionCounts['activity:instant-insights'] += 1
+    }
+  }
+
+  const matchingRequests = visibleRequests.filter((request) =>
+    matchesActiveFilters(getRequestInsightTags(request), activeFiltersByFacet)
+  )
+
+  return {
+    requests: matchingRequests,
+    matchingRequestCount: matchingRequests.length,
+    totalRequestCount: visibleRequests.length,
+    optionCounts,
+  }
+}
+
+export function toggleRequestInsightFilter(
+  activeFilters: readonly RequestInsightFilter[],
+  filter: RequestInsightFilter
+): RequestInsightFilter[] {
+  return activeFilters.includes(filter)
+    ? activeFilters.filter((activeFilter) => activeFilter !== filter)
+    : [...activeFilters, filter]
+}
+
+function getRequestInsightTags(
+  request: RequestInsight
+): Set<RequestInsightFilter> {
+  const tags = new Set<RequestInsightFilter>()
+  const source = getRequestSourceFilter(request)
+  if (source) {
+    tags.add(source)
+  }
+
+  switch (getRequestInsightRepresentation(request)) {
+    case 'html':
+      tags.add('representation:html')
+      break
+    case 'rsc':
+      tags.add('representation:rsc')
+      break
+    case 'unknown':
+      tags.add('representation:unknown')
+      break
+    case 'not-applicable':
+      break
+  }
+
+  if (hasRequestInsightProxyActivity(request)) {
+    tags.add('activity:proxy')
+  }
+  const routerActivity = getRequestInsightRouterActivity(request)
+  if (routerActivity) {
+    tags.add(`activity:${routerActivity}`)
+  }
+  if (getRequestInsightKind(request) === 'instant-insights') {
+    tags.add('activity:instant-insights')
+  }
+
+  if (
+    request.status === 'error' ||
+    request.spans.some((span) => span.status === 'error' || span.error)
+  ) {
+    tags.add('status:error')
+  }
+  const statusCode = getRequestInsightStatusCode(request)
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+    tags.add('status:http-4xx')
+  } else if (
+    statusCode !== undefined &&
+    statusCode >= 500 &&
+    statusCode < 600
+  ) {
+    tags.add('status:http-5xx')
+  }
+
+  if (request.fetches.length === 0) {
+    tags.add('fetches:none')
+    tags.add('cache:none')
+  } else {
+    tags.add('fetches:present')
+    for (const fetch of request.fetches) {
+      if (
+        fetch.cacheStatus === 'hit' ||
+        fetch.cacheStatus === 'miss' ||
+        fetch.cacheStatus === 'skip'
+      ) {
+        tags.add(`cache:${fetch.cacheStatus}`)
+      }
+    }
+  }
+
+  return tags
+}
+
+function getRequestSourceFilter(
+  request: RequestInsight
+): RequestInsightFilter | undefined {
+  const source = getRequestInsightSource(request)
+  if (source === 'page' && request.serverAction) {
+    return 'source:action'
+  }
+
+  switch (source) {
+    case 'page':
+      return 'source:page'
+    case 'app-route':
+    case 'pages-api':
+      return 'source:api'
+    case 'image':
+      return 'source:image'
+    case 'asset':
+      return 'source:asset'
+    case 'proxy':
+    case 'instant-insights':
+      return undefined
+    case 'unknown':
+      return 'source:unknown'
+  }
+}
+
+function groupFiltersByFacet(
+  filters: readonly RequestInsightFilter[]
+): Map<string, RequestInsightFilter[]> {
+  const filtersByFacet = new Map<string, RequestInsightFilter[]>()
+
+  for (const filter of filters) {
+    const facet = filter.slice(0, filter.indexOf(':'))
+    const facetFilters = filtersByFacet.get(facet)
+    if (facetFilters) {
+      facetFilters.push(filter)
+    } else {
+      filtersByFacet.set(facet, [filter])
+    }
+  }
+
+  return filtersByFacet
+}
+
+function matchesActiveFilters(
+  tags: ReadonlySet<RequestInsightFilter>,
+  activeFiltersByFacet: ReadonlyMap<string, RequestInsightFilter[]>
+): boolean {
+  for (const facetFilters of activeFiltersByFacet.values()) {
+    if (!facetFilters.some((filter) => tags.has(filter))) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -1,3 +1,9 @@
+.request-insights-panel-container {
+  container-type: inline-size;
+  height: 100%;
+  min-height: 0;
+}
+
 .request-insights-panel {
   display: grid;
   grid-template-columns: minmax(210px, 320px) minmax(420px, 1fr);
@@ -462,13 +468,61 @@
 }
 
 .request-insights-overview span {
+  overflow: hidden;
+  max-width: 100%;
   min-width: 0;
   border: 1px solid var(--color-gray-400);
   border-radius: 4px;
   padding: 2px 6px;
   color: var(--color-gray-900);
   font-size: var(--size-12);
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-overview .request-insights-route-template {
+  border-style: dashed;
+  font-family: var(--font-mono);
+}
+
+.request-insights-params-trigger {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: help;
+  font: inherit;
+}
+
+.request-insights-params-trigger:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.request-insights-params-tooltip,
+.request-insights-fetch-tooltip,
+.request-insights-trace-tooltip {
+  --tooltip-background: var(--color-background-100);
+
+  border: 1px solid var(--color-gray-alpha-400);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 16%);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-params-tooltip {
+  max-width: min(420px, calc(100vw - 32px));
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.request-insights-fetch-tooltip,
+.request-insights-trace-tooltip {
+  max-width: min(640px, calc(100vw - 32px));
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .request-insights-error {
@@ -596,9 +650,18 @@
   flex-direction: column;
 }
 
+.request-insights-trace-rows:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -1px;
+}
+
 .request-insights-span-row {
   min-height: 28px;
   border-bottom: 1px solid var(--color-gray-300);
+}
+
+.request-insights-span-row[data-active='true'] {
+  background: var(--color-gray-200);
 }
 
 .request-insights-span-row:last-child {
@@ -642,7 +705,6 @@
   background: var(--color-red-800);
 }
 
-.request-insights-fetch-host,
 .request-insights-cache-reason {
   min-width: 0;
   overflow: hidden;
@@ -720,7 +782,52 @@
   gap: 8px;
 }
 
-@media (max-width: 900px) {
+.request-insights-fetch-url-trigger {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  cursor: help;
+}
+
+.request-insights-fetch-path,
+.request-insights-fetch-origin {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.request-insights-fetch-path {
+  color: var(--color-gray-1000);
+  text-overflow: ellipsis;
+}
+
+.request-insights-fetch-origin {
+  max-width: 240px;
+  flex-shrink: 0;
+  border: 1px solid var(--color-gray-400);
+  border-radius: 999px;
+  padding: 0 5px;
+  color: var(--color-gray-800);
+  font-family: inherit;
+  font-size: var(--size-10);
+  text-overflow: ellipsis;
+}
+
+.request-insights-fetch-origin[data-origin='external'] {
+  border-color: var(--color-purple-500);
+  color: var(--color-purple-900);
+}
+
+@media (forced-colors: active) {
+  .request-insights-trace-rows:focus-visible,
+  .request-insights-span-row[data-active='true'] {
+    outline: 1px solid Highlight;
+    outline-offset: -1px;
+  }
+}
+
+@container (width <= 900px) {
   .request-insights-summary {
     align-items: flex-start;
   }
@@ -730,7 +837,7 @@
   }
 }
 
-@media (max-width: 700px) {
+@container (width < 630px) {
   .request-insights-panel {
     grid-template-columns: 1fr;
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -40,6 +40,162 @@
   font-size: var(--size-12);
 }
 
+.request-insights-list-controls,
+.request-insights-update-status {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.request-insights-update-status {
+  color: var(--color-gray-800);
+  font-size: var(--size-11);
+  white-space: nowrap;
+}
+
+.request-insights-paused-state::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 4px;
+  border-radius: 999px;
+  background: var(--color-amber-800);
+  content: '';
+}
+
+.request-insights-filter-trigger {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--color-gray-400);
+  border-radius: 4px;
+  padding: 2px 6px;
+  background: transparent;
+  color: var(--color-gray-900);
+  cursor: pointer;
+  font: inherit;
+}
+
+.request-insights-filter-trigger:hover,
+.request-insights-filter-trigger[aria-expanded='true'] {
+  background: var(--color-gray-200);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-filter-active-count {
+  min-width: 16px;
+  border-radius: 999px;
+  padding: 0 4px;
+  background: var(--color-blue-800);
+  color: var(--color-background-100);
+  font-size: var(--size-10);
+  line-height: 16px;
+  text-align: center;
+}
+
+.request-insights-filter-positioner {
+  z-index: var(--top-z-index);
+}
+
+.request-insights-filter-menu {
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  width: min(280px, calc(100vw - 24px));
+  max-height: min(560px, calc(100vh - 48px));
+  border: 1px solid var(--color-gray-400);
+  border-radius: 8px;
+  background: var(--color-background-100);
+  box-shadow: 0px 4px 8px -4px
+    color-mix(in srgb, var(--color-gray-900) 4%, transparent);
+  padding: 4px;
+  user-select: none;
+}
+
+.request-insights-filter-group-label {
+  padding: 8px 8px 3px;
+  color: var(--color-gray-800);
+  font-size: var(--size-10);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.request-insights-filter-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  font-size: var(--size-12);
+}
+
+.request-insights-filter-item[data-highlighted] {
+  background: var(--color-gray-200);
+}
+
+.request-insights-filter-item[data-disabled] {
+  color: var(--color-gray-700);
+  cursor: default;
+}
+
+.request-insights-filter-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.request-insights-filter-option-count {
+  min-width: 20px;
+  color: var(--color-gray-800);
+  font-family: var(--font-mono);
+  font-size: var(--size-11);
+  text-align: right;
+}
+
+.request-insights-filter-reset {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  margin-top: 4px;
+  border-top: 1px solid var(--color-gray-400);
+  padding: 6px 8px 2px;
+  color: var(--color-blue-900);
+  cursor: pointer;
+  font-size: var(--size-12);
+}
+
+.request-insights-filter-reset[data-disabled] {
+  color: var(--color-gray-700);
+  cursor: default;
+}
+
+.request-insights-filter-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--color-gray-400);
+  background: var(--color-gray-100);
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
+}
+
+.request-insights-filter-status button,
+.request-insights-list-empty button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-blue-900);
+  cursor: pointer;
+  font: inherit;
+}
+
 .request-insights-settings {
   position: relative;
   display: inline-flex;
@@ -186,48 +342,49 @@
   font-weight: 400;
 }
 
-.request-insights-row[data-nested='true'] .request-insights-route {
-  padding-left: 18px;
-}
-
-.request-insights-nested-arrow {
-  flex-shrink: 0;
-  color: var(--color-gray-700);
-}
-
-.request-insights-internal-badge {
-  flex-shrink: 0;
-  margin-right: 6px;
-  border: 1px solid var(--color-gray-500);
-  border-radius: 999px;
-  padding: 1px 6px;
-  color: var(--color-gray-800);
-  font-size: var(--size-10);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.request-insights-page-load {
-  flex-shrink: 0;
-  border-radius: 999px;
-  padding: 1px 5px;
-  background: var(--color-blue-100);
-  color: var(--color-blue-900);
-  font-size: var(--size-10);
-  font-weight: 600;
-  line-height: 16px;
-  white-space: nowrap;
-}
-
-.request-insights-item-context {
+.request-insights-row-metadata {
+  display: flex;
   min-width: 0;
   overflow: hidden;
+  align-items: center;
+  gap: 5px;
+  grid-column: 2;
+  grid-row: 2;
+  text-overflow: ellipsis;
+}
+
+.request-insights-request-type,
+.request-insights-request-activity {
+  flex-shrink: 0;
   color: var(--color-gray-900);
   font-size: var(--size-11);
-  font-weight: 400;
-  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-request-type[data-type='page-load'],
+.request-insights-request-type[data-type='rsc'],
+.request-insights-request-type[data-type='prefetch'],
+.request-insights-request-type[data-type='segment-prefetch'],
+.request-insights-request-type[data-type='hmr-refresh'] {
+  color: var(--color-blue-900);
+}
+
+.request-insights-request-type[data-type='action'] {
+  color: var(--color-amber-900);
+}
+
+.request-insights-request-type[data-type='api'] {
+  color: var(--color-purple-900);
+}
+
+.request-insights-request-type[data-type='image'],
+.request-insights-request-type[data-type='asset'],
+.request-insights-request-type[data-type='proxy'] {
+  color: var(--color-green-900);
+}
+
+.request-insights-request-activity {
+  color: var(--color-gray-800);
 }
 
 .request-insights-duration,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -13,7 +13,16 @@ import { CopyButton } from '../copy-button'
 import GearIcon from '../../icons/gear-icon'
 import { formatDuration } from './format-duration'
 import {
+  getRequestInsightFilterResult,
+  REQUEST_INSIGHT_FILTER_GROUPS,
+  toggleRequestInsightFilter,
+  type RequestInsightFilter,
+} from './request-filters'
+import {
   getActiveRequestKey,
+  getRequestInsightRowType,
+  getRequestInsightStatusCode,
+  getRequestInsightSummaryTypeLabel,
   getRequestListEntries,
   isInternalRequestInsight,
   isPageLoadRequest,
@@ -30,10 +39,18 @@ const TRACE_TICK_COUNT = 5
 
 export function RequestInsightsPanel() {
   const { dispatch, state, shadowRoot } = useDevOverlayContext()
+  const [activeFilters, setActiveFilters] = useState<
+    readonly RequestInsightFilter[]
+  >([])
+  const [pausedRequests, setPausedRequests] = useState<
+    readonly RequestInsight[] | null
+  >(null)
+  const displayedRequests = pausedRequests ?? state.requestInsights
   const requests = useMemo(
-    () => [...state.requestInsights].reverse(),
-    [state.requestInsights]
+    () => [...displayedRequests].reverse(),
+    [displayedRequests]
   )
+  const isPaused = pausedRequests !== null
   const { showInternal, verbose } = state.requestInsightsConfig
   const setRequestInsightsConfig = (patch: {
     showInternal?: boolean
@@ -45,9 +62,15 @@ export function RequestInsightsPanel() {
     })
     saveDevToolsConfig({ requestInsights: patch })
   }
+  const filterResult = useMemo(
+    () => getRequestInsightFilterResult(requests, activeFilters, showInternal),
+    [activeFilters, requests, showInternal]
+  )
+  const showInternalInList =
+    showInternal || activeFilters.includes('activity:instant-insights')
   const listEntries = useMemo(
-    () => getRequestListEntries(requests, showInternal),
-    [requests, showInternal]
+    () => getRequestListEntries(filterResult.requests, showInternalInList),
+    [filterResult.requests, showInternalInList]
   )
   const visibleRequests = useMemo(
     () => listEntries.map((entry) => entry.request),
@@ -76,7 +99,7 @@ export function RequestInsightsPanel() {
   // internal activity to reveal.
   const showInternalToggle = internalRequests.length > 0
 
-  if (requests.length === 0) {
+  if (displayedRequests.length === 0) {
     return (
       <div className="request-insights-empty">
         Request insights will appear after the next App Router request.
@@ -89,81 +112,143 @@ export function RequestInsightsPanel() {
       <div className="request-insights-list">
         <div className="request-insights-list-toolbar">
           <strong>Requests</strong>
-          <div className="request-insights-settings">
-            {hiddenInternalErrorCount > 0 ? (
-              <span
-                aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
-                className="request-insights-settings-dot"
-                role="img"
-              />
-            ) : null}
-            <Menu.Root delay={0} modal={false}>
-              <Menu.Trigger
-                aria-label="Request list settings"
-                className="request-insights-settings-trigger"
+          <div className="request-insights-list-controls">
+            {isPaused ? (
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                className="request-insights-update-status"
+                role="status"
               >
-                <GearIcon />
-              </Menu.Trigger>
-              <Menu.Portal container={shadowRoot}>
-                <Menu.Positioner
-                  align="end"
-                  className="request-insights-settings-positioner"
-                  side="bottom"
-                  sideOffset={4}
+                <span className="request-insights-paused-state">Paused</span>
+              </div>
+            ) : null}
+            <RequestFiltersMenu
+              activeFilters={activeFilters}
+              onReset={() => setActiveFilters([])}
+              onToggle={(filter) =>
+                setActiveFilters((filters) =>
+                  toggleRequestInsightFilter(filters, filter)
+                )
+              }
+              optionCounts={filterResult.optionCounts}
+              shadowRoot={shadowRoot}
+            />
+            <div className="request-insights-settings">
+              {hiddenInternalErrorCount > 0 ? (
+                <span
+                  aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
+                  className="request-insights-settings-dot"
+                  role="img"
+                />
+              ) : null}
+              <Menu.Root delay={0} modal={false}>
+                <Menu.Trigger
+                  aria-label="Request list settings"
+                  className="request-insights-settings-trigger"
                 >
-                  <Menu.Popup className="request-insights-settings-menu">
-                    {showInternalToggle ? (
+                  <GearIcon />
+                </Menu.Trigger>
+                <Menu.Portal container={shadowRoot}>
+                  <Menu.Positioner
+                    align="end"
+                    className="request-insights-settings-positioner"
+                    side="bottom"
+                    sideOffset={4}
+                  >
+                    <Menu.Popup className="request-insights-settings-menu">
                       <Menu.CheckboxItem
-                        checked={showInternal}
+                        checked={isPaused}
                         className="request-insights-settings-item"
                         closeOnClick={false}
                         onCheckedChange={(checked) =>
-                          setRequestInsightsConfig({ showInternal: checked })
+                          setPausedRequests(
+                            checked ? [...state.requestInsights] : null
+                          )
                         }
                       >
                         <span
                           className="request-insights-settings-checkbox"
-                          data-checked={showInternal || undefined}
+                          data-checked={isPaused || undefined}
                         >
-                          {showInternal ? <CheckIcon /> : null}
+                          {isPaused ? <CheckIcon /> : null}
                         </span>
-                        Internal activity
+                        Pause updates
                       </Menu.CheckboxItem>
-                    ) : null}
-                    <Menu.CheckboxItem
-                      checked={verbose}
-                      className="request-insights-settings-item"
-                      closeOnClick={false}
-                      onCheckedChange={(checked) =>
-                        setRequestInsightsConfig({ verbose: checked })
-                      }
-                    >
-                      <span
-                        className="request-insights-settings-checkbox"
-                        data-checked={verbose || undefined}
+                      {showInternalToggle ? (
+                        <Menu.CheckboxItem
+                          checked={showInternal}
+                          className="request-insights-settings-item"
+                          closeOnClick={false}
+                          onCheckedChange={(checked) =>
+                            setRequestInsightsConfig({ showInternal: checked })
+                          }
+                        >
+                          <span
+                            className="request-insights-settings-checkbox"
+                            data-checked={showInternal || undefined}
+                          >
+                            {showInternal ? <CheckIcon /> : null}
+                          </span>
+                          Internal activity
+                        </Menu.CheckboxItem>
+                      ) : null}
+                      <Menu.CheckboxItem
+                        checked={verbose}
+                        className="request-insights-settings-item"
+                        closeOnClick={false}
+                        onCheckedChange={(checked) =>
+                          setRequestInsightsConfig({ verbose: checked })
+                        }
                       >
-                        {verbose ? <CheckIcon /> : null}
-                      </span>
-                      Verbose traces
-                    </Menu.CheckboxItem>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
+                        <span
+                          className="request-insights-settings-checkbox"
+                          data-checked={verbose || undefined}
+                        >
+                          {verbose ? <CheckIcon /> : null}
+                        </span>
+                        Verbose traces
+                      </Menu.CheckboxItem>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            </div>
           </div>
         </div>
+        {activeFilters.length > 0 ? (
+          <div className="request-insights-filter-status">
+            <span>
+              {filterResult.matchingRequestCount} of{' '}
+              {filterResult.totalRequestCount} requests
+            </span>
+            <button onClick={() => setActiveFilters([])} type="button">
+              Reset
+            </button>
+          </div>
+        ) : null}
         {listEntries.length === 0 ? (
           <div className="request-insights-list-empty">
-            Only internal activity has been captured. Enable “Internal activity”
-            to view it.
+            {activeFilters.length > 0 ? (
+              <>
+                No requests match the active filters.{' '}
+                <button onClick={() => setActiveFilters([])} type="button">
+                  Reset filters
+                </button>
+              </>
+            ) : (
+              <>
+                Only internal activity has been captured. Enable “Internal
+                activity” to view it.
+              </>
+            )}
           </div>
         ) : (
-          listEntries.map(({ request, nested }) => {
+          listEntries.map(({ request }) => {
             const requestKey = getRequestInsightKey(request)
             return (
               <RequestRow
                 key={requestKey}
-                nested={nested}
                 request={request}
                 pageLoad={isPageLoadRequest(request, initialRequestId)}
                 selected={requestKey === activeRequestKey}
@@ -181,15 +266,99 @@ export function RequestInsightsPanel() {
   )
 }
 
+function RequestFiltersMenu({
+  activeFilters,
+  onReset,
+  onToggle,
+  optionCounts,
+  shadowRoot,
+}: {
+  activeFilters: readonly RequestInsightFilter[]
+  onReset: () => void
+  onToggle: (filter: RequestInsightFilter) => void
+  optionCounts: Readonly<Record<RequestInsightFilter, number>>
+  shadowRoot: ShadowRoot
+}) {
+  return (
+    <Menu.Root delay={0} modal={false}>
+      <Menu.Trigger
+        aria-label={`Filter requests${activeFilters.length > 0 ? `, ${activeFilters.length} active` : ''}`}
+        className="request-insights-filter-trigger"
+      >
+        Filter
+        {activeFilters.length > 0 ? (
+          <span className="request-insights-filter-active-count">
+            {activeFilters.length}
+          </span>
+        ) : null}
+      </Menu.Trigger>
+      <Menu.Portal container={shadowRoot}>
+        <Menu.Positioner
+          align="end"
+          className="request-insights-filter-positioner"
+          side="bottom"
+          sideOffset={4}
+        >
+          <Menu.Popup
+            aria-label="Request filters"
+            className="request-insights-filter-menu"
+          >
+            {REQUEST_INSIGHT_FILTER_GROUPS.map((group) => (
+              <Menu.Group key={group.label}>
+                <Menu.GroupLabel className="request-insights-filter-group-label">
+                  {group.label}
+                </Menu.GroupLabel>
+                {group.options.map((option) => {
+                  const checked = activeFilters.includes(option.value)
+                  const count = optionCounts[option.value]
+                  return (
+                    <Menu.CheckboxItem
+                      key={option.value}
+                      checked={checked}
+                      className="request-insights-filter-item"
+                      closeOnClick={false}
+                      data-filter-value={option.value}
+                      disabled={!checked && count === 0}
+                      onCheckedChange={() => onToggle(option.value)}
+                    >
+                      <span
+                        className="request-insights-settings-checkbox"
+                        data-checked={checked || undefined}
+                      >
+                        {checked ? <CheckIcon /> : null}
+                      </span>
+                      <span className="request-insights-filter-option-label">
+                        {option.label}
+                      </span>
+                      <span className="request-insights-filter-option-count">
+                        {count}
+                      </span>
+                    </Menu.CheckboxItem>
+                  )
+                })}
+              </Menu.Group>
+            ))}
+            <Menu.Item
+              className="request-insights-filter-reset"
+              disabled={activeFilters.length === 0}
+              onClick={onReset}
+            >
+              Reset filters
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  )
+}
+
 function RequestRow({
   request,
-  nested,
   pageLoad,
   selected,
   onSelect,
 }: {
   request: RequestInsight
-  nested: boolean
   pageLoad: boolean
   selected: boolean
   onSelect: () => void
@@ -197,12 +366,15 @@ function RequestRow({
   const isInstantInsights =
     getRequestInsightKind(request) === 'instant-insights'
   const route = request.route ?? request.url ?? 'Unknown route'
+  const requestType = getRequestInsightRowType(request, pageLoad)
+  const clockTime = formatClockTime(request.startTime)
+  const bypassesProxy = request.proxyStatus === 'bypassed'
 
   return (
     <button
+      aria-label={`${isInstantInsights ? `Instant Insights for ${route}` : route}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
-      data-nested={nested || undefined}
       data-page-load={pageLoad}
       data-selected={selected}
       onClick={onSelect}
@@ -210,24 +382,30 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        {nested ? <NestedArrowIcon /> : null}
-        {isInstantInsights && !nested ? (
-          <span className="request-insights-internal-badge">Internal</span>
-        ) : null}
         <span className="request-insights-route-label">
           {isInstantInsights ? 'Instant Insights' : route}
         </span>
-        {isInstantInsights && !nested ? (
-          <span className="request-insights-item-context">{route}</span>
-        ) : pageLoad ? (
-          <span className="request-insights-page-load">Page load</span>
-        ) : null}
       </span>
       <span className="request-insights-duration">
         {formatDuration(request.durationMs)}
       </span>
-      <span className="request-insights-meta">
-        {formatClockTime(request.startTime)}
+      <span className="request-insights-meta request-insights-row-metadata">
+        <span
+          className="request-insights-request-type"
+          data-type={requestType.type}
+          title={requestType.accessibleLabel}
+        >
+          {requestType.label}
+        </span>
+        {bypassesProxy ? (
+          <span
+            className="request-insights-request-activity"
+            title="This request did not match the configured proxy"
+          >
+            No proxy
+          </span>
+        ) : null}
+        <span>{clockTime}</span>
       </span>
       <span className="request-insights-meta request-insights-fetch-summary">
         {request.fetches.length
@@ -235,25 +413,6 @@ function RequestRow({
           : 'No fetches'}
       </span>
     </button>
-  )
-}
-
-function NestedArrowIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      className="request-insights-nested-arrow"
-      fill="none"
-      height="12"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.5"
-      viewBox="0 0 16 16"
-      width="12"
-    >
-      <path d="M4 3v5.5A2.5 2.5 0 0 0 6.5 11H12M12 11l-3-3m3 3-3 3" />
-    </svg>
   )
 }
 
@@ -492,8 +651,7 @@ function getRequestOverview(request: RequestInsight) {
     : (getFirstStringAttribute(request, 'http.method') ??
       getMethodFromName(request.spans[0]?.name) ??
       'GET')
-  const statusCode = getFirstNumberAttribute(request, 'http.status_code')
-  const isRsc = getFirstBooleanAttribute(request, 'next.rsc')
+  const statusCode = getRequestInsightStatusCode(request)
   const erroredSpan = request.spans.find(
     (span) => span.status === 'error' || span.error
   )
@@ -516,11 +674,7 @@ function getRequestOverview(request: RequestInsight) {
     method,
     statusCode,
     statusLabel: statusCode ?? request.status,
-    kind: isInstantInsights
-      ? 'Instant Insights'
-      : isRsc
-        ? 'RSC request'
-        : 'HTML request',
+    kind: getRequestInsightSummaryTypeLabel(request),
     fetchSummary: request.fetches.length
       ? `${request.fetches.length} fetch${request.fetches.length === 1 ? '' : 'es'}`
       : 'No fetches',
@@ -592,30 +746,6 @@ function getFirstStringAttribute(
   for (const span of request.spans) {
     const value = span.attributes?.[key]
     if (typeof value === 'string') {
-      return value
-    }
-  }
-}
-
-function getFirstNumberAttribute(
-  request: RequestInsight,
-  key: string
-): number | undefined {
-  for (const span of request.spans) {
-    const value = span.attributes?.[key]
-    if (typeof value === 'number') {
-      return value
-    }
-  }
-}
-
-function getFirstBooleanAttribute(
-  request: RequestInsight,
-  key: string
-): boolean | undefined {
-  for (const span of request.spans) {
-    const value = span.attributes?.[key]
-    if (typeof value === 'boolean') {
       return value
     }
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -1,4 +1,13 @@
-import { useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react'
 import { Menu } from '@base-ui-components/react/menu'
 import {
   getRequestInsightKey,
@@ -10,7 +19,9 @@ import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { ACTION_DEVTOOLS_CONFIG } from '../../shared'
 import { saveDevToolsConfig } from '../../utils/save-devtools-config'
 import { CopyButton } from '../copy-button'
+import { Tooltip } from '../tooltip/tooltip'
 import GearIcon from '../../icons/gear-icon'
+import { getFetchUrlPresentation } from './fetch-label'
 import { formatDuration } from './format-duration'
 import {
   getRequestInsightFilterResult,
@@ -18,6 +29,12 @@ import {
   toggleRequestInsightFilter,
   type RequestInsightFilter,
 } from './request-filters'
+import {
+  formatRequestRouteParams,
+  getRequestDisplayUrl,
+  getRequestListDisplayUrl,
+  getRequestRouteParams,
+} from './request-label'
 import {
   getActiveRequestKey,
   getRequestInsightRowType,
@@ -29,6 +46,7 @@ import {
 } from './request-list'
 import {
   getTraceItems,
+  getTraceNavigationIndex,
   getTracePosition,
   getTraceRange,
   type TraceItem,
@@ -181,7 +199,9 @@ export function RequestInsightsPanel() {
                           className="request-insights-settings-item"
                           closeOnClick={false}
                           onCheckedChange={(checked) =>
-                            setRequestInsightsConfig({ showInternal: checked })
+                            setRequestInsightsConfig({
+                              showInternal: checked,
+                            })
                           }
                         >
                           <span
@@ -365,14 +385,17 @@ function RequestRow({
 }) {
   const isInstantInsights =
     getRequestInsightKind(request) === 'instant-insights'
-  const route = request.route ?? request.url ?? 'Unknown route'
   const requestType = getRequestInsightRowType(request, pageLoad)
+  const requestUrl = getRequestListDisplayUrl(
+    request,
+    requestType.type === 'rsc'
+  )
   const clockTime = formatClockTime(request.startTime)
   const bypassesProxy = request.proxyStatus === 'bypassed'
 
   return (
     <button
-      aria-label={`${isInstantInsights ? `Instant Insights for ${route}` : route}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
       data-page-load={pageLoad}
@@ -383,7 +406,7 @@ function RequestRow({
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
         <span className="request-insights-route-label">
-          {isInstantInsights ? 'Instant Insights' : route}
+          {isInstantInsights ? 'Instant Insights' : requestUrl}
         </span>
       </span>
       <span className="request-insights-duration">
@@ -438,11 +461,17 @@ function RequestDetails({
   verbose: boolean
 }) {
   const traceItems = useMemo(
-    () => getTraceItems(request, verbose),
+    () =>
+      getTraceItems(
+        request,
+        verbose,
+        typeof window === 'undefined' ? undefined : window.location.origin
+      ),
     [request, verbose]
   )
   const overview = useMemo(() => getRequestOverview(request), [request])
   const diagnosis = getDiagnosis(request, traceItems)
+  const requestUrl = getRequestDisplayUrl(request)
 
   return (
     <div className="request-insights-details">
@@ -451,8 +480,8 @@ function RequestDetails({
           <div className="request-insights-title-row">
             <div className="request-insights-title">
               {getRequestInsightKind(request) === 'instant-insights'
-                ? `Instant Insights · ${request.route ?? request.url ?? request.requestId}`
-                : (request.route ?? request.url ?? request.requestId)}
+                ? `Instant Insights · ${requestUrl}`
+                : requestUrl}
             </div>
             <CopyButton
               actionLabel="Copy request JSON"
@@ -473,7 +502,11 @@ function RequestDetails({
       ) : null}
       <div className="request-insights-diagnosis">{diagnosis}</div>
 
-      <Trace items={traceItems} request={request} />
+      <Trace
+        items={traceItems}
+        key={getRequestInsightKey(request)}
+        request={request}
+      />
 
       <FetchTable fetches={request.fetches} />
     </div>
@@ -493,6 +526,27 @@ function RequestOverview({
       <span>{overview.fetchSummary}</span>
       <span>{overview.cacheSummary}</span>
       <span>{overview.spanSummary}</span>
+      {overview.route ? (
+        <span className="request-insights-route-template">
+          Route {overview.route}
+        </span>
+      ) : null}
+      {overview.routeParams?.length ? (
+        <Tooltip
+          className="request-insights-params-tooltip"
+          title={formatRequestRouteParams(overview.routeParams)}
+        >
+          <button
+            aria-label={`Route parameters: ${overview.routeParams
+              .map(({ name }) => name)
+              .join(', ')}`}
+            className="request-insights-params-trigger"
+            type="button"
+          >
+            Params {overview.routeParams.map(({ name }) => name).join(', ')}
+          </button>
+        </Tooltip>
+      ) : null}
     </div>
   )
 }
@@ -504,7 +558,41 @@ function Trace({
   request: RequestInsight
   items: TraceItem[]
 }) {
+  const [activeItemId, setActiveItemId] = useState<string | null>(
+    items[0]?.id ?? null
+  )
+  const [activeTraceRow, setActiveTraceRow] = useState<HTMLElement | null>(null)
+  const traceRowsRef = useRef<HTMLDivElement>(null)
+  const shouldScrollActiveItemIntoViewRef = useRef(false)
+  const traceId = useId()
   const range = getTraceRange(request)
+  const activeItemIndex = items.findIndex((item) => item.id === activeItemId)
+  const safeActiveItemIndex =
+    items.length === 0 ? -1 : Math.max(activeItemIndex, 0)
+  const activeItem = items[safeActiveItemIndex]
+  const activeItemDescription = activeItem
+    ? getTraceItemDescription(activeItem, range)
+    : null
+
+  useEffect(() => {
+    if (
+      !shouldScrollActiveItemIntoViewRef.current ||
+      safeActiveItemIndex === -1
+    ) {
+      return
+    }
+
+    shouldScrollActiveItemIntoViewRef.current = false
+    const activeOption =
+      traceRowsRef.current?.children.item(safeActiveItemIndex)
+    if (activeOption instanceof HTMLElement) {
+      activeOption.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      })
+    }
+  }, [safeActiveItemIndex])
+
   const ticks = Array.from({ length: TRACE_TICK_COUNT }, (_, index) => {
     const position = index / (TRACE_TICK_COUNT - 1)
     return {
@@ -512,6 +600,52 @@ function Trace({
       position: position * 100,
     }
   })
+  const handleTraceKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return
+      }
+
+      const nextIndex = getTraceNavigationIndex(
+        activeItemIndex,
+        items.length,
+        event.key
+      )
+      if (nextIndex === undefined) {
+        return
+      }
+
+      event.preventDefault()
+      shouldScrollActiveItemIntoViewRef.current = true
+      setActiveItemId(items[nextIndex]?.id ?? null)
+    },
+    [activeItemIndex, items]
+  )
+  const handleTracePointerOver = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      const row = target.closest<HTMLElement>('[data-trace-index]')
+      if (row === null || !event.currentTarget.contains(row)) {
+        return
+      }
+
+      const index = Number(row.dataset.traceIndex)
+      if (Number.isSafeInteger(index)) {
+        shouldScrollActiveItemIntoViewRef.current = false
+        const itemId = items[index]?.id
+        if (itemId !== undefined) {
+          setActiveItemId((currentItemId) =>
+            currentItemId === itemId ? currentItemId : itemId
+          )
+        }
+      }
+    },
+    [items]
+  )
 
   return (
     <div className="request-insights-section">
@@ -548,54 +682,98 @@ function Trace({
               Duration
             </span>
           </div>
-          <div className="request-insights-trace-rows">
-            {items.map((item) => {
-              const position = getTracePosition(item, range)
+          <Tooltip
+            anchor={activeTraceRow}
+            asChild
+            className="request-insights-trace-tooltip"
+            direction="top"
+            title={activeItemDescription}
+          >
+            <div
+              aria-activedescendant={
+                safeActiveItemIndex === -1
+                  ? undefined
+                  : `${traceId}-item-${safeActiveItemIndex}`
+              }
+              aria-label={`Trace spans, ${items.length} item${items.length === 1 ? '' : 's'}. Use arrow keys to inspect timing.`}
+              className="request-insights-trace-rows"
+              onKeyDown={handleTraceKeyDown}
+              onPointerOver={handleTracePointerOver}
+              ref={traceRowsRef}
+              role="listbox"
+              tabIndex={items.length === 0 ? undefined : 0}
+            >
+              {items.map((item, index) => {
+                const position = getTracePosition(item, range)
+                const description = getTraceItemDescription(item, range)
 
-              return (
-                <div
-                  className="request-insights-span-row"
-                  data-kind={item.kind}
-                  key={item.id}
-                  title={`${item.label} · +${formatDuration(position.offsetMs)} · ${formatDuration(item.durationMs)}`}
-                >
-                  <span
-                    className="request-insights-span-name"
-                    style={{ paddingLeft: `${item.depth * 14 + 4}px` }}
+                return (
+                  <div
+                    aria-label={description}
+                    aria-selected={index === safeActiveItemIndex}
+                    className="request-insights-span-row"
+                    data-active={index === safeActiveItemIndex || undefined}
+                    data-kind={item.kind}
+                    data-trace-item-id={item.id}
+                    data-trace-index={index}
+                    id={`${traceId}-item-${index}`}
+                    key={item.id}
+                    ref={
+                      index === safeActiveItemIndex
+                        ? setActiveTraceRow
+                        : undefined
+                    }
+                    role="option"
                   >
-                    <span className="request-insights-span-label">
-                      <span
-                        className="request-insights-span-marker"
-                        data-kind={item.kind}
-                        data-status={item.status}
-                      />
-                      <span>{item.label}</span>
-                    </span>
-                  </span>
-                  <span className="request-insights-span-track">
                     <span
-                      className="request-insights-span-bar"
-                      data-status={item.status}
-                      style={{
-                        left: `${position.left}%`,
-                        width: `${position.width}%`,
-                      }}
-                    />
-                  </span>
-                  <span className="request-insights-span-duration">
-                    {formatDuration(item.durationMs)}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
+                      className="request-insights-span-name"
+                      style={{ paddingLeft: `${item.depth * 14 + 4}px` }}
+                    >
+                      <span className="request-insights-span-label">
+                        <span
+                          className="request-insights-span-marker"
+                          data-kind={item.kind}
+                          data-status={item.status}
+                        />
+                        <span>{item.label}</span>
+                      </span>
+                    </span>
+                    <span className="request-insights-span-track">
+                      <span
+                        className="request-insights-span-bar"
+                        data-status={item.status}
+                        style={{
+                          left: `${position.left}%`,
+                          width: `${position.width}%`,
+                        }}
+                      />
+                    </span>
+                    <span className="request-insights-span-duration">
+                      {formatDuration(item.durationMs)}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </Tooltip>
         </div>
       </div>
     </div>
   )
 }
 
+function getTraceItemDescription(
+  item: TraceItem,
+  range: ReturnType<typeof getTraceRange>
+): string {
+  const position = getTracePosition(item, range)
+  return `${item.fullLabel ?? item.label} · +${formatDuration(position.offsetMs)} · ${formatDuration(item.durationMs)}`
+}
+
 function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
+  const currentOrigin =
+    typeof window === 'undefined' ? undefined : window.location.origin
+
   return (
     <div className="request-insights-section">
       <div className="request-insights-section-title">Fetches</div>
@@ -614,19 +792,33 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
             <span>Reason</span>
           </div>
           {fetches.map((fetch, index) => {
-            const urlParts = formatUrl(fetch.url)
+            const url = getFetchUrlPresentation(fetch.url, currentOrigin)
             return (
-              <div className="request-insights-fetch" key={index}>
+              <div
+                className="request-insights-fetch"
+                data-origin={url.originKind}
+                key={index}
+              >
                 <span className="request-insights-method">
                   {fetch.method ?? 'GET'}
                 </span>
                 <span className="request-insights-fetch-url">
-                  <span>{urlParts.path}</span>
-                  {urlParts.host ? (
-                    <span className="request-insights-fetch-host">
-                      {urlParts.host}
+                  <Tooltip
+                    className="request-insights-fetch-tooltip"
+                    title={url.fullUrl}
+                  >
+                    <span className="request-insights-fetch-url-trigger">
+                      <span className="request-insights-fetch-path">
+                        {url.path}
+                      </span>
+                      <span
+                        className="request-insights-fetch-origin"
+                        data-origin={url.originKind}
+                      >
+                        {url.originLabel}
+                      </span>
                     </span>
-                  ) : null}
+                  </Tooltip>
                 </span>
                 <span>{formatDuration(fetch.durationMs)}</span>
                 <span>{fetch.statusCode ?? '-'}</span>
@@ -687,6 +879,8 @@ function getRequestOverview(request: RequestInsight) {
               cacheCounts.unknown ? `, ${cacheCounts.unknown} unknown` : ''
             }`,
     spanSummary: `${request.spans.length} span${request.spans.length === 1 ? '' : 's'}`,
+    route: request.route,
+    routeParams: getRequestRouteParams(request),
     errorSummary,
   }
 }
@@ -719,8 +913,11 @@ function getDiagnosis(
     (!criticalItem ||
       (slowestFetch.durationMs ?? 0) >= (criticalItem.durationMs ?? 0))
   ) {
-    const urlParts = formatUrl(slowestFetch.url)
-    return `Slowest recorded operation: ${urlParts.path} · ${formatDuration(slowestFetch.durationMs)}${getCacheSummary(slowestFetch)}.`
+    const url = getFetchUrlPresentation(
+      slowestFetch.url,
+      typeof window === 'undefined' ? undefined : window.location.origin
+    )
+    return `Slowest recorded operation: ${url.path} · ${formatDuration(slowestFetch.durationMs)}${getCacheSummary(slowestFetch)}.`
   }
 
   if (criticalItem) {
@@ -756,24 +953,6 @@ function getMethodFromName(name: string | undefined): string | undefined {
     /^(?:RSC )?(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)\b/
   )
   return match?.[1]
-}
-
-function formatUrl(url: string | undefined): { path: string; host?: string } {
-  if (!url) {
-    return { path: 'Unknown URL' }
-  }
-
-  try {
-    const parsedUrl = new URL(url, window.location.origin)
-    const path = `${parsedUrl.pathname}${parsedUrl.search}`
-    const sameHost = parsedUrl.host === window.location.host
-    return {
-      path,
-      host: sameHost ? undefined : parsedUrl.host,
-    }
-  } catch {
-    return { path: url }
-  }
 }
 
 function formatClockTime(timestamp: number): string {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.test.ts
@@ -1,0 +1,87 @@
+import {
+  formatRequestRouteParams,
+  getRequestDisplayUrl,
+  getRequestListDisplayUrl,
+  getRequestRouteParams,
+} from './request-label'
+
+describe('request insight request labels', () => {
+  it('prefers the concrete URL and hides the transport-only RSC query', () => {
+    const request = {
+      requestId: 'request-1',
+      route: '/products/[id]',
+      url: '/products/blue?tab=details&_rsc=redacted#summary',
+    }
+
+    expect(getRequestDisplayUrl(request)).toBe(
+      '/products/blue?tab=details&_rsc=redacted#summary'
+    )
+    expect(getRequestListDisplayUrl(request, true)).toBe(
+      '/products/blue?tab=details#summary'
+    )
+    expect(getRequestListDisplayUrl(request, false)).toBe(
+      '/products/blue?tab=details&_rsc=redacted#summary'
+    )
+    expect(
+      getRequestListDisplayUrl(
+        {
+          requestId: 'request-2',
+          route: '/products/[id]',
+          url: '//example.test/products/blue?_rsc=redacted',
+        },
+        true
+      )
+    ).toBe('//example.test/products/blue')
+  })
+
+  it('extracts dynamic, catch-all, and optional catch-all parameters', () => {
+    expect(
+      getRequestRouteParams({
+        route: '/products/[category]/[...slug]',
+        url: '/products/widgets/blue/large?sort=redacted',
+      })
+    ).toEqual([
+      { name: 'category', value: 'widgets' },
+      { name: 'slug', value: ['blue', 'large'] },
+    ])
+    expect(
+      getRequestRouteParams({
+        route: '/docs/[[...slug]]',
+        url: '/docs',
+      })
+    ).toEqual([{ name: 'slug', value: [] }])
+  })
+
+  it('handles base paths and encoded route values', () => {
+    const params = getRequestRouteParams(
+      {
+        route: '/products/[category]/[...slug]',
+        url: '/shop/products/home%20goods/blue%2Flarge',
+      },
+      '/shop'
+    )
+
+    expect(params).toEqual([
+      { name: 'category', value: 'home goods' },
+      { name: 'slug', value: ['blue/large'] },
+    ])
+    expect(formatRequestRouteParams(params!)).toBe(
+      '{\n  "category": "home goods",\n  "slug": [\n    "blue/large"\n  ]\n}'
+    )
+  })
+
+  it('does not guess parameters from malformed or mismatched routes', () => {
+    expect(
+      getRequestRouteParams({ route: '/products/[id]', url: '/users/1' })
+    ).toBeUndefined()
+    expect(
+      getRequestRouteParams({ route: '/products/[id]', url: '/products/%zz' })
+    ).toBeUndefined()
+    expect(
+      getRequestRouteParams({
+        route: '/products/[id]/[id]',
+        url: '/products/one/two',
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.ts
@@ -1,0 +1,180 @@
+import type { RequestInsight } from '../../../shared/request-insights'
+import { removePathPrefix } from '../../../../shared/lib/router/utils/remove-path-prefix'
+
+type RequestIdentity = Pick<RequestInsight, 'requestId' | 'route' | 'url'>
+
+export type RequestRouteParam = {
+  name: string
+  value: string | string[]
+}
+
+export function getRequestDisplayUrl(request: RequestIdentity): string {
+  return request.url ?? request.route ?? request.requestId
+}
+
+export function getRequestListDisplayUrl(
+  request: RequestIdentity,
+  rscRequest: boolean
+): string {
+  const displayUrl = getRequestDisplayUrl(request)
+  if (!rscRequest) {
+    return displayUrl
+  }
+
+  try {
+    const protocolRelative = displayUrl.startsWith('//')
+    const rootRelative = !protocolRelative && displayUrl.startsWith('/')
+    const parsed = new URL(displayUrl, 'http://next.local')
+    if (!parsed.searchParams.has('_rsc')) {
+      return displayUrl
+    }
+
+    parsed.searchParams.delete('_rsc')
+    return protocolRelative
+      ? `//${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`
+      : rootRelative
+        ? `${parsed.pathname}${parsed.search}${parsed.hash}`
+        : parsed.toString()
+  } catch {
+    return displayUrl
+  }
+}
+
+export function getRequestRouteParams(
+  request: Pick<RequestIdentity, 'route' | 'url'>,
+  basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+): RequestRouteParam[] | undefined {
+  if (!request.route || !request.url) {
+    return undefined
+  }
+
+  const pathname = getPathname(request.url)
+  if (!pathname) {
+    return undefined
+  }
+
+  const routeSegments = splitPathname(request.route)
+  const pathnameSegments = splitPathname(removePathPrefix(pathname, basePath))
+  if (!routeSegments || !pathnameSegments) {
+    return undefined
+  }
+
+  const params: RequestRouteParam[] = []
+  const names = new Set<string>()
+  let pathnameIndex = 0
+
+  for (const routeSegment of routeSegments) {
+    const dynamicSegment = parseDynamicSegment(routeSegment)
+
+    if (!dynamicSegment) {
+      if (
+        routeSegment.includes('[') ||
+        routeSegment.includes(']') ||
+        pathnameSegments[pathnameIndex] !== routeSegment
+      ) {
+        return undefined
+      }
+      pathnameIndex += 1
+      continue
+    }
+
+    if (names.has(dynamicSegment.name)) {
+      return undefined
+    }
+    names.add(dynamicSegment.name)
+
+    if (dynamicSegment.catchAll) {
+      const value = pathnameSegments.slice(pathnameIndex)
+      if (value.length === 0 && !dynamicSegment.optional) {
+        return undefined
+      }
+      params.push({ name: dynamicSegment.name, value })
+      pathnameIndex = pathnameSegments.length
+      continue
+    }
+
+    const value = pathnameSegments[pathnameIndex]
+    if (value === undefined) {
+      return undefined
+    }
+    params.push({ name: dynamicSegment.name, value })
+    pathnameIndex += 1
+  }
+
+  return pathnameIndex === pathnameSegments.length ? params : undefined
+}
+
+export function formatRequestRouteParams(params: RequestRouteParam[]): string {
+  return JSON.stringify(
+    Object.fromEntries(params.map(({ name, value }) => [name, value])),
+    null,
+    2
+  )
+}
+
+function getPathname(url: string): string | undefined {
+  try {
+    if (url.startsWith('/')) {
+      return new URL(url, 'http://next.local').pathname
+    }
+
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.pathname
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function splitPathname(pathname: string): string[] | undefined {
+  if (!pathname.startsWith('/')) {
+    return undefined
+  }
+
+  const segments = pathname.split('/').slice(1)
+  if (segments.at(-1) === '') {
+    segments.pop()
+  }
+
+  const decoded: string[] = []
+  for (const segment of segments) {
+    const value = decodeSegment(segment)
+    if (value === undefined) {
+      return undefined
+    }
+    decoded.push(value)
+  }
+  return decoded
+}
+
+function decodeSegment(segment: string): string | undefined {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return undefined
+  }
+}
+
+function parseDynamicSegment(segment: string):
+  | {
+      name: string
+      catchAll: boolean
+      optional: boolean
+    }
+  | undefined {
+  const optionalCatchAll = segment.match(/^\[\[\.\.\.([^[/\]]+)\]\]$/)
+  const catchAll = segment.match(/^\[\.\.\.([^[/\]]+)\]$/)
+  const dynamic = segment.match(/^\[([^[/\]]+)\]$/)
+  const match = optionalCatchAll ?? catchAll ?? dynamic
+
+  if (!match) {
+    return undefined
+  }
+
+  return {
+    name: match[1],
+    catchAll: optionalCatchAll !== null || catchAll !== null,
+    optional: optionalCatchAll !== null,
+  }
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -1,7 +1,11 @@
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsight,
+  type RequestInsightSpan,
 } from '../../../shared/request-insights'
 
 export function getActiveRequestKey(
@@ -30,65 +34,291 @@ export function isInternalRequestInsight(
 
 export type RequestListEntry = {
   request: RequestInsight
-  nested: boolean
 }
 
 export function getRequestListEntries(
   requests: readonly RequestInsight[],
   showInternal: boolean
 ): RequestListEntry[] {
-  if (!showInternal) {
-    return requests
-      .filter((request) => !isInternalRequestInsight(request))
-      .map((request) => ({ request, nested: false }))
-  }
+  return requests
+    .filter((request) => showInternal || !isInternalRequestInsight(request))
+    .map((request) => ({ request }))
+}
 
-  // Group internal records by the request they belong to, and record which
-  // request ids have a parent (non-internal) record present, both in one pass.
-  const internalByRequestId = new Map<string, RequestInsight[]>()
-  const parentRequestIds = new Set<string>()
-  for (const request of requests) {
-    if (isInternalRequestInsight(request)) {
-      const group = internalByRequestId.get(request.requestId)
-      if (group) {
-        group.push(request)
-      } else {
-        internalByRequestId.set(request.requestId, [request])
+export type RequestInsightRowType =
+  | 'page'
+  | 'page-load'
+  | 'rsc'
+  | 'action'
+  | 'prefetch'
+  | 'segment-prefetch'
+  | 'hmr-refresh'
+  | 'api'
+  | 'image'
+  | 'asset'
+  | 'proxy'
+  | 'instant-insights'
+  | 'unknown'
+
+export type RequestInsightRowTypePresentation = Readonly<{
+  type: RequestInsightRowType
+  label: string
+  accessibleLabel: string
+}>
+
+const REQUEST_INSIGHT_ROW_TYPES: Readonly<
+  Record<RequestInsightRowType, RequestInsightRowTypePresentation>
+> = {
+  page: { type: 'page', label: 'Page', accessibleLabel: 'Page request' },
+  'page-load': {
+    type: 'page-load',
+    label: 'Page load',
+    accessibleLabel: 'Page load',
+  },
+  rsc: {
+    type: 'rsc',
+    label: 'RSC',
+    accessibleLabel: 'React Server Component request',
+  },
+  action: {
+    type: 'action',
+    label: 'Action',
+    accessibleLabel: 'Server Action request',
+  },
+  prefetch: {
+    type: 'prefetch',
+    label: 'Prefetch',
+    accessibleLabel: 'App Router prefetch request',
+  },
+  'segment-prefetch': {
+    type: 'segment-prefetch',
+    label: 'Segment',
+    accessibleLabel: 'App Router segment prefetch request',
+  },
+  'hmr-refresh': {
+    type: 'hmr-refresh',
+    label: 'HMR',
+    accessibleLabel: 'Hot Module Replacement refresh request',
+  },
+  api: { type: 'api', label: 'API', accessibleLabel: 'API request' },
+  image: {
+    type: 'image',
+    label: 'Image',
+    accessibleLabel: 'Image optimization request',
+  },
+  asset: {
+    type: 'asset',
+    label: 'Asset',
+    accessibleLabel: 'Static asset request',
+  },
+  proxy: { type: 'proxy', label: 'Proxy', accessibleLabel: 'Proxy request' },
+  'instant-insights': {
+    type: 'instant-insights',
+    label: 'Instant',
+    accessibleLabel: 'Instant Insights activity',
+  },
+  unknown: {
+    type: 'unknown',
+    label: 'Unknown',
+    accessibleLabel: 'Unclassified request',
+  },
+}
+
+export function getRequestInsightRowType(
+  request: RequestInsight,
+  pageLoad = false
+): RequestInsightRowTypePresentation {
+  switch (getRequestInsightSource(request)) {
+    case 'page': {
+      if (request.serverAction) {
+        return REQUEST_INSIGHT_ROW_TYPES.action
       }
-    } else {
-      parentRequestIds.add(request.requestId)
+      const routerActivity = getRequestInsightRouterActivity(request)
+      if (routerActivity) {
+        return REQUEST_INSIGHT_ROW_TYPES[routerActivity]
+      }
+      if (getRequestInsightIsRsc(request) === true) {
+        return REQUEST_INSIGHT_ROW_TYPES.rsc
+      }
+      return REQUEST_INSIGHT_ROW_TYPES[pageLoad ? 'page-load' : 'page']
     }
+    case 'app-route':
+    case 'pages-api':
+      return REQUEST_INSIGHT_ROW_TYPES.api
+    case 'image':
+      return REQUEST_INSIGHT_ROW_TYPES.image
+    case 'asset':
+      return REQUEST_INSIGHT_ROW_TYPES.asset
+    case 'proxy':
+      return REQUEST_INSIGHT_ROW_TYPES.proxy
+    case 'instant-insights':
+      return REQUEST_INSIGHT_ROW_TYPES['instant-insights']
+    case 'unknown':
+      return REQUEST_INSIGHT_ROW_TYPES.unknown
   }
+}
 
-  const entries: RequestListEntry[] = []
-  for (const request of requests) {
-    if (isInternalRequestInsight(request)) {
-      // Orphans (no parent request in the list) remain top-level and preserve
-      // their ordering relative to other top-level records. Nested internal
-      // records are emitted under their request below.
-      if (!parentRequestIds.has(request.requestId)) {
-        entries.push({ request, nested: false })
-      }
+export function hasRequestInsightProxyActivity(
+  request: RequestInsight
+): boolean {
+  return (
+    getRequestInsightSource(request) === 'proxy' ||
+    request.proxyStatus === 'matched' ||
+    request.spans.some(
+      (span) =>
+        span.attributes?.['next.span_type'] === REQUEST_INSIGHT_PROXY_SPAN_TYPE
+    )
+  )
+}
+
+export function getCanonicalRequestSpan(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): RequestInsightSpan | undefined {
+  let latestRequestSpan: RequestInsightSpan | undefined
+  let latestMatchedRouteSpan: RequestInsightSpan | undefined
+
+  for (const span of request.spans) {
+    if (
+      span.attributes?.['next.span_type'] !== REQUEST_INSIGHT_REQUEST_SPAN_TYPE
+    ) {
       continue
     }
-
-    entries.push({ request, nested: false })
-    const nested = internalByRequestId.get(request.requestId)
-    if (nested) {
-      for (const internalRequest of nested) {
-        entries.push({ request: internalRequest, nested: true })
-      }
+    if (!latestRequestSpan || span.startTime >= latestRequestSpan.startTime) {
+      latestRequestSpan = span
+    }
+    if (
+      request.route &&
+      span.attributes?.['next.route'] === request.route &&
+      (!latestMatchedRouteSpan ||
+        span.startTime >= latestMatchedRouteSpan.startTime)
+    ) {
+      latestMatchedRouteSpan = span
     }
   }
-  return entries
+
+  return latestMatchedRouteSpan ?? latestRequestSpan
+}
+
+export function getRequestInsightStatusCode(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): number | undefined {
+  return getCanonicalThenAnySpanAttribute(
+    request,
+    'http.status_code',
+    (value): value is number => typeof value === 'number'
+  )
+}
+
+export function getRequestInsightIsRsc(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): boolean | undefined {
+  return getCanonicalThenAnySpanAttribute(
+    request,
+    'next.rsc',
+    (value): value is boolean => typeof value === 'boolean'
+  )
+}
+
+export type RequestInsightRepresentation =
+  | 'html'
+  | 'rsc'
+  | 'not-applicable'
+  | 'unknown'
+
+export function getRequestInsightRepresentation(
+  request: Pick<
+    RequestInsight,
+    'kind' | 'source' | 'serverAction' | 'route' | 'spans'
+  >
+): RequestInsightRepresentation {
+  if (request.serverAction) {
+    return 'not-applicable'
+  }
+
+  switch (getRequestInsightSource(request)) {
+    case 'page': {
+      const isRsc = getRequestInsightIsRsc(request)
+      return isRsc === true ? 'rsc' : isRsc === false ? 'html' : 'unknown'
+    }
+    case 'unknown':
+      return 'unknown'
+    case 'app-route':
+    case 'pages-api':
+    case 'image':
+    case 'asset':
+    case 'proxy':
+    case 'instant-insights':
+      return 'not-applicable'
+  }
+}
+
+export function getRequestInsightRouterActivity(
+  request: Pick<RequestInsight, 'routerActivity'>
+): RequestInsight['routerActivity'] {
+  switch (request.routerActivity) {
+    case 'prefetch':
+    case 'segment-prefetch':
+    case 'hmr-refresh':
+      return request.routerActivity
+    case undefined:
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+export function getRequestInsightSummaryTypeLabel(
+  request: RequestInsight
+): string {
+  const rowType = getRequestInsightRowType(request)
+  if (
+    rowType.type === 'instant-insights' ||
+    rowType.type === 'action' ||
+    rowType.type === 'prefetch' ||
+    rowType.type === 'segment-prefetch' ||
+    rowType.type === 'hmr-refresh'
+  ) {
+    return rowType.accessibleLabel
+  }
+
+  switch (getRequestInsightRepresentation(request)) {
+    case 'html':
+      return 'HTML request'
+    case 'rsc':
+      return 'RSC request'
+    case 'not-applicable':
+    case 'unknown':
+      return rowType.accessibleLabel
+  }
+}
+
+function getCanonicalThenAnySpanAttribute<T>(
+  request: Pick<RequestInsight, 'route' | 'spans'>,
+  key: string,
+  isValue: (value: unknown) => value is T
+): T | undefined {
+  const canonicalValue = getCanonicalRequestSpan(request)?.attributes?.[key]
+  if (isValue(canonicalValue)) {
+    return canonicalValue
+  }
+
+  for (const span of request.spans) {
+    const value = span.attributes?.[key]
+    if (isValue(value)) {
+      return value
+    }
+  }
 }
 
 export function isPageLoadRequest(
-  request: Pick<RequestInsight, 'requestId' | 'kind'>,
+  request: RequestInsight,
   initialRequestId: string | undefined
 ): boolean {
   return (
     getRequestInsightKind(request) === 'request' &&
-    request.requestId === initialRequestId
+    getRequestInsightSource(request) === 'page' &&
+    !request.serverAction &&
+    getRequestInsightIsRsc(request) === false &&
+    request.htmlRequestId === initialRequestId
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -11,6 +11,7 @@ function createRequest(
 ): RequestInsight {
   return {
     requestId: 'request-1',
+    source: 'unknown',
     htmlRequestId: 'html-1',
     startTime: 100,
     durationMs: 100,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -9,7 +9,12 @@ import {
   getRequestListEntries,
   isPageLoadRequest,
 } from './request-list'
-import { getTraceItems, getTracePosition, getTraceRange } from './trace-viewer'
+import {
+  getTraceItems,
+  getTraceNavigationIndex,
+  getTracePosition,
+  getTraceRange,
+} from './trace-viewer'
 
 function createRequest(
   overrides: Partial<RequestInsight> = {}
@@ -28,6 +33,18 @@ function createRequest(
 }
 
 describe('request insights trace viewer', () => {
+  it('moves the active trace row without leaving the listbox', () => {
+    expect(getTraceNavigationIndex(0, 3, 'ArrowDown')).toBe(1)
+    expect(getTraceNavigationIndex(2, 3, 'ArrowDown')).toBe(2)
+    expect(getTraceNavigationIndex(2, 3, 'ArrowUp')).toBe(1)
+    expect(getTraceNavigationIndex(1, 3, 'Home')).toBe(0)
+    expect(getTraceNavigationIndex(1, 3, 'End')).toBe(2)
+    expect(getTraceNavigationIndex(1, 3, 'ArrowRight')).toBeUndefined()
+    expect(getTraceNavigationIndex(1, 3, 'ArrowLeft')).toBeUndefined()
+    expect(getTraceNavigationIndex(0, 0, 'ArrowDown')).toBeUndefined()
+    expect(getTraceNavigationIndex(0, 3, 'Enter')).toBeUndefined()
+  })
+
   it('keeps the active request selected when newer requests arrive', () => {
     const selectedRequest = createRequest({ requestId: 'selected' })
     const newerRequest = createRequest({ requestId: 'newer' })
@@ -272,6 +289,40 @@ describe('request insights trace viewer', () => {
         }),
       })
     )
+  })
+
+  it('distinguishes same-origin and external fetches in the trace', () => {
+    const request = createRequest({
+      fetches: [
+        {
+          method: 'GET',
+          url: 'https://app.test/api/data?token=%3Credacted%3E',
+          startTime: 110,
+          durationMs: 10,
+        },
+        {
+          method: 'POST',
+          url: 'https://api.example.test/api/data',
+          startTime: 120,
+          durationMs: 20,
+        },
+      ],
+    })
+
+    expect(
+      getTraceItems(request, true, 'https://app.test').map(
+        ({ label, fullLabel }) => ({ label, fullLabel })
+      )
+    ).toEqual([
+      {
+        label: 'GET /api/data?token=%3Credacted%3E · Same origin',
+        fullLabel: 'GET https://app.test/api/data?token=%3Credacted%3E',
+      },
+      {
+        label: 'POST /api/data · External origin · api.example.test',
+        fullLabel: 'POST https://api.example.test/api/data',
+      },
+    ])
   })
 
   it('orders spans by their recorded parent-child hierarchy', () => {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -199,6 +199,31 @@ describe('request insights trace viewer', () => {
     ])
   })
 
+  it('uses Proxy terminology without changing the recorded OTel span', () => {
+    const middlewareSpan = {
+      name: 'middleware POST',
+      startTime: 100,
+      durationMs: 10,
+      attributes: {
+        'http.method': 'POST',
+        'next.span_name': 'middleware POST',
+        'next.span_type': 'Middleware.execute',
+      },
+    }
+    const request = createRequest({ spans: [middlewareSpan] })
+
+    expect(getTraceItems(request, false)[0]?.label).toBe('proxy POST')
+    expect(middlewareSpan).toEqual(
+      expect.objectContaining({
+        name: 'middleware POST',
+        attributes: expect.objectContaining({
+          'next.span_name': 'middleware POST',
+          'next.span_type': 'Middleware.execute',
+        }),
+      })
+    )
+  })
+
   it('orders spans by their recorded parent-child hierarchy', () => {
     const request = createRequest({
       spans: [

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -1,6 +1,11 @@
-import type { RequestInsight } from '../../../shared/request-insights'
+import {
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  type RequestInsight,
+} from '../../../shared/request-insights'
+import { getRequestInsightFilterResult } from './request-filters'
 import {
   getActiveRequestKey,
+  getRequestInsightRowType,
   getRequestListEntries,
   isPageLoadRequest,
 } from './request-list'
@@ -58,11 +63,11 @@ describe('request insights trace viewer', () => {
     })
 
     expect(getRequestListEntries([instantInsights, request], false)).toEqual([
-      { request, nested: false },
+      { request },
     ])
   })
 
-  it('nests internal records directly after their request row', () => {
+  it('keeps internal records flat and in capture order', () => {
     const newerRequest = createRequest({ requestId: 'newer' })
     const olderRequest = createRequest({ requestId: 'older' })
     const newerInstantInsights = createRequest({
@@ -85,49 +90,89 @@ describe('request insights trace viewer', () => {
         true
       )
     ).toEqual([
-      { request: newerRequest, nested: false },
-      { request: newerInstantInsights, nested: true },
-      { request: olderRequest, nested: false },
-      { request: olderInstantInsights, nested: true },
+      { request: newerInstantInsights },
+      { request: newerRequest },
+      { request: olderInstantInsights },
+      { request: olderRequest },
     ])
   })
 
-  it('keeps orphaned internal records top-level and in root ordering', () => {
-    const request = createRequest({ requestId: 'present' })
-    const presentInstantInsights = createRequest({
-      requestId: 'present',
-      kind: 'instant-insights',
+  it('labels and filters normalized request activity', () => {
+    const requestSpan = (rsc: boolean) => ({
+      name: 'GET',
+      startTime: 100,
+      attributes: {
+        'next.span_type': REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+        'next.rsc': rsc,
+      },
     })
-    const orphanInstantInsights = createRequest({
-      requestId: 'evicted',
-      kind: 'instant-insights',
+    const page = createRequest({
+      requestId: 'page',
+      source: 'page',
+      spans: [requestSpan(false)],
+      fetches: [{ cacheStatus: 'miss' }],
     })
+    const rsc = createRequest({
+      requestId: 'rsc',
+      source: 'page',
+      spans: [requestSpan(true)],
+    })
+    const action = createRequest({
+      requestId: 'action',
+      source: 'page',
+      serverAction: true,
+      spans: [requestSpan(true)],
+    })
+    const api = createRequest({ requestId: 'api', source: 'app-route' })
+    const asset = createRequest({ requestId: 'asset', source: 'asset' })
 
-    const entries = getRequestListEntries(
-      [presentInstantInsights, orphanInstantInsights, request],
-      true
-    )
-
-    expect(entries).toEqual([
-      { request: orphanInstantInsights, nested: false },
-      { request, nested: false },
-      { request: presentInstantInsights, nested: true },
-    ])
-    // Every record appears exactly once.
-    expect(new Set(entries.map((entry) => entry.request)).size).toBe(
-      entries.length
-    )
-    expect(entries).toHaveLength(3)
+    expect(getRequestInsightRowType(page, true).label).toBe('Page load')
+    expect(getRequestInsightRowType(rsc).label).toBe('RSC')
+    expect(getRequestInsightRowType(action).label).toBe('Action')
+    expect(getRequestInsightRowType(api).label).toBe('API')
+    expect(getRequestInsightRowType(asset).label).toBe('Asset')
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api],
+        ['source:page', 'cache:miss']
+      ).requests
+    ).toEqual([page])
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api, asset],
+        ['source:action', 'source:api']
+      ).requests
+    ).toEqual([action, api])
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api, asset],
+        ['source:asset']
+      ).requests
+    ).toEqual([asset])
   })
 
   it('only marks the exact initial document request as the page load', () => {
     const initialRequestId = 'document-request'
+    const htmlSpan = {
+      name: 'GET',
+      startTime: 100,
+      attributes: {
+        'next.span_type': REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+        'next.rsc': false,
+      },
+    }
+    const rscSpan = {
+      ...htmlSpan,
+      attributes: { ...htmlSpan.attributes, 'next.rsc': true },
+    }
 
     expect(
       isPageLoadRequest(
         createRequest({
-          requestId: initialRequestId,
+          requestId: 'server-owned-request',
+          source: 'page',
           htmlRequestId: initialRequestId,
+          spans: [htmlSpan],
         }),
         initialRequestId
       )
@@ -136,7 +181,9 @@ describe('request insights trace viewer', () => {
       isPageLoadRequest(
         createRequest({
           requestId: 'related-rsc-request',
+          source: 'page',
           htmlRequestId: initialRequestId,
+          spans: [rscSpan],
         }),
         initialRequestId
       )
@@ -145,7 +192,9 @@ describe('request insights trace viewer', () => {
       isPageLoadRequest(
         createRequest({
           requestId: initialRequestId,
+          source: 'instant-insights',
           kind: 'instant-insights',
+          spans: [htmlSpan],
         }),
         initialRequestId
       )

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -3,6 +3,7 @@ import type {
   RequestInsightFetch,
   RequestInsightSpan,
 } from '../../../shared/request-insights'
+import { getFetchUrlPresentation } from './fetch-label'
 
 export type TraceItem = {
   id: string
@@ -11,6 +12,7 @@ export type TraceItem = {
   spanType?: string
   category: 'nextjs' | 'application'
   label: string
+  fullLabel?: string
   startTime: number
   durationMs?: number
   status: 'ok' | 'error' | 'pending'
@@ -21,6 +23,32 @@ export type TraceItem = {
 export type TraceRange = {
   startTime: number
   durationMs: number
+}
+
+export function getTraceNavigationIndex(
+  currentIndex: number,
+  itemCount: number,
+  key: string
+): number | undefined {
+  if (itemCount <= 0) {
+    return undefined
+  }
+
+  const lastIndex = itemCount - 1
+  const safeCurrentIndex = Math.min(Math.max(currentIndex, 0), lastIndex)
+
+  switch (key) {
+    case 'ArrowDown':
+      return Math.min(safeCurrentIndex + 1, lastIndex)
+    case 'ArrowUp':
+      return Math.max(safeCurrentIndex - 1, 0)
+    case 'Home':
+      return 0
+    case 'End':
+      return lastIndex
+    default:
+      return undefined
+  }
 }
 
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
@@ -74,7 +102,8 @@ const SPAN_WORD_CASE: Record<string, string> = {
 
 export function getTraceItems(
   request: RequestInsight,
-  verbose: boolean
+  verbose: boolean,
+  currentOrigin?: string
 ): TraceItem[] {
   const fetchSpansByIndex = new Map<number, RequestInsightSpan>()
 
@@ -108,7 +137,7 @@ export function getTraceItems(
   request.fetches.forEach((fetch, index) => {
     const matchingSpan =
       fetch.index === undefined ? undefined : fetchSpansByIndex.get(fetch.index)
-    const item = getFetchTraceItem(fetch, index, matchingSpan)
+    const item = getFetchTraceItem(fetch, index, matchingSpan, currentOrigin)
     if (item) {
       items.push(item)
     }
@@ -171,12 +200,16 @@ function getSpanTraceItem(
 function getFetchTraceItem(
   fetch: RequestInsightFetch,
   index: number,
-  matchingSpan: RequestInsightSpan | undefined
+  matchingSpan: RequestInsightSpan | undefined,
+  currentOrigin: string | undefined
 ): UnnestedTraceItem | null {
   const startTime = fetch.startTime ?? matchingSpan?.startTime
   if (startTime === undefined) {
     return null
   }
+
+  const method = fetch.method ?? 'GET'
+  const url = getFetchUrlPresentation(fetch.url, currentOrigin)
 
   return {
     id: `fetch:${matchingSpan?.spanId ?? fetch.index ?? index}:${startTime}`,
@@ -184,7 +217,8 @@ function getFetchTraceItem(
     parentSpanId: matchingSpan?.parentSpanId,
     spanType: FETCH_SPAN_TYPE,
     category: matchingSpan ? getSpanCategory(matchingSpan) : 'application',
-    label: `${fetch.method ?? 'GET'} ${getUrlPath(fetch.url)}`,
+    label: `${method} ${url.path}${currentOrigin ? ` · ${url.originLabel}` : ''}`,
+    fullLabel: `${method} ${url.fullUrl}`,
     startTime,
     durationMs: fetch.durationMs ?? matchingSpan?.durationMs,
     status:
@@ -391,17 +425,4 @@ function getSpanLabel(span: RequestInsightSpan): string {
   }
 
   return words.join(' ')
-}
-
-function getUrlPath(url: string | undefined): string {
-  if (!url) {
-    return 'Unknown URL'
-  }
-
-  try {
-    const parsedUrl = new URL(url, 'http://localhost')
-    return `${parsedUrl.pathname}${parsedUrl.search}`
-  } catch {
-    return url
-  }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -26,9 +26,10 @@ export type TraceRange = {
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
 
 const FETCH_SPAN_TYPE = 'AppRender.fetch'
+const MIDDLEWARE_SPAN_TYPE = 'Middleware.execute'
 const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'BaseServer.handleRequest',
-  'Middleware.execute',
+  MIDDLEWARE_SPAN_TYPE,
   'NextNodeServer.matchRoute',
   'DevRouteMatcherManager.ensureRoute',
   'BaseServer.render',
@@ -349,6 +350,13 @@ function getSpanLabel(span: RequestInsightSpan): string {
   const displayName = name
     .replace(FIZZ_WORD, 'HTML')
     .replace(FLIGHT_WORD, 'RSC')
+
+  if (span.attributes?.['next.span_type'] === MIDDLEWARE_SPAN_TYPE) {
+    const method = span.attributes['http.method']
+    return typeof method === 'string' && method.length > 0
+      ? `proxy ${method}`
+      : displayName.replace(/^middleware\b/i, 'proxy')
+  }
 
   if (displayName === 'resolve segment modules') {
     return 'resolve segment'

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.css
@@ -5,6 +5,8 @@
 }
 
 .tooltip {
+  --tooltip-background: var(--color-gray-1000);
+
   position: relative;
   padding: 6px 12px;
   border-radius: 8px;
@@ -12,7 +14,7 @@
   line-height: 1.4;
   pointer-events: none;
   color: var(--color-gray-100);
-  background-color: var(--color-gray-1000);
+  background-color: var(--tooltip-background);
 }
 
 .tooltip-arrow {
@@ -27,7 +29,7 @@
 .tooltip-arrow--top {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px) 0
     var(--arrow-size, 6px);
-  border-top-color: var(--color-gray-1000);
+  border-top-color: var(--tooltip-background);
   bottom: 0;
   transform: translateY(100%);
 }
@@ -35,7 +37,7 @@
 .tooltip-arrow--bottom {
   border-width: 0 var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-bottom-color: var(--color-gray-1000);
+  border-bottom-color: var(--tooltip-background);
   top: 0;
   transform: translateY(-100%);
 }
@@ -43,7 +45,7 @@
 .tooltip-arrow--left {
   border-width: var(--arrow-size, 6px) 0 var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-left-color: var(--color-gray-1000);
+  border-left-color: var(--tooltip-background);
   right: 0;
   transform: translateX(100%);
 }
@@ -51,7 +53,7 @@
 .tooltip-arrow--right {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px) 0;
-  border-right-color: var(--color-gray-1000);
+  border-right-color: var(--tooltip-background);
   left: 0;
   transform: translateX(-100%);
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, isValidElement } from 'react'
 import { Tooltip as BaseTooltip } from '@base-ui-components/react/tooltip'
 import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { cx } from '../../utils/cx'
@@ -9,72 +9,80 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
 interface TooltipProps {
   children: React.ReactNode
   title: string | null
+  anchor?: React.ComponentProps<typeof BaseTooltip.Positioner>['anchor']
+  asChild?: boolean
   direction?: TooltipDirection
   arrowSize?: number
   offset?: number
   className?: string
 }
 
-export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
-  function Tooltip(
-    {
-      className,
-      children,
-      title,
-      direction = 'top',
-      arrowSize = 6,
-      offset = 8,
-    },
-    ref
-  ) {
-    const { shadowRoot } = useDevOverlayContext()
-    if (!title) {
-      return children
-    }
-    return (
-      <BaseTooltip.Provider>
-        <BaseTooltip.Root delay={400}>
-          <BaseTooltip.Trigger
-            ref={ref}
-            render={(triggerProps) => {
-              return <span {...triggerProps}>{children}</span>
-            }}
-          />
+export const Tooltip = forwardRef<HTMLElement, TooltipProps>(function Tooltip(
+  {
+    className,
+    children,
+    title,
+    anchor,
+    asChild = false,
+    direction = 'top',
+    arrowSize = 6,
+    offset = 8,
+  },
+  ref
+) {
+  const { shadowRoot } = useDevOverlayContext()
+  if (!title) {
+    return children
+  }
+  return (
+    <BaseTooltip.Provider>
+      <BaseTooltip.Root delay={400}>
+        <BaseTooltip.Trigger
+          ref={ref}
+          render={
+            asChild && isValidElement<Record<string, unknown>>(children)
+              ? children
+              : (triggerProps) => {
+                  return <span {...triggerProps}>{children}</span>
+                }
+          }
+        />
 
-          <BaseTooltip.Portal container={shadowRoot}>
-            <BaseTooltip.Positioner
-              side={direction}
-              sideOffset={offset + arrowSize}
-              className="tooltip-positioner"
+        <BaseTooltip.Portal container={shadowRoot}>
+          <BaseTooltip.Positioner
+            anchor={anchor}
+            positionMethod={anchor ? 'fixed' : undefined}
+            side={direction}
+            sideOffset={offset + arrowSize}
+            className="tooltip-positioner"
+            style={
+              {
+                '--anchor-width': `${arrowSize}px`,
+                '--anchor-height': `${arrowSize}px`,
+              } as React.CSSProperties
+            }
+          >
+            <BaseTooltip.Popup
+              className={cx('tooltip', className)}
               style={
                 {
-                  '--anchor-width': `${arrowSize}px`,
-                  '--anchor-height': `${arrowSize}px`,
+                  '--arrow-size': `${arrowSize}px`,
                 } as React.CSSProperties
               }
             >
-              <BaseTooltip.Popup
-                className={cx('tooltip', className)}
+              {title}
+              <BaseTooltip.Arrow
+                className={cx('tooltip-arrow', `tooltip-arrow--${direction}`)}
                 style={
                   {
                     '--arrow-size': `${arrowSize}px`,
                   } as React.CSSProperties
                 }
-              >
-                {title}
-                <BaseTooltip.Arrow
-                  className={cx('tooltip-arrow', `tooltip-arrow--${direction}`)}
-                  style={
-                    {
-                      '--arrow-size': `${arrowSize}px`,
-                    } as React.CSSProperties
-                  }
-                />
-              </BaseTooltip.Popup>
-            </BaseTooltip.Positioner>
-          </BaseTooltip.Portal>
-        </BaseTooltip.Root>
-      </BaseTooltip.Provider>
-    )
-  }
-)
+              />
+            </BaseTooltip.Popup>
+          </BaseTooltip.Positioner>
+        </BaseTooltip.Portal>
+      </BaseTooltip.Root>
+    </BaseTooltip.Provider>
+  )
+})

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -374,6 +374,7 @@ export const PanelRouter = () => {
       {isAppRouter && !!process.env.__NEXT_REQUEST_INSIGHTS && (
         <PanelRoute name="request-insights">
           <DynamicPanel
+            containerProps={{ className: 'request-insights-panel-container' }}
             sharePanelSizeGlobally={false}
             sharePanelPositionGlobally={false}
             draggable

--- a/packages/next/src/next-devtools/dev-overlay/shared.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.test.ts
@@ -23,6 +23,7 @@ function createRequestInsight(
   return {
     requestId: 'shared-request',
     kind,
+    source: kind === 'instant-insights' ? 'instant-insights' : 'page',
     htmlRequestId: 'shared-html',
     route: '/dashboard',
     startTime: 100,

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
+type DevToolsWindow = Window & {
+  [PAGEHIDE_LISTENER_KEY]?: () => void
+}
+
+const originalFetch = global.fetch
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function removePagehideListener() {
+  const devToolsWindow = window as DevToolsWindow
+  const listener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+
+  if (listener) {
+    window.removeEventListener('pagehide', listener)
+    delete devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  }
+}
+
+describe('saveDevToolsConfig', () => {
+  let fetchMock: jest.Mock
+  let warnMock: jest.SpyInstance
+
+  beforeEach(() => {
+    removePagehideListener()
+    jest.resetModules()
+    jest.useFakeTimers()
+    fetchMock = jest.fn()
+    global.fetch = fetchMock
+    warnMock = jest.spyOn(console, 'warn').mockImplementation()
+  })
+
+  afterEach(async () => {
+    await flushMicrotasks()
+    removePagehideListener()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    global.fetch = originalFetch
+    warnMock.mockRestore()
+  })
+
+  it('serializes writes and retries a merged patch after a failed response', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let activeRequests = 0
+    let maximumActiveRequests = 0
+
+    fetchMock
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return new Promise<{ ok: boolean }>((resolve) => {
+          resolveFirstRequest = resolve
+        }).finally(() => {
+          activeRequests--
+        })
+      })
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return Promise.resolve({ ok: true }).finally(() => {
+          activeRequests--
+        })
+      })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({
+      requestInsights: { showInternal: true, verbose: false },
+    })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveFirstRequest!({ ok: false })
+    await jest.advanceTimersByTimeAsync(0)
+
+    await jest.advanceTimersByTimeAsync(239)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    expect(maximumActiveRequests).toBe(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: false },
+      }
+    )
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: true },
+      }
+    )
+  })
+
+  it('retries a patch when fetch throws synchronously without logging it', async () => {
+    fetchMock
+      .mockImplementationOnce(() => {
+        throw new Error('sensitive value: dark')
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ theme: 'dark' })
+    jest.advanceTimersByTime(120)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('dark')
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('sensitive')
+
+    await jest.advanceTimersByTimeAsync(240)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({ theme: 'dark' }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a pending patch immediately on pagehide with keepalive', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/__nextjs_devtools_config',
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: { showInternal: true },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a queued patch on pagehide while a save is in flight', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(
+      fetchMock.mock.calls.map((call) => JSON.parse(call[1].body))
+    ).toEqual([
+      { requestInsights: { showInternal: true } },
+      {
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      },
+    ])
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ keepalive: true })
+    )
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+  })
+
+  it('retries a failed pagehide flush after the in-flight save completes', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let rejectPagehideRequest: (error: Error) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((_resolve, reject) => {
+            rejectPagehideRequest = reject
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+    rejectPagehideRequest!(new Error('page was hidden'))
+    await flushMicrotasks()
+
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: {
+            showInternal: true,
+            verbose: true,
+          },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('does not restore an older failed patch after a newer pagehide flush succeeds', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { verbose: false } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      requestInsights: { verbose: true },
+    })
+
+    resolveFirstRequest!({ ok: false })
+    await flushMicrotasks()
+    await jest.advanceTimersByTimeAsync(5_000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
@@ -2,29 +2,124 @@ import type { DevToolsConfig } from '../shared'
 import { devToolsConfigSchema } from '../../shared/devtools-config-schema'
 import { deepMerge } from '../../shared/deepmerge'
 
+const SAVE_DEBOUNCE_DELAY = 120
+const INITIAL_RETRY_DELAY = 240
+const MAX_RETRY_DELAY = 5_000
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
 let queuedConfigPatch: DevToolsConfig = {}
 let timer: ReturnType<typeof setTimeout> | null = null
+let flushInFlight: Promise<void> | null = null
+let inFlightFlush:
+  | {
+      patch: DevToolsConfig
+      supersedingPatch?: DevToolsConfig
+      supersedingFlush?: Promise<void>
+      supersedingVersion: number
+    }
+  | undefined
+let flushImmediatelyAfterInFlight = false
+let retryDelay = INITIAL_RETRY_DELAY
 
-function flushPatch() {
-  if (Object.keys(queuedConfigPatch).length === 0) {
-    return
+function hasQueuedPatch() {
+  return Object.keys(queuedConfigPatch).length > 0
+}
+
+function scheduleFlush(delay: number) {
+  if (timer) {
+    clearTimeout(timer)
   }
 
-  const body = JSON.stringify(queuedConfigPatch)
-  queuedConfigPatch = {}
+  timer = setTimeout(flushPatch, delay)
+}
 
-  fetch('/__nextjs_devtools_config', {
+async function sendConfigPatch(body: string) {
+  const response = await fetch('/__nextjs_devtools_config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body,
     // keepalive in case of fetch interrupted, e.g. navigation or reload
     keepalive: true,
-  }).catch((error) => {
-    console.warn('[Next.js DevTools] Failed to save config:', {
-      data: body,
-      error,
-    })
   })
+
+  if (!response.ok) {
+    throw new Error('Failed to save DevTools config')
+  }
+}
+
+function flushPatch(immediatelyAfterInFlight = false) {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+
+  if (flushInFlight) {
+    flushImmediatelyAfterInFlight ||= immediatelyAfterInFlight
+    return
+  }
+
+  if (!hasQueuedPatch()) {
+    return
+  }
+
+  const patch = queuedConfigPatch
+  const body = JSON.stringify(patch)
+  queuedConfigPatch = {}
+
+  const currentFlush: NonNullable<typeof inFlightFlush> = {
+    patch,
+    supersedingVersion: 0,
+  }
+  inFlightFlush = currentFlush
+  const request = sendConfigPatch(body)
+
+  flushInFlight = request
+    .then(() => {
+      retryDelay = INITIAL_RETRY_DELAY
+    })
+    .catch(async () => {
+      // A pagehide write contains this patch plus everything queued after it.
+      // Let that newer write own restoration so an older failed request can
+      // never overwrite a successful newer one.
+      if (currentFlush.supersedingFlush) {
+        await currentFlush.supersedingFlush
+        return
+      }
+
+      // Restore the failed patch without overwriting changes queued while the
+      // request was in flight.
+      queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+
+      const delay = retryDelay
+      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY)
+      scheduleFlush(delay)
+
+      // Do not include the request body or error details here. Config patches
+      // can contain user-defined shortcut values.
+      console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+    })
+    .finally(() => {
+      if (inFlightFlush === currentFlush) {
+        inFlightFlush = undefined
+      }
+      flushInFlight = null
+
+      if (!hasQueuedPatch()) {
+        flushImmediatelyAfterInFlight = false
+        return
+      }
+
+      if (flushImmediatelyAfterInFlight) {
+        flushImmediatelyAfterInFlight = false
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        flushPatch(true)
+      } else if (!timer) {
+        scheduleFlush(0)
+      }
+    })
 }
 
 export function saveDevToolsConfig(patch: DevToolsConfig) {
@@ -43,5 +138,59 @@ export function saveDevToolsConfig(patch: DevToolsConfig) {
     clearTimeout(timer)
   }
 
-  timer = setTimeout(flushPatch, 120)
+  timer = setTimeout(flushPatch, SAVE_DEBOUNCE_DELAY)
+}
+
+if (typeof window !== 'undefined') {
+  const devToolsWindow = window as Window & {
+    [PAGEHIDE_LISTENER_KEY]?: () => void
+  }
+  const previousListener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  if (typeof previousListener === 'function') {
+    previousListener()
+    window.removeEventListener('pagehide', previousListener)
+  }
+
+  // A reload can happen before the debounced write starts. Flush the pending
+  // patch while the page is still alive; keepalive lets the request finish
+  // during page teardown.
+  const flushPatchOnPagehide = () => {
+    if (flushInFlight && inFlightFlush && hasQueuedPatch()) {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      const currentFlush = inFlightFlush
+      const patch = deepMerge(
+        currentFlush.supersedingPatch ?? currentFlush.patch,
+        queuedConfigPatch
+      )
+      queuedConfigPatch = {}
+      const version = ++currentFlush.supersedingVersion
+      currentFlush.supersedingPatch = patch
+      currentFlush.supersedingFlush = sendConfigPatch(JSON.stringify(patch))
+        .then(() => {
+          retryDelay = INITIAL_RETRY_DELAY
+        })
+        .catch(() => {
+          // Ignore an older pagehide failure when a newer cumulative write is
+          // already responsible for the same data.
+          if (version !== currentFlush.supersedingVersion) {
+            return
+          }
+
+          // The document may survive through the back-forward cache. Restore
+          // the complete superseding patch and retry it without logging user
+          // config values.
+          queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+          scheduleFlush(0)
+          console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+        })
+      return
+    }
+
+    flushPatch(true)
+  }
+  window.addEventListener('pagehide', flushPatchOnPagehide)
+  devToolsWindow[PAGEHIDE_LISTENER_KEY] = flushPatchOnPagehide
 }

--- a/packages/next/src/next-devtools/server/devtools-config-middleware.ts
+++ b/packages/next/src/next-devtools/server/devtools-config-middleware.ts
@@ -1,9 +1,9 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { DevToolsConfig } from '../dev-overlay/shared'
 
-import { existsSync } from 'fs'
-import { readFile, writeFile, mkdir } from 'fs/promises'
-import { dirname, join } from 'path'
+import * as fsPromises from 'fs/promises'
+import { randomUUID } from 'crypto'
+import { basename, dirname, join } from 'path'
 
 import { middlewareResponse } from './middleware-response'
 import { devToolsConfigSchema } from '../shared/devtools-config-schema'
@@ -11,6 +11,8 @@ import { deepMerge } from '../shared/deepmerge'
 
 const DEVTOOLS_CONFIG_FILENAME = 'next-devtools-config.json'
 const DEVTOOLS_CONFIG_MIDDLEWARE_ENDPOINT = '/__nextjs_devtools_config'
+const DEVTOOLS_CONFIG_BODY_LIMIT = 64 * 1024
+const configUpdateQueues = new Map<string, Promise<void>>()
 
 export function devToolsConfigMiddleware({
   distDir,
@@ -36,36 +38,63 @@ export function devToolsConfigMiddleware({
       return middlewareResponse.methodNotAllowed(res)
     }
 
-    const currentConfig = await getDevToolsConfig(distDir)
+    const previousUpdate = (
+      configUpdateQueues.get(configPath) ?? Promise.resolve()
+    ).catch(() => {})
+    let releaseUpdate!: () => void
+    const updateCompleted = new Promise<void>((resolve) => {
+      releaseUpdate = resolve
+    })
+    const queueTail = previousUpdate.then(() => updateCompleted)
+    configUpdateQueues.set(configPath, queueTail)
+    void queueTail.then(() => {
+      if (configUpdateQueues.get(configPath) === queueTail) {
+        configUpdateQueues.delete(configPath)
+      }
+    })
 
-    const chunks: Buffer[] = []
-    for await (const chunk of req) {
-      chunks.push(Buffer.from(chunk))
-    }
-
-    let body = Buffer.concat(chunks).toString('utf8')
     try {
-      body = JSON.parse(body)
-    } catch (error) {
-      console.error('[Next.js DevTools] Invalid config body passed:', error)
-      return middlewareResponse.badRequest(res)
-    }
+      const chunks: Buffer[] = []
+      let bodySize = 0
+      for await (const chunk of req) {
+        const buffer = Buffer.from(chunk)
+        bodySize += buffer.byteLength
+        if (bodySize > DEVTOOLS_CONFIG_BODY_LIMIT) {
+          return middlewareResponse.payloadTooLarge(res)
+        }
+        chunks.push(buffer)
+      }
 
-    const validation = devToolsConfigSchema.safeParse(body)
-    if (!validation.success) {
-      console.error(
-        '[Next.js DevTools] Invalid config passed:',
-        validation.error.message
+      let body = Buffer.concat(chunks).toString('utf8')
+      try {
+        body = JSON.parse(body)
+      } catch (error) {
+        console.error('[Next.js DevTools] Invalid config body passed:', error)
+        return middlewareResponse.badRequest(res)
+      }
+
+      const validation = devToolsConfigSchema.safeParse(body)
+      if (!validation.success) {
+        console.error(
+          '[Next.js DevTools] Invalid config passed:',
+          validation.error.message
+        )
+        return middlewareResponse.badRequest(res)
+      }
+
+      await previousUpdate
+      const currentConfig = await getDevToolsConfig(distDir)
+      const newConfig = deepMerge(currentConfig, validation.data)
+      await writeDevToolsConfigAtomically(
+        configPath,
+        JSON.stringify(newConfig, null, 2)
       )
-      return middlewareResponse.badRequest(res)
+      sendUpdateSignal(newConfig)
+
+      return middlewareResponse.noContent(res)
+    } finally {
+      releaseUpdate()
     }
-
-    const newConfig = deepMerge(currentConfig, validation.data)
-    await writeFile(configPath, JSON.stringify(newConfig, null, 2))
-
-    sendUpdateSignal(newConfig)
-
-    return middlewareResponse.noContent(res)
   }
 }
 
@@ -74,11 +103,41 @@ export async function getDevToolsConfig(
 ): Promise<DevToolsConfig> {
   const configPath = join(distDir, 'cache', DEVTOOLS_CONFIG_FILENAME)
 
-  if (!existsSync(configPath)) {
-    await mkdir(dirname(configPath), { recursive: true })
-    await writeFile(configPath, JSON.stringify({}))
-    return {}
+  try {
+    const parsed = JSON.parse(await fsPromises.readFile(configPath, 'utf8'))
+    const validation = devToolsConfigSchema.safeParse(parsed)
+    return validation.success ? validation.data : {}
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {}
+    }
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return {}
+    }
+    throw error
   }
+}
 
-  return JSON.parse(await readFile(configPath, 'utf8'))
+async function writeDevToolsConfigAtomically(
+  configPath: string,
+  contents: string
+): Promise<void> {
+  const temporaryPath = join(
+    dirname(configPath),
+    `.${basename(configPath)}.${process.pid}.${randomUUID()}.tmp`
+  )
+
+  try {
+    await fsPromises.mkdir(dirname(configPath), { recursive: true })
+    await fsPromises.writeFile(temporaryPath, contents)
+    await fsPromises.rename(temporaryPath, configPath)
+  } catch (error) {
+    await fsPromises.unlink(temporaryPath).catch(() => {})
+    throw error
+  }
 }

--- a/packages/next/src/next-devtools/server/middleware-response.ts
+++ b/packages/next/src/next-devtools/server/middleware-response.ts
@@ -23,6 +23,10 @@ export const middlewareResponse = {
     res.statusCode = 405
     res.end('Method Not Allowed')
   },
+  payloadTooLarge(res: ServerResponse) {
+    res.statusCode = 413
+    res.end('Payload Too Large')
+  },
   internalServerError(res: ServerResponse, error?: unknown) {
     res.statusCode = 500
     res.setHeader('Content-Type', 'text/plain')

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -1,10 +1,19 @@
-import type { RequestInsightKind } from '../../shared/lib/request-insights'
+import type {
+  RequestInsightKind,
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../shared/lib/request-insights'
 
 export {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
   type RequestInsightIdentity,
   type RequestInsightKind,
+  type RequestInsightProxyStatus,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../shared/lib/request-insights'
 
 type RequestInsightAttributeValue =
@@ -54,6 +63,10 @@ export type RequestInsightFetch = {
 export type RequestInsight = {
   requestId: string
   kind?: RequestInsightKind
+  source: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId: string
   route?: string
   url?: string

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -9,6 +9,8 @@ export {
   getRequestInsightKey,
   getRequestInsightKind,
   getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsightIdentity,
   type RequestInsightKind,
   type RequestInsightProxyStatus,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -65,6 +65,7 @@ import {
   extractInfoFromServerReferenceId,
   mightBeServerReferenceId,
 } from '../../shared/lib/server-reference-info'
+import { isUseCacheFunction } from '../../lib/client-and-server-references'
 import type { ServerActionLogInfo } from '../dev/server-action-logger'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { synchronizeMutableCookies } from '../async-storage/request-store'
@@ -752,6 +753,9 @@ export async function handleAction({
     // action in the current handler, so we forward the request to a worker that
     // has the action.
     if (forwardedWorker) {
+      if (extractInfoFromServerReferenceId(actionId).type === 'server-action') {
+        markServerActionRequest()
+      }
       return {
         type: 'done',
         result: await createForwardedActionResponse(
@@ -869,6 +873,10 @@ export async function handleAction({
               const action = await decodeAction(formData, serverModuleMap)
               if (typeof action === 'function') {
                 // an MPA action.
+
+                if (!isUseCacheFunction(action)) {
+                  markServerActionRequest()
+                }
 
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
@@ -1079,6 +1087,10 @@ export async function handleAction({
               if (typeof action === 'function') {
                 // an MPA action.
 
+                if (!isUseCacheFunction(action)) {
+                  markServerActionRequest()
+                }
+
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
@@ -1175,6 +1187,9 @@ export async function handleAction({
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
         const { type: actionType } = extractInfoFromServerReferenceId(actionId!)
+        if (actionType !== 'use-cache') {
+          markServerActionRequest()
+        }
         if (
           process.env.NODE_ENV === 'development' &&
           ctx.renderOpts.logServerFunctions &&
@@ -1372,6 +1387,19 @@ export async function handleAction({
  * stack overflow during `action.apply()` from malicious requests.
  */
 const SERVER_ACTION_ARGS_LIMIT = 1000
+
+function markServerActionRequest(): void {
+  if (process.env.__NEXT_DEV_SERVER && process.env.NEXT_RUNTIME !== 'edge') {
+    const { getRequestInsightsIdentity } =
+      require('../lib/trace/request-insights-identity') as typeof import('../lib/trace/request-insights-identity')
+    const identity = getRequestInsightsIdentity()
+    if (identity) {
+      const { recordRequestInsightServerAction } =
+        require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
+      recordRequestInsightServerAction(identity)
+    }
+  }
+}
 
 async function executeActionAndPrepareForRender<
   TFn extends (...args: any[]) => Promise<any>,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -115,6 +115,7 @@ import {
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
+import { getRequestInsightRouterActivity } from '../lib/trace/request-insights-router-activity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
@@ -2761,7 +2762,18 @@ async function prepareAppPageRender(
 
   const { flightRouterState, isPrefetchRequest, nonce } = parsedRequestHeaders
 
-  if (parsedRequestHeaders.requestId) {
+  const routerActivity = requestInsightsIdentity
+    ? getRequestInsightRouterActivity(req.headers)
+    : undefined
+  if (requestInsightsIdentity && routerActivity) {
+    const { recordRequestInsightRouterActivity } =
+      require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
+    recordRequestInsightRouterActivity(requestInsightsIdentity, routerActivity)
+  }
+
+  if (requestInsightsIdentity?.debugRequestId) {
+    requestId = requestInsightsIdentity.debugRequestId
+  } else if (parsedRequestHeaders.requestId) {
     // If the client has provided a request ID (in development mode), we use it.
     requestId = parsedRequestHeaders.requestId
   } else if (requestInsightsIdentity) {
@@ -4938,7 +4950,7 @@ async function runInstantInsightsWithTracing<T>(
 
   return runWithRequestInsightsIdentity(
     {
-      requestId: ctx.requestId,
+      requestId: getRequestInsightsIdentity()?.requestId ?? ctx.requestId,
       kind: 'instant-insights',
       htmlRequestId: ctx.htmlRequestId,
       url: ctx.url.href,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -114,7 +114,10 @@ import {
   SpanStatusCode,
 } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
-import { runWithRequestInsightsIdentity } from './lib/trace/request-insights-identity'
+import {
+  resolveRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './lib/trace/request-insights-identity'
 import { isRequestInsightsEnabled } from './lib/trace/span-store'
 import { I18NProvider } from './lib/i18n-provider'
 import { sendResponse } from './send-response'
@@ -1002,25 +1005,33 @@ export default abstract class Server<
       return handleRequest()
     }
 
-    const requestIdHeader = req.headers[NEXT_REQUEST_ID_HEADER]
-    const requestId =
-      typeof requestIdHeader === 'string' ? requestIdHeader : nanoid()
-    const htmlRequestIdHeader = req.headers[NEXT_HTML_REQUEST_ID_HEADER]
+    const requestInsightsIdentity = resolveRequestInsightsIdentity({
+      previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+      requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+      htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+      url: req.url,
+      createRequestId: nanoid,
+    })
+    const isMiddlewareInvoke = getRequestMeta(req, 'middlewareInvoke') === true
+    const sourceBeforeMiddleware = requestInsightsIdentity.source
+    if (isMiddlewareInvoke) {
+      requestInsightsIdentity.source = 'proxy'
+    }
+    addRequestMeta(req, 'requestInsightsIdentity', requestInsightsIdentity)
 
     // The request root and route-matching spans start before App Render creates
     // its workStore. Carry their identity in this outer scope; App Render copies
     // it into the workStore so the complete timeline uses one request ID.
-    return runWithRequestInsightsIdentity(
-      {
-        requestId,
-        htmlRequestId:
-          typeof htmlRequestIdHeader === 'string'
-            ? htmlRequestIdHeader
-            : requestId,
-        url: req.url,
-      },
-      handleRequest
-    )
+    try {
+      return await runWithRequestInsightsIdentity(
+        requestInsightsIdentity,
+        handleRequest
+      )
+    } finally {
+      if (isMiddlewareInvoke && requestInsightsIdentity.source === 'proxy') {
+        requestInsightsIdentity.source = sourceBeforeMiddleware
+      }
+    }
   }
 
   private async handleRequestImpl(

--- a/packages/next/src/server/lib/dev-request-id.ts
+++ b/packages/next/src/server/lib/dev-request-id.ts
@@ -1,0 +1,44 @@
+import {
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from '../../client/components/app-router-headers'
+
+type HeaderValue = string | string[] | undefined
+
+const REQUEST_ID_PATTERN = /^[0-9a-f]{1,8}$/
+const HTML_REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
+
+export function getValidatedDevRequestId(
+  value: HeaderValue
+): string | undefined {
+  return typeof value === 'string' && REQUEST_ID_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function getValidatedDevHtmlRequestId(
+  value: HeaderValue
+): string | undefined {
+  return typeof value === 'string' && HTML_REQUEST_ID_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function filterInvalidDevRequestIdHeaders(
+  headers: Record<string, HeaderValue>
+): void {
+  if (
+    headers[NEXT_REQUEST_ID_HEADER] !== undefined &&
+    getValidatedDevRequestId(headers[NEXT_REQUEST_ID_HEADER]) === undefined
+  ) {
+    delete headers[NEXT_REQUEST_ID_HEADER]
+  }
+
+  if (
+    headers[NEXT_HTML_REQUEST_ID_HEADER] !== undefined &&
+    getValidatedDevHtmlRequestId(headers[NEXT_HTML_REQUEST_ID_HEADER]) ===
+      undefined
+  ) {
+    delete headers[NEXT_HTML_REQUEST_ID_HEADER]
+  }
+}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -71,7 +71,15 @@ import { getNextConfigRuntime, type NextConfigComplete } from '../config-shared'
 import {
   getRequestInsightsSnapshot,
   isRequestInsightsEnabled,
+  recordRequestInsightSource,
 } from './trace/request-insights'
+import {
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from '../../client/components/app-router-headers'
+import { nanoid } from 'next/dist/compiled/nanoid'
+import { filterInvalidDevRequestIdHeaders } from './dev-request-id'
+import { resolveRequestInsightsIdentity } from './trace/request-insights-identity'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -252,9 +260,21 @@ export async function initialize(opts: {
       filterInternalHeaders(req.headers)
     }
 
+    if (opts.dev) {
+      filterInvalidDevRequestIdHeaders(req.headers)
+    }
+
     if (opts.dev && req.url) {
       if (config.experimental.requestInsights) {
         process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+        const identity = resolveRequestInsightsIdentity({
+          previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+          requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+          htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+          url: req.url,
+          createRequestId: nanoid,
+        })
+        addRequestMeta(req, 'requestInsightsIdentity', identity)
       }
 
       const urlParts = req.url.split('?', 1)
@@ -619,6 +639,15 @@ export async function initialize(opts: {
         }
 
         try {
+          if (config.experimental.requestInsights) {
+            const requestInsightsIdentity = getRequestMeta(
+              req,
+              'requestInsightsIdentity'
+            )
+            if (requestInsightsIdentity) {
+              recordRequestInsightSource(requestInsightsIdentity, 'asset')
+            }
+          }
           return await serveStatic(req, res, matchedOutput.itemPath, {
             root: matchedOutput.itemsRoot,
             // Ensures that etags are not generated for static files when disabled.

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -32,7 +32,7 @@ import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-p
 import { NextDataPathnameNormalizer } from '../../normalizers/request/next-data'
 import { BasePathPathnameNormalizer } from '../../normalizers/request/base-path'
 
-import { addRequestMeta } from '../../request-meta'
+import { addRequestMeta, getRequestMeta } from '../../request-meta'
 import { isRSCRequestHeader } from '../is-rsc-request'
 import {
   compileNonPath,
@@ -565,7 +565,7 @@ export function getResolveRoutes(
             /* non-fatal we can't decode so can't match it */
           }
 
-          if (
+          const matchesMiddleware =
             // @ts-expect-error BaseNextRequest stuff
             match?.(parsedUrl.pathname, req, parsedUrl.query) ||
             match?.(
@@ -574,7 +574,17 @@ export function getResolveRoutes(
               req,
               parsedUrl.query
             )
-          ) {
+          const requestInsightsIdentity = getRequestMeta(
+            req,
+            'requestInsightsIdentity'
+          )
+          if (requestInsightsIdentity && match) {
+            requestInsightsIdentity.proxyStatus = matchesMiddleware
+              ? 'matched'
+              : 'bypassed'
+          }
+
+          if (matchesMiddleware) {
             if (ensureMiddleware) {
               await ensureMiddleware(req.url)
             }

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -6,12 +6,16 @@ import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
 import { createLocalSpan, traceLocalSpan } from './local-span-recorder'
-import { runWithRequestInsightsIdentity } from './request-insights-identity'
+import {
+  resolveRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './request-insights-identity'
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 import {
   workAsyncStorage,
   type WorkStore,
 } from '../../app-render/work-async-storage.external'
+import { filterInvalidDevRequestIdHeaders } from '../dev-request-id'
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const spanRecords: SpanStoreRecord[] = []
@@ -67,6 +71,98 @@ describe('local recording span', () => {
         },
       }),
     ])
+  })
+
+  it('keeps browser debug IDs separate from server-owned storage IDs', () => {
+    const identity = resolveRequestInsightsIdentity({
+      previousIdentity: undefined,
+      requestIdHeader: '1a2b3c4d',
+      htmlRequestIdHeader: 'html_request',
+      url: '/dashboard',
+      createRequestId: () => 'server_request',
+    })
+
+    expect(identity).toEqual({
+      requestId: 'server_request',
+      debugRequestId: '1a2b3c4d',
+      htmlRequestId: 'html_request',
+      url: '/dashboard',
+    })
+    expect(
+      resolveRequestInsightsIdentity({
+        previousIdentity: identity,
+        requestIdHeader: 'ffffffff',
+        htmlRequestIdHeader: 'other_html',
+        url: '/rewritten',
+        createRequestId: () => 'other_server_request',
+      })
+    ).toBe(identity)
+  })
+
+  it('records the framework-owned request source from the request identity', () => {
+    runWithRequestInsightsIdentity(
+      {
+        requestId: 'asset-request',
+        source: 'asset',
+        htmlRequestId: 'asset-request',
+        url: '/asset.svg',
+      },
+      () => {
+        const span = createLocalSpan({ name: 'serve static asset' })
+        span.end()
+      }
+    )
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        requestId: 'asset-request',
+        requestInsightSource: 'asset',
+        url: '/asset.svg',
+      }),
+    ])
+  })
+
+  it('rejects malformed browser IDs instead of using them as storage keys', () => {
+    expect(
+      resolveRequestInsightsIdentity({
+        previousIdentity: undefined,
+        requestIdHeader: 'not a request id',
+        htmlRequestIdHeader: '../not-safe',
+        url: '/',
+        createRequestId: () => 'server_request',
+      })
+    ).toEqual({
+      requestId: 'server_request',
+      debugRequestId: undefined,
+      htmlRequestId: 'server_request',
+      url: '/',
+    })
+  })
+
+  it('drops malformed development correlation headers at router ingress', () => {
+    const headers = {
+      'x-nextjs-request-id': 'not a request id',
+      'x-nextjs-html-request-id': '../not-safe',
+    }
+
+    filterInvalidDevRequestIdHeaders(headers)
+
+    expect(headers).toEqual({})
+  })
+
+  it('does not merge independent requests that reuse a valid browser ID', () => {
+    const createIdentity = (requestId: string) =>
+      resolveRequestInsightsIdentity({
+        previousIdentity: undefined,
+        requestIdHeader: '1a2b3c4d',
+        htmlRequestIdHeader: undefined,
+        url: '/',
+        createRequestId: () => requestId,
+      })
+
+    expect(createIdentity('server_request_1').requestId).not.toBe(
+      createIdentity('server_request_2').requestId
+    )
   })
 
   it('ignores undefined values when setting attributes', () => {

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -14,6 +14,11 @@ import {
   type SpanStoreLink,
 } from './span-store'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 
 export { isLocalSpanRecordingEnabled } from './span-store'
 
@@ -169,6 +174,10 @@ function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {
 type RequestIdentity = {
   requestId?: string
   requestInsightKind?: RequestInsightKind
+  requestInsightSource?: RequestInsightSource
+  requestInsightProxyStatus?: RequestInsightProxyStatus
+  requestInsightRouterActivity?: RequestInsightRouterActivity
+  requestInsightServerAction?: true
   htmlRequestId?: string
   route?: string
   url?: string
@@ -371,6 +380,12 @@ class LocalRecordingSpan implements Span {
       parentSpanId: this.parentSpanId,
       requestId: this.requestIdentity.requestId,
       requestInsightKind: this.requestIdentity.requestInsightKind,
+      requestInsightSource: this.requestIdentity.requestInsightSource,
+      requestInsightProxyStatus: this.requestIdentity.requestInsightProxyStatus,
+      requestInsightRouterActivity:
+        this.requestIdentity.requestInsightRouterActivity,
+      requestInsightServerAction:
+        this.requestIdentity.requestInsightServerAction,
       htmlRequestId: this.requestIdentity.htmlRequestId,
       route:
         getStringAttribute(recordAttributes, 'next.route') ??
@@ -565,6 +580,10 @@ function getCurrentRequestIdentity(): RequestIdentity {
     return {
       requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
       requestInsightKind: requestInsightsIdentity?.kind,
+      requestInsightSource: requestInsightsIdentity?.source,
+      requestInsightProxyStatus: requestInsightsIdentity?.proxyStatus,
+      requestInsightRouterActivity: requestInsightsIdentity?.routerActivity,
+      requestInsightServerAction: requestInsightsIdentity?.serverAction,
       htmlRequestId:
         requestInsightsIdentity?.htmlRequestId ?? workStore?.htmlRequestId,
       route: workStore?.route,

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -1,12 +1,55 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+import {
+  getValidatedDevHtmlRequestId,
+  getValidatedDevRequestId,
+} from '../dev-request-id'
 
 export type RequestInsightsIdentity = {
+  // This is a server-owned storage key. Browser-provided IDs are only used by
+  // the development debug channel and must never become Request Insights keys.
   requestId: string
+  debugRequestId?: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId: string
   url: string | undefined
+}
+
+export function resolveRequestInsightsIdentity({
+  previousIdentity,
+  requestIdHeader,
+  htmlRequestIdHeader,
+  url,
+  createRequestId,
+}: {
+  previousIdentity: RequestInsightsIdentity | undefined
+  requestIdHeader: string | string[] | undefined
+  htmlRequestIdHeader: string | string[] | undefined
+  url: string | undefined
+  createRequestId: () => string
+}): RequestInsightsIdentity {
+  if (previousIdentity) {
+    return previousIdentity
+  }
+
+  const requestId = createRequestId()
+  return {
+    requestId,
+    debugRequestId: getValidatedDevRequestId(requestIdHeader),
+    htmlRequestId:
+      getValidatedDevHtmlRequestId(htmlRequestIdHeader) ?? requestId,
+    url,
+  }
 }
 
 // This storage covers the part of BaseServer request handling that runs before

--- a/packages/next/src/server/lib/trace/request-insights-router-activity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-router-activity.ts
@@ -1,0 +1,36 @@
+import {
+  NEXT_HMR_REFRESH_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  RSC_HEADER,
+} from '../../../client/components/app-router-headers'
+import type { RequestInsightRouterActivity } from '../../../shared/lib/request-insights'
+import { isRSCRequestHeader } from '../is-rsc-request'
+
+type RouterHeaders = Record<string, string | string[] | undefined>
+
+export function getRequestInsightRouterActivity(
+  headers: RouterHeaders
+): RequestInsightRouterActivity | undefined {
+  if (!isRSCRequestHeader(headers[RSC_HEADER])) {
+    return undefined
+  }
+
+  if (headers[NEXT_HMR_REFRESH_HEADER] === '1') {
+    return 'hmr-refresh'
+  }
+
+  const prefetch = headers[NEXT_ROUTER_PREFETCH_HEADER]
+  if (prefetch !== '1' && prefetch !== '2' && prefetch !== '3') {
+    return undefined
+  }
+
+  if (
+    prefetch === '1' &&
+    typeof headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === 'string'
+  ) {
+    return 'segment-prefetch'
+  }
+
+  return 'prefetch'
+}

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -538,17 +538,18 @@ describe('request insights', () => {
   it('redacts sensitive request insight payload fields', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
+    const secret = 'Q2_SECRET_SENTINEL'
     recordSpan({
-      name: 'fetch GET https://example.vercel.sh/api',
+      name: `fetch GET https://example.vercel.sh/api?token=${secret}`,
       startTime: 100,
       durationMs: 10,
       requestId: 'req_4',
       route: '/account',
       attributes: {
         'next.span_type': 'AppRender.fetch',
-        'http.url':
-          'https://user:pass@example.vercel.sh/api?access_token=abc&delay=1&signature=sig',
+        'http.url': `https://user:pass@example.vercel.sh/api?access_token=${secret}&delay=1&signature=sig`,
         'http.method': 'GET',
+        'next.span_name': `fetch GET https://user:pass@example.vercel.sh/api?access_token=${secret}`,
         'custom.secret': 'should not be exposed',
       },
       events: [
@@ -588,11 +589,13 @@ describe('request insights', () => {
       expect.objectContaining({
         spans: [
           expect.objectContaining({
+            name: 'fetch GET https://example.vercel.sh/api?query=redacted',
             attributes: {
               'next.span_type': 'AppRender.fetch',
-              'http.url':
-                'https://example.vercel.sh/api?access_token=redacted&delay=1&signature=redacted',
+              'http.url': 'https://example.vercel.sh/api?query=redacted',
               'http.method': 'GET',
+              'next.span_name':
+                'fetch GET https://example.vercel.sh/api?query=redacted',
             },
             events: [
               {
@@ -614,13 +617,95 @@ describe('request insights', () => {
         ],
         fetches: [
           expect.objectContaining({
-            url: 'https://example.vercel.sh/api?access_token=redacted&delay=1&signature=redacted',
+            url: 'https://example.vercel.sh/api?query=redacted',
           }),
           expect.objectContaining({
-            url: 'https://example.vercel.sh/api?token=redacted&keep=1',
+            url: 'https://example.vercel.sh/api?query=redacted',
           }),
         ],
       })
     )
+    expect(JSON.stringify(getRequestInsightsSnapshot())).not.toContain(secret)
+  })
+
+  it('only exposes bounded URLs without query payloads', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const cases = [
+      {
+        requestId: 'relative',
+        input: '/products/blue?sort=price#details',
+        expected: '/products/blue?query=redacted',
+      },
+      {
+        requestId: 'protocol-relative',
+        input: '//example.com/items?cursor=secret',
+        expected: '//example.com/items?query=redacted',
+      },
+      {
+        requestId: 'absolute',
+        input: 'https://user:password@example.com/items?visible=value#details',
+        expected: 'https://example.com/items?query=redacted',
+      },
+      {
+        requestId: 'opaque',
+        input: 'data:text/plain,secret',
+        expected: 'data:redacted',
+      },
+      {
+        requestId: 'untrusted-relative',
+        input: 'items?token=secret',
+        expected: undefined,
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      recordRequestInsightFetch(
+        { requestId: testCase.requestId },
+        { url: testCase.input, startTime: 100, durationMs: 1 }
+      )
+    }
+
+    const requests = new Map(
+      getRequestInsightsSnapshot().requests.map((request) => [
+        request.requestId,
+        request,
+      ])
+    )
+    for (const testCase of cases) {
+      expect(requests.get(testCase.requestId)?.fetches[0]?.url).toBe(
+        testCase.expected
+      )
+    }
+
+    recordRequestInsightFetch(
+      { requestId: 'oversized' },
+      {
+        url: `https://example.com/${'x'.repeat(64 * 1024)}`,
+        startTime: 100,
+        durationMs: 1,
+      }
+    )
+    expect(
+      getRequestInsightsSnapshot().requests.find(
+        (request) => request.requestId === 'oversized'
+      )?.fetches[0]?.url
+    ).toBeUndefined()
+
+    recordRequestInsightFetch(
+      { requestId: 'query-name' },
+      {
+        url: 'https://example.com/items?sk_live_SENTINEL',
+        startTime: 100,
+        durationMs: 1,
+      }
+    )
+    expect(
+      JSON.stringify(
+        getRequestInsightsSnapshot().requests.find(
+          (request) => request.requestId === 'query-name'
+        )
+      )
+    ).not.toContain('sk_live_SENTINEL')
   })
 })

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -2,9 +2,13 @@ import {
   clearRequestInsightsForTest,
   getRequestInsightsSnapshot,
   recordRequestInsightFetch,
+  recordRequestInsightRouterActivity,
+  recordRequestInsightServerAction,
+  recordRequestInsightSource,
   subscribeRequestInsights,
 } from './request-insights'
 import { recordSpan } from './span-store'
+import { getRequestInsightRouterActivity } from './request-insights-router-activity'
 
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -183,6 +187,224 @@ describe('request insights', () => {
         durationMs: 50,
       })
     )
+  })
+
+  it('classifies framework request sources without letting the root span erase a specific source', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'run app route',
+      requestId: 'req_source',
+      attributes: {
+        'next.span_type': 'AppRouteRouteHandlers.runHandler',
+      },
+    })
+    recordSpan({
+      name: 'GET /api/items',
+      requestId: 'req_source',
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source: 'app-route' })
+    )
+  })
+
+  it.each([
+    ['Node.runHandler', 'pages-api'],
+    ['NextNodeServer.imageOptimizer', 'image'],
+    ['Middleware.execute', 'proxy'],
+  ] as const)('classifies %s spans as %s requests', (spanType, source) => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: spanType,
+      requestId: `req_${source}`,
+      attributes: {
+        'next.span_type': spanType,
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source })
+    )
+  })
+
+  it('records an authoritative static asset source after tracing starts', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity: Parameters<typeof recordRequestInsightSource>[0] = {
+      requestId: 'req_asset',
+    }
+
+    recordSpan({
+      name: 'GET /asset.svg',
+      requestId: identity.requestId,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    recordRequestInsightSource(identity, 'asset')
+
+    expect(identity.source).toBe('asset')
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source: 'asset' })
+    )
+  })
+
+  it('does not create a request only because a source was recorded', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordRequestInsightSource({ requestId: 'untraced-asset' }, 'asset')
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([])
+  })
+
+  it('does not classify the middleware pass as a page before an App Route runs', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = {
+      requestId: 'middleware-app-route',
+      source: 'proxy' as const,
+    }
+
+    recordSpan({
+      name: 'proxy POST /api/stream',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 1,
+      attributes: {
+        'next.span_type': 'Middleware.execute',
+      },
+    })
+    recordSpan({
+      name: 'POST /api/stream',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 2,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'proxy',
+      }),
+    ])
+
+    recordRequestInsightSource(identity, 'app-route')
+    recordSpan({
+      name: 'execute route handler',
+      requestId: identity.requestId,
+      startTime: 3,
+      attributes: {
+        'next.span_type': 'AppRouteRouteHandlers.runHandler',
+      },
+    })
+
+    const requests = getRequestInsightsSnapshot().requests
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toEqual(
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'app-route',
+      })
+    )
+    expect(
+      requests[0].spans.map((span) => span.attributes?.['next.span_type'])
+    ).toEqual([
+      'Middleware.execute',
+      'BaseServer.handleRequest',
+      'AppRouteRouteHandlers.runHandler',
+    ])
+  })
+
+  it('classifies the route pass as a page after middleware completes', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = {
+      requestId: 'middleware-page',
+      source: 'proxy' as 'proxy' | undefined,
+    }
+
+    recordSpan({
+      name: 'proxy GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 1,
+      attributes: {
+        'next.span_type': 'Middleware.execute',
+      },
+    })
+    recordSpan({
+      name: 'GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 2,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    identity.source = undefined
+    recordSpan({
+      name: 'GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 3,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'page',
+      }),
+    ])
+  })
+
+  it('records normalized router activity and confirmed Server Actions', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = { requestId: 'req_activity' }
+
+    recordSpan({
+      name: 'render route (app) /dashboard',
+      requestId: identity.requestId,
+    })
+
+    recordRequestInsightRouterActivity(identity, 'segment-prefetch')
+    recordRequestInsightServerAction(identity)
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        source: 'unknown',
+        routerActivity: 'segment-prefetch',
+        serverAction: true,
+      })
+    )
+  })
+
+  it('derives router activity only from valid RSC protocol headers', () => {
+    expect(
+      getRequestInsightRouterActivity({
+        rsc: '1',
+        'next-router-prefetch': '1',
+        'next-router-segment-prefetch': '/dashboard',
+      })
+    ).toBe('segment-prefetch')
+    expect(
+      getRequestInsightRouterActivity({
+        'next-router-prefetch': '1',
+      })
+    ).toBeUndefined()
+    expect(
+      getRequestInsightRouterActivity({
+        rsc: '1',
+        'next-hmr-refresh': '1',
+      })
+    ).toBe('hmr-refresh')
   })
 
   it('keeps request and Instant Insights data separate for the same request ID', () => {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -8,6 +8,12 @@ import type { RequestInsightKind } from '../../../shared/lib/request-insights'
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  type RequestInsightProxyStatus,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { SpanStoreRecord } from './span-store'
 export { isRequestInsightsEnabled } from './span-store'
@@ -21,6 +27,10 @@ type RequestInsightsListener = (insight: RequestInsight) => void
 type RequestInsightIdentity = {
   requestId?: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId?: string
   route?: string
   url?: string
@@ -38,6 +48,7 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.fetch.cache_status',
   'next.fetch.idx',
   'next.route',
+  'next.request_source',
   'next.rsc',
   'next.segment',
   'next.span_category',
@@ -65,6 +76,10 @@ class InMemoryRequestInsightsStore {
       {
         requestId: span.requestId,
         kind: span.requestInsightKind,
+        source: span.requestInsightSource,
+        proxyStatus: span.requestInsightProxyStatus,
+        routerActivity: span.requestInsightRouterActivity,
+        serverAction: span.requestInsightServerAction,
         htmlRequestId: span.htmlRequestId,
         route: span.route,
         url: span.url,
@@ -74,6 +89,17 @@ class InMemoryRequestInsightsStore {
 
     const spanStartTime = span.startTime ?? span.timestamp
     insight.htmlRequestId = span.htmlRequestId ?? insight.htmlRequestId
+    this.updateClassification(
+      insight,
+      {
+        kind: span.requestInsightKind,
+        source: span.requestInsightSource,
+        proxyStatus: span.requestInsightProxyStatus,
+        routerActivity: span.requestInsightRouterActivity,
+        serverAction: span.requestInsightServerAction,
+      },
+      span
+    )
     insight.route = insight.route ?? span.route
     insight.url = insight.url ?? sanitizeUrl(span.url)
     this.updateTiming(
@@ -120,6 +146,25 @@ class InMemoryRequestInsightsStore {
     const insight = this.getOrCreateRequest(identity, fetchStartTime)
     this.updateTiming(insight, fetchStartTime, fetch.durationMs, false)
     this.recordFetchForInsight(insight, sanitizeFetchInsight(fetch))
+    this.notify(insight)
+  }
+
+  recordClassification(identity: RequestInsightIdentity): void {
+    if (!identity.requestId) {
+      return
+    }
+
+    const insight = this.requests.get(
+      getRequestInsightKey({
+        requestId: identity.requestId,
+        kind: identity.kind,
+      })
+    )
+    if (!insight) {
+      return
+    }
+
+    this.updateClassification(insight, identity)
     this.notify(insight)
   }
 
@@ -193,6 +238,10 @@ class InMemoryRequestInsightsStore {
       insight = {
         requestId,
         kind: getRequestInsightKind(identity),
+        source: getRequestInsightSource(identity),
+        proxyStatus: identity.proxyStatus,
+        routerActivity: identity.routerActivity,
+        serverAction: identity.serverAction,
         htmlRequestId: identity.htmlRequestId ?? requestId,
         route: identity.route,
         url: sanitizeUrl(identity.url),
@@ -207,11 +256,24 @@ class InMemoryRequestInsightsStore {
     }
 
     insight.htmlRequestId = identity.htmlRequestId ?? insight.htmlRequestId
+    this.updateClassification(insight, identity)
     insight.route = insight.route ?? identity.route
     insight.url = insight.url ?? sanitizeUrl(identity.url)
     insight.startTime = Math.min(insight.startTime, startTime)
 
     return insight
+  }
+
+  private updateClassification(
+    insight: RequestInsight,
+    identity: RequestInsightIdentity,
+    span?: SpanStoreRecord
+  ): void {
+    const source = identity.source ?? getSourceFromSpan(span)
+    insight.source = refineSource(insight.source, source)
+    insight.proxyStatus = identity.proxyStatus ?? insight.proxyStatus
+    insight.routerActivity = identity.routerActivity ?? insight.routerActivity
+    insight.serverAction = identity.serverAction ?? insight.serverAction
   }
 
   private recordFetchForInsight(
@@ -244,6 +306,28 @@ class InMemoryRequestInsightsStore {
   }
 }
 
+function refineSource(
+  current: RequestInsightSource,
+  candidate: RequestInsightSource | undefined
+): RequestInsightSource {
+  if (!candidate || candidate === 'unknown') {
+    return current
+  }
+  if (
+    candidate === 'app-route' ||
+    candidate === 'pages-api' ||
+    candidate === 'image' ||
+    candidate === 'asset' ||
+    candidate === 'instant-insights'
+  ) {
+    return candidate
+  }
+  if (current === 'unknown' || current === 'proxy') {
+    return candidate
+  }
+  return current
+}
+
 export function recordRequestInsightSpan(span: SpanStoreRecord): void {
   if (
     span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
@@ -259,6 +343,29 @@ export function recordRequestInsightFetch(
   fetch: RequestInsightFetch
 ): void {
   getRequestInsightsStore().recordFetch(identity, fetch)
+}
+
+export function recordRequestInsightRouterActivity(
+  identity: RequestInsightIdentity,
+  routerActivity: RequestInsightRouterActivity
+): void {
+  identity.routerActivity = routerActivity
+  getRequestInsightsStore().recordClassification(identity)
+}
+
+export function recordRequestInsightServerAction(
+  identity: RequestInsightIdentity
+): void {
+  identity.serverAction = true
+  getRequestInsightsStore().recordClassification(identity)
+}
+
+export function recordRequestInsightSource(
+  identity: RequestInsightIdentity,
+  source: RequestInsightSource
+): void {
+  identity.source = source
+  getRequestInsightsStore().recordClassification(identity)
 }
 
 export function getRequestInsightsSnapshot(): RequestInsightsSnapshot {
@@ -301,6 +408,39 @@ function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
     cacheReason: getStringAttribute(attributes['next.fetch.cache_reason']),
     index: getNumberAttribute(attributes['next.fetch.idx']),
   }
+}
+
+function getSourceFromSpan(
+  span: SpanStoreRecord | undefined
+): RequestInsightSource | undefined {
+  if (!span) {
+    return undefined
+  }
+
+  const spanType = getStringAttribute(span.attributes?.['next.span_type'])
+  const markedSource = getStringAttribute(
+    span.attributes?.['next.request_source']
+  )
+  if (markedSource === 'image' || markedSource === 'asset') {
+    return markedSource
+  }
+
+  if (spanType === 'AppRouteRouteHandlers.runHandler') {
+    return 'app-route'
+  }
+  if (spanType === 'Node.runHandler') {
+    return 'pages-api'
+  }
+  if (spanType === 'NextNodeServer.imageOptimizer') {
+    return 'image'
+  }
+  if (spanType === REQUEST_INSIGHT_REQUEST_SPAN_TYPE) {
+    return 'page'
+  }
+  if (spanType === REQUEST_INSIGHT_PROXY_SPAN_TYPE) {
+    return 'proxy'
+  }
+  return undefined
 }
 
 function sanitizeFetchInsight(fetch: RequestInsightFetch): RequestInsightFetch {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -19,6 +19,8 @@ import type { SpanStoreRecord } from './span-store'
 export { isRequestInsightsEnabled } from './span-store'
 
 const MAX_REQUEST_INSIGHTS = 100
+const MAX_REQUEST_INSIGHT_URL_LENGTH = 2048
+const MAX_REQUEST_INSIGHT_RAW_URL_LENGTH = 64 * 1024
 const REQUEST_INSIGHTS_STORE_KEY = Symbol.for('@next/request-insights-store')
 const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
   'NextNodeServer.clientComponentLoading'
@@ -55,9 +57,6 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.span_name',
   'next.span_type',
 ])
-const SENSITIVE_PARAM_NAME_RE =
-  /(?:^|[_-])(?:access[_-]?token|api[_-]?key|auth|authorization|code|cookie|credential|id[_-]?token|jwt|key|password|secret|session|signature|sig|token)(?:$|[_-])/i
-
 class InMemoryRequestInsightsStore {
   private readonly requests = new Map<string, RequestInsight>()
   private readonly requestTimings = new Map<
@@ -116,7 +115,7 @@ class InMemoryRequestInsightsStore {
           : insight.status
 
     insight.spans.push({
-      name: span.name,
+      name: sanitizeSpanName(span),
       startTime: spanStartTime,
       durationMs: span.durationMs,
       status: span.status,
@@ -462,15 +461,43 @@ function sanitizeSpanAttributes(
   }
 
   const sanitized: NonNullable<SpanStoreRecord['attributes']> = {}
+  const sanitizedFetchSpanName =
+    attributes['next.span_type'] === 'AppRender.fetch'
+      ? getSanitizedFetchSpanName(attributes)
+      : undefined
   for (const [key, value] of Object.entries(attributes)) {
     if (!SAFE_SPAN_ATTRIBUTE_KEYS.has(key)) {
       continue
     }
 
-    sanitized[key] = key === 'http.url' ? sanitizeUrlAttribute(value) : value
+    sanitized[key] =
+      key === 'http.url'
+        ? sanitizeUrlAttribute(value)
+        : key === 'next.span_name' && sanitizedFetchSpanName
+          ? sanitizedFetchSpanName
+          : value
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+function sanitizeSpanName(span: SpanStoreRecord): string {
+  if (span.attributes?.['next.span_type'] !== 'AppRender.fetch') {
+    return span.name
+  }
+
+  return getSanitizedFetchSpanName(span.attributes, span.url)
+}
+
+function getSanitizedFetchSpanName(
+  attributes: NonNullable<SpanStoreRecord['attributes']>,
+  fallbackUrl?: string
+): string {
+  const method = getStringAttribute(attributes['http.method'])
+  const url = sanitizeUrl(
+    getStringAttribute(attributes['http.url']) ?? fallbackUrl
+  )
+  return ['fetch', method, url].filter(Boolean).join(' ')
 }
 
 function sanitizeSpanEvents(
@@ -500,24 +527,67 @@ function sanitizeUrl(value: string | undefined): string | undefined {
     return value
   }
 
-  const isRelativeUrl = value.startsWith('/')
+  if (value.length > MAX_REQUEST_INSIGHT_RAW_URL_LENGTH) {
+    return undefined
+  }
+
+  const isProtocolRelativeUrl = value.startsWith('//')
+  const isRootRelativeUrl = !isProtocolRelativeUrl && value.startsWith('/')
+  const hasProtocol = /^[a-z][a-z\d+.-]*:/i.test(value)
+
+  if (!isProtocolRelativeUrl && !isRootRelativeUrl && !hasProtocol) {
+    return undefined
+  }
 
   try {
-    const url = isRelativeUrl ? new URL(value, 'http://n') : new URL(value)
+    const url =
+      isProtocolRelativeUrl || isRootRelativeUrl
+        ? new URL(value, 'http://n')
+        : new URL(value)
+
+    if (
+      url.protocol !== 'http:' &&
+      url.protocol !== 'https:' &&
+      !isProtocolRelativeUrl &&
+      !isRootRelativeUrl
+    ) {
+      return `${url.protocol}${REDACTED_VALUE}`
+    }
 
     url.username = ''
     url.password = ''
+    url.hash = ''
 
-    for (const name of Array.from(url.searchParams.keys())) {
-      if (SENSITIVE_PARAM_NAME_RE.test(name)) {
-        url.searchParams.set(name, REDACTED_VALUE)
-      }
-    }
+    const hasApplicationQuery = Array.from(url.searchParams.keys()).some(
+      (name) => name !== '_rsc'
+    )
+    url.search = hasApplicationQuery ? `?query=${REDACTED_VALUE}` : ''
 
-    return isRelativeUrl ? `${url.pathname}${url.search}${url.hash}` : url.href
+    const sanitizedUrl = isProtocolRelativeUrl
+      ? `//${url.host}${url.pathname}${url.search}`
+      : isRootRelativeUrl
+        ? `${url.pathname}${url.search}`
+        : url.href
+
+    return truncateText(sanitizedUrl, MAX_REQUEST_INSIGHT_URL_LENGTH)
   } catch {
+    return undefined
+  }
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
     return value
   }
+
+  let end = Math.max(0, maxLength - 1)
+  if (end > 0) {
+    const lastCharCode = value.charCodeAt(end - 1)
+    if (lastCharCode >= 0xd800 && lastCharCode <= 0xdbff) {
+      end--
+    }
+  }
+  return `${value.slice(0, end)}…`
 }
 
 function getStringAttribute(value: AttributeValue | undefined) {

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -1,5 +1,10 @@
 import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 
 export type SpanStoreAttributes = Record<string, AttributeValue>
 
@@ -26,6 +31,10 @@ export type SpanStoreRecord = {
   parentSpanId?: string
   requestId?: string
   requestInsightKind?: RequestInsightKind
+  requestInsightSource?: RequestInsightSource
+  requestInsightProxyStatus?: RequestInsightProxyStatus
+  requestInsightRouterActivity?: RequestInsightRouterActivity
+  requestInsightServerAction?: true
   htmlRequestId?: string
   route?: string
   url?: string

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -14,6 +14,7 @@ import type { OpaqueFallbackRouteParams } from './request/fallback-params'
 import type { IncrementalCache } from './lib/incremental-cache'
 import type { RevalidateFn } from './lib/router-utils/router-server-context'
 import type { NextRequest } from './web/exports'
+import type { RequestInsightsIdentity } from './lib/trace/request-insights-identity'
 
 // FIXME: (wyattjoh) this is a temporary solution to allow us to pass data between bundled modules
 export const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
@@ -49,6 +50,8 @@ export type OnCacheEntryHandler = (
 ) => Promise<boolean | void> | boolean | void
 
 export interface RequestMeta {
+  /** Server-owned identity for the development Request Insights timeline. */
+  requestInsightsIdentity?: RequestInsightsIdentity
   /**
    * The query that was used to make the request.
    */

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -91,6 +91,37 @@ import { InvariantError } from '../../../shared/lib/invariant-error'
 import { LazyModule } from '../../lib/lazy-module'
 import { createPrerenderResumeDataCache } from '../../resume-data-cache/resume-data-cache'
 
+type AppRouteRequestInsightsRuntime = {
+  getRequestInsightsIdentity: typeof import('../../lib/trace/request-insights-identity').getRequestInsightsIdentity
+  recordRequestInsightSource: typeof import('../../lib/trace/request-insights').recordRequestInsightSource
+}
+
+let appRouteRequestInsightsRuntime: AppRouteRequestInsightsRuntime | undefined
+
+function markAppRouteRequestSource(): void {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!appRouteRequestInsightsRuntime) {
+      const { getRequestInsightsIdentity } =
+        require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
+      const { recordRequestInsightSource } =
+        require('../../lib/trace/request-insights') as typeof import('../../lib/trace/request-insights')
+
+      appRouteRequestInsightsRuntime = {
+        getRequestInsightsIdentity,
+        recordRequestInsightSource,
+      }
+    }
+
+    const identity = appRouteRequestInsightsRuntime.getRequestInsightsIdentity()
+    if (identity) {
+      appRouteRequestInsightsRuntime.recordRequestInsightSource(
+        identity,
+        'app-route'
+      )
+    }
+  }
+}
+
 export class WrappedNextRouterError {
   constructor(
     public readonly error: RedirectError,
@@ -838,6 +869,8 @@ export class AppRouteRouteModule extends RouteModule<
     req: NextRequest,
     context: AppRouteRouteHandlerContext
   ): Promise<PreparedAppRouteExecution> {
+    markAppRouteRequestSource()
+
     // Ensure userland is fully loaded (handles async modules with top-level
     // await, where require() returns a Promise instead of the module).
     await this.ensureUserland()

--- a/packages/next/src/shared/lib/request-insights.ts
+++ b/packages/next/src/shared/lib/request-insights.ts
@@ -1,14 +1,52 @@
 export type RequestInsightKind = 'request' | 'instant-insights'
 
+export const REQUEST_INSIGHT_REQUEST_SPAN_TYPE = 'BaseServer.handleRequest'
+export const REQUEST_INSIGHT_PROXY_SPAN_TYPE = 'Middleware.execute'
+
+export const REQUEST_INSIGHT_SOURCES = [
+  'page',
+  'app-route',
+  'pages-api',
+  'image',
+  'asset',
+  'proxy',
+  'instant-insights',
+  'unknown',
+] as const
+
+export type RequestInsightSource = (typeof REQUEST_INSIGHT_SOURCES)[number]
+export type RequestInsightProxyStatus = 'matched' | 'bypassed'
+
+export const REQUEST_INSIGHT_ROUTER_ACTIVITIES = [
+  'prefetch',
+  'segment-prefetch',
+  'hmr-refresh',
+] as const
+
+export type RequestInsightRouterActivity =
+  (typeof REQUEST_INSIGHT_ROUTER_ACTIVITIES)[number]
+
 export type RequestInsightIdentity = {
   requestId: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
 }
 
 export function getRequestInsightKind(
   insight: Pick<RequestInsightIdentity, 'kind'>
 ): RequestInsightKind {
   return insight.kind ?? 'request'
+}
+
+export function getRequestInsightSource(
+  insight: Pick<RequestInsightIdentity, 'kind' | 'source'>
+): RequestInsightSource {
+  if (getRequestInsightKind(insight) === 'instant-insights') {
+    return 'instant-insights'
+  }
+  return insight.source ?? 'unknown'
 }
 
 export function getRequestInsightKey(insight: RequestInsightIdentity): string {

--- a/packages/next/src/telemetry/post-telemetry-payload.test.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.test.ts
@@ -45,6 +45,92 @@ describe('postNextTelemetryPayload', () => {
     )
   })
 
+  it('bypasses only the Next.js patched fetch wrapper', async () => {
+    const originFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    const patchedFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      (input, init) => originFetch(input, init)
+    )
+    Object.assign(patchedFetch, {
+      __nextPatched: true,
+      _nextOriginalFetch: originFetch,
+    })
+    global.fetch = patchedFetch
+
+    const payload = {
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    }
+
+    await postNextTelemetryPayload(payload)
+
+    expect(patchedFetch).not.toHaveBeenCalled()
+    expect(originFetch).toHaveBeenCalledTimes(1)
+
+    await global.fetch('https://telemetry.nextjs.org/api/v1/record')
+
+    expect(patchedFetch).toHaveBeenCalledTimes(1)
+    expect(originFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not trust an unbranded _nextOriginalFetch property', async () => {
+    const unrelatedOriginalFetch = jest.fn(
+      async () => new Response(null, { status: 204 })
+    )
+    const customFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    Object.assign(customFetch, {
+      _nextOriginalFetch: unrelatedOriginalFetch,
+    })
+    global.fetch = customFetch
+
+    await postNextTelemetryPayload({
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    })
+
+    expect(customFetch).toHaveBeenCalledTimes(1)
+    expect(unrelatedOriginalFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not trust a non-callable _nextOriginalFetch property', async () => {
+    const customFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    Object.assign(customFetch, {
+      __nextPatched: true,
+      _nextOriginalFetch: 'not a function',
+    })
+    global.fetch = customFetch
+
+    await postNextTelemetryPayload({
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    })
+
+    expect(customFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('retries on failure', async () => {
     const mockFetch = jest
       .fn()

--- a/packages/next/src/telemetry/post-telemetry-payload.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.ts
@@ -15,6 +15,23 @@ interface Payload {
   }>
 }
 
+type MaybePatchedFetch = typeof fetch & {
+  readonly __nextPatched?: true
+  readonly _nextOriginalFetch?: typeof fetch
+}
+
+function getTelemetryFetch(): typeof fetch {
+  const currentFetch = globalThis.fetch as MaybePatchedFetch
+
+  // Framework telemetry is process activity, not application request work.
+  // Avoid inheriting an active render's patched-fetch context while preserving
+  // any user-provided fetch implementation when Next has not patched it.
+  return currentFetch.__nextPatched === true &&
+    typeof currentFetch._nextOriginalFetch === 'function'
+    ? currentFetch._nextOriginalFetch
+    : currentFetch
+}
+
 export function postNextTelemetryPayload(payload: Payload, signal?: any) {
   if (!signal && 'timeout' in AbortSignal) {
     signal = AbortSignal.timeout(5000)
@@ -22,7 +39,7 @@ export function postNextTelemetryPayload(payload: Payload, signal?: any) {
   return (
     retry(
       () =>
-        fetch('https://telemetry.nextjs.org/api/v1/record', {
+        getTelemetryFetch()('https://telemetry.nextjs.org/api/v1/record', {
           method: 'POST',
           body: JSON.stringify(payload),
           headers: { 'content-type': 'application/json' },

--- a/test/development/app-dir/request-insights/app/actions/cached-function-button.tsx
+++ b/test/development/app-dir/request-insights/app/actions/cached-function-button.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { runCachedFunction } from './cached'
+
+export function CachedFunctionButton() {
+  const [result, setResult] = useState('idle')
+  const [, startTransition] = useTransition()
+
+  return (
+    <>
+      <button
+        id="run-cached-function"
+        type="button"
+        onClick={() => {
+          startTransition(async () => {
+            setResult(await runCachedFunction())
+          })
+        }}
+      >
+        Run cached function
+      </button>
+      <p id="cached-function-result">{result}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/actions/cached.ts
+++ b/test/development/app-dir/request-insights/app/actions/cached.ts
@@ -1,0 +1,5 @@
+'use cache'
+
+export async function runCachedFunction() {
+  return 'cached-function-complete'
+}

--- a/test/development/app-dir/request-insights/app/actions/page.tsx
+++ b/test/development/app-dir/request-insights/app/actions/page.tsx
@@ -1,0 +1,18 @@
+import { CachedFunctionButton } from './cached-function-button'
+
+export default function ActionsPage() {
+  async function runAction() {
+    'use server'
+  }
+
+  return (
+    <>
+      <form action={runAction}>
+        <button id="run-server-action" type="submit">
+          Run action
+        </button>
+      </form>
+      <CachedFunctionButton />
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/api/app-stream-lifecycle/route.ts
+++ b/test/development/app-dir/request-insights/app/api/app-stream-lifecycle/route.ts
@@ -1,0 +1,46 @@
+const requestInsightsGlobal = globalThis as typeof globalThis & {
+  requestInsightsPendingAppRouteHandlers?: Map<string, () => void>
+}
+const pendingHandlers =
+  (requestInsightsGlobal.requestInsightsPendingAppRouteHandlers ??= new Map())
+
+export async function GET(request: Request) {
+  const waitKey = new URL(request.url).searchParams.get('wait')
+  if (waitKey) {
+    await new Promise<void>((resolve) => {
+      pendingHandlers.set(waitKey, resolve)
+    })
+  }
+
+  const encoder = new TextEncoder()
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('started\n'))
+        queueMicrotask(() => {
+          controller.enqueue(encoder.encode('finished\n'))
+          controller.close()
+        })
+      },
+    }),
+    {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      status: 202,
+    }
+  )
+}
+
+export function POST(request: Request) {
+  const waitKey = new URL(request.url).searchParams.get('release')
+  const release = waitKey ? pendingHandlers.get(waitKey) : undefined
+  if (!waitKey || !release) {
+    return new Response(null, { status: 404 })
+  }
+
+  pendingHandlers.delete(waitKey)
+  release()
+  return new Response(null, { status: 204 })
+}

--- a/test/development/app-dir/request-insights/app/api/proxied-page/page.tsx
+++ b/test/development/app-dir/request-insights/app/api/proxied-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>proxied page</p>
+}

--- a/test/development/app-dir/request-insights/app/api/source/route.ts
+++ b/test/development/app-dir/request-insights/app/api/source/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ source: 'app-route' })
+}

--- a/test/development/app-dir/request-insights/app/behind-proxy/page.tsx
+++ b/test/development/app-dir/request-insights/app/behind-proxy/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>behind proxy</p>
+}

--- a/test/development/app-dir/request-insights/app/products/[id]/page.tsx
+++ b/test/development/app-dir/request-insights/app/products/[id]/page.tsx
@@ -1,0 +1,23 @@
+import { headers } from 'next/headers'
+import { connection } from 'next/server'
+
+export const instant = false
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  await connection()
+  const { id } = await params
+  const host = (await headers()).get('host')
+  if (!host) {
+    throw new Error('Missing request host')
+  }
+
+  await fetch(`http://${host}/api/source?token=Q2_SECRET_SENTINEL`, {
+    cache: 'no-store',
+  })
+
+  return <p id="product-id">{id}</p>
+}

--- a/test/development/app-dir/request-insights/proxy.ts
+++ b/test/development/app-dir/request-insights/proxy.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  if (
+    request.nextUrl.pathname === '/request-insights-asset.svg' &&
+    request.nextUrl.searchParams.has('rewrite-to-page')
+  ) {
+    return NextResponse.rewrite(new URL('/behind-proxy', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/:path*', '/request-insights-asset.svg'],
+}

--- a/test/development/app-dir/request-insights/public/request-insights-asset.svg
+++ b/test/development/app-dir/request-insights/public/request-insights-asset.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path d="M0 0h1v1H0z" />
+</svg>

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -481,6 +481,7 @@ describe('request insights', () => {
     await browser.elementByCss('.request-insights-settings-trigger').click()
     await retry(async () => {
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: null },
         { label: 'Verbose traces', checked: null },
       ])
@@ -498,26 +499,26 @@ describe('request insights', () => {
       .click()
 
     await retry(async () => {
-      const nestedRows = await browser.eval(() => {
+      const internalRows = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
         return Array.from(
-          root?.querySelectorAll('.request-insights-row[data-nested="true"]') ??
-            []
+          root?.querySelectorAll(
+            '.request-insights-row[data-internal="true"]'
+          ) ?? []
         ).map((row) => ({
-          internal: row.getAttribute('data-internal'),
-          hasArrow: !!row.querySelector('.request-insights-nested-arrow'),
+          nested: row.hasAttribute('data-nested'),
           label: row.textContent ?? '',
         }))
       })
 
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
-      expect(nestedRows.length).toBeGreaterThan(0)
-      for (const row of nestedRows) {
-        expect(row.internal).toBe('true')
-        expect(row.hasArrow).toBe(true)
+      expect(internalRows.length).toBeGreaterThan(0)
+      for (const row of internalRows) {
+        expect(row.nested).toBe(false)
         expect(row.label).toContain('Instant Insights')
       }
     })
@@ -539,9 +540,76 @@ describe('request insights', () => {
 
     await retry(async () => {
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
+    })
+  })
+
+  it('filters typed request rows and pauses live updates', async () => {
+    const browser = await next.browser('/instant-insights')
+    expect((await next.fetch('/api/source?before=pause')).status).toBe(200)
+
+    await openRequestInsightsPanel(browser)
+    await browser.elementByCss('.request-insights-filter-trigger').click()
+    await browser
+      .elementByCss(
+        '.request-insights-filter-item[data-filter-value="source:api"]'
+      )
+      .click()
+
+    await retry(async () => {
+      const rowTypes = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-request-type') ?? []
+        ).map((type) => type.textContent?.trim())
+      })
+      expect(rowTypes.length).toBeGreaterThan(0)
+      expect(new Set(rowTypes)).toEqual(new Set(['API']))
+    })
+
+    await browser.elementByCss('.request-insights-details').click()
+    await browser.elementByCss('.request-insights-settings-trigger').click()
+    await browser
+      .elementByCss('.request-insights-settings-item:has-text("Pause updates")')
+      .click()
+
+    const pausedRowCount = await browser.eval(() => {
+      const root = document.querySelector('nextjs-portal')?.shadowRoot
+      return root?.querySelectorAll('.request-insights-row').length ?? 0
+    })
+    expect((await next.fetch('/api/source?while=paused')).status).toBe(200)
+
+    await retry(async () => {
+      const pausedState = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return {
+          paused: root?.querySelector('.request-insights-paused-state')
+            ?.textContent,
+          rowCount: root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(pausedState).toEqual({
+        paused: 'Paused',
+        rowCount: pausedRowCount,
+      })
+    })
+
+    await browser
+      .elementByCss('.request-insights-settings-item:has-text("Pause updates")')
+      .click()
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return {
+          paused: root?.querySelector('.request-insights-paused-state'),
+          rowCount: root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(state.paused).toBeNull()
+      expect(state.rowCount).toBeGreaterThan(pausedRowCount)
     })
   })
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -10,8 +10,21 @@ import {
 type RequestInsight = {
   requestId: string
   kind?: 'request' | 'instant-insights'
+  source:
+    | 'page'
+    | 'app-route'
+    | 'pages-api'
+    | 'image'
+    | 'asset'
+    | 'proxy'
+    | 'instant-insights'
+    | 'unknown'
+  proxyStatus?: 'matched' | 'bypassed'
+  routerActivity?: 'prefetch' | 'segment-prefetch' | 'hmr-refresh'
+  serverAction?: true
   htmlRequestId: string
   route: string
+  url?: string
   startTime: number
   status: 'ok'
   spans: Array<{
@@ -37,6 +50,7 @@ describe('request insights', () => {
   function createRequest(index: number, fetchCount = 0): RequestInsight {
     return {
       requestId: `request-${index}`,
+      source: 'page',
       htmlRequestId: `page-${index}`,
       route: `/route-${index}`,
       startTime: index,
@@ -167,6 +181,61 @@ describe('request insights', () => {
           'AppRender.getBodyResult',
         ])
       )
+    })
+  })
+
+  it('classifies static files as assets in the serialized snapshot', async () => {
+    const response = await next.fetch('/request-insights-asset.svg')
+    expect(response.status).toBe(200)
+    await response.text()
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/request-insights-asset.svg' &&
+          candidate.kind !== 'instant-insights'
+      )
+
+      expect(request).toEqual(expect.objectContaining({ source: 'asset' }))
+    })
+  })
+
+  it('does not classify an asset URL rewritten by proxy as an asset', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((insightsResponse) => insightsResponse.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const response = await next.fetch(
+      '/request-insights-asset.svg?rewrite-to-page=1'
+    )
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('behind proxy')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.route === '/behind-proxy' &&
+          !existingRequestIds.has(candidate.requestId) &&
+          candidate.kind !== 'instant-insights'
+      )
+
+      expect(request).toEqual(expect.objectContaining({ source: 'page' }))
     })
   })
 
@@ -473,6 +542,269 @@ describe('request insights', () => {
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
+    })
+  })
+
+  it('classifies framework-owned request activity without retaining action IDs', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const routeResponse = await next.fetch('/api/source')
+    expect(routeResponse.status).toBe(200)
+    const prefetchResponse = await next.fetch('/?activity=prefetch', {
+      headers: {
+        rsc: '1',
+        'next-router-prefetch': '2',
+      },
+    })
+    expect(prefetchResponse.status).toBe(200)
+    const actionIds: string[] = []
+    const browser = await next.browser('/actions', {
+      beforePageLoad(page) {
+        page.route('**/actions**', async (route) => {
+          const actionId = (await route.request().allHeaders())['next-action']
+          if (actionId) {
+            actionIds.push(actionId)
+          }
+          await route.continue()
+        })
+      },
+    })
+    await browser.eval(() => {
+      document.querySelector<HTMLButtonElement>('#run-server-action')?.click()
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const requests = snapshot.requests.filter(
+        (request) => !existingRequestIds.has(request.requestId)
+      )
+
+      expect(requests.find((request) => request.url === '/api/source')).toEqual(
+        expect.objectContaining({
+          source: 'app-route',
+          proxyStatus: 'matched',
+        })
+      )
+      expect(
+        requests.find((request) => request.routerActivity === 'prefetch')
+      ).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          proxyStatus: 'bypassed',
+          routerActivity: 'prefetch',
+        })
+      )
+      expect(
+        requests.find(
+          (request) =>
+            request.route === '/actions' && request.serverAction === true
+        )
+      ).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          serverAction: true,
+        })
+      )
+
+      const serialized = JSON.stringify(requests)
+      expect(actionIds).toHaveLength(1)
+      expect(actionIds[0]).toMatch(/^[0-9a-f]{42}$/)
+      for (const actionId of actionIds) {
+        expect(serialized).not.toContain(actionId)
+      }
+      expect(serialized).not.toContain('next-action')
+    })
+
+    const requestIdsAfterAction = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    await browser.elementById('run-cached-function').click()
+    await retry(async () => {
+      expect(await browser.elementById('cached-function-result').text()).toBe(
+        'cached-function-complete'
+      )
+    })
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const cacheRequests = snapshot.requests.filter(
+        (request) =>
+          !requestIdsAfterAction.has(request.requestId) &&
+          request.route === '/actions' &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'POST'
+          )
+      )
+
+      expect(cacheRequests).toHaveLength(1)
+      expect(cacheRequests[0].serverAction).toBeUndefined()
+      expect(actionIds).toHaveLength(2)
+      expect(JSON.stringify(cacheRequests[0])).not.toContain(actionIds[1])
+    })
+  })
+
+  it('classifies an App Route before its handler completes', async () => {
+    const waitKey = `active-${Date.now()}`
+    const requestPath = `/api/app-stream-lifecycle?wait=${waitKey}`
+    const responsePromise = next.fetch(requestPath)
+
+    try {
+      await retry(async () => {
+        const snapshot = (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+        const matchingRequests = snapshot.requests.filter(
+          (request) => request.url === requestPath
+        )
+
+        expect(matchingRequests).toHaveLength(1)
+        expect(matchingRequests[0]).toEqual(
+          expect.objectContaining({
+            source: 'app-route',
+            proxyStatus: 'matched',
+          })
+        )
+      })
+    } finally {
+      const release = await next.fetch(
+        `/api/app-stream-lifecycle?release=${waitKey}`,
+        { method: 'POST' }
+      )
+      expect(release.status).toBe(204)
+    }
+
+    const response = await responsePromise
+    expect(response.status).toBe(202)
+    expect(await response.text()).toContain('finished')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const matchingRequests = snapshot.requests.filter(
+        (request) =>
+          request.url === requestPath && request.kind !== 'instant-insights'
+      )
+
+      expect(matchingRequests).toHaveLength(1)
+      expect(
+        matchingRequests[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'Middleware.execute',
+          'BaseServer.handleRequest',
+          'AppRouteRouteHandlers.runHandler',
+        ])
+      )
+    })
+  })
+
+  it('classifies a Page after proxy completes', async () => {
+    const requestPath = `/api/proxied-page?run=${Date.now()}`
+    const response = await next.fetch(requestPath)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('proxied page')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const matchingRequests = snapshot.requests.filter(
+        (request) =>
+          request.url === requestPath && request.kind !== 'instant-insights'
+      )
+
+      expect(matchingRequests).toHaveLength(1)
+      expect(matchingRequests[0]).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          proxyStatus: 'matched',
+        })
+      )
+      expect(
+        matchingRequests[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'Middleware.execute',
+          'BaseServer.handleRequest',
+          'AppRender.getBodyResult',
+        ])
+      )
+    })
+  })
+
+  it('does not trust an unrecognized Server Action header', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const forgedActionId = '00'.repeat(21)
+
+    const response = await next.fetch('/actions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'text/plain',
+        'next-action': forgedActionId,
+      },
+      body: '[]',
+    })
+    expect(response.ok).toBe(false)
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const forgedRequest = snapshot.requests.find(
+        (request) =>
+          !existingRequestIds.has(request.requestId) &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'POST'
+          )
+      )
+
+      expect(forgedRequest).toBeDefined()
+      expect(forgedRequest?.serverAction).toBeUndefined()
+      expect(JSON.stringify(forgedRequest)).not.toContain(forgedActionId)
     })
   })
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -613,6 +613,246 @@ describe('request insights', () => {
     })
   })
 
+  it('shows concrete request URLs, route params, and fetch origins', async () => {
+    const browser = await next.browser('/products/blue?tab=details')
+
+    await retry(async () => {
+      expect(await browser.elementById('product-id').text()).toBe('blue')
+    })
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/products/blue?query=redacted')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+
+    await retry(async () => {
+      const details = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const panel = root?.querySelector('.request-insights-details')
+        return {
+          text: panel?.textContent ?? '',
+          paramsLabel:
+            panel?.querySelector('.request-insights-params-trigger')
+              ?.textContent ?? '',
+          fetchOrigins: Array.from(
+            panel?.querySelectorAll('.request-insights-fetch-origin') ?? []
+          ).map((element) => element.textContent ?? ''),
+          fetchTraceLabels: Array.from(
+            panel?.querySelectorAll(
+              '.request-insights-span-row[data-kind="fetch"] .request-insights-span-label'
+            ) ?? []
+          ).map((element) => element.textContent ?? ''),
+        }
+      })
+
+      expect(details.text).toContain('/products/blue?query=redacted')
+      expect(details.text).toContain('Route /products/[id]')
+      expect(details.paramsLabel).toBe('Params id')
+      expect(details.fetchOrigins).toContain('Same origin')
+      expect(
+        details.fetchTraceLabels.some((label) => label.includes('Same origin'))
+      ).toBe(true)
+      expect(details.text).not.toContain('Q2_SECRET_SENTINEL')
+    })
+  })
+
+  it('keeps trace inspection anchored while the panel is resized', async () => {
+    const browser = await next.browser('/products/blue?tab=details')
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/products/blue?query=redacted')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+
+    await browser
+      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .hover()
+    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+
+    const readTraceState = () =>
+      browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const panel = root?.querySelector<HTMLElement>(
+          '.request-insights-panel-container'
+        )
+        const listbox = root?.querySelector<HTMLElement>(
+          '.request-insights-trace-rows'
+        )
+        const activeDescendant = listbox?.getAttribute('aria-activedescendant')
+        const activeRow = listbox?.querySelector<HTMLElement>(
+          '.request-insights-span-row[data-active="true"]'
+        )
+        const firstRow = listbox?.querySelector<HTMLElement>(
+          '.request-insights-span-row'
+        )
+        const tooltip = root?.querySelector<HTMLElement>(
+          '.request-insights-trace-tooltip'
+        )
+        const panelRect = panel?.getBoundingClientRect()
+        const rowRect = activeRow?.getBoundingClientRect()
+        const tooltipRect = tooltip?.getBoundingClientRect()
+
+        return {
+          activeDescendant,
+          activeRowId: activeRow?.id ?? null,
+          activeTraceItemId: activeRow?.dataset.traceItemId ?? null,
+          firstRowId: firstRow?.id ?? null,
+          activeLabel: activeRow?.getAttribute('aria-label') ?? null,
+          focused: root?.activeElement === listbox,
+          horizontalOverlap:
+            !!rowRect &&
+            !!tooltipRect &&
+            tooltipRect.right >= rowRect.left &&
+            tooltipRect.left <= rowRect.right,
+          tooltipLabel: tooltip?.textContent?.trim() ?? null,
+          tooltipNearPanel:
+            !!panelRect &&
+            !!tooltipRect &&
+            tooltipRect.right >= panelRect.left - 100 &&
+            tooltipRect.left <= panelRect.right + 100 &&
+            tooltipRect.bottom >= panelRect.top - 100 &&
+            tooltipRect.top <= panelRect.bottom + 100,
+          verticalGap:
+            rowRect && tooltipRect
+              ? Math.min(
+                  Math.abs(tooltipRect.bottom - rowRect.top),
+                  Math.abs(tooltipRect.top - rowRect.bottom)
+                )
+              : Number.POSITIVE_INFINITY,
+        }
+      })
+
+    const expectAnchoredTrace = async (expectedTraceItemId?: string | null) =>
+      retry(async () => {
+        const state = await readTraceState()
+        expect(state.activeDescendant).toEqual(expect.any(String))
+        if (expectedTraceItemId !== undefined) {
+          expect(state.activeTraceItemId).toBe(expectedTraceItemId)
+        }
+        expect(state.activeRowId).toBe(state.activeDescendant)
+        expect(state.activeLabel).toBe(state.tooltipLabel)
+        expect(state.focused).toBe(true)
+        expect(state.horizontalOverlap).toBe(true)
+        expect(state.tooltipNearPanel).toBe(true)
+        expect(state.verticalGap).toBeLessThan(160)
+        return state
+      })
+
+    const initialState = await expectAnchoredTrace()
+
+    await browser.eval(() => {
+      const root = document.querySelector('nextjs-portal')?.shadowRoot
+      root
+        ?.querySelector<HTMLElement>('.request-insights-trace-rows')
+        ?.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            altKey: true,
+            bubbles: true,
+            key: 'ArrowDown',
+          })
+        )
+    })
+    expect((await readTraceState()).activeTraceItemId).toBe(
+      initialState.activeTraceItemId
+    )
+
+    await browser.keydown('ArrowDown')
+    await browser.keyup('ArrowDown')
+
+    const nextState = await retry(async () => {
+      const state = await readTraceState()
+      expect(state.activeTraceItemId).not.toBe(initialState.activeTraceItemId)
+      return state
+    })
+    await expectAnchoredTrace(nextState.activeTraceItemId)
+
+    const columnCountAtPanelWidth = async (width: number): Promise<number> => {
+      return await browser.eval(`(() => {
+        const root = document.querySelector('nextjs-portal').shadowRoot
+        const panelContainer = root.querySelector('.dynamic-panel-container')
+        panelContainer.style.width = '${width}px'
+        const panel = root.querySelector('.request-insights-panel')
+        return getComputedStyle(panel).gridTemplateColumns.split(' ').length
+      })()`)
+    }
+
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(760)).toBe(2)
+    })
+    await expectAnchoredTrace()
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(560)).toBe(1)
+    })
+    await expectAnchoredTrace()
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(760)).toBe(2)
+    })
+    await expectAnchoredTrace()
+
+    await browser
+      .locator('nextjs-portal .request-insights-row[aria-label^="/api/source"]')
+      .first()
+      .click()
+
+    await retry(async () => {
+      const selection = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) => candidate.textContent?.includes('/api/source'))
+        return {
+          found: row !== undefined,
+          selected: row?.dataset.selected,
+          title: root
+            ?.querySelector<HTMLElement>('.request-insights-title')
+            ?.textContent?.trim(),
+          activeRowId: root?.querySelector<HTMLElement>(
+            '.request-insights-span-row[data-active="true"]'
+          )?.id,
+          firstRowId: root?.querySelector<HTMLElement>(
+            '.request-insights-span-row'
+          )?.id,
+        }
+      })
+      expect(selection.found).toBe(true)
+      expect(selection.selected).toBe('true')
+      expect(selection.title).toBe('/api/source?query=redacted')
+      expect(selection.firstRowId).toEqual(expect.any(String))
+      expect(selection.activeRowId).toBe(selection.firstRowId)
+    })
+
+    await browser
+      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .hover()
+    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+
+    const switchedState = await expectAnchoredTrace()
+    expect(switchedState.activeDescendant).toBe(switchedState.firstRowId)
+  })
+
   it('classifies framework-owned request activity without retaining action IDs', async () => {
     const existingRequestIds = new Set(
       (
@@ -734,8 +974,18 @@ describe('request insights', () => {
   })
 
   it('classifies an App Route before its handler completes', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
     const waitKey = `active-${Date.now()}`
     const requestPath = `/api/app-stream-lifecycle?wait=${waitKey}`
+    const recordedRequestPath = '/api/app-stream-lifecycle?query=redacted'
     const responsePromise = next.fetch(requestPath)
 
     try {
@@ -746,7 +996,10 @@ describe('request insights', () => {
           requests: RequestInsight[]
         }
         const matchingRequests = snapshot.requests.filter(
-          (request) => request.url === requestPath
+          (request) =>
+            !existingRequestIds.has(request.requestId) &&
+            request.url === recordedRequestPath &&
+            request.kind !== 'instant-insights'
         )
 
         expect(matchingRequests).toHaveLength(1)
@@ -777,7 +1030,12 @@ describe('request insights', () => {
       }
       const matchingRequests = snapshot.requests.filter(
         (request) =>
-          request.url === requestPath && request.kind !== 'instant-insights'
+          !existingRequestIds.has(request.requestId) &&
+          request.url === recordedRequestPath &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'GET'
+          )
       )
 
       expect(matchingRequests).toHaveLength(1)
@@ -796,7 +1054,17 @@ describe('request insights', () => {
   })
 
   it('classifies a Page after proxy completes', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
     const requestPath = `/api/proxied-page?run=${Date.now()}`
+    const recordedRequestPath = '/api/proxied-page?query=redacted'
     const response = await next.fetch(requestPath)
     expect(response.status).toBe(200)
     expect(await response.text()).toContain('proxied page')
@@ -809,7 +1077,9 @@ describe('request insights', () => {
       }
       const matchingRequests = snapshot.requests.filter(
         (request) =>
-          request.url === requestPath && request.kind !== 'instant-insights'
+          !existingRequestIds.has(request.requestId) &&
+          request.url === recordedRequestPath &&
+          request.kind !== 'instant-insights'
       )
 
       expect(matchingRequests).toHaveLength(1)

--- a/test/unit/devtools-config-middleware/index.test.ts
+++ b/test/unit/devtools-config-middleware/index.test.ts
@@ -1,0 +1,364 @@
+import type { IncomingMessage, ServerResponse } from 'http'
+import * as fsPromises from 'fs/promises'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  devToolsConfigMiddleware,
+  getDevToolsConfig,
+} from 'next/dist/next-devtools/server/devtools-config-middleware'
+
+jest.mock('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises')
+  return {
+    ...actual,
+    rename: jest.fn(actual.rename),
+    writeFile: jest.fn(actual.writeFile),
+  }
+})
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function createRequest(
+  body: object,
+  {
+    bodyRequested,
+    bodyConsumed,
+    releaseBody,
+  }: {
+    bodyRequested?: ReturnType<typeof createDeferred>
+    bodyConsumed?: ReturnType<typeof createDeferred>
+    releaseBody?: Promise<void>
+  } = {}
+): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      bodyRequested?.resolve()
+      await releaseBody
+      yield Buffer.from(JSON.stringify(body))
+      bodyConsumed?.resolve()
+    },
+  } as IncomingMessage
+}
+
+function createResponse(): ServerResponse {
+  return {
+    end: jest.fn(),
+    setHeader: jest.fn(),
+  } as unknown as ServerResponse
+}
+
+function createChunkedRequest(chunks: Buffer[]): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      yield* chunks
+    },
+  } as IncomingMessage
+}
+
+describe('DevTools config middleware', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    distDir = await mkdtemp(join(tmpdir(), 'next-devtools-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(distDir, { recursive: true, force: true })
+  })
+
+  it('commits concurrent patches in request arrival order', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const bodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstResponse = createResponse()
+    const secondResponse = createResponse()
+
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { showInternal: true, verbose: false } },
+        {
+          bodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      firstResponse,
+      jest.fn()
+    )
+
+    await bodyRequested.promise
+    const secondBodyConsumed = createDeferred()
+    const secondRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: secondBodyConsumed }
+      ),
+      secondResponse,
+      jest.fn()
+    )
+
+    await secondBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, secondRequest])
+
+    const config = JSON.parse(
+      await readFile(
+        join(distDir, 'cache', 'next-devtools-config.json'),
+        'utf8'
+      )
+    )
+    expect(config).toEqual({
+      requestInsights: {
+        showInternal: true,
+        verbose: true,
+      },
+    })
+    expect(firstResponse.statusCode).toBe(204)
+    expect(secondResponse.statusCode).toBe(204)
+    expect(sendUpdateSignal).toHaveBeenLastCalledWith(config)
+  })
+
+  it('keeps a queue reservation after an invalid request finishes early', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    const firstBodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: false } },
+        {
+          bodyRequested: firstBodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await firstBodyRequested.promise
+    const invalidResponse = createResponse()
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      invalidResponse,
+      jest.fn()
+    )
+    expect(invalidResponse.statusCode).toBe(413)
+
+    const thirdBodyConsumed = createDeferred()
+    const thirdRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: thirdBodyConsumed }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await thirdBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, thirdRequest])
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { verbose: true },
+    })
+  })
+
+  it('keeps the previous config readable until an update is complete', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    const writeStarted = createDeferred()
+    const releaseWrite = createDeferred()
+    const { writeFile } =
+      jest.requireActual<typeof import('fs/promises')>('fs/promises')
+    const writeFileMock = jest.mocked(fsPromises.writeFile)
+    writeFileMock.mockImplementation(async (path, contents, options) => {
+      const serialized = String(contents)
+      if (serialized.includes('"verbose": true')) {
+        await writeFile(path, serialized.slice(0, serialized.length / 2))
+        writeStarted.resolve()
+        await releaseWrite.promise
+      }
+      return writeFile(path, contents, options)
+    })
+
+    try {
+      const update = middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+      await writeStarted.promise
+
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: { showInternal: true },
+      })
+
+      releaseWrite.resolve()
+      await update
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      })
+    } finally {
+      releaseWrite.resolve()
+      writeFileMock.mockImplementation(writeFile)
+      writeFileMock.mockClear()
+    }
+  })
+
+  it('does not let a missing-file read overwrite the first update', async () => {
+    const writeFile = jest.mocked(fsPromises.writeFile)
+    writeFile.mockClear()
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+    expect(writeFile).not.toHaveBeenCalled()
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a corrupted config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, '{not valid JSON')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a schema-invalid config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, JSON.stringify({ theme: 123 }))
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('keeps the previous config and releases the queue after a failed rename', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    sendUpdateSignal.mockClear()
+
+    jest
+      .mocked(fsPromises.rename)
+      .mockRejectedValueOnce(new Error('rename failed'))
+
+    await expect(
+      middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+    ).rejects.toThrow('rename failed')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(fsPromises.readdir(join(distDir, 'cache'))).resolves.toEqual([
+      'next-devtools-config.json',
+    ])
+
+    await middleware(
+      createRequest({ requestInsights: { verbose: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true, verbose: true },
+    })
+  })
+
+  it('rejects config request bodies larger than 64 KiB', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const response = createResponse()
+
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      response,
+      jest.fn()
+    )
+
+    expect(response.statusCode).toBe(413)
+    expect(response.end).toHaveBeenCalledWith('Payload Too Large')
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary

- show sanitized concrete request URLs, dynamic and catch-all params, and same-origin versus external fetch origins in Request Insights
- redact query values and user information from recorded and reconstructed span names while retaining useful route and hostname context
- add stable trace-item keyboard selection, request-keyed viewer state, responsive container-query layout, and row-anchored bounded tooltips
- cover Unicode-safe truncation, forced-colors focus state, request transitions, modifier keys, narrow layouts, and serialized secret-redaction regressions

## Verification

- focused request-label, fetch-label, trace-viewer, recorder, and Request Insights server unit suites (57/57 on the completed stack)
- full Request Insights development suite in Turbopack (22/22) and Webpack (22/22) on the completed stack
- changed-file Prettier, ESLint, lint-staged checks, and `git diff --check`
