### PR TITLE
Next.js: expire dev HTML handoff entries whose client never connects

### DIFF
--- a/packages/next/src/server/dev/debug-channel.ts
+++ b/packages/next/src/server/dev/debug-channel.ts
@@ -6,6 +6,7 @@ import {
   type HmrMessageSentToBrowser,
 } from './hot-reloader-types'
 import type { AnyStream } from '../app-render/stream-ops'
+import { setWithExpiry } from './expiring-map'
 
 // Chunks are sent to the browser in batches to reduce overhead, flushing
 // synchronously once this many bytes have accumulated.
@@ -115,9 +116,9 @@ export function setReactDebugChannelForHtmlRequest(
   htmlRequestId: string,
   debugChannel: ReactDebugChannelForBrowser
 ) {
-  // TODO: Clean up after a timeout, in case the client never connects, e.g.
-  // when CURL'ing the page, or loading the page with JavaScript disabled etc.
-  reactDebugChannelsByHtmlRequestId.set(htmlRequestId, debugChannel)
+  // Expire entries whose client never connects, e.g. when CURL'ing the page,
+  // or loading the page with JavaScript disabled etc.
+  setWithExpiry(reactDebugChannelsByHtmlRequestId, htmlRequestId, debugChannel)
 }
 
 export function deleteReactDebugChannelForHtmlRequest(htmlRequestId: string) {

--- a/packages/next/src/server/dev/expiring-map.test.ts
+++ b/packages/next/src/server/dev/expiring-map.test.ts
@@ -1,0 +1,64 @@
+import { setWithExpiry } from './expiring-map'
+
+describe('setWithExpiry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('keeps the entry until the ttl elapses', () => {
+    const map = new Map<string, string>()
+    setWithExpiry(map, 'a', 'value', 1_000)
+    expect(map.get('a')).toBe('value')
+    jest.advanceTimersByTime(999)
+    expect(map.get('a')).toBe('value')
+  })
+
+  it('deletes the entry after the ttl', () => {
+    const map = new Map<string, string>()
+    setWithExpiry(map, 'a', 'value', 1_000)
+    jest.advanceTimersByTime(1_000)
+    expect(map.has('a')).toBe(false)
+  })
+
+  it('does not delete a replaced value when the stale timer fires', () => {
+    const map = new Map<string, string>()
+    setWithExpiry(map, 'a', 'old', 1_000)
+    jest.advanceTimersByTime(500)
+    setWithExpiry(map, 'a', 'new', 1_000)
+    // The first timer fires here and must not remove 'new'.
+    jest.advanceTimersByTime(500)
+    expect(map.get('a')).toBe('new')
+    jest.advanceTimersByTime(500)
+    expect(map.has('a')).toBe(false)
+  })
+
+  it('leaves a consumed entry deleted when its timer fires', () => {
+    const map = new Map<string, string>()
+    setWithExpiry(map, 'a', 'value', 500)
+    map.delete('a')
+    jest.advanceTimersByTime(1_000)
+    expect(map.has('a')).toBe(false)
+  })
+
+  it('guards by reference identity for object values', () => {
+    const map = new Map<string, { v: number }>()
+    const oldValue = { v: 1 }
+    const newValue = { v: 2 }
+    setWithExpiry(map, 'a', oldValue, 1_000)
+    map.set('a', newValue)
+    jest.advanceTimersByTime(2_000)
+    expect(map.get('a')).toBe(newValue)
+  })
+
+  it('does not keep the process alive (timer is unrefed)', () => {
+    const map = new Map<string, string>()
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+    setWithExpiry(map, 'a', 'value', 1_000)
+    const timer = setTimeoutSpy.mock.results[0].value as NodeJS.Timeout
+    expect(typeof timer.unref).toBe('function')
+    setTimeoutSpy.mockRestore()
+  })
+})

