### PR TITLE
Serve a new dev route as soon as Turbopack announces it

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -69,6 +69,7 @@ import {
   type ServerFields,
   type SetupOpts,
 } from '../lib/router-utils/setup-dev-bundler'
+import { deriveDevRouteState } from '../lib/router-utils/dev-route-state'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
 import type { RouteDefinition } from '../route-definitions/route-definition'
@@ -1098,6 +1099,44 @@ export async function createHotReloaderTurbopack(
           },
         },
       })
+
+      // Turbopack knows about a route before the file watcher does, so the
+      // router takes its route table from here. Otherwise it would announce a
+      // route it can't serve yet, and the browser would refetch too early and
+      // get a 404.
+      let routeState
+      try {
+        routeState = deriveDevRouteState(routes, {
+          useFileSystemPublicRoutes: opts.nextConfig.useFileSystemPublicRoutes,
+          i18n: opts.nextConfig.i18n,
+        })
+      } catch (e) {
+        // Conflicting routes make building the route list throw. Keep serving
+        // the previous route state, like the file watcher pass does.
+        Log.warn('Failed to reload dynamic routes:', e)
+        routeState = undefined
+      }
+
+      if (routeState) {
+        const { appFiles, pageFiles, nextDataRoutes } = opts.fsChecker
+        appFiles.clear()
+        pageFiles.clear()
+        for (const pathname of routeState.appFiles) {
+          appFiles.add(pathname)
+        }
+        for (const pathname of routeState.pageFiles) {
+          pageFiles.add(pathname)
+          nextDataRoutes.add(pathname)
+        }
+        opts.fsChecker.dynamicRoutes = routeState.dynamicRoutes
+
+        serverFields.appPathRoutes = routeState.appPathRoutes
+        await propagateServerField(
+          opts,
+          'appPathRoutes',
+          routeState.appPathRoutes
+        )
+      }
 
       // Reload matchers when the files have been compiled
       await propagateServerField(opts, 'reloadMatchers', undefined)

