### PR TITLE
Give route-shaped dev server strings distinct types

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -21,6 +21,7 @@ import type {
   NapiCodeFrameOptions,
 } from './generated-native'
 import type {
+  AppEntryName,
   Binding,
   BuildFeatureUsage,
   CompilationEvent,
@@ -36,6 +37,7 @@ import type {
   Route,
   TurboEngineOptions,
   TurbopackResult,
+  TurbopackRouteKey,
   TurbopackStackFrame,
   Update,
   UpdateMessage,
@@ -1202,7 +1204,7 @@ function bindingToApi(
   function napiEntrypointsToRawEntrypoints(
     entrypoints: TurbopackResult<NapiEntrypoints>
   ): TurbopackResult<RawEntrypoints> {
-    const routes = new Map()
+    const routes = new Map<TurbopackRouteKey, Route>()
     for (const { pathname, ...nativeRoute } of entrypoints.routes) {
       let route: Route
       const routeType = nativeRoute.type
@@ -1224,7 +1226,7 @@ function bindingToApi(
           route = {
             type: 'app-page',
             pages: nativeRoute.pages.map((page) => ({
-              originalName: page.originalName,
+              originalName: page.originalName as AppEntryName,
               htmlEndpoint: new EndpointImpl(page.htmlEndpoint),
               rscHmrEndpoint: new EndpointImpl(page.rscHmrEndpoint),
             })),
@@ -1233,7 +1235,7 @@ function bindingToApi(
         case 'app-route':
           route = {
             type: 'app-route',
-            originalName: nativeRoute.originalName,
+            originalName: nativeRoute.originalName as AppEntryName,
             endpoint: new EndpointImpl(nativeRoute.endpoint),
           }
           break
@@ -1250,7 +1252,7 @@ function bindingToApi(
           )
         }
       }
-      routes.set(pathname, route)
+      routes.set(pathname as TurbopackRouteKey, route)
     }
     const napiMiddlewareToMiddleware = (middleware: NapiMiddleware) => ({
       endpoint: new EndpointImpl(middleware.endpoint),

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -190,8 +190,32 @@ export interface Instrumentation {
   edge: Endpoint
 }
 
+// Route-shaped strings come in several namespaces that look alike but rarely
+// equal each other, so comparing across them silently never matches. The
+// brands turn a cross-namespace lookup into a type error. (`EntryKey` does
+// the same for entry keys.)
+declare const __routeStringBrand: unique symbol
+
+/**
+ * A key of `RawEntrypoints.routes`: the route pathname, as Turbopack keys
+ * routes. For an App Router page this is the route ("/blog"), not the entry
+ * name ("/blog/page").
+ */
+export type TurbopackRouteKey = string & {
+  [__routeStringBrand]: 'turbopack-route-key'
+}
+
+/**
+ * An App Router entry name, including the leaf: "/blog/page",
+ * "/api/hello/route". This is `originalName` in Turbopack's routes and the
+ * key of `AppEntrypoints`.
+ */
+export type AppEntryName = string & {
+  [__routeStringBrand]: 'app-entry-name'
+}
+
 export interface RawEntrypoints {
-  routes: Map<string, Route>
+  routes: Map<TurbopackRouteKey, Route>
   middleware?: Middleware
   instrumentation?: Instrumentation
   pagesDocumentEndpoint: Endpoint
@@ -385,14 +409,14 @@ export type Route =
   | {
       type: 'app-page'
       pages: {
-        originalName: string
+        originalName: AppEntryName
         htmlEndpoint: Endpoint
         rscHmrEndpoint: Endpoint
       }[]
     }
   | {
       type: 'app-route'
-      originalName: string
+      originalName: AppEntryName
       endpoint: Endpoint
     }
   | {
@@ -559,7 +583,7 @@ export type AppRoute =
 export type PageEntrypoints = Map<string, PageRoute>
 
 // originalName / page -> route
-export type AppEntrypoints = Map<string, AppRoute>
+export type AppEntrypoints = Map<AppEntryName, AppRoute>
 
 export type Entrypoints = {
   global: GlobalEntrypoints

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -28,6 +28,8 @@ import type {
   Entrypoints,
   NodeJsHmrUpdate,
   NodeJsPartialHmrUpdate,
+  AppEntryName,
+  TurbopackRouteKey,
 } from '../../build/swc/types'
 import { createDefineEnv, getBindingsSync, HmrTarget } from '../../build/swc'
 import * as Log from '../../build/output/log'
@@ -797,7 +799,7 @@ export async function createHotReloaderTurbopack(
   let hmrHash = 0
   // Undefined until the first entrypoints emission. That one has nothing to
   // compare against, so every route it lists would look added.
-  let previousRouteKeys: Set<string> | undefined
+  let previousRouteKeys: Set<TurbopackRouteKey> | undefined
 
   // HACK: Defer sending `building` messages. Turbopack emits a compile pass for every
   // foreground-job cycle, including empty no-op recompiles scheduled by
@@ -1969,7 +1971,8 @@ export async function createHotReloaderTurbopack(
                 page,
                 extname(routeDef.filename)
               )
-            : page
+            : // For non-metadata entries the entry name is the page name.
+              (page as AppEntryName)
 
           const route = isInsideAppDir
             ? currentEntrypoints.app.get(normalizedAppPage)

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -18,7 +18,12 @@ import * as Log from '../../build/output/log'
 import { warnAboutEdgeRuntime } from '../../build/warn-about-edge-runtime'
 import type { PropagateToWorkersField } from '../lib/router-utils/types'
 import type { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
-import type { AppRoute, Entrypoints, PageRoute } from '../../build/swc/types'
+import type {
+  AppEntryName,
+  AppRoute,
+  Entrypoints,
+  PageRoute,
+} from '../../build/swc/types'
 import {
   type EntryKey,
   getEntryKey,
@@ -554,7 +559,8 @@ export function hasEntrypointForKey(
 
   switch (type) {
     case 'app':
-      return entrypoints.app.has(page)
+      // App entry keys are constructed from entry names.
+      return entrypoints.app.has(page as AppEntryName)
     case 'pages':
       switch (page) {
         case '_app':
@@ -1035,7 +1041,7 @@ export function addMetadataIdToRoute(route: string): string {
 export function normalizedPageToTurbopackStructureRoute(
   route: string,
   ext: string | false
-): string {
+): AppEntryName {
   let entrypointKey = route
   if (isMetadataRoute(entrypointKey)) {
     entrypointKey = entrypointKey.endsWith('/route')
@@ -1054,5 +1060,5 @@ export function normalizedPageToTurbopackStructureRoute(
     }
     entrypointKey = entrypointKey + '/route'
   }
-  return entrypointKey
+  return entrypointKey as AppEntryName
 }

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -8,6 +8,7 @@ import type {
   RawEntrypoints,
   StyledString,
   TurbopackResult,
+  TurbopackRouteKey,
   UpdateInfo,
 } from 'next/dist/build/swc/types'
 import loadConfig from 'next/dist/server/config'
@@ -468,7 +469,7 @@ describe('next.rs api', () => {
         throw new Error('Entrypoints not available due to compilation errors')
       }
 
-      const route = entrypoints.routes.get(path)
+      const route = entrypoints.routes.get(path as TurbopackRouteKey)
       entrypointsSubscribtion.return()
 
       expect(route.type).toBe(type)
@@ -592,7 +593,7 @@ describe('next.rs api', () => {
           throw new Error('Entrypoints not available due to compilation errors')
         }
 
-        const route = entrypoints.routes.get(path)
+        const route = entrypoints.routes.get(path as TurbopackRouteKey)
         entrypointsSubscribtion.return()
 
         expect(route.type).toBe(type)
@@ -734,7 +735,7 @@ describe('next.rs api', () => {
       throw new Error('Entrypoints not available due to compilation errors')
     }
 
-    const route = entrypoints.routes.get('/')
+    const route = entrypoints.routes.get('/' as TurbopackRouteKey)
     entrypointsSubscribtion.return()
 
     if (route.type !== 'page') throw new Error('unknown route type')


### PR DESCRIPTION
Stacked on #96783.

Turbopack's entrypoints keep routes in maps keyed by string namespaces that look alike but rarely equal each other: the routes map is keyed by route pathname (`/blog`), while the app entrypoints map is keyed by entry name (`/blog/page`). Mixing them up compiles fine and silently never matches — which is how the dev server came to announce every app route as added on every update (fixed at the bottom of this stack, #96250).

This brands the two namespaces the way `EntryKey` already guards entry keys:

- `TurbopackRouteKey` — keys of `RawEntrypoints.routes`
- `AppEntryName` — `originalName` / keys of `AppEntrypoints`

A plain string can't be used where a branded key is expected, and the brands can't be used in each other's place. Reverting #96250's fix no longer compiles:

```
hot-reloader-turbopack.ts: error TS2345: Argument of type 'TurbopackRouteKey'
  is not assignable to parameter of type 'AppEntryName'.
hot-reloader-turbopack.ts: error TS2345: Argument of type 'string'
  is not assignable to parameter of type 'TurbopackRouteKey'.
```

Strings enter the namespaces at the NAPI boundary (route construction in `swc/index.ts`) and leave through message payloads, where the brands widen back to plain strings. `normalizedPageToTurbopackStructureRoute` returns an entry name — per its own comment it maps a normalized page path back to Turbopack's entry key — and is typed accordingly. Pages Router maps are left as plain strings: there the route pathname and the page name are genuinely the same string.

No runtime change; `route-change-refetch` passes 10/10 as a sanity check.