### PR TITLE
Development: don't 404 routes whose files exist on disk

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1966,11 +1966,13 @@ export async function createHotReloaderTurbopack(
                   resolve(true)
                 })
               })
-              if (!updated) break
               pendingEntrypointsUpdate = nextEntrypointsUpdate.promise
               route = isInsideAppDir
                 ? currentEntrypoints.app.get(normalizedAppPage)
                 : currentEntrypoints.page.get(page)
+              // The route is checked once more even when the deadline was
+              // hit, in case an update finished at the same time.
+              if (!updated) break
             }
           }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1,5 +1,5 @@
 import type { Socket } from 'net'
-import { mkdir, writeFile } from 'fs/promises'
+import { access, mkdir, writeFile } from 'fs/promises'
 import { realpathSync } from 'fs'
 import * as inspector from 'inspector'
 import { join, extname, relative, isAbsolute, sep } from 'path'
@@ -37,6 +37,7 @@ import {
   getOriginalStackFrames,
 } from './middleware-turbopack'
 import { PageNotFoundError } from '../../shared/lib/utils'
+import { DetachedPromise } from '../../lib/detached-promise'
 import { debounce } from '../utils'
 import { clearManifestCache } from '../load-manifest.external'
 import { deleteCache } from './require-cache'
@@ -157,6 +158,16 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
+
+/**
+ * How long `ensurePage` waits for a route whose file exists on disk to show
+ * up in Turbopack's entrypoints. The expected wake-up is the next entrypoints
+ * update; this deadline is only a liveness backstop for states where no
+ * update ever arrives (e.g. a broken file watcher, or a build error that
+ * prevents entrypoints from being computed), in which case the request fails
+ * with "not found" as it did before waiting.
+ */
+const ENSURE_PAGE_ENTRYPOINTS_WAIT_MS = 10_000
 
 declare const __next__clear_chunk_cache__: (() => void) | null | undefined
 
@@ -552,6 +563,18 @@ export async function createHotReloaderTurbopack(
   let currentEntriesHandling = new Promise(
     (resolve) => (currentEntriesHandlingResolve = resolve)
   )
+  // Unlike `currentEntriesHandling`, which is resolved while no entrypoints
+  // update is in flight, this promise is always pending. Awaiting it observes
+  // the completion of the next entrypoints update, including updates that
+  // haven't started yet.
+  let nextEntrypointsUpdate = new DetachedPromise<void>()
+  function finishEntrypointsUpdate() {
+    currentEntriesHandlingResolve!()
+    currentEntriesHandlingResolve = undefined
+    const settled = nextEntrypointsUpdate
+    nextEntrypointsUpdate = new DetachedPromise<void>()
+    settled.resolve()
+  }
 
   const assetMapper = new AssetMapper()
 
@@ -1035,8 +1058,7 @@ export async function createHotReloaderTurbopack(
       if (!('routes' in entrypoints)) {
         printBuildErrors(entrypoints, true)
 
-        currentEntriesHandlingResolve!()
-        currentEntriesHandlingResolve = undefined
+        finishEntrypointsUpdate()
         continue
       }
 
@@ -1119,8 +1141,7 @@ export async function createHotReloaderTurbopack(
         })
       }
 
-      currentEntriesHandlingResolve!()
-      currentEntriesHandlingResolve = undefined
+      finishEntrypointsUpdate()
     }
   }
 
@@ -1903,7 +1924,10 @@ export async function createHotReloaderTurbopack(
               )
             : page
 
-          const route = isInsideAppDir
+          // Captured before checking the entrypoints so that an update
+          // finishing in between cannot be missed while waiting below.
+          let pendingEntrypointsUpdate = nextEntrypointsUpdate.promise
+          let route = isInsideAppDir
             ? currentEntrypoints.app.get(normalizedAppPage)
             : currentEntrypoints.page.get(page)
 
