### PR TITLE
fix(segment-cache): normalize repeated slashes in route cache key pathname

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache-key.test.ts
+++ b/packages/next/src/client/components/segment-cache/cache-key.test.ts
@@ -1,0 +1,36 @@
+import { createCacheKey } from './cache-key'
+
+describe('createCacheKey', () => {
+  it('creates a key from the pathname, search, and nextUrl', () => {
+    const key = createCacheKey('https://example.com/foo/bar?a=1', null)
+    expect(key.pathname).toBe('/foo/bar')
+    expect(key.search).toBe('?a=1')
+    expect(key.nextUrl).toBe(null)
+
+    const keyWithNextUrl = createCacheKey(
+      'https://example.com/foo/bar?a=1',
+      '/some-intercepted-route'
+    )
+    expect(keyWithNextUrl.nextUrl).toBe('/some-intercepted-route')
+  })
+
+  it('normalizes repeated slashes in the pathname', () => {
+    const key = createCacheKey('https://example.com/a//b///c', null)
+    expect(key.pathname).toBe('/a/b/c')
+  })
+
+  it('collapses a leading double slash so the pathname cannot be re-parsed as an authority', () => {
+    // A pathname that begins with `//` would be interpreted as a host when
+    // passed to `new URL(pathname, location.origin)`, escaping the origin
+    // that was validated when the prefetch URL was created.
+    const key = createCacheKey('https://example.com//attacker.example/x', null)
+    expect(key.pathname).toBe('/attacker.example/x')
+
+    // The reconstructed request URL must stay on the original origin.
+    const reconstructed = new URL(
+      key.pathname + key.search,
+      'https://example.com'
+    )
+    expect(reconstructed.origin).toBe('https://example.com')
+  })
+})

--- a/packages/next/src/client/components/segment-cache/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache/cache-key.ts
@@ -1,3 +1,5 @@
+import { normalizeRepeatedSlashes } from '../../../shared/lib/utils'
+
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
 
@@ -23,7 +25,14 @@ export function createCacheKey(
 ): RouteCacheKey {
   const originalUrl = new URL(originalHref)
   const cacheKey = {
-    pathname: originalUrl.pathname as NormalizedPathname,
+    // Collapse repeated slashes so the pathname can't be re-parsed as an
+    // authority (a `//host` prefix) when the request URL is reconstructed via
+    // `new URL(key.pathname + key.search, location.origin)`. The server
+    // canonicalizes repeated slashes the same way (via a 308 redirect), so
+    // this doesn't change which page is fetched.
+    pathname: normalizeRepeatedSlashes(
+      originalUrl.pathname
+    ) as NormalizedPathname,
     search: originalUrl.search as NormalizedSearch,
     nextUrl: nextUrl as NormalizedNextUrl | null,
   } as RouteCacheKey


### PR DESCRIPTION
## What

`createCacheKey()` (segment-cache/cache-key.ts) reduces a validated same-origin `URL` to `{ pathname, search, nextUrl }`. Consumers reconstruct the request URL by string-concatenating the pathname back onto `location.origin`, e.g. `fetchRouteOnCacheMiss()`: `new URL(pathname + search, location.origin)` (cache.ts).

A pathname beginning with `//` — e.g. from a same-origin href like `https://app.example//attacker.example/x` (or the scheme-relative `//app.example//attacker.example/x`), both of which pass the `isExternalURL` origin check — is re-parsed as an **authority** by the WHATWG URL parser when used as the input to `new URL(input, base)`. The reconstructed request URL therefore points at a different origin than the one that was validated:

```js
const u = new URL('https://app.example//attacker.example/x')
u.pathname                    // '//attacker.example/x'  (origin check passed)
new URL(u.pathname, u.origin) // 'https://attacker.example/x'  (origin escaped)
```

Because `<Link>` prefetches automatically on viewport intersection in production, this issues automatic cross-origin requests carrying the internal routing headers (`RSC`, `Next-Router-Prefetch`, `Next-Router-Segment-Prefetch`, `Next-Url`) to an attacker-chosen host, and the response is decoded as a Flight payload into the route cache.

## Fix

Collapse repeated slashes when the key is created, using the existing shared `normalizeRepeatedSlashes` helper. The Next.js server already canonicalizes repeated-slash paths the same way (base-server 308-redirects `//`/\` paths to their normalized form), so this doesn't change which page is fetched — it only prevents the cached pathname from being re-parsed as an authority at every consumer, present and future.

## Tests

Added `cache-key.test.ts` covering key creation, repeated-slash normalization, and a regression test asserting that a `//host`-prefixed pathname can no longer reconstruct to a different origin. `pnpm jest packages/next/src/client` passes (44 tests).

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.