### PR TITLE
Turbopack: derive the dev route matchers from the entrypoints

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1054,6 +1054,139 @@ async fn project_contains_route_operation(
     Ok(Vc::cell(contains))
 }
 
+/// Invalidates any tracked filesystem reads under the given
+/// project-relative directories, so that files created or deleted after
+/// Turbopack's file watcher last reported are taken into account by the
+/// next read.
+async fn invalidate_project_relative_dirs(
+    container: ResolvedVc<ProjectContainer>,
+    invalidate_dirs: &[String],
+) -> Result<()> {
+    if invalidate_dirs.is_empty() {
+        return Ok(());
+    }
+
+    #[turbo_tasks::value(cell = "new", eq = "manual")]
+    struct ProjectDirInfo(FileSystemPath, DiskFileSystem);
+
+    #[turbo_tasks::function(operation, root)]
+    async fn project_dir_info_operation(
+        container: ResolvedVc<ProjectContainer>,
+    ) -> Result<Vc<ProjectDirInfo>> {
+        let project = container.project();
+        let project_path = project.project_path().owned().await?;
+        let project_fs = project.project_fs().owned().await?;
+        Ok(ProjectDirInfo(project_path, project_fs).cell())
+    }
+
+    let ProjectDirInfo(project_path, project_fs) = &*project_dir_info_operation(container)
+        .read_strongly_consistent()
+        .await?;
+
+    // Use `to_sys_path_raw` (not `to_sys_path`): these paths are compared against
+    // the invalidator map keys inside `invalidate_path_and_children_with_reason`,
+    // which use the internal (verbatim on Windows) representation.
+    let project_sys_path = project_fs.to_sys_path_raw(project_path);
+    let paths_to_invalidate = invalidate_dirs
+        .iter()
+        .map(|dir| {
+            let relative_dir = dir.trim_start_matches('/');
+            if relative_dir.is_empty() {
+                project_sys_path.clone()
+            } else {
+                project_sys_path.join(unix_to_sys(relative_dir).as_ref())
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // The synced variant serializes with the file watcher's own invalidation
+    // batches, so a concurrent read cannot observe directory listings and
+    // file contents from different sides of this invalidation.
+    project_fs
+        .invalidate_path_and_children_with_reason_synced(paths_to_invalidate, |path| {
+            invalidation::Initialize {
+                path: RcStr::from(path.to_string_lossy()),
+            }
+        })
+        .await;
+
+    Ok(())
+}
+
+#[napi(object)]
+#[derive(Clone, Debug, PartialEq, Eq, TraceRawVcs)]
+pub struct NapiRouteInfo {
+    pub pathname: RcStr,
+    pub route_type: String,
+    /// The original names of the app pages behind this route (there are
+    /// multiple for parallel routes), or the original name of an app route.
+    /// Empty for pages routes.
+    pub original_names: Vec<RcStr>,
+}
+
+#[turbo_tasks::value(transparent, serialization = "skip")]
+struct RouteInfos(#[turbo_tasks(trace_ignore)] Vec<NapiRouteInfo>);
+
+#[turbo_tasks::function(operation, root)]
+async fn project_route_infos_operation(
+    container: ResolvedVc<ProjectContainer>,
+) -> Result<Vc<RouteInfos>> {
+    let entrypoints = container.entrypoints().await?;
+    let infos = entrypoints
+        .routes
+        .iter()
+        .map(|(pathname, route)| {
+            let (route_type, original_names) = match route {
+                Route::Page { .. } => ("page", Vec::new()),
+                Route::PageApi { .. } => ("page-api", Vec::new()),
+                Route::AppPage(pages) => (
+                    "app-page",
+                    pages
+                        .iter()
+                        .map(|page| page.original_name.clone())
+                        .collect(),
+                ),
+                Route::AppRoute { original_name, .. } => ("app-route", vec![original_name.clone()]),
+                Route::Conflict => ("conflict", Vec::new()),
+            };
+            NapiRouteInfo {
+                pathname: pathname.clone(),
+                route_type: route_type.into(),
+                original_names,
+            }
+        })
+        .collect();
+    Ok(Vc::cell(infos))
+}
+
+/// Returns the routes in the entrypoints, recomputed against the current
+/// state of the filesystem: tracked filesystem reads under the given
+/// project-relative directories are invalidated first, so files that were
+/// created or deleted after Turbopack's file watcher last reported are taken
+/// into account. Routes are keyed the same way `entrypointsSubscribe` emits
+/// them.
+#[napi]
+pub async fn project_get_routes(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    invalidate_dirs: Vec<String>,
+) -> napi::Result<Vec<NapiRouteInfo>> {
+    let container = project.container;
+
+    project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run_once(async move {
+            invalidate_project_relative_dirs(container, &invalidate_dirs).await?;
+
+            let infos = project_route_infos_operation(container)
+                .read_strongly_consistent()
+                .await?;
+            Ok(infos.to_vec())
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))
+}
+
 /// Returns whether the entrypoints contain the given route, recomputed
 /// against the current state of the filesystem: any tracked filesystem reads
 /// under the given project-relative directories are invalidated first, so a
@@ -1073,53 +1206,7 @@ pub async fn project_contains_route(
         .turbopack_ctx
         .turbo_tasks()
         .run_once(async move {
-            if !invalidate_dirs.is_empty() {
-                #[turbo_tasks::value(cell = "new", eq = "manual")]
-                struct ProjectDirInfo(FileSystemPath, DiskFileSystem);
-
-                #[turbo_tasks::function(operation, root)]
-                async fn project_dir_info_operation(
-                    container: ResolvedVc<ProjectContainer>,
-                ) -> Result<Vc<ProjectDirInfo>> {
-                    let project = container.project();
-                    let project_path = project.project_path().owned().await?;
-                    let project_fs = project.project_fs().owned().await?;
-                    Ok(ProjectDirInfo(project_path, project_fs).cell())
-                }
-
-                let ProjectDirInfo(project_path, project_fs) =
-                    &*project_dir_info_operation(container)
-                        .read_strongly_consistent()
-                        .await?;
-
-                // Use `to_sys_path_raw` (not `to_sys_path`): these paths are compared against
-                // the invalidator map keys inside `invalidate_path_and_children_with_reason`,
-                // which use the internal (verbatim on Windows) representation.
-                let project_sys_path = project_fs.to_sys_path_raw(project_path);
-                let paths_to_invalidate = invalidate_dirs
-                    .iter()
-                    .map(|dir| {
-                        let relative_dir = dir.trim_start_matches('/');
-                        if relative_dir.is_empty() {
-                            project_sys_path.clone()
-                        } else {
-                            project_sys_path.join(unix_to_sys(relative_dir).as_ref())
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                // The synced variant serializes with the file watcher's own
-                // invalidation batches, so a concurrent read cannot observe
-                // directory listings and file contents from different sides
-                // of this invalidation.
-                project_fs
-                    .invalidate_path_and_children_with_reason_synced(paths_to_invalidate, |path| {
-                        invalidation::Initialize {
-                            path: RcStr::from(path.to_string_lossy()),
-                        }
-                    })
-                    .await;
-            }
+            invalidate_project_relative_dirs(container, &invalidate_dirs).await?;
 
             let contains = project_contains_route_operation(container, route_key)
                 .read_strongly_consistent()

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -408,6 +408,28 @@ export declare function projectContainsRoute(
   routeKey: string,
   invalidateDirs: Array<string>
 ): Promise<boolean>
+export interface NapiRouteInfo {
+  pathname: RcStr
+  routeType: string
+  /**
+   * The original names of the app pages behind this route (there are
+   * multiple for parallel routes), or the original name of an app route.
+   * Empty for pages routes.
+   */
+  originalNames: Array<RcStr>
+}
+/**
+ * Returns the routes in the entrypoints, recomputed against the current
+ * state of the filesystem: tracked directory reads under the given
+ * project-relative directories are invalidated first, so files that were
+ * created or deleted after Turbopack's file watcher last reported are taken
+ * into account. Routes are keyed the same way `entrypointsSubscribe` emits
+ * them.
+ */
+export declare function projectGetRoutes(
+  project: { __napiType: 'Project' },
+  invalidateDirs: Array<string>
+): Promise<Array<NapiRouteInfo>>
 export interface NapiDebugBuildPaths {
   app: Array<RcStr>
   pages: Array<RcStr>

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -34,6 +34,7 @@ import type {
   ProjectOptions,
   RawEntrypoints,
   Route,
+  RouteInfo,
   TurboEngineOptions,
   TurbopackResult,
   TurbopackStackFrame,
@@ -708,6 +709,10 @@ function bindingToApi(
         routeKey,
         invalidateDirs
       )
+    }
+
+    getRoutes(invalidateDirs: string[]): Promise<RouteInfo[]> {
+      return binding.projectGetRoutes(this._nativeProject, invalidateDirs)
     }
 
     async writeAnalyzeData(

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -295,6 +295,17 @@ export type UpdateMessage =
       value: UpdateInfo
     }
 
+export interface RouteInfo {
+  pathname: string
+  routeType: string
+  /**
+   * The original names of the app pages behind this route (there are
+   * multiple for parallel routes), or the original name of an app route.
+   * Empty for pages routes.
+   */
+  originalNames: string[]
+}
+
 export type CompilationEvent = {
   typeName: string
   message: string
@@ -339,6 +350,16 @@ export interface Project {
    * original name — the same keys `entrypointsSubscribe` emits.
    */
   containsRoute(routeKey: string, invalidateDirs: string[]): Promise<boolean>
+
+  /**
+   * Returns the routes in the entrypoints, recomputed against the current
+   * state of the filesystem: tracked directory reads under `invalidateDirs`
+   * (project-relative) are invalidated first, so files that were created or
+   * deleted after Turbopack's file watcher last reported are taken into
+   * account. Routes are keyed the same way `entrypointsSubscribe` emits
+   * them.
+   */
+  getRoutes(invalidateDirs: string[]): Promise<RouteInfo[]>
 
   entrypointsSubscribe(): AsyncIterableIterator<
     TurbopackResult<RawEntrypoints | {}>

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1,5 +1,5 @@
 import type { Socket } from 'net'
-import { access, mkdir, writeFile } from 'fs/promises'
+import { mkdir, writeFile } from 'fs/promises'
 import { realpathSync } from 'fs'
 import * as inspector from 'inspector'
 import { join, extname, relative, isAbsolute, sep, dirname } from 'path'
@@ -69,7 +69,13 @@ import {
   type ServerFields,
   type SetupOpts,
 } from '../lib/router-utils/setup-dev-bundler'
-import { deriveDevRouteState } from '../lib/router-utils/dev-route-state'
+import {
+  deriveDevRouteDefinitions,
+  deriveDevRouteState,
+  routeInfoListToDevRouteInfoMap,
+  toDevRouteInfoMap,
+  type DevRouteInfo,
+} from '../lib/router-utils/dev-route-state'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
 import type { RouteDefinition } from '../route-definitions/route-definition'
@@ -519,6 +525,13 @@ export async function createHotReloaderTurbopack(
     await lockfile?.unlock()
   })
   const entrypointsSubscription = project.entrypointsSubscribe()
+
+  // Invalidated when the route list is recomputed on demand, so that files
+  // the file watcher hasn't reported yet are taken into account.
+  const devRouteRefreshDirs = [opts.appDir, opts.pagesDir]
+    .filter((dir): dir is string => Boolean(dir))
+    .map((dir) => relative(projectPath, dir).split(sep).join('/'))
+    .filter((dir) => dir !== '' && !dir.startsWith('..'))
 
   const currentWrittenEntrypoints: Map<EntryKey, WrittenEndpoint> = new Map()
   const currentEntrypoints: Entrypoints = {
@@ -1034,6 +1047,53 @@ export async function createHotReloaderTurbopack(
     state.clientIssues.delete(key)
   }
 
+  /**
+   * Writes everything that is derived from the routes Turbopack has
+   * compiled: the router's route tables, `appPathRoutes`, and the route
+   * definitions the dev matchers serve from. Called on every entrypoints
+   * update, and from `refreshDevRouteState` with a freshly recomputed route
+   * list when a request path doesn't match.
+   */
+  async function applyDevRouteState(infos: Map<string, DevRouteInfo>) {
+    let routeState
+    try {
+      routeState = deriveDevRouteState(infos, {
+        useFileSystemPublicRoutes: opts.nextConfig.useFileSystemPublicRoutes,
+        i18n: opts.nextConfig.i18n,
+      })
+    } catch (e) {
+      // Conflicting routes make building the route list throw. Keep serving
+      // the previous route state, like the file watcher pass does.
+      Log.warn('Failed to reload dynamic routes:', e)
+      return
+    }
+
+    const { appFiles, pageFiles, nextDataRoutes } = opts.fsChecker
+    appFiles.clear()
+    pageFiles.clear()
+    for (const pathname of routeState.appFiles) {
+      appFiles.add(pathname)
+    }
+    for (const pathname of routeState.pageFiles) {
+      pageFiles.add(pathname)
+      nextDataRoutes.add(pathname)
+    }
+    opts.fsChecker.dynamicRoutes = routeState.dynamicRoutes
+
+    serverFields.appPathRoutes = routeState.appPathRoutes
+    await propagateServerField(opts, 'appPathRoutes', routeState.appPathRoutes)
+
+    serverFields.devRouteDefinitions = deriveDevRouteDefinitions(infos, {
+      appDir: opts.appDir,
+      pagesDir: opts.pagesDir,
+    })
+    await propagateServerField(
+      opts,
+      'devRouteDefinitions',
+      serverFields.devRouteDefinitions
+    )
+  }
+
   async function handleEntrypointsSubscription() {
     for await (const entrypoints of entrypointsSubscription) {
       if (!currentEntriesHandlingResolve) {
@@ -1104,39 +1164,7 @@ export async function createHotReloaderTurbopack(
       // router takes its route table from here. Otherwise it would announce a
       // route it can't serve yet, and the browser would refetch too early and
       // get a 404.
-      let routeState
-      try {
-        routeState = deriveDevRouteState(routes, {
-          useFileSystemPublicRoutes: opts.nextConfig.useFileSystemPublicRoutes,
-          i18n: opts.nextConfig.i18n,
-        })
-      } catch (e) {
-        // Conflicting routes make building the route list throw. Keep serving
-        // the previous route state, like the file watcher pass does.
-        Log.warn('Failed to reload dynamic routes:', e)
-        routeState = undefined
-      }
-
-      if (routeState) {
-        const { appFiles, pageFiles, nextDataRoutes } = opts.fsChecker
-        appFiles.clear()
-        pageFiles.clear()
-        for (const pathname of routeState.appFiles) {
-          appFiles.add(pathname)
-        }
-        for (const pathname of routeState.pageFiles) {
-          pageFiles.add(pathname)
-          nextDataRoutes.add(pathname)
-        }
-        opts.fsChecker.dynamicRoutes = routeState.dynamicRoutes
-
-        serverFields.appPathRoutes = routeState.appPathRoutes
-        await propagateServerField(
-          opts,
-          'appPathRoutes',
-          routeState.appPathRoutes
-        )
-      }
+      await applyDevRouteState(toDevRouteInfoMap(routes))
 
       // Reload matchers when the files have been compiled
       await propagateServerField(opts, 'reloadMatchers', undefined)
@@ -1678,6 +1706,11 @@ export async function createHotReloaderTurbopack(
       return String(hmrHash)
     },
 
+    async refreshDevRouteState() {
+      const routeInfos = await project.getRoutes(devRouteRefreshDirs)
+      await applyDevRouteState(routeInfoListToDevRouteInfoMap(routeInfos))
+    },
+
     sendToLegacyClients(action) {
       const payload = JSON.stringify(action)
 
@@ -1968,45 +2001,44 @@ export async function createHotReloaderTurbopack(
           }
 
           if (!route) {
-            // The route can be missing from the entrypoints even though its
-            // file exists on disk: routes are discovered by a separate watcher
-            // in setup-dev-bundler.ts, which can pick up a freshly written
-            // file before Turbopack's own watcher does. Ask Turbopack
-            // directly, forcing it to re-read the file's directory. While it
-            // reports that the route exists, the entrypoints subscription is
-            // guaranteed to deliver an update containing it (under the same
-            // key; see handleEntrypoints), so wait for that instead of
-            // failing the request.
+            // The route can be missing from the entrypoints even though
+            // Turbopack knows it: the entrypoints are only updated by the
+            // subscription, which may not have delivered a freshly
+            // discovered route yet. Ask Turbopack directly. While it
+            // reports that the route exists, the subscription is guaranteed
+            // to deliver an update containing it (under the same key; see
+            // handleEntrypoints), so wait for that instead of failing the
+            // request.
             const routeKey = isInsideAppDir ? normalizedAppPage : page
-            const relativeDir = relative(
-              projectPath,
-              dirname(routeDef.filename)
-            )
-            // Files outside the project (e.g. built-in fallback routes)
-            // aren't watched, so there is nothing to invalidate for them.
-            const invalidateDirs =
-              relativeDir.startsWith('..') || isAbsolute(relativeDir)
-                ? []
-                : [relativeDir.split(sep).join('/')]
-            let invalidated = false
-            while (!route) {
-              try {
-                await access(routeDef.filename)
-              } catch {
-                break
+            // When the route was looked up on the filesystem above, its
+            // directory may not have been read by Turbopack yet, so it is
+            // invalidated for the first check. Routes with a definition were
+            // matched from Turbopack's own routes and need no invalidation.
+            let invalidateDirs: string[] = []
+            if (!definition) {
+              const relativeDir = relative(
+                projectPath,
+                dirname(routeDef.filename)
+              )
+              // Files outside the project (e.g. built-in fallback routes)
+              // aren't watched, so there is nothing to invalidate for them.
+              if (!relativeDir.startsWith('..') && !isAbsolute(relativeDir)) {
+                invalidateDirs = [relativeDir.split(sep).join('/')]
               }
+            }
+            while (!route) {
               let routeExists = false
               try {
                 routeExists = await project.containsRoute(
                   routeKey,
-                  invalidated ? [] : invalidateDirs
+                  invalidateDirs
                 )
               } catch {
                 // The entrypoints cannot currently be computed, e.g. because
                 // of a build error in a file they depend on.
                 break
               }
-              invalidated = true
+              invalidateDirs = []
               if (!routeExists) break
               await pendingEntrypointsUpdate
               pendingEntrypointsUpdate = nextEntrypointsUpdate.promise

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -265,6 +265,12 @@ export interface NextJsHotReloaderInterface {
    * for every client, regardless of whether it runs the HMR client.
    */
   getServerComponentsHmrRefreshHash(): string | undefined
+  /**
+   * Refreshes the derived dev route state from the bundler's current routes,
+   * recomputed against the current state of the filesystem. Called when a
+   * request path doesn't match any known route. Turbopack only.
+   */
+  refreshDevRouteState?(): Promise<void>
   setCacheStatus(status: ServerCacheStatus, htmlRequestId: string): void
   setReactDebugChannel(
     debugChannel: ReactDebugChannelForBrowser,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -68,6 +68,7 @@ import { DevPagesRouteMatcherProvider } from '../route-matcher-providers/dev/dev
 import { DevPagesAPIRouteMatcherProvider } from '../route-matcher-providers/dev/dev-pages-api-route-matcher-provider'
 import { DevAppPageRouteMatcherProvider } from '../route-matcher-providers/dev/dev-app-page-route-matcher-provider'
 import { DevAppRouteRouteMatcherProvider } from '../route-matcher-providers/dev/dev-app-route-route-matcher-provider'
+import { DevEntrypointsRouteMatcherProvider } from '../route-matcher-providers/dev/dev-entrypoints-route-matcher-provider'
 import { NodeManifestLoader } from '../route-matcher-providers/helpers/manifest-loaders/node-manifest-loader'
 import { BatchedFileReader } from '../route-matcher-providers/dev/helpers/file-reader/batched-file-reader'
 import { DefaultFileReader } from '../route-matcher-providers/dev/helpers/file-reader/default-file-reader'
@@ -143,6 +144,7 @@ export default class DevServer extends Server {
   private actualMiddlewareFile?: string
   private actualInstrumentationHookFile?: string
   private middleware?: MiddlewareRoutingItem
+  private devRouteDefinitions?: RouteDefinition[]
   private readonly bundlerService: DevBundlerService
   private staticPathsCache: LRUCache<
     UnwrapPromise<ReturnType<DevServer['getStaticPaths']>>
@@ -278,6 +280,28 @@ export default class DevServer extends Server {
           url: pathname,
         })
       },
+    }
+
+    // With Turbopack the matchers serve from the route definitions derived
+    // from the compiled entrypoints, so all route knowledge comes from a
+    // single source. On a match miss they ask the bundler for a fresh route
+    // list instead of re-scanning the filesystem.
+    if (process.env.TURBOPACK) {
+      const matchers = new DevRouteMatcherManager(
+        super.getRouteMatchers(),
+        ensurer,
+        this.dir,
+        async () => {
+          await this.bundlerService?.refreshDevRouteState()
+        }
+      )
+      matchers.push(
+        new DevEntrypointsRouteMatcherProvider(
+          () => this.devRouteDefinitions,
+          Boolean(this.i18nProvider)
+        )
+      )
+      return matchers
     }
 
     const matchers = new DevRouteMatcherManager(

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -68,6 +68,10 @@ export class DevBundlerService {
     return this.bundler.hotReloader.getServerComponentsHmrRefreshHash()
   }
 
+  public async refreshDevRouteState(): Promise<void> {
+    await this.bundler.hotReloader.refreshDevRouteState?.()
+  }
+
   public logErrorWithOriginalStack =
     this.bundler.logErrorWithOriginalStack.bind(this.bundler)
 

--- a/packages/next/src/server/lib/router-utils/dev-route-state.ts
+++ b/packages/next/src/server/lib/router-utils/dev-route-state.ts
@@ -1,11 +1,68 @@
 import type { FilesystemDynamicRoute } from './filesystem'
 import type { NextConfigComplete } from '../../config-shared'
-import type { Route } from '../../../build/swc/types'
+import type { Route, RouteInfo } from '../../../build/swc/types'
+import type { RouteDefinition } from '../../route-definitions/route-definition'
+import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
+import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
+import type { PagesRouteDefinition } from '../../route-definitions/pages-route-definition'
+import type { PagesAPIRouteDefinition } from '../../route-definitions/pages-api-route-definition'
+import { RouteKind } from '../../route-kind'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
 import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
 import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
 import { compareAppPaths } from '../../../shared/lib/router/utils/app-paths'
+import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
+import { posix, join } from 'path'
 import { buildDataRoute } from './build-data-route'
+
+/**
+ * The part of a Turbopack route that the dev route state is derived from,
+ * shared between the entrypoints subscription (which carries full routes with
+ * endpoints) and the on-demand route list (which doesn't).
+ */
+export interface DevRouteInfo {
+  type: Route['type']
+  /**
+   * The original names of the app pages behind the route (there are multiple
+   * for parallel routes), or the original name of an app route. Empty for
+   * pages routes.
+   */
+  originalNames: string[]
+}
+
+export function toDevRouteInfoMap(
+  routes: ReadonlyMap<string, Route>
+): Map<string, DevRouteInfo> {
+  const infos = new Map<string, DevRouteInfo>()
+  for (const [pathname, route] of routes) {
+    let originalNames: string[]
+    switch (route.type) {
+      case 'app-page':
+        originalNames = route.pages.map((page) => page.originalName)
+        break
+      case 'app-route':
+        originalNames = [route.originalName]
+        break
+      default:
+        originalNames = []
+    }
+    infos.set(pathname, { type: route.type, originalNames })
+  }
+  return infos
+}
+
+export function routeInfoListToDevRouteInfoMap(
+  routes: RouteInfo[]
+): Map<string, DevRouteInfo> {
+  const infos = new Map<string, DevRouteInfo>()
+  for (const route of routes) {
+    infos.set(route.pathname, {
+      type: route.routeType as Route['type'],
+      originalNames: route.originalNames,
+    })
+  }
+  return infos
+}
 
 /**
  * Everything the dev router needs in order to serve a route: which pathnames
@@ -80,7 +137,7 @@ export function buildDevDynamicRoutes(
  * `/_not-found` route the App Router synthesizes for us.
  */
 export function deriveDevRouteState(
-  routes: ReadonlyMap<string, Route>,
+  routes: ReadonlyMap<string, DevRouteInfo>,
   {
     useFileSystemPublicRoutes,
     i18n,
@@ -95,8 +152,6 @@ export function deriveDevRouteState(
   const routedPages: string[] = []
 
   for (const [pathname, route] of routes) {
-    let originalNames: string[]
-
     switch (route.type) {
       case 'page':
       case 'page-api':
@@ -106,15 +161,12 @@ export function deriveDevRouteState(
         routedPages.push(pathname)
         continue
       case 'app-page':
-        originalNames = route.pages.map((page) => page.originalName)
-        break
       case 'app-route':
-        originalNames = [route.originalName]
         break
       case 'conflict':
         continue
       default:
-        route satisfies never
+        route.type satisfies never
         continue
     }
 
@@ -126,7 +178,7 @@ export function deriveDevRouteState(
       appFiles.add(pathname)
     }
     // Make sure to sort parallel routes to make the result deterministic.
-    appPathRoutes[pathname] = originalNames.sort(compareAppPaths)
+    appPathRoutes[pathname] = [...route.originalNames].sort(compareAppPaths)
     routedPages.push(pathname)
   }
 
@@ -136,4 +188,90 @@ export function deriveDevRouteState(
     appPathRoutes,
     dynamicRoutes: buildDevDynamicRoutes(routedPages, i18n),
   }
+}
+
+/**
+ * Derives the route definitions the dev route matchers serve from. These are
+ * the same definitions the filesystem-scanning dev matcher providers would
+ * produce, except that the filename is a reconstruction: Turbopack doesn't
+ * report source paths, and nothing routes on the filename. Pages routes are
+ * keyed by pathname and app routes by original name, matching how
+ * `ensurePage` looks routes up in the entrypoints.
+ */
+export function deriveDevRouteDefinitions(
+  routes: ReadonlyMap<string, DevRouteInfo>,
+  {
+    appDir,
+    pagesDir,
+  }: {
+    appDir: string | undefined
+    pagesDir: string | undefined
+  }
+): RouteDefinition[] {
+  const definitions: RouteDefinition[] = []
+
+  for (const [pathname, route] of routes) {
+    switch (route.type) {
+      case 'page':
+      case 'page-api': {
+        if (!pagesDir) continue
+        const shared = {
+          pathname,
+          page: pathname,
+          bundlePath: posix.join('pages', normalizePagePath(pathname)),
+          filename: join(pagesDir, pathname),
+          // Matches all locales; the matcher parses the locale from the
+          // request when the application is configured for i18n.
+          i18n: {},
+        }
+        definitions.push(
+          route.type === 'page'
+            ? ({
+                kind: RouteKind.PAGES,
+                ...shared,
+              } satisfies PagesRouteDefinition)
+            : ({
+                kind: RouteKind.PAGES_API,
+                ...shared,
+              } satisfies PagesAPIRouteDefinition)
+        )
+        continue
+      }
+      case 'app-page': {
+        if (!appDir || pathname === '/_not-found') continue
+        const appPaths = [...route.originalNames].sort(compareAppPaths)
+        for (const originalName of appPaths) {
+          const definition: AppPageRouteDefinition = {
+            kind: RouteKind.APP_PAGE,
+            pathname,
+            page: originalName,
+            bundlePath: posix.join('app', originalName),
+            filename: join(appDir, originalName),
+            appPaths,
+          }
+          definitions.push(definition)
+        }
+        continue
+      }
+      case 'app-route': {
+        if (!appDir || pathname === '/_not-found') continue
+        const originalName = route.originalNames[0]
+        if (originalName === undefined) continue
+        definitions.push({
+          kind: RouteKind.APP_ROUTE,
+          pathname,
+          page: originalName,
+          bundlePath: posix.join('app', originalName),
+          filename: join(appDir, originalName),
+        } satisfies AppRouteRouteDefinition)
+        continue
+      }
+      case 'conflict':
+        continue
+      default:
+        route.type satisfies never
+    }
+  }
+
+  return definitions
 }

--- a/packages/next/src/server/lib/router-utils/dev-route-state.ts
+++ b/packages/next/src/server/lib/router-utils/dev-route-state.ts
@@ -43,7 +43,13 @@ export function toDevRouteInfoMap(
       case 'app-route':
         originalNames = [route.originalName]
         break
+      case 'page':
+      case 'page-api':
+      case 'conflict':
+        originalNames = []
+        break
       default:
+        route satisfies never
         originalNames = []
     }
     infos.set(pathname, { type: route.type, originalNames })

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -134,6 +134,7 @@ export type ServerFields = {
   actualMiddlewareFile?: string | undefined
   actualInstrumentationHookFile?: string | undefined
   appPathRoutes?: Record<string, string | string[]>
+  devRouteDefinitions?: import('../../route-definitions/route-definition').RouteDefinition[]
   middleware?:
     | {
         page: string

--- a/packages/next/src/server/lib/router-utils/types.ts
+++ b/packages/next/src/server/lib/router-utils/types.ts
@@ -3,6 +3,7 @@ export type PropagateToWorkersField =
   | 'actualInstrumentationHookFile'
   | 'reloadMatchers'
   | 'testRouteMatch'
+  | 'devRouteDefinitions'
   | 'loadEnvConfig'
   | 'appPathRoutes'
   | 'middleware'

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -17,7 +17,13 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
   constructor(
     private readonly production: RouteMatcherManager,
     private readonly ensurer: RouteEnsurer,
-    private readonly dir: string
+    private readonly dir: string,
+    /**
+     * Called before retrying an unmatched request path, so the providers can
+     * refresh the routes they serve from. When not given, the retry relies
+     * on the providers re-scanning the filesystem in `reload`.
+     */
+    private readonly refresh?: () => Promise<void>
   ) {
     super()
   }
@@ -65,10 +71,10 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
 
   /**
    * Iterates over the development matches for the request path. The
-   * development matchers are reloaded when the file watcher has processed a
-   * change, so they can lag behind the filesystem when a request arrives
-   * right after a file was written. On a miss, this re-scans the filesystem
-   * once and retries before treating the request path as unmatched.
+   * development matchers are reloaded when the bundler or file watcher has
+   * processed a change, so they can lag behind the filesystem when a request
+   * arrives right after a file was written. On a miss, this refreshes the
+   * routes once and retries before treating the request path as unmatched.
    */
   private async *developmentMatchAll(
     pathname: string,
@@ -83,6 +89,7 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
 
       if (matched || attempt === 1) break
 
+      await this.refresh?.()
       await super.reload()
     }
 

--- a/packages/next/src/server/route-matcher-providers/dev/dev-entrypoints-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-entrypoints-route-matcher-provider.ts
@@ -65,8 +65,10 @@ export class DevEntrypointsRouteMatcherProvider
               : new PagesAPIRouteMatcher(definition as PagesAPIRouteDefinition)
           )
           break
-        default:
+        case RouteKind.IMAGE:
           break
+        default:
+          definition.kind satisfies never
       }
     }
 

--- a/packages/next/src/server/route-matcher-providers/dev/dev-entrypoints-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-entrypoints-route-matcher-provider.ts
@@ -1,0 +1,75 @@
+import type { RouteMatcherProvider } from '../route-matcher-provider'
+import type { RouteMatcher } from '../../route-matchers/route-matcher'
+import type { RouteDefinition } from '../../route-definitions/route-definition'
+import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
+import type { AppRouteRouteDefinition } from '../../route-definitions/app-route-route-definition'
+import type { PagesRouteDefinition } from '../../route-definitions/pages-route-definition'
+import type { PagesAPIRouteDefinition } from '../../route-definitions/pages-api-route-definition'
+import { RouteKind } from '../../route-kind'
+import { AppPageRouteMatcher } from '../../route-matchers/app-page-route-matcher'
+import { AppRouteRouteMatcher } from '../../route-matchers/app-route-route-matcher'
+import {
+  PagesRouteMatcher,
+  PagesLocaleRouteMatcher,
+} from '../../route-matchers/pages-route-matcher'
+import {
+  PagesAPIRouteMatcher,
+  PagesAPILocaleRouteMatcher,
+} from '../../route-matchers/pages-api-route-matcher'
+
+/**
+ * Serves route matchers from the route definitions the bundler derived from
+ * its compiled entrypoints, instead of scanning the filesystem. The
+ * definitions are pushed on every entrypoints update and pulled on demand
+ * when a request path doesn't match.
+ */
+export class DevEntrypointsRouteMatcherProvider
+  implements RouteMatcherProvider
+{
+  constructor(
+    private readonly getDefinitions: () =>
+      | ReadonlyArray<RouteDefinition>
+      | undefined,
+    private readonly localeAware: boolean
+  ) {}
+
+  async matchers(): Promise<ReadonlyArray<RouteMatcher>> {
+    const definitions = this.getDefinitions() ?? []
+    const matchers: Array<RouteMatcher> = []
+
+    for (const definition of definitions) {
+      switch (definition.kind) {
+        case RouteKind.APP_PAGE:
+          matchers.push(
+            new AppPageRouteMatcher(definition as AppPageRouteDefinition)
+          )
+          break
+        case RouteKind.APP_ROUTE:
+          matchers.push(
+            new AppRouteRouteMatcher(definition as AppRouteRouteDefinition)
+          )
+          break
+        case RouteKind.PAGES:
+          matchers.push(
+            this.localeAware
+              ? new PagesLocaleRouteMatcher(definition as PagesRouteDefinition)
+              : new PagesRouteMatcher(definition as PagesRouteDefinition)
+          )
+          break
+        case RouteKind.PAGES_API:
+          matchers.push(
+            this.localeAware
+              ? new PagesAPILocaleRouteMatcher(
+                  definition as PagesAPIRouteDefinition
+                )
+              : new PagesAPIRouteMatcher(definition as PagesAPIRouteDefinition)
+          )
+          break
+        default:
+          break
+      }
+    }
+
+    return matchers
+  }
+}


### PR DESCRIPTION
With Turbopack, the dev route matchers no longer scan the filesystem.
They serve from route definitions derived from the compiled entrypoints,
pushed on every entrypoints update, so the route tables, the matchers,
and the entrypoints all describe the same state. When a request path
doesn't match, the matchers ask Turbopack for a freshly recomputed route
list (projectGetRoutes) instead of re-scanning the filesystem.

Since matched definitions now always originate from Turbopack's own
routes, ensurePage no longer consults the filesystem either: the
containsRoute probe is the existence authority, and a missing file shows
up as the route disappearing from a strongly consistent recompute.

Dynamic metadata routes are served both as a single route and under
/[__metadata_id__]; the entrypoints report them by the page they serve,
so the derivation needs no metadata knowledge.

Webpack keeps the filesystem-scanning providers.

<!-- NEXT_JS_LLM -->