### PR TITLE
Only announce server component changes when compiled output changed

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -547,6 +547,11 @@ export async function createHotReloaderTurbopack(
 
   // Dev specific
   const changeSubscriptions: ChangeSubscriptions = new Map()
+  // Baselines for deciding whether an applied server HMR update changed any
+  // entry's compiled output. Seeded when an entry's change subscription
+  // starts; advanced only by the apply loop (`onApplied` below).
+  const serverContentHashEndpoints = new Map<EntryKey, Endpoint>()
+  const appliedServerContentHashes = new Map<EntryKey, string>()
   const serverPathState = new Map<string, string>()
   const readyIds: ReadyIds = new Set()
   let currentEntriesHandlingResolve: ((value?: unknown) => void) | undefined
@@ -927,6 +932,7 @@ export async function createHotReloaderTurbopack(
    * advance the hash when it actually changed.
    */
   async function* serverChanges(
+    key: EntryKey,
     changedPromise: Promise<
       AsyncIterableIterator<TurbopackResult<ServerChanged>>
     >,
@@ -934,6 +940,11 @@ export async function createHotReloaderTurbopack(
   ) {
     const changed = await changedPromise
     let contentHash = await endpoint.serverContentHash()
+
+    serverContentHashEndpoints.set(key, endpoint)
+    if (contentHash !== null && !appliedServerContentHashes.has(key)) {
+      appliedServerContentHashes.set(key, contentHash)
+    }
 
     for await (const change of changed) {
       // A null hash means the entry has no compiled output (it was removed,
@@ -988,7 +999,7 @@ export async function createHotReloaderTurbopack(
     if (side === 'server') {
       const changedPromise = endpoint.serverChanged(includeIssues)
       changeSubscriptions.set(key, changedPromise)
-      changes = serverChanges(changedPromise, endpoint)
+      changes = serverChanges(key, changedPromise, endpoint)
     } else {
       const changedPromise = endpoint.clientChanged()
       changeSubscriptions.set(key, changedPromise)
@@ -1005,6 +1016,8 @@ export async function createHotReloaderTurbopack(
       }
     } catch (e) {
       changeSubscriptions.delete(key)
+      serverContentHashEndpoints.delete(key)
+      appliedServerContentHashes.delete(key)
       const payload = await onError?.(e as Error)
       if (payload) {
         sendHmr(key, payload)
@@ -1012,6 +1025,8 @@ export async function createHotReloaderTurbopack(
       return
     }
     changeSubscriptions.delete(key)
+    serverContentHashEndpoints.delete(key)
+    appliedServerContentHashes.delete(key)
   }
 
   async function unsubscribeFromClientChanges(key: EntryKey) {
@@ -1020,6 +1035,8 @@ export async function createHotReloaderTurbopack(
       await subscription.return?.()
       changeSubscriptions.delete(key)
     }
+    serverContentHashEndpoints.delete(key)
+    appliedServerContentHashes.delete(key)
     currentEntryIssues.delete(key)
   }
 
@@ -2195,7 +2212,7 @@ export async function createHotReloaderTurbopack(
 
         notifyServerComponentChanges()
       },
-      onApplied: (chunkPaths: string[]) => {
+      onApplied: async (chunkPaths: string[]) => {
         // Clear the evalManifest() shared cache for each updated chunk so the
         // next RSC render picks up the HMR-applied module changes. Unlike
         // a full restart, this does NOT clear require.cache — the HMR-applied
@@ -2204,7 +2221,29 @@ export async function createHotReloaderTurbopack(
           clearManifestCache(join(distDir, chunkPath))
         }
 
-        notifyServerComponentChanges()
+        // An apply doesn't imply anything a browser renders changed — e.g.
+        // removing a page applies a throwing stub for its module while every
+        // other entry's output stays identical. Announce only when some
+        // entry's compiled output actually differs.
+        const changes = await Promise.allSettled(
+          [...serverContentHashEndpoints].map(async ([key, endpoint]) => {
+            const previousHash = appliedServerContentHashes.get(key)
+            if (previousHash === undefined) {
+              return false
+            }
+            const hash = await endpoint.serverContentHash()
+            // A null (removed or failing) hash keeps the baseline, so output
+            // coming back changed is still announced.
+            if (hash === null || hash === previousHash) {
+              return false
+            }
+            appliedServerContentHashes.set(key, hash)
+            return true
+          })
+        )
+        if (changes.some((c) => c.status === 'rejected' || c.value === true)) {
+          notifyServerComponentChanges()
+        }
       },
     })
   }

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -309,8 +309,27 @@ describe('route-change-refetch - App Router refetch count', () => {
     return browser.eval(() => (window as any).__refetches)
   }
 
-  it('refetches an open tab exactly once when a page is added', async () => {
-    const browser = await next.browser('/counted')
+  it('refetches an open tab exactly once per page addition, removal, and edit', async () => {
+    // Adding or removing a page changes no other page's server components,
+    // so nothing may announce that they changed.
+    const serverComponentChangeAnnouncements: string[] = []
+    const browser = await next.browser('/counted', {
+      beforePageLoad(page: any) {
+        page.on('websocket', (socket: any) => {
+          socket.on('framereceived', (frame: { payload: string | Buffer }) => {
+            let message
+            try {
+              message = JSON.parse(String(frame.payload))
+            } catch {
+              return
+            }
+            if (message.type === 'serverComponentChanges') {
+              serverComponentChangeAnnouncements.push(String(frame.payload))
+            }
+          })
+        })
+      },
+    })
     expect(await browser.elementById('counted').text()).toBe('counted')
     await startCountingRefetches(browser)
 
@@ -327,6 +346,35 @@ describe('route-change-refetch - App Router refetch count', () => {
     // A later one would mean the change was announced more than once.
     await waitFor(1000)
     expect(await countRefetches(browser)).toBe(1)
+
+    await next.deleteFile('app/zz-added/page.tsx')
+    await retry(async () => {
+      expect((await next.fetch('/zz-added')).status).toBe(404)
+    }, 15_000)
+    await retry(async () => {
+      expect(await countRefetches(browser)).toBe(2)
+    }, 15_000)
+    await waitFor(1000)
+    expect(await countRefetches(browser)).toBe(2)
+
+    expect(serverComponentChangeAnnouncements).toEqual([])
+
+    // Editing the page the tab is showing must announce changed server
+    // components, exactly once. This also proves the capture above works.
+    await next.patchFile(
+      'app/counted/page.tsx',
+      `export default function Page() { return <p id="counted">counted!</p> }`
+    )
+    await retry(async () => {
+      expect(await browser.elementById('counted').text()).toBe('counted!')
+    }, 15_000)
+    await retry(async () => {
+      expect(serverComponentChangeAnnouncements.length).toBe(1)
+      expect(await countRefetches(browser)).toBe(3)
+    }, 15_000)
+    await waitFor(1000)
+    expect(serverComponentChangeAnnouncements.length).toBe(1)
+    expect(await countRefetches(browser)).toBe(3)
   })
 })
 


### PR DESCRIPTION
Stacked on #96248.

In dev with Turbopack, applying a server HMR update ends with telling every connected tab to refetch its RSC payload. But an applied update doesn't necessarily change anything a tab renders. Removing a page is the clearest case: the update just rewrites the removed page's module into a throwing stub inside the merged server chunks —

```
"code": "((__turbopack_context__, module, exports) => {
  var e = new Error(\"Could not parse module '[project]/app/zz-probe/page.tsx', file not found\");
  e.code = 'MODULE_UNPARSABLE';
  throw e;
})"
```

— and no other page's output changes. Every tab was still told to refetch. Since the removed-page announcement already makes tabs refetch, deleting one page made every tab refetch twice instead of once.

Messages the server sends for `rm app/zz-added/page.tsx` while a tab shows `/counted`, before the fix:

```
{"type":"removedPage","data":["/zz-added"]}
{"type":"serverComponentChanges"}            ← 2–4ms later, from the HMR apply
```

after:

```
{"type":"removedPage","data":["/zz-added"]}
```

Because the two messages arrive within milliseconds, the browser sometimes handles them as one refetch and sometimes as two, depending on the machine. This is why the refetch-count test could not pin down the removal: idle machines usually saw two fetches, CI machines usually saw one, and the test expected an exact number. That was the `Expected: 3, Received: 2` failure every Turbopack CI job showed for the PRs below this one. Since no exact refetch count is correct while the extra announcement exists, the test now also asserts on the announcement itself, which doesn't depend on timing: without this fix it fails every run, on every machine.

The apply loop now decides the same way the `"use cache"` refresh hash already does one PR down: compare each subscribed entry's compiled-output hash (`serverContentHash()` from #96248) against a baseline, and announce only when one differs.

- Baselines are seeded when an entry's change subscription starts, before the entry's first render is underway. An edit landing in the few milliseconds between the two can be absorbed into the baseline, losing one announcement. The refresh-hash baseline one PR down has the same window, and the next change corrects it.
- A null hash means the entry has no compiled output right now (removed, or failing to build). It keeps the previous baseline, so output that comes back different is still announced.
- A hash that can't be read counts as changed. The reads go through `Promise.allSettled` because a rejected read must not take down the apply loop — its failure path re-evaluates every server module.
- Env-change invalidations announce through a separate path and are unaffected.

## Test plan

The first commit extends the refetch-count test with a removal phase — exactly one refetch per addition and one per removal, on both bundlers — and asserts that no `serverComponentChanges` is announced for either. The test ends by checking the opposite direction too: editing the page the tab is showing must produce exactly one `serverComponentChanges` and exactly one more refetch. Besides covering the edit path, this proves the message capture works — if the capture silently broke, the "no announcements" assertions would pass without checking anything.

Without the fix, the test fails on Turbopack 3 of 3 runs; webpack passes it unchanged. With the fix, Turbopack passes 3 of 3, and an earlier revision of the same test (without the edit phase) passed 30 consecutive full-suite runs.

<details>
<summary>Suites covering the changed loop, all green with the fix (locally built binding)</summary>

- `route-change-refetch` — 30 consecutive Turbopack runs of the counted test green; webpack 3×10/10. The pre-existing "tab stuck on 404 after a page add" flake (the ensurePage/watcher race, being fixed separately) is unaffected: matched warm runs are 10/10 both with and without this fix.
- `server-components-hmr-cache` (17) — edits and env changes must still refetch and invalidate
- `middleware-dev-update` (4)
- `hmr` basic (4), error-recovery (12 + 1 skipped), full-reload (2)
- `cache-components-spurious-cache-invalidation` (6, idle and under CPU load)
- `dynamic-optional-routing` under experimental Turbopack (33)

</details>
