### PR TITLE
Next.js: dedupe dev once-warnings by stable issue key

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.test.ts
+++ b/packages/next/src/server/dev/turbopack-utils.test.ts
@@ -1,0 +1,36 @@
+import { shouldEmitOnceWarning } from './turbopack-utils'
+import type { Issue } from '../../build/swc/types'
+
+function invalidPageConfigIssue(filePath: string): Issue {
+  return {
+    severity: 'warning',
+    stage: 'collect',
+    filePath,
+    title: { type: 'text', value: 'Invalid page configuration' },
+    description: {
+      type: 'text',
+      value: 'The page config is invalid.',
+    },
+  } as unknown as Issue
+}
+
+describe('shouldEmitOnceWarning', () => {
+  it('deduplicates across fresh issue objects with identical content', () => {
+    // Each subscription emission rebuilds issue objects, so identity-based
+    // dedupe never matches: the same warning must still emit only once.
+    const first = invalidPageConfigIssue('pages/once-a.tsx')
+    const second = invalidPageConfigIssue('pages/once-a.tsx')
+    expect(first).not.toBe(second)
+    expect(shouldEmitOnceWarning(first)).toBe(true)
+    expect(shouldEmitOnceWarning(second)).toBe(false)
+    expect(
+      shouldEmitOnceWarning(invalidPageConfigIssue('pages/once-a.tsx'))
+    ).toBe(false)
+  })
+
+  it('still emits distinct warnings', () => {
+    expect(
+      shouldEmitOnceWarning(invalidPageConfigIssue('pages/another-b.tsx'))
+    ).toBe(true)
+  })
+})

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -38,30 +38,36 @@ import {
 } from '../../shared/lib/turbopack/utils'
 import { MIDDLEWARE_FILENAME, PROXY_FILENAME } from '../../lib/constants'
 
-const onceErrorSet = new Set()
+// Keys of once-warnings already emitted. Keyed by stable issue content (not
+// object identity): fresh issue objects arrive on every subscription
+// emission, so identity-based storage both defeated deduplication across
+// recompiles and retained every Issue object forever.
+const onceErrorSet = new Set<string>()
 /**
  * Check if given issue is a warning to be display only once.
  * This mimics behavior of get-page-static-info's warnOnce.
  * @param issue
  * @returns
  */
-function shouldEmitOnceWarning(issue: Issue): boolean {
+export function shouldEmitOnceWarning(issue: Issue): boolean {
   const { severity, title, stage } = issue
   if (severity === 'warning' && title.value === 'Invalid page configuration') {
-    if (onceErrorSet.has(issue)) {
+    const key = getIssueKey(issue)
+    if (onceErrorSet.has(key)) {
       return false
     }
-    onceErrorSet.add(issue)
+    onceErrorSet.add(key)
   }
   if (
     severity === 'warning' &&
     stage === 'config' &&
     renderStyledStringToErrorAnsi(issue.title).includes("can't be external")
   ) {
-    if (onceErrorSet.has(issue)) {
+    const key = getIssueKey(issue)
+    if (onceErrorSet.has(key)) {
       return false
     }
-    onceErrorSet.add(issue)
+    onceErrorSet.add(key)
   }
 
   return true


### PR DESCRIPTION
## What

`onceErrorSet` (dev once-warnings such as “Invalid page configuration”)
stored full `Issue` objects and matched them **by object identity**. Fresh
issue objects arrive on every subscription emission, so after each recompile
that re-emitted the warning the set both

- re-printed the “once” warning (deduplication defeated), and
- permanently retained every new `Issue` object (title, description,
  filePath strings) for the process lifetime.

The set is now keyed by the existing stable `getIssueKey(issue)` content
string, which bounds retention to distinct warning kinds and restores
cross-recompile deduplication.

## Regression test

Two fresh objects with identical content must emit once:

- unmodified canary: the second object returns “emit” again (test **fails**);
- this change: it is deduped (test **passes**). A distinct warning still
  emits.

## Validation

- `npx jest packages/next/src/server/dev/turbopack-utils.test.ts` (2/2)
- `pnpm --filter next typescript`

Stacked PR 8 of 9.
