### PR TITLE
Turbopack: index aggregate HMR entry chunks

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -4,15 +4,15 @@ use next_core::emit_assets;
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
+    FxIndexMap, FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State,
+    TryFlatJoinIterExt, TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::{ExpandedOutputAssets, OptionOutputAsset, OutputAsset},
     source_map::GenerateSourceMap,
-    version::OptionVersionedContent,
+    version::{OptionVersionedContent, VersionedContent},
 };
 
 use crate::aggregate_hmr::{HmrChunkWithContent, is_entry_chunk_list_content};
@@ -61,12 +61,91 @@ struct ExpandedOutputAssetsOperationSet(
     #[bincode(with = "turbo_bincode::indexset")] FxIndexSet<OperationVc<ExpandedOutputAssets>>,
 );
 
-// HACK: This is technically incorrect because the map's key contains a `ResolvedVc`...
+#[turbo_tasks::value(transparent)]
+struct HmrEntryChunks(Vec<(FileSystemPath, ResolvedVc<Box<dyn VersionedContent>>)>);
+
+#[derive(
+    Clone,
+    Default,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Debug,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+struct HmrEntryChunkOperations(
+    #[bincode(with = "turbo_bincode::indexmap")]
+    FxIndexMap<OperationVc<ExpandedOutputAssets>, ResolvedVc<Box<dyn VersionedContent>>>,
+);
+
+#[derive(
+    Clone,
+    Default,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Debug,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+struct PathToHmrEntryChunks(FxHashMap<FileSystemPath, HmrEntryChunkOperations>);
+
+// HACK: These maps contain `ResolvedVc`s in their keys or values.
 unsafe impl OperationValue for PathToOutputOperation {}
+unsafe impl OperationValue for PathToHmrEntryChunks {}
+unsafe impl OperationValue for HmrEntryOperationGenerations {}
+unsafe impl OperationValue for HmrEntryRootGenerations {}
 
 // A precomputed map for quick access to output asset by filepath
 type OutputOperationToComputeEntry =
     FxHashMap<OperationVc<ExpandedOutputAssets>, OperationVc<OptionMapEntry>>;
+
+#[derive(
+    Clone,
+    Default,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Debug,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+struct HmrEntryOperationGenerations(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<OperationVc<ExpandedOutputAssets>, u64>,
+);
+
+#[derive(
+    Clone,
+    Default,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Debug,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
+struct HmrEntryRootGenerations(FxHashMap<FileSystemPath, HmrEntryOperationGenerations>);
+
+fn scope_hmr_entry_refresh<T>(refresh: Result<T>, is_current_owner: bool) -> Result<Option<T>> {
+    match refresh {
+        Ok(value) => Ok(Some(value)),
+        // An indexed owner must preserve the existing full-recovery behavior
+        // and its last-good baseline.
+        Err(error) if is_current_owner => Err(error),
+        // A pending-only operation may belong to another root, so its error
+        // must not poison this root; leave its generation pending.
+        Err(_) => Ok(None),
+    }
+}
 
 // TODO: Ideally this structure is never persisted, so new sessions start from scratch and don't
 // accumulate entries or force rebuilds of all chunks when a new session is only interested in some
