### PR TITLE
fix(metadata): escape XML special characters in sitemap serialization

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
@@ -291,5 +291,57 @@ describe('resolveRouteData', () => {
         "
       `)
     })
+    it('should escape XML special characters in sitemap values', () => {
+      expect(
+        resolveSitemap([
+          {
+            url: 'https://example.com/page?a=1&b=2',
+            lastModified: '2021-01-01',
+            alternates: {
+              languages: {
+                'x-default':
+                  'https://example.com/en?x=1&y=2" onclick="alert(1)',
+              },
+            },
+            images: ['https://example.com/image.jpg?a=1&b=2'],
+            videos: [
+              {
+                title: '</video:title><video:title>',
+                thumbnail_loc: 'https://example.com/thumb.jpg?a=1&b=2',
+                description: 'description with <script> & "quotes"',
+                restriction: {
+                  relationship: 'allow',
+                  content: 'IE & GB',
+                },
+                uploader: {
+                  info: 'https://example.com/uploader?a=1&b=2',
+                  content: 'Uploader <b>',
+                },
+              },
+            ],
+          },
+        ])
+      ).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+        <url>
+        <loc>https://example.com/page?a=1&amp;b=2</loc>
+        <xhtml:link rel="alternate" hreflang="x-default" href="https://example.com/en?x=1&amp;y=2&quot; onclick=&quot;alert(1)" />
+        <image:image>
+        <image:loc>https://example.com/image.jpg?a=1&amp;b=2</image:loc>
+        </image:image>
+        <video:video>
+        <video:title>&lt;/video:title&gt;&lt;video:title&gt;</video:title>
+        <video:thumbnail_loc>https://example.com/thumb.jpg?a=1&amp;b=2</video:thumbnail_loc>
+        <video:description>description with &lt;script&gt; &amp; &quot;quotes&quot;</video:description>
+        <video:restriction relationship="allow">IE &amp; GB</video:restriction>
+        <video:uploader info="https://example.com/uploader?a=1&amp;b=2">Uploader &lt;b&gt;</video:uploader>
+        </video:video>
+        <lastmod>2021-01-01</lastmod>
+        </url>
+        </urlset>
+        "
+      `)
+    })
   })
 })

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -51,6 +51,24 @@ export function resolveRobots(data: MetadataRoute.Robots): string {
   return content
 }
 
