### PR TITLE
Make legacy PPR paths explicit

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -358,8 +358,8 @@ export type AppSharedContext = {
 }
 
 type AppRenderCapabilities = {
-  /** Whether this render may postpone dynamic subtrees. */
-  canPostpone: boolean
+  /** Whether this render uses legacy PPR and may call React.unstable_postpone. */
+  isLegacyPPR: boolean
   /**
    * Whether the response may contain postponed holes. This is conservatively
    * true for prerenders with PPR enabled, even when the response turns out to
@@ -3205,7 +3205,7 @@ async function renderToHTMLOrFlightImpl(
       renderOpts.cacheComponents
     ),
     {
-      canPostpone: false,
+      isLegacyPPR: false,
       isPossiblyPartialResponse: false,
       supportsPerSegmentPrefetching: renderOpts.cacheComponents,
     }
@@ -3246,9 +3246,7 @@ async function prerenderToHTMLOrFlightImpl(
       renderOpts.cacheComponents
     ),
     {
-      // These are distinct rendering and protocol properties even though they
-      // are both determined by route-level PPR support today.
-      canPostpone: isRoutePPREnabled,
+      isLegacyPPR: isRoutePPREnabled && !renderOpts.cacheComponents,
       isPossiblyPartialResponse: isRoutePPREnabled,
       supportsPerSegmentPrefetching: true,
     }
@@ -8177,7 +8175,7 @@ async function validateInstantConfigInBuildWithSample(
         outerCtx.renderOpts.cacheComponents
       ),
       renderCapabilities: {
-        canPostpone: false,
+        isLegacyPPR: false,
         isPossiblyPartialResponse: false,
         supportsPerSegmentPrefetching:
           outerCtx.renderCapabilities.supportsPerSegmentPrefetching,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -357,8 +357,8 @@ export type AppSharedContext = {
 }
 
 type AppRenderCapabilities = {
-  /** Whether this render may postpone dynamic subtrees. */
-  canPostpone: boolean
+  /** Whether this render uses legacy PPR and may call React.unstable_postpone. */
+  isLegacyPPR: boolean
   /**
    * Whether the response may contain postponed holes. This is conservatively
    * true for prerenders with PPR enabled, even when the response turns out to
@@ -3204,7 +3204,7 @@ async function renderToHTMLOrFlightImpl(
       renderOpts.cacheComponents
     ),
     {
-      canPostpone: false,
+      isLegacyPPR: false,
       isPossiblyPartialResponse: false,
       supportsPerSegmentPrefetching: renderOpts.cacheComponents,
     }
@@ -3245,9 +3245,7 @@ async function prerenderToHTMLOrFlightImpl(
       renderOpts.cacheComponents
     ),
     {
-      // These are distinct rendering and protocol properties even though they
-      // are both determined by route-level PPR support today.
-      canPostpone: isRoutePPREnabled,
+      isLegacyPPR: isRoutePPREnabled && !renderOpts.cacheComponents,
       isPossiblyPartialResponse: isRoutePPREnabled,
       supportsPerSegmentPrefetching: true,
     }
@@ -8183,7 +8181,7 @@ async function validateInstantConfigInBuildWithSample(
         outerCtx.renderOpts.cacheComponents
       ),
       renderCapabilities: {
-        canPostpone: false,
+        isLegacyPPR: false,
         isPossiblyPartialResponse: false,
         supportsPerSegmentPrefetching:
           outerCtx.renderCapabilities.supportsPerSegmentPrefetching,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -177,7 +177,7 @@ async function createComponentTreeInternal(
       createServerParamsForServerSegment,
       createPrerenderParamsForClientSegment,
       serverHooks: { DynamicServerError },
-      Postpone,
+      LegacyPostpone,
     },
     pagePath,
     getDynamicParamFromSegment,
@@ -186,7 +186,7 @@ async function createComponentTreeInternal(
     query,
   } = ctx
 
-  const { canPostpone, isPossiblyPartialResponse } = renderCapabilities
+  const { isLegacyPPR, isPossiblyPartialResponse } = renderCapabilities
 
   const { page, conventionPath, segment, modules, parallelRoutes } =
     parseLoaderTree(tree)
@@ -328,9 +328,9 @@ async function createComponentTreeInternal(
       workStore.forceDynamic = true
 
       // TODO: (PPR) remove this bailout once PPR is the default
-      if (isPrerendering && !canPostpone) {
-        // If the postpone API isn't available, we can't postpone the render and
-        // therefore we can't use the dynamic API.
+      if (isPrerendering && !isLegacyPPR) {
+        // Without legacy PPR, this route cannot postpone the render and
+        // therefore cannot use the dynamic API.
         const err = new DynamicServerError(
           `Page with \`dynamic = "force-dynamic"\` won't be rendered statically.`
         )
@@ -383,9 +383,9 @@ async function createComponentTreeInternal(
       !workStore.forceStatic &&
       isPrerendering &&
       defaultRevalidate === 0 &&
-      // If the postpone API isn't available, we can't postpone the render and
-      // therefore we can't use the dynamic API.
-      !canPostpone
+      // Without legacy PPR, this route cannot postpone the render and
+      // therefore cannot use the dynamic API.
+      !isLegacyPPR
     ) {
       const dynamicUsageDescription = `revalidate: 0 configured ${segment}`
       workStore.dynamicUsageDescription = dynamicUsageDescription
@@ -821,10 +821,9 @@ async function createComponentTreeInternal(
   }
 
   const Component = MaybeComponent
-  // If force-dynamic is used and the current render supports postponing, we
-  // replace it with a node that will postpone the render. This ensures that the
-  // postpone is invoked during the react render phase and not during the next
-  // render phase.
+  // If force-dynamic is used with legacy PPR, replace it with a node that will
+  // postpone the render. This ensures that postpone is invoked during the React
+  // render phase and not during the Next.js render phase.
   // @TODO this does not actually do what it seems like it would or should do. The idea is that
   // if we are rendering in a force-dynamic mode and we can postpone we should only make the segments
   // that ask for force-dynamic to be dynamic, allowing other segments to still prerender. However
@@ -832,7 +831,7 @@ async function createComponentTreeInternal(
   // along the parent path of a force-dynamic segment will hit this condition effectively making the entire
   // render force-dynamic. We should refactor this function so that we can correctly track which segments
   // need to be dynamic
-  if (canPostpone && workStore.forceDynamic) {
+  if (isLegacyPPR && workStore.forceDynamic) {
     return createTransportNode(
       ctx,
       transportSegment,
@@ -842,7 +841,7 @@ async function createComponentTreeInternal(
         {
           key: cacheNodeKey,
         },
-        createElement(Postpone, {
+        createElement(LegacyPostpone, {
           reason: 'dynamic = "force-dynamic" was used',
           route: workStore.route,
         }),

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -210,7 +210,7 @@ export function markCurrentScopeAsDynamic(
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender-ppr':
-        return postponeWithTracking(
+        return postponeWithTrackingForLegacyPPR(
           store.route,
           expression,
           workUnitStore.dynamicTracking
@@ -394,22 +394,23 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
 }
 
 /**
- * This component will call `React.postpone` that throws the postponed error.
+ * This legacy PPR component calls `React.unstable_postpone`, which throws the
+ * postponed value.
  */
-type PostponeProps = {
+type LegacyPostponeProps = {
   reason: string
   route: string
 }
-export function Postpone({ reason, route }: PostponeProps): never {
+export function LegacyPostpone({ reason, route }: LegacyPostponeProps): never {
   const prerenderStore = workUnitAsyncStorage.getStore()
   const dynamicTracking =
     prerenderStore && prerenderStore.type === 'prerender-ppr'
       ? prerenderStore.dynamicTracking
       : null
-  postponeWithTracking(route, reason, dynamicTracking)
+  postponeWithTrackingForLegacyPPR(route, reason, dynamicTracking)
 }
 
-export function postponeWithTracking(
+export function postponeWithTrackingForLegacyPPR(
   route: string,
   expression: string,
   dynamicTracking: null | DynamicTrackingState
@@ -672,7 +673,7 @@ export function useDynamicRouteParams(expression: string) {
       case 'prerender-ppr': {
         const fallbackParams = workUnitStore.fallbackRouteParams
         if (fallbackParams && fallbackParams.size > 0) {
-          return postponeWithTracking(
+          return postponeWithTrackingForLegacyPPR(
             workStore.route,
             expression,
             workUnitStore.dynamicTracking

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -63,7 +63,7 @@ export { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 
 export { preloadStyle, preloadFont, preconnect } from './rsc/preloads'
 export { isEmptyHTMLPrelude } from './postponed-state'
-export { Postpone } from './rsc/postpone'
+export { LegacyPostpone } from './rsc/postpone'
 export { taintObjectReference } from './rsc/taint'
 export {
   collectSegmentData,

--- a/packages/next/src/server/app-render/rsc/postpone.ts
+++ b/packages/next/src/server/app-render/rsc/postpone.ts
@@ -4,5 +4,5 @@ Files in the rsc directory are meant to be packaged as part of the RSC graph usi
 
 */
 
-// When postpone is available in canary React we can switch to importing it directly
-export { Postpone } from '../dynamic-rendering'
+// Legacy PPR packages this component into the RSC graph through entry-base.
+export { LegacyPostpone } from '../dynamic-rendering'

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -317,7 +317,11 @@ interface StaticPrerenderStoreCommon {
   readonly fallbackRouteParams: OpaqueFallbackRouteParams | null
 }
 
-export interface PrerenderStorePPR
+/**
+ * The legacy PPR prerender context. This is the only prerender context that
+ * may call `React.unstable_postpone`.
+ */
+export interface PrerenderStoreLegacyPPR
   extends CommonWorkUnitStore,
     RevalidateStore {
   readonly type: 'prerender-ppr'
@@ -345,7 +349,7 @@ export interface PrerenderStoreLegacy
 
 export type PrerenderStore =
   | PrerenderStoreLegacy
-  | PrerenderStorePPR
+  | PrerenderStoreLegacyPPR
   | PrerenderStoreModern
 
 // /** Like `PrerenderStoreModern`, but only including static prerenders (i.e. not runtime prerenders) */

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -302,7 +302,11 @@ interface StaticPrerenderStoreCommon {
   readonly fallbackRouteParams: OpaqueFallbackRouteParams | null
 }
 
-export interface PrerenderStorePPR
+/**
+ * The legacy PPR prerender context. This is the only prerender context that
+ * may call `React.unstable_postpone`.
+ */
+export interface PrerenderStoreLegacyPPR
   extends CommonWorkUnitStore,
     RevalidateStore {
   readonly type: 'prerender-ppr'
@@ -330,7 +334,7 @@ export interface PrerenderStoreLegacy
 
 export type PrerenderStore =
   | PrerenderStoreLegacy
-  | PrerenderStorePPR
+  | PrerenderStoreLegacyPPR
   | PrerenderStoreModern
 
 // /** Like `PrerenderStoreModern`, but only including static prerenders (i.e. not runtime prerenders) */

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -4,7 +4,7 @@ import {
   workUnitAsyncStorage,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -99,7 +99,7 @@ export function connection(): Promise<void> {
         case 'prerender-ppr':
           // We use React's postpone API to interrupt rendering here to create a
           // dynamic hole
-          return postponeWithTracking(
+          return postponeWithTrackingForLegacyPPR(
             workStore.route,
             'connection',
             workUnitStore.dynamicTracking

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -15,7 +15,7 @@ import {
   type RequestStore,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -84,7 +84,7 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
         case 'prerender-ppr':
           // We need track dynamic access here eagerly to keep continuity with
           // how cookies has worked in PPR without cacheComponents.
-          return postponeWithTracking(
+          return postponeWithTrackingForLegacyPPR(
             workStore.route,
             callingExpression,
             workUnitStore.dynamicTracking

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -12,7 +12,7 @@ import {
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -244,7 +244,7 @@ function trackDynamicDraftMode(expression: string, constructorOpt: Function) {
             `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
           )
         case 'prerender-ppr':
-          return postponeWithTracking(
+          return postponeWithTrackingForLegacyPPR(
             workStore.route,
             expression,
             workUnitStore.dynamicTracking

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -13,7 +13,7 @@ import {
   type RequestStore,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -110,7 +110,7 @@ export function headers(): Promise<ReadonlyHeaders> {
           // We are prerendering with PPR. We need track dynamic access here eagerly
           // to keep continuity with how headers has worked in PPR without cacheComponents.
           // TODO consider switching the semantic to throw on property access instead
-          return postponeWithTracking(
+          return postponeWithTrackingForLegacyPPR(
             workStore.route,
             callingExpression,
             workUnitStore.dynamicTracking

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -12,12 +12,12 @@ import {
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import {
   throwToInterruptStaticGeneration,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
 } from '../app-render/dynamic-rendering'
 
 import {
   workUnitAsyncStorage,
-  type PrerenderStorePPR,
+  type PrerenderStoreLegacyPPR,
   type PrerenderStoreLegacy,
   type StaticPrerenderStoreModern,
   type StaticPrerenderStore,
@@ -756,7 +756,7 @@ function makeErroringParams(
   underlyingParams: Params,
   fallbackParams: OpaqueFallbackRouteParams,
   workStore: WorkStore,
-  prerenderStore: PrerenderStorePPR | PrerenderStoreLegacy
+  prerenderStore: PrerenderStoreLegacyPPR | PrerenderStoreLegacy
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
@@ -788,7 +788,7 @@ function makeErroringParams(
             // will be no `dynamic = "error"`
             if (prerenderStore.type === 'prerender-ppr') {
               // PPR Prerender (no cacheComponents)
-              postponeWithTracking(
+              postponeWithTrackingForLegacyPPR(
                 workStore.route,
                 expression,
                 prerenderStore.dynamicTracking

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -12,12 +12,12 @@ import {
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import {
   throwToInterruptStaticGeneration,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
 } from '../app-render/dynamic-rendering'
 
 import {
   workUnitAsyncStorage,
-  type PrerenderStorePPR,
+  type PrerenderStoreLegacyPPR,
   type PrerenderStoreLegacy,
   type StaticPrerenderStoreModern,
   type StaticPrerenderStore,
@@ -768,7 +768,7 @@ function makeErroringParams(
   underlyingParams: Params,
   fallbackParams: OpaqueFallbackRouteParams,
   workStore: WorkStore,
-  prerenderStore: PrerenderStorePPR | PrerenderStoreLegacy
+  prerenderStore: PrerenderStoreLegacyPPR | PrerenderStoreLegacy
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
@@ -800,7 +800,7 @@ function makeErroringParams(
             // will be no `dynamic = "error"`
             if (prerenderStore.type === 'prerender-ppr') {
               // PPR Prerender (no cacheComponents)
-              postponeWithTracking(
+              postponeWithTrackingForLegacyPPR(
                 workStore.route,
                 expression,
                 prerenderStore.dynamicTracking

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -4,7 +4,7 @@ import {
 } from '../app-render/work-async-storage.external'
 
 import {
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   type DynamicTrackingState,
 } from '../app-render/dynamic-rendering'
 
@@ -13,7 +13,7 @@ import {
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
   type PrerenderStoreModernServer,
-  type PrerenderStorePPR,
+  type PrerenderStoreLegacyPPR,
 } from '../app-render/work-unit-async-storage.external'
 import {
   makeDynamicHangingPromise,
@@ -98,7 +98,7 @@ function createPrerenderPathname(
   workStore: WorkStore,
   prerenderStore:
     | PrerenderStoreLegacy
-    | PrerenderStorePPR
+    | PrerenderStoreLegacyPPR
     | PrerenderStoreModernServer
 ): Promise<string> {
   switch (prerenderStore.type) {
@@ -150,7 +150,7 @@ function makeErroringPathname<T>(
   promise.then = (onfulfilled, onrejected) => {
     if (reject) {
       try {
-        postponeWithTracking(
+        postponeWithTrackingForLegacyPPR(
           workStore.route,
           'metadata relative url resolving',
           dynamicTracking

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -1,6 +1,6 @@
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   throwToInterruptStaticGeneration,
 } from '../app-render/dynamic-rendering'
 import {
@@ -11,7 +11,7 @@ import {
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
   type PrerenderStoreModernServer,
-  type PrerenderStorePPR,
+  type PrerenderStoreLegacyPPR,
 } from '../app-render/work-unit-async-storage.external'
 import { makeFallbackParamsHangingPromise } from '../dynamic-rendering-utils'
 import type { ParamValue } from './params'
@@ -140,7 +140,7 @@ function createPrerenderRootParamPromise(
   paramName: string,
   workStore: WorkStore,
   prerenderStore:
-    | PrerenderStorePPR
+    | PrerenderStoreLegacyPPR
     | PrerenderStoreLegacy
     | PrerenderStoreModernServer,
   apiName: string
@@ -205,7 +205,7 @@ function createPrerenderRootParamPromise(
 async function makeErroringRootParamPromise(
   paramName: string,
   workStore: WorkStore,
-  prerenderStore: PrerenderStorePPR | PrerenderStoreLegacy,
+  prerenderStore: PrerenderStoreLegacyPPR | PrerenderStoreLegacy,
   apiName: string
 ): Promise<ParamValue> {
   const expression = describeStringPropertyAccess(apiName, paramName)
@@ -215,7 +215,7 @@ async function makeErroringRootParamPromise(
   // TODO: remove this comment when cacheComponents is the default since there will be no `dynamic = "error"`
   switch (prerenderStore.type) {
     case 'prerender-ppr': {
-      return postponeWithTracking(
+      return postponeWithTrackingForLegacyPPR(
         workStore.route,
         expression,
         prerenderStore.dynamicTracking

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -11,7 +11,7 @@ import {
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import {
   throwToInterruptStaticGeneration,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   annotateDynamicAccess,
 } from '../app-render/dynamic-rendering'
 import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
@@ -19,7 +19,7 @@ import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-st
 import {
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
-  type PrerenderStorePPR,
+  type PrerenderStoreLegacyPPR,
   type PrerenderStoreModern,
   type PrerenderStoreModernRuntime,
   type StaticPrerenderStore,
@@ -463,7 +463,7 @@ function makeHangingSearchParams(
 
 function makeErroringSearchParams(
   workStore: WorkStore,
-  prerenderStore: PrerenderStoreLegacy | PrerenderStorePPR
+  prerenderStore: PrerenderStoreLegacy | PrerenderStoreLegacyPPR
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(workStore)
   if (cachedSearchParams) {
@@ -495,7 +495,7 @@ function makeErroringSearchParams(
           )
         } else if (prerenderStore.type === 'prerender-ppr') {
           // PPR Prerender (no cacheComponents)
-          postponeWithTracking(
+          postponeWithTrackingForLegacyPPR(
             workStore.route,
             expression,
             prerenderStore.dynamicTracking

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -61,7 +61,7 @@ import { StaticGenBailoutError } from '../../../client/components/static-generat
 import { isStaticGenEnabled } from './helpers/is-static-gen-enabled'
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   createDynamicTrackingState,
   getFirstDynamicReason,
 } from '../../app-render/dynamic-rendering'
@@ -1476,7 +1476,7 @@ function trackDynamic(
           'A runtime prerender store should not be used for a route handler.'
         )
       case 'prerender-ppr':
-        return postponeWithTracking(
+        return postponeWithTrackingForLegacyPPR(
           store.route,
           expression,
           workUnitStore.dynamicTracking

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -95,7 +95,7 @@ import {
 } from './use-cache-errors'
 import {
   createHangingInputAbortSignal,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   throwToInterruptStaticGeneration,
 } from '../app-render/dynamic-rendering'
 import {
@@ -1859,7 +1859,7 @@ export async function cache(
           workUnitStore
         )
       case 'prerender-ppr':
-        return postponeWithTracking(
+        return postponeWithTrackingForLegacyPPR(
           workStore.route,
           expression,
           workUnitStore.dynamicTracking

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -95,7 +95,7 @@ import {
 } from './use-cache-errors'
 import {
   createHangingInputAbortSignal,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
   throwToInterruptStaticGeneration,
 } from '../app-render/dynamic-rendering'
 import {
@@ -1872,7 +1872,7 @@ export async function cache(
           workUnitStore
         )
       case 'prerender-ppr':
-        return postponeWithTracking(
+        return postponeWithTrackingForLegacyPPR(
           workStore.route,
           expression,
           workUnitStore.dynamicTracking

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -1,6 +1,6 @@
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
-  postponeWithTracking,
+  postponeWithTrackingForLegacyPPR,
 } from '../../app-render/dynamic-rendering'
 import { isDynamicRoute } from '../../../shared/lib/router/utils'
 import {
@@ -177,7 +177,7 @@ function revalidate(
           `${expression} must not be used within a client component. Next.js should be preventing ${expression} from being included in client components statically, but did not in this case.`
         )
       case 'prerender-ppr':
-        return postponeWithTracking(
+        return postponeWithTrackingForLegacyPPR(
           store.route,
           expression,
           workUnitStore.dynamicTracking

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -318,13 +318,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSearchParams (webpack:///<next-src>)
                      at UseSearchParams (webpack:///app/client-hook-abort-reasons/client.tsx:27:18)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-search-params/[id]/page.tsx:8:7)
-                   728 |       return
-                   729 |     case 'prerender-client': {
-                 > 730 |       React.use(
+                   729 |       return
+                   730 |     case 'prerender-client': {
+                 > 731 |       React.use(
                        |             ^
-                   731 |         makeClientHookHangingPromise(
-                   732 |           workUnitStore.renderSignal,
-                   733 |           new ClientHookDynamicError(workStore.route, expression) {
+                   732 |         makeClientHookHangingPromise(
+                   733 |           workUnitStore.renderSignal,
+                   734 |           new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-search-params/[id]" in your browser to investigate the error.
@@ -608,13 +608,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at usePathname (webpack:///<next-src>)
                      at UsePathname (webpack:///app/client-hook-abort-reasons/client.tsx:22:14)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-pathname/[id]/page.tsx:7:7)
-                   657 |           // hang here and never resolve. This will cause the currently
-                   658 |           // rendering component to effectively be a dynamic hole.
-                 > 659 |           React.use(
+                   658 |           // hang here and never resolve. This will cause the currently
+                   659 |           // rendering component to effectively be a dynamic hole.
+                 > 660 |           React.use(
                        |                 ^
-                   660 |             makeClientHookHangingPromise(
-                   661 |               workUnitStore.renderSignal,
-                   662 |               new ClientHookDynamicError(workStore.route, expression) {
+                   661 |             makeClientHookHangingPromise(
+                   662 |               workUnitStore.renderSignal,
+                   663 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-pathname/[id]" in your browser to investigate the error.
@@ -898,13 +898,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-params/[id]/page.tsx:8:7)
-                   657 |           // hang here and never resolve. This will cause the currently
-                   658 |           // rendering component to effectively be a dynamic hole.
-                 > 659 |           React.use(
+                   658 |           // hang here and never resolve. This will cause the currently
+                   659 |           // rendering component to effectively be a dynamic hole.
+                 > 660 |           React.use(
                        |                 ^
-                   660 |             makeClientHookHangingPromise(
-                   661 |               workUnitStore.renderSignal,
-                   662 |               new ClientHookDynamicError(workStore.route, expression) {
+                   661 |             makeClientHookHangingPromise(
+                   662 |               workUnitStore.renderSignal,
+                   663 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-params/[id]" in your browser to investigate the error.
@@ -1188,13 +1188,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegments (webpack:///<next-src>)
                      at UseSelectedLayoutSegments (webpack:///app/client-hook-abort-reasons/client.tsx:37:28)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]/page.tsx:7:7)
-                   657 |           // hang here and never resolve. This will cause the currently
-                   658 |           // rendering component to effectively be a dynamic hole.
-                 > 659 |           React.use(
+                   658 |           // hang here and never resolve. This will cause the currently
+                   659 |           // rendering component to effectively be a dynamic hole.
+                 > 660 |           React.use(
                        |                 ^
-                   660 |             makeClientHookHangingPromise(
-                   661 |               workUnitStore.renderSignal,
-                   662 |               new ClientHookDynamicError(workStore.route, expression) {
+                   661 |             makeClientHookHangingPromise(
+                   662 |               workUnitStore.renderSignal,
+                   663 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]" in your browser to investigate the error.
@@ -1478,13 +1478,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   657 |           // hang here and never resolve. This will cause the currently
-                   658 |           // rendering component to effectively be a dynamic hole.
-                 > 659 |           React.use(
+                   658 |           // hang here and never resolve. This will cause the currently
+                   659 |           // rendering component to effectively be a dynamic hole.
+                 > 660 |           React.use(
                        |                 ^
-                   660 |             makeClientHookHangingPromise(
-                   661 |               workUnitStore.renderSignal,
-                   662 |               new ClientHookDynamicError(workStore.route, expression) {
+                   661 |             makeClientHookHangingPromise(
+                   662 |               workUnitStore.renderSignal,
+                   663 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]" in your browser to investigate the error.
@@ -2198,13 +2198,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-params/[id]/page.tsx:7:7)
-                   657 |           // hang here and never resolve. This will cause the currently
-                   658 |           // rendering component to effectively be a dynamic hole.
-                 > 659 |           React.use(
+                   658 |           // hang here and never resolve. This will cause the currently
+                   659 |           // rendering component to effectively be a dynamic hole.
+                 > 660 |           React.use(
                        |                 ^
-                   660 |             makeClientHookHangingPromise(
-                   661 |               workUnitStore.renderSignal,
-                   662 |               new ClientHookDynamicError(workStore.route, expression) {
+                   661 |             makeClientHookHangingPromise(
+                   662 |               workUnitStore.renderSignal,
+                   663 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-params/[id]" in your browser to investigate the error.
@@ -2697,13 +2697,13 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   657 |           // hang here and never resolve. This will cause the currently
-                   658 |           // rendering component to effectively be a dynamic hole.
-                 > 659 |           React.use(
+                   658 |           // hang here and never resolve. This will cause the currently
+                   659 |           // rendering component to effectively be a dynamic hole.
+                 > 660 |           React.use(
                        |                 ^
-                   660 |             makeClientHookHangingPromise(
-                   661 |               workUnitStore.renderSignal,
-                   662 |               new ClientHookDynamicError(workStore.route, expression) {
+                   661 |             makeClientHookHangingPromise(
+                   662 |               workUnitStore.renderSignal,
+                   663 |               new ClientHookDynamicError(workStore.route, expression) {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]" in your browser to investigate the error.


### PR DESCRIPTION
## Summary

Make the remaining legacy PPR implementation explicit by renaming the render capability, prerender store, component, and tracking helper around `React.unstable_postpone`.

`isLegacyPPR` is only enabled for route-level PPR without Cache Components. The existing `prerender-ppr` work-unit discriminator and rendering behavior are preserved, making this deprecated path easier to audit and eventually remove.