### PR TITLE
Harden the dev route matchers against reload races

### DIFF
--- a/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
@@ -36,13 +36,44 @@ export class DefaultRouteMatcherManager implements RouteMatcherManager {
   private waitTillReadyPromise?: Promise<void>
   public async waitTillReady(): Promise<void> {
     if (this.waitTillReadyPromise) {
-      await this.waitTillReadyPromise
-      delete this.waitTillReadyPromise
+      try {
+        await this.waitTillReadyPromise
+      } finally {
+        // Also delete the promise when it rejected, so that one failed
+        // reload doesn't fail every subsequent request.
+        delete this.waitTillReadyPromise
+      }
     }
   }
 
+  private inFlightReload?: Promise<void>
+  private queuedReload?: Promise<void>
+
+  public reload(): Promise<void> {
+    // Coalesce concurrent reloads. A caller that arrives while a reload is
+    // in flight cannot join it, because that reload may have scanned the
+    // filesystem before the change the caller wants to observe, so it waits
+    // for one queued follow-up reload instead. This bounds the work under
+    // concurrent reloads to one running and one queued scan.
+    if (!this.inFlightReload) {
+      this.inFlightReload = this.reloadImpl().finally(() => {
+        this.inFlightReload = undefined
+      })
+      return this.inFlightReload
+    }
+
+    if (!this.queuedReload) {
+      this.queuedReload = this.inFlightReload.then(() => {
+        this.queuedReload = undefined
+        return this.reload()
+      })
+    }
+
+    return this.queuedReload
+  }
+
   private previousMatchers: ReadonlyArray<RouteMatcher> = []
-  public async reload() {
+  private async reloadImpl() {
     const { promise, resolve, reject } = new DetachedPromise<void>()
     this.waitTillReadyPromise = promise
 

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -1,4 +1,5 @@
 import { RouteKind } from '../route-kind'
+import { PageNotFoundError } from '../../shared/lib/utils'
 import type { RouteMatch } from '../route-matches/route-match'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import { DefaultRouteMatcherManager } from './default-route-matcher-manager'
@@ -70,7 +71,15 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     for await (const developmentMatch of super.matchAll(pathname, options)) {
       // We're here, which means that we haven't seen this match yet, so we
       // should try to ensure it and recompile the production matcher.
-      await this.ensurer.ensure(developmentMatch, pathname)
+      try {
+        await this.ensurer.ensure(developmentMatch, pathname)
+      } catch (err) {
+        // The route was removed after the matchers last scanned the
+        // filesystem. Treat the stale match as no match rather than failing
+        // the request.
+        if (err instanceof PageNotFoundError) continue
+        throw err
+      }
       await this.production.reload()
 
       // Iterate over the production matches again, this time we should be able

--- a/test/development/app-dir/new-route-first-request/app/layout.tsx
+++ b/test/development/app-dir/new-route-first-request/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/new-route-first-request/app/page.tsx
+++ b/test/development/app-dir/new-route-first-request/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
+++ b/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
@@ -1,0 +1,50 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+describe('new-route-first-request', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('responds 404 for a route that does not exist', async () => {
+    expect((await next.fetch('/does-not-exist')).status).toBe(404)
+  })
+
+  it('responds 404 (not 500) to the first request for a deleted page', async () => {
+    const dir = path.join(next.testDir, 'app/removed')
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(
+      path.join(dir, 'page.tsx'),
+      'export default function Page() { return <p>removed</p> }'
+    )
+    await retry(async () => {
+      expect((await next.fetch('/removed')).status).toBe(200)
+    })
+
+    for (let i = 0; i < 5; i++) {
+      await fs.rm(dir, { recursive: true })
+      // Start requesting at varying points of the watchers' catch-up work,
+      // beginning at "immediately". The route may briefly keep serving while
+      // the deletion propagates, but it must converge to a 404.
+      await waitFor(i * 15)
+      await retry(async () => {
+        expect((await next.fetch('/removed')).status).toBe(404)
+      })
+
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, 'page.tsx'),
+        'export default function Page() { return <p>removed</p> }'
+      )
+      await retry(async () => {
+        expect((await next.fetch('/removed')).status).toBe(200)
+      })
+    }
+
+    // Requests that hit the window where the route info was stale must have
+    // been answered from the routes on disk, not failed on the stale state.
+    expect(next.cliOutput).not.toContain('route not found /removed')
+  })
+})

--- a/test/development/app-dir/new-route-first-request/next.config.js
+++ b/test/development/app-dir/new-route-first-request/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/500-page/500-page.test.ts
+++ b/test/e2e/500-page/500-page.test.ts
@@ -49,8 +49,8 @@ describe('500 Page Support', () => {
           export default page
         `
         )
-        await next.render('/500')
         await retry(async () => {
+          await next.render('/500')
           expect(next.cliOutput).toMatch(
             /`pages\/500` can not have getInitialProps\/getServerSideProps/
           )
@@ -94,8 +94,8 @@ describe('500 Page Support', () => {
           export default page
         `
         )
-        await next.render('/500')
         await retry(async () => {
+          await next.render('/500')
           expect(next.cliOutput).toMatch(
             /`pages\/500` can not have getInitialProps\/getServerSideProps/
           )


### PR DESCRIPTION
Three independent fixes for the development route matcher manager, each observable on its own:

- A failed reload left `waitTillReady` holding a rejected promise, so one transient filesystem error while scanning failed every subsequent request with a 500 until the next reload replaced the promise.
- Concurrent reloads ran unserialized, interleaving scans of different filesystem states and mutating shared matcher objects (`matcher.duplicated`). Reloads are now coalesced into one running and one queued scan; a caller that arrives mid-scan waits for the queued one, since the running scan may predate the change the caller wants to observe.
- A route deleted after the matchers last scanned the filesystem could still match, and the ensure step then failed the request with a 500 where rendering the 404 page is expected. A `PageNotFoundError` from ensure now means the match is stale and is skipped. The new test deletes and recreates a page while requesting it and asserts the responses converge without erroring.

Also makes the 500-page getInitialProps dev tests re-render inside `retry` so they don't depend on a single render landing after recompilation.

<!-- NEXT_JS_LLM -->