### PR TITLE
Turbopack: drop late task messages instead of recreating orphaned channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10810,6 +10810,7 @@ dependencies = [
  "indoc",
  "napi",
  "napi-derive",
+ "napi-sys",
  "owo-colors",
  "parking_lot",
  "regex",

--- a/turbopack/crates/turbopack-node/Cargo.toml
+++ b/turbopack/crates/turbopack-node/Cargo.toml
@@ -56,6 +56,9 @@ napi = { workspace = true, features = ["error_anyhow"], optional = true }
 napi-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
+# Resolve N-API symbols dynamically at runtime so test binaries for the
+# worker_pool feature link without libnode; tests never call into Node.
+napi-sys = { version = "2", features = ["dyn-symbols"] }
 rustc-hash = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 turbo-tasks-testing = { workspace = true }

--- a/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
@@ -175,10 +175,15 @@ impl WorkerPoolOperation {
 
     pub(crate) fn send_task_message(&self, message: TaskMessage) -> Result<()> {
         let channel = {
-            let mut map = self.task_routed_channel.lock();
-            map.entry(message.task_id)
-                .or_insert_with(|| Arc::new(MessageChannel::unbounded()))
-                .clone()
+            let map = self.task_routed_channel.lock();
+            map.get(&message.task_id).cloned()
+        };
+        let Some(channel) = channel else {
+            // The task's channels were already torn down (the task was
+            // canceled, failed, or completed early). Drop the late message:
+            // recreating the channel would leave an entry no receiver ever
+            // drains, retaining the queued bytes forever.
+            return Ok(());
         };
         channel
             .send_sync(message.data)
@@ -304,5 +309,39 @@ impl Operation for WorkerOperation {
             // Clearing the return-to-pool callback does not stop the underlying Node.js worker.
             let _ = terminate_worker(self.worker_options.clone(), self.worker_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A message arriving for a task whose channels were already torn down
+    /// must be discarded instead of recreating a channel that no receiver
+    /// will ever drain (which would retain the queued bytes forever).
+    #[test]
+    fn late_task_message_after_task_drop_is_discarded() {
+        let task_id = 4_000_000_001;
+        let worker_id = 4_000_000_002;
+        {
+            let _channels = TaskChannels::new(task_id, worker_id);
+        }
+        // Simulate the JS worker's late end/error message arriving after the
+        // Rust task was torn down (canceled, failed, or completed early).
+        WORKER_POOL_OPERATION
+            .send_task_message(TaskMessage {
+                task_id,
+                data: Bytes::from_static(b"late"),
+            })
+            .expect("late messages are dropped, not an error");
+        assert!(
+            !WORKER_POOL_OPERATION
+                .task_routed_channel
+                .lock()
+                .contains_key(&task_id),
+            "late message must not recreate a task channel"
+        );
+        // Clean up the worker channel created by TaskChannels::new.
+        WORKER_POOL_OPERATION.remove_worker_channel(worker_id);
     }
 }


### PR DESCRIPTION
## What

`send_task_message` looked up the per-task channel with
`entry(task_id).or_insert_with(...)`. When a worker message arrives **after**
its task was torn down (the task was canceled, failed, or completed early), that
lookup inserts a brand-new channel with no receiver, queues the payload's
`Bytes` into it, and — since `task_id`s are never reused and the only removal
runs in `TaskChannels::drop` — the orphan entry and its buffered bytes are
retained for the process lifetime.

This makes the lookup a pure `get`: a message for a dropped task is discarded
(a normal race), never materialized into an orphaned channel.

## Why this matters

Every early-exit path that drops a task while its JS worker is mid-evaluation
(cancellation, in-process project restarts, protocol errors) is followed by the
worker's eventual late `end`/`error` message. Each such message grew the global
`task_routed_channel` map by one permanent entry plus its payload.

This is independent of #96592: that PR terminates the worker itself; this PR
stops the late messages it can still emit from accumulating channel state.

## Regression test

The new Rust unit test creates a task's channels, drops them, then delivers a
late message:

- unmodified canary: the message recreates a map entry (test **fails**);
- this change: no entry is created and the send succeeds as a no-op (test
  **passes**).

## Validation

- `cargo test -p turbopack-node --lib --features worker_pool` (new test passes)
- `cargo test -p turbopack-node` (existing process-pool integration suite: 5/5)
- `cargo fmt --check`, `cargo clippy --features worker_pool --lib --tests -- -D warnings`

Stacked PR 1 of 9 from a Turbopack/Next.js memory-leak sweep; see the stack tip
for the full set.
