### PR TITLE
Turbopack: prune canceled worker-pool waiters on push

### DIFF
--- a/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     worker_pool::{
         operation::{
             PoolState, TaskChannels, WORKER_POOL_OPERATION, WorkerOperation, WorkerOptions,
-            get_pool_state,
+            get_pool_state, push_waiter,
         },
         worker_thread::create_worker,
     },
@@ -121,7 +121,7 @@ impl WorkerThreadPool {
                     },
                 ));
             }
-            waiters.push(tx);
+            push_waiter(&mut waiters, tx);
         }
 
         let bootup = async {

--- a/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
@@ -65,6 +65,15 @@ pub(crate) struct PoolState {
     pub(crate) waiters: Mutex<Vec<oneshot::Sender<u32>>>,
 }
 
+/// Registers a waiter for the next released worker, first pruning any
+/// waiters whose receivers were canceled. Without pruning, canceled
+/// acquisitions accumulate until some unrelated worker is released — and
+/// forever if none is.
+pub(crate) fn push_waiter(waiters: &mut Vec<oneshot::Sender<u32>>, tx: oneshot::Sender<u32>) {
+    waiters.retain(|tx| !tx.is_closed());
+    waiters.push(tx);
+}
+
 #[turbo_tasks::value(cell = "new", serialization = "skip", eq = "manual", shared)]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub(super) struct WorkerOptions {
@@ -343,5 +352,22 @@ mod tests {
         );
         // Clean up the worker channel created by TaskChannels::new.
         WORKER_POOL_OPERATION.remove_worker_channel(worker_id);
+    }
+
+    /// Waiters whose receivers were canceled must not linger until the next
+    /// worker release: they are pruned eagerly when a new waiter registers.
+    #[test]
+    fn canceled_waiters_are_pruned_on_push() {
+        let mut waiters: Vec<oneshot::Sender<u32>> = Vec::new();
+        let (stale_tx, stale_rx) = oneshot::channel();
+        drop(stale_rx);
+        push_waiter(&mut waiters, stale_tx);
+        let (live_tx, _live_rx) = oneshot::channel::<u32>();
+        push_waiter(&mut waiters, live_tx);
+        assert_eq!(
+            waiters.len(),
+            1,
+            "canceled waiters must be pruned when a new waiter registers"
+        );
     }
 }


### PR DESCRIPTION
## What

`acquire_worker` pushes a `oneshot::Sender<u32>` into the pool's waiter vector
before racing the receiver against the bootup branch. When the bootup branch
wins — or the caller is canceled — the pushed sender stays in the vector. The
only pruning is in the release path, so canceled acquisitions accumulate until
some unrelated worker happens to be released, and forever when none is.

`push_waiter` now prunes closed senders (`is_closed()`) eagerly when a new
waiter registers, keeping cancellation cleanup O(1) instead of dependent on
future pool activity. This is a hygiene fix: the accumulation is small per
entry and lazily reclaimed in an active pool, but it is unbounded for a
quiescent one.

## Regression test

Push a canceled sender, then a live one:

- baseline behavior: both remain (test **fails**);
- this change: only the live sender remains (test **passes**).

## Validation

- `cargo test -p turbopack-node --lib --features worker_pool` (new test passes)
- `cargo test -p turbopack-node` (existing process-pool integration suite: 5/5)
- `cargo fmt --check`, `cargo clippy --features worker_pool --lib --tests -- -D warnings`

Stacked PR 4 of 9.
