### PR TITLE
Turbopack: reap dead worker threads and fail their in-flight tasks

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -39,9 +39,23 @@ export declare function registerWorkerScheduler(
   creator: (arg: NapiWorkerCreation) => any,
   terminator: (arg: NapiWorkerTermination) => any
 ): void
-export declare function workerCreated(workerId: number): void
+export declare function workerCreated(
+  workerId: number,
+  nonce: number,
+  options: NapiWorkerOptions
+): void
+export declare function workerExited(
+  termination: NapiWorkerTermination,
+  nonce: number
+): void
 export interface NapiWorkerCreation {
   options: NapiWorkerOptions
+  /**
+   * Opaque creation nonce (a u64 passed as f64). The JS creator forwards
+   * it to the worker's `workerData`; the booted worker announces it back
+   * in `workerCreated`, and the exit handler reports it in `workerExited`.
+   */
+  nonce: number
 }
 export interface NapiWorkerOptions {
   filename: RcStr

--- a/packages/next/src/build/swc/loaderWorkerPool.ts
+++ b/packages/next/src/build/swc/loaderWorkerPool.ts
@@ -14,6 +14,7 @@ export async function runLoaderWorkerPool(
     (creation) => {
       const {
         options: { filename, cwd },
+        nonce,
       } = creation
 
       const poolId = getPoolId(cwd, filename)
@@ -22,6 +23,8 @@ export async function runLoaderWorkerPool(
         workerData: {
           bindingPath,
           cwd,
+          filename,
+          creationNonce: nonce,
         },
       })
 
@@ -31,7 +34,30 @@ export async function runLoaderWorkerPool(
       const workers =
         loaderWorkers[poolId] || (loaderWorkers[poolId] = new Map())
 
-      workers.set(worker.threadId, worker)
+      // Capture the id now: `worker.threadId` is -1 after the worker exits,
+      // so it cannot be read in the exit handler.
+      const workerId = worker.threadId
+      workers.set(workerId, worker)
+
+      // An 'error' without a listener would become an uncaughtException in
+      // the parent; 'exit' always follows and performs the reap.
+      worker.on('error', () => {})
+      worker.on('exit', () => {
+        // First deleter wins: the Rust-initiated terminator below removes the
+        // entry first when tearing this worker down intentionally, so reaching
+        // the Rust side here means the exit was unexpected (boot failure,
+        // crash, OOM, a loader calling process.exit).
+        if (!workers.delete(workerId)) {
+          return
+        }
+        bindings.workerExited(
+          {
+            options: { filename, cwd },
+            workerId,
+          },
+          nonce
+        )
+      })
     },
     (termination) => {
       const {
@@ -41,8 +67,8 @@ export async function runLoaderWorkerPool(
 
       const poolId = getPoolId(cwd, filename)
       const workers = loaderWorkers[poolId]
-      workers.get(workerId)?.terminate()
-      workers.delete(workerId)
+      workers?.get(workerId)?.terminate()
+      workers?.delete(workerId)
     }
   )
 }

--- a/test/development/app-dir/turbopack-worker-thread-exit-cleanup/app/layout.tsx
+++ b/test/development/app-dir/turbopack-worker-thread-exit-cleanup/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/turbopack-worker-thread-exit-cleanup/app/page.tsx
+++ b/test/development/app-dir/turbopack-worker-thread-exit-cleanup/app/page.tsx
@@ -1,0 +1,5 @@
+const data = require('../input.probe')
+
+export default function Page() {
+  return <p>{data.default}</p>
+}

--- a/test/development/app-dir/turbopack-worker-thread-exit-cleanup/exit-loader.js
+++ b/test/development/app-dir/turbopack-worker-thread-exit-cleanup/exit-loader.js
@@ -1,0 +1,11 @@
+module.exports = function exitLoader(source) {
+  const value = source.trim()
+  if (value === 'exit') {
+    // Kill this worker thread mid-evaluation. In worker_threads, process.exit
+    // terminates only the current worker, which then emits 'exit' on the
+    // parent's Worker object.
+    process.exit(1)
+  }
+
+  return `export default ${JSON.stringify(value)}`
+}

--- a/test/development/app-dir/turbopack-worker-thread-exit-cleanup/input.probe
+++ b/test/development/app-dir/turbopack-worker-thread-exit-cleanup/input.probe
@@ -1,0 +1,1 @@
+initial

--- a/test/development/app-dir/turbopack-worker-thread-exit-cleanup/next.config.js
+++ b/test/development/app-dir/turbopack-worker-thread-exit-cleanup/next.config.js
@@ -1,0 +1,18 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    turbopackPluginRuntimeStrategy: 'workerThreads',
+  },
+  turbopack: {
+    rules: {
+      '*.probe': {
+        as: '*.js',
+        loaders: [
+          {
+            loader: require.resolve('./exit-loader.js'),
+          },
+        ],
+      },
+    },
+  },
+}