--- a/packages/next/src/server/lib/router-utils/dev-route-state.ts
+++ b/packages/next/src/server/lib/router-utils/dev-route-state.ts
@@ -1,0 +1,139 @@
+import type { FilesystemDynamicRoute } from './filesystem'
+import type { NextConfigComplete } from '../../config-shared'
+import type { Route } from '../../../build/swc/types'
+import { getSortedRoutes } from '../../../shared/lib/router/utils'
+import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
+import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
+import { compareAppPaths } from '../../../shared/lib/router/utils/app-paths'
+import { buildDataRoute } from './build-data-route'
+
+/**
+ * Everything the dev router needs in order to serve a route: which pathnames
+ * exist, which of them belong to the App Router, and which regexes to try once
+ * an exact pathname lookup misses.
+ */
+export interface DevRouteState {
+  appFiles: Set<string>
+  pageFiles: Set<string>
+  appPathRoutes: Record<string, string[]>
+  dynamicRoutes: FilesystemDynamicRoute[]
+}
+
+/**
+ * Builds the route list the dev router matches a request against once an exact
+ * path lookup missed. The `/_next/data` routes come first so a data request
+ * doesn't match the page route it shadows.
+ */
+export function buildDevDynamicRoutes(
+  routedPages: string[],
+  i18n: NextConfigComplete['i18n']
+): FilesystemDynamicRoute[] {
+  const sortedRoutes = getSortedRoutes(routedPages)
+
+  const pageRoutes = sortedRoutes.map((page): FilesystemDynamicRoute => {
+    const regex = getNamedRouteRegex(page, {
+      prefixRouteKeys: true,
+    })
+    return {
+      regex: regex.re.toString(),
+      namedRegex: regex.namedRegex,
+      routeKeys: regex.routeKeys,
+      match: getRouteMatcher(regex),
+      page,
+    }
+  })
+
+  const dataRoutes = sortedRoutes.map((page): FilesystemDynamicRoute => {
+    const route = buildDataRoute(page, 'development')
+    const routeRegex = getNamedRouteRegex(route.page, {
+      prefixRouteKeys: true,
+    })
+    return {
+      ...route,
+      regex: routeRegex.re.toString(),
+      namedRegex: routeRegex.namedRegex,
+      routeKeys: routeRegex.routeKeys,
+      match: getRouteMatcher({
+        // TODO: fix this in the manifest itself, must also be fixed in
+        // upstream builder that relies on this
+        re: i18n
+          ? new RegExp(
+              route.dataRouteRegex.replace(
+                `/development/`,
+                `/development/(?<nextLocale>[^/]+?)/`
+              )
+            )
+          : new RegExp(route.dataRouteRegex),
+        groups: routeRegex.groups,
+      }),
+    }
+  })
+
+  return [...dataRoutes, ...pageRoutes]
+}
+
+/**
+ * Derives the dev route state from the routes Turbopack has compiled. The
+ * pathnames Turbopack reports are already normalized the way the router wants
+ * them: route groups are stripped, private folders are left out, and escaped
+ * underscores are decoded. The only entry that isn't a real URL is the
+ * `/_not-found` route the App Router synthesizes for us.
+ */
+export function deriveDevRouteState(
+  routes: ReadonlyMap<string, Route>,
+  {
+    useFileSystemPublicRoutes,
+    i18n,
+  }: {
+    useFileSystemPublicRoutes: boolean
+    i18n: NextConfigComplete['i18n']
+  }
+): DevRouteState {
+  const appFiles = new Set<string>()
+  const pageFiles = new Set<string>()
+  const appPathRoutes: Record<string, string[]> = {}
+  const routedPages: string[] = []
+
+  for (const [pathname, route] of routes) {
+    let originalNames: string[]
+
+    switch (route.type) {
+      case 'page':
+      case 'page-api':
+        if (useFileSystemPublicRoutes) {
+          pageFiles.add(pathname)
+        }
+        routedPages.push(pathname)
+        continue
+      case 'app-page':
+        originalNames = route.pages.map((page) => page.originalName)
+        break
+      case 'app-route':
+        originalNames = [route.originalName]
+        break
+      case 'conflict':
+        continue
+      default:
+        route satisfies never
+        continue
+    }
+
+    if (pathname === '/_not-found') {
+      continue
+    }
+
+    if (useFileSystemPublicRoutes) {
+      appFiles.add(pathname)
+    }
+    // Make sure to sort parallel routes to make the result deterministic.
+    appPathRoutes[pathname] = originalNames.sort(compareAppPaths)
+    routedPages.push(pathname)
+  }
+
+  return {
+    appFiles,
+    pageFiles,
+    appPathRoutes,
+    dynamicRoutes: buildDevDynamicRoutes(routedPages, i18n),
+  }
+}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1,5 +1,4 @@
 import type { NextConfigComplete } from '../../config-shared'
-import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
@@ -28,9 +27,7 @@ import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import { sortByPageExts } from '../../../build/sort-by-page-exts'
 import { verifyAndRunTypeScript } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
-import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
-import { buildDataRoute } from './build-data-route'
-import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
+import { buildDevDynamicRoutes } from './dev-route-state'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { createClientRouterFilter } from '../../../lib/create-client-router-filter'
 import { absolutePathToPage } from '../../../shared/lib/page-path/absolute-path-to-page'
@@ -447,8 +444,13 @@ async function startWatcher(
 
       const { appFiles, pageFiles, staticMetadataFiles } = opts.fsChecker
 
-      appFiles.clear()
-      pageFiles.clear()
+      // With Turbopack the route table is written from the entrypoints event
+      // instead, so that the router can serve a route as soon as Turbopack
+      // announces it.
+      if (!opts.turbo) {
+        appFiles.clear()
+        pageFiles.clear()
+      }
       staticMetadataFiles.clear()
       devPageFiles.clear()
 
@@ -700,7 +702,7 @@ async function startWatcher(
                 lastSegment
               )
               staticMetadataFiles.set(normalizedPath, fileName)
-            } else {
+            } else if (!opts.turbo) {
               appFiles.add(pageName)
             }
           }
