### PR TITLE
Serve a new dev route as soon as Turbopack announces it

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -19,8 +19,9 @@ use crate::{
     next_app::{
         AppPage, AppPath, PageSegment, PageType,
         metadata::{
-            GlobalMetadataFileMatch, MetadataFileMatch, match_global_metadata_file,
-            match_local_metadata_file, normalize_metadata_route,
+            GlobalMetadataFileMatch, MetadataFileMatch, is_multi_dynamic_metadata,
+            match_global_metadata_file, match_local_metadata_file, multi_dynamic_metadata_page,
+            normalize_metadata_route,
         },
     },
     next_import_map::get_next_package,
@@ -1650,14 +1651,12 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         .chain(open_graph.iter().cloned().map(MetadataItem::from))
     {
         let app_page = app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
+        let mut page = normalize_metadata_route(app_page)?;
+        if *is_multi_dynamic_metadata(meta.clone()).await? {
+            page = multi_dynamic_metadata_page(page)?;
+        }
 
-        add_app_metadata_route(
-            app_dir.clone(),
-            &mut result,
-            normalize_metadata_route(app_page)?,
-            meta,
-            root_params,
-        );
+        add_app_metadata_route(app_dir.clone(), &mut result, page, meta, root_params);
     }
 
     // root path: /
@@ -1671,11 +1670,15 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         for meta in favicon.iter().chain(robots.iter()).chain(manifest.iter()) {
             let app_page =
                 app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
+            let mut page = normalize_metadata_route(app_page)?;
+            if *is_multi_dynamic_metadata(meta.clone()).await? {
+                page = multi_dynamic_metadata_page(page)?;
+            }
 
             add_app_metadata_route(
                 app_dir.clone(),
                 &mut result,
-                normalize_metadata_route(app_page)?,
+                page,
                 meta.clone(),
                 root_params,
             );

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -3,10 +3,16 @@ use std::sync::LazyLock;
 use anyhow::Result;
 use phf::phf_map;
 use regex::Regex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
+use turbopack_core::file_source::FileSource;
 
-use crate::next_app::{AppPage, AppPath, PageSegment, PageType};
+use crate::{
+    app_structure::MetadataItem,
+    next_app::{AppPage, AppPath, PageSegment, PageType},
+    segment_config::{ParseSegmentMode, parse_segment_config_from_source},
+};
 
 pub mod image;
 pub mod route;
@@ -415,6 +421,39 @@ pub fn normalize_metadata_route(mut page: AppPage) -> Result<AppPage> {
 
         page.push(PageSegment::PageType(PageType::Route))?;
     }
+
+    Ok(page)
+}
+
+/// Whether a dynamic metadata file exports a generator
+/// (`generateSitemaps`/`generateImageMetadata`), in which case its route is
+/// served under an id instead of its own name.
+#[turbo_tasks::function]
+pub async fn is_multi_dynamic_metadata(metadata: MetadataItem) -> Result<Vc<bool>> {
+    Ok(match metadata {
+        MetadataItem::Dynamic { path } => {
+            let source = Vc::upcast(FileSource::new(path));
+            let config = parse_segment_config_from_source(source, ParseSegmentMode::App).await?;
+            Vc::cell(config.generate_sitemaps || config.generate_image_metadata)
+        }
+        MetadataItem::Static { .. } => Vc::cell(false),
+    })
+}
+
+/// Maps the page of a multi-dynamic metadata route to the page it is served
+/// under, e.g. /sitemap.xml/route -> /sitemap/[__metadata_id__]/route.
+pub fn multi_dynamic_metadata_page(mut page: AppPage) -> Result<AppPage> {
+    // remove the last /route segment of page
+    page.0.pop();
+
+    // For sitemap.xml routes with generateSitemaps, revert to sitemap
+    // since multi-dynamic sitemaps use /sitemap/[__metadata_id__]
+    if page.last() == Some(&PageSegment::Static(rcstr!("sitemap.xml"))) {
+        page.0.pop();
+        page.push(PageSegment::Static(rcstr!("sitemap")))?;
+    }
+    page.push(PageSegment::Dynamic(rcstr!("__metadata_id__")))?;
+    page.push(PageSegment::PageType(PageType::Route))?;
 
     Ok(page)
 }

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -24,7 +24,8 @@ use crate::{
     app_structure::MetadataItem,
     mode::NextMode,
     next_app::{
-        AppPage, PageSegment, PageType, app_entry::AppEntry, app_route_entry::get_app_route_entry,
+        AppPage, app_entry::AppEntry, app_route_entry::get_app_route_entry,
+        metadata::is_multi_dynamic_metadata,
     },
     next_config::NextConfig,
     parse_segment_config_from_source,
@@ -60,7 +61,7 @@ pub async fn get_app_metadata_route_entry(
     nodejs_context: Vc<ModuleAssetContext>,
     edge_context: Vc<ModuleAssetContext>,
     project_root: FileSystemPath,
-    mut page: AppPage,
+    page: AppPage,
     mode: NextMode,
     metadata: MetadataItem,
     next_config: Vc<NextConfig>,
@@ -71,35 +72,7 @@ pub async fn get_app_metadata_route_entry(
 
     let source = Vc::upcast(FileSource::new(original_path));
     let segment_config = parse_segment_config_from_source(source, ParseSegmentMode::App);
-    let is_dynamic_metadata = matches!(metadata, MetadataItem::Dynamic { .. });
-    let is_multi_dynamic: bool = if Some(segment_config).is_some() {
-        // is_multi_dynamic is true when config.generateSitemaps or
-        // config.generateImageMetadata is defined in dynamic routes
-        let config = segment_config.await.unwrap();
-        config.generate_sitemaps || config.generate_image_metadata
-    } else {
-        false
-    };
-
-    // Map dynamic sitemap and image routes based on the exports.
-    // if there's generator export: add /[__metadata_id__] to the route;
-    // otherwise keep the original route.
-    if is_dynamic_metadata {
-        // remove the last /route segment of page
-        page.0.pop();
-
-        if is_multi_dynamic {
-            // For sitemap.xml routes with generateSitemaps, revert to sitemap
-            // since multi-dynamic sitemaps use /sitemap/[__metadata_id__]
-            if page.last() == Some(&PageSegment::Static(rcstr!("sitemap.xml"))) {
-                page.0.pop();
-                page.push(PageSegment::Static(rcstr!("sitemap")))?;
-            }
-            page.push(PageSegment::Dynamic(rcstr!("__metadata_id__")))?;
-        };
-        // Push /route back
-        page.push(PageSegment::PageType(PageType::Route))?;
-    };
+    let is_multi_dynamic = *is_multi_dynamic_metadata(metadata.clone()).await?;
 
     Ok(get_app_route_entry(
         nodejs_context,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1107,29 +1107,39 @@ export async function createHotReloaderTurbopack(
       // router takes its route table from here. Otherwise it would announce a
       // route it can't serve yet, and the browser would refetch too early and
       // get a 404.
-      const routeState = deriveDevRouteState(routes, {
-        useFileSystemPublicRoutes: opts.nextConfig.useFileSystemPublicRoutes,
-        i18n: opts.nextConfig.i18n,
-      })
-
-      const { appFiles, pageFiles, nextDataRoutes } = opts.fsChecker
-      appFiles.clear()
-      pageFiles.clear()
-      for (const pathname of routeState.appFiles) {
-        appFiles.add(pathname)
+      let routeState
+      try {
+        routeState = deriveDevRouteState(routes, {
+          useFileSystemPublicRoutes: opts.nextConfig.useFileSystemPublicRoutes,
+          i18n: opts.nextConfig.i18n,
+        })
+      } catch (e) {
+        // Conflicting routes make building the route list throw. Keep serving
+        // the previous route state, like the file watcher pass does.
+        Log.warn('Failed to reload dynamic routes:', e)
+        routeState = undefined
       }
-      for (const pathname of routeState.pageFiles) {
-        pageFiles.add(pathname)
-        nextDataRoutes.add(pathname)
-      }
-      opts.fsChecker.dynamicRoutes = routeState.dynamicRoutes
 
-      serverFields.appPathRoutes = routeState.appPathRoutes
-      await propagateServerField(
-        opts,
-        'appPathRoutes',
-        routeState.appPathRoutes
-      )
+      if (routeState) {
+        const { appFiles, pageFiles, nextDataRoutes } = opts.fsChecker
+        appFiles.clear()
+        pageFiles.clear()
+        for (const pathname of routeState.appFiles) {
+          appFiles.add(pathname)
+        }
+        for (const pathname of routeState.pageFiles) {
+          pageFiles.add(pathname)
+          nextDataRoutes.add(pathname)
+        }
+        opts.fsChecker.dynamicRoutes = routeState.dynamicRoutes
+
+        serverFields.appPathRoutes = routeState.appPathRoutes
+        await propagateServerField(
+          opts,
+          'appPathRoutes',
+          routeState.appPathRoutes
+        )
+      }
 
       // Reload matchers when the files have been compiled
       await propagateServerField(opts, 'reloadMatchers', undefined)

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -69,6 +69,7 @@ import {
   type ServerFields,
   type SetupOpts,
 } from '../lib/router-utils/setup-dev-bundler'
+import { deriveDevRouteState } from '../lib/router-utils/dev-route-state'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
 import type { RouteDefinition } from '../route-definitions/route-definition'
@@ -1101,6 +1102,34 @@ export async function createHotReloaderTurbopack(
           },
         },
       })
+
+      // Turbopack knows about a route before the file watcher does, so the
+      // router takes its route table from here. Otherwise it would announce a
+      // route it can't serve yet, and the browser would refetch too early and
+      // get a 404.
+      const routeState = deriveDevRouteState(routes, {
+        useFileSystemPublicRoutes: opts.nextConfig.useFileSystemPublicRoutes,
+        i18n: opts.nextConfig.i18n,
+      })
+
+      const { appFiles, pageFiles, nextDataRoutes } = opts.fsChecker
+      appFiles.clear()
+      pageFiles.clear()
+      for (const pathname of routeState.appFiles) {
+        appFiles.add(pathname)
+      }
+      for (const pathname of routeState.pageFiles) {
+        pageFiles.add(pathname)
+        nextDataRoutes.add(pathname)
+      }
+      opts.fsChecker.dynamicRoutes = routeState.dynamicRoutes
+
+      serverFields.appPathRoutes = routeState.appPathRoutes
+      await propagateServerField(
+        opts,
+        'appPathRoutes',
+        routeState.appPathRoutes
+      )
 
       // Reload matchers when the files have been compiled
       await propagateServerField(opts, 'reloadMatchers', undefined)

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -1037,12 +1037,13 @@ export function normalizedPageToTurbopackStructureRoute(
       : entrypointKey
 
     if (ext) {
-      if (entrypointKey.endsWith('/[__metadata_id__]')) {
-        entrypointKey = entrypointKey.slice(0, -'/[__metadata_id__]'.length)
-      }
-      // After stripping [__metadata_id__], add .xml for dynamic sitemap routes
-      // to match the Turbopack entry key from normalize_metadata_route
-      if (entrypointKey.endsWith('/sitemap') && ext !== '.xml') {
+      // Dynamic sitemap routes without a generator are keyed with an .xml
+      // extension (see normalize_metadata_route).
+      if (
+        !entrypointKey.endsWith('/[__metadata_id__]') &&
+        entrypointKey.endsWith('/sitemap') &&
+        ext !== '.xml'
+      ) {
         entrypointKey = entrypointKey + '.xml'
       }
     }

--- a/packages/next/src/server/lib/router-utils/dev-route-state.ts
+++ b/packages/next/src/server/lib/router-utils/dev-route-state.ts
@@ -1,0 +1,139 @@
+import type { FilesystemDynamicRoute } from './filesystem'
+import type { NextConfigComplete } from '../../config-shared'
+import type { Route } from '../../../build/swc/types'
+import { getSortedRoutes } from '../../../shared/lib/router/utils'
+import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
+import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
+import { compareAppPaths } from '../../../shared/lib/router/utils/app-paths'
+import { buildDataRoute } from './build-data-route'
+
+/**
+ * Everything the dev router needs in order to serve a route: which pathnames
+ * exist, which of them belong to the App Router, and which regexes to try once
+ * an exact pathname lookup misses.
+ */
+export interface DevRouteState {
+  appFiles: Set<string>
+  pageFiles: Set<string>
+  appPathRoutes: Record<string, string[]>
+  dynamicRoutes: FilesystemDynamicRoute[]
+}
+
+/**
+ * Builds the route list the dev router matches a request against once an exact
+ * path lookup missed. The `/_next/data` routes come first so a data request
+ * doesn't match the page route it shadows.
+ */
+export function buildDevDynamicRoutes(
+  routedPages: string[],
+  i18n: NextConfigComplete['i18n']
+): FilesystemDynamicRoute[] {
+  const sortedRoutes = getSortedRoutes(routedPages)
+
+  const pageRoutes = sortedRoutes.map((page): FilesystemDynamicRoute => {
+    const regex = getNamedRouteRegex(page, {
+      prefixRouteKeys: true,
+    })
+    return {
+      regex: regex.re.toString(),
+      namedRegex: regex.namedRegex,
+      routeKeys: regex.routeKeys,
+      match: getRouteMatcher(regex),
+      page,
+    }
+  })
+
+  const dataRoutes = sortedRoutes.map((page): FilesystemDynamicRoute => {
+    const route = buildDataRoute(page, 'development')
+    const routeRegex = getNamedRouteRegex(route.page, {
+      prefixRouteKeys: true,
+    })
+    return {
+      ...route,
+      regex: routeRegex.re.toString(),
+      namedRegex: routeRegex.namedRegex,
+      routeKeys: routeRegex.routeKeys,
+      match: getRouteMatcher({
+        // TODO: fix this in the manifest itself, must also be fixed in
+        // upstream builder that relies on this
+        re: i18n
+          ? new RegExp(
+              route.dataRouteRegex.replace(
+                `/development/`,
+                `/development/(?<nextLocale>[^/]+?)/`
+              )
+            )
+          : new RegExp(route.dataRouteRegex),
+        groups: routeRegex.groups,
+      }),
+    }
+  })
+
+  return [...dataRoutes, ...pageRoutes]
+}
+
+/**
+ * Derives the dev route state from the routes Turbopack has compiled. The
+ * pathnames Turbopack reports are already normalized the way the router wants
+ * them: route groups are stripped, private folders are left out, and escaped
+ * underscores are decoded. The only entry that isn't a real URL is the
+ * `/_not-found` route the App Router synthesizes for us.
+ */
+export function deriveDevRouteState(
+  routes: ReadonlyMap<string, Route>,
+  {
+    useFileSystemPublicRoutes,
+    i18n,
+  }: {
+    useFileSystemPublicRoutes: boolean
+    i18n: NextConfigComplete['i18n']
+  }
+): DevRouteState {
+  const appFiles = new Set<string>()
+  const pageFiles = new Set<string>()
+  const appPathRoutes: Record<string, string[]> = {}
+  const routedPages: string[] = []
+
+  for (const [pathname, route] of routes) {
+    let originalNames: string[]
+
+    switch (route.type) {
+      case 'page':
+      case 'page-api':
+        if (useFileSystemPublicRoutes) {
+          pageFiles.add(pathname)
+        }
+        routedPages.push(pathname)
+        continue
+      case 'app-page':
+        originalNames = route.pages.map((page) => page.originalName)
+        break
+      case 'app-route':
+        originalNames = [route.originalName]
+        break
+      case 'conflict':
+        continue
+      default:
+        route satisfies never
+        continue
+    }
+
+    if (pathname === '/_not-found') {
+      continue
+    }
+
+    if (useFileSystemPublicRoutes) {
+      appFiles.add(pathname)
+    }
+    // Make sure to sort parallel routes to make the result deterministic.
+    appPathRoutes[pathname] = originalNames.sort(compareAppPaths)
+    routedPages.push(pathname)
+  }
+
+  return {
+    appFiles,
+    pageFiles,
+    appPathRoutes,
+    dynamicRoutes: buildDevDynamicRoutes(routedPages, i18n),
+  }
+}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1,5 +1,4 @@
 import type { NextConfigComplete } from '../../config-shared'
-import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
@@ -28,9 +27,7 @@ import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import { sortByPageExts } from '../../../build/sort-by-page-exts'
 import { verifyAndRunTypeScript } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
-import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
-import { buildDataRoute } from './build-data-route'
-import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
+import { buildDevDynamicRoutes } from './dev-route-state'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { createClientRouterFilter } from '../../../lib/create-client-router-filter'
 import { absolutePathToPage } from '../../../shared/lib/page-path/absolute-path-to-page'
@@ -446,8 +443,13 @@ async function startWatcher(
 
       const { appFiles, pageFiles, staticMetadataFiles } = opts.fsChecker
 
-      appFiles.clear()
-      pageFiles.clear()
+      // With Turbopack the route table is written from the entrypoints event
+      // instead, so that the router can serve a route as soon as Turbopack
+      // announces it.
+      if (!opts.turbo) {
+        appFiles.clear()
+        pageFiles.clear()
+      }
       staticMetadataFiles.clear()
       devPageFiles.clear()
 
@@ -699,7 +701,7 @@ async function startWatcher(
                 lastSegment
               )
               staticMetadataFiles.set(normalizedPath, fileName)
-            } else {
+            } else if (!opts.turbo) {
               appFiles.add(pageName)
             }
           }
@@ -714,7 +716,7 @@ async function startWatcher(
           if (routedPages.includes(pageName)) continue
         } else {
           // Pages router
-          if (useFileSystemPublicRoutes) {
+          if (useFileSystemPublicRoutes && !opts.turbo) {
             pageFiles.add(pageName)
             opts.fsChecker.nextDataRoutes.add(pageName)
           }
@@ -957,15 +959,17 @@ async function startWatcher(
         nestedMiddleware = []
       }
 
-      // Make sure to sort parallel routes to make the result deterministic.
-      serverFields.appPathRoutes = Object.fromEntries(
-        Object.entries(appPaths).map(([k, v]) => [k, v.sort(compareAppPaths)])
-      )
-      await propagateServerField(
-        opts,
-        'appPathRoutes',
-        serverFields.appPathRoutes
-      )
+      if (!opts.turbo) {
+        // Make sure to sort parallel routes to make the result deterministic.
+        serverFields.appPathRoutes = Object.fromEntries(
+          Object.entries(appPaths).map(([k, v]) => [k, v.sort(compareAppPaths)])
+        )
+        await propagateServerField(
+          opts,
+          'appPathRoutes',
+          serverFields.appPathRoutes
+        )
+      }
 
       // TODO: pass this to fsChecker/next-dev-server?
       serverFields.middleware = middlewareMatchers
@@ -1036,49 +1040,12 @@ async function startWatcher(
         // before it has been built and is populated in the _buildManifest
         const sortedRoutes = getSortedRoutes(routedPages)
 
-        opts.fsChecker.dynamicRoutes = sortedRoutes.map(
-          (page): FilesystemDynamicRoute => {
-            const regex = getNamedRouteRegex(page, {
-              prefixRouteKeys: true,
-            })
-            return {
-              regex: regex.re.toString(),
-              namedRegex: regex.namedRegex,
-              routeKeys: regex.routeKeys,
-              match: getRouteMatcher(regex),
-              page,
-            }
-          }
-        )
-
-        const dataRoutes: typeof opts.fsChecker.dynamicRoutes = []
-
-        for (const page of sortedRoutes) {
-          const route = buildDataRoute(page, 'development')
-          const routeRegex = getNamedRouteRegex(route.page, {
-            prefixRouteKeys: true,
-          })
-          dataRoutes.push({
-            ...route,
-            regex: routeRegex.re.toString(),
-            namedRegex: routeRegex.namedRegex,
-            routeKeys: routeRegex.routeKeys,
-            match: getRouteMatcher({
-              // TODO: fix this in the manifest itself, must also be fixed in
-              // upstream builder that relies on this
-              re: opts.nextConfig.i18n
-                ? new RegExp(
-                    route.dataRouteRegex.replace(
-                      `/development/`,
-                      `/development/(?<nextLocale>[^/]+?)/`
-                    )
-                  )
-                : new RegExp(route.dataRouteRegex),
-              groups: routeRegex.groups,
-            }),
-          })
+        if (!opts.turbo) {
+          opts.fsChecker.dynamicRoutes = buildDevDynamicRoutes(
+            routedPages,
+            opts.nextConfig.i18n
+          )
         }
-        opts.fsChecker.dynamicRoutes.unshift(...dataRoutes)
 
         // For Turbopack ADDED_PAGE and REMOVED_PAGE are implemented in hot-reloader-turbopack.ts
         // in order to avoid a race condition where ADDED_PAGE and REMOVED_PAGE are sent before Turbopack picked up the file change.


### PR DESCRIPTION
## Summary

Stacked on #96782 (which stacks on #96775).

In dev the router works out what it can serve from three pieces of state: the exact path table (`appFiles` and `pageFiles`), the dynamic route list, and `appPathRoutes`, which says whether a path belongs to the App Router or the Pages Router. All three are written by the watchpack handler in setup-dev-bundler.ts.

With Turbopack, `ADDED_PAGE` and `REMOVED_PAGE` are sent from the entrypoints event instead, and Turbopack gets there before watchpack. So the browser hears about a route, refetches right away, and gets a 404 because the router can't serve it yet. Under load that gap grows to seconds.

Now the route table is written from the entrypoints event too, so the state the router serves from and the event that tells the browser to refetch come from the same place. Webpack still writes it from watchpack, where it already announces from inside the same handler and so never had the race.

#83829 moved the events but left the state behind. This is the other half.

On top of the two PRs below it, this also removes a whole class of skew: the router's tables, the `ADDED_PAGE` announcements, and the entrypoints the render server compiles from now all come from the same event. Requests arriving before that event are covered by the on-miss reconciliation from #96775/#96782 (dev matchers re-scan the filesystem; `ensurePage` asks Turbopack directly).

## Verification

- `pnpm test-dev-turbo test/development/app-dir/new-route-first-request` (2 consecutive runs)
- `pnpm test-dev-turbo test/development/app-hmr test/development/basic/gssp-ssr-change-reloading test/e2e/app-dir/not-found/index.test.ts test/development/duplicate-pages` (data routes, page add/remove, 404 rendering)

<!-- NEXT_JS_LLM -->