--- a/test/development/app-dir/turbopack-worker-thread-exit-cleanup/turbopack-worker-thread-exit-cleanup.test.ts
+++ b/test/development/app-dir/turbopack-worker-thread-exit-cleanup/turbopack-worker-thread-exit-cleanup.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+describe('turbopack worker thread exit cleanup', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  const itOnlyTurbopack = isTurbopack ? it : it.skip
+
+  itOnlyTurbopack(
+    'reaps a worker that dies mid-evaluation and recovers on a fresh worker',
+    async () => {
+      expect((await next.render$('/'))('p').text()).toBe('initial')
+
+      // The loader calls process.exit(1) mid-evaluation, killing the worker
+      // thread. The dead worker must not wedge the task or be handed out
+      // again: the compile must fail with a crash issue instead of hanging.
+      await next.patchFile('input.probe', 'exit')
+      // Give the filesystem watcher a moment to invalidate before the fetch,
+      // so the loader actually reruns (and kills its worker thread).
+      await waitFor(1000)
+      await next.fetch('/')
+      await retry(
+        async () => {
+          expect(next.cliOutput).toContain('crashed while evaluating')
+        },
+        30_000,
+        500
+      )
+
+      // A later compile gets a fresh worker and the route recovers.
+      await next.patchFile('input.probe', 'recovered')
+      await retry(
+        async () => {
+          expect((await next.render$('/'))('p').text()).toBe('recovered')
+        },
+        30_000,
+        500
+      )
+    }
+  )
+})

--- a/turbopack/crates/turbopack-node/js/src/worker_thread/evaluate.ts
+++ b/turbopack/crates/turbopack-node/js/src/worker_thread/evaluate.ts
@@ -11,7 +11,13 @@ const binding: Binding = require(
   /* turbopackIgnore: true */ workerData.bindingPath
 )
 
