### PR TITLE
Relate Request Insights activity

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -8,6 +8,7 @@ import {
   getRequestInsightRouterActivity,
   getRequestInsightStatusCode,
   hasRequestInsightProxyActivity,
+  type RequestListEntry,
 } from './request-list'
 
 export type RequestInsightFilter =
@@ -105,46 +106,37 @@ const ALL_FILTERS = REQUEST_INSIGHT_FILTER_GROUPS.flatMap((group) =>
 )
 
 type RequestInsightFilterResult = Readonly<{
-  requests: RequestInsight[]
+  entries: RequestListEntry[]
   matchingRequestCount: number
   totalRequestCount: number
   optionCounts: Readonly<Record<RequestInsightFilter, number>>
 }>
 
 export function getRequestInsightFilterResult(
-  requests: readonly RequestInsight[],
-  activeFilters: readonly RequestInsightFilter[],
-  showInternal = false
+  entries: readonly RequestListEntry[],
+  activeFilters: readonly RequestInsightFilter[]
 ): RequestInsightFilterResult {
-  const revealInternal =
-    showInternal || activeFilters.includes('activity:instant-insights')
-  const visibleRequests = requests.filter(
-    (request) => getRequestInsightKind(request) === 'request' || revealInternal
-  )
   const activeFiltersByFacet = groupFiltersByFacet(activeFilters)
   const optionCounts = Object.fromEntries(
     ALL_FILTERS.map((filter) => [filter, 0])
   ) as Record<RequestInsightFilter, number>
 
-  for (const request of requests) {
-    const tags = getRequestInsightTags(request)
-    if (getRequestInsightKind(request) === 'request' || showInternal) {
-      for (const tag of tags) {
-        optionCounts[tag] += 1
-      }
-    } else if (tags.has('activity:instant-insights')) {
-      optionCounts['activity:instant-insights'] += 1
+  for (const entry of entries) {
+    const tags = getRequestInsightTags(entry)
+    for (const tag of tags) {
+      optionCounts[tag] += 1
     }
   }
 
-  const matchingRequests = visibleRequests.filter((request) =>
-    matchesActiveFilters(getRequestInsightTags(request), activeFiltersByFacet)
-  )
+  const matchingEntries = entries.filter((entry) => {
+    const tags = getRequestInsightTags(entry)
+    return matchesActiveFilters(tags, activeFiltersByFacet)
+  })
 
   return {
-    requests: matchingRequests,
-    matchingRequestCount: matchingRequests.length,
-    totalRequestCount: visibleRequests.length,
+    entries: matchingEntries,
+    matchingRequestCount: matchingEntries.length,
+    totalRequestCount: entries.length,
     optionCounts,
   }
 }
@@ -159,8 +151,9 @@ export function toggleRequestInsightFilter(
 }
 
 function getRequestInsightTags(
-  request: RequestInsight
+  entry: RequestListEntry
 ): Set<RequestInsightFilter> {
+  const { request } = entry
   const tags = new Set<RequestInsightFilter>()
   const source = getRequestSourceFilter(request)
   if (source) {
@@ -188,13 +181,19 @@ function getRequestInsightTags(
   if (routerActivity) {
     tags.add(`activity:${routerActivity}`)
   }
-  if (getRequestInsightKind(request) === 'instant-insights') {
+  if (
+    entry.instantInsights.length > 0 ||
+    getRequestInsightKind(request) === 'instant-insights'
+  ) {
     tags.add('activity:instant-insights')
   }
 
   if (
-    request.status === 'error' ||
-    request.spans.some((span) => span.status === 'error' || span.error)
+    [request, ...entry.instantInsights].some(
+      (item) =>
+        item.status === 'error' ||
+        item.spans.some((span) => span.status === 'error' || span.error)
+    )
   ) {
     tags.add('status:error')
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -28,6 +28,7 @@
 .request-insights-list {
   border-right: 1px solid var(--color-gray-400);
   overflow: auto;
+  overscroll-behavior: contain;
   min-width: 0;
 }
 
@@ -54,8 +55,50 @@
   gap: 6px;
 }
 
+.request-insights-scope-switcher {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--color-gray-400);
+  background: var(--color-background-100);
+}
+
+.request-insights-scope-switcher button {
+  min-height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-gray-900);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--size-11);
+}
+
+.request-insights-scope-switcher button:focus-visible,
+.request-insights-row:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.request-insights-scope-switcher button:hover:not(:disabled) {
+  background: var(--color-gray-200);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-scope-switcher button[aria-pressed='true'] {
+  background: var(--color-gray-300);
+  color: var(--color-gray-1000);
+  font-weight: 500;
+}
+
+.request-insights-scope-switcher button:disabled {
+  color: var(--color-gray-600);
+  cursor: default;
+}
+
 .request-insights-update-status {
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-11);
   white-space: nowrap;
 }
@@ -95,7 +138,7 @@
   border-radius: 999px;
   padding: 0 4px;
   background: var(--color-blue-800);
-  color: var(--color-background-100);
+  color: white;
   font-size: var(--size-10);
   line-height: 16px;
   text-align: center;
@@ -121,7 +164,7 @@
 
 .request-insights-filter-group-label {
   padding: 8px 8px 3px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-10);
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -157,7 +200,7 @@
 
 .request-insights-filter-option-count {
   min-width: 20px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-family: var(--font-mono);
   font-size: var(--size-11);
   text-align: right;
@@ -393,6 +436,20 @@
   color: var(--color-gray-800);
 }
 
+.request-insights-request-error {
+  flex-shrink: 0;
+  color: var(--color-red-900);
+  font-size: var(--size-11);
+}
+
+.request-insights-request-activity[data-activity='instant-insights'] {
+  color: var(--color-blue-900);
+}
+
+.request-insights-request-activity[data-activity='instant-insights'][data-status='error'] {
+  color: var(--color-red-900);
+}
+
 .request-insights-duration,
 .request-insights-meta {
   color: var(--color-gray-900);
@@ -418,6 +475,69 @@
   min-width: 0;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.request-insights-instant-section {
+  border-top: 1px solid var(--color-gray-400);
+}
+
+.request-insights-instant-section > summary {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  font-size: var(--size-12);
+  font-weight: 600;
+  list-style: none;
+}
+
+.request-insights-instant-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+.request-insights-instant-section > summary::before {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  content: '';
+  transform-origin: 2px 50%;
+}
+
+.request-insights-instant-section[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.request-insights-instant-section > summary > :first-child {
+  flex: 1;
+}
+
+.request-insights-instant-section > summary:hover {
+  background: var(--color-gray-100);
+}
+
+.request-insights-instant-section > summary:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.request-insights-instant-record {
+  border-top: 1px solid var(--color-gray-400);
+}
+
+.request-insights-instant-record-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
 }
 
 .request-insights-summary {
@@ -565,7 +685,7 @@
 }
 
 .request-insights-section-note {
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-11);
 }
 
@@ -747,6 +867,8 @@
 .request-insights-fetch-table {
   display: flex;
   flex-direction: column;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
   border-top: 1px solid var(--color-gray-400);
 }
 
@@ -760,6 +882,7 @@
   color: var(--color-gray-900);
   font-family: var(--font-mono);
   font-size: var(--size-12);
+  min-width: 640px;
 }
 
 .request-insights-fetch-header {
@@ -808,7 +931,7 @@
   border: 1px solid var(--color-gray-400);
   border-radius: 999px;
   padding: 0 5px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-family: inherit;
   font-size: var(--size-10);
   text-overflow: ellipsis;
@@ -846,13 +969,5 @@
     max-height: 180px;
     border-right: 0;
     border-bottom: 1px solid var(--color-gray-400);
-  }
-
-  .request-insights-fetch {
-    grid-template-columns: 44px minmax(0, 1fr) 56px;
-  }
-
-  .request-insights-fetch > span:nth-child(n + 4) {
-    display: none;
   }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -41,6 +41,7 @@ import {
   getRequestInsightStatusCode,
   getRequestInsightSummaryTypeLabel,
   getRequestListEntries,
+  getRequestListEntriesForPage,
   isInternalRequestInsight,
   isPageLoadRequest,
 } from './request-list'
@@ -54,6 +55,7 @@ import {
 import './request-insights-panel.css'
 
 const TRACE_TICK_COUNT = 5
+type RequestScope = 'all' | 'page'
 
 export function RequestInsightsPanel() {
   const { dispatch, state, shadowRoot } = useDevOverlayContext()
@@ -63,11 +65,13 @@ export function RequestInsightsPanel() {
   const [pausedRequests, setPausedRequests] = useState<
     readonly RequestInsight[] | null
   >(null)
+  const [requestScope, setRequestScope] = useState<RequestScope>('all')
   const displayedRequests = pausedRequests ?? state.requestInsights
   const requests = useMemo(
     () => [...displayedRequests].reverse(),
     [displayedRequests]
   )
+  const initialRequestId = self.__next_r
   const isPaused = pausedRequests !== null
   const { showInternal, verbose } = state.requestInsightsConfig
   const setRequestInsightsConfig = (patch: {
@@ -80,16 +84,30 @@ export function RequestInsightsPanel() {
     })
     saveDevToolsConfig({ requestInsights: patch })
   }
+  const retainedEntries = useMemo(
+    () => getRequestListEntries(requests, true),
+    [requests]
+  )
+  const allListEntries = useMemo(
+    () =>
+      showInternal
+        ? retainedEntries
+        : retainedEntries.filter(
+            ({ request }) => !isInternalRequestInsight(request)
+          ),
+    [retainedEntries, showInternal]
+  )
+  const currentPageEntries = useMemo(
+    () => getRequestListEntriesForPage(allListEntries, initialRequestId),
+    [allListEntries, initialRequestId]
+  )
+  const scopedEntries =
+    requestScope === 'page' ? currentPageEntries : allListEntries
   const filterResult = useMemo(
-    () => getRequestInsightFilterResult(requests, activeFilters, showInternal),
-    [activeFilters, requests, showInternal]
+    () => getRequestInsightFilterResult(scopedEntries, activeFilters),
+    [activeFilters, scopedEntries]
   )
-  const showInternalInList =
-    showInternal || activeFilters.includes('activity:instant-insights')
-  const listEntries = useMemo(
-    () => getRequestListEntries(filterResult.requests, showInternalInList),
-    [filterResult.requests, showInternalInList]
-  )
+  const listEntries = filterResult.entries
   const visibleRequests = useMemo(
     () => listEntries.map((entry) => entry.request),
     [listEntries]
@@ -101,21 +119,23 @@ export function RequestInsightsPanel() {
     visibleRequests,
     selectedRequestKey
   )
-  const selectedRequest =
-    visibleRequests.find(
-      (request) => getRequestInsightKey(request) === activeRequestKey
+  const selectedEntry =
+    listEntries.find(
+      ({ request }) => getRequestInsightKey(request) === activeRequestKey
     ) ?? null
-  const initialRequestId = self.__next_r
-  const internalRequests = useMemo(
-    () => requests.filter((request) => isInternalRequestInsight(request)),
-    [requests]
+  const selectedRequest = selectedEntry?.request ?? null
+  const orphanedInternalRequests = useMemo(
+    () =>
+      retainedEntries
+        .filter(({ request }) => isInternalRequestInsight(request))
+        .map(({ request }) => request),
+    [retainedEntries]
   )
   const hiddenInternalErrorCount = showInternal
     ? 0
-    : internalRequests.filter((request) => request.status === 'error').length
-  // Only offer the internal-activity toggle once the session has captured
-  // internal activity to reveal.
-  const showInternalToggle = internalRequests.length > 0
+    : orphanedInternalRequests.filter((request) => request.status === 'error')
+        .length
+  const showInternalToggle = orphanedInternalRequests.length > 0
 
   if (displayedRequests.length === 0) {
     return (
@@ -236,6 +256,28 @@ export function RequestInsightsPanel() {
             </div>
           </div>
         </div>
+        <div
+          aria-label="Request scope"
+          className="request-insights-scope-switcher"
+          role="group"
+        >
+          <button
+            aria-pressed={requestScope === 'all'}
+            onClick={() => setRequestScope('all')}
+            type="button"
+          >
+            All
+          </button>
+          <button
+            aria-pressed={requestScope === 'page'}
+            disabled={currentPageEntries.length === 0}
+            onClick={() => setRequestScope('page')}
+            title="Show requests correlated to this browser document"
+            type="button"
+          >
+            This page
+          </button>
+        </div>
         {activeFilters.length > 0 ? (
           <div className="request-insights-filter-status">
             <span>
@@ -256,6 +298,8 @@ export function RequestInsightsPanel() {
                   Reset filters
                 </button>
               </>
+            ) : requestScope === 'page' ? (
+              <>No requests are correlated to this browser document.</>
             ) : (
               <>
                 Only internal activity has been captured. Enable “Internal
@@ -264,10 +308,11 @@ export function RequestInsightsPanel() {
             )}
           </div>
         ) : (
-          listEntries.map(({ request }) => {
+          listEntries.map(({ request, instantInsights }) => {
             const requestKey = getRequestInsightKey(request)
             return (
               <RequestRow
+                instantInsights={instantInsights}
                 key={requestKey}
                 request={request}
                 pageLoad={isPageLoadRequest(request, initialRequestId)}
@@ -280,7 +325,11 @@ export function RequestInsightsPanel() {
       </div>
 
       {selectedRequest && (
-        <RequestDetails request={selectedRequest} verbose={verbose} />
+        <RequestDetails
+          instantInsights={selectedEntry?.instantInsights ?? []}
+          request={selectedRequest}
+          verbose={verbose}
+        />
       )}
     </div>
   )
@@ -373,11 +422,13 @@ function RequestFiltersMenu({
 }
 
 function RequestRow({
+  instantInsights,
   request,
   pageLoad,
   selected,
   onSelect,
 }: {
+  instantInsights: readonly RequestInsight[]
   request: RequestInsight
   pageLoad: boolean
   selected: boolean
@@ -392,10 +443,21 @@ function RequestRow({
   )
   const clockTime = formatClockTime(request.startTime)
   const bypassesProxy = request.proxyStatus === 'bypassed'
+  const hasInstantInsightsError = instantInsights.some(
+    (item) =>
+      item.status === 'error' ||
+      item.spans.some((span) => span.status === 'error' || span.error)
+  )
+  const hasRequestError =
+    request.status === 'error' ||
+    request.spans.some((span) => span.status === 'error' || span.error)
+  const hasVisibleError = hasRequestError || hasInstantInsightsError
+  const statusLabel = getRequestInsightStatusCode(request) ?? request.status
 
   return (
     <button
-      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, Status ${statusLabel}, ${instantInsights.length > 0 ? `Includes Instant Insights${hasInstantInsightsError ? ' with errors' : ''}, ` : ''}${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-pressed={selected}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
       data-page-load={pageLoad}
@@ -405,7 +467,7 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        <span className="request-insights-route-label">
+        <span className="request-insights-route-label" title={requestUrl}>
           {isInstantInsights ? 'Instant Insights' : requestUrl}
         </span>
       </span>
@@ -420,6 +482,16 @@ function RequestRow({
         >
           {requestType.label}
         </span>
+        {instantInsights.length > 0 ? (
+          <span
+            className="request-insights-request-activity"
+            data-activity="instant-insights"
+            data-status={hasInstantInsightsError ? 'error' : 'ok'}
+            title={`${instantInsights.length} Instant Insights record${instantInsights.length === 1 ? '' : 's'}${hasInstantInsightsError ? ' with errors' : ''}`}
+          >
+            Instant
+          </span>
+        ) : null}
         {bypassesProxy ? (
           <span
             className="request-insights-request-activity"
@@ -427,6 +499,9 @@ function RequestRow({
           >
             No proxy
           </span>
+        ) : null}
+        {hasVisibleError ? (
+          <span className="request-insights-request-error">Error</span>
         ) : null}
         <span>{clockTime}</span>
       </span>
@@ -454,9 +529,11 @@ function CheckIcon() {
 }
 
 function RequestDetails({
+  instantInsights,
   request,
   verbose,
 }: {
+  instantInsights: readonly RequestInsight[]
   request: RequestInsight
   verbose: boolean
 }) {
@@ -478,7 +555,7 @@ function RequestDetails({
       <div className="request-insights-summary">
         <div className="request-insights-heading">
           <div className="request-insights-title-row">
-            <div className="request-insights-title">
+            <div className="request-insights-title" title={requestUrl}>
               {getRequestInsightKind(request) === 'instant-insights'
                 ? `Instant Insights · ${requestUrl}`
                 : requestUrl}
@@ -508,6 +585,65 @@ function RequestDetails({
         request={request}
       />
 
+      <FetchTable fetches={request.fetches} />
+
+      {instantInsights.length > 0 ? (
+        <InstantInsightsSection requests={instantInsights} verbose={verbose} />
+      ) : null}
+    </div>
+  )
+}
+
+function InstantInsightsSection({
+  requests,
+  verbose,
+}: {
+  requests: readonly RequestInsight[]
+  verbose: boolean
+}) {
+  return (
+    <details className="request-insights-instant-section">
+      <summary>
+        <span>Instant Insights</span>
+        <span className="request-insights-section-note">
+          {requests.length} record{requests.length === 1 ? '' : 's'}
+        </span>
+      </summary>
+      {requests.map((request) => (
+        <InstantInsightsRecord
+          key={getRequestInsightKey(request)}
+          request={request}
+          verbose={verbose}
+        />
+      ))}
+    </details>
+  )
+}
+
+function InstantInsightsRecord({
+  request,
+  verbose,
+}: {
+  request: RequestInsight
+  verbose: boolean
+}) {
+  const traceItems = useMemo(
+    () =>
+      getTraceItems(
+        request,
+        verbose,
+        typeof window === 'undefined' ? undefined : window.location.origin
+      ),
+    [request, verbose]
+  )
+
+  return (
+    <div className="request-insights-instant-record">
+      <div className="request-insights-instant-record-summary">
+        <span>Status {request.status}</span>
+        <span>{formatDuration(request.durationMs)}</span>
+      </div>
+      <Trace items={traceItems} request={request} />
       <FetchTable fetches={request.fetches} />
     </div>
   )
@@ -782,14 +918,17 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
           No server fetches captured.
         </div>
       ) : (
-        <div className="request-insights-fetch-table">
-          <div className="request-insights-fetch request-insights-fetch-header">
-            <span>Method</span>
-            <span>URL</span>
-            <span>Duration</span>
-            <span>Status</span>
-            <span>Cache</span>
-            <span>Reason</span>
+        <div className="request-insights-fetch-table" role="table">
+          <div
+            className="request-insights-fetch request-insights-fetch-header"
+            role="row"
+          >
+            <span role="columnheader">Method</span>
+            <span role="columnheader">URL</span>
+            <span role="columnheader">Duration</span>
+            <span role="columnheader">Status</span>
+            <span role="columnheader">Cache</span>
+            <span role="columnheader">Reason</span>
           </div>
           {fetches.map((fetch, index) => {
             const url = getFetchUrlPresentation(fetch.url, currentOrigin)
@@ -798,11 +937,12 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
                 className="request-insights-fetch"
                 data-origin={url.originKind}
                 key={index}
+                role="row"
               >
-                <span className="request-insights-method">
+                <span className="request-insights-method" role="cell">
                   {fetch.method ?? 'GET'}
                 </span>
-                <span className="request-insights-fetch-url">
+                <span className="request-insights-fetch-url" role="cell">
                   <Tooltip
                     className="request-insights-fetch-tooltip"
                     title={url.fullUrl}
@@ -820,10 +960,10 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
                     </span>
                   </Tooltip>
                 </span>
-                <span>{formatDuration(fetch.durationMs)}</span>
-                <span>{fetch.statusCode ?? '-'}</span>
-                <span>{fetch.cacheStatus ?? 'unknown'}</span>
-                <span className="request-insights-cache-reason">
+                <span role="cell">{formatDuration(fetch.durationMs)}</span>
+                <span role="cell">{fetch.statusCode ?? '-'}</span>
+                <span role="cell">{fetch.cacheStatus ?? 'unknown'}</span>
+                <span className="request-insights-cache-reason" role="cell">
                   {fetch.cacheReason ?? '-'}
                 </span>
               </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -32,17 +32,60 @@ export function isInternalRequestInsight(
   return getRequestInsightKind(request) !== 'request'
 }
 
-export type RequestListEntry = {
+export type RequestListEntry = Readonly<{
   request: RequestInsight
-}
+  instantInsights: readonly RequestInsight[]
+}>
 
 export function getRequestListEntries(
   requests: readonly RequestInsight[],
   showInternal: boolean
 ): RequestListEntry[] {
-  return requests
-    .filter((request) => showInternal || !isInternalRequestInsight(request))
-    .map((request) => ({ request }))
+  const requestIds = new Set(
+    requests
+      .filter((request) => !isInternalRequestInsight(request))
+      .map((request) => request.requestId)
+  )
+  const instantInsightsByOwner = new Map<string, RequestInsight[]>()
+  for (const request of requests) {
+    if (getRequestInsightKind(request) !== 'instant-insights') {
+      continue
+    }
+    const owned = instantInsightsByOwner.get(request.requestId)
+    if (owned) {
+      owned.push(request)
+    } else {
+      instantInsightsByOwner.set(request.requestId, [request])
+    }
+  }
+
+  return requests.flatMap((request) => {
+    if (isInternalRequestInsight(request)) {
+      return showInternal && !requestIds.has(request.requestId)
+        ? [{ request, instantInsights: [] }]
+        : []
+    }
+
+    return [
+      {
+        request,
+        instantInsights: instantInsightsByOwner.get(request.requestId) ?? [],
+      },
+    ]
+  })
+}
+
+export function getRequestListEntriesForPage(
+  entries: readonly RequestListEntry[],
+  htmlRequestId: string | undefined
+): RequestListEntry[] {
+  if (!htmlRequestId) {
+    return []
+  }
+
+  return entries.filter(
+    (entry) => entry.request.htmlRequestId === htmlRequestId
+  )
 }
 
 export type RequestInsightRowType =

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -7,6 +7,7 @@ import {
   getActiveRequestKey,
   getRequestInsightRowType,
   getRequestListEntries,
+  getRequestListEntriesForPage,
   isPageLoadRequest,
 } from './request-list'
 import {
@@ -80,11 +81,12 @@ describe('request insights trace viewer', () => {
     })
 
     expect(getRequestListEntries([instantInsights, request], false)).toEqual([
-      { request },
+      { request, instantInsights: [instantInsights] },
     ])
+    expect(getRequestListEntries([instantInsights], false)).toEqual([])
   })
 
-  it('keeps internal records flat and in capture order', () => {
+  it('keeps owned internal activity off the list and reveals only orphans', () => {
     const newerRequest = createRequest({ requestId: 'newer' })
     const olderRequest = createRequest({ requestId: 'older' })
     const newerInstantInsights = createRequest({
@@ -95,6 +97,10 @@ describe('request insights trace viewer', () => {
       requestId: 'older',
       kind: 'instant-insights',
     })
+    const orphanedInstantInsights = createRequest({
+      requestId: 'orphaned',
+      kind: 'instant-insights',
+    })
 
     expect(
       getRequestListEntries(
@@ -103,15 +109,51 @@ describe('request insights trace viewer', () => {
           newerRequest,
           olderInstantInsights,
           olderRequest,
+          orphanedInstantInsights,
         ],
         true
       )
     ).toEqual([
-      { request: newerInstantInsights },
-      { request: newerRequest },
-      { request: olderInstantInsights },
-      { request: olderRequest },
+      { request: newerRequest, instantInsights: [newerInstantInsights] },
+      { request: olderRequest, instantInsights: [olderInstantInsights] },
+      { request: orphanedInstantInsights, instantInsights: [] },
     ])
+  })
+
+  it('scopes requests to an exact document identity', () => {
+    const currentPage = createRequest({
+      requestId: 'current-page',
+      htmlRequestId: 'current-document',
+    })
+    const currentNavigation = createRequest({
+      requestId: 'current-navigation',
+      htmlRequestId: 'current-document',
+    })
+    const earlierPage = createRequest({
+      requestId: 'earlier-page',
+      htmlRequestId: 'earlier-document',
+    })
+    const currentPageInstantInsights = createRequest({
+      requestId: 'current-page',
+      kind: 'instant-insights',
+      htmlRequestId: 'different-correlation-metadata',
+    })
+    const entries = getRequestListEntries(
+      [currentNavigation, earlierPage, currentPageInstantInsights, currentPage],
+      true
+    )
+
+    expect(getRequestListEntriesForPage(entries, 'current-document')).toEqual([
+      { request: currentNavigation, instantInsights: [] },
+      {
+        request: currentPage,
+        instantInsights: [currentPageInstantInsights],
+      },
+    ])
+    expect(getRequestListEntriesForPage(entries, 'missing-document')).toEqual(
+      []
+    )
+    expect(getRequestListEntriesForPage(entries, undefined)).toEqual([])
   })
 
   it('labels and filters normalized request activity', () => {
@@ -142,6 +184,29 @@ describe('request insights trace viewer', () => {
     })
     const api = createRequest({ requestId: 'api', source: 'app-route' })
     const asset = createRequest({ requestId: 'asset', source: 'asset' })
+    const instantInsights = createRequest({
+      requestId: 'page',
+      kind: 'instant-insights',
+      source: 'instant-insights',
+      status: 'error',
+    })
+    const entries = getRequestListEntries(
+      [page, instantInsights, rsc, action, api, asset],
+      false
+    )
+    const orphanedInstantInsights = createRequest({
+      requestId: 'orphaned',
+      kind: 'instant-insights',
+      source: 'instant-insights',
+    })
+    const entriesWithOrphan = getRequestListEntries(
+      [page, instantInsights, orphanedInstantInsights, rsc, action, api, asset],
+      true
+    )
+    const entriesWithHiddenOrphan = getRequestListEntries(
+      [page, instantInsights, orphanedInstantInsights, rsc, action, api, asset],
+      false
+    )
 
     expect(getRequestInsightRowType(page, true).label).toBe('Page load')
     expect(getRequestInsightRowType(rsc).label).toBe('RSC')
@@ -149,23 +214,37 @@ describe('request insights trace viewer', () => {
     expect(getRequestInsightRowType(api).label).toBe('API')
     expect(getRequestInsightRowType(asset).label).toBe('Asset')
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api],
-        ['source:page', 'cache:miss']
-      ).requests
+      getRequestInsightFilterResult(entries, [
+        'source:page',
+        'cache:miss',
+      ]).entries.map(({ request }) => request)
     ).toEqual([page])
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api, asset],
-        ['source:action', 'source:api']
-      ).requests
+      getRequestInsightFilterResult(entries, [
+        'source:action',
+        'source:api',
+      ]).entries.map(({ request }) => request)
     ).toEqual([action, api])
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api, asset],
-        ['source:asset']
-      ).requests
+      getRequestInsightFilterResult(entries, ['source:asset']).entries.map(
+        ({ request }) => request
+      )
     ).toEqual([asset])
+    expect(
+      getRequestInsightFilterResult(entriesWithHiddenOrphan, [
+        'activity:instant-insights',
+      ]).entries.map(({ request }) => request)
+    ).toEqual([page])
+    expect(
+      getRequestInsightFilterResult(entriesWithOrphan, [
+        'activity:instant-insights',
+      ]).entries.map(({ request }) => request)
+    ).toEqual([page, orphanedInstantInsights])
+    expect(
+      getRequestInsightFilterResult(entries, ['status:error']).entries.map(
+        ({ request }) => request
+      )
+    ).toEqual([page])
   })
 
   it('only marks the exact initial document request as the page load', () => {

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -437,113 +437,118 @@ describe('request insights', () => {
     })
   })
 
-  it('hides internal activity behind the settings menu', async () => {
+  it('relates owned Instant Insights to the foreground request', async () => {
     const browser = await next.browser('/instant-insights')
     shouldResetRequestInsightsConfig = true
 
-    function getSettingsMenuItems(): Promise<
-      Array<{ label: string | undefined; checked: string | null }>
-    > {
-      return browser.eval(() => {
-        const root = document.querySelector('nextjs-portal')?.shadowRoot
-        return Array.from(
-          root?.querySelectorAll('.request-insights-settings-item') ?? []
-        ).map((item) => ({
-          label: item.textContent?.trim(),
-          checked:
-            item
-              .querySelector('.request-insights-settings-checkbox')
-              ?.getAttribute('data-checked') ?? null,
-        }))
-      })
-    }
-
     await openRequestInsightsPanel(browser)
 
+    let allRequestCount = 0
     await retry(async () => {
       const state = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
         const rows = Array.from(
           root?.querySelectorAll('.request-insights-row') ?? []
         )
+        const owner = rows.find(
+          (row) =>
+            row.querySelector('.request-insights-route-label')?.textContent ===
+            '/instant-insights'
+        )
         return {
           rowCount: rows.length,
-          hasInstantInsightsRow: rows.some((row) =>
-            row.textContent?.includes('Instant Insights')
-          ),
+          internalRowCount: rows.filter(
+            (row) => row.getAttribute('data-internal') === 'true'
+          ).length,
+          ownerInstantLabel: owner
+            ?.querySelector('[data-activity="instant-insights"]')
+            ?.textContent?.trim(),
         }
       })
 
+      allRequestCount = state.rowCount
       expect(state.rowCount).toBeGreaterThan(0)
-      expect(state.hasInstantInsightsRow).toBe(false)
+      expect(state.internalRowCount).toBe(0)
+      expect(state.ownerInstantLabel).toBe('Instant')
     })
 
-    await browser.elementByCss('.request-insights-settings-trigger').click()
     await retry(async () => {
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: null },
-        { label: 'Verbose traces', checked: null },
-      ])
-    })
-
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Internal activity")'
-      )
-      .click()
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Verbose traces")'
-      )
-      .click()
-
-    await retry(async () => {
-      const internalRows = await browser.eval(() => {
+      const selected = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
-        return Array.from(
-          root?.querySelectorAll(
-            '.request-insights-row[data-internal="true"]'
-          ) ?? []
-        ).map((row) => ({
-          nested: row.hasAttribute('data-nested'),
-          label: row.textContent ?? '',
-        }))
+        const owner = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find(
+          (row) =>
+            row.querySelector('.request-insights-route-label')?.textContent ===
+            '/instant-insights'
+        )
+        owner?.click()
+        return owner !== undefined
       })
-
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: 'true' },
-        { label: 'Verbose traces', checked: 'true' },
-      ])
-      expect(internalRows.length).toBeGreaterThan(0)
-      for (const row of internalRows) {
-        expect(row.nested).toBe(false)
-        expect(row.label).toContain('Instant Insights')
-      }
+      expect(selected).toBe(true)
     })
 
     await retry(async () => {
-      const config = JSON.parse(
-        await next.readFile('build/dev/cache/next-devtools-config.json')
+      const instantSection = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const section = root?.querySelector<HTMLDetailsElement>(
+          '.request-insights-instant-section'
+        )
+        return {
+          exists: section !== null,
+          open: section?.open ?? null,
+          title: section
+            ?.querySelector('summary > span:first-child')
+            ?.textContent?.trim(),
+        }
+      })
+      expect(instantSection.exists).toBe(true)
+      expect(instantSection.open).toBe(false)
+      expect(instantSection.title).toBe('Instant Insights')
+    })
+
+    await browser
+      .elementByCss('.request-insights-instant-section > summary')
+      .click()
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const section = root?.querySelector<HTMLDetailsElement>(
+          '.request-insights-instant-section'
+        )
+        return {
+          open: section?.open ?? false,
+          traceRows:
+            section?.querySelectorAll('.request-insights-span-row').length ?? 0,
+        }
+      })
+      expect(state.open).toBe(true)
+      expect(state.traceRows).toBeGreaterThan(0)
+    })
+
+    await browser
+      .elementByCss(
+        '.request-insights-scope-switcher button:has-text("This page")'
       )
-      expect(config.requestInsights).toEqual({
-        showInternal: true,
-        verbose: true,
-      })
-    })
-
-    await browser.elementByCss('.request-insights-details').click()
-    await browser.refresh()
-    await openRequestInsightsPanel(browser)
-    await browser.elementByCss('.request-insights-settings-trigger').click()
-
+      .click()
     await retry(async () => {
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: 'true' },
-        { label: 'Verbose traces', checked: 'true' },
-      ])
+      const pageScope = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const button = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>(
+            '.request-insights-scope-switcher button'
+          ) ?? []
+        ).find((item) => item.textContent?.trim() === 'This page')
+        return {
+          pressed: button?.getAttribute('aria-pressed'),
+          requestCount:
+            root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(pageScope.pressed).toBe('true')
+      expect(pageScope.requestCount).toBeGreaterThan(0)
+      expect(pageScope.requestCount).toBeLessThan(allRequestCount)
     })
   })
 
@@ -671,6 +676,9 @@ describe('request insights', () => {
     const browser = await next.browser('/products/blue?tab=details')
     await openRequestInsightsPanel(browser)
 
+    const foregroundTraceSelector =
+      '.request-insights-details > .request-insights-section .request-insights-trace-rows'
+
     await retry(async () => {
       const selected = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
@@ -681,15 +689,17 @@ describe('request insights', () => {
           candidate.textContent?.includes('/products/blue?query=redacted')
         )
         row?.click()
-        return row !== undefined
+        return row?.dataset.selected === 'true'
       })
       expect(selected).toBe(true)
     })
 
     await browser
-      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .locator(
+        `nextjs-portal ${foregroundTraceSelector} .request-insights-span-row[data-active="true"]`
+      )
       .hover()
-    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+    await browser.locator(`nextjs-portal ${foregroundTraceSelector}`).focus()
 
     const readTraceState = () =>
       browser.eval(() => {
@@ -698,7 +708,7 @@ describe('request insights', () => {
           '.request-insights-panel-container'
         )
         const listbox = root?.querySelector<HTMLElement>(
-          '.request-insights-trace-rows'
+          '.request-insights-details > .request-insights-section .request-insights-trace-rows'
         )
         const activeDescendant = listbox?.getAttribute('aria-activedescendant')
         const activeRow = listbox?.querySelector<HTMLElement>(
@@ -715,11 +725,19 @@ describe('request insights', () => {
         const tooltipRect = tooltip?.getBoundingClientRect()
 
         return {
+          activeRowCount:
+            listbox?.querySelectorAll(
+              '.request-insights-span-row[data-active="true"]'
+            ).length ?? 0,
           activeDescendant,
           activeRowId: activeRow?.id ?? null,
           activeTraceItemId: activeRow?.dataset.traceItemId ?? null,
           firstRowId: firstRow?.id ?? null,
           activeLabel: activeRow?.getAttribute('aria-label') ?? null,
+          requestTitle:
+            root
+              ?.querySelector('.request-insights-title')
+              ?.textContent?.trim() ?? null,
           focused: root?.activeElement === listbox,
           horizontalOverlap:
             !!rowRect &&
@@ -747,6 +765,7 @@ describe('request insights', () => {
     const expectAnchoredTrace = async (expectedTraceItemId?: string | null) =>
       retry(async () => {
         const state = await readTraceState()
+        expect(state.activeRowCount).toBe(1)
         expect(state.activeDescendant).toEqual(expect.any(String))
         if (expectedTraceItemId !== undefined) {
           expect(state.activeTraceItemId).toBe(expectedTraceItemId)
@@ -765,7 +784,9 @@ describe('request insights', () => {
     await browser.eval(() => {
       const root = document.querySelector('nextjs-portal')?.shadowRoot
       root
-        ?.querySelector<HTMLElement>('.request-insights-trace-rows')
+        ?.querySelector<HTMLElement>(
+          '.request-insights-details > .request-insights-section .request-insights-trace-rows'
+        )
         ?.dispatchEvent(
           new KeyboardEvent('keydown', {
             altKey: true,
@@ -844,10 +865,19 @@ describe('request insights', () => {
       expect(selection.activeRowId).toBe(selection.firstRowId)
     })
 
+    await retry(async () => {
+      const state = await readTraceState()
+      expect(state.activeRowCount).toBe(1)
+      expect(state.requestTitle).toBe('/api/source?query=redacted')
+      expect(state.activeTraceItemId).not.toBe(nextState.activeTraceItemId)
+    })
+
     await browser
-      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .locator(
+        `nextjs-portal ${foregroundTraceSelector} .request-insights-span-row:first-child`
+      )
       .hover()
-    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+    await browser.locator(`nextjs-portal ${foregroundTraceSelector}`).focus()
 
     const switchedState = await expectAnchoredTrace()
     expect(switchedState.activeDescendant).toBe(switchedState.firstRowId)


### PR DESCRIPTION
## Summary

- attach Instant Insights validation activity to its exact foreground request owner instead of presenting it as an unrelated request row
- add a compact inline `Instant` marker and collapsed detail trace while keeping internal timing separate from foreground request latency
- keep only genuinely orphaned internal work as standalone activity and provide exact-document `All` and `This page` lenses without inventing a causal hierarchy
- independently scope foreground and owned-internal trace selection and cover ownership, errors, filtering, pointer races, and accessible active-row behavior

## Verification

- focused Request Insights unit suites (57/57 on the completed stack)
- full Request Insights development suite in Turbopack (22/22)
- full Request Insights development suite in Webpack (22/22)
- Next package types, changed-file Prettier, ESLint, lint-staged checks, and `git diff --check`