@@ -715,7 +717,7 @@ async function startWatcher(
           if (routedPages.includes(pageName)) continue
         } else {
           // Pages router
-          if (useFileSystemPublicRoutes) {
+          if (useFileSystemPublicRoutes && !opts.turbo) {
             pageFiles.add(pageName)
             opts.fsChecker.nextDataRoutes.add(pageName)
           }
@@ -958,15 +960,17 @@ async function startWatcher(
         nestedMiddleware = []
       }
 
-      // Make sure to sort parallel routes to make the result deterministic.
-      serverFields.appPathRoutes = Object.fromEntries(
-        Object.entries(appPaths).map(([k, v]) => [k, v.sort(compareAppPaths)])
-      )
-      await propagateServerField(
-        opts,
-        'appPathRoutes',
-        serverFields.appPathRoutes
-      )
+      if (!opts.turbo) {
+        // Make sure to sort parallel routes to make the result deterministic.
+        serverFields.appPathRoutes = Object.fromEntries(
+          Object.entries(appPaths).map(([k, v]) => [k, v.sort(compareAppPaths)])
+        )
+        await propagateServerField(
+          opts,
+          'appPathRoutes',
+          serverFields.appPathRoutes
+        )
+      }
 
       // TODO: pass this to fsChecker/next-dev-server?
       serverFields.middleware = middlewareMatchers
@@ -1037,49 +1041,12 @@ async function startWatcher(
         // before it has been built and is populated in the _buildManifest
         const sortedRoutes = getSortedRoutes(routedPages)
 
-        opts.fsChecker.dynamicRoutes = sortedRoutes.map(
-          (page): FilesystemDynamicRoute => {
-            const regex = getNamedRouteRegex(page, {
-              prefixRouteKeys: true,
-            })
-            return {
-              regex: regex.re.toString(),
-              namedRegex: regex.namedRegex,
-              routeKeys: regex.routeKeys,
-              match: getRouteMatcher(regex),
-              page,
-            }
-          }
-        )
-
-        const dataRoutes: typeof opts.fsChecker.dynamicRoutes = []
-
-        for (const page of sortedRoutes) {
-          const route = buildDataRoute(page, 'development')
-          const routeRegex = getNamedRouteRegex(route.page, {
-            prefixRouteKeys: true,
-          })
-          dataRoutes.push({
-            ...route,
-            regex: routeRegex.re.toString(),
-            namedRegex: routeRegex.namedRegex,
-            routeKeys: routeRegex.routeKeys,
-            match: getRouteMatcher({
-              // TODO: fix this in the manifest itself, must also be fixed in
-              // upstream builder that relies on this
-              re: opts.nextConfig.i18n
-                ? new RegExp(
-                    route.dataRouteRegex.replace(
-                      `/development/`,
-                      `/development/(?<nextLocale>[^/]+?)/`
-                    )
-                  )
-                : new RegExp(route.dataRouteRegex),
-              groups: routeRegex.groups,
-            }),
-          })
+        if (!opts.turbo) {
+          opts.fsChecker.dynamicRoutes = buildDevDynamicRoutes(
+            routedPages,
+            opts.nextConfig.i18n
+          )
         }
-        opts.fsChecker.dynamicRoutes.unshift(...dataRoutes)
 
         // For Turbopack ADDED_PAGE and REMOVED_PAGE are implemented in hot-reloader-turbopack.ts
         // in order to avoid a race condition where ADDED_PAGE and REMOVED_PAGE are sent before Turbopack picked up the file change.


### PR DESCRIPTION
In dev the router works out what it can serve from three pieces of state:
the exact path table (appFiles and pageFiles), the dynamic route list, and
appPathRoutes, which says whether a path belongs to the App Router or the
Pages Router. All three are written by the watchpack handler in
setup-dev-bundler.ts.

With Turbopack, ADDED_PAGE and REMOVED_PAGE are sent from the entrypoints
event instead, and Turbopack gets there before watchpack. So the browser
hears about a route, refetches right away, and gets a 404 because the
router can't serve it yet. Under load that gap grows to seconds.

Now the route table is written from the entrypoints event too, so the state
the router serves from and the event that tells the browser to refetch come
from the same place. Webpack still writes it from watchpack, where it
already announces from inside the same handler and so never had the race.

#83829 moved the events but left the state behind. This is the other half.

Conflicting routes make building the route list throw; the subscription
treats an escaped error as fatal, so the derive keeps serving the
previous route state and warns instead, like the file watcher pass does.

<!-- NEXT_JS_LLM -->