-binding.workerCreated(workerId)
+// Check in with the pool, echoing the creation nonce and pool identity the
+// creator placed in workerData so the creation is paired with exactly one
+// acquirer (and an unclaimed worker is terminated instead of retained).
+binding.workerCreated(workerId, workerData.creationNonce, {
+  filename: workerData.filename,
+  cwd: workerData.cwd,
+})
 
 export const run = async (
   moduleFactory: () => Promise<{

--- a/turbopack/crates/turbopack-node/js/src/worker_thread/taskChannel.ts
+++ b/turbopack/crates/turbopack-node/js/src/worker_thread/taskChannel.ts
@@ -11,7 +11,11 @@ export interface TaskMessage {
 export interface Binding {
   recvTaskMessageInWorker(workerId: number): Promise<TaskMessage>
   sendTaskMessage(msg: TaskMessage): void
-  workerCreated(workerId: number): void
+  workerCreated(
+    workerId: number,
+    nonce: number,
+    options: { filename: string; cwd: string }
+  ): void
 }
 
 // Export this, maybe in the future, we can add an implementation via web worker on browser

--- a/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/mod.rs
@@ -241,6 +241,14 @@ impl EvaluateOperation for WorkerThreadPool {
                 worker_id,
                 state: state.clone(),
                 on_drop: Some(Box::new(move |worker_id| {
+                    if !WORKER_POOL_OPERATION.is_worker_alive(worker_id) {
+                        // The worker died or was terminated while checked out;
+                        // it must not be handed out again. Account for it here
+                        // instead: idle workers are reaped by `worker_exited`,
+                        // checked-out ones by this teardown.
+                        state.stats.lock().remove_worker();
+                        return;
+                    }
                     let mut waiters = state.waiters.lock();
                     loop {
                         if let Some(tx) = waiters.pop() {

--- a/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/operation.rs
@@ -7,10 +7,13 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
-use tokio::sync::{
-    Mutex as AsyncMutex,
-    mpsc::{self, UnboundedReceiver, UnboundedSender},
-    oneshot,
+use tokio::{
+    select,
+    sync::{
+        Mutex as AsyncMutex,
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        oneshot, watch,
+    },
 };
 use turbo_rcstr::RcStr;
 
@@ -94,6 +97,12 @@ pub(crate) struct WorkerPoolOperation {
     worker_routed_channel: Mutex<FxHashMap<u32, Arc<MessageChannel<(u32, Bytes)>>>>,
     #[allow(clippy::type_complexity)]
     task_routed_channel: Mutex<FxHashMap<u32, Arc<MessageChannel<Bytes>>>>,
+    /// Per-worker death notification, set to `true` when the worker exits
+    /// unexpectedly or is terminated. Wakes tasks blocked in
+    /// [`TaskChannels::recv_from_worker`] so they fail instead of waiting
+    /// forever for a response that can never arrive. Entries are retained
+    /// for the process lifetime (one tiny entry per worker ever created).
+    worker_death: Mutex<FxHashMap<u32, watch::Sender<bool>>>,
     pub(crate) pools: Mutex<FxHashMap<Arc<WorkerOptions>, Arc<PoolState>>>,
 }
 
@@ -161,8 +170,60 @@ impl WorkerPoolOperation {
         worker_id: u32,
     ) -> Result<()> {
         self.remove_worker_channel(worker_id);
+        self.signal_worker_death(worker_id);
         worker_thread::terminate_worker(worker_options, worker_id);
         Ok(())
+    }
+
+    /// Handles an unexpected worker exit reported by the JS side: wakes tasks
+    /// blocked on the worker, removes its routed channel so the dead worker
+    /// is never handed out again, and reaps it from the idle pool. A worker
+    /// that was checked out is accounted for by its task's teardown path
+    /// (see [`WorkerOperation`]'s drop), not here.
+    pub(crate) fn worker_exited(&self, worker_options: Arc<WorkerOptions>, worker_id: u32) {
+        self.remove_worker_channel(worker_id);
+        // Tombstone: create the entry even if no task ever subscribed, so a
+        // later subscriber observes the death immediately instead of waiting
+        // forever.
+        let death = {
+            let mut map = self.worker_death.lock();
+            map.entry(worker_id)
+                .or_insert_with(|| watch::channel(false).0)
+                .clone()
+        };
+        let _ = death.send(true);
+
+        let pools = self.pools.lock();
+        if let Some(state) = pools.get(&worker_options) {
+            let mut idle = state.idle_workers.lock();
+            let len_before = idle.len();
+            idle.retain(|&id| id != worker_id);
+            if idle.len() != len_before {
+                state.stats.lock().remove_worker();
+            }
+        }
+    }
+
+    /// Whether the worker is still expected to be usable: its routed channel
+    /// is removed when the worker is terminated or exits.
+    pub(crate) fn is_worker_alive(&self, worker_id: u32) -> bool {
+        self.worker_routed_channel.lock().contains_key(&worker_id)
+    }
+
+    /// Subscribes to the death signal for `worker_id`; `true` means the
+    /// worker exited or was terminated.
+    fn worker_death_receiver(&self, worker_id: u32) -> watch::Receiver<bool> {
+        self.worker_death
+            .lock()
+            .entry(worker_id)
+            .or_insert_with(|| watch::channel(false).0)
+            .subscribe()
+    }
+
+    fn signal_worker_death(&self, worker_id: u32) {
+        if let Some(death) = self.worker_death.lock().get(&worker_id) {
+            let _ = death.send(true);
+        }
     }
 
     fn remove_worker_channel(&self, worker_id: u32) {
@@ -219,6 +280,10 @@ pub(crate) struct TaskChannels {
     /// Channel for Worker -> Rust communication (data)
     task_channel: Arc<MessageChannel<Bytes>>,
     task_id: u32,
+    worker_id: u32,
+    /// Set when the worker exits or is terminated; see
+    /// [`WorkerPoolOperation::worker_death`].
+    death: watch::Receiver<bool>,
 }
 
 impl TaskChannels {
@@ -239,10 +304,14 @@ impl TaskChannels {
                 .clone()
         };
 
+        let death = WORKER_POOL_OPERATION.worker_death_receiver(worker_id);
+
         Self {
             worker_channel,
             task_channel,
             task_id,
+            worker_id,
+            death,
         }
     }
 
@@ -255,11 +324,23 @@ impl TaskChannels {
     }
 
     /// Receive message from worker (JS Worker -> Rust)
+    ///
+    /// Fails promptly when the worker dies or is terminated, instead of
+    /// waiting forever for a response that can never arrive.
     pub(crate) async fn recv_from_worker(&self) -> Result<Bytes> {
-        self.task_channel
-            .recv()
-            .await
-            .context("failed to recv task message")
+        if *self.death.borrow() {
+            anyhow::bail!("worker {} exited", self.worker_id);
+        }
+        let mut death = self.death.clone();
+        select! {
+            biased;
+            message = self.task_channel.recv() => {
+                message.context("failed to recv task message")
+            }
+            _ = death.changed() => {
+                anyhow::bail!("worker {} exited", self.worker_id)
+            }
+        }
     }
 }
 
@@ -369,5 +450,71 @@ mod tests {
             1,
             "canceled waiters must be pruned when a new waiter registers"
         );
+    }
+
+    fn test_worker_options(tag: &str) -> Arc<WorkerOptions> {
+        Arc::new(WorkerOptions {
+            filename: tag.into(),
+            cwd: "/".into(),
+        })
+    }
+
+    /// An unexpected worker exit must reap the worker from the idle pool,
+    /// fail its in-flight task promptly (instead of hanging forever), and
+    /// keep the dead id from ever being handed out again.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn worker_exited_reaps_pool_and_fails_inflight_task() {
+        let options = test_worker_options("exited-pool.js");
+        let worker_id = 4_000_001_101;
+        let task_id = 4_000_001_102;
+
+        let state = WORKER_POOL_OPERATION.get_pool_state(options.clone()).await;
+        state.idle_workers.lock().push(worker_id);
+        {
+            let mut stats = state.stats.lock();
+            stats.add_booting_worker();
+            stats.finished_booting_worker();
+        }
+
+        // An in-flight task blocked in recv on the dying worker.
+        let channels = TaskChannels::new(task_id, worker_id);
+        let recv = channels.recv_from_worker();
+
+        WORKER_POOL_OPERATION.worker_exited(options.clone(), worker_id);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), recv)
+            .await
+            .expect("recv must not hang after worker exit")
+            .expect_err("recv must fail after worker exit");
+
+        // The idle worker was reaped and accounted for exactly once.
+        assert!(state.idle_workers.lock().is_empty());
+        assert_eq!(state.stats.lock().workers, 0);
+        // And the dead id can never be handed out again.
+        assert!(!WORKER_POOL_OPERATION.is_worker_alive(worker_id));
+        // A channel created after the death observes the tombstone.
+        let late = TaskChannels::new(4_000_001_103, worker_id);
+        assert!(*late.death.borrow());
+    }
+
+    /// Terminating a worker (scale-down, non-reusable operation, wait/kill)
+    /// must also wake tasks blocked on it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terminate_worker_wakes_inflight_task() {
+        let options = test_worker_options("terminated-pool.js");
+        let worker_id = 4_000_002_101;
+        let task_id = 4_000_002_102;
+
+        let channels = TaskChannels::new(task_id, worker_id);
+        let recv = channels.recv_from_worker();
+
+        WORKER_POOL_OPERATION
+            .terminate_worker(options, worker_id)
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), recv)
+            .await
+            .expect("recv must not hang after terminate")
+            .expect_err("recv must fail after terminate");
     }
 }

--- a/turbopack/crates/turbopack-node/src/worker_pool/worker_thread.rs
+++ b/turbopack/crates/turbopack-node/src/worker_pool/worker_thread.rs
@@ -1,6 +1,6 @@
-use std::{
-    collections::VecDeque,
-    sync::{Arc, OnceLock},
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicU64, Ordering},
 };
 
 use bytes::Bytes;
@@ -10,6 +10,7 @@ use napi::{
 };
 use napi_derive::napi;
 use parking_lot::Mutex;
+use rustc_hash::FxHashMap;
 use tokio::sync::oneshot;
 use turbo_rcstr::RcStr;
 
@@ -25,7 +26,18 @@ static WORKER_TERMINATOR: OnceLock<
     ThreadsafeFunction<NapiWorkerTermination, ErrorStrategy::Fatal>,
 > = OnceLock::new();
 
-static PENDING_CREATIONS: OnceLock<Mutex<VecDeque<oneshot::Sender<u32>>>> = OnceLock::new();
+/// A creation announced to the JS side whose worker has not checked in yet.
+struct PendingCreation {
+    sender: oneshot::Sender<u32>,
+}
+
+/// Creations in flight, keyed by a nonce that is handed to the JS creator and
+/// announced back by the booted worker (and by the exit handler). The nonce
+/// correlation replaces the previous global FIFO, which mis-paired workers
+/// and acquirers across pools and after any canceled/failed creation.
+static PENDING_CREATIONS: OnceLock<Mutex<FxHashMap<u64, PendingCreation>>> = OnceLock::new();
+
+static NEXT_CREATION_NONCE: AtomicU64 = AtomicU64::new(1);
 
 // Allow dead_code for test builds where napi exports are not entry points
 #[allow(dead_code)]
@@ -60,24 +72,31 @@ pub fn register_worker_scheduler(
 
 pub async fn create_worker(options: Arc<WorkerOptions>) -> anyhow::Result<u32> {
     let (tx, rx) = oneshot::channel();
+    let nonce = NEXT_CREATION_NONCE.fetch_add(1, Ordering::Relaxed);
 
     let napi_options = (&options).into();
 
     {
-        let pending = PENDING_CREATIONS.get_or_init(|| Mutex::new(VecDeque::new()));
+        let pending = PENDING_CREATIONS.get_or_init(|| Mutex::new(FxHashMap::default()));
         // ensure pool entry exists for these options so scale ops can observe it
         WORKER_POOL_OPERATION
             .pools
             .lock()
             .entry(options.clone())
             .or_default();
-        pending.lock().push_back(tx);
+        pending.lock().insert(nonce, PendingCreation { sender: tx });
     }
+
+    // If this future is dropped while waiting (caller canceled), drop the
+    // pending entry so the eventual announcement is recognized as unclaimed
+    // and the booted worker is terminated instead of retained forever.
+    let _guard = PendingCreationGuard { nonce };
 
     if let Some(creator) = WORKER_CREATOR.get() {
         creator.call(
             NapiWorkerCreation {
                 options: napi_options,
+                nonce: nonce as f64,
             },
             ThreadsafeFunctionCallMode::NonBlocking,
         );
@@ -89,15 +108,83 @@ pub async fn create_worker(options: Arc<WorkerOptions>) -> anyhow::Result<u32> {
     Ok(worker_id)
 }
 
+struct PendingCreationGuard {
+    nonce: u64,
+}
+
+impl Drop for PendingCreationGuard {
+    fn drop(&mut self) {
+        if let Some(pending) = PENDING_CREATIONS.get() {
+            pending.lock().remove(&self.nonce);
+        }
+    }
+}
+
+/// The result of pairing a booted worker with its pending creation.
+#[derive(Debug, PartialEq, Eq)]
+enum ClaimOutcome {
+    /// The acquirer received the worker id.
+    Claimed,
+    /// The creation was canceled or unknown; the unclaimed worker was asked
+    /// to terminate so it is not retained by the JS worker map forever.
+    Unclaimed,
+}
+
+fn claim_worker(worker_id: u32, nonce: u64, options: Arc<WorkerOptions>) -> ClaimOutcome {
+    let creation = PENDING_CREATIONS
+        .get()
+        .and_then(|pending| pending.lock().remove(&nonce));
+    match creation {
+        Some(creation) => {
+            if creation.sender.send(worker_id).is_ok() {
+                ClaimOutcome::Claimed
+            } else {
+                // The acquirer was canceled while the worker was booting.
+                terminate_worker(options, worker_id);
+                ClaimOutcome::Unclaimed
+            }
+        }
+        None => {
+            // Announcement for a canceled or otherwise unknown creation.
+            terminate_worker(options, worker_id);
+            ClaimOutcome::Unclaimed
+        }
+    }
+}
+
+/// Fails the pending creation for `nonce`, if one exists, so the acquirer
+/// stops waiting and the boot failure surfaces as an error (which the pool
+/// retries) instead of hanging forever.
+fn fail_pending_creation(nonce: u64) -> bool {
+    PENDING_CREATIONS
+        .get()
+        .and_then(|pending| pending.lock().remove(&nonce))
+        .is_some()
+}
+
 // Allow dead_code for test builds where napi exports are not entry points
 #[allow(dead_code)]
 #[napi]
-pub fn worker_created(worker_id: u32) {
-    if let Some(pending) = PENDING_CREATIONS.get()
-        && let Some(tx) = pending.lock().pop_front()
-    {
-        let _ = tx.send(worker_id);
-    }
+pub fn worker_created(worker_id: u32, nonce: f64, options: NapiWorkerOptions) {
+    let options = Arc::new(WorkerOptions {
+        filename: options.filename,
+        cwd: options.cwd,
+    });
+    claim_worker(worker_id, nonce as u64, options);
+}
+
+// Allow dead_code for test builds where napi exports are not entry points
+#[allow(dead_code)]
+#[napi]
+pub fn worker_exited(termination: NapiWorkerTermination, nonce: f64) {
+    // A worker that died before announcing itself fails its pending creation;
+    // for an announced worker this is a no-op.
+    fail_pending_creation(nonce as u64);
+    let options = Arc::new(WorkerOptions {
+        filename: termination.options.filename,
+        cwd: termination.options.cwd,
+    });
+    WORKER_POOL_OPERATION.worker_exited(options, termination.worker_id);
 }
 
 pub fn terminate_worker(options: Arc<WorkerOptions>, worker_id: u32) {
@@ -115,6 +202,10 @@ pub fn terminate_worker(options: Arc<WorkerOptions>, worker_id: u32) {
 #[napi(object)]
 pub struct NapiWorkerCreation {
     pub options: NapiWorkerOptions,
+    /// Opaque creation nonce (a u64 passed as f64). The JS creator forwards
+    /// it to the worker's `workerData`; the booted worker announces it back
+    /// in `workerCreated`, and the exit handler reports it in `workerExited`.
+    pub nonce: f64,
 }
 
 #[napi(object)]
@@ -185,4 +276,88 @@ pub async fn recv_task_message_in_worker(worker_id: u32) -> napi::Result<NapiTas
 #[napi]
 pub fn send_task_message(message: NapiTaskMessage) -> napi::Result<()> {
     Ok(WORKER_POOL_OPERATION.send_task_message(message.into())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_options() -> Arc<WorkerOptions> {
+        Arc::new(WorkerOptions {
+            filename: "creation-test.js".into(),
+            cwd: "/".into(),
+        })
+    }
+
+    fn insert_pending(nonce: u64, sender: oneshot::Sender<u32>) {
+        PENDING_CREATIONS
+            .get_or_init(|| Mutex::new(FxHashMap::default()))
+            .lock()
+            .insert(nonce, PendingCreation { sender });
+    }
+
+    /// The nonce pairs each announced worker with exactly its own acquirer,
+    /// across pools and interleaved creations.
+    #[test]
+    fn claim_pairs_announced_worker_with_its_acquirer() {
+        let nonce = 9_000_000_001_u64;
+        let (tx, rx) = oneshot::channel::<u32>();
+        insert_pending(nonce, tx);
+        assert_eq!(
+            claim_worker(42, nonce, test_options()),
+            ClaimOutcome::Claimed
+        );
+        assert_eq!(rx.blocking_recv().unwrap(), 42);
+    }
+
+    /// An announcement for a canceled/unknown creation must terminate the
+    /// unclaimed worker rather than let the JS map retain it forever.
+    #[test]
+    fn claim_unknown_nonce_is_unclaimed() {
+        assert_eq!(
+            claim_worker(43, 9_000_000_002, test_options()),
+            ClaimOutcome::Unclaimed
+        );
+    }
+
+    /// An acquirer canceled while its worker was booting must not strand the
+    /// fresh worker.
+    #[test]
+    fn claim_canceled_acquirer_is_unclaimed() {
+        let nonce = 9_000_000_003_u64;
+        let (tx, rx) = oneshot::channel::<u32>();
+        drop(rx);
+        insert_pending(nonce, tx);
+        assert_eq!(
+            claim_worker(44, nonce, test_options()),
+            ClaimOutcome::Unclaimed
+        );
+    }
+
+    /// A worker that dies before announcing fails its pending creation so the
+    /// acquirer stops waiting instead of hanging forever.
+    #[test]
+    fn fail_pending_creation_unblocks_acquirer() {
+        let nonce = 9_000_000_004_u64;
+        let (tx, rx) = oneshot::channel::<u32>();
+        insert_pending(nonce, tx);
+        assert!(fail_pending_creation(nonce));
+        assert!(rx.blocking_recv().is_err());
+        // A duplicate exit report is a no-op.
+        assert!(!fail_pending_creation(nonce));
+    }
+
+    /// A creation that fails before reaching JS must not leave a stale
+    /// pending entry behind.
+    #[tokio::test(flavor = "current_thread")]
+    async fn create_worker_without_creator_leaves_no_pending_entry() {
+        let nonce_before = NEXT_CREATION_NONCE.load(Ordering::Relaxed);
+        let result = create_worker(test_options()).await;
+        assert!(result.is_err());
+        let pending = PENDING_CREATIONS.get().unwrap();
+        let pending = pending.lock();
+        for nonce in nonce_before..=NEXT_CREATION_NONCE.load(Ordering::Relaxed) {
+            assert!(!pending.contains_key(&nonce));
+        }
+    }
 }


### PR DESCRIPTION
## What

A worker thread that died **unexpectedly** — boot failure, uncaught exception,
OOM, or a loader calling `process.exit` — was never reaped:

- `loaderWorkerPool.ts` registered no `'error'`/`'exit'` handlers, so the
  global `loaderWorkers` map retained the dead `Worker` (an `'error'` with no
  listener would also surface as an uncaught exception in the parent);
- Rust never learned about the death, so the pool kept the dead id in
  `idle_workers` and handed it out as healthy; each assigned task queued its
  payload on a channel no consumer drained and then waited forever for a
  response — a hang plus retention per misrouted task;
- the global `PENDING_CREATIONS` FIFO mis-paired workers with acquirers across
  pools and after any canceled/failed creation, stranding live unclaimed
  workers, and a worker that died before announcing itself left its acquirer
  waiting forever.

Changes:

1. **Exit reporting.** `loaderWorkerPool` attaches `'error'`/`'exit'` handlers
   and reports unexpected exits via a new `workerExited` binding. The thread id
   is captured at creation — `worker.threadId` is `-1` by the time the exit
   event fires (this took one debugging round to find).
2. **Nonce-correlated creation.** Creations carry a nonce through
   `workerData`; the booted worker announces it back and the exit handler
   reports it. This replaces the FIFO, fails pending creations on boot death
   (the pool then retries instead of hanging), drops canceled pending entries,
   and terminates unclaimed workers instead of retaining them.
3. **Death-aware pool.** A per-worker death signal wakes tasks blocked in
   `recv_from_worker` so they fail with a crash issue instead of hanging;
   `worker_exited` removes the dead worker's routed channel and reaps it from
   the idle pool; the return-to-pool callback never hands out a dead worker.
   Terminate paths signal death too, so no blocked task survives its worker.

## Behavioral evidence

Real dev-server fixture whose loader calls `process.exit(1)` mid-evaluation
under `turbopackPluginRuntimeStrategy: 'workerThreads'`:

- **Baseline (published `next@16.3.1-canary.3`):** the compile **hangs
  forever** — 45 s and 75 s probes both timed out with no response and no
  issue; the route never completes.
- **This change:** the compile fails in ~9 s with the synthesized
  “crashed while evaluating” issue (HTTP 500), and a subsequent edit compiles
  on a fresh worker and renders the recovered route (HTTP 200 in ~30 ms).

## Regression tests

- The new development e2e schedules `process.exit(1)` inside a loader and
  requires the crash issue plus full recovery on a fresh worker (it hangs on
  the baseline).
- Rust unit tests: idle-pool reap + in-flight failure + tombstone after
  `worker_exited`; terminate wakes blocked tasks; nonce claim pairing;
  unclaimed workers terminated for unknown/canceled creations; boot-death
  unblocks the acquirer; failed creations leave no pending entries.

## Validation

- `cargo test -p turbopack-node --lib --features worker_pool` (13 tests pass)
- `cargo test -p turbopack-node` (existing process-pool integration suite: 5/5)
- e2e: `turbopack-worker-thread-exit-cleanup` passes (Turbopack)
- `pnpm --filter next typescript`, `pnpm --filter next build`
- `cargo fmt --check`, `cargo clippy --features worker_pool --lib --tests -- -D warnings`

Stacked PR 5 of 9.
