### PR TITLE
Trace App Router RSC rendering

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1466,5 +1466,6 @@
   "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1468": "Missing workUnitStore in createComponentTree"
+  "1468": "Missing workUnitStore in createComponentTree",
+  "1469": "%s stream closed before completion"
 }

--- a/packages/next/src/server/app-render/app-render-prerender-utils.test.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.test.ts
@@ -1,5 +1,9 @@
 import { PassThrough } from 'node:stream'
-import { ReplayableNodeStream } from './app-render-prerender-utils'
+import {
+  createTrackedStream,
+  ReplayableNodeStream,
+  trackWebStreamCompletion,
+} from './app-render-prerender-utils'
 
 function collectBytes(
   stream: import('node:stream').Readable
@@ -17,6 +21,117 @@ function tick(): Promise<void> {
 }
 
 describe('ReplayableNodeStream', () => {
+  describe('tracked source completion', () => {
+    it('reports a clean end once', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      await createTrackedStream(() => source, onComplete)
+
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.resume()
+      source.end()
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith()
+    })
+
+    it('attaches completion listeners before a direct stream ends on the next tick', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      const trackedSource = createTrackedStream(() => {
+        process.nextTick(() => source.end())
+        return source
+      }, onComplete)
+
+      expect(trackedSource).toBe(source)
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.resume()
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith()
+    })
+
+    it('reports source errors once', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      await createTrackedStream(() => source, onComplete)
+
+      const error = new Error('RSC render failed')
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.destroy(error)
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+
+    it('attaches error listeners before a direct stream errors on the next tick', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      const error = new Error('RSC render failed')
+      const trackedSource = createTrackedStream(() => {
+        process.nextTick(() => source.destroy(error))
+        return source
+      }, onComplete)
+
+      expect(trackedSource).toBe(source)
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+
+    it('rejects replay consumers when the source closes prematurely', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      const trackedSource = await createTrackedStream(() => source, onComplete)
+      const replayable = new ReplayableNodeStream(trackedSource)
+      const replayResult = collectBytes(replayable.createReplayStream())
+
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.destroy()
+      await closed
+
+      await expect(replayResult).rejects.toEqual(
+        expect.objectContaining({ name: 'AbortError' })
+      )
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({
+        error: expect.objectContaining({ name: 'AbortError' }),
+      })
+      expect((replayable as any)._subscribers.size).toBe(0)
+    })
+
+    it('reports synchronous stream creation failures', () => {
+      const onComplete = jest.fn()
+      const error = new Error('RSC render failed')
+
+      expect(() =>
+        createTrackedStream(() => {
+          throw error
+        }, onComplete)
+      ).toThrow(error)
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+
+    it('reports asynchronous stream creation failures', async () => {
+      const onComplete = jest.fn()
+      const error = new Error('RSC render failed')
+
+      await expect(
+        createTrackedStream(() => Promise.reject(error), onComplete)
+      ).rejects.toBe(error)
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+  })
+
   describe('construction and buffering', () => {
     it('buffers Uint8Array chunks from the source', async () => {
       const source = new PassThrough()
@@ -387,6 +502,62 @@ describe('ReplayableNodeStream', () => {
         [1, 2],
         [3, 4],
       ])
+    })
+  })
+})
+
+describe('trackWebStreamCompletion', () => {
+  it('forwards chunks and reports a clean end', async () => {
+    const onComplete = jest.fn()
+    const stream = trackWebStreamCompletion(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          controller.close()
+        },
+      }),
+      onComplete
+    )
+
+    const reader = stream.getReader()
+    expect(await reader.read()).toEqual({
+      done: false,
+      value: new Uint8Array([1, 2, 3]),
+    })
+    expect(await reader.read()).toEqual({ done: true, value: undefined })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(onComplete).toHaveBeenCalledWith()
+  })
+
+  it('reports source errors', async () => {
+    const onComplete = jest.fn()
+    const error = new Error('RSC render failed')
+    const stream = trackWebStreamCompletion(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          throw error
+        },
+      }),
+      onComplete
+    )
+
+    await expect(stream.getReader().read()).rejects.toBe(error)
+    expect(onComplete).toHaveBeenCalledWith({ error })
+  })
+
+  it('reports cancellation as an abort', async () => {
+    const onComplete = jest.fn()
+    const cancel = jest.fn()
+    const stream = trackWebStreamCompletion(
+      new ReadableStream<Uint8Array>({ cancel }, { highWaterMark: 0 }),
+      onComplete
+    )
+
+    await stream.cancel('not needed')
+
+    expect(cancel).toHaveBeenCalledWith('not needed')
+    expect(onComplete).toHaveBeenCalledWith({
+      error: expect.objectContaining({ name: 'AbortError' }),
     })
   })
 })

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -2,6 +2,8 @@ import type { Readable } from 'node:stream'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 export type AnyStream = ReadableStream<Uint8Array> | Readable
+export type StreamCompletion = { error: unknown }
+type OnStreamComplete = (completion?: StreamCompletion) => void
 
 function isWebStream(stream: AnyStream): stream is ReadableStream<Uint8Array> {
   return typeof (stream as ReadableStream).tee === 'function'
@@ -133,6 +135,17 @@ export class ReplayableNodeStream {
       }
       this._subscribers.clear()
     })