--- a/packages/next/src/server/dev/expiring-map.ts
+++ b/packages/next/src/server/dev/expiring-map.ts
@@ -1,0 +1,28 @@
+/**
+ * Default lifetime for dev-server HTML handoff entries. The HMR websocket
+ * connects within milliseconds of a real page load; entries whose client
+ * never connects (curl, no-JS crawlers, failed hydration) would otherwise be
+ * retained forever.
+ */
+export const HTML_REQUEST_HANDOFF_TTL_MS = 60_000
+
+/**
+ * Sets a map entry that is automatically deleted after `ttlMs` unless it is
+ * consumed (or replaced) first. The timer is unref'd so it never keeps the
+ * process alive, and the identity check ensures a newer value for the same
+ * key is never deleted by a stale timer.
+ */
+export function setWithExpiry<K, V>(
+  map: Map<K, V>,
+  key: K,
+  value: V,
+  ttlMs: number = HTML_REQUEST_HANDOFF_TTL_MS
+): void {
+  const timer = setTimeout(() => {
+    if (map.get(key) === value) {
+      map.delete(key)
+    }
+  }, ttlMs)
+  timer.unref?.()
+  map.set(key, value)
+}

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -103,6 +103,7 @@ import {
   setReactDebugChannelForHtmlRequest,
   type ReactDebugChannelForBrowser,
 } from './debug-channel'
+import { setWithExpiry } from './expiring-map'
 import {
   getVersionInfo,
   matchNextPageBundleRequest,
@@ -1778,8 +1779,9 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       })
     } else {
       // If the client is not connected, store the status so that we can send it
-      // when the client connects.
-      this.cacheStatusesByRequestId.set(htmlRequestId, status)
+      // when the client connects. The entry expires if no client ever
+      // connects (e.g. curl or no-JS page loads).
+      setWithExpiry(this.cacheStatusesByRequestId, htmlRequestId, status)
     }
   }
 

--- a/packages/next/src/server/dev/serialized-errors.ts
+++ b/packages/next/src/server/dev/serialized-errors.ts
@@ -4,6 +4,7 @@ import {
 } from './hot-reloader-types'
 import type { AnyStream } from '../app-render/stream-ops'
 import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
+import { setWithExpiry } from './expiring-map'
 
 const errorsRscStreamsByHtmlRequestId = new Map<string, AnyStream>()
 
@@ -43,9 +44,9 @@ export function setErrorsRscStreamForHtmlRequest(
   htmlRequestId: string,
   errorsRscStream: AnyStream
 ) {
-  // TODO: Clean up after a timeout, in case the client never connects, e.g.
-  // when CURL'ing the page, or loading the page with JavaScript disabled etc.
-  errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
+  // Expire entries whose client never connects, e.g. when CURL'ing the page,
+  // or loading the page with JavaScript disabled etc.
+  setWithExpiry(errorsRscStreamsByHtmlRequestId, htmlRequestId, errorsRscStream)
 }
 
 export function deleteErrorsRscStreamForHtmlRequest(htmlRequestId: string) {


### PR DESCRIPTION
## What

Four dev-server registries hand state from an HTML request to the HMR
websocket that connects right after page load:

- `errorsRscStreamsByHtmlRequestId` (serialized-errors.ts)
- `reactDebugChannelsByHtmlRequestId` (debug-channel.ts)
- `cacheStatusesByHtmlRequestId` (hot-reloader-turbopack.ts)
- `cacheStatusesByRequestId` (hot-reloader-webpack.ts)

Each inserts one entry per HTML request and deletes it **only** when the
matching websocket connects. Requests whose client never connects — `curl`,
no-JS crawlers, failed hydration — leak the entry for the process lifetime: a
cache status per request, and (with Cache Components dev / the debug channel /
dev validation errors) full stream objects per request. The source TODOs
conceded the missing timeout cleanup.

Adds `setWithExpiry` (`server/dev/expiring-map.ts`): an unref'd 60-second TTL
timer with an identity-guarded delete (a replaced value is never removed by a
stale timer), wired into all four set sites. The timer never keeps the process
alive, and a client that still connects within the TTL sees exactly the same
behavior.

## Regression test

Colocated unit tests cover: retention until TTL, deletion after TTL, stale
timers not deleting replaced values, consumed entries staying deleted,
reference-identity guarding, and the unref requirement — 6/6 pass.

## Validation

- `npx jest packages/next/src/server/dev/expiring-map.test.ts` (6/6)
- `pnpm --filter next typescript`, `pnpm --filter next build`

Stacked PR 7 of 9.