@@ -76,7 +155,10 @@ pub struct VersionedContentMap {
     // TODO: turn into a bi-directional multimap, ExpandedOutputAssets ->
     // FxIndexSet<FileSystemPath>
     map_path_to_op: State<PathToOutputOperation>,
+    map_path_to_hmr_entry_chunks: State<PathToHmrEntryChunks>,
     map_op_to_compute_entry: State<OutputOperationToComputeEntry>,
+    hmr_entry_operation_generations: State<HmrEntryOperationGenerations>,
+    hmr_entry_root_generations: State<HmrEntryRootGenerations>,
 }
 
 impl VersionedContentMap {
@@ -85,7 +167,10 @@ impl VersionedContentMap {
     pub fn new() -> ResolvedVc<Self> {
         VersionedContentMap {
             map_path_to_op: State::new(PathToOutputOperation(FxHashMap::default())),
+            map_path_to_hmr_entry_chunks: State::new(PathToHmrEntryChunks(FxHashMap::default())),
             map_op_to_compute_entry: State::new(FxHashMap::default()),
+            hmr_entry_operation_generations: State::new(HmrEntryOperationGenerations::default()),
+            hmr_entry_root_generations: State::new(HmrEntryRootGenerations::default()),
         }
         .resolved_cell()
     }
@@ -96,55 +181,115 @@ impl VersionedContentMap {
     /// entries are included by narrowing `root` (e.g. the aggregate server-HMR
     /// subscription passes `server/app` to include App Router entries only).
     ///
-    /// `map_path_to_op` is an `FxHashMap`, whose iteration order depends on
-    /// bucket layout rather than insertion order, so the same set of paths can
-    /// come out in a different order across calls. Since this map contains
-    /// entries that span server and client contexts, changes for one context
-    /// can shift the internals of the map, making iteration order different
-    /// for the same set of paths.
+    /// The entry index is maintained when endpoint output sets change. Reading
+    /// it here avoids reconnecting every side-effectful output operation on an
+    /// ordinary source edit.
     pub async fn hmr_chunks_in_path(
         self: Vc<Self>,
         root: &FileSystemPath,
     ) -> Result<Vec<HmrChunkWithContent>> {
-        let this = self.await?;
-        // `State::get` returns a lock guard, which can't be held across the
-        // awaits below, so snapshot the keys and release it.
-        let paths: Vec<FileSystemPath> = {
-            let map = &this.map_path_to_op.get().0;
-            map.keys().cloned().collect()
+        // Refresh operations whose structural generation has not yet been
+        // observed under this root, plus the operations that currently own an
+        // indexed entry here. Per-root generations make deleted and out-of-root
+        // endpoints inactive while preserving empty -> non-empty discovery and
+        // preventing a concurrent newer generation from being cleared.
+        let resolved_self = self.to_resolved().await?;
+        let this = resolved_self.await?;
+        let compute_operations = {
+            let operation_generations = this.hmr_entry_operation_generations.get();
+            // This state is bookkeeping, not a discovery signal. Reading it
+            // untracked avoids self-invalidating this task when successful
+            // generations are recorded below.
+            let root_generations = this.hmr_entry_root_generations.get_untracked();
+            let processed_generations = root_generations.0.get(root);
+            let mut assets_operations = operation_generations
+                .0
+                .iter()
+                .filter(|(operation, generation)| {
+                    processed_generations
+                        .and_then(|processed| processed.0.get(*operation))
+                        .copied()
+                        != Some(**generation)
+                })
+                .map(|(operation, generation)| (*operation, (*generation, false)))
+                .collect::<FxIndexMap<_, _>>();
+
+            // The final index read below is tracked after refresh. This
+            // pre-refresh owner snapshot is only scheduling input and must not
+            // self-invalidate the caller when a scan changes the index.
+            for (path, entries) in &this.map_path_to_hmr_entry_chunks.get_untracked().0 {
+                if root.get_path_to(path).is_some() {
+                    for operation in entries.0.keys() {
+                        if let Some(&generation) = operation_generations.0.get(operation) {
+                            assets_operations
+                                .entry(*operation)
+                                .and_modify(|(_, is_current_owner)| *is_current_owner = true)
+                                .or_insert((generation, true));
+                        }
+                    }
+                }
+            }
+
+            let registered_operations = this.map_op_to_compute_entry.get();
+            assets_operations
+                .into_iter()
+                .filter(|(operation, _)| registered_operations.contains_key(operation))
+                .map(|(operation, (generation, is_current_owner))| {
+                    let compute_operation =
+                        compute_hmr_entry_operation(resolved_self, operation, root.clone());
+                    (operation, generation, is_current_owner, compute_operation)
+                })
+                .collect::<Vec<_>>()
         };
-
-        let mut chunks = paths
+        let refreshed_generations = compute_operations
             .into_iter()
-            .filter_map(|path| {
-                let rel = root.get_path_to(&path)?;
-                Some((RcStr::from(rel), path))
-            })
-            .map(|(name, path)| async move {
-                // Skip Redirect assets: they're symlinks with no file content,
-                // so versioning them would bail with "not a file".
-                let Some(asset) = *self.get_asset(path).await? else {
-                    return Ok::<_, anyhow::Error>(None);
-                };
-                if !matches!(*asset.content().await?, AssetContent::File(_)) {
-                    return Ok(None);
-                }
-                let content = asset.versioned_content().to_resolved().await?;
-
-                // *Important*: only chunk lists are subscribed to. Individual chunks are already
-                // covered by the chunk list that owns them, so including them here
-                // would produce duplicate updates for the same change.
-                if !is_entry_chunk_list_content(content) {
-                    return Ok(None);
-                }
-
-                Ok(Some(HmrChunkWithContent {
-                    path: name,
-                    content,
-                }))
-            })
+            .map(
+                |(assets_operation, generation, is_current_owner, operation)| async move {
+                    scope_hmr_entry_refresh(
+                        operation
+                            .connect()
+                            .await
+                            .map(|_| (assets_operation, generation)),
+                        is_current_owner,
+                    )
+                },
+            )
             .try_flat_join()
             .await?;
+
+        self.await?
+            .hmr_entry_root_generations
+            .update_conditionally(|root_generations| {
+                let processed = root_generations.0.entry(root.clone()).or_default();
+                let mut changed = false;
+                for (operation, generation) in refreshed_generations {
+                    if processed
+                        .0
+                        .get(&operation)
+                        .is_none_or(|&processed| processed < generation)
+                    {
+                        processed.0.insert(operation, generation);
+                        changed = true;
+                    }
+                }
+                changed
+            });
+
+        let this = self.await?;
+        let mut chunks = this
+            .map_path_to_hmr_entry_chunks
+            .get()
+            .0
+            .iter()
+            .filter_map(|(path, operations)| {
+                let rel = root.get_path_to(path)?;
+                let content = operations.0.values().next().copied()?;
+                Some(HmrChunkWithContent {
+                    path: RcStr::from(rel),
+                    content,
+                })
+            })
+            .collect::<Vec<_>>();
         chunks.sort_by(|a, b| a.path.cmp(&b.path));
         Ok(chunks)
     }
@@ -177,6 +322,67 @@ impl VersionedContentMap {
         this.map_op_to_compute_entry.update_conditionally(|map| {
             map.insert(assets_operation, compute_entry) != Some(compute_entry)
         });
+        this.hmr_entry_operation_generations
+            .update_conditionally(|generations| {
+                *generations.0.entry(assets_operation).or_default() += 1;
+                true
+            });
+        Ok(())
+    }
+
+    /// Maintains the aggregate-HMR entry index without reconnecting the full
+    /// `compute_entry` operation and its asset-emission side effect.
+    #[turbo_tasks::function]
+    async fn compute_hmr_entry(
+        &self,
+        assets_operation: OperationVc<ExpandedOutputAssets>,
+        root: FileSystemPath,
+    ) -> Result<()> {
+        // Propagate in-root structural scan failures so the HMR subscriber
+        // performs its full-recovery path. The last good index stays intact
+        // until the scan succeeds, preventing a recovered entry from being
+        // misclassified as new. Out-of-root asset content is never evaluated.
+        let hmr_entry_chunks = get_hmr_entry_chunks(assets_operation, root.clone())
+            .read_strongly_consistent()
+            .await?;
+
+        self.map_path_to_hmr_entry_chunks
+            .update_conditionally(|map| {
+                let mut changed = false;
+                let mut stale_paths = map
+                    .0
+                    .iter()
+                    .filter_map(|(path, operations)| {
+                        (root.get_path_to(path).is_some()
+                            && operations.0.contains_key(&assets_operation))
+                        .then_some(path.clone())
+                    })
+                    .collect::<FxHashSet<_>>();
+
+                for (path, content) in hmr_entry_chunks.iter() {
+                    let previous = map
+                        .0
+                        .entry(path.clone())
+                        .or_default()
+                        .0
+                        .insert(assets_operation, *content);
+                    stale_paths.remove(path);
+                    changed = changed || previous != Some(*content);
+                }
+
+                for path in &stale_paths {
+                    let remove_path = {
+                        let operations = map.0.get_mut(path).unwrap();
+                        changed = operations.0.swap_remove(&assets_operation).is_some() || changed;
+                        operations.0.is_empty()
+                    };
+                    if remove_path {
+                        map.0.remove(path);
+                    }
+                }
+                changed
+            });
+
         Ok(())
     }
 
@@ -195,7 +401,6 @@ impl VersionedContentMap {
             .await
             // Any error should result in an empty list, which removes all assets from the map
             .ok();
-
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
@@ -226,6 +431,15 @@ impl VersionedContentMap {
             }
             changed
         });
+        // Structural output changes are the discovery signal for new, deleted,
+        // or recreated aggregate-HMR entries. Every root records the exact
+        // generation completed by its lightweight scan, so concurrent changes
+        // cannot be cleared by an older scan.
+        self.hmr_entry_operation_generations
+            .update_conditionally(|generations| {
+                *generations.0.entry(assets_operation).or_default() += 1;
+                true
+            });
 
         // Make sure all written client assets are up-to-date
         emit_assets(
@@ -348,6 +562,48 @@ async fn get_entries(assets: OperationVc<ExpandedOutputAssets>) -> Result<Vc<Get
     Ok(Vc::cell(entries))
 }
 
+/// Computes only the entry chunks needed by aggregate HMR. This reconnects the
+/// endpoint output operation to inspect its structure, but avoids reconnecting the
+/// full `compute_entry` operation that owns the asset-emission side effect.
+#[turbo_tasks::function(operation, root)]
+async fn get_hmr_entry_chunks(
+    assets: OperationVc<ExpandedOutputAssets>,
+    root: FileSystemPath,
+) -> Result<Vc<HmrEntryChunks>> {
+    let assets_ref = assets.read_strongly_consistent().await?;
+    let entries = assets_ref
+        .iter()
+        .map(|&asset| {
+            let root = root.clone();
+            async move {
+                let path = asset.path().owned().await?;
+                if root.get_path_to(&path).is_none() {
+                    return Ok::<_, anyhow::Error>(None);
+                }
+                if !matches!(*asset.content().await?, AssetContent::File(_)) {
+                    return Ok(None);
+                }
+                let content = asset.versioned_content().to_resolved().await?;
+                if !is_entry_chunk_list_content(content) {
+                    return Ok(None);
+                }
+                Ok(Some((path, content)))
+            }
+        })
+        .try_flat_join()
+        .await?;
+    Ok(Vc::cell(entries))
+}
+
+#[turbo_tasks::function(operation, root)]
+fn compute_hmr_entry_operation(
+    map: ResolvedVc<VersionedContentMap>,
+    assets_operation: OperationVc<ExpandedOutputAssets>,
+    root: FileSystemPath,
+) -> Vc<()> {
+    map.compute_hmr_entry(assets_operation, root)
+}
+
 #[turbo_tasks::function(operation, root)]
 fn compute_entry_operation(
     map: ResolvedVc<VersionedContentMap>,
@@ -362,4 +618,28 @@ fn compute_entry_operation(
         client_relative_path,
         client_output_path,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::scope_hmr_entry_refresh;
+
+    #[test]
+    fn hmr_entry_refresh_errors_are_scoped_to_current_owners() {
+        assert_eq!(
+            scope_hmr_entry_refresh::<u8>(Ok(7), false).unwrap(),
+            Some(7)
+        );
+
+        let owner_error =
+            scope_hmr_entry_refresh::<()>(Err(anyhow!("owner scan failed")), true).unwrap_err();
+        assert_eq!(owner_error.to_string(), "owner scan failed");
+
+        assert_eq!(
+            scope_hmr_entry_refresh::<()>(Err(anyhow!("other root failed")), false).unwrap(),
+            None
+        );
+    }
 }

--- a/test/development/app-dir/hmr-entry-index/app/layout.tsx
+++ b/test/development/app-dir/hmr-entry-index/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-entry-index/app/page.tsx
+++ b/test/development/app-dir/hmr-entry-index/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/hmr-entry-index/app/unmodified-module.ts
+++ b/test/development/app-dir/hmr-entry-index/app/unmodified-module.ts
@@ -1,0 +1,3 @@
+// An always-imported dependency that is never edited during the test.
+// Its evaluation timestamp detects a server runtime clear/full re-evaluation.
+export const depEvalTime = Date.now()

--- a/test/development/app-dir/hmr-entry-index/hmr-entry-index.test.ts
+++ b/test/development/app-dir/hmr-entry-index/hmr-entry-index.test.ts
@@ -1,0 +1,139 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+const addedPage = (value: string) => `
+import { depEvalTime } from '../unmodified-module'
+
+export default function Page() {
+  return (
+    <>
+      <p id="value">${value}</p>
+      <span id="dep-eval-time">{depEvalTime}</span>
+    </>
+  )
+}
+`
+
+describe('hmr-entry-index', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  const itTurbopack = isTurbopack ? it : it.skip
+
+  itTurbopack(
+    'keeps aggregate HMR entries current across errors, additions, and removals',
+    async () => {
+      const outsideBrowser = await next.browser('/outside')
+      expect(await outsideBrowser.elementByCss('#outside-value').text()).toBe(
+        'outside-v1'
+      )
+
+      const browser = await next.browser('/')
+      expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+      await next.patchFile('app/added/page.tsx', addedPage('added-v1'))
+
+      await retry(async () => {
+        const html = await next.render('/added')
+        expect(html).toContain('added-v1')
+      })
+
+      await browser.loadPage(next.url + '/added')
+      expect(await browser.elementByCss('#value').text()).toBe('added-v1')
+      const initialDepEvalTime = await browser
+        .elementByCss('#dep-eval-time')
+        .text()
+
+      await next.patchFile('app/added/page.tsx', (source) =>
+        source.replace('added-v1', 'added-v2')
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#value').text()).toBe('added-v2')
+      })
+      expect(await browser.elementByCss('#dep-eval-time').text()).toBe(
+        initialDepEvalTime
+      )
+
+      // Keep a Pages Router endpoint registered while App Router entries
+      // update, exercising mixed-root registration and owner selection.
+      await next.patchFile(
+        'app/added/page.tsx',
+        addedPage('added-v2-outside-registered')
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#value').text()).toBe(
+          'added-v2-outside-registered'
+        )
+      })
+      expect(await browser.elementByCss('#dep-eval-time').text()).toBe(
+        initialDepEvalTime
+      )
+
+      // A JSX parse error emits a throwing error chunk rather than failing the
+      // structural scan. Keep /added loaded through that runtime error, exercise
+      // an unrelated root while the global overlay is active, then recover. The
+      // Rust unit test covers owner-error propagation versus cross-root isolation.
+      await next.patchFile(
+        'app/added/page.tsx',
+        "import { depEvalTime } from '../unmodified-module'\n\n" +
+          'export default function Page() { return <p id="value">broken</span> }\n'
+      )
+      await retry(async () => {
+        expect((await next.fetch('/added')).status).toBe(500)
+      })
+
+      await next.patchFile('app/page.tsx', (source) =>
+        source.replace('hello world', 'hello index')
+      )
+      // Development errors are global, so this unrelated request deterministically
+      // surfaces the same overlay between writes.
+      expect((await next.fetch('/')).status).toBe(500)
+
+      await next.patchFile('app/added/page.tsx', addedPage('added-v3'))
+      await retry(async () => {
+        expect(await browser.elementByCss('#value').text()).toBe('added-v3')
+      })
+      expect(await browser.elementByCss('#dep-eval-time').text()).toBe(
+        initialDepEvalTime
+      )
+
+      await next.deleteFile('app/added/page.tsx')
+      await retry(async () => {
+        expect((await next.fetch('/added')).status).toBe(404)
+      })
+
+      await next.patchFile('app/added/page.tsx', addedPage('added-v4'))
+      await retry(async () => {
+        const html = await next.render('/added')
+        expect(html).toContain('added-v4')
+      })
+
+      // Recreated endpoints can reuse the same stable output operation. Verify
+      // it is rediscovered by requiring a subsequent incremental update.
+      await browser.loadPage(next.url + '/added')
+      const recreatedDepEvalTime = await browser
+        .elementByCss('#dep-eval-time')
+        .text()
+      await next.patchFile('app/added/page.tsx', (source) =>
+        source.replace('added-v4', 'added-v5')
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#value').text()).toBe('added-v5')
+      })
+      expect(await browser.elementByCss('#dep-eval-time').text()).toBe(
+        recreatedDepEvalTime
+      )
+
+      await browser.loadPage(next.url + '/')
+      expect(await browser.elementByCss('p').text()).toBe('hello index')
+
+      await next.patchFile('app/page.tsx', (source) =>
+        source.replace('hello index', 'hello final')
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe('hello final')
+      })
+    }
+  )
+})

