### PR TITLE
Turbopack: name multi-dynamic metadata routes by the page they serve

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -19,8 +19,9 @@ use crate::{
     next_app::{
         AppPage, AppPath, PageSegment, PageType,
         metadata::{
-            GlobalMetadataFileMatch, MetadataFileMatch, match_global_metadata_file,
-            match_local_metadata_file, normalize_metadata_route,
+            GlobalMetadataFileMatch, MetadataFileMatch, is_multi_dynamic_metadata,
+            match_global_metadata_file, match_local_metadata_file, multi_dynamic_metadata_page,
+            normalize_metadata_route,
         },
     },
     next_import_map::get_next_package,
@@ -1650,14 +1651,12 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         .chain(open_graph.iter().cloned().map(MetadataItem::from))
     {
         let app_page = app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
+        let mut page = normalize_metadata_route(app_page)?;
+        if *is_multi_dynamic_metadata(meta.clone()).await? {
+            page = multi_dynamic_metadata_page(page)?;
+        }
 
-        add_app_metadata_route(
-            app_dir.clone(),
-            &mut result,
-            normalize_metadata_route(app_page)?,
-            meta,
-            root_params,
-        );
+        add_app_metadata_route(app_dir.clone(), &mut result, page, meta, root_params);
     }
 
     // root path: /
@@ -1671,11 +1670,15 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         for meta in favicon.iter().chain(robots.iter()).chain(manifest.iter()) {
             let app_page =
                 app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
+            let mut page = normalize_metadata_route(app_page)?;
+            if *is_multi_dynamic_metadata(meta.clone()).await? {
+                page = multi_dynamic_metadata_page(page)?;
+            }
 
             add_app_metadata_route(
                 app_dir.clone(),
                 &mut result,
-                normalize_metadata_route(app_page)?,
+                page,
                 meta.clone(),
                 root_params,
             );

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -3,10 +3,16 @@ use std::sync::LazyLock;
 use anyhow::Result;
 use phf::phf_map;
 use regex::Regex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
+use turbopack_core::file_source::FileSource;
 
-use crate::next_app::{AppPage, AppPath, PageSegment, PageType};
+use crate::{
+    app_structure::MetadataItem,
+    next_app::{AppPage, AppPath, PageSegment, PageType},
+    segment_config::{ParseSegmentMode, parse_segment_config_from_source},
+};
 
 pub mod image;
 pub mod route;
@@ -415,6 +421,39 @@ pub fn normalize_metadata_route(mut page: AppPage) -> Result<AppPage> {
 
         page.push(PageSegment::PageType(PageType::Route))?;
     }
+
+    Ok(page)
+}
+
+/// Whether a dynamic metadata file exports a generator
+/// (`generateSitemaps`/`generateImageMetadata`), in which case its route is
+/// served under an id instead of its own name.
+#[turbo_tasks::function]
+pub async fn is_multi_dynamic_metadata(metadata: MetadataItem) -> Result<Vc<bool>> {
+    Ok(match metadata {
+        MetadataItem::Dynamic { path } => {
+            let source = Vc::upcast(FileSource::new(path));
+            let config = parse_segment_config_from_source(source, ParseSegmentMode::App).await?;
+            Vc::cell(config.generate_sitemaps || config.generate_image_metadata)
+        }
+        MetadataItem::Static { .. } => Vc::cell(false),
+    })
+}
+
+/// Maps the page of a multi-dynamic metadata route to the page it is served
+/// under, e.g. /sitemap.xml/route -> /sitemap/[__metadata_id__]/route.
+pub fn multi_dynamic_metadata_page(mut page: AppPage) -> Result<AppPage> {
+    // remove the last /route segment of page
+    page.0.pop();
+
+    // For sitemap.xml routes with generateSitemaps, revert to sitemap
+    // since multi-dynamic sitemaps use /sitemap/[__metadata_id__]
+    if page.last() == Some(&PageSegment::Static(rcstr!("sitemap.xml"))) {
+        page.0.pop();
+        page.push(PageSegment::Static(rcstr!("sitemap")))?;
+    }
+    page.push(PageSegment::Dynamic(rcstr!("__metadata_id__")))?;
+    page.push(PageSegment::PageType(PageType::Route))?;
 
     Ok(page)
 }

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -24,7 +24,8 @@ use crate::{
     app_structure::MetadataItem,
     mode::NextMode,
     next_app::{
-        AppPage, PageSegment, PageType, app_entry::AppEntry, app_route_entry::get_app_route_entry,
+        AppPage, app_entry::AppEntry, app_route_entry::get_app_route_entry,
+        metadata::is_multi_dynamic_metadata,
     },
     next_config::NextConfig,
     parse_segment_config_from_source,
@@ -60,7 +61,7 @@ pub async fn get_app_metadata_route_entry(
     nodejs_context: Vc<ModuleAssetContext>,
     edge_context: Vc<ModuleAssetContext>,
     project_root: FileSystemPath,
-    mut page: AppPage,
+    page: AppPage,
     mode: NextMode,
     metadata: MetadataItem,
     next_config: Vc<NextConfig>,
@@ -71,35 +72,7 @@ pub async fn get_app_metadata_route_entry(
 
     let source = Vc::upcast(FileSource::new(original_path));
     let segment_config = parse_segment_config_from_source(source, ParseSegmentMode::App);
-    let is_dynamic_metadata = matches!(metadata, MetadataItem::Dynamic { .. });
-    let is_multi_dynamic: bool = if Some(segment_config).is_some() {
-        // is_multi_dynamic is true when config.generateSitemaps or
-        // config.generateImageMetadata is defined in dynamic routes
-        let config = segment_config.await.unwrap();
-        config.generate_sitemaps || config.generate_image_metadata
-    } else {
-        false
-    };
-
-    // Map dynamic sitemap and image routes based on the exports.
-    // if there's generator export: add /[__metadata_id__] to the route;
-    // otherwise keep the original route.
-    if is_dynamic_metadata {
-        // remove the last /route segment of page
-        page.0.pop();
-
-        if is_multi_dynamic {
-            // For sitemap.xml routes with generateSitemaps, revert to sitemap
-            // since multi-dynamic sitemaps use /sitemap/[__metadata_id__]
-            if page.last() == Some(&PageSegment::Static(rcstr!("sitemap.xml"))) {
-                page.0.pop();
-                page.push(PageSegment::Static(rcstr!("sitemap")))?;
-            }
-            page.push(PageSegment::Dynamic(rcstr!("__metadata_id__")))?;
-        };
-        // Push /route back
-        page.push(PageSegment::PageType(PageType::Route))?;
-    };
+    let is_multi_dynamic = *is_multi_dynamic_metadata(metadata.clone()).await?;
 
     Ok(get_app_route_entry(
         nodejs_context,

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -1037,12 +1037,13 @@ export function normalizedPageToTurbopackStructureRoute(
       : entrypointKey
 
     if (ext) {
-      if (entrypointKey.endsWith('/[__metadata_id__]')) {
-        entrypointKey = entrypointKey.slice(0, -'/[__metadata_id__]'.length)
-      }
-      // After stripping [__metadata_id__], add .xml for dynamic sitemap routes
-      // to match the Turbopack entry key from normalize_metadata_route
-      if (entrypointKey.endsWith('/sitemap') && ext !== '.xml') {
+      // Dynamic sitemap routes without a generator are keyed with an .xml
+      // extension (see normalize_metadata_route).
+      if (
+        !entrypointKey.endsWith('/[__metadata_id__]') &&
+        entrypointKey.endsWith('/sitemap') &&
+        ext !== '.xml'
+      ) {
         entrypointKey = entrypointKey + '.xml'
       }
     }


### PR DESCRIPTION
A dynamic metadata file with a generator export (generateSitemaps or
generateImageMetadata) is served under an id, e.g. app/sitemap.ts with
generateSitemaps serves /sitemap/[__metadata_id__] and writes its
manifests under that name. The entrypoints still reported such a route
under its single-form name (/sitemap.xml), because the generator check
only happened when the route's endpoint was constructed. Everything
consuming the entrypoints has to paper over the difference, e.g. the
manifest loader probes both names on disk and ensurePage re-derives the
key from the matched file's extension.

Move the check to entrypoint naming, so the reported route matches what
the endpoint serves.

<!-- NEXT_JS_LLM -->