### PR TITLE
[Bench] Run every remote exec detached

### DIFF
--- a/.agents/skills/sandbox-bench/scripts/bench-common.mjs
+++ b/.agents/skills/sandbox-bench/scripts/bench-common.mjs
@@ -4,7 +4,7 @@
 // CI-green gate, cached react arm builds, snapshots, the status.json
 // recovery record, and live interim estimates. Workload-specific code
 // (what runs on a measurement VM) stays in each launcher.
-import { execFile, spawn } from 'child_process'
+import { execFile } from 'child_process'
 import { promisify } from 'util'
 import fs from 'fs'
 import os from 'os'
@@ -389,16 +389,32 @@ export async function runDetached(vm, tag, script, onLine, deadlineMin) {
   )
   await sb(['cp', local, `${vm}:/vercel/sandbox/loop.sh`])
   fs.rmSync(local, { force: true })
-  await sb([
-    'exec',
-    vm,
-    '--timeout',
-    '2m',
-    '--',
-    'bash',
-    '-c',
-    'rm -f /vercel/sandbox/loop.done /vercel/sandbox/loop.log; nohup bash /vercel/sandbox/loop.sh >/vercel/sandbox/loop.log 2>&1 & echo kicked',
-  ])
+  // Marker before nohup: a kick that dies mid-transport then skips on
+  // retry (the poll deadline catches a never-started loop) instead of
+  // racing a second copy of the script against the first.
+  const kickId = crypto.randomBytes(8).toString('hex')
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await sb([
+        'exec',
+        vm,
+        '--timeout',
+        '2m',
+        '--',
+        'bash',
+        '-c',
+        `if [ "$(cat /vercel/sandbox/loop.kick 2>/dev/null)" = "${kickId}" ]; then echo already kicked; ` +
+          `else printf '%s' '${kickId}' > /vercel/sandbox/loop.kick; ` +
+          `rm -f /vercel/sandbox/loop.done /vercel/sandbox/loop.log; ` +
+          `nohup bash /vercel/sandbox/loop.sh >/vercel/sandbox/loop.log 2>&1 & echo kicked; fi`,
+      ])
+      break
+    } catch (e) {
+      if (attempt >= 3)
+        throw new Error(`${tag}: kick failed: ${e.message.slice(0, 200)}`)
+      await new Promise((r) => setTimeout(r, 5_000 * attempt))
+    }
+  }
   let offset = 0
   let failures = 0
   let pollDelay = 3_000