@@ -1915,7 +1939,42 @@ export async function createHotReloaderTurbopack(
             if (page === '/src/proxy') return
             if (page === '/instrumentation') return
             if (page === '/src/instrumentation') return
+          }
 
+          if (!route) {
+            // The route can be missing from the entrypoints even though its
+            // file exists on disk: routes are discovered by a separate watcher
+            // in setup-dev-bundler.ts, which can pick up a freshly written
+            // file before Turbopack's own watcher does. As long as the file
+            // exists, wait for Turbopack to catch up instead of failing the
+            // request.
+            const deadline = Date.now() + ENSURE_PAGE_ENTRYPOINTS_WAIT_MS
+            while (!route) {
+              try {
+                await access(routeDef.filename)
+              } catch {
+                break
+              }
+              const timeLeft = deadline - Date.now()
+              if (timeLeft <= 0) break
+              const pending = pendingEntrypointsUpdate
+              const updated = await new Promise<boolean>((resolve) => {
+                const timer = setTimeout(() => resolve(false), timeLeft)
+                timer.unref()
+                pending.then(() => {
+                  clearTimeout(timer)
+                  resolve(true)
+                })
+              })
+              if (!updated) break
+              pendingEntrypointsUpdate = nextEntrypointsUpdate.promise
+              route = isInsideAppDir
+                ? currentEntrypoints.app.get(normalizedAppPage)
+                : currentEntrypoints.page.get(page)
+            }
+          }
+
+          if (!route) {
             throw new PageNotFoundError(`route not found ${page}`)
           }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -41,6 +41,7 @@ import Server, { WrappedBuildError } from '../next-server'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
+import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
 import { Telemetry } from '../../telemetry/storage'
 import {
   type Span,
@@ -459,6 +460,7 @@ export default class DevServer extends Server {
       }
       pathname = removePathPrefix(pathname, basePath) || '/'
     }