+
+    stream.on('close', () => {
+      if (!this._done && !this._error) {
+        const error = createPrematureStreamCloseError('RSC')
+        this._error = error
+        for (const sub of this._subscribers) {
+          sub.onError(error)
+        }
+        this._subscribers.clear()
+      }
+    })
   }
 
   /**
@@ -230,6 +243,136 @@ export class ReplayableNodeStream {
   dispose(): void {
     this._chunks = null
   }
+}
+
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => T,
+  onComplete: OnStreamComplete
+): T
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => Promise<T>,
+  onComplete: OnStreamComplete
+): Promise<T>
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => T | Promise<T>,
+  onComplete: OnStreamComplete
+): T | Promise<T>
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => T | Promise<T>,
+  onComplete: OnStreamComplete
+): T | Promise<T> {
+  let stream: T | Promise<T>
+  try {
+    stream = createStream()
+  } catch (error) {
+    onComplete({ error })
+    throw error
+  }
+
+  if (isThenable(stream)) {
+    return stream.then(
+      (resolvedStream) => trackStreamCompletion(resolvedStream, onComplete),
+      (error) => {
+        onComplete({ error })
+        throw error
+      }
+    )
+  }
+
+  return trackStreamCompletion(stream, onComplete)
+}
+
+function isThenable<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>).then === 'function'
+}
+
+function trackStreamCompletion<T extends AnyStream>(
+  stream: T,
+  onComplete: OnStreamComplete
+): T {
+  if (isWebStream(stream)) {
+    return trackWebStreamCompletion(stream, onComplete) as T
+  }
+
+  trackNodeStreamCompletion(stream, onComplete)
+  return stream
+}
+
+function trackNodeStreamCompletion(
+  stream: Readable,
+  onComplete: OnStreamComplete
+): void {
+  const complete = createOneShotCompletion(onComplete)
+
+  stream.on('end', () => complete())
+  stream.on('error', (error) => complete({ error }))
+  stream.on('close', () => {
+    if (!stream.readableEnded && !stream.errored) {
+      complete({ error: createPrematureStreamCloseError('RSC') })
+    }
+  })
+}
+
+/**
+ * Ends the render phase when the RSC source stream finishes producing without
+ * eagerly reading from the stream or adding another buffer.
+ */
+export function trackWebStreamCompletion(
+  stream: ReadableStream<Uint8Array>,
+  onComplete: OnStreamComplete
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader()
+  const complete = createOneShotCompletion(onComplete)
+
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        let result: ReadableStreamReadResult<Uint8Array>
+        try {
+          result = await reader.read()
+        } catch (error) {
+          complete({ error })
+          controller.error(error)
+          return
+        }
+
+        if (result.done) {
+          complete()
+          controller.close()
+        } else {
+          controller.enqueue(result.value)
+        }
+      },
+      cancel(reason) {
+        complete({ error: createPrematureStreamCloseError('RSC') })
+        return reader.cancel(reason)
+      },
+    },
+    { highWaterMark: 0 }
+  )
+}
+
+function createOneShotCompletion(
+  onComplete: OnStreamComplete
+): OnStreamComplete {
+  let isComplete = false
+  return (completion) => {
+    if (isComplete) {
+      return
+    }
+    isComplete = true
+    if (completion) {
+      onComplete(completion)
+    } else {
+      onComplete()
+    }
+  }
+}
+
+function createPrematureStreamCloseError(streamName: string): Error {
+  const error = new Error(`${streamName} stream closed before completion`)
+  error.name = 'AbortError'
+  return error
 }
 
 export type ReactServerPrerenderResolveToType = {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -116,6 +116,7 @@ import {
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
+import { createOneShotTracePhase } from '../lib/trace/phase'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
@@ -234,6 +235,7 @@ import {
   createReactServerPrerenderResult,
   ReactServerResult,
   ReplayableNodeStream,
+  createTrackedStream,
   createReactServerPrerenderResultFromRender,
 } from './app-render-prerender-utils'
 import {
@@ -966,19 +968,21 @@ async function generateDynamicFlightRenderResult(
       options
     )
 
-    const flightStream = workUnitAsyncStorage.run(
-      requestStore,
-      renderToNodeFlightStream,
-      ctx.componentMod,
-      rscPayload,
-      clientModules,
-      {
-        onError,
-        temporaryReferences: options?.temporaryReferences,
-        filterStackFrame,
-        debugChannel: debugChannel?.serverSide,
-        signal: requestAbortSignal,
-      }
+    const flightStream = createTrackedRSCStream(() =>
+      workUnitAsyncStorage.run(
+        requestStore,
+        renderToNodeFlightStream,
+        ctx.componentMod,
+        rscPayload,
+        clientModules,
+        {
+          onError,
+          temporaryReferences: options?.temporaryReferences,
+          filterStackFrame,
+          debugChannel: debugChannel?.serverSide,
+          signal: requestAbortSignal,
+        }
+      )
     )
 
     return new FlightRenderResult(
@@ -1002,19 +1006,21 @@ async function generateDynamicFlightRenderResult(
       options
     )
 
-    const flightStream = workUnitAsyncStorage.run(
-      requestStore,
-      renderToWebFlightStream,
-      ctx.componentMod,
-      rscPayload,
-      clientModules,
-      {
-        onError,
-        temporaryReferences: options?.temporaryReferences,
-        filterStackFrame,
-        debugChannel: debugChannel?.serverSide,
-        signal: requestAbortSignal,
-      }
+    const flightStream = createTrackedRSCStream(() =>
+      workUnitAsyncStorage.run(
+        requestStore,
+        renderToWebFlightStream,
+        ctx.componentMod,
+        rscPayload,
+        clientModules,
+        {
+          onError,
+          temporaryReferences: options?.temporaryReferences,
+          filterStackFrame,
+          debugChannel: debugChannel?.serverSide,
+          signal: requestAbortSignal,
+        }
+      )
     )
 
     return new FlightRenderResult(
@@ -1150,14 +1156,17 @@ async function generateStagedDynamicFlightRenderResultNode(
     () => {
       stageController.advanceStage(RenderStage.ShellStatic)
 
-      const sourceStream = workUnitAsyncStorage.run(
-        requestStore,
-        renderToNodeFlightStream,
-        ctx.componentMod,
-        rscPayload,
-        clientModules,
-        { onError, filterStackFrame }
-      ) as Readable
+      const sourceStream = createTrackedRSCStream(
+        () =>
+          workUnitAsyncStorage.run(
+            requestStore,
+            renderToNodeFlightStream,
+            ctx.componentMod,
+            rscPayload,
+            clientModules,
+            { onError, filterStackFrame }
+          ) as Readable
+      )
 
       const replayable = new ReplayableNodeStream(sourceStream)
       const dynamicStream = replayable.createReplayStream()
@@ -1303,16 +1312,18 @@ async function stagedRenderWithoutCachesInDevNode(
     () => {
       stageController.advanceStage(RenderStage.ShellStatic)
 
-      return workUnitAsyncStorage.run(
-        requestStore,
-        renderToNodeFlightStream,
-        ctx.componentMod,
-        rscPayload,
-        clientModules,
-        {
-          ...options,
-          environmentName,
-        }
+      return createTrackedRSCStream(() =>
+        workUnitAsyncStorage.run(
+          requestStore,
+          renderToNodeFlightStream,
+          ctx.componentMod,
+          rscPayload,
+          clientModules,
+          {
+            ...options,
+            environmentName,
+          }
+        )
       )
     },
     () => {
@@ -1947,17 +1958,19 @@ async function finalRuntimeServerPrerender(
     async () => {
       finalStageController.advanceStage(RenderStage.ShellStatic)
 
-      let stream = workUnitAsyncStorage.run(
-        finalServerPrerenderStore,
-        ComponentMod.renderToReadableStream,
-        finalRSCPayload,
-        clientModules,
-        {
-          filterStackFrame,
-          onError,
-          signal: finalServerController.signal,
-          debugChannel,
-        }
+      const stream = createTrackedRSCStream(() =>
+        workUnitAsyncStorage.run(
+          finalServerPrerenderStore,
+          ComponentMod.renderToReadableStream,
+          finalRSCPayload,
+          clientModules,
+          {
+            filterStackFrame,
+            onError,
+            signal: finalServerController.signal,
+            debugChannel,
+          }
+        )
       )
 
       // Note: this await will only resolve after the last task (unless sync IO aborts the render earlier)
@@ -3498,6 +3511,30 @@ type RSCInitialPayloadPartialDev = {
   c?: InitialRSCPayload['c']
 }
 
+/**
+ * Traces React's RSC stream production only. Payload preparation happens
+ * before this boundary, and response delivery happens after it.
+ */
+function createTrackedRSCStream<T extends AnyStream>(createStream: () => T): T
+function createTrackedRSCStream<T extends AnyStream>(
+  createStream: () => Promise<T>
+): Promise<T>
+function createTrackedRSCStream<T extends AnyStream>(
+  createStream: () => T | Promise<T>
+): T | Promise<T> {
+  if (!isRequestInsightsEnabled() && process.env.NEXT_OTEL_VERBOSE !== '1') {
+    return createStream()
+  }
+
+  return createTrackedStream(
+    createStream,
+    createOneShotTracePhase(
+      AppRenderSpan.renderRSCResponse,
+      'render RSC response'
+    )
+  )
+}
+
 async function renderToStream(
   requestStore: RequestStore,
   req: BaseNextRequest,
@@ -3781,17 +3818,18 @@ async function renderToStream(
 
           const debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
-          const serverStream = await stagedRenderWithoutCachesInDevNode(
-            ctx,
-            requestStore,
-            getPayload,
-            {
-              onError: serverComponentsErrorHandler,
-              filterStackFrame,
-              debugChannel: debugChannel?.serverSide,
-            }
+          reactServerResult = new ReactServerResult(
+            await stagedRenderWithoutCachesInDevNode(
+              ctx,
+              requestStore,
+              getPayload,
+              {
+                onError: serverComponentsErrorHandler,
+                filterStackFrame,
+                debugChannel: debugChannel?.serverSide,
+              }
+            )
           )
-          reactServerResult = new ReactServerResult(serverStream)
 
           if (debugChannel) {
             debugChannelClientStream = new ReplayableNodeStream(
@@ -3906,17 +3944,20 @@ async function renderToStream(
           () => {
             stageController.advanceStage(RenderStage.ShellStatic)
 
-            const stream = workUnitAsyncStorage.run(
-              requestStore,
-              renderToNodeFlightStream,
-              ctx.componentMod,
-              RSCPayload,
-              clientModules,
-              {
-                onError: serverComponentsErrorHandler,
-                filterStackFrame,
-              }
-            ) as Readable
+            const stream = createTrackedRSCStream(
+              () =>
+                workUnitAsyncStorage.run(
+                  requestStore,
+                  renderToNodeFlightStream,
+                  ctx.componentMod,
+                  RSCPayload,
+                  clientModules,
+                  {
+                    onError: serverComponentsErrorHandler,
+                    filterStackFrame,
+                  }
+                ) as Readable
+            )
 
             const replayable = new ReplayableNodeStream(stream)
             const dynamicStream = replayable.createReplayStream()
@@ -3984,17 +4025,19 @@ async function renderToStream(
           }
 
           reactServerResult = new ReactServerResult(
-            workUnitAsyncStorage.run(
-              requestStore,
-              renderToNodeFlightStream,
-              ctx.componentMod,
-              RSCPayload,
-              clientModules,
-              {
-                filterStackFrame,
-                onError: serverComponentsErrorHandler,
-                debugChannel: debugChannel?.serverSide,
-              }
+            createTrackedRSCStream(() =>
+              workUnitAsyncStorage.run(
+                requestStore,
+                renderToNodeFlightStream,
+                ctx.componentMod,
+                RSCPayload,
+                clientModules,
+                {
+                  filterStackFrame,
+                  onError: serverComponentsErrorHandler,
+                  debugChannel: debugChannel?.serverSide,
+                }
+              )
             )
           )
         } else {
@@ -4026,17 +4069,19 @@ async function renderToStream(
           }
 
           reactServerResult = new ReactServerResult(
-            workUnitAsyncStorage.run(
-              requestStore,
-              renderToWebFlightStream,
-              ctx.componentMod,
-              RSCPayload,
-              clientModules,
-              {
-                filterStackFrame,
-                onError: serverComponentsErrorHandler,
-                debugChannel: debugChannel?.serverSide,
-              }
+            createTrackedRSCStream(() =>
+              workUnitAsyncStorage.run(
+                requestStore,
+                renderToWebFlightStream,
+                ctx.componentMod,
+                RSCPayload,
+                clientModules,
+                {
+                  filterStackFrame,
+                  onError: serverComponentsErrorHandler,
+                  debugChannel: debugChannel?.serverSide,
+                }
+              )
             )
           )
         }
@@ -4045,7 +4090,11 @@ async function renderToStream(
       // React doesn't start rendering synchronously but we want the RSC render to have a chance to start
       // before we begin SSR rendering because we want to capture any available preload headers so we tick
       // one task before continuing
-      await waitAtLeastOneReactRenderTask()
+      await getTracer().trace(
+        AppRenderSpan.waitForRSC,
+        { spanName: 'wait for RSC render task' },
+        waitAtLeastOneReactRenderTask
+      )
 
       // MARK: nodeStreams HTML
       if (process.env.__NEXT_USE_NODE_STREAMS) {
@@ -5562,23 +5611,25 @@ async function streamStagedRenderInDev({
       stageController.advanceStage(RenderStage.ShellStatic)
       startTime = performance.now() + performance.timeOrigin
 
-      const replayable = new ReplayableNodeStream(
-        workUnitAsyncStorage.run(
-          requestStore,
-          renderToNodeFlightStream,
-          ComponentMod,
-          rscPayload,
-          clientModules,
-          {
-            onError,
-            environmentName,
-            startTime,
-            filterStackFrame,
-            debugChannel: debugChannel?.serverSide,
-            signal: requestAbortSignal,
-          }
-        ) as Readable
+      const sourceStream = createTrackedRSCStream(
+        () =>
+          workUnitAsyncStorage.run(
+            requestStore,
+            renderToNodeFlightStream,
+            ComponentMod,
+            rscPayload,
+            clientModules,
+            {
+              onError,
+              environmentName,
+              startTime,
+              filterStackFrame,
+              debugChannel: debugChannel?.serverSide,
+              signal: requestAbortSignal,
+            }
+          ) as Readable
       )
+      const replayable = new ReplayableNodeStream(sourceStream)
 
       streamReady.resolve({
         stream: replayable.createReplayStream(),

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -85,6 +85,8 @@ enum RenderSpan {
 enum AppRenderSpan {
   prepareAppPageResponse = 'AppRender.prepareAppPageResponse',
   initializeRender = 'AppRender.initializeRender',
+  renderRSCResponse = 'AppRender.renderRSCResponse',
+  waitForRSC = 'AppRender.waitForRSC',
   renderToString = 'AppRender.renderToString',
   renderToReadableStream = 'AppRender.renderToReadableStream',
   getBodyResult = 'AppRender.getBodyResult',

--- a/packages/next/src/server/lib/trace/phase.ts
+++ b/packages/next/src/server/lib/trace/phase.ts
@@ -1,0 +1,53 @@
+import type { SpanTypes } from './constants'
+import { getTracer, SpanStatusCode } from './tracer'
+
+export type TracePhaseCompletion = { error: unknown }
+export type FinishTracePhase = (completion?: TracePhaseCompletion) => void
+
+export function createOneShotTracePhase(
+  type: SpanTypes,
+  spanName: string
+): FinishTracePhase {
+  if (
+    !process.env.__NEXT_REQUEST_INSIGHTS &&
+    process.env.NEXT_OTEL_VERBOSE !== '1'
+  ) {
+    return () => {}
+  }
+
+  const tracer = getTracer()
+  const startTime = performance.timeOrigin + performance.now()
+  const parentSpan = tracer.getActiveScopeSpan()
+  let isFinished = false
+
+  return (completion) => {
+    if (isFinished) {
+      return
+    }
+    isFinished = true
+
+    tracer.trace(
+      type,
+      {
+        startTime,
+        parentSpan,
+        spanName,
+      },
+      (span) => {
+        if (!completion) {
+          return
+        }
+
+        const { error } = completion
+        if (error instanceof Error) {
+          span?.recordException(error)
+          span?.setAttribute('error.type', error.name)
+        }
+        span?.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : undefined,
+        })
+      }
+    )
+  }
+}

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '@opentelemetry/api'
 import type { WorkStore } from '../../app-render/work-async-storage.external'
 import type { WorkUnitStore } from '../../app-render/work-unit-async-storage.external'
+import { PassThrough } from 'node:stream'
 import {
   ROOT_CONTEXT,
   context,
@@ -30,12 +31,19 @@ import {
   NextNodeServerSpan,
   NodeSpan,
 } from './constants'
+import { createOneShotTracePhase } from './phase'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
+import {
+  createTrackedStream,
+  ReactServerResult,
+  type AnyStream,
+} from '../../app-render/app-render-prerender-utils'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const originalOtelVerbose = process.env.NEXT_OTEL_VERBOSE
+const originalUseNodeStreams = process.env.__NEXT_USE_NODE_STREAMS
 const spanRecords: SpanStoreRecord[] = []
 
 function getSpanRecords(filter: { name?: string } = {}): SpanStoreRecord[] {
@@ -186,6 +194,11 @@ describe('local span recording', () => {
     } else {
       process.env.NEXT_OTEL_VERBOSE = originalOtelVerbose
     }
+    if (originalUseNodeStreams === undefined) {
+      delete process.env.__NEXT_USE_NODE_STREAMS
+    } else {
+      process.env.__NEXT_USE_NODE_STREAMS = originalUseNodeStreams
+    }
     context.disable()
     trace.disable()
     setSpanRecorderForTest(undefined)
@@ -199,6 +212,150 @@ describe('local span recording', () => {
 
     expect(result).toBe('result')
     expect(getSpanRecords()).toEqual([])
+  })
+
+  it('does not create internal phases when their recording modes are disabled', () => {
+    const finishPhase = createOneShotTracePhase(
+      AppRenderSpan.initializeRender,
+      'initialize app render'
+    )
+
+    finishPhase()
+
+    expect(getSpanRecords()).toEqual([])
+  })
+
+  it('records a one-shot phase with its captured parent and elapsed timing', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    let finishPhase: ReturnType<typeof createOneShotTracePhase>
+
+    getTracer().trace(BaseServerSpan.render, () => {
+      finishPhase = createOneShotTracePhase(
+        AppRenderSpan.initializeRender,
+        'initialize app render'
+      )
+    })
+
+    finishPhase!()
+    finishPhase!()
+
+    const parentSpan = getSpanRecords({ name: BaseServerSpan.render })[0]
+    const phaseSpans = getSpanRecords({ name: 'initialize app render' })
+    expect(phaseSpans).toHaveLength(1)
+    expect(phaseSpans[0]).toEqual(
+      expect.objectContaining({
+        startTime: expect.any(Number),
+        durationMs: expect.any(Number),
+        parentSpanId: parentSpan.spanId,
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_name': 'initialize app render',
+          'next.span_type': AppRenderSpan.initializeRender,
+        }),
+      })
+    )
+    expect(phaseSpans[0].startTime).toBeLessThanOrEqual(parentSpan.timestamp)
+    expect(phaseSpans[0].durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('records Error and non-Error phase failures without throwing them', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const finishErrorPhase = createOneShotTracePhase(
+      AppRenderSpan.prepareAppPageResponse,
+      'prepare app page response'
+    )
+    finishErrorPhase({ error: new TypeError('prepare failed') })
+
+    const finishNonErrorPhase = createOneShotTracePhase(
+      AppRenderSpan.initializeRender,
+      'initialize app render'
+    )
+    finishNonErrorPhase({ error: 'initialize failed' })
+
+    expect(getSpanRecords({ name: 'prepare app page response' })[0]).toEqual(
+      expect.objectContaining({
+        status: 'error',
+        error: {
+          type: 'TypeError',
+          message: 'prepare failed',
+        },
+        events: [
+          expect.objectContaining({
+            name: 'exception',
+          }),
+        ],
+      })
+    )
+    expect(getSpanRecords({ name: 'initialize app render' })[0]).toEqual(
+      expect.objectContaining({
+        status: 'error',
+      })
+    )
+  })
+
+  async function createTrackedReactServerResult(
+    createStream: () => AnyStream | Promise<AnyStream>
+  ) {
+    return getTracer().trace(BaseServerSpan.render, async () => {
+      const finishPhase = createOneShotTracePhase(
+        AppRenderSpan.renderRSCResponse,
+        'render RSC response'
+      )
+      const stream = await createTrackedStream(createStream, finishPhase)
+      return new ReactServerResult(stream)
+    })
+  }
+
+  function expectSingleFailedRSCPhase() {
+    const parentSpan = getSpanRecords({ name: BaseServerSpan.render })[0]
+    const phaseSpans = getSpanRecords({ name: 'render RSC response' })
+
+    expect(phaseSpans).toHaveLength(1)
+    expect(phaseSpans[0]).toEqual(
+      expect.objectContaining({
+        parentSpanId: parentSpan.spanId,
+        status: 'error',
+        attributes: expect.objectContaining({
+          'next.span_type': AppRenderSpan.renderRSCResponse,
+        }),
+      })
+    )
+  }
+
+  it('records one failed RSC phase when a ReactServerResult source errors', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    process.env.__NEXT_USE_NODE_STREAMS = '1'
+    const source = new PassThrough()
+    const result = await createTrackedReactServerResult(() => source)
+    const replay = result.tee() as PassThrough
+    const replayError = new Promise<Error>((resolve) => {
+      replay.on('error', resolve)
+    })
+    const error = new TypeError('RSC render failed')
+
+    source.destroy(error)
+
+    await expect(replayError).resolves.toBe(error)
+    expectSingleFailedRSCPhase()
+  })
+
+  it('records one failed RSC phase when both tee branches are cancelled', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    delete process.env.__NEXT_USE_NODE_STREAMS
+    const cancel = jest.fn()
+    const source = new ReadableStream<Uint8Array>(
+      { cancel },
+      { highWaterMark: 0 }
+    )
+    const result = await createTrackedReactServerResult(() => source)
+    const branch = result.tee() as ReadableStream<Uint8Array>
+    const remaining = result.consume() as ReadableStream<Uint8Array>
+
+    await Promise.all([branch.cancel('branch'), remaining.cancel('remaining')])
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expectSingleFailedRSCPhase()
   })
 
   it('records non-vanilla trace and wrapped spans for request insights', () => {

--- a/test/development/app-dir/request-insights-route-preparation/next.config.js
+++ b/test/development/app-dir/request-insights-route-preparation/next.config.js
@@ -2,6 +2,7 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
+  cacheComponents: true,
   experimental: {
     requestInsights: true,
   },

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import {
+  NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_RSC_UNION_QUERY,
   RSC_HEADER,
 } from 'next/dist/client/components/app-router-headers'
+import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('request-insights-route-preparation', () => {
   const { next } = nextTestSetup({
@@ -33,6 +35,8 @@ describe('request-insights-route-preparation', () => {
   const routeCompilationSpanType = 'DevBundlerService.ensurePage'
   const appPagePreparationSpanType = 'AppRender.prepareAppPageResponse'
   const renderInitializationSpanType = 'AppRender.initializeRender'
+  const renderRSCResponseSpanType = 'AppRender.renderRSCResponse'
+  const waitForRSCSpanType = 'AppRender.waitForRSC'
 
   async function getRequestInsights() {
     return (await next
@@ -44,7 +48,8 @@ describe('request-insights-route-preparation', () => {
 
   async function captureRequest(
     route: string,
-    request: () => Promise<unknown>
+    request: () => Promise<unknown>,
+    requiredSpanTypes: string[] = []
   ) {
     const existingRequestIds = new Set(
       (await getRequestInsights()).requests
@@ -79,6 +84,11 @@ describe('request-insights-route-preparation', () => {
           insight.spans.some(
             (span) =>
               span.attributes?.['next.span_type'] === routeCompilationSpanType
+          ) &&
+          requiredSpanTypes.every((spanType) =>
+            insight.spans.some(
+              (span) => span.attributes?.['next.span_type'] === spanType
+            )
           )
       )
 
@@ -86,6 +96,70 @@ describe('request-insights-route-preparation', () => {
     }, 10_000)
 
     return capturedRequest!
+  }
+
+  function expectAppPageRSCSpans(
+    request: RequestInsight,
+    { expectWaitSpan = true }: { expectWaitSpan?: boolean } = {}
+  ) {
+    const bodyRenderSpan = request.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+    )
+    const renderRSCSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === renderRSCResponseSpanType
+    )
+    const waitForRSCSpans = request.spans.filter(
+      (span) => span.attributes?.['next.span_type'] === waitForRSCSpanType
+    )
+
+    expect(renderRSCSpans).toHaveLength(1)
+    expect(waitForRSCSpans).toHaveLength(expectWaitSpan ? 1 : 0)
+
+    const renderRSCSpan = renderRSCSpans[0]
+    const renderRSCParent = request.spans.find(
+      (span) => span.spanId === renderRSCSpan.parentSpanId
+    )
+    expect(renderRSCParent).toBeDefined()
+    if (expectWaitSpan) {
+      expect(bodyRenderSpan?.spanId).toBeDefined()
+      expect(renderRSCParent?.spanId).toBe(bodyRenderSpan?.spanId)
+    }
+
+    const expectedSpans = [
+      [renderRSCSpan, 'render RSC response', renderRSCResponseSpanType],
+      ...(expectWaitSpan
+        ? ([
+            [
+              waitForRSCSpans[0],
+              'wait for RSC render task',
+              waitForRSCSpanType,
+            ],
+          ] as const)
+        : []),
+    ] as const
+
+    for (const [span, name, type] of expectedSpans) {
+      expect(span).toEqual(
+        expect.objectContaining({
+          name,
+          startTime: expect.any(Number),
+          durationMs: expect.any(Number),
+          status: 'ok',
+          traceId: renderRSCParent?.traceId,
+          parentSpanId: renderRSCParent?.spanId,
+          attributes: {
+            'next.span_category': 'nextjs',
+            'next.span_name': name,
+            'next.span_type': type,
+          },
+        })
+      )
+      expect(Number.isFinite(span.startTime)).toBe(true)
+      expect(Number.isFinite(span.durationMs)).toBe(true)
+      expect(span.durationMs).toBeGreaterThanOrEqual(0)
+    }
   }
 
   function expectRoutePreparationSpans(request: RequestInsight) {
@@ -297,43 +371,92 @@ describe('request-insights-route-preparation', () => {
   }
 
   it('records route preparation for first and subsequent App Page requests', async () => {
-    const coldRequest = await captureRequest('/', async () => {
-      const response = await next.fetch('/')
-      expect(response.status).toBe(200)
-      expect(await response.text()).toContain('route preparation page')
-    })
-    const warmRequest = await captureRequest('/', async () => {
-      const response = await next.fetch('/')
-      expect(response.status).toBe(200)
-      await response.text()
-    })
+    const requiredSpanTypes = [renderRSCResponseSpanType, waitForRSCSpanType]
+    const coldRequest = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch('/')
+        expect(response.status).toBe(200)
+        expect(await response.text()).toContain('route preparation page')
+      },
+      requiredSpanTypes
+    )
+    const warmRequest = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch('/')
+        expect(response.status).toBe(200)
+        await response.text()
+      },
+      requiredSpanTypes
+    )
 
     expectRoutePreparationSpans(coldRequest)
     expectRoutePreparationSpans(warmRequest)
     expectAppPageRenderPreparationSpans(coldRequest)
     expectAppPageRenderPreparationSpans(warmRequest)
+    expectAppPageRSCSpans(coldRequest)
+    expectAppPageRSCSpans(warmRequest)
   })
 
   it('records App Page preparation and initialization for RSC requests', async () => {
-    const request = await captureRequest('/', async () => {
-      const response = await next.fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
-        headers: {
-          [RSC_HEADER]: '1',
-        },
-      })
-      expect(response.status).toBe(200)
-      expect(response.headers.get('content-type')).toContain('text/x-component')
-      await response.text()
-    })
+    const request = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
+          headers: {
+            [RSC_HEADER]: '1',
+          },
+        })
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toContain(
+          'text/x-component'
+        )
+        await response.text()
+      },
+      [renderRSCResponseSpanType]
+    )
 
     expectRoutePreparationSpans(request)
     expectAppPageRenderPreparationSpans(request, { expectBodyRender: false })
+    expectAppPageRSCSpans(request, { expectWaitSpan: false })
     expect(
       request.spans.find(
         (span) =>
           span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
       )?.attributes?.['next.rsc']
     ).toBe(true)
+  })
+
+  it('records RSC rendering for runtime prefetch requests', async () => {
+    const cacheBustingSearchParam = await computeCacheBustingSearchParam(
+      '2',
+      undefined,
+      undefined,
+      undefined
+    )
+    const request = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch(
+          `/?${NEXT_RSC_UNION_QUERY}=${cacheBustingSearchParam}`,
+          {
+            headers: {
+              [RSC_HEADER]: '1',
+              [NEXT_ROUTER_PREFETCH_HEADER]: '2',
+            },
+          }
+        )
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toContain(
+          'text/x-component'
+        )
+        await response.text()
+      },
+      [renderRSCResponseSpanType]
+    )
+
+    expectAppPageRSCSpans(request, { expectWaitSpan: false })
   })
 
   it('records route preparation for first and subsequent App Route requests', async () => {


### PR DESCRIPTION
## Summary

- trace App Router RSC source production for HTML rendering, RSC navigation, staged rendering, and runtime prefetches
- record bounded RSC task waits and finish Node and Web stream spans exactly once across completion, errors, premature closes, and cancellation
- preserve the synchronous production fast path when local tracing is disabled and keep the new spans out of the default public OpenTelemetry allowlist

## Verification

- `pnpm --filter=next build`
- `pnpm --filter=next types`
- 53 focused stream and tracer unit tests
- 4 Request Insights render tests with Turbopack
- 4 Request Insights render tests with Webpack
- Prettier, ESLint, and `git diff --check`