--- a/test/development/app-dir/hmr-entry-index/next.config.js
+++ b/test/development/app-dir/hmr-entry-index/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/hmr-entry-index/pages/outside.tsx
+++ b/test/development/app-dir/hmr-entry-index/pages/outside.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="outside-value">outside-v1</p>
+}


### PR DESCRIPTION
## What?

Maintain a lightweight, synchronized index of aggregate-HMR entry chunk lists
in `VersionedContentMap`.

The index:

- stores file-backed entry chunk-list content by output path
- preserves multiple endpoint owners with insertion-ordered per-path maps
- keeps the last-good entry intact when a structural scan fails
- refreshes operations whose generation is unseen for a root plus current owners
- makes deleted/out-of-root endpoints inactive, while allowing stable operation
  identities to reactivate after recreation

A development integration test covers route add, loaded-route error and
recovery, hot edit, delete, recreate, post-recreation hot edit, and a subsequent
edit to an existing route.

## Why?

`hmr_chunks_in_path` currently enumerates every emitted output path and calls
`get_asset` for each candidate whenever aggregate server HMR updates. On large
App Router graphs, those lookups reconnect side-effectful endpoint output
operations and replay their captured asset-emission effects.

In a 240-route / 3,756-module fixture, the baseline made 512,750
`VersionedContentMap::get_asset` calls over an equivalent 20-edit run. This
change reduces that to 2. It adds 240 initial lightweight index operations, one
per warmed endpoint, and reduces total recorded Turbo Tasks lookups by 13.99%.

