### PR TITLE
Add fetchpriority prop for nextscript and gtm

### DIFF
--- a/packages/next/src/client/script.tsx
+++ b/packages/next/src/client/script.tsx
@@ -344,8 +344,14 @@ function Script(props: ScriptProps): JSX.Element | null {
                 integrity: restProps.integrity,
                 nonce,
                 crossOrigin: restProps.crossOrigin,
+                fetchPriority: restProps.fetchPriority,
               }
-            : { as: 'script', nonce, crossOrigin: restProps.crossOrigin }
+            : {
+                as: 'script',
+                nonce,
+                crossOrigin: restProps.crossOrigin,
+                fetchPriority: restProps.fetchPriority,
+              }
         )
         return (
           <script
@@ -369,8 +375,14 @@ function Script(props: ScriptProps): JSX.Element | null {
                 integrity: restProps.integrity,
                 nonce,
                 crossOrigin: restProps.crossOrigin,
+                fetchPriority: restProps.fetchPriority,
               }
-            : { as: 'script', nonce, crossOrigin: restProps.crossOrigin }
+            : {
+                as: 'script',
+                nonce,
+                crossOrigin: restProps.crossOrigin,
+                fetchPriority: restProps.fetchPriority,
+              }
         )
       }
     }

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -73,6 +73,11 @@ declare module 'react' {
   interface ImgHTMLAttributes<T> {
     fetchPriority?: 'high' | 'low' | 'auto' | undefined
   }
+  // <script fetchPriority=""> support
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- It's actually required for module augmentation to work.
+  interface ScriptHTMLAttributes<T> {
+    fetchPriority?: 'high' | 'low' | 'auto' | undefined
+  }
 }
 
 export type Redirect =

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -16,6 +16,7 @@ export function GoogleTagManager(props: GTMParams) {
     preview,
     dataLayer,
     nonce,
+    fetchPriority,
   } = props
 
   currDataLayerName = dataLayerName
@@ -69,6 +70,7 @@ export function GoogleTagManager(props: GTMParams) {
         data-ntpc="GTM"
         src={scriptUrl.href}
         nonce={nonce}
+        fetchPriority={fetchPriority}
       />
     </>
   )

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -18,6 +18,7 @@ type GTMParamsBaseParams = {
   auth?: string
   preview?: string
   nonce?: string
+  fetchPriority?: 'high' | 'low' | 'auto'
 }
 
 type GTMParamsWithId = GTMParamsBaseParams & {

--- a/test/e2e/app-dir/next-script/app/page.tsx
+++ b/test/e2e/app-dir/next-script/app/page.tsx
@@ -5,6 +5,7 @@ export default function Page() {
     <Script
       src="https://code.jquery.com/jquery-3.7.1.min.js"
       crossOrigin="use-credentials"
+      fetchPriority="low"
     />
   )
 }

--- a/test/e2e/app-dir/next-script/next-script.test.ts
+++ b/test/e2e/app-dir/next-script/next-script.test.ts
@@ -14,4 +14,14 @@ describe('Script component with crossOrigin props', () => {
 
     expect(crossorigin).toBe('use-credentials')
   })
+
+  it('should be set fetchPriority also in preload link tag', async () => {
+    const browser = await next.browser('/')
+
+    const fetchPriority = await browser
+      .elementByCss('link[href="https://code.jquery.com/jquery-3.7.1.min.js"]')
+      .getAttribute('fetchpriority')
+
+    expect(fetchPriority).toBe('low')
+  })
 })

--- a/test/e2e/app-dir/third-parties/app/gtm/page.tsx
+++ b/test/e2e/app-dir/third-parties/app/gtm/page.tsx
@@ -10,12 +10,12 @@ const Page = () => {
 
   return (
     <div className="container">
-      <GoogleTagManager gtmId="GTM-XYZ" />
+      <GoogleTagManager gtmId="GTM-XYZ" fetchPriority="low" />
       <h1>GTM</h1>
       <button id="gtm-send" onClick={onClick}>
         Click
       </button>
-      <GoogleTagManager gtmId="GTM-XYZ" />
+      <GoogleTagManager gtmId="GTM-XYZ" fetchPriority="low" />
     </div>
   )
 }

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -38,6 +38,18 @@ describe('@next/third-parties basic usage', () => {
       'script[src^="https://www.googletagmanager.com/gtm.js?id=GTM-XYZ"]'
     )
 
+    const scriptFetchPriority = await browser
+      .elementByCss('script#_next-gtm')
+      .getAttribute('fetchpriority')
+    expect(scriptFetchPriority).toBe('low')
+
+    const preloadFetchPriority = await browser
+      .elementByCss(
+        'link[href^="https://www.googletagmanager.com/gtm.js?id=GTM-XYZ"]'
+      )
+      .getAttribute('fetchpriority')
+    expect(preloadFetchPriority).toBe('low')
+
     const dataLayer = await browser.eval('window.dataLayer')
     expect(dataLayer.length).toBe(1)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

`next/script` (and `@next/third-parties`'s `GoogleTagManager`, which renders a `<Script>` under the hood) now forwards `fetchPriority` into the `ReactDOM.preload()` call it makes for `beforeInteractive`/`afterInteractive` scripts. Also adds a `ScriptHTMLAttributes` type augmentation, matching the existing one for `ImgHTMLAttributes`, so `fetchPriority` type-checks on `<Script>` regardless of the consumer's installed `@types/react` version.

### Why?

`fetchPriority` was already accepted as a prop and applied to the rendered `<script>` element, but never reached the `ReactDOM.preload()` options — `crossOrigin`, `integrity`, and `nonce` were all threaded through, `fetchPriority` wasn't. Since the browser reads request priority from the preload, not the eventual script tag, the actual network fetch always went out at default priority no matter what was passed.

Ultimately I had to manually append a script to the DOM with a low fetchpriority instead of utilizing next/script.

### How?

Added `fetchPriority: restProps.fetchPriority` to both `ReactDOM.preload()` call sites in `packages/next/src/client/script.tsx`, forwarded the prop through `GoogleTagManager` in `packages/third-parties/src/google/gtm.tsx`, and added the module augmentation in `packages/next/src/types.ts`.
