### PR TITLE
Check the filesystem before rendering a dev 404

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -41,6 +41,7 @@ import Server, { WrappedBuildError } from '../next-server'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
+import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
 import { Telemetry } from '../../telemetry/storage'
 import {
   type Span,
@@ -440,6 +441,35 @@ export default class DevServer extends Server {
     }
 
     return Boolean(appFile || pagesFile)
+  }
+
+  /**
+   * Called by the router server before it renders a 404 for a request
+   * pathname that its filesystem route info does not include. That info is
+   * updated when the file watcher has processed a change, so it can lag
+   * behind the filesystem when a request arrives right after a file was
+   * written. The development route matchers re-scan the filesystem when they
+   * don't have a match, so this reflects the routes that exist on disk at
+   * the time of the call.
+   */
+  public async testRouteMatch(pathname: string): Promise<boolean> {
+    const { basePath } = this.nextConfig
+    if (basePath) {
+      if (!pathHasPrefix(pathname, basePath)) {
+        return false
+      }
+      pathname = removePathPrefix(pathname, basePath) || '/'
+    }
+    pathname = removeTrailingSlash(pathname)
+
+    const i18n = this.i18nProvider?.analyze(pathname)
+    // API routes are not served under locale-prefixed paths; see the
+    // corresponding check in resolveRoutes.
+    if (i18n?.detectedLocale && pathHasPrefix(i18n.pathname, '/api')) {
+      return false
+    }
+
+    return this.matchers.test(pathname, { i18n })
   }
 
   async runMiddleware(params: {

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -76,7 +76,7 @@ export async function propagateServerField(
   if (wrappedServer) {
     if (typeof wrappedServer[_field] === 'function') {
       // @ts-expect-error
-      await wrappedServer[_field].apply(
+      return await wrappedServer[_field].apply(
         wrappedServer,
         Array.isArray(value) ? value : []
       )

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -492,6 +492,7 @@ export async function initialize(opts: {
         resHeaders,
         bodyStream,
         matchedOutput,
+        didRewrite,
       } = await resolveRoutes({
         req,
         res,
@@ -758,6 +759,43 @@ export async function initialize(opts: {
         res.statusCode = 404
         res.end('')
         return null
+      }
+
+      // The filesystem route info is updated when the file watcher has
+      // processed a change, so it can lag behind the filesystem when a
+      // request arrives right after a file was written. Before rendering a
+      // 404, check the request path against the routes on disk via the
+      // development route matchers, and render the route when it exists.
+      // Plain-text 404s for static assets and subresources above stay on
+      // their fast path deliberately: they self-heal on retry and aren't
+      // worth a filesystem re-scan.
+      if (
+        opts.dev &&
+        // Filesystem routes are only served for rewritten requests when
+        // `useFileSystemPublicRoutes` is disabled.
+        (config.useFileSystemPublicRoutes || didRewrite) &&
+        parsedUrl.pathname &&
+        !parsedUrl.pathname.startsWith('/_next/') &&
+        !invokedOutputs.has(parsedUrl.pathname)
+      ) {
+        let routeExists = false
+        try {
+          routeExists = Boolean(
+            await renderServer?.instance?.propagateServerField(
+              opts.dir,
+              'testRouteMatch',
+              [parsedUrl.pathname]
+            )
+          )
+        } catch {
+          // The render server hasn't been initialized yet; there are no
+          // routes it could have missed.
+        }
+
+        if (routeExists) {
+          invokedOutputs.add(parsedUrl.pathname)
+          return await invokeRender(parsedUrl, parsedUrl.pathname, handleIndex)
+        }
       }
 
       const appNotFound = opts.dev

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -133,6 +133,7 @@ export function getResolveRoutes(
     resHeaders: Record<string, string | string[]> | null
     parsedUrl: NextUrlWithParsedQuery
     matchedOutput?: FsOutput | null
+    didRewrite?: boolean
   }> {
     let finished = false
     let resHeaders: Record<string, string | string[]> = {}
@@ -953,6 +954,7 @@ export function getResolveRoutes(
       parsedUrl,
       resHeaders,
       matchedOutput,
+      didRewrite,
     }
   }
 

--- a/packages/next/src/server/lib/router-utils/types.ts
+++ b/packages/next/src/server/lib/router-utils/types.ts
@@ -2,6 +2,7 @@ export type PropagateToWorkersField =
   | 'actualMiddlewareFile'
   | 'actualInstrumentationHookFile'
   | 'reloadMatchers'
+  | 'testRouteMatch'
   | 'loadEnvConfig'
   | 'appPathRoutes'
   | 'middleware'

--- a/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
+++ b/test/development/app-dir/new-route-first-request/new-route-first-request.test.ts
@@ -8,7 +8,34 @@ describe('new-route-first-request', () => {
     files: __dirname,
   })
 
-  it('responds 404 for a route that does not exist', async () => {
+  it('responds 200 to the first request for a newly added page', async () => {
+    expect((await next.fetch('/')).status).toBe(200)
+
+    const failures: string[] = []
+    for (let i = 0; i < 30; i++) {
+      const pathname = `/added-${i}`
+      // Write the file directly instead of using next.patchFile, which waits
+      // 500ms after writes into app/ to let the watchers catch up. The first
+      // request for the route has to race the watchers.
+      const dir = path.join(next.testDir, `app/added-${i}`)
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, 'page.tsx'),
+        `export default function Page() { return <p>added-${i}</p> }`
+      )
+      // Make the first-ever request for the route at varying points of the
+      // watchers' catch-up work, starting at "immediately".
+      await waitFor((i % 5) * 15)
+      const res = await next.fetch(pathname)
+      if (res.status !== 200) {
+        failures.push(`${pathname}: ${res.status}`)
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+
+  it('still responds 404 for a route that does not exist', async () => {
     expect((await next.fetch('/does-not-exist')).status).toBe(404)
   })
 

--- a/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
+++ b/test/development/app-dir/route-change-refetch/route-change-refetch.test.ts
@@ -41,16 +41,6 @@ describe('route-change-refetch - App Router', () => {
 
     try {
       await addPageAndWaitUntilServable('/zz-added')
-      // If the tab reacts to the announcement before the server can serve
-      // the page, it gets the 404 again and stays there — a pre-existing
-      // bug that's being fixed separately. Editing the page makes the
-      // server announce again, now that the page can be served.
-      // TODO: Remove these edits (in the tests below too) once that bug is
-      // fixed; these tests then cover it directly.
-      await next.patchFile(
-        'app/zz-added/page.tsx',
-        `export default function Page() { return <p id="added" data-rev="2">/zz-added</p> }`
-      )
       await retry(async () => {
         expect(await browser.elementById('added').text()).toBe('/zz-added')
       }, 15_000)
@@ -101,15 +91,6 @@ describe('route-change-refetch - App Router', () => {
       await retry(async () => {
         expect((await next.fetch('/docs/abc')).status).toBe(200)
       }, 15_000)
-      await next.patchFile(
-        'app/docs/[slug]/page.tsx',
-        `export default async function Page(props: {
-          params: Promise<{ slug: string }>
-        }) {
-          const { slug } = await props.params
-          return <p id="added" data-rev="2">{slug}</p>
-        }`
-      )
       await retry(async () => {
         expect(await browser.elementById('added').text()).toBe('abc')
       }, 15_000)
@@ -137,10 +118,6 @@ describe('route-change-refetch - App Router', () => {
       await retry(async () => {
         expect((await next.fetch('/grouped')).status).toBe(200)
       }, 15_000)
-      await next.patchFile(
-        'app/(group)/grouped/page.tsx',
-        `export default function Page() { return <p id="added" data-rev="2">grouped</p> }`
-      )
       await retry(async () => {
         expect(await browser.elementById('added').text()).toBe('grouped')
       }, 15_000)
@@ -170,10 +147,6 @@ describe('route-change-refetch - App Router', () => {
           'id="static"'
         )
       }, 15_000)
-      await next.patchFile(
-        'app/posts/123/page.tsx',
-        `export default function Page() { return <p id="static" data-rev="2">static 123</p> }`
-      )
       await retry(async () => {
         expect(await browser.elementById('static').text()).toBe('static 123')
       }, 15_000)


### PR DESCRIPTION
The router's filesystem route info is updated when the file watcher has
processed a change, so it can lag behind the filesystem when a request
arrives right after a file was written, and the request renders a 404
even though the route's file exists. Before rendering a dev 404, ask the
render server whether the request path matches a route on disk (the
development matchers re-scan the filesystem on a miss), and render the
route when it does.

Locale-prefixed API paths are rejected the same way route resolution
rejects them, and requests already invoked once are excluded so
fallback: false re-resolution still terminates.

The test makes the first-ever request for a freshly written page at
varying delays, starting at "immediately": with the write on disk, the
request must be served no matter which watchers have caught up.

<!-- NEXT_JS_LLM -->