### PR TITLE
Next.js: dispose native subscriptions when iterators are canceled or the dev server closes

### DIFF
--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -84,7 +84,13 @@ pub struct RootTask {
 
 impl Drop for RootTask {
     fn drop(&mut self) {
-        // TODO stop the root task
+        // GC backstop: JavaScript is expected to call `root_task_dispose` in a
+        // `try...finally`, but if the `External` is finalized without that
+        // (e.g. a torn-down iterator), stop the root task instead of leaking
+        // the subscription computation.
+        if let Some(task) = self.task_id.take() {
+            self.turbopack_ctx.turbo_tasks().dispose_root_task(task);
+        }
     }
 }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { pathToFileURL } from 'url'
+import { subscribe as createSubscription } from './subscribe'
 import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
 import { arch, platform } from 'os'
 import { platformArchTriples } from 'next/dist/compiled/@napi-rs/triples'
@@ -563,8 +564,6 @@ function bindingToApi(
       }
   )
 
-  const cancel = new (class Cancel extends Error {})()
-
   /**
    * Utility function to ensure all variants of an enum are handled.
    */
@@ -579,79 +578,18 @@ function bindingToApi(
    * Calls a native function and streams the result.
    * If useBuffer is true, all values will be preserved, potentially buffered
    * if consumed slower than produced. Else, only the latest value will be
-   * preserved.
+   * preserved. The implementation lives in ./subscribe so it can be unit
+   * tested; the wrapper binds the native root-task disposer.
    */
-  function subscribe<T>(
+  const subscribe = <T>(
     useBuffer: boolean,
     nativeFunction:
       | NativeFunction<T>
       | ((callback: (err: Error, value: T) => void) => Promise<void>)
-  ): AsyncIterableIterator<T> {
-    type BufferItem =
-      | { err: Error; value: undefined }
-      | { err: undefined; value: T }
-    // A buffer of produced items. This will only contain values if the
-    // consumer is slower than the producer.
-    let buffer: BufferItem[] = []
-    // A deferred value waiting for the next produced item. This will only
-    // exist if the consumer is faster than the producer.
-    let waiting:
-      | {
-          resolve: (value: T) => void
-          reject: (error: Error) => void
-        }
-      | undefined
-    let canceled = false
-
-    // The native function will call this every time it emits a new result. We
-    // either need to notify a waiting consumer, or buffer the new result until
-    // the consumer catches up.
-    function emitResult(err: Error | undefined, value: T | undefined) {
-      if (waiting) {
-        let { resolve, reject } = waiting
-        waiting = undefined
-        if (err) reject(err)
-        else resolve(value!)
-      } else {
-        const item = { err, value } as BufferItem
-        if (useBuffer) buffer.push(item)
-        else buffer[0] = item
-      }
-    }
-
-    async function* createIterator() {
-      const task = await nativeFunction(emitResult)
-      try {
-        while (!canceled) {
-          if (buffer.length > 0) {
-            const item = buffer.shift()!
-            if (item.err) throw item.err
-            yield item.value
-          } else {
-            // eslint-disable-next-line no-loop-func
-            yield new Promise<T>((resolve, reject) => {
-              waiting = { resolve, reject }
-            })
-          }
-        }
-      } catch (e) {
-        if (e === cancel) return
-        throw e
-      } finally {
-        if (task) {
-          binding.rootTaskDispose(task)
-        }
-      }
-    }
-
-    const iterator = createIterator()
-    iterator.return = async () => {
-      canceled = true
-      if (waiting) waiting.reject(cancel)
-      return { value: undefined, done: true } as IteratorReturnResult<never>
-    }
-    return iterator
-  }
+  ): AsyncIterableIterator<T> =>
+    createSubscription(useBuffer, nativeFunction, (task: any) =>
+      binding.rootTaskDispose(task)
+    )
 
   async function rustifyProjectOptions(
     options: ProjectOptions

--- a/packages/next/src/build/swc/subscribe.test.ts
+++ b/packages/next/src/build/swc/subscribe.test.ts
@@ -1,0 +1,100 @@
+import { subscribe } from './subscribe'
+
+describe('subscribe', () => {
+  function createHarness<T>() {
+    let emit: (err: Error | undefined, value: T | undefined) => void = () => {
+      throw new Error('native function not started')
+    }
+    const disposed: unknown[] = []
+    const task = { id: Math.random() }
+    const iterator = subscribe<T>(
+      true,
+      async (callback) => {
+        emit = callback as (
+          err: Error | undefined,
+          value: T | undefined
+        ) => void
+        return task
+      },
+      (t) => {
+        disposed.push(t)
+      }
+    )
+    return {
+      iterator,
+      disposeCount: () => disposed.length,
+      emit: (err: Error | undefined, value: T | undefined) => emit(err, value),
+    }
+  }
+
+  it('yields emitted values in order', async () => {
+    const { iterator, emit } = createHarness<string>()
+    const first = iterator.next()
+    emit(undefined, 'a')
+    expect(await first).toEqual({ value: 'a', done: false })
+    const second = iterator.next()
+    emit(undefined, 'b')
+    expect(await second).toEqual({ value: 'b', done: false })
+    await iterator.return!()
+  })
+
+  it('disposes the native task when canceled while idle', async () => {
+    const { iterator, disposeCount } = createHarness<string>()
+    const pending = iterator.next()
+    // The generator is suspended at the idle yield, waiting for an emission.
+    await iterator.return!()
+    expect(disposeCount()).toBe(1)
+    expect(await pending).toEqual({ value: undefined, done: true })
+    expect(await iterator.next()).toEqual({ value: undefined, done: true })
+  })
+
+  it('disposes the native task when canceled while suspended after a yield', async () => {
+    const { iterator, emit, disposeCount } = createHarness<string>()
+    const first = iterator.next()
+    emit(undefined, 'a')
+    expect(await first).toEqual({ value: 'a', done: false })
+    // The generator is now suspended *after* yielding a value, with no
+    // pending idle wait to reject. Canceling must still run its `finally`.
+    await iterator.return!()
+    expect(disposeCount()).toBe(1)
+    expect(await iterator.next()).toEqual({ value: undefined, done: true })
+  })
+
+  it('disposes the native task when a for-await consumer breaks', async () => {
+    const { iterator, emit, disposeCount } = createHarness<string>()
+    const consumed: string[] = []
+    const loop = (async () => {
+      for await (const value of iterator) {
+        consumed.push(value)
+        break
+      }
+    })()
+    emit(undefined, 'a')
+    await loop
+    expect(consumed).toEqual(['a'])
+    // Give the iterator teardown a chance to settle.
+    await iterator.return!()
+    expect(disposeCount()).toBe(1)
+  })
+
+  it('drops late native emissions after cancel', async () => {
+    const { iterator, emit, disposeCount } = createHarness<string>()
+    const first = iterator.next()
+    emit(undefined, 'a')
+    expect(await first).toEqual({ value: 'a', done: false })
+    await iterator.return!()
+    // Emissions after cancel must not be delivered or retained.
+    emit(undefined, 'late')
+    expect(await iterator.next()).toEqual({ value: undefined, done: true })
+    expect(disposeCount()).toBe(1)
+  })
+
+  it('propagates native errors to the consumer', async () => {
+    const { iterator, emit } = createHarness<string>()
+    const pending = iterator.next()
+    const failure = new Error('native failure')
+    emit(failure, undefined)
+    await expect(pending).rejects.toThrow('native failure')
+    await iterator.return!()
+  })
+})

--- a/packages/next/src/build/swc/subscribe.ts
+++ b/packages/next/src/build/swc/subscribe.ts
@@ -1,0 +1,101 @@
+/**
+ * Calls a native function and streams the result.
+ * If useBuffer is true, all values will be preserved, potentially buffered
+ * if consumed slower than produced. Else, only the latest value will be
+ * preserved.
+ *
+ * The returned iterator's `return()` (invoked directly or by `for await`)
+ * always drives the generator through its `finally` block so the native
+ * subscription task is disposed deterministically.
+ */
+export function subscribe<T>(
+  useBuffer: boolean,
+  nativeFunction: (
+    callback: (err: Error, value: T) => void
+  ) => Promise<unknown>,
+  disposeTask: (task: unknown) => unknown
+): AsyncIterableIterator<T> {
+  type BufferItem =
+    | { err: Error; value: undefined }
+    | { err: undefined; value: T }
+
+  const cancel = new (class Cancel extends Error {})()
+
+  // A buffer of produced items. This will only contain values if the
+  // consumer is slower than the producer.
+  let buffer: BufferItem[] = []
+  // A deferred value waiting for the next produced item. This will only
+  // exist if the consumer is faster than the producer.
+  let waiting:
+    | {
+        resolve: (value: T) => void
+        reject: (error: Error) => void
+      }
+    | undefined
+  let canceled = false
+
+  // The native function will call this every time it emits a new result. We
+  // either need to notify a waiting consumer, or buffer the new result until
+  // the consumer catches up. Once the consumer has canceled, late emissions
+  // are dropped instead of accumulating in a buffer nobody will read.
+  function emitResult(err: Error | undefined, value: T | undefined) {
+    if (canceled) {
+      return
+    }
+    if (waiting) {
+      let { resolve, reject } = waiting
+      waiting = undefined
+      if (err) reject(err)
+      else resolve(value!)
+    } else {
+      const item = { err, value } as BufferItem
+      if (useBuffer) buffer.push(item)
+      else buffer[0] = item
+    }
+  }
+
+  async function* createIterator() {
+    const task = await nativeFunction(emitResult)
+    try {
+      while (!canceled) {
+        if (buffer.length > 0) {
+          const item = buffer.shift()!
+          if (item.err) throw item.err
+          yield item.value
+        } else {
+          // eslint-disable-next-line no-loop-func
+          yield new Promise<T>((resolve, reject) => {
+            waiting = { resolve, reject }
+          })
+        }
+      }
+    } catch (e) {
+      if (e === cancel) return
+      throw e
+    } finally {
+      if (task) {
+        disposeTask(task)
+      }
+    }
+  }
+
+  const iterator = createIterator()
+  const generatorReturn = iterator.return!.bind(iterator)
+  iterator.return = async () => {
+    canceled = true
+    // Reject the pending idle wait first so a generator suspended at that
+    // yield resumes and reaches its `finally`. Then drive the generator to
+    // completion in every other suspension state (e.g. suspended after
+    // yielding a value): the previous override never resumed the generator,
+    // so its `finally` — the only place the native root task is disposed —
+    // never ran and the native subscription leaked.
+    if (waiting) waiting.reject(cancel)
+    try {
+      await generatorReturn()
+    } catch {
+      // Teardown errors are not actionable for a consumer that is leaving.
+    }
+    return { value: undefined, done: true } as IteratorReturnResult<never>
+  }
+  return iterator
+}

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -122,6 +122,7 @@ import {
   deleteReactDebugChannelForHtmlRequest,
   setReactDebugChannelForHtmlRequest,
 } from './debug-channel'
+import { setWithExpiry } from './expiring-map'
 import {
   getVersionInfo,
   matchNextPageBundleRequest,
@@ -211,9 +212,13 @@ function setupServerHmr(
     reEvaluateAllModulesExpensive: () => void | Promise<void>
     onApplied: (chunkPaths: string[]) => void | Promise<void>
   }
-) {
+): () => void {
+  let currentSubscription: { return?: () => Promise<unknown> } | undefined
+  let stopped = false
+
   async function runSubscription() {
     const subscription = project.allHmrEvents(HmrTarget.Server)
+    currentSubscription = subscription
 
     // Subscribing immediately emits one event describing the current state.
     // There's no previous state to diff it against, so it never carries anything
@@ -288,16 +293,28 @@ function setupServerHmr(
   // initial read) from hot-looping through reEvaluateAllModulesExpensive().
   ;(async () => {
     for (;;) {
+      if (stopped) {
+        return
+      }
       try {
         await runSubscription()
         return
       } catch (err) {
+        if (stopped) {
+          return
+        }
         console.error('[Server HMR] Subscription error, resubscribing:', err)
         await reEvaluateAllModulesExpensive()
         await new Promise((resolve) => setTimeout(resolve, 1000))
       }
     }
   })()
+
+  // Stops the background loop and disposes the current native subscription.
+  return () => {
+    stopped = true
+    currentSubscription?.return?.()
+  }
 }
 
 function getSourceMapFromTurbopack(
@@ -1014,6 +1031,10 @@ export async function createHotReloaderTurbopack(
 
     const subscription = state.subscriptions.get(id)
     subscription?.return!()
+    // Delete the dead iterator as well: returning it disposes the native
+    // subscription, but keeping the map entry would retain it (and re-return
+    // it) until the whole client disconnects.
+    state.subscriptions.delete(id)
 
     const key = getEntryKey('assets', 'client', id)
     state.clientIssues.delete(key)
@@ -1661,8 +1682,9 @@ export async function createHotReloaderTurbopack(
         })
       } else {
         // If the client is not connected, store the status so that we can send it
-        // when the client connects.
-        cacheStatusesByHtmlRequestId.set(htmlRequestId, status)
+        // when the client connects. The entry expires if no client ever
+        // connects (e.g. curl or no-JS page loads).
+        setWithExpiry(cacheStatusesByHtmlRequestId, htmlRequestId, status)
       }
     },
 
@@ -1971,6 +1993,20 @@ export async function createHotReloaderTurbopack(
       // Report MCP telemetry if MCP server is enabled
       recordMcpTelemetry(opts.telemetry)
 
+      // Tear down every long-lived subscription so the native root tasks
+      // behind them are disposed instead of leaking past the dev server's
+      // lifetime.
+      entrypointsSubscription.return?.()
+      updateInfoSubscription.return?.()
+      teardownServerHmr?.()
+      for (const changedPromise of changeSubscriptions.values()) {
+        void changedPromise.then(
+          (subscription) => subscription?.return?.(),
+          () => {}
+        )
+      }
+      changeSubscriptions.clear()
+
       for (const wsClient of [
         ...clientsWithoutHtmlRequestId,
         ...clientsByHtmlRequestId.values(),
@@ -1996,9 +2032,11 @@ export async function createHotReloaderTurbopack(
     entrypoints: currentEntrypoints,
   })
 
+  const updateInfoSubscription = project.updateInfoSubscribe(30)
+
   async function handleProjectUpdates() {
     const BUILDING_MESSAGE_DEFER_MS = 100
-    for await (const updateMessage of project.updateInfoSubscribe(30)) {
+    for await (const updateMessage of updateInfoSubscription) {
       switch (updateMessage.updateType) {
         case 'start': {
           updateInProgress = true
@@ -2116,8 +2154,9 @@ export async function createHotReloaderTurbopack(
     })
   }
 
+  let teardownServerHmr: (() => void) | undefined
   if (serverFastRefresh) {
-    setupServerHmr(project, {
+    teardownServerHmr = setupServerHmr(project, {
       reEvaluateAllModulesExpensive: async () => {
         // Evict every server-HMR-managed chunk from `require.cache`.
         // Trailing `sep` so e.g. `server/chunks-other/...` doesn't match.


### PR DESCRIPTION
## What

`subscribe()` (the helper behind every project/endpoint subscription —
entrypoints, HMR events, update info, compilation events, server/client
changed) overrode the returned async iterator's `return()` to only mark
`canceled` and reject the consumer's pending wait. Because the override never
resumed the generator, its `finally` — the only `binding.rootTaskDispose(task)`
call in the tree — ran **only** when the generator happened to be suspended at
the idle yield. In every other suspension state (notably: suspended after
yielding a value, i.e. any fast producer), canceling the iterator left the
native root task alive forever, still re-executing on dependency changes and
pushing emissions into an abandoned `buffer`.

- `return()` now also drives the original generator return, so the `finally`
  and `rootTaskDispose` always run (the idle-wait rejection is kept so that
  path still resumes promptly);
- `emitResult` drops post-cancel emissions instead of buffering them;
- `RootTask::drop` now stops the root task as a GC backstop (it was a
  `// TODO stop the root task`);
- consumer cleanups: `unsubscribeFromClientHmrEvents` now deletes the dead
  `state.subscriptions` entry (it only called `return!()`), and the hot
  reloader's `close()` tears down the entrypoints, update-info, server-HMR
  (with a resubscribe guard), and endpoint-change subscriptions — previously
  none were closed.

## Behavioral evidence

A scripted replay of the pre-fix helper shows the discriminator: canceling
while the generator is suspended after a yield never disposes the native task
(**leak confirmed**); canceling while idle did dispose (the path that happened
to work). The extracted `subscribe.ts` is covered by colocated unit tests:
cancel-while-idle, cancel-after-yield, `for await` break, post-cancel emission
dropping, error propagation, and ordering — all pass.

## Validation

- `npx jest packages/next/src/build/swc/subscribe.test.ts` (6/6)
- `cargo check -p next-napi-bindings`
- `pnpm --filter next typescript`, `pnpm --filter next build`

Stacked PR 6 of 9.