## How?

Each endpoint registers a dedicated index-maintenance operation and a monotonic
structural generation. Aggregate HMR connects generations not yet processed for
its root plus endpoints that currently own an indexed entry there, then reads
and sorts the structural index. Each root records only generations whose scans
completed successfully. Structural `compute_entry` bumps the generation for
additions, deletions, and recreations, so a cached operation that goes empty can
later become active again without reconnecting every registered endpoint.

The lightweight scan reconnects the endpoint output operation to inspect its
structure, but does not reconnect the full `compute_entry` operation that owns
the asset-emission side effect. Indexed-owner scan errors propagate to the
existing full HMR recovery path and preserve the last-good index. Pending-only
errors from another root stay unseen for retry without poisoning this root.

An earlier live-content-only index failed `hmr-refetch-coalescing` after a
syntax error. Review also exposed lifecycle bugs in error handling, stable
operation pruning, a pending-set race, cross-root error coupling, and tracked
bookkeeping self-invalidation. A deterministic Rust unit test covers owner
error propagation and cross-root isolation. The browser regression covers
throwing-chunk recovery without a server-runtime clear and hot editing after
delete/recreate.

## Performance

Measured on one 16-vCPU / 32-GiB Vercel DevBox at commit `89ca693c20`. Each
boot deleted `.next`, started a fresh process, compiled the target route, warmed
every route, ran 5 warm-up edits, and recorded 15 edits with a 500 ms settle
outside the timed interval. Baseline and candidate native binaries were SHA-256
verified and interleaved in `ABBA BAAB ABBA` order.

