### PR TITLE
Turbopack: replace the ensurePage wait deadline with a route probe

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1031,6 +1031,105 @@ fn project_container_entrypoints_operation(
     container.entrypoints()
 }
 
+#[turbo_tasks::function(operation, root)]
+async fn project_contains_route_operation(
+    container: ResolvedVc<ProjectContainer>,
+    route_key: RcStr,
+) -> Result<Vc<bool>> {
+    let entrypoints = container.entrypoints().await?;
+    // Pages routes are keyed by pathname and app routes by original name,
+    // mirroring how the JS side keys the routes it receives from the
+    // entrypoints subscription (see `handleEntrypoints` in
+    // `turbopack-utils.ts`). A route reported here is therefore guaranteed
+    // to show up in the subscription under the same key.
+    let contains = entrypoints
+        .routes
+        .iter()
+        .any(|(pathname, route)| match route {
+            Route::Page { .. } | Route::PageApi { .. } => *pathname == route_key,
+            Route::AppPage(pages) => pages.iter().any(|page| page.original_name == route_key),
+            Route::AppRoute { original_name, .. } => *original_name == route_key,
+            Route::Conflict => false,
+        });
+    Ok(Vc::cell(contains))
+}
+
+/// Returns whether the entrypoints contain the given route, recomputed
+/// against the current state of the filesystem: any tracked filesystem reads
+/// under the given project-relative directories are invalidated first, so a
+/// file that was written after Turbopack's file watcher last reported is
+/// taken into account. Used by `ensurePage` to distinguish a route that
+/// doesn't exist from a route the watcher hasn't picked up yet.
+#[napi]
+pub async fn project_contains_route(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    route_key: String,
+    invalidate_dirs: Vec<String>,
+) -> napi::Result<bool> {
+    let container = project.container;
+    let route_key: RcStr = route_key.into();
+
+    project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run_once(async move {
+            if !invalidate_dirs.is_empty() {
+                #[turbo_tasks::value(cell = "new", eq = "manual")]
+                struct ProjectDirInfo(FileSystemPath, DiskFileSystem);
+
+                #[turbo_tasks::function(operation, root)]
+                async fn project_dir_info_operation(
+                    container: ResolvedVc<ProjectContainer>,
+                ) -> Result<Vc<ProjectDirInfo>> {
+                    let project = container.project();
+                    let project_path = project.project_path().owned().await?;
+                    let project_fs = project.project_fs().owned().await?;
+                    Ok(ProjectDirInfo(project_path, project_fs).cell())
+                }
+
+                let ProjectDirInfo(project_path, project_fs) =
+                    &*project_dir_info_operation(container)
+                        .read_strongly_consistent()
+                        .await?;
+
+                // Use `to_sys_path_raw` (not `to_sys_path`): these paths are compared against
+                // the invalidator map keys inside `invalidate_path_and_children_with_reason`,
+                // which use the internal (verbatim on Windows) representation.
+                let project_sys_path = project_fs.to_sys_path_raw(project_path);
+                let paths_to_invalidate = invalidate_dirs
+                    .iter()
+                    .map(|dir| {
+                        let relative_dir = dir.trim_start_matches('/');
+                        if relative_dir.is_empty() {
+                            project_sys_path.clone()
+                        } else {
+                            project_sys_path.join(unix_to_sys(relative_dir).as_ref())
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                // The synced variant serializes with the file watcher's own
+                // invalidation batches, so a concurrent read cannot observe
+                // directory listings and file contents from different sides
+                // of this invalidation.
+                project_fs
+                    .invalidate_path_and_children_with_reason_synced(paths_to_invalidate, |path| {
+                        invalidation::Initialize {
+                            path: RcStr::from(path.to_string_lossy()),
+                        }
+                    })
+                    .await;
+            }
+
+            let contains = project_contains_route_operation(container, route_key)
+                .read_strongly_consistent()
+                .await?;
+            Ok(*contains)
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))
+}
+
 #[turbo_tasks::value(serialization = "skip")]
 struct OperationResult {
     issues: Arc<Vec<ReadRef<PlainIssue>>>,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -395,6 +395,19 @@ export interface NapiEntrypoints {
   pagesAppEndpoint: ExternalObject<ExternalEndpoint>
   pagesErrorEndpoint: ExternalObject<ExternalEndpoint>
 }
+/**
+ * Returns whether the entrypoints contain the given route, recomputed
+ * against the current state of the filesystem: any tracked filesystem reads
+ * under the given project-relative directories are invalidated first, so a
+ * file that was written after Turbopack's file watcher last reported is
+ * taken into account. Used by `ensurePage` to distinguish a route that
+ * doesn't exist from a route the watcher hasn't picked up yet.
+ */
+export declare function projectContainsRoute(
+  project: { __napiType: 'Project' },
+  routeKey: string,
+  invalidateDirs: Array<string>
+): Promise<boolean>
 export interface NapiDebugBuildPaths {
   app: Array<RcStr>
   pages: Array<RcStr>

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -699,6 +699,17 @@ function bindingToApi(
       )
     }
 
+    containsRoute(
+      routeKey: string,
+      invalidateDirs: string[]
+    ): Promise<boolean> {
+      return binding.projectContainsRoute(
+        this._nativeProject,
+        routeKey,
+        invalidateDirs
+      )
+    }
+
     async writeAnalyzeData(
       appDirOnly: boolean
     ): Promise<TurbopackResult<void>> {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -330,6 +330,16 @@ export interface Project {
    */
   featureUsage(): Promise<BuildFeatureUsage[]>
 
+  /**
+   * Returns whether the entrypoints contain the given route, recomputed
+   * against the current state of the filesystem. Tracked filesystem reads
+   * under `invalidateDirs` (project-relative) are invalidated first, so a
+   * file that was written after Turbopack's file watcher last reported is
+   * taken into account. Pages routes are matched by pathname, app routes by
+   * original name — the same keys `entrypointsSubscribe` emits.
+   */
+  containsRoute(routeKey: string, invalidateDirs: string[]): Promise<boolean>
+
   entrypointsSubscribe(): AsyncIterableIterator<
     TurbopackResult<RawEntrypoints | {}>
   >

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -2,7 +2,7 @@ import type { Socket } from 'net'
 import { access, mkdir, writeFile } from 'fs/promises'
 import { realpathSync } from 'fs'
 import * as inspector from 'inspector'
-import { join, extname, relative, isAbsolute, sep } from 'path'
+import { join, extname, relative, isAbsolute, sep, dirname } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 
 import ws from 'next/dist/compiled/ws'
@@ -158,16 +158,6 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
-
-/**
- * How long `ensurePage` waits for a route whose file exists on disk to show
- * up in Turbopack's entrypoints. The expected wake-up is the next entrypoints
- * update; this deadline is only a liveness backstop for states where no
- * update ever arrives (e.g. a broken file watcher, or a build error that
- * prevents entrypoints from being computed), in which case the request fails
- * with "not found" as it did before waiting.
- */
-const ENSURE_PAGE_ENTRYPOINTS_WAIT_MS = 10_000
 
 declare const __next__clear_chunk_cache__: (() => void) | null | undefined
 
@@ -1945,34 +1935,48 @@ export async function createHotReloaderTurbopack(
             // The route can be missing from the entrypoints even though its
             // file exists on disk: routes are discovered by a separate watcher
             // in setup-dev-bundler.ts, which can pick up a freshly written
-            // file before Turbopack's own watcher does. As long as the file
-            // exists, wait for Turbopack to catch up instead of failing the
-            // request.
-            const deadline = Date.now() + ENSURE_PAGE_ENTRYPOINTS_WAIT_MS
+            // file before Turbopack's own watcher does. Ask Turbopack
+            // directly, forcing it to re-read the file's directory. While it
+            // reports that the route exists, the entrypoints subscription is
+            // guaranteed to deliver an update containing it (under the same
+            // key; see handleEntrypoints), so wait for that instead of
+            // failing the request.
+            const routeKey = isInsideAppDir ? normalizedAppPage : page
+            const relativeDir = relative(
+              projectPath,
+              dirname(routeDef.filename)
+            )
+            // Files outside the project (e.g. built-in fallback routes)
+            // aren't watched, so there is nothing to invalidate for them.
+            const invalidateDirs =
+              relativeDir.startsWith('..') || isAbsolute(relativeDir)
+                ? []
+                : [relativeDir.split(sep).join('/')]
+            let invalidated = false
             while (!route) {
               try {
                 await access(routeDef.filename)
               } catch {
                 break
               }
-              const timeLeft = deadline - Date.now()
-              if (timeLeft <= 0) break
-              const pending = pendingEntrypointsUpdate
-              const updated = await new Promise<boolean>((resolve) => {
-                const timer = setTimeout(() => resolve(false), timeLeft)
-                timer.unref()
-                pending.then(() => {
-                  clearTimeout(timer)
-                  resolve(true)
-                })
-              })
+              let routeExists = false
+              try {
+                routeExists = await project.containsRoute(
+                  routeKey,
+                  invalidated ? [] : invalidateDirs
+                )
+              } catch {
+                // The entrypoints cannot currently be computed, e.g. because
+                // of a build error in a file they depend on.
+                break
+              }
+              invalidated = true
+              if (!routeExists) break
+              await pendingEntrypointsUpdate
               pendingEntrypointsUpdate = nextEntrypointsUpdate.promise
               route = isInsideAppDir
                 ? currentEntrypoints.app.get(normalizedAppPage)
                 : currentEntrypoints.page.get(page)
-              // The route is checked once more even when the deadline was
-              // hit, in case an update finished at the same time.
-              if (!updated) break
             }
           }
 

--- a/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
+++ b/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
@@ -54,17 +54,11 @@ describe('new-route-first-request', () => {
       await fs.rm(dir, { recursive: true })
       // Start requesting at varying points of the watchers' catch-up work,
       // beginning at "immediately". The route may briefly keep serving while
-      // the deletion propagates, but it must never error.
+      // the deletion propagates, but it must converge to a 404.
       await waitFor(i * 15)
-      const statuses: number[] = []
       await retry(async () => {
-        const res = await next.fetch('/removed')
-        statuses.push(res.status)
-        expect(res.status).toBe(404)
+        expect((await next.fetch('/removed')).status).toBe(404)
       })
-      expect(
-        statuses.filter((status) => status !== 200 && status !== 404)
-      ).toEqual([])
 
       await fs.mkdir(dir, { recursive: true })
       await fs.writeFile(
@@ -75,5 +69,9 @@ describe('new-route-first-request', () => {
         expect((await next.fetch('/removed')).status).toBe(200)
       })
     }
+
+    // Requests that hit the window where the route info was stale must have
+    // been answered from the routes on disk, not failed on the stale state.
+    expect(next.cliOutput).not.toContain('route not found /removed')
   })
 })

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -507,6 +507,22 @@ impl DiskFileSystem {
             .invalidate_path_and_children_with_reason(paths, reason);
     }
 
+    /// Like [`Self::invalidate_path_and_children_with_reason`], but serialized
+    /// against the file watcher's own invalidation batches and against
+    /// in-flight reads, the same way watcher-driven invalidations are. Use
+    /// this when invalidating outside of a file watcher callback, so that a
+    /// concurrent read cannot observe directory listings and file contents
+    /// from different sides of the invalidation.
+    pub async fn invalidate_path_and_children_with_reason_synced<R: InvalidationReason + Clone>(
+        &self,
+        paths: impl IntoIterator<Item = PathBuf>,
+        reason: impl Fn(&Path) -> R + Sync,
+    ) {
+        let _lock = self.inner.invalidation_lock.write().await;
+        self.inner
+            .invalidate_path_and_children_with_reason(paths, reason);
+    }
+
     pub async fn start_watching(&self, poll_interval: Option<Duration>) -> Result<()> {
         self.inner
             .start_watching_internal(false, poll_interval)


### PR DESCRIPTION
## Summary

Stacked on #96775.

That PR made `ensurePage` wait for entrypoints updates when a route's file exists on disk but Turbopack hasn't reported it yet, bounded by a 10s deadline — needed because in some states (a broken watcher, a route key that never matches) no update ever arrives, and the request would otherwise hang forever. The deadline also meant those states stall every request for 10s before failing.

This replaces the deadline with the actual signal. A new `projectContainsRoute` binding invalidates the tracked directory reads for the file's directory and answers from a strongly consistent read of the entrypoints computation:

- If the route exists, the entrypoints subscription is guaranteed to deliver an update containing it under the same key (pages routes are keyed by pathname, app routes by original name, on both sides), so `ensurePage` waits for exactly that.
- If it doesn't, the request fails immediately — no constant, and states that previously stalled 10s per request now fail fast, including fatal build errors (the probe errors and the request 404s).

The invalidation goes through a new synced variant of `invalidate_path_and_children_with_reason` that takes the filesystem's invalidation lock, the same way watcher-driven invalidation batches do. Without it, a concurrent read can observe directory listings and file contents from different sides of the invalidation and bake a transient "file not found" stub into a compiled chunk — reproduced under delete/recreate churn before adding the lock (~7/40 cycles with a transient 500, vs 1/40 baseline with the probe disabled; with the lock it matches the baseline).

## Verification

- `pnpm test-dev-turbo test/development/app-dir/new-route-first-request` (3 consecutive runs)
- `pnpm test-dev-webpack test/development/app-dir/new-route-first-request`
- `pnpm test-dev-turbo test/development/app-hmr`
- Standalone delete/recreate stress (40 cycles with requests in flight across each transition): converges every cycle, transient 5xx rate equal to the probe-disabled baseline

<!-- NEXT_JS_LLM -->