### PR TITLE
[Bench] Fixes for pure Fizz bench

### DIFF
--- a/.agents/skills/sandbox-bench/scripts/bench-status.mjs
+++ b/.agents/skills/sandbox-bench/scripts/bench-status.mjs
@@ -54,6 +54,9 @@ for (const dir of dirs) {
   let action
   if (st.phase === 'done') {
     action = 'complete — bench-analyze.mjs re-reads it any time'
+  } else if (String(st.phase).startsWith('prepared')) {
+    action =
+      'complete (--prepare: caches only) — launch the real run without --prepare'
   } else if (alive) {
     action = 'RUNNING — leave it alone'
   } else if (

--- a/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
@@ -50,12 +50,9 @@ import {
 
 // Runtime provenance: the compiled server files prod app-page runtimes
 // are bundled from — BOTH bundlers, so changes touching only one still
-// move the fingerprint. Covers every server-side React layer the
-// runtime executes — Flight (react-server-dom-*), Fizz (react-dom
-// server), and the shared react-server runtime (hooks/cache) — because
-// a change confined to one layer leaves the other layers' files
-// byte-identical, and two genuinely different arms would fingerprint
-// the same.
+// move the fingerprint. One file per server-side React layer (Flight,
+// Fizz, shared react-server runtime): a change confined to one layer
+// leaves the other layers' files byte-identical.
 const FP_FILES = [
   'packages/next/dist/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js',
   'packages/next/dist/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js',
@@ -585,10 +582,8 @@ for arm in ${base} ${cand}; do
   echo "tree $arm ver=$V fp=$F"; [ "$V" != MISSING ]
   eval "VER_$arm=$V; FP_$arm=$F"
 done
-# Identical fingerprints are legitimate only when the arms differ in
-# files outside FP_FILES (e.g. client-only changes) — say so loudly at
-# boot instead of leaving it for the analysis footer, so a bad A/B is
-# caught before VM-hours are spent.
+# Identical fingerprints can be legitimate (arms differing only in
+# files outside FP_FILES, e.g. client-only changes), so warn, not fail.
 if [ "$FP_${base}" = "$FP_${cand}" ]; then
   echo "WARNING: arms fingerprint identically ($FP_${base}) — the hashed server bundles are byte-identical; verify the arms differ where intended"
 fi
@@ -687,11 +682,10 @@ wc -l /vercel/sandbox/results.jsonl`
       })
       // Profiled passes run strictly AFTER the timed runs — profiling
       // overhead must never touch the numbers.
-      // Alternate the arm order by VM index: within one VM the second
-      // arm runs warmer (page cache, CPU governor), which shows up as a
-      // uniform few-percent deflation of every function in that arm's
-      // profile. Balancing the order across VMs cancels the drift in
-      // cross-VM aggregates, so untouched code diffs to ~zero.
+      // Within one VM the second arm runs warmer (page cache, CPU
+      // governor) — a uniform few-percent deflation of every function
+      // in its profile. Alternating order across VMs cancels the drift
+      // in cross-VM aggregates.
       const profOrder = index % 2 === 1 ? `${cand} ${base}` : `${base} ${cand}`
       const prof = `set -e
 for arm in ${profOrder}; do
@@ -702,9 +696,8 @@ for arm in ${profOrder}; do
     || (tail -10 /tmp/prof.log; exit 1)
   echo "profiled $arm"
 done
-# Self-describing artifacts: record this VM's capture order so profile
-# analysis can split by order (order-drift check) without re-deriving
-# it from VM index parity.
+# Lets profile analysis split by capture order without re-deriving it
+# from VM index parity.
 echo "${profOrder}" > /vercel/sandbox/prof-order.txt
 cd /vercel/sandbox && tar -czf profiles.tgz prof-*`
       // Profile capture is best-effort: a failed pass or transfer on one VM
@@ -980,9 +973,9 @@ try {
   })
   const expSnap = await ensureExperimentSnapshot(cfg)
   if (cfg.prepare) {
-    // Terminal phase, not 'measuring': a prepare run launches no
-    // measurement VMs, and a stale 'measuring' status makes
-    // bench-status prescribe collecting data that never existed.
+    // A prepare run launches no measurement VMs; anything but a
+    // terminal phase here makes bench-status prescribe collecting
+    // data that never existed.
     writeStatus({ phase: 'prepared (caches only, no measurement)', expSnap })
     console.error(
       `prepared: arms + experiment snapshot ${expSnap}; exiting (--prepare)`

--- a/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
@@ -50,14 +50,17 @@ import {
 
 // Runtime provenance: the compiled server files prod app-page runtimes
 // are bundled from — BOTH bundlers, so changes touching only one still
-// move the fingerprint. Covers both the Flight layer and the Fizz
-// layer: a Fizz-only React change leaves the react-server-dom-* files
-// byte-identical, so without the react-dom server file two genuinely
-// different arms fingerprint the same.
+// move the fingerprint. Covers every server-side React layer the
+// runtime executes — Flight (react-server-dom-*), Fizz (react-dom
+// server), and the shared react-server runtime (hooks/cache) — because
+// a change confined to one layer leaves the other layers' files
+// byte-identical, and two genuinely different arms would fingerprint
+// the same.
 const FP_FILES = [
   'packages/next/dist/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js',
   'packages/next/dist/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js',
   'packages/next/dist/compiled/react-dom-experimental/cjs/react-dom-server.node.production.js',
+  'packages/next/dist/compiled/react-experimental/cjs/react.react-server.production.js',
 ]
 
 function parseArgs() {
@@ -582,6 +585,13 @@ for arm in ${base} ${cand}; do
   echo "tree $arm ver=$V fp=$F"; [ "$V" != MISSING ]
   eval "VER_$arm=$V; FP_$arm=$F"
 done
+# Identical fingerprints are legitimate only when the arms differ in
+# files outside FP_FILES (e.g. client-only changes) — say so loudly at
+# boot instead of leaving it for the analysis footer, so a bad A/B is
+# caught before VM-hours are spent.
+if [ "$FP_${base}" = "$FP_${cand}" ]; then
+  echo "WARNING: arms fingerprint identically ($FP_${base}) — the hashed server bundles are byte-identical; verify the arms differ where intended"
+fi
 for run in $(seq 1 ${total}); do
   # Alternate within the boot AND stagger by VM index: with an odd run
   # count, otherwise every boot gives the same arm the cold first slot
@@ -692,6 +702,10 @@ for arm in ${profOrder}; do
     || (tail -10 /tmp/prof.log; exit 1)
   echo "profiled $arm"
 done
+# Self-describing artifacts: record this VM's capture order so profile
+# analysis can split by order (order-drift check) without re-deriving
+# it from VM index parity.
+echo "${profOrder}" > /vercel/sandbox/prof-order.txt
 cd /vercel/sandbox && tar -czf profiles.tgz prof-*`
       // Profile capture is best-effort: a failed pass or transfer on one VM
       // must not kill collection for the whole run (the timed results are

--- a/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
@@ -50,10 +50,14 @@ import {
 
 // Runtime provenance: the compiled server files prod app-page runtimes
 // are bundled from — BOTH bundlers, so changes touching only one still
-// move the fingerprint.
+// move the fingerprint. Covers both the Flight layer and the Fizz
+// layer: a Fizz-only React change leaves the react-server-dom-* files
+// byte-identical, so without the react-dom server file two genuinely
+// different arms fingerprint the same.
 const FP_FILES = [
   'packages/next/dist/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js',
   'packages/next/dist/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js',
+  'packages/next/dist/compiled/react-dom-experimental/cjs/react-dom-server.node.production.js',
 ]
 
 function parseArgs() {
@@ -673,8 +677,14 @@ wc -l /vercel/sandbox/results.jsonl`
       })
       // Profiled passes run strictly AFTER the timed runs — profiling
       // overhead must never touch the numbers.
+      // Alternate the arm order by VM index: within one VM the second
+      // arm runs warmer (page cache, CPU governor), which shows up as a
+      // uniform few-percent deflation of every function in that arm's
+      // profile. Balancing the order across VMs cancels the drift in
+      // cross-VM aggregates, so untouched code diffs to ~zero.
+      const profOrder = index % 2 === 1 ? `${cand} ${base}` : `${base} ${cand}`
       const prof = `set -e
-for arm in ${base} ${cand}; do
+for arm in ${profOrder}; do
   if [ "$arm" = "${base}" ]; then PORT=3720; else PORT=3721; fi
   cd /vercel/sandbox/next-$arm
   pnpm bench:render-pipeline ${benchArgs('--capture-cpu')} \
@@ -955,18 +965,22 @@ try {
     arms: cfg.arms.map((a) => `${a.name}=${armId(a)}`),
   })
   const expSnap = await ensureExperimentSnapshot(cfg)
+  if (cfg.prepare) {
+    // Terminal phase, not 'measuring': a prepare run launches no
+    // measurement VMs, and a stale 'measuring' status makes
+    // bench-status prescribe collecting data that never existed.
+    writeStatus({ phase: 'prepared (caches only, no measurement)', expSnap })
+    console.error(
+      `prepared: arms + experiment snapshot ${expSnap}; exiting (--prepare)`
+    )
+    process.exit(0)
+  }
   writeStatus({
     phase: 'measuring',
     expSnap,
     rowsExpected:
       cfg.vms * cfg.blocks * cfg.runs * 2 * cfg.routes.split(',').length * 2,
   })
-  if (cfg.prepare) {
-    console.error(
-      `prepared: arms + experiment snapshot ${expSnap}; exiting (--prepare)`
-    )
-    process.exit(0)
-  }
   await Promise.all(
     Array.from({ length: cfg.vms }, (_, i) => runVm(i, cfg, expSnap, outDir))
   )

--- a/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
@@ -46,13 +46,16 @@ import {
 const FIXTURE_DIR = 'fixtures/flight-ssr-bench'
 // Provenance: the Flight server/client files the fixture actually
 // executes — Node and Edge entry points, so changes touching only one
-// stream flavor still move the fingerprint.
+// stream flavor still move the fingerprint — plus the shared
+// react-server runtime (hooks/cache), which none of the layer files
+// reflect.
 const FP_FILES = [
   'react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js',
   'react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js',
   'react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.production.js',
   'react-dom/cjs/react-dom-server.node.production.js',
   'react-dom/cjs/react-dom-server.edge.production.js',
+  'react/cjs/react.react-server.production.js',
 ]
 
 function parseArgs() {
@@ -349,6 +352,11 @@ for arm in ${base} ${cand}; do
   echo "arm $arm ver=$V fp=$F"
   eval "VER_$arm=$V; FP_$arm=$F"
 done
+# Loud early warning; identical fingerprints are legitimate only when
+# the arms differ outside the hashed files (see sandbox-e2e.mjs).
+if [ "$FP_${base}" = "$FP_${cand}" ]; then
+  echo "WARNING: arms fingerprint identically ($FP_${base}) — the hashed React builds are byte-identical; verify the arms differ where intended"
+fi
 for run in $(seq 1 ${cfg.runs}); do
   # Alternate within the boot AND stagger by VM index so no arm owns
   # the cold first slot across the fleet.
@@ -427,6 +435,8 @@ for arm in ${profOrder}; do
   mkdir -p /vercel/sandbox/prof-$arm && mv build/profiles/* /vercel/sandbox/prof-$arm/
   echo "profiled $arm"
 done
+# Record capture order for order-drift checks (see sandbox-e2e.mjs).
+echo "${profOrder}" > /vercel/sandbox/prof-order.txt
 cd /vercel/sandbox && tar -czf profiles.tgz prof-*`
       try {
         await sbExec(vm, '40m', prof, `${tag}:prof`)

--- a/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
@@ -415,9 +415,12 @@ wc -l /vercel/sandbox/results.jsonl`
       })
       // Strictly AFTER the timed runs — profiling never touches the
       // numbers. Best-effort: a failed pass must not kill collection.
+      // Alternate the arm order by VM index so the second-arm-runs-warmer
+      // drift cancels in cross-VM aggregates (see sandbox-e2e.mjs).
+      const profOrder = index % 2 === 1 ? `${cand} ${base}` : `${base} ${cand}`
       const prof = `set -e
 cd /vercel/sandbox/fixture
-for arm in ${base} ${cand}; do
+for arm in ${profOrder}; do
   for p in /vercel/sandbox/arm-$arm/build/oss-experimental/*; do rm -rf node_modules/$(basename $p); done
   cp -r /vercel/sandbox/arm-$arm/build/oss-experimental/* node_modules/
   NODE_ENV=production node --expose-gc bench.js --profile >/tmp/prof.log 2>&1 || (tail -10 /tmp/prof.log; exit 1)

--- a/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
@@ -352,8 +352,8 @@ for arm in ${base} ${cand}; do
   echo "arm $arm ver=$V fp=$F"
   eval "VER_$arm=$V; FP_$arm=$F"
 done
-# Loud early warning; identical fingerprints are legitimate only when
-# the arms differ outside the hashed files (see sandbox-e2e.mjs).
+# Identical fingerprints can be legitimate (arms differing only in
+# files outside FP_FILES), so warn, not fail.
 if [ "$FP_${base}" = "$FP_${cand}" ]; then
   echo "WARNING: arms fingerprint identically ($FP_${base}) — the hashed React builds are byte-identical; verify the arms differ where intended"
 fi
@@ -423,8 +423,8 @@ wc -l /vercel/sandbox/results.jsonl`
       })
       // Strictly AFTER the timed runs — profiling never touches the
       // numbers. Best-effort: a failed pass must not kill collection.
-      // Alternate the arm order by VM index so the second-arm-runs-warmer
-      // drift cancels in cross-VM aggregates (see sandbox-e2e.mjs).
+      // Second-arm-runs-warmer drift cancels across VMs (see
+      // sandbox-e2e.mjs).
       const profOrder = index % 2 === 1 ? `${cand} ${base}` : `${base} ${cand}`
       const prof = `set -e
 cd /vercel/sandbox/fixture
@@ -435,7 +435,7 @@ for arm in ${profOrder}; do
   mkdir -p /vercel/sandbox/prof-$arm && mv build/profiles/* /vercel/sandbox/prof-$arm/
   echo "profiled $arm"
 done
-# Record capture order for order-drift checks (see sandbox-e2e.mjs).
+# Lets profile analysis split by capture order (see sandbox-e2e.mjs).
 echo "${profOrder}" > /vercel/sandbox/prof-order.txt
 cd /vercel/sandbox && tar -czf profiles.tgz prof-*`
       try {


### PR DESCRIPTION
## Summary

Harness fixes, all surfaced while benching a Fizz-only React PR (react/react#37022):

- **Profile pass now alternates arm order by VM index.** The timed runs are ABBA, but the CPU profile pass ran base-then-cand on every VM. The second arm runs warmer (page cache, governor), which deflated every function in the cand profile by a uniform few percent — untouched Flight frames "improved" ~7%. With balanced order the same untouched frames diff to ~1.5% across 14 paired VMs while real movers keep their magnitude. Each VM records its capture order in the profiles tarball (`prof-order.txt`) so analyses can check order drift directly.
- **The fingerprint now covers every server-side React layer.** `FP_FILES` hashed only the vendored Flight server files, which a Fizz-only React change leaves byte-identical — both arms of a valid A/B reported the same fingerprint. Added the vendored Fizz bundle and the shared react-server runtime (hooks/cache) in both suites. The VM boot loop also warns loudly when arms fingerprint identically, instead of leaving it for the analysis footer.
- **`--prepare` writes a terminal status phase.** It previously exited leaving `phase: "measuring"`, so `bench-status` prescribed collecting measurement data that never existed. `bench-status` now reports prepare-only runs as complete rather than "DEAD — relaunch".

## Verification

- Full 16-VM e2e run with the ordering + Fizz-fingerprint changes (`run-pr37022-e2e-prof2`): arms fingerprint distinctly (`18ea275e` vs `f9805be5`), profile order alternates per VM, untouched hot frames diff to ~zero in the cross-VM profile aggregate.
- `bench-status.mjs` against a real `--prepare` run dir reports `complete (--prepare: caches only)`.
- `--dry-run` smoke of the modified launcher; `node --check` on all three scripts.

<!-- NEXT_JS_LLM -->