The metric is atomic source rename to a browser React `useEffect` commit
containing the exact new server-rendered marker. Each observation also verified
preserved client input state and zero document reloads. Confidence intervals
use 100,000 bootstrap resamples of fresh-boot medians.

| Fixture | Baseline | Candidate | Improvement | Boot-level 95% CI |
| --- | ---: | ---: | ---: | ---: |
| Medium: 60 routes / 718 modules | 181.33 ms | 77.08 ms | 57.49% | 55.83–59.00% |
| Large: 240 routes / 3,756 modules | 571.16 ms | 95.15 ms | 83.34% | 82.83–83.99% |

Pooled p95 improved 55.67% medium and 82.68% large. A/A boot-median ranges
under the same protocol were 2.32% medium and 6.18% large.

Secondary median deltas:

| Fixture | Target ready | Warm all routes | Peak RSS |
| --- | ---: | ---: | ---: |
| Medium | -1.20% | +1.40% | +0.36% |
| Large | +2.13% | -10.04% | +0.05% |

A broad edit to a barrel-exported dependency used by 22 large-fixture routes
improved from 920.16 ms to 459.84 ms (50.03%). This was a one-boot qualification
probe, not a confidence-interval claim.

The exact committed source and candidate binary (`d361d3b4…`) were reproduced
after the final lifecycle and deterministic-coverage changes in a shorter clean
`ABBA` run (two boots and 30 measured edits per variant): 58.29% faster medium
(57.71–58.85% CI) and 83.83% faster large (83.57–84.09% CI). Startup changed
+6.53% medium / +0.43% large, and peak RSS changed -1.76% / +2.35%. All 120
reproduction edits passed with zero reloads.

## Tests

- `pnpm build-all` — 18/18 tasks
- deterministic Rust refresh-error classification — 1/1
- focused HMR regression — 1/1
- expanded Turbopack development matrix — 46/46 tests across 11 suites
- `pnpm test-dev-turbo hmr-entry-index` — 1/1 through the isolated packed-package path
- `cargo fmt --check --package next-api`
- Prettier on the added/modified fixture files
- `git diff --check`

The expanded matrix includes server/client HMR, new and dynamic imports, source
maps, metadata and route handlers, shared CSS, parallel/intercepted routes,
route deletion/move, syntax-error refetch coalescing, config restarts, and
server-component HMR caching.

Exact-tree adversarial review was rerun with Codex GPT-5.6 Sol xhigh and Claude
Opus 5 xhigh. Codex returned zero findings; Claude also judged the patch correct
and raised two low-confidence concerns. The claimed owner-error regression does
not hold because canary's later `emit_assets(assets_operation.connect()).await?`
already propagates the failing operation. An unseen out-of-root generation does
receive one lightweight scan per root before being recorded; this bounded cost
is a possible follow-up if an isolated client-only benchmark shows material
impact, while the retained large trace shows a 13.99% net task-lookup reduction.

<!-- NEXT_JS_LLM -->