+// Escape a value for safe interpolation into XML text or attribute content.
+function escapeXml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;'
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '"':
+        return '&quot;'
+      default:
+        return '&apos;'
+    }
+  })
+}
+
 // TODO-METADATA: support multi sitemap files
 // convert sitemap data to xml string
 export function resolveSitemap(data: MetadataRoute.Sitemap): string {
@@ -76,55 +94,57 @@ export function resolveSitemap(data: MetadataRoute.Sitemap): string {
   }
   for (const item of data) {
     content += '<url>\n'
-    content += `<loc>${item.url}</loc>\n`
+    content += `<loc>${escapeXml(item.url)}</loc>\n`
 
     const languages = item.alternates?.languages
     if (languages && Object.keys(languages).length) {
       // Since sitemap is separated from the page rendering, there's not metadataBase accessible yet.
       // we give the default setting that won't effect the languages resolving.
       for (const language in languages) {
-        content += `<xhtml:link rel="alternate" hreflang="${language}" href="${
-          languages[language as keyof typeof languages]
-        }" />\n`
+        content += `<xhtml:link rel="alternate" hreflang="${escapeXml(
+          language
+        )}" href="${escapeXml(
+          languages[language as keyof typeof languages] ?? ''
+        )}" />\n`
       }
     }
     if (item.images?.length) {
       for (const image of item.images) {
-        content += `<image:image>\n<image:loc>${image}</image:loc>\n</image:image>\n`
+        content += `<image:image>\n<image:loc>${escapeXml(image)}</image:loc>\n</image:image>\n`
       }
     }
     if (item.videos?.length) {
       for (const video of item.videos) {
         let videoFields = [
           `<video:video>`,
-          `<video:title>${video.title}</video:title>`,
-          `<video:thumbnail_loc>${video.thumbnail_loc}</video:thumbnail_loc>`,
-          `<video:description>${video.description}</video:description>`,
+          `<video:title>${escapeXml(video.title)}</video:title>`,
+          `<video:thumbnail_loc>${escapeXml(video.thumbnail_loc)}</video:thumbnail_loc>`,
+          `<video:description>${escapeXml(video.description)}</video:description>`,
           video.content_loc &&
-            `<video:content_loc>${video.content_loc}</video:content_loc>`,
+            `<video:content_loc>${escapeXml(video.content_loc)}</video:content_loc>`,
           video.player_loc &&
-            `<video:player_loc>${video.player_loc}</video:player_loc>`,
+            `<video:player_loc>${escapeXml(video.player_loc)}</video:player_loc>`,
           video.duration &&
             `<video:duration>${video.duration}</video:duration>`,
           video.view_count &&
             `<video:view_count>${video.view_count}</video:view_count>`,
-          video.tag && `<video:tag>${video.tag}</video:tag>`,
+          video.tag && `<video:tag>${escapeXml(video.tag)}</video:tag>`,
           video.rating && `<video:rating>${video.rating}</video:rating>`,
           video.expiration_date &&
-            `<video:expiration_date>${video.expiration_date}</video:expiration_date>`,
+            `<video:expiration_date>${escapeXml(String(video.expiration_date))}</video:expiration_date>`,
           video.publication_date &&
-            `<video:publication_date>${video.publication_date}</video:publication_date>`,
+            `<video:publication_date>${escapeXml(String(video.publication_date))}</video:publication_date>`,
           video.family_friendly &&
             `<video:family_friendly>${video.family_friendly}</video:family_friendly>`,
           video.requires_subscription &&
             `<video:requires_subscription>${video.requires_subscription}</video:requires_subscription>`,
           video.live && `<video:live>${video.live}</video:live>`,
           video.restriction &&
-            `<video:restriction relationship="${video.restriction.relationship}">${video.restriction.content}</video:restriction>`,
+            `<video:restriction relationship="${escapeXml(video.restriction.relationship)}">${escapeXml(video.restriction.content)}</video:restriction>`,
           video.platform &&
-            `<video:platform relationship="${video.platform.relationship}">${video.platform.content}</video:platform>`,
+            `<video:platform relationship="${escapeXml(video.platform.relationship)}">${escapeXml(video.platform.content)}</video:platform>`,
           video.uploader &&
-            `<video:uploader${video.uploader.info && ` info="${video.uploader.info}"`}>${video.uploader.content}</video:uploader>`,
+            `<video:uploader${video.uploader.info && ` info="${escapeXml(video.uploader.info)}"`}>${escapeXml(video.uploader.content ?? '')}</video:uploader>`,
           `</video:video>\n`,
         ].filter(Boolean)
         content += videoFields.join('\n')
@@ -136,11 +156,11 @@ export function resolveSitemap(data: MetadataRoute.Sitemap): string {
           ? item.lastModified.toISOString()
           : item.lastModified
 
-      content += `<lastmod>${serializedDate}</lastmod>\n`
+      content += `<lastmod>${escapeXml(serializedDate)}</lastmod>\n`
     }
 
     if (item.changeFrequency) {
-      content += `<changefreq>${item.changeFrequency}</changefreq>\n`
+      content += `<changefreq>${escapeXml(item.changeFrequency)}</changefreq>\n`
     }
 
     if (typeof item.priority === 'number') {


### PR DESCRIPTION
## What

`resolveSitemap()` in `packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts` interpolated application-provided sitemap values into the sitemap XML document by raw string concatenation, with no XML entity encoding anywhere.

## Why it matters

- A value containing `&` (extremely common in query-string URLs, e.g. `/page?a=1&b=2`) produced a **non-well-formed XML document**, which sitemap consumers may reject — silently breaking indexing for the whole site.
- Values containing `<`, `>`, or quotes allowed XML/markup injection into a same-origin response served as `application/xml` (e.g. forging extra `<url>` entries, or attribute breakouts via `hreflang`/`href`/`relationship`/`info`).

The framework owns this serialization boundary: apps hand Next.js typed plain strings (`MetadataRoute.Sitemap`), so output encoding is Next.js's responsibility.

## Fix

- Add an `escapeXml` helper (escapes `&`, `<`, `>`, `"`, `'` in a single pass — no double-escaping).
- Apply it to **every** string interpolation in `resolveSitemap()`: `<loc>`, `hreflang`/`href` attributes, `<image:loc>`, all video string fields (including `restriction`/`platform`/`uploader` attribute contexts), `<lastmod>`, and `<changefreq>`.
- Numeric and `'yes'/'no'` literal fields are left as-is (typed contracts).

Turbopack consumes the same `resolveRouteData` module (`crates/next-core/src/next_app/metadata/route.rs`), so both bundlers are fixed.

## Tests

- Added a regression test covering `&` in URLs, `<`/`>` breakout payloads in video text fields, and `"` attribute-breakout payloads in `href`.
- `jest packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts` — 9/9 pass.
- `tsc --noEmit -p packages/next/tsconfig.json` — clean; `prettier --check` — clean.

Found by an automated deepsec scan (vercel-labs/next-maintainer-agent run 30547162760).