### PR TITLE
Require Cache Components for Instant Navigation testing

### DIFF
--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -61,6 +61,9 @@ export function createWebpackAliases({
   const pageExtensions = config.pageExtensions
   const customAppAliases: CompilerAliases = {}
   const customDocumentAliases: CompilerAliases = {}
+  const isInstantNavigationTestingEnabled =
+    config.cacheComponents === true &&
+    (dev || config.experimental.exposeTestingApiInProductionBuild === true)
 
   // tell webpack where to look for _app and _document
   // using aliases to allow falling back to the default
@@ -181,13 +184,13 @@ export function createWebpackAliases({
             ])
           ),
 
-          // When the Instant Navigation Testing API is disabled (production
-          // build without `experimental.exposeTestingApiInProductionBuild`),
-          // swap the navigation lock implementation for an inert shim so the
-          // testing machinery does not ship in the browser bundle. Same
-          // resolved-path matching as the browser-variant swap above.
-          ...(!dev &&
-          config.experimental.exposeTestingApiInProductionBuild !== true
+          // When the Instant Navigation Testing API is unavailable (Cache
+          // Components is disabled, or this is a production build without
+          // `experimental.exposeTestingApiInProductionBuild`), swap the
+          // navigation lock implementation for an inert shim so the testing
+          // machinery does not ship in the browser bundle. Same resolved-path
+          // matching as the browser-variant swap above.
+          ...(!isInstantNavigationTestingEnabled
             ? {
                 [path.join(
                   NEXT_PROJECT_ROOT_DIST,

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -394,7 +394,8 @@ export function getDefineEnv({
       config.experimental.instrumentationClientRouterTransitionEvents ?? false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':
-      dev || config.experimental.exposeTestingApiInProductionBuild === true,
+      isCacheComponentsEnabled &&
+      (dev || config.experimental.exposeTestingApiInProductionBuild === true),
     'process.env.__NEXT_CACHE_LIFE': config.cacheLife,
     'process.env.__NEXT_CLIENT_PARAM_PARSING_ORIGINS':
       config.experimental.clientParamParsingOrigins || [],

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -433,8 +433,9 @@ export function createAppPageEntrypoint({
 
     // Whether the testing API is exposed (dev mode or explicit flag)
     const exposeTestingApi =
-      routeModule.isDev === true ||
-      nextConfig.experimental.exposeTestingApiInProductionBuild === true
+      nextConfig.cacheComponents === true &&
+      (routeModule.isDev === true ||
+        nextConfig.experimental.exposeTestingApiInProductionBuild === true)
 
     // Enable the Instant Navigation Testing API. Renders only the prefetched
     // portion of the page, excluding dynamic content. This allows tests to
@@ -457,11 +458,7 @@ export function createAppPageEntrypoint({
     // This page supports PPR if it is marked as being `PARTIALLY_STATIC` in the
     // prerender manifest and this is an app page.
     const isRoutePPREnabled: boolean =
-      // When the instant navigation testing API is active, enable the PPR
-      // prerender path even without Cache Components. In dev mode without CC,
-      // static pages need this path to produce buffered segment data (the
-      // legacy prerender path hangs in dev mode).
-      (couldSupportPPR || isInstantNavigationTest) &&
+      couldSupportPPR &&
       ((
         prerenderManifest.routes[normalizedSrcPage] ??
         prerenderManifest.dynamicRoutes[normalizedSrcPage]

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -186,8 +186,9 @@ async function requestHandler(
           nextConfig.experimental.maxPostponedStateSize
         ),
         exposeTestingApi:
-          pageRouteModule.isDev === true ||
-          nextConfig.experimental.exposeTestingApiInProductionBuild === true,
+          nextConfig.cacheComponents === true &&
+          (pageRouteModule.isDev === true ||
+            nextConfig.experimental.exposeTestingApiInProductionBuild === true),
       },
 
       incrementalCache: await pageRouteModule.getIncrementalCache(

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -616,9 +616,10 @@ export default abstract class Server<
           this.nextConfig.experimental.maxPostponedStateSize
         ),
         exposeTestingApi:
-          this.dev === true ||
-          this.nextConfig.experimental.exposeTestingApiInProductionBuild ===
-            true,
+          this.nextConfig.cacheComponents === true &&
+          (this.dev === true ||
+            this.nextConfig.experimental.exposeTestingApiInProductionBuild ===
+              true),
       },
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/app/target/loading.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/app/target/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div data-testid="loading-shell">Loading target page...</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/app/target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/app/target/page.tsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function TargetPage() {
+  await connection()
+
+  return <div data-testid="dynamic-content">Dynamic content loaded</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/no-cache-components/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    exposeTestingApiInProductionBuild: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1196,28 +1196,30 @@ describe('instant-navigation-testing-api', () => {
     expect(content).toContain('testCookie:')
   })
 })
-
-describe('instant-navigation-testing-api - without Cache Components', () => {
-  const { next } = nextTestSetup({
-    files: join(__dirname, 'fixtures', 'no-cache-components'),
-  })
-
-  it('does not enable instant navigation', async () => {
-    const page = await openPage(next, '/target')
-
-    const dynamicContent = page.locator('[data-testid="dynamic-content"]')
-    await dynamicContent.waitFor({ state: 'visible' })
-
-    await instant(page, async () => {
-      const response = await page.reload()
-      expect(response?.status()).toBe(200)
-
-      const loadingShell = page.locator('[data-testid="loading-shell"]')
-      expect(await loadingShell.count()).toBe(0)
-      await dynamicContent.waitFor({ state: 'visible' })
+;(process.env.__NEXT_CACHE_COMPONENTS === 'true' ? describe.skip : describe)(
+  'instant-navigation-testing-api - without Cache Components',
+  () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'fixtures', 'no-cache-components'),
     })
-  })
-})
+
+    it('does not enable instant navigation', async () => {
+      const page = await openPage(next, '/target')
+
+      const dynamicContent = page.locator('[data-testid="dynamic-content"]')
+      await dynamicContent.waitFor({ state: 'visible' })
+
+      await instant(page, async () => {
+        const response = await page.reload()
+        expect(response?.status()).toBe(200)
+
+        const loadingShell = page.locator('[data-testid="loading-shell"]')
+        expect(await loadingShell.count()).toBe(0)
+        await dynamicContent.waitFor({ state: 'visible' })
+      })
+    })
+  }
+)
 
 describe('instant-navigation-testing-api - root params', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1197,6 +1197,28 @@ describe('instant-navigation-testing-api', () => {
   })
 })
 
+describe('instant-navigation-testing-api - without Cache Components', () => {
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'fixtures', 'no-cache-components'),
+  })
+
+  it('does not enable instant navigation', async () => {
+    const page = await openPage(next, '/target')
+
+    const dynamicContent = page.locator('[data-testid="dynamic-content"]')
+    await dynamicContent.waitFor({ state: 'visible' })
+
+    await instant(page, async () => {
+      const response = await page.reload()
+      expect(response?.status()).toBe(200)
+
+      const loadingShell = page.locator('[data-testid="loading-shell"]')
+      expect(await loadingShell.count()).toBe(0)
+      await dynamicContent.waitFor({ state: 'visible' })
+    })
+  })
+})
+
 describe('instant-navigation-testing-api - root params', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'root-params'),


### PR DESCRIPTION
## Summary

The Instant Navigation testing API is only supported with Cache Components, but its testing cookie could previously force a non-Cache Components route into the legacy PPR rendering path. This can cause requests to fail because that path relies on React’s deprecated `unstable_postpone` API, which is unavailable in the stable React runtime.

This change couples testing API exposure and its client bundle machinery to Cache Components, removes the testing-only PPR capability override, and adds regression coverage confirming that the API remains inactive without Cache Components. Supported Instant Navigation behavior is unchanged.