+    pathname = removeTrailingSlash(pathname)
 
     return this.matchers.test(pathname, {
       i18n: this.i18nProvider?.analyze(pathname),

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -462,9 +462,14 @@ export default class DevServer extends Server {
     }
     pathname = removeTrailingSlash(pathname)
 
-    return this.matchers.test(pathname, {
-      i18n: this.i18nProvider?.analyze(pathname),
-    })
+    const i18n = this.i18nProvider?.analyze(pathname)
+    // API routes are not served under locale-prefixed paths; see the
+    // corresponding check in resolveRoutes.
+    if (i18n?.detectedLocale && pathHasPrefix(i18n.pathname, '/api')) {
+      return false
+    }
+
+    return this.matchers.test(pathname, { i18n })
   }
 
   async runMiddleware(params: {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -442,6 +442,29 @@ export default class DevServer extends Server {
     return Boolean(appFile || pagesFile)
   }
 
+  /**
+   * Called by the router server before it renders a 404 for a request
+   * pathname that its filesystem route info does not include. That info is
+   * updated when the file watcher has processed a change, so it can lag
+   * behind the filesystem when a request arrives right after a file was
+   * written. The development route matchers re-scan the filesystem when they
+   * don't have a match, so this reflects the routes that exist on disk at
+   * the time of the call.
+   */
+  public async testRouteMatch(pathname: string): Promise<boolean> {
+    const { basePath } = this.nextConfig
+    if (basePath) {
+      if (!pathHasPrefix(pathname, basePath)) {
+        return false
+      }
+      pathname = removePathPrefix(pathname, basePath) || '/'
+    }
+
+    return this.matchers.test(pathname, {
+      i18n: this.i18nProvider?.analyze(pathname),
+    })
+  }
+
   async runMiddleware(params: {
     request: NodeNextRequest
     response: NodeNextResponse

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -76,7 +76,7 @@ export async function propagateServerField(
   if (wrappedServer) {
     if (typeof wrappedServer[_field] === 'function') {
       // @ts-expect-error
-      await wrappedServer[_field].apply(
+      return await wrappedServer[_field].apply(
         wrappedServer,
         Array.isArray(value) ? value : []
       )

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -492,6 +492,7 @@ export async function initialize(opts: {
         resHeaders,
         bodyStream,
         matchedOutput,
+        didRewrite,
       } = await resolveRoutes({
         req,
         res,
@@ -765,10 +766,16 @@ export async function initialize(opts: {
       // request arrives right after a file was written. Before rendering a
       // 404, check the request path against the routes on disk via the
       // development route matchers, and render the route when it exists.
+      // Plain-text 404s for static assets and subresources above stay on
+      // their fast path deliberately: they self-heal on retry and aren't
+      // worth a filesystem re-scan.
       if (
         opts.dev &&
-        config.useFileSystemPublicRoutes &&
+        // Filesystem routes are only served for rewritten requests when
+        // `useFileSystemPublicRoutes` is disabled.
+        (config.useFileSystemPublicRoutes || didRewrite) &&
         parsedUrl.pathname &&
+        !parsedUrl.pathname.startsWith('/_next/') &&
         !invokedOutputs.has(parsedUrl.pathname)
       ) {
         let routeExists = false

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -760,6 +760,37 @@ export async function initialize(opts: {
         return null
       }
 
+      // The filesystem route info is updated when the file watcher has
+      // processed a change, so it can lag behind the filesystem when a
+      // request arrives right after a file was written. Before rendering a
+      // 404, check the request path against the routes on disk via the
+      // development route matchers, and render the route when it exists.
+      if (
+        opts.dev &&
+        config.useFileSystemPublicRoutes &&
+        parsedUrl.pathname &&
+        !invokedOutputs.has(parsedUrl.pathname)
+      ) {
+        let routeExists = false
+        try {
+          routeExists = Boolean(
+            await renderServer?.instance?.propagateServerField(
+              opts.dir,
+              'testRouteMatch',
+              [parsedUrl.pathname]
+            )
+          )
+        } catch {
+          // The render server hasn't been initialized yet; there are no
+          // routes it could have missed.
+        }
+
+        if (routeExists) {
+          invokedOutputs.add(parsedUrl.pathname)
+          return await invokeRender(parsedUrl, parsedUrl.pathname, handleIndex)
+        }
+      }
+
       const appNotFound = opts.dev
         ? development?.bundler?.serverFields.hasAppNotFound
         : await fsChecker.getItem(UNDERSCORE_NOT_FOUND_ROUTE)

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -133,6 +133,7 @@ export function getResolveRoutes(
     resHeaders: Record<string, string | string[]> | null
     parsedUrl: NextUrlWithParsedQuery
     matchedOutput?: FsOutput | null
+    didRewrite?: boolean
   }> {
     let finished = false
     let resHeaders: Record<string, string | string[]> = {}
@@ -953,6 +954,7 @@ export function getResolveRoutes(
       parsedUrl,
       resHeaders,
       matchedOutput,
+      didRewrite,
     }
   }
 

--- a/packages/next/src/server/lib/router-utils/types.ts
+++ b/packages/next/src/server/lib/router-utils/types.ts
@@ -2,6 +2,7 @@ export type PropagateToWorkersField =
   | 'actualMiddlewareFile'
   | 'actualInstrumentationHookFile'
   | 'reloadMatchers'
+  | 'testRouteMatch'
   | 'loadEnvConfig'
   | 'appPathRoutes'
   | 'middleware'

--- a/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
@@ -36,13 +36,44 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
   private waitTillReadyPromise?: Promise<void>
   public async waitTillReady(): Promise<void> {
     if (this.waitTillReadyPromise) {
-      await this.waitTillReadyPromise
-      delete this.waitTillReadyPromise
+      try {
+        await this.waitTillReadyPromise
+      } finally {
+        // Also delete the promise when it rejected, so that one failed
+        // reload doesn't fail every subsequent request.
+        delete this.waitTillReadyPromise
+      }
     }
   }
 
+  private inFlightReload?: Promise<void>
+  private queuedReload?: Promise<void>
+
+  public reload(): Promise<void> {
+    // Coalesce concurrent reloads. A caller that arrives while a reload is
+    // in flight cannot join it, because that reload may have scanned the
+    // filesystem before the change the caller wants to observe, so it waits
+    // for one queued follow-up reload instead. This bounds the work under
+    // concurrent reloads to one running and one queued scan.
+    if (!this.inFlightReload) {
+      this.inFlightReload = this.reloadImpl().finally(() => {
+        this.inFlightReload = undefined
+      })
+      return this.inFlightReload
+    }
+
+    if (!this.queuedReload) {
+      this.queuedReload = this.inFlightReload.then(() => {
+        this.queuedReload = undefined
+        return this.reload()
+      })
+    }
+
+    return this.queuedReload
+  }
+
   private previousMatchers: ReadonlyArray<RouteMatcher> = []
-  public async reload() {
+  private async reloadImpl() {
     const { promise, resolve, reject } = new DetachedPromise<void>()
     this.waitTillReadyPromise = promise
 

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -22,13 +22,14 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
   }
 
   public async test(pathname: string, options: MatchOptions): Promise<boolean> {
-    // Try to find a match within the developer routes.
-    const match = await super.match(pathname, options)
+    // Try to find a match within the developer routes. Unlike the
+    // implementation of `match` which uses `matchAll` here, this does not
+    // call `ensure` on the match found via the development matches.
+    for await (const match of this.developmentMatchAll(pathname, options)) {
+      if (match) return true
+    }
 
-    // Return if the match wasn't null. Unlike the implementation of `match`
-    // which uses `matchAll` here, this does not call `ensure` on the match
-    // found via the development matches.
-    return match !== null
+    return false
   }
 
   protected validate(
@@ -61,13 +62,42 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     return match
   }
 
+  /**
+   * Iterates over the development matches for the request path. The
+   * development matchers are reloaded when the file watcher has processed a
+   * change, so they can lag behind the filesystem when a request arrives
+   * right after a file was written. On a miss, this re-scans the filesystem
+   * once and retries before treating the request path as unmatched.
+   */
+  private async *developmentMatchAll(
+    pathname: string,
+    options: MatchOptions
+  ): AsyncGenerator<RouteMatch<RouteDefinition<RouteKind>>, null, undefined> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      let matched = false
+      for await (const developmentMatch of super.matchAll(pathname, options)) {
+        matched = true
+        yield developmentMatch
+      }
+
+      if (matched || attempt === 1) break
+
+      await super.reload()
+    }
+
+    return null
+  }
+
   public async *matchAll(
     pathname: string,
     options: MatchOptions
   ): AsyncGenerator<RouteMatch<RouteDefinition<RouteKind>>, null, undefined> {
     // Iterate over the development matches to see if one of them match the
     // request path.
-    for await (const developmentMatch of super.matchAll(pathname, options)) {
+    for await (const developmentMatch of this.developmentMatchAll(
+      pathname,
+      options
+    )) {
       // We're here, which means that we haven't seen this match yet, so we
       // should try to ensure it and recompile the production matcher.
       await this.ensurer.ensure(developmentMatch, pathname)

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -1,4 +1,5 @@
 import { RouteKind } from '../route-kind'
+import { PageNotFoundError } from '../../shared/lib/utils'
 import type { RouteMatch } from '../route-matches/route-match'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import { DefaultRouteMatcherManager } from './default-route-matcher-manager'
@@ -100,7 +101,15 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     )) {
       // We're here, which means that we haven't seen this match yet, so we
       // should try to ensure it and recompile the production matcher.
-      await this.ensurer.ensure(developmentMatch, pathname)
+      try {
+        await this.ensurer.ensure(developmentMatch, pathname)
+      } catch (err) {
+        // The route was removed after the matchers last scanned the
+        // filesystem. Treat the stale match as no match rather than failing
+        // the request.
+        if (err instanceof PageNotFoundError) continue
+        throw err
+      }
       await this.production.reload()
 
       // Iterate over the production matches again, this time we should be able

--- a/test/development/app-dir/new-route-first-request/app/layout.tsx
+++ b/test/development/app-dir/new-route-first-request/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/new-route-first-request/app/page.tsx
+++ b/test/development/app-dir/new-route-first-request/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
+++ b/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { waitFor } from 'next-test-utils'
+
+describe('new-route-first-request', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('responds 200 to the first request for a newly added page', async () => {
+    expect((await next.fetch('/')).status).toBe(200)
+
+    const failures: string[] = []
+    for (let i = 0; i < 30; i++) {
+      const pathname = `/added-${i}`
+      // Write the file directly instead of using next.patchFile, which waits
+      // 500ms after writes into app/ to let the watchers catch up. The first
+      // request for the route has to race the watchers.
+      const dir = path.join(next.testDir, `app/added-${i}`)
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, 'page.tsx'),
+        `export default function Page() { return <p>added-${i}</p> }`
+      )
+      // Make the first-ever request for the route at varying points of the
+      // watchers' catch-up work, starting at "immediately".
+      await waitFor((i % 5) * 15)
+      const res = await next.fetch(pathname)
+      if (res.status !== 200) {
+        failures.push(`${pathname}: ${res.status}`)
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+
+  it('still responds 404 for a route that does not exist', async () => {
+    expect((await next.fetch('/does-not-exist')).status).toBe(404)
+  })
+})

--- a/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
+++ b/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { waitFor } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 
 describe('new-route-first-request', () => {
   const { next } = nextTestSetup({
@@ -37,5 +37,43 @@ describe('new-route-first-request', () => {
 
   it('still responds 404 for a route that does not exist', async () => {
     expect((await next.fetch('/does-not-exist')).status).toBe(404)
+  })
+
+  it('responds 404 (not 500) to the first request for a deleted page', async () => {
+    const dir = path.join(next.testDir, 'app/removed')
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(
+      path.join(dir, 'page.tsx'),
+      'export default function Page() { return <p>removed</p> }'
+    )
+    await retry(async () => {
+      expect((await next.fetch('/removed')).status).toBe(200)
+    })
+
+    for (let i = 0; i < 5; i++) {
+      await fs.rm(dir, { recursive: true })
+      // Start requesting at varying points of the watchers' catch-up work,
+      // beginning at "immediately". The route may briefly keep serving while
+      // the deletion propagates, but it must never error.
+      await waitFor(i * 15)
+      const statuses: number[] = []
+      await retry(async () => {
+        const res = await next.fetch('/removed')
+        statuses.push(res.status)
+        expect(res.status).toBe(404)
+      })
+      expect(
+        statuses.filter((status) => status !== 200 && status !== 404)
+      ).toEqual([])
+
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, 'page.tsx'),
+        'export default function Page() { return <p>removed</p> }'
+      )
+      await retry(async () => {
+        expect((await next.fetch('/removed')).status).toBe(200)
+      })
+    }
   })
 })

--- a/test/development/app-dir/new-route-first-request/next.config.js
+++ b/test/development/app-dir/new-route-first-request/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/500-page/500-page.test.ts
+++ b/test/e2e/500-page/500-page.test.ts
@@ -49,8 +49,8 @@ describe('500 Page Support', () => {
           export default page
         `
         )
-        await next.render('/500')
         await retry(async () => {
+          await next.render('/500')
           expect(next.cliOutput).toMatch(
             /`pages\/500` can not have getInitialProps\/getServerSideProps/
           )
@@ -94,8 +94,8 @@ describe('500 Page Support', () => {
           export default page
         `
         )
-        await next.render('/500')
         await retry(async () => {
+          await next.render('/500')
           expect(next.cliOutput).toMatch(
             /`pages\/500` can not have getInitialProps\/getServerSideProps/
           )

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -248,87 +248,70 @@ export class NextDevInstance extends NextInstance {
     }
   }
 
-  private async handleDevWatchDelayAfterChange(filename: string) {
-    // to help alleviate flakiness with tests that create
-    // dynamic routes // and then request it we give a buffer
-    // of 500ms to allow WatchPack to detect the changed files
-    // TODO: replace this with an event directly from WatchPack inside
-    // router-server for better accuracy
-    if (filename.startsWith('app/') || filename.startsWith('pages/')) {
-      require('console').log('fs dev delay', filename)
-      await new Promise((resolve) => setTimeout(resolve, 500))
-    }
-  }
-
   public override async patchFile(
     filename: string,
     content: string | ((content: string) => string),
     runWithTempContent?: (context: { newFile: boolean }) => Promise<void>
   ) {
     await this.handleDevWatchDelayBeforeChange(filename)
-    try {
-      let cliOutputLength = this.cliOutput.length
-      const isServerRunning = this.childProcess && !this.isStopping
+    let cliOutputLength = this.cliOutput.length
+    const isServerRunning = this.childProcess && !this.isStopping
 
-      const detectServerRestart = async () => {
-        await retry(async () => {
-          const isServerReady = this.serverReadyPattern.test(
-            this.cliOutput.slice(cliOutputLength)
-          )
-          if (isServerRunning && !isServerReady) {
-            throw new Error('Server has not finished restarting.')
-          }
-        }, 5000)
-      }
-
-      const waitServerToBeReadyAfterPatchFile = async () => {
-        if (!isServerRunning) {
-          return
-        }
-
-        // If the patch file is a next.config.js, we ignore the delay and wait server restart
-        if (filename.startsWith('next.config')) {
-          await detectServerRestart()
-          return
-        }
-
-        if (this.patchFileDelay > 0) {
-          require('console').warn(
-            `Applying patch delay of ${this.patchFileDelay}ms. Note: Introducing artificial delays is generally discouraged, as it may affect test reliability. However, this delay is configurable on a per-test basis.`
-          )
-          await waitFor(this.patchFileDelay)
-          return
-        }
-      }
-
-      try {
-        return await super.patchFile(
-          filename,
-          content,
-          runWithTempContent
-            ? async (...args) => {
-                await waitServerToBeReadyAfterPatchFile()
-                cliOutputLength = this.cliOutput.length
-
-                return runWithTempContent(...args)
-              }
-            : undefined
+    const detectServerRestart = async () => {
+      await retry(async () => {
+        const isServerReady = this.serverReadyPattern.test(
+          this.cliOutput.slice(cliOutputLength)
         )
-      } finally {
-        // It's intentional: when runWithTempContent is defined, we wait twice: once for the patch,
-        // and once for the restore of the original file
+        if (isServerRunning && !isServerReady) {
+          throw new Error('Server has not finished restarting.')
+        }
+      }, 5000)
+    }
 
-        await waitServerToBeReadyAfterPatchFile()
+    const waitServerToBeReadyAfterPatchFile = async () => {
+      if (!isServerRunning) {
+        return
       }
+
+      // If the patch file is a next.config.js, we ignore the delay and wait server restart
+      if (filename.startsWith('next.config')) {
+        await detectServerRestart()
+        return
+      }
+
+      if (this.patchFileDelay > 0) {
+        require('console').warn(
+          `Applying patch delay of ${this.patchFileDelay}ms. Note: Introducing artificial delays is generally discouraged, as it may affect test reliability. However, this delay is configurable on a per-test basis.`
+        )
+        await waitFor(this.patchFileDelay)
+        return
+      }
+    }
+
+    try {
+      return await super.patchFile(
+        filename,
+        content,
+        runWithTempContent
+          ? async (...args) => {
+              await waitServerToBeReadyAfterPatchFile()
+              cliOutputLength = this.cliOutput.length
+
+              return runWithTempContent(...args)
+            }
+          : undefined
+      )
     } finally {
-      await this.handleDevWatchDelayAfterChange(filename)
+      // It's intentional: when runWithTempContent is defined, we wait twice: once for the patch,
+      // and once for the restore of the original file
+
+      await waitServerToBeReadyAfterPatchFile()
     }
   }
 
   public override async renameFile(filename: string, newFilename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
     await super.renameFile(filename, newFilename)
-    await this.handleDevWatchDelayAfterChange(filename)
   }
 
   public override async renameFolder(
@@ -337,12 +320,10 @@ export class NextDevInstance extends NextInstance {
   ) {
     await this.handleDevWatchDelayBeforeChange(foldername)
     await super.renameFolder(foldername, newFoldername)
-    await this.handleDevWatchDelayAfterChange(foldername)
   }
 
   public override async deleteFile(filename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
     await super.deleteFile(filename)
-    await this.handleDevWatchDelayAfterChange(filename)
   }
 }

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -248,70 +248,87 @@ export class NextDevInstance extends NextInstance {
     }
   }
 
+  private async handleDevWatchDelayAfterChange(filename: string) {
+    // to help alleviate flakiness with tests that create
+    // dynamic routes // and then request it we give a buffer
+    // of 500ms to allow WatchPack to detect the changed files
+    // TODO: replace this with an event directly from WatchPack inside
+    // router-server for better accuracy
+    if (filename.startsWith('app/') || filename.startsWith('pages/')) {
+      require('console').log('fs dev delay', filename)
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+  }
+
   public override async patchFile(
     filename: string,
     content: string | ((content: string) => string),
     runWithTempContent?: (context: { newFile: boolean }) => Promise<void>
   ) {
     await this.handleDevWatchDelayBeforeChange(filename)
-    let cliOutputLength = this.cliOutput.length
-    const isServerRunning = this.childProcess && !this.isStopping
-
-    const detectServerRestart = async () => {
-      await retry(async () => {
-        const isServerReady = this.serverReadyPattern.test(
-          this.cliOutput.slice(cliOutputLength)
-        )
-        if (isServerRunning && !isServerReady) {
-          throw new Error('Server has not finished restarting.')
-        }
-      }, 5000)
-    }
-
-    const waitServerToBeReadyAfterPatchFile = async () => {
-      if (!isServerRunning) {
-        return
-      }
-
-      // If the patch file is a next.config.js, we ignore the delay and wait server restart
-      if (filename.startsWith('next.config')) {
-        await detectServerRestart()
-        return
-      }
-
-      if (this.patchFileDelay > 0) {
-        require('console').warn(
-          `Applying patch delay of ${this.patchFileDelay}ms. Note: Introducing artificial delays is generally discouraged, as it may affect test reliability. However, this delay is configurable on a per-test basis.`
-        )
-        await waitFor(this.patchFileDelay)
-        return
-      }
-    }
-
     try {
-      return await super.patchFile(
-        filename,
-        content,
-        runWithTempContent
-          ? async (...args) => {
-              await waitServerToBeReadyAfterPatchFile()
-              cliOutputLength = this.cliOutput.length
+      let cliOutputLength = this.cliOutput.length
+      const isServerRunning = this.childProcess && !this.isStopping
 
-              return runWithTempContent(...args)
-            }
-          : undefined
-      )
+      const detectServerRestart = async () => {
+        await retry(async () => {
+          const isServerReady = this.serverReadyPattern.test(
+            this.cliOutput.slice(cliOutputLength)
+          )
+          if (isServerRunning && !isServerReady) {
+            throw new Error('Server has not finished restarting.')
+          }
+        }, 5000)
+      }
+
+      const waitServerToBeReadyAfterPatchFile = async () => {
+        if (!isServerRunning) {
+          return
+        }
+
+        // If the patch file is a next.config.js, we ignore the delay and wait server restart
+        if (filename.startsWith('next.config')) {
+          await detectServerRestart()
+          return
+        }
+
+        if (this.patchFileDelay > 0) {
+          require('console').warn(
+            `Applying patch delay of ${this.patchFileDelay}ms. Note: Introducing artificial delays is generally discouraged, as it may affect test reliability. However, this delay is configurable on a per-test basis.`
+          )
+          await waitFor(this.patchFileDelay)
+          return
+        }
+      }
+
+      try {
+        return await super.patchFile(
+          filename,
+          content,
+          runWithTempContent
+            ? async (...args) => {
+                await waitServerToBeReadyAfterPatchFile()
+                cliOutputLength = this.cliOutput.length
+
+                return runWithTempContent(...args)
+              }
+            : undefined
+        )
+      } finally {
+        // It's intentional: when runWithTempContent is defined, we wait twice: once for the patch,
+        // and once for the restore of the original file
+
+        await waitServerToBeReadyAfterPatchFile()
+      }
     } finally {
-      // It's intentional: when runWithTempContent is defined, we wait twice: once for the patch,
-      // and once for the restore of the original file
-
-      await waitServerToBeReadyAfterPatchFile()
+      await this.handleDevWatchDelayAfterChange(filename)
     }
   }
 
   public override async renameFile(filename: string, newFilename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
     await super.renameFile(filename, newFilename)
+    await this.handleDevWatchDelayAfterChange(filename)
   }
 
   public override async renameFolder(
@@ -320,10 +337,12 @@ export class NextDevInstance extends NextInstance {
   ) {
     await this.handleDevWatchDelayBeforeChange(foldername)
     await super.renameFolder(foldername, newFoldername)
+    await this.handleDevWatchDelayAfterChange(foldername)
   }
 
   public override async deleteFile(filename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
     await super.deleteFile(filename)
+    await this.handleDevWatchDelayAfterChange(filename)
   }
 }


### PR DESCRIPTION
## Summary

In dev, the first request for a newly written page can return a 404 even though the file is on disk. Route knowledge lives in three places that each lag the filesystem on their own schedule: the router server's `fsChecker` (filled by Watchpack), the render server's route matchers (reloaded from Turbopack's entrypoints subscription), and Turbopack's entrypoints themselves. A request that arrives between the write and any of them catching up gets a 404. #83829 diagnosed the underlying race — "the watchpack aggregate event runs before Turbopack's watcher has emitted a change event" — and moved the browser `ADDED_PAGE` announcements out of harm's way, but requests can still observe the stale state directly.

This makes each layer reconcile with a more truthful source before returning a 404, on the miss path only:

- The router server checks the request path against the development route matchers (new `testRouteMatch`) before rendering a 404.
- `DevRouteMatcherManager` re-scans the filesystem once when it has no match for a path.
- Turbopack's `ensurePage` waits for the next entrypoints update instead of throwing `route not found` while the route's file exists on disk, with a 10s liveness backstop for states where no update will ever arrive (e.g. a broken watcher).

Requests for known routes stay on the same code path as before; the extra work only happens on misses.

Measured with the new test (write `app/x/page.tsx`, then make the first-ever request for `/x`):

- before: 12-18 of 30 first requests returned 404, at delays up to ~60ms after the write
- after: all 30 return 200, including a request issued immediately after the write

This also removes the 500ms sleep the test harness added after every `app/`/`pages/` write to paper over this race (`handleDevWatchDelayAfterChange`, whose TODO points at exactly this problem).

## Verification

- `pnpm test-dev-turbo test/development/app-dir/new-route-first-request` (new test; fails on canary)
- `pnpm test-dev-webpack test/development/app-dir/new-route-first-request`
- `pnpm test-dev-turbo test/development/basic test/development/app-hmr test/development/ondemand test/development/duplicate-pages test/development/dynamic-route-rename test/e2e/app-dir/not-found test/e2e/app-dir/not-found-default` (35 suites, 249 tests — run before the harness sleep removal; the matrix without the sleep is left to CI)

<!-- NEXT_JS_LLM -->