### PR TITLE
[turbopack] Separate async-imported client components into their own chunk group

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1346,6 +1346,12 @@ impl AppEndpoint {
             *client_chunking_context,
             availability_info,
             ssr_chunking_context.map(|ctx| *ctx),
+            *this
+                .app_project
+                .project()
+                .next_config()
+                .turbopack_separate_async_client_references()
+                .await?,
         )
         .to_resolved()
         .await?;

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -33,6 +33,10 @@ pub struct ClientReferencesChunks {
     #[bincode(with = "turbo_bincode::indexmap")]
     pub layout_segment_client_chunks:
         FxIndexMap<ResolvedVc<NextServerComponentModule>, ResolvedVc<OutputAssetsWithReferenced>>,
+    /// Async-only: contributes `entryCSSFiles`, never `entryJSFiles`.
+    #[bincode(with = "turbo_bincode::indexmap")]
+    pub layout_segment_async_client_chunks:
+        FxIndexMap<ResolvedVc<NextServerComponentModule>, ResolvedVc<OutputAssetsWithReferenced>>,
 }
 
 /// Computes all client references chunks.
@@ -46,294 +50,358 @@ pub async fn get_app_client_references_chunks(
     client_chunking_context: Vc<Box<dyn ChunkingContext>>,
     client_availability_info: AvailabilityInfo,
     ssr_chunking_context: Option<Vc<Box<dyn ChunkingContext>>>,
+    separate_async_client_references: bool,
 ) -> Result<Vc<ClientReferencesChunks>> {
     async move {
-        // TODO Reconsider this. Maybe it need to be true in production.
-        let separate_chunk_group_per_client_reference = false;
         let app_client_references = app_client_references.await?;
-        if separate_chunk_group_per_client_reference {
-            todo!();
-            // let app_client_references_chunks: Vec<(_, (_, Option<_>))> = app_client_references
-            //     .client_references
-            //     .iter()
-            //     .map(|client_reference| async move {
-            //         Ok((
-            //             client_reference.ty,
-            //             match client_reference.ty {
-            //                 ClientReferenceType::EcmascriptClientReference(
-            //                     ecmascript_client_reference,
-            //                 ) => {
-            //                     let ecmascript_client_reference_ref =
-            //                         ecmascript_client_reference.await?;
-
-            //                     let client_chunk_group = client_chunking_context
-            //                         .root_chunk_group(
-            //                             module_graph,
-            //                             *ResolvedVc::upcast(
-            //                                 ecmascript_client_reference_ref.client_module,
-            //                             ),
-            //                         )
-            //                         .await?;
-
-            //                     (
-            //                         (
-            //                             client_chunk_group.assets,
-            //                             client_chunk_group.availability_info,
-            //                         ),
-            //                         if let Some(ssr_chunking_context) = ssr_chunking_context {
-            //                             let ssr_chunk_group = ssr_chunking_context
-            //                                 .root_chunk_group(
-            //                                     *ResolvedVc::upcast(
-            //                                         ecmascript_client_reference_ref.ssr_module,
-            //                                     ),
-            //                                     module_graph,
-            //                                 )
-            //                                 .await?;
-
-            //                             Some((
-            //                                 ssr_chunk_group.assets,
-            //                                 ssr_chunk_group.availability_info,
-            //                             ))
-            //                         } else {
-            //                             None
-            //                         },
-            //                     )
-            //                 }
-            //                 ClientReferenceType::CssClientReference(css_client_reference) => {
-            //                     let client_chunk_group = client_chunking_context
-            //                         .root_chunk_group(
-            //                             *ResolvedVc::upcast(css_client_reference),
-            //                             module_graph,
-            //                         )
-            //                         .await?;
-
-            //                     (
-            //                         (
-            //                             client_chunk_group.assets,
-            //                             client_chunk_group.availability_info,
-            //                         ),
-            //                         None,
-            //                     )
-            //                 }
-            //             },
-            //         ))
-            //     })
-            //     .try_join()
-            //     .await?;
-
-            // Ok(ClientReferencesChunks {
-            //     client_component_client_chunks: app_client_references_chunks
-            //         .iter()
-            //         .map(|&(client_reference_ty, (client_chunks, _))| {
-            //             (client_reference_ty, client_chunks)
-            //         })
-            //         .collect(),
-            //     client_component_ssr_chunks: app_client_references_chunks
-            //         .iter()
-            //         .flat_map(|&(client_reference_ty, (_, ssr_chunks))| {
-            //             ssr_chunks.map(|ssr_chunks| (client_reference_ty, ssr_chunks))
-            //         })
-            //         .collect(),
-            //     layout_segment_client_chunks: FxIndexMap::default(),
-            // }
-            // .cell())
-        } else {
-            let mut client_references_by_server_component: FxIndexMap<_, Vec<_>> =
-                FxIndexMap::default();
-            let mut framework_reference_types = Vec::new();
-            for &server_component in app_client_references.server_component_entries.iter() {
+        let mut client_references_by_server_component: FxIndexMap<_, Vec<_>> =
+            FxIndexMap::default();
+        let mut framework_reference_types = Vec::new();
+        for &server_component in app_client_references.server_component_entries.iter() {
+            client_references_by_server_component
+                .entry(server_component)
+                .or_default();
+        }
+        for client_reference in app_client_references.client_references.iter() {
+            if let Some(server_component) = client_reference.server_component {
                 client_references_by_server_component
                     .entry(server_component)
-                    .or_default();
+                    .or_default()
+                    .push(client_reference.ty);
+            } else {
+                framework_reference_types.push(client_reference.ty);
             }
-            for client_reference in app_client_references.client_references.iter() {
-                if let Some(server_component) = client_reference.server_component {
-                    client_references_by_server_component
-                        .entry(server_component)
-                        .or_default()
-                        .push(client_reference.ty);
-                } else {
-                    framework_reference_types.push(client_reference.ty);
-                }
-            }
-            // Framework components need to go into first layout segment
-            if let Some((_, list)) = client_references_by_server_component.first_mut() {
-                list.extend(framework_reference_types);
-            }
+        }
+        // Framework components need to go into first layout segment
+        if let Some((_, list)) = client_references_by_server_component.first_mut() {
+            list.extend(framework_reference_types);
+        }
 
-            let chunk_group_info = module_graph.chunk_group_info();
+        let chunk_group_info = module_graph.chunk_group_info();
+        let chunk_group_info_ref = chunk_group_info.await?;
+        let client_merge_tag = ecmascript_client_reference_merge_tag();
 
-            let mut current_client_chunk_group = ChunkGroupResult {
-                assets: ResolvedVc::cell(vec![]),
-                referenced_assets: ResolvedVc::cell(vec![]),
-                references: ResolvedVc::cell(vec![]),
-                availability_info: client_availability_info,
-                chunk_group_bootstrap_params: None,
-            }
-            .resolved_cell();
-            let mut current_ssr_chunk_group = ChunkGroupResult::empty_resolved();
-
-            let mut layout_segment_client_chunks = FxIndexMap::default();
-            let mut client_component_ssr_chunks = FxIndexMap::default();
-            let mut client_component_client_chunks = FxIndexMap::default();
-
-            for (server_component, client_reference_types) in
-                client_references_by_server_component.into_iter()
-            {
-                let parent_chunk_group = *chunk_group_info
-                    .get_index_of(ChunkGroup::Shared(ResolvedVc::upcast(server_component)))
-                    .await?;
-
-                let base_ident = server_component.ident().owned().await?;
-
-                let server_path = server_component.server_path().owned().await?;
-                let is_layout = server_path.file_stem() == Some("layout");
-                let server_component_path = server_path.to_string_ref().await?;
-
-                let ssr_modules = client_reference_types
+        // The graph already separates async-only client references into their own merged group.
+        // Left empty when the flag is off, which keeps every reference in the eager bucket below.
+        let client_reference_groups: FxIndexMap<ClientReferenceType, Vec<usize>> =
+            if !separate_async_client_references {
+                FxIndexMap::default()
+            } else {
+                let module_chunk_groups = chunk_group_info_ref.module_chunk_groups.await?;
+                let merged_modules = module_graph.merged_modules().await?;
+                app_client_references
+                    .client_references
                     .iter()
-                    .map(|client_reference_ty| async move {
-                        Ok(match client_reference_ty {
-                            ClientReferenceType::EcmascriptClientReference(
-                                ecmascript_client_reference,
-                            ) => {
-                                let ecmascript_client_reference_ref =
-                                    ecmascript_client_reference.await?;
-
-                                Some(ResolvedVc::upcast(
-                                    ecmascript_client_reference_ref.ssr_module,
-                                ))
+                    .map(async |client_reference| {
+                        let module: ResolvedVc<Box<dyn Module>> = match client_reference.ty {
+                            ClientReferenceType::EcmascriptClientReference(r) => {
+                                ResolvedVc::upcast(r.await?.client_module)
                             }
-                            _ => None,
-                        })
-                    })
-                    .try_flat_join()
-                    .await?;
-
-                let ssr_chunk_group = if !ssr_modules.is_empty()
-                    && let Some(ssr_chunking_context) = ssr_chunking_context
-                {
-                    let availability_info = current_ssr_chunk_group.await?.availability_info;
-                    let _span = tracing::info_span!(
-                        "server side rendering",
-                        layout_segment = display(&server_component_path),
-                    )
-                    .entered();
-
-                    Some(
-                        ssr_chunking_context.chunk_group(
-                            base_ident
-                                .clone()
-                                .with_modifier(rcstr!("ssr modules"))
-                                .into_vc(),
-                            ChunkGroup::IsolatedMerged {
-                                parent: parent_chunk_group,
-                                merge_tag: ecmascript_client_reference_merge_tag_ssr(),
-                                entries: ssr_modules,
+                            ClientReferenceType::CssClientReference(r) => ResolvedVc::upcast(r),
+                        };
+                        let groups = match module_chunk_groups.get(&module) {
+                            Some(groups) => Some(groups),
+                            // Merged-away modules are absent; look up what they replaced.
+                            None => match merged_modules.get_original_module(module).await? {
+                                Some(original) => module_chunk_groups.get(&original),
+                                None => None,
                             },
-                            module_graph,
-                            availability_info,
-                        ),
-                    )
-                } else {
-                    None
-                };
-
-                let client_modules = client_reference_types
-                    .iter()
-                    .map(|client_reference_ty| async move {
-                        Ok(match client_reference_ty {
-                            ClientReferenceType::EcmascriptClientReference(
-                                ecmascript_client_reference,
-                            ) => {
-                                ResolvedVc::upcast(ecmascript_client_reference.await?.client_module)
-                            }
-                            ClientReferenceType::CssClientReference(css_client_reference) => {
-                                ResolvedVc::upcast(*css_client_reference)
-                            }
-                        })
+                        };
+                        let groups = groups
+                            .into_iter()
+                            .flat_map(|groups| groups.iter())
+                            .filter(|&index| {
+                                matches!(
+                                    chunk_group_info_ref.chunk_groups.get_index(index as usize),
+                                    Some(ChunkGroup::IsolatedMerged { merge_tag, .. })
+                                        if *merge_tag == client_merge_tag
+                                )
+                            })
+                            .map(|index| index as usize)
+                            .collect::<Vec<_>>();
+                        Ok((client_reference.ty, groups))
                     })
                     .try_join()
-                    .await?;
-                let client_chunk_group = if !client_modules.is_empty() {
-                    let availability_info = current_client_chunk_group.await?.availability_info;
-                    let _span = tracing::info_span!(
-                        "client side rendering",
-                        layout_segment = display(&server_component_path),
-                    )
-                    .entered();
+                    .await?
+                    .into_iter()
+                    .collect()
+            };
 
-                    Some(client_chunking_context.chunk_group(
-                        base_ident.with_modifier(rcstr!("client modules")).into_vc(),
+        // Reachable from several segments, each of which would chunk it against its own
+        // availability, emitting a second copy whenever it shares a module with that
+        // segment's eager chunks.
+        let mut chunked_async_groups: FxIndexMap<usize, ResolvedVc<ChunkGroupResult>> =
+            FxIndexMap::default();
+
+        let mut current_client_chunk_group = ChunkGroupResult {
+            assets: ResolvedVc::cell(vec![]),
+            referenced_assets: ResolvedVc::cell(vec![]),
+            references: ResolvedVc::cell(vec![]),
+            availability_info: client_availability_info,
+            chunk_group_bootstrap_params: None,
+        }
+        .resolved_cell();
+        let mut current_ssr_chunk_group = ChunkGroupResult::empty_resolved();
+
+        let mut layout_segment_client_chunks = FxIndexMap::default();
+        let mut layout_segment_async_client_chunks = FxIndexMap::default();
+        let mut client_component_ssr_chunks = FxIndexMap::default();
+        let mut client_component_client_chunks = FxIndexMap::default();
+
+        for (server_component, client_reference_types) in
+            client_references_by_server_component.into_iter()
+        {
+            let parent_chunk_group = *chunk_group_info
+                .get_index_of(ChunkGroup::Shared(ResolvedVc::upcast(server_component)))
+                .await?;
+
+            let base_ident = server_component.ident().owned().await?;
+
+            let server_path = server_component.server_path().owned().await?;
+            let is_layout = server_path.file_stem() == Some("layout");
+            let server_component_path = server_path.to_string_ref().await?;
+
+            let mut eager_reference_types = Vec::new();
+            let mut async_group_reference_types: FxIndexMap<usize, Vec<ClientReferenceType>> =
+                FxIndexMap::default();
+            for &client_reference_ty in client_reference_types.iter() {
+                let groups = client_reference_groups
+                    .get(&client_reference_ty)
+                    .map_or(&[][..], |groups| groups.as_slice());
+                // Async only if every group leaves it lazy for this segment.
+                let is_async = !groups.is_empty()
+                    && groups.iter().all(|&index| {
+                        let parent = match chunk_group_info_ref.chunk_groups.get_index(index) {
+                            Some(ChunkGroup::IsolatedMerged { parent, .. }) => *parent,
+                            _ => return false,
+                        };
+                        match chunk_group_info_ref.chunk_groups.get_index(parent) {
+                            // Behind an async import.
+                            Some(ChunkGroup::Async(..)) => true,
+                            // This segment imports it directly, so it has to be eager. Another
+                            // segment's group says nothing about reachability from here.
+                            Some(ChunkGroup::Shared(module)) => {
+                                *module != ResolvedVc::upcast(server_component)
+                            }
+                            _ => false,
+                        }
+                    });
+                if is_async {
+                    for &index in groups {
+                        async_group_reference_types
+                            .entry(index)
+                            .or_default()
+                            .push(client_reference_ty);
+                    }
+                } else {
+                    eager_reference_types.push(client_reference_ty);
+                }
+            }
+
+            let ssr_modules = client_reference_types
+                .iter()
+                .map(|client_reference_ty| async move {
+                    Ok(match client_reference_ty {
+                        ClientReferenceType::EcmascriptClientReference(
+                            ecmascript_client_reference,
+                        ) => {
+                            let ecmascript_client_reference_ref =
+                                ecmascript_client_reference.await?;
+
+                            Some(ResolvedVc::upcast(
+                                ecmascript_client_reference_ref.ssr_module,
+                            ))
+                        }
+                        _ => None,
+                    })
+                })
+                .try_flat_join()
+                .await?;
+
+            let ssr_chunk_group = if !ssr_modules.is_empty()
+                && let Some(ssr_chunking_context) = ssr_chunking_context
+            {
+                let availability_info = current_ssr_chunk_group.await?.availability_info;
+                let _span = tracing::info_span!(
+                    "server side rendering",
+                    layout_segment = display(&server_component_path),
+                )
+                .entered();
+
+                Some(
+                    ssr_chunking_context.chunk_group(
+                        base_ident
+                            .clone()
+                            .with_modifier(rcstr!("ssr modules"))
+                            .into_vc(),
                         ChunkGroup::IsolatedMerged {
                             parent: parent_chunk_group,
-                            merge_tag: ecmascript_client_reference_merge_tag(),
+                            merge_tag: ecmascript_client_reference_merge_tag_ssr(),
+                            entries: ssr_modules,
+                        },
+                        module_graph,
+                        availability_info,
+                    ),
+                )
+            } else {
+                None
+            };
+
+            let client_modules = eager_reference_types
+                .iter()
+                .map(|client_reference_ty| async move {
+                    Ok(match client_reference_ty {
+                        ClientReferenceType::EcmascriptClientReference(
+                            ecmascript_client_reference,
+                        ) => ResolvedVc::upcast(ecmascript_client_reference.await?.client_module),
+                        ClientReferenceType::CssClientReference(css_client_reference) => {
+                            ResolvedVc::upcast(*css_client_reference)
+                        }
+                    })
+                })
+                .try_join()
+                .await?;
+            let client_chunk_group = if !client_modules.is_empty() {
+                let availability_info = current_client_chunk_group.await?.availability_info;
+                let _span = tracing::info_span!(
+                    "client side rendering",
+                    layout_segment = display(&server_component_path),
+                )
+                .entered();
+
+                Some(
+                    client_chunking_context.chunk_group(
+                        base_ident
+                            .clone()
+                            .with_modifier(rcstr!("client modules"))
+                            .into_vc(),
+                        ChunkGroup::IsolatedMerged {
+                            parent: parent_chunk_group,
+                            merge_tag: client_merge_tag.clone(),
                             entries: client_modules,
                         },
                         module_graph,
                         availability_info,
-                    ))
-                } else {
-                    None
+                    ),
+                )
+            } else {
+                None
+            };
+
+            let mut segment_client_chunk_group = current_client_chunk_group;
+            if let Some(client_chunk_group) = client_chunk_group {
+                let client_chunk_group = current_client_chunk_group
+                    .concatenate(client_chunk_group)
+                    .to_resolved()
+                    .await?;
+
+                if is_layout {
+                    current_client_chunk_group = client_chunk_group;
+                }
+                segment_client_chunk_group = client_chunk_group;
+
+                let assets = client_chunk_group
+                    .output_assets_with_referenced()
+                    .to_resolved()
+                    .await?;
+                layout_segment_client_chunks.insert(server_component, assets);
+
+                for &client_reference_ty in eager_reference_types.iter() {
+                    if let ClientReferenceType::EcmascriptClientReference(_) = client_reference_ty {
+                        client_component_client_chunks
+                            .insert(client_reference_ty, client_chunk_group);
+                    }
+                }
+            }
+
+            // Uses the eager group's availability, so its modules are excluded not duplicated.
+            let mut segment_async_chunk_group: Option<ResolvedVc<ChunkGroupResult>> = None;
+            for (group_index, reference_types) in async_group_reference_types {
+                let async_chunk_group = match chunked_async_groups.get(&group_index) {
+                    Some(&already_chunked) => already_chunked,
+                    None => {
+                        let availability_info = segment_client_chunk_group.await?.availability_info;
+                        let chunk_group = {
+                            let _span = tracing::info_span!(
+                                "client side rendering (async)",
+                                layout_segment = display(&server_component_path),
+                            )
+                            .entered();
+
+                            client_chunking_context.chunk_group(
+                                base_ident
+                                    .clone()
+                                    .with_modifier(rcstr!("async client modules"))
+                                    .into_vc(),
+                                chunk_group_info_ref.chunk_groups[group_index].clone(),
+                                module_graph,
+                                availability_info,
+                            )
+                        };
+                        let async_chunk_group = segment_client_chunk_group
+                            .concatenate(chunk_group)
+                            .to_resolved()
+                            .await?;
+                        chunked_async_groups.insert(group_index, async_chunk_group);
+                        segment_async_chunk_group = Some(match segment_async_chunk_group {
+                            Some(previous) => {
+                                previous
+                                    .concatenate(*async_chunk_group)
+                                    .to_resolved()
+                                    .await?
+                            }
+                            None => async_chunk_group,
+                        });
+                        async_chunk_group
+                    }
                 };
 
-                if let Some(client_chunk_group) = client_chunk_group {
-                    let client_chunk_group = current_client_chunk_group
-                        .concatenate(client_chunk_group)
-                        .to_resolved()
-                        .await?;
-
-                    if is_layout {
-                        current_client_chunk_group = client_chunk_group;
-                    }
-
-                    let assets = client_chunk_group
-                        .output_assets_with_referenced()
-                        .to_resolved()
-                        .await?;
-                    layout_segment_client_chunks.insert(server_component, assets);
-
-                    for &client_reference_ty in client_reference_types.iter() {
-                        if let ClientReferenceType::EcmascriptClientReference(_) =
-                            client_reference_ty
-                        {
-                            client_component_client_chunks
-                                .insert(client_reference_ty, client_chunk_group);
-                        }
-                    }
-                }
-
-                if let Some(ssr_chunk_group) = ssr_chunk_group {
-                    let ssr_chunk_group = current_ssr_chunk_group
-                        .concatenate(ssr_chunk_group)
-                        .to_resolved()
-                        .await?;
-
-                    if is_layout {
-                        current_ssr_chunk_group = ssr_chunk_group;
-                    }
-
-                    let assets = ssr_chunk_group
-                        .output_assets_with_referenced()
-                        .to_resolved()
-                        .await?;
-                    for &client_reference_ty in client_reference_types.iter() {
-                        if let ClientReferenceType::EcmascriptClientReference(_) =
-                            client_reference_ty
-                        {
-                            client_component_ssr_chunks.insert(client_reference_ty, assets);
-                        }
+                for client_reference_ty in reference_types {
+                    if let ClientReferenceType::EcmascriptClientReference(_) = client_reference_ty {
+                        client_component_client_chunks
+                            .insert(client_reference_ty, async_chunk_group);
                     }
                 }
             }
-
-            Ok(ClientReferencesChunks {
-                client_component_client_chunks,
-                client_component_ssr_chunks,
-                layout_segment_client_chunks,
+            if let Some(segment_async_chunk_group) = segment_async_chunk_group {
+                layout_segment_async_client_chunks.insert(
+                    server_component,
+                    segment_async_chunk_group
+                        .output_assets_with_referenced()
+                        .to_resolved()
+                        .await?,
+                );
             }
-            .cell())
+
+            if let Some(ssr_chunk_group) = ssr_chunk_group {
+                let ssr_chunk_group = current_ssr_chunk_group
+                    .concatenate(ssr_chunk_group)
+                    .to_resolved()
+                    .await?;
+
+                if is_layout {
+                    current_ssr_chunk_group = ssr_chunk_group;
+                }
+
+                let assets = ssr_chunk_group
+                    .output_assets_with_referenced()
+                    .to_resolved()
+                    .await?;
+                for &client_reference_ty in client_reference_types.iter() {
+                    if let ClientReferenceType::EcmascriptClientReference(_) = client_reference_ty {
+                        client_component_ssr_chunks.insert(client_reference_ty, assets);
+                    }
+                }
+            }
         }
+
+        Ok(ClientReferencesChunks {
+            client_component_client_chunks,
+            client_component_ssr_chunks,
+            layout_segment_client_chunks,
+            layout_segment_async_client_chunks,
+        }
+        .cell())
     }
     .instrument(tracing::info_span!("process client references"))
     .await

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1393,6 +1393,7 @@ pub struct ExperimentalConfig {
     turbopack_input_source_maps: Option<bool>,
     turbopack_module_fragments: Option<bool>,
     turbopack_scope_hoisting: Option<bool>,
+    turbopack_separate_async_client_references: Option<bool>,
     turbopack_shared_runtime: Option<bool>,
     /// Custom URL prefix for Web Worker URLs (the entrypoint and the module
     /// chunks loaded inside the worker) produced by
@@ -2544,6 +2545,15 @@ impl NextConfig {
             NextMode::Development => false,
             NextMode::Build => self.experimental.turbopack_scope_hoisting.unwrap_or(true),
         }))
+    }
+
+    #[turbo_tasks::function]
+    pub fn turbopack_separate_async_client_references(&self) -> Vc<bool> {
+        Vc::cell(
+            self.experimental
+                .turbopack_separate_async_client_references
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -200,6 +200,7 @@ async fn build_manifest(
         let ClientReferencesChunks {
             client_component_client_chunks,
             layout_segment_client_chunks,
+            layout_segment_async_client_chunks,
             client_component_ssr_chunks,
         } = &*client_references_chunks.await?;
         let client_relative_path = client_relative_path.clone();
@@ -450,7 +451,18 @@ async fn build_manifest(
         }
 
         // per layout segment chunks need to be emitted into the manifest too
-        for (server_component, client_assets) in layout_segment_client_chunks.iter() {
+        // Async-only chunks are visited too, but contribute CSS only.
+        for (server_component, client_assets, eager) in layout_segment_client_chunks
+            .iter()
+            .map(|(server_component, client_assets)| (server_component, client_assets, true))
+            .chain(
+                layout_segment_async_client_chunks
+                    .iter()
+                    .map(|(server_component, client_assets)| {
+                        (server_component, client_assets, false)
+                    }),
+            )
+        {
             // Use source_path() to get the original source path (e.g., page.mdx) instead of
             // server_path() which returns the transformed path (e.g., page.mdx.tsx).
             // This ensures the manifest key matches what the LoaderTree stores and what
@@ -506,9 +518,10 @@ async fn build_manifest(
                             inlined: inlined_css,
                             content,
                         });
-                    } else if !mode.is_production()
-                        || !generate_component_chunks
-                        || !client_reference_chunk_paths.contains(&path)
+                    } else if eager
+                        && (!mode.is_production()
+                            || !generate_component_chunks
+                            || !client_reference_chunk_paths.contains(&path))
                     {
                         entry_js_files.insert(path);
                     }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -383,6 +383,7 @@ export const experimentalSchema = {
   turbopackRemoveUnusedImports: z.boolean().optional(),
   turbopackRemoveUnusedExports: z.boolean().optional(),
   turbopackScopeHoisting: z.boolean().optional(),
+  turbopackSeparateAsyncClientReferences: z.boolean().optional(),
   turbopackSharedRuntime: z.boolean().optional(),
   turbopackChunking: z
     .object({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -762,6 +762,12 @@ export interface ExperimentalConfig {
   turbopackScopeHoisting?: boolean
 
   /**
+   * Give Client Components only imported through async imports their own chunk group, instead
+   * of bundling them with the rest of the page's chunks (that are loaded eagerly).
+   */
+  turbopackSeparateAsyncClientReferences?: boolean
+
+  /**
    * Share the browser runtime across routes in a single `runtime.js` asset and inline the
    * per-route chunk-group bootstrap into the HTML, dropping the per-route runtime. Defaults to
    * false. Only applies to production builds; has no effect in development mode.

--- a/test/e2e/app-dir/async-client-reference-chunking/app/eager-client.tsx
+++ b/test/e2e/app-dir/async-client-reference-chunking/app/eager-client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useState } from 'react'
+
+export function EagerClient() {
+  const [count, setCount] = useState(0)
+  return (
+    <button id="eager" onClick={() => setCount(count + 1)}>
+      eager {count}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/async-client-reference-chunking/app/layout.tsx
+++ b/test/e2e/app-dir/async-client-reference-chunking/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/async-client-reference-chunking/app/lazy-client.tsx
+++ b/test/e2e/app-dir/async-client-reference-chunking/app/lazy-client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function LazyClient() {
+  const [count, setCount] = useState(0)
+  return (
+    <button id="lazy" onClick={() => setCount(count + 1)}>
+      lazy {count}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/async-client-reference-chunking/app/page.tsx
+++ b/test/e2e/app-dir/async-client-reference-chunking/app/page.tsx
@@ -1,0 +1,33 @@
+import { lazy, Suspense } from 'react'
+import { EagerClient } from './eager-client'
+
+// Only reachable through an async import from a Server Component, so it must not be
+// bundled into the chunks the page segment loads eagerly.
+const LazyClient = lazy(() => import('./lazy-client'))
+
+// `searchParams` is read here rather than in the page so that the route can still be
+// prerendered with cache components enabled.
+async function MaybeLazy({
+  searchParams,
+}: {
+  searchParams: Promise<{ lazy?: string }>
+}) {
+  const { lazy: showLazy } = await searchParams
+  return showLazy ? <LazyClient /> : null
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ lazy?: string }>
+}) {
+  return (
+    <main>
+      <p>hello world</p>
+      <EagerClient />
+      <Suspense fallback={null}>
+        <MaybeLazy searchParams={searchParams} />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/async-client-reference-chunking/async-client-reference-chunking.test.ts
+++ b/test/e2e/app-dir/async-client-reference-chunking/async-client-reference-chunking.test.ts
@@ -1,0 +1,83 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getClientReferenceManifest, retry } from 'next-test-utils'
+
+/**
+ * The `src` of every chunk `<script>` in the document, as a `.next`-relative path so it can be
+ * compared against the paths in `entryJSFiles`.
+ */
+function chunkScripts(html: string): string[] {
+  return [
+    ...new Set(
+      Array.from(
+        html.matchAll(
+          /<script[^>]+src="([^"]*\/_next\/([^"]*chunks\/[^"]+))"/g
+        ),
+        (match) => match[2]
+      )
+    ),
+  ]
+}
+
+describe('async-client-reference-chunking', () => {
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  it('should render and hydrate the eagerly imported client component', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('#eager').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#eager').text()).toBe('eager 1')
+    })
+  })
+
+  it('should render and hydrate the lazily imported client component', async () => {
+    const browser = await next.browser('/?lazy=1')
+    await browser.elementByCss('#lazy').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#lazy').text()).toBe('lazy 1')
+    })
+  })
+
+  // Webpack merges a lazily imported Client Component into the chunks of the Server Component
+  // that imports it, so it is always shipped. Turbopack chunks it separately.
+  //
+  // Only asserted for `next start`: dev also chunks the component separately, but doesn't
+  // preinit client reference chunks as `<script>` tags during SSR, so there the difference only
+  // shows up in the Flight payload.
+  if (isTurbopack && isNextStart) {
+    it('should only load the lazily imported client component when it is rendered', async () => {
+      const withoutLazy = chunkScripts(await next.render('/'))
+      const withLazy = chunkScripts(await next.render('/', { lazy: '1' }))
+
+      expect(withoutLazy.length).toBeGreaterThan(0)
+
+      // Rendering the lazy branch pulls in chunks the page does not load otherwise...
+      const lazyOnly = withLazy.filter((src) => !withoutLazy.includes(src))
+      expect(lazyOnly.length).toBeGreaterThan(0)
+
+      // ...and nothing the page loads eagerly disappears when the branch renders.
+      expect(withoutLazy.filter((src) => !withLazy.includes(src))).toEqual([])
+    })
+
+    it('should keep the lazily imported client component out of entryJSFiles', async () => {
+      // `entryJSFiles` is emitted as eager `<script>` tags for a layout segment, so a client
+      // reference only reachable through an async import must not appear in it.
+      const withoutLazy = chunkScripts(await next.render('/'))
+      const withLazy = chunkScripts(await next.render('/', { lazy: '1' }))
+      const lazyOnly = withLazy.filter((src) => !withoutLazy.includes(src))
+      expect(lazyOnly.length).toBeGreaterThan(0)
+
+      const manifest = getClientReferenceManifest(next, '/page')
+      const entryJsFiles = Object.values(
+        manifest.entryJSFiles as unknown as Record<string, string[]>
+      ).flat()
+      expect(entryJsFiles.length).toBeGreaterThan(0)
+
+      for (const src of lazyOnly) {
+        expect(entryJsFiles).not.toContain(src)
+      }
+    })
+  }
+})

--- a/test/e2e/app-dir/async-client-reference-chunking/next.config.js
+++ b/test/e2e/app-dir/async-client-reference-chunking/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbopackSeparateAsyncClientReferences: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
This is controlled by the `turbopackSeparateAsyncClientReferences` experimental option. This means that we don't eagerly load all client components that are dynamically imported. 