--- a/.agents/skills/sandbox-bench/scripts/bench-common.mjs
+++ b/.agents/skills/sandbox-bench/scripts/bench-common.mjs
@@ -372,11 +372,9 @@ export async function rmVm(name) {
 
 // Remote execution: nohup the script on the VM, then poll its log with
 // short execs. The exec stream drops flakily on multi-minute commands and
-// the CLI does not reliably propagate remote exit codes, so executions are
-// detached (they run exactly once and survive the transport) and the
-// stream is only used for kicks and polls, which are safe to repeat.
-// One detached command per VM at a time: the fixed loop.* paths are the
-// crash-recovery contract (bench-collect.mjs, SKILL.md).
+// misreports remote exit codes, so nothing rides it: kicks and polls are
+// safe to repeat. One detached command per VM at a time — the fixed
+// loop.* paths are the crash-recovery contract (bench-collect.mjs, SKILL.md).
 export async function runDetached(vm, tag, script, onLine, deadlineMin) {
   let transcript = ''
   const local = path.join(os.tmpdir(), `loop-${vm}.sh`)
@@ -389,9 +387,8 @@ export async function runDetached(vm, tag, script, onLine, deadlineMin) {
   )
   await sb(['cp', local, `${vm}:/vercel/sandbox/loop.sh`])
   fs.rmSync(local, { force: true })
-  // Marker before nohup: a kick that dies mid-transport then skips on
-  // retry (the poll deadline catches a never-started loop) instead of
-  // racing a second copy of the script against the first.
+  // Marker before nohup: a kick retried after a mid-transport death skips
+  // instead of racing a second copy of the script against the first.
   const kickId = crypto.randomBytes(8).toString('hex')
   for (let attempt = 1; ; attempt++) {
     try {

--- a/.agents/skills/sandbox-bench/scripts/bench-common.mjs
+++ b/.agents/skills/sandbox-bench/scripts/bench-common.mjs
@@ -106,11 +106,14 @@ export async function sbCpToVm(vm, localPath, vmDest) {
       await execFileP('shasum', ['-a', '256', localPath])
     ).stdout.split(' ')[0]
     const catList = parts.map((p) => `'${vmDest}.${p}'`).join(' ')
-    const out = await sbExec(
+    const tag = `cp:${path.basename(vmDest)}`
+    // Parts are deleted only after the sha verifies, so a dropped exec
+    // stream mid-concat can safely re-run from the same parts.
+    const out = await sbExecRetry(
       vm,
       '10m',
-      `cat ${catList} > '${vmDest}' && rm -f ${catList} && sha256sum '${vmDest}' | cut -d' ' -f1`,
-      `cp:${path.basename(vmDest)}`
+      `cat ${catList} > '${vmDest}' && sha256sum '${vmDest}' | cut -d' ' -f1`,
+      tag
     )
     // sbExec output interleaves stderr (CLI banners); take the last
     // sha-shaped token rather than the last line.
@@ -121,6 +124,8 @@ export async function sbCpToVm(vm, localPath, vmDest) {
         `chunked upload of ${localPath} corrupt: local ${localSha} != remote ${remoteSha}`
       )
     }
+    // Leaked parts would be captured into snapshots taken from this VM.
+    await sbExecRetry(vm, '2m', `rm -f ${catList}`, tag)
   } finally {
     fs.rmSync(partDir, { recursive: true, force: true })
   }
@@ -430,6 +435,21 @@ ${script}`
   })
 }
 
+// The exec stream drops flakily; short idempotent commands are safe to
+// just re-run. Anything that runs for minutes belongs in runDetached.
+export async function sbExecRetry(vm, timeout, script, tag, attempts = 3) {
+  for (let i = 1; ; i++) {
+    try {
+      return await sbExec(vm, timeout, script, tag)
+    } catch (e) {
+      if (i >= attempts) throw e
+      process.stderr.write(
+        `${tag}: exec attempt ${i}/${attempts} failed, retrying: ${String(e.message).split('\n')[0].slice(0, 120)}\n`
+      )
+    }
+  }
+}
+
 export async function rmVm(name) {
   try {
     await sb(['rm', name])
@@ -465,9 +485,13 @@ export async function runDetached(vm, tag, script, onLine, deadlineMin) {
   ])
   let offset = 0
   let failures = 0
+  let pollDelay = 3_000
   const deadline = Date.now() + deadlineMin * 60_000
   while (true) {
-    await new Promise((r) => setTimeout(r, 45_000))
+    await new Promise((r) => setTimeout(r, pollDelay))
+    // Backing off to the cap keeps short commands cheap (first poll at 3s)
+    // without hammering long builds with exec round trips.
+    pollDelay = Math.min(pollDelay * 2, 45_000)
     if (Date.now() > deadline)
       throw new Error(`${tag}: detached loop deadline exceeded`)
     let out
@@ -583,19 +607,31 @@ export async function ensureReactBuildSnapshot(refSha) {
     ])
     await sb(['cp', src, `${vm}:/vercel/sandbox/src.tgz`])
     fs.rmSync(src, { force: true })
-    await sb([
-      'exec',
-      vm,
-      '--timeout',
-      '10m',
-      '--sudo',
-      '--',
-      'dnf',
-      'install',
-      '-y',
-      '-q',
-      'java-21-amazon-corretto-headless',
-    ])
+    // dnf runs for a minute or two through the same drop-prone exec
+    // stream, and installs are idempotent.
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await sb([
+          'exec',
+          vm,
+          '--timeout',
+          '10m',
+          '--sudo',
+          '--',
+          'dnf',
+          'install',
+          '-y',
+          '-q',
+          'java-21-amazon-corretto-headless',
+        ])
+        break
+      } catch (e) {
+        if (attempt >= 3) throw e
+        process.stderr.write(
+          `react-snap: dnf attempt ${attempt}/3 failed, retrying: ${String(e.message).split('\n')[0].slice(0, 120)}\n`
+        )
+      }
+    }
     await runDetached(
       vm,
       'react-snap',

--- a/.agents/skills/sandbox-bench/scripts/bench-common.mjs
+++ b/.agents/skills/sandbox-bench/scripts/bench-common.mjs
@@ -106,17 +106,15 @@ export async function sbCpToVm(vm, localPath, vmDest) {
       await execFileP('shasum', ['-a', '256', localPath])
     ).stdout.split(' ')[0]
     const catList = parts.map((p) => `'${vmDest}.${p}'`).join(' ')
-    const tag = `cp:${path.basename(vmDest)}`
-    // Parts are deleted only after the sha verifies, so a dropped exec
-    // stream mid-concat can safely re-run from the same parts.
-    const out = await sbExecRetry(
+    const out = await runDetached(
       vm,
-      '10m',
-      `cat ${catList} > '${vmDest}' && sha256sum '${vmDest}' | cut -d' ' -f1`,
-      tag
+      `cp:${path.basename(vmDest)}`,
+      `cat ${catList} > '${vmDest}' && sha256sum '${vmDest}' | cut -d' ' -f1 && rm -f ${catList}`,
+      null,
+      12
     )
-    // sbExec output interleaves stderr (CLI banners); take the last
-    // sha-shaped token rather than the last line.
+    // The transcript interleaves other lines; take the last sha-shaped
+    // token rather than the last line.
     const shaTokens = out.match(/\b[0-9a-f]{64}\b/g)
     const remoteSha = shaTokens ? shaTokens[shaTokens.length - 1] : ''
     if (remoteSha !== localSha) {
@@ -124,8 +122,6 @@ export async function sbCpToVm(vm, localPath, vmDest) {
         `chunked upload of ${localPath} corrupt: local ${localSha} != remote ${remoteSha}`
       )
     }
-    // Leaked parts would be captured into snapshots taken from this VM.
-    await sbExecRetry(vm, '2m', `rm -f ${catList}`, tag)
   } finally {
     fs.rmSync(partDir, { recursive: true, force: true })
   }
@@ -366,90 +362,6 @@ export function pairedP(deltas) {
   return Math.min(1, integral / norm)
 }
 
-export function sbExec(vm, timeout, script, tag, onRow) {
-  return new Promise((resolve, reject) => {
-    // The CLI does not reliably propagate the remote exit code (observed
-    // exit 0 after a remote `exit 1`, CLI 56.3.x), so the script reports
-    // its own exit through an EXIT-trap marker; no marker means the
-    // transport died mid-run. Both are failures.
-    const wrapped = `trap 'echo "@@EXEC_EXIT $?"' EXIT
-${script}`
-    const child = spawn(
-      VERCEL,
-      [
-        'sandbox',
-        'exec',
-        vm,
-        ...SCOPE,
-        '--timeout',
-        timeout,
-        '--',
-        'bash',
-        '-c',
-        wrapped,
-      ],
-      { stdio: ['ignore', 'pipe', 'pipe'] }
-    )
-    let out = ''
-    let buf = ''
-    child.stdout.on('data', (c) => {
-      out += c
-      buf += c
-      const lines = buf.split('\n')
-      buf = lines.pop()
-      for (const l of lines) {
-        if (!l) continue
-        if (l.startsWith('ROW ') && onRow) {
-          try {
-            onRow(JSON.parse(l.slice(4)))
-          } catch {}
-        } else {
-          process.stderr.write(`[${tag}] ${l}\n`)
-        }
-      }
-    })
-    child.stderr.on('data', (c) => {
-      out += c
-      process.stderr.write(
-        String(c)
-          .split('\n')
-          .filter(Boolean)
-          .map((l) => `[${tag}!] ${l}\n`)
-          .join('')
-      )
-    })
-    child.on('exit', (code) => {
-      const marker = out.match(/@@EXEC_EXIT (\d+)\s*$/m)
-      if (code === 0 && marker && marker[1] === '0') {
-        resolve(out)
-      } else {
-        const why =
-          code !== 0
-            ? `cli exit ${code}`
-            : marker
-              ? `remote exit ${marker[1]}`
-              : 'no exit marker (transport died mid-run)'
-        reject(new Error(`${tag}: ${why}\n${out.slice(-2000)}`))
-      }
-    })
-  })
-}
-
-// The exec stream drops flakily; short idempotent commands are safe to
-// just re-run. Anything that runs for minutes belongs in runDetached.
-export async function sbExecRetry(vm, timeout, script, tag, attempts = 3) {
-  for (let i = 1; ; i++) {
-    try {
-      return await sbExec(vm, timeout, script, tag)
-    } catch (e) {
-      if (i >= attempts) throw e
-      process.stderr.write(
-        `${tag}: exec attempt ${i}/${attempts} failed, retrying: ${String(e.message).split('\n')[0].slice(0, 120)}\n`
-      )
-    }
-  }
-}
-
 export async function rmVm(name) {
   try {
     await sb(['rm', name])
@@ -458,9 +370,13 @@ export async function rmVm(name) {
   }
 }
 
-// Long-running remote work detached from the exec stream (streams drop
-// flakily on multi-minute silences): nohup the script on the VM, then
-// poll its log with short execs. Immune to transport hiccups.
+// Remote execution: nohup the script on the VM, then poll its log with
+// short execs. The exec stream drops flakily on multi-minute commands and
+// the CLI does not reliably propagate remote exit codes, so executions are
+// detached (they run exactly once and survive the transport) and the
+// stream is only used for kicks and polls, which are safe to repeat.
+// One detached command per VM at a time: the fixed loop.* paths are the
+// crash-recovery contract (bench-collect.mjs, SKILL.md).
 export async function runDetached(vm, tag, script, onLine, deadlineMin) {
   let transcript = ''
   const local = path.join(os.tmpdir(), `loop-${vm}.sh`)
@@ -569,13 +485,24 @@ export async function takeSnapshot(vm, cacheDir, key) {
 
 // React build environment (repo + node_modules + JDK), shared with
 // sandbox-ab.mjs. Keyed on the arm's yarn.lock.
+const reactSnapPromises = new Map()
 export async function ensureReactBuildSnapshot(refSha) {
+  // Raw bytes, exactly as cached snapshots hashed it: a trim here would
+  // silently fork the cache key and build every snapshot twice.
   const lock = await execFileP(
     'git',
     ['-C', REACT_REPO_LAZY(), 'show', `${refSha}:yarn.lock`],
     { maxBuffer: 1 << 28 }
   )
   const key = await sha256(SETUP_VERSION + lock.stdout)
+  // Concurrent callers with the same lockfile share one build.
+  if (!reactSnapPromises.has(key)) {
+    reactSnapPromises.set(key, ensureReactBuildSnapshotForKey(refSha, key))
+  }
+  return reactSnapPromises.get(key)
+}
+
+async function ensureReactBuildSnapshotForKey(refSha, key) {
   let id = await snapshotIdFor(REACT_SNAP_CACHE, key)
   if (id) return id
   const vm = `react-snap-build-${Date.now().toString(36)}`
@@ -607,38 +534,15 @@ export async function ensureReactBuildSnapshot(refSha) {
     ])
     await sb(['cp', src, `${vm}:/vercel/sandbox/src.tgz`])
     fs.rmSync(src, { force: true })
-    // dnf runs for a minute or two through the same drop-prone exec
-    // stream, and installs are idempotent.
-    for (let attempt = 1; ; attempt++) {
-      try {
-        await sb([
-          'exec',
-          vm,
-          '--timeout',
-          '10m',
-          '--sudo',
-          '--',
-          'dnf',
-          'install',
-          '-y',
-          '-q',
-          'java-21-amazon-corretto-headless',
-        ])
-        break
-      } catch (e) {
-        if (attempt >= 3) throw e
-        process.stderr.write(
-          `react-snap: dnf attempt ${attempt}/3 failed, retrying: ${String(e.message).split('\n')[0].slice(0, 120)}\n`
-        )
-      }
-    }
+    // The default user has passwordless sudo (verified on node24 VMs).
     await runDetached(
       vm,
       'react-snap',
-      `mkdir -p /vercel/sandbox/react && cd /vercel/sandbox/react && tar -xzf ../src.tgz && rm -f ../src.tgz && ` +
+      `sudo dnf install -y -q java-21-amazon-corretto-headless && ` +
+        `mkdir -p /vercel/sandbox/react && cd /vercel/sandbox/react && tar -xzf ../src.tgz && rm -f ../src.tgz && ` +
         `npm i -g yarn >/dev/null 2>&1 && yarn install --frozen-lockfile --ignore-engines >/dev/null 2>&1 && echo react env ready`,
       null,
-      25
+      30
     )
     return await takeSnapshot(vm, REACT_SNAP_CACHE, key)
   } finally {

--- a/.agents/skills/sandbox-bench/scripts/bench-common.mjs
+++ b/.agents/skills/sandbox-bench/scripts/bench-common.mjs
@@ -596,12 +596,13 @@ export async function ensureReactBuildSnapshot(refSha) {
       '-q',
       'java-21-amazon-corretto-headless',
     ])
-    await sbExec(
+    await runDetached(
       vm,
-      '20m',
-      `set -e; mkdir -p /vercel/sandbox/react && cd /vercel/sandbox/react && tar -xzf ../src.tgz && rm -f ../src.tgz && ` +
+      'react-snap',
+      `mkdir -p /vercel/sandbox/react && cd /vercel/sandbox/react && tar -xzf ../src.tgz && rm -f ../src.tgz && ` +
         `npm i -g yarn >/dev/null 2>&1 && yarn install --frozen-lockfile --ignore-engines >/dev/null 2>&1 && echo react env ready`,
-      'react-snap'
+      null,
+      25
     )
     return await takeSnapshot(vm, REACT_SNAP_CACHE, key)
   } finally {
@@ -758,15 +759,12 @@ export async function ensureRefArm(arm) {
     }
     await sb(['cp', src, `${vm}:/vercel/sandbox/src.tgz`])
     fs.rmSync(src, { force: true })
-    // The exec stream drops on long silent commands; heartbeat keeps it
-    // alive during the ~10min dual-channel build. Newline before the
-    // backgrounded heartbeat: a trailing & after && backgrounds the
-    // whole chain.
-    await sbExec(
+    // Newline before the backgrounded heartbeat: a trailing & after &&
+    // backgrounds the whole chain.
+    await runDetached(
       vm,
-      '40m',
-      `set -e
-ls /vercel/sandbox/react/node_modules >/dev/null
+      `armbuild:${arm.name}`,
+      `ls /vercel/sandbox/react/node_modules >/dev/null
 cd /vercel/sandbox/react
 find . -mindepth 1 -maxdepth 1 ! -name node_modules -exec rm -rf {} +
 tar -xzf ../src.tgz
@@ -776,7 +774,8 @@ yarn build "${E2E_BUILD_TARGETS}" >/tmp/build.log 2>&1 || (kill $HB; tail -20 /t
 kill $HB
 tar -czf /vercel/sandbox/arm.tgz build/oss-stable build/oss-experimental
 echo arm built`,
-      `armbuild:${arm.name}`
+      null,
+      45
     )
     fs.mkdirSync(CACHE, { recursive: true })
     const armTmp = `${cached}.tmp-${process.pid}`

--- a/.agents/skills/sandbox-bench/scripts/config.mjs
+++ b/.agents/skills/sandbox-bench/scripts/config.mjs
@@ -79,7 +79,7 @@ function expandHome(p) {
 // Scope flags appended to every `vercel sandbox` call. Never widen scope
 // beyond the configured team/project: the project may be shared.
 export function sandboxScope(cfg) {
-  return ['--team', cfg.team, '--project', cfg.project]
+  return ['--scope', cfg.team, '--project', cfg.project]
 }
 
 // Repos: use the configured checkout, else clone lazily into the cache.

--- a/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
@@ -34,7 +34,6 @@ import {
   writeStatus,
   sb,
   sbCpToVm,
-  sbExecRetry,
   rmVm,
   runDetached,
   resolvePrArms,
@@ -499,11 +498,12 @@ echo "tree ${a.name} ready"`
         }
       }
     }
-    await sbExecRetry(
+    await runDetached(
       vm,
-      '5m',
+      'expsnap',
       `rm -f /vercel/sandbox/tree-*.tgz /vercel/sandbox/tree-*-out.tgz; echo cleaned`,
-      'expsnap'
+      null,
+      5
     )
     return await takeSnapshot(vm, CACHE, key)
   } finally {

--- a/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
@@ -466,15 +466,16 @@ ${a.treeCached ? ':' : `echo "PHASE pack-${a.name} $(date +%s)" && tar -czf /ver
 echo "tree ${a.name} ready"`
       )
       .join('\n')
-    await sbExec(
+    await runDetached(
       vm,
-      '55m',
-      `set -e\nnpm i -g pnpm@10.33.0 >/dev/null 2>&1\n` +
+      'expsnap',
+      `npm i -g pnpm@10.33.0 >/dev/null 2>&1\n` +
         `(while true; do echo "hb mem=$(free -m | awk '/^Mem/{print $3}')MB"; sleep 30; done) & HB=$!\n` +
         `${extractCached}\n${installs}\n${builds}\n${waits}\n${verifies}\nkill $HB\n` +
         `echo "PHASE done $(date +%s)"\n` +
         `find /vercel/sandbox -maxdepth 1 -name '*.tgz' ! -name 'tree-*-out.tgz' -delete\necho experiment ready`,
-      'expsnap'
+      null,
+      58
     )
     // Pull freshly built trees into the cache before snapshotting (the
     // snapshot must not contain the multi-GB tarballs).
@@ -705,7 +706,7 @@ cd /vercel/sandbox && tar -czf profiles.tgz prof-*`
       // already on disk at this point). Each VM extracts into its own
       // subdirectory so VMs don't overwrite each other's prof-<arm> dirs.
       try {
-        await sbExec(vm, '30m', prof, `${tag}:prof`)
+        await runDetached(vm, `${tag}:prof`, prof, null, 35)
         const profTgz = path.join(outDir, `profiles-vm${index}.tgz`)
         await sb(['cp', `${vm}:/vercel/sandbox/profiles.tgz`, profTgz])
         if (!fs.existsSync(profTgz) || fs.statSync(profTgz).size === 0) {

--- a/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-e2e.mjs
@@ -34,7 +34,7 @@ import {
   writeStatus,
   sb,
   sbCpToVm,
-  sbExec,
+  sbExecRetry,
   rmVm,
   runDetached,
   resolvePrArms,
@@ -499,7 +499,7 @@ echo "tree ${a.name} ready"`
         }
       }
     }
-    await sbExec(
+    await sbExecRetry(
       vm,
       '5m',
       `rm -f /vercel/sandbox/tree-*.tgz /vercel/sandbox/tree-*-out.tgz; echo cleaned`,

--- a/.agents/skills/sandbox-bench/scripts/sandbox-gate.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-gate.mjs
@@ -10,13 +10,13 @@
 // Usage: node sandbox-gate.mjs --arms name=ref[,name=ref...]
 //        [--pattern <jest pattern>, default: full suite] [--extra "yarn flow dom-node"]
 //        [--snapshot snap_x] [--dry-run]
-import { execFile, spawn } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import crypto from 'node:crypto'
 import { loadConfig, sandboxScope, ensureReactRepo } from './config.mjs'
+import { runDetached, ensureReactBuildSnapshot } from './bench-common.mjs'
 
 const execFileP = promisify(execFile)
 const DRY_RUN = process.argv.includes('--dry-run')
@@ -24,8 +24,6 @@ const CONFIG = loadConfig({ requireScope: !DRY_RUN })
 const REACT = ensureReactRepo(CONFIG)
 const VERCEL = CONFIG.vercelBin
 const SCOPE = CONFIG.team ? sandboxScope(CONFIG) : []
-const SETUP_VERSION = 'v1-al2023-node24-jdk21'
-const REACT_SNAP_CACHE = path.join(CONFIG.cacheDir, 'react-snap')
 
 function parseArgs() {
   const args = { arms: [], snapshot: undefined, extra: [], pattern: '' }
@@ -88,69 +86,6 @@ async function rmVm(name) {
     await sb(['rm', name])
   } catch (e) {
     process.stderr.write(`warning: could not remove ${name}: ${e.message}\n`)
-  }
-}
-
-// Same detached-nohup-and-poll shape as sandbox-e2e.mjs runDetached:
-// exec streams drop flakily on multi-minute silences, so never hold one.
-async function runDetached(vm, tag, script, deadlineMin) {
-  const local = path.join(os.tmpdir(), `gate-${vm}.sh`)
-  fs.writeFileSync(
-    local,
-    // EXIT trap, not ERR: see sandbox-e2e.mjs runDetached.
-    `trap 'code=$?; if [ $code -eq 0 ]; then echo LOOPOK; else echo LOOPFAIL; fi > /vercel/sandbox/loop.done' EXIT\nset -e\n${script}\n`
-  )
-  await sb(['cp', local, `${vm}:/vercel/sandbox/loop.sh`])
-  fs.rmSync(local, { force: true })
-  await sb([
-    'exec',
-    vm,
-    '--timeout',
-    '2m',
-    '--',
-    'bash',
-    '-c',
-    'rm -f /vercel/sandbox/loop.done /vercel/sandbox/loop.log; nohup bash /vercel/sandbox/loop.sh >/vercel/sandbox/loop.log 2>&1 & echo kicked',
-  ])
-  let offset = 0
-  let failures = 0
-  const deadline = Date.now() + deadlineMin * 60_000
-  while (true) {
-    await new Promise((r) => setTimeout(r, 45_000))
-    if (Date.now() > deadline) throw new Error(`${tag}: deadline exceeded`)
-    let out
-    try {
-      out = await sb([
-        'exec',
-        vm,
-        '--timeout',
-        '2m',
-        '--',
-        'bash',
-        '-c',
-        `tail -c +${offset + 1} /vercel/sandbox/loop.log | head -c 200000; printf '\\n@@SIZE %s @@DONE %s\\n' "$(stat -c %s /vercel/sandbox/loop.log 2>/dev/null || echo 0)" "$(cat /vercel/sandbox/loop.done 2>/dev/null || echo no)"`,
-      ])
-      failures = 0
-    } catch (e) {
-      if (++failures >= 6)
-        throw new Error(
-          `${tag}: ${failures} consecutive poll failures: ${e.message.slice(0, 200)}`
-        )
-      continue
-    }
-    const m = out.match(/@@SIZE (\d+) @@DONE (\S+)/)
-    const body = out.slice(0, out.lastIndexOf('\n@@SIZE'))
-    for (const l of body.split('\n')) {
-      if (l) process.stderr.write(`[${tag}] ${l}\n`)
-    }
-    if (m) {
-      offset = Math.min(Number(m[1]), offset + 200000)
-      if (m[2] === 'LOOPOK') return
-      if (m[2] === 'LOOPFAIL')
-        throw new Error(
-          `${tag}: remote gate failed; tail:\n${body.slice(-3000)}`
-        )
-    }
   }
 }
 
@@ -241,6 +176,7 @@ async function gateArm(arm, snapshot, tmp, extra = [], pattern = '') {
           )
           .join('') +
         `echo "== ${arm.name} GATE PASS =="\n`,
+      null,
       90
     )
     return { arm: arm.name, sha: short, pass: true }
@@ -252,102 +188,6 @@ async function gateArm(arm, snapshot, tmp, extra = [], pattern = '') {
 // Build-env snapshot: node_modules installed + JDK for the closure
 // compiler, keyed on yarn.lock. Created once per lockfile, reused by
 // every later gate.
-const snapshotPromises = new Map()
-
-async function ensureReactBuildSnapshot(refSha) {
-  // Raw bytes, exactly as the e2e harness hashes it: a trim here would
-  // silently fork the cache key and build every snapshot twice.
-  const lock = (
-    await execFileP('git', ['-C', REACT, 'show', `${refSha}:yarn.lock`], {
-      maxBuffer: 256 * 1024 * 1024,
-    })
-  ).stdout
-  const memoKey = crypto.createHash('sha256').update(lock).digest('hex')
-  if (!snapshotPromises.has(memoKey)) {
-    snapshotPromises.set(memoKey, ensureReactBuildSnapshotForLock(refSha, lock))
-  }
-  return snapshotPromises.get(memoKey)
-}
-
-async function ensureReactBuildSnapshotForLock(refSha, lock) {
-  const key = crypto
-    .createHash('sha256')
-    .update(SETUP_VERSION + lock)
-    .digest('hex')
-    .slice(0, 16)
-  const file = path.join(REACT_SNAP_CACHE, `snap-${key}`)
-  if (fs.existsSync(file)) {
-    const id = fs.readFileSync(file, 'utf8').trim()
-    try {
-      await sb(['snapshots', 'get', id])
-      return id
-    } catch {}
-  }
-  const vm = `sbench-snapbuild-${Date.now().toString(36)}`
-  console.error(
-    'creating react build-env snapshot (one-time for this yarn.lock)...'
-  )
-  await sb([
-    'create',
-    '--name',
-    vm,
-    '--runtime',
-    'node24',
-    '--vcpus',
-    '8',
-    '--timeout',
-    '45m',
-    '--non-persistent',
-    '--network-policy',
-    'allow-all',
-    '--tag',
-    'purpose=sandbox-bench',
-    '--silent',
-  ])
-  try {
-    const src = path.join(os.tmpdir(), `react-snap-src-${key}.tgz`)
-    await execFileP('bash', [
-      '-c',
-      `git -C ${REACT} archive ${refSha} | gzip -1 > ${src}`,
-    ])
-    await sb(['cp', src, `${vm}:/vercel/sandbox/src.tgz`])
-    fs.rmSync(src, { force: true })
-    await sb([
-      'exec',
-      vm,
-      '--timeout',
-      '10m',
-      '--sudo',
-      '--',
-      'dnf',
-      'install',
-      '-y',
-      '-q',
-      'java-21-amazon-corretto-headless',
-    ])
-    await runDetached(
-      vm,
-      'react-snap',
-      `mkdir -p /vercel/sandbox/react && cd /vercel/sandbox/react && tar -xzf ../src.tgz && rm -f ../src.tgz\n` +
-        `npm i -g yarn >/dev/null 2>&1\n` +
-        `yarn install --frozen-lockfile --ignore-engines >/dev/null 2>&1\n` +
-        `echo react env ready\n`,
-      30
-    )
-    const out = await sb(['snapshot', vm, '--stop', '--expiration', '30d'], {
-      withStderr: true,
-    })
-    const snapId = out.match(/snap_[A-Za-z0-9]+/)?.[0]
-    if (!snapId)
-      throw new Error(`could not parse snapshot id from: ${out.slice(-500)}`)
-    fs.mkdirSync(REACT_SNAP_CACHE, { recursive: true })
-    fs.writeFileSync(file, `${snapId}\n`)
-    return snapId
-  } finally {
-    await rmVm(vm)
-  }
-}
-
 async function main() {
   const args = parseArgs()
   if (DRY_RUN) {

--- a/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
@@ -260,8 +260,7 @@ async function ensureSsrSnapshot(cfg) {
     await runDetached(
       vm,
       'ssrsnap',
-      `set -e
-npm i -g yarn >/dev/null 2>&1
+      `npm i -g yarn >/dev/null 2>&1
 mkdir -p /vercel/sandbox/fixture
 tar -xzf /vercel/sandbox/fixture.tgz --strip-components=2 -C /vercel/sandbox/fixture
 ${extractArms}

--- a/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
+++ b/.agents/skills/sandbox-bench/scripts/sandbox-ssr.mjs
@@ -29,7 +29,6 @@ import {
   status,
   writeStatus,
   sb,
-  sbExec,
   rmVm,
   runDetached,
   resolvePrArms,
@@ -258,9 +257,9 @@ async function ensureSsrSnapshot(cfg) {
     // Smoke: one full bench pass on the base arm proves the fixture
     // installs, builds its bundle, and emits parseable JSON before 16
     // VMs boot from this snapshot.
-    await sbExec(
+    await runDetached(
       vm,
-      '35m',
+      'ssrsnap',
       `set -e
 npm i -g yarn >/dev/null 2>&1
 mkdir -p /vercel/sandbox/fixture
@@ -277,7 +276,8 @@ node -e 'const j=require("/tmp/smoke.json"); if (!Array.isArray(j.results) || j.
 rm -f /tmp/smoke.json /vercel/sandbox/fixture.tgz /vercel/sandbox/arm-*.tgz
 echo "PHASE done $(date +%s)"
 echo ssr env ready`,
-      'ssrsnap'
+      null,
+      40
     )
     return await takeSnapshot(vm, CACHE, key)
   } finally {
@@ -439,7 +439,7 @@ done
 echo "${profOrder}" > /vercel/sandbox/prof-order.txt
 cd /vercel/sandbox && tar -czf profiles.tgz prof-*`
       try {
-        await sbExec(vm, '40m', prof, `${tag}:prof`)
+        await runDetached(vm, `${tag}:prof`, prof, null, 45)
         const profTgz = path.join(outDir, `profiles-vm${index}.tgz`)
         await sb(['cp', `${vm}:/vercel/sandbox/profiles.tgz`, profTgz])
         if (!fs.existsSync(profTgz) || fs.statSync(profTgz).size === 0) {


### PR DESCRIPTION
`vercel sandbox exec` drops its stream on multi-minute commands. It also doesn't reliably propagate the remote exit code, so the build fails while the work on the VM keeps going fine:

```
[expsnap] PHASE pack-pr37147 1785965258
[expsnap] hb mem=1367MB
Error: Stream ended before command finished
```

It hit three of four consecutive snapshot/arm builds.

`runDetached` already avoided this for the measurement loops. It nohups the script on the VM and polls the log with short execs, so nothing depends on a long-lived stream. This PR makes it the only way anything runs remotely. Kicks and polls are then the only things riding the stream, and both are safe to repeat — retrying a build is not.

- every remote command goes through `runDetached`: snapshot builds, arm builds, profile passes, upload concat, cleanup. `sbExec` is gone.
- polling starts at 3s and backs off to the 45s cap, so short commands stay cheap
- the kick writes a nonce to `loop.kick` before the `nohup`, so a kick retried after the transport died skips instead of starting a second copy alongside the first. Kicks retry up to 3 times.
- the java install moves into the react-snap script via `sudo` (the VM user has passwordless sudo, verified on a node24 VM)
- `sandbox-gate.mjs` uses the shared `runDetached` and `ensureReactBuildSnapshot` instead of its own copies; its same-lockfile memoization moves into the shared one
- `--scope` replaces the `--team` alias in the CLI invocations (unrelated to PR but this started failing)

After the first commit, the workload that had failed three times completed on the first attempt: arm build, snapshot, 16-VM e2e run, profile passes, no transport casualties. A second arm build and a gate run also completed under the detached path.
