### PR TITLE
docs: present each Skill as steps in the AI agents guide

### DIFF
--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -180,7 +180,13 @@ After every edit, verify the page still works at runtime using the next-dev-loop
 
 ### `next-cache-components-adoption`
 
-The [`next-cache-components-adoption`](https://www.skills.sh/vercel/next.js/next-cache-components-adoption) Skill turns on [Cache Components](/docs/app/getting-started/caching) and resolves blocking routes until the app builds.
+The [`next-cache-components-adoption`](https://www.skills.sh/vercel/next.js/next-cache-components-adoption) Skill migrates an app to [Cache Components](/docs/app/getting-started/caching):
+
+1. Turns the flag on and finds the routes that can't prerender.
+2. Fixes them one feature at a time, checking in with you before moving on.
+3. Confirms a feature against `next dev` and `next build` before leaving it.
+
+You choose whether the work lands as a series of PRs or stays on one branch.
 
 ```bash filename="Terminal"
 npx skills add vercel/next.js --skill next-cache-components-adoption
@@ -194,21 +200,33 @@ Adopt Cache Components in this project using the next-cache-components-adoption 
 
 ### `next-cache-components-optimizer`
 
-The [`next-cache-components-optimizer`](https://www.skills.sh/vercel/next.js/next-cache-components-optimizer) Skill maximizes the meaningful UI available on an exact navigation and guards it with an `@next/playwright` `instant()` test.
+The [`next-cache-components-optimizer`](https://www.skills.sh/vercel/next.js/next-cache-components-optimizer) Skill takes a target route or set of routes and works toward the UI you want on screen at click time:
+
+1. Writes a failing [`instant()`](/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) test for the UI you named.
+2. Refactors the route until it passes, often by moving a data read below a `<Suspense>` boundary.
+3. Commits the passing test with the refactoring, so it catches future regressions.
+
+It needs a route that already builds with [Cache Components](/docs/app/getting-started/caching).
 
 ```bash filename="Terminal"
 npx skills add vercel/next.js --skill next-cache-components-optimizer
 ```
 
-For example, give the agent this prompt:
+Then give the agent a prompt like:
 
 ```prompt
-Make the navigation to `/settings` instant using the next-cache-components-optimizer Skill.
+Make the navigation from /settings to /dashboard instant using the next-cache-components-optimizer Skill. The header and the project list should be part of the instant UI.
 ```
 
 ### `next-partial-prefetching-adoption`
 
-The [`next-partial-prefetching-adoption`](https://www.skills.sh/vercel/next.js/next-partial-prefetching-adoption) Skill turns on [Partial Prefetching](/docs/app/guides/adopting-partial-prefetching) and resolves its insights until all routes reuse a shared App Shell.
+The [`next-partial-prefetching-adoption`](https://www.skills.sh/vercel/next.js/next-partial-prefetching-adoption) Skill moves an app onto [Partial Prefetching](/docs/app/guides/adopting-partial-prefetching), where links share one App Shell:
+
+1. Audits the existing `<Link prefetch={true}>` calls with you.
+2. Turns the flag on and resolves the insights it surfaces.
+3. Marks the routes whose URL data might be worth prefetching later.
+
+It needs [Cache Components](/docs/app/getting-started/caching) already adopted.
 
 ```bash filename="Terminal"
 npx skills add vercel/next.js --skill next-partial-prefetching-adoption

--- a/skills/next-cache-components-optimizer/SKILL.md
+++ b/skills/next-cache-components-optimizer/SKILL.md
@@ -87,13 +87,11 @@ trustworthy.
 
 ## Reporting to the user
 
-This loop is meant to run unattended — ideally across many navigations in one
-pass — so it doesn't stop to ask after each route. If the user names one route,
-finish it and stop. If they ask to make the app or its navigations instant, work
-the whole route queue without pausing between routes. What matters is how you
-word and present the results, not how often you
-interrupt. The mechanics below — the rig, RED, GREEN, the gates — are your
-scaffolding; the user never needs to hear those words.
+This loop is meant to run unattended, so it doesn't stop to ask between steps.
+Work the navigation the user named, finish it, and stop. What matters is how you
+word and present the results, not how often you interrupt. The mechanics below —
+the rig, RED, GREEN, the gates — are your scaffolding; the user never needs to
+hear those words.
 
 - **Speak their language.** Describe the gap and the result in terms of what the
   user sees: "navigating to the dashboard waited on the charts query before


### PR DESCRIPTION
Each Skill section was a prose paragraph that assumed you had read the ones above it. Reframe the three shipped Skills as a lead sentence, three steps, and a linked prerequisite, so landing on an anchor from search is enough.

Also drops the claim that the optimizer makes a route instant. It works one navigation toward the UI you decide should be there, and commits the passing test with the refactoring.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
