### PR TITLE
fix(next-code-frame): snap highlight scan window and display offsets to char boundaries

### DIFF
--- a/crates/next-code-frame/src/highlight.rs
+++ b/crates/next-code-frame/src/highlight.rs
@@ -563,9 +563,15 @@ pub fn extract_highlights(
                 .copied()
                 .unwrap_or(source.len());
             let (rs, re) = if let Some((trunc_offset, avail_width)) = visible_window {
+                // Snap the window to char boundaries. The scan end is emitted
+                // verbatim as a span end by the template-literal and
+                // regex-literal scanners, and span offsets are later used as
+                // byte indices when rendering — a mid-character offset would
+                // panic when slicing. (`truncate_line` snaps its start offset
+                // forward the same way.)
                 (
-                    (ls + trunc_offset).min(line_end),
-                    (ls + trunc_offset + avail_width).min(line_end),
+                    source.ceil_char_boundary((ls + trunc_offset).min(line_end)),
+                    source.floor_char_boundary((ls + trunc_offset + avail_width).min(line_end)),
                 )
             } else {
                 (ls, line_end)
@@ -1005,11 +1011,16 @@ pub fn apply_line_highlights(
             break;
         }
 
-        // Clamp span to the visible window and convert to display coordinates
-        let display_start = (span.start.max(truncation_offset) - truncation_offset + prefix_len)
-            .min(visible_content.len());
-        let display_end =
-            (span.end.min(visible_end) - truncation_offset + prefix_len).min(visible_content.len());
+        // Clamp span to the visible window and convert to display coordinates.
+        // Snap to char boundaries defensively: span offsets originate from the
+        // tokenizer and a mid-character offset would panic when slicing below.
+        let display_start = visible_content.ceil_char_boundary(
+            (span.start.max(truncation_offset) - truncation_offset + prefix_len)
+                .min(visible_content.len()),
+        );
+        let display_end = visible_content.floor_char_boundary(
+            (span.end.min(visible_end) - truncation_offset + prefix_len).min(visible_content.len()),
+        );
 
         if display_start < display_end {
             // Emit unstyled text before this span

--- a/crates/next-code-frame/src/tests.rs
+++ b/crates/next-code-frame/src/tests.rs
@@ -892,3 +892,80 @@ fn test_multibyte_cjk_truncation_with_highlighting() {
     assert!(stripped.contains("あ"), "Should contain CJK characters");
     assert!(stripped.contains("^"), "Should contain marker");
 }
+
+#[test]
+fn test_multibyte_template_literal_beyond_window_does_not_panic() {
+    // Template literal whose contents are multi-byte chars and whose closing
+    // backtick lies beyond the visible window: the unterminated-template scan
+    // must not emit a mid-character span end (previously panicked slicing at
+    // a non-char-boundary byte index).
+    let source = format!("const t = `{}`", "\u{3042}".repeat(200));
+    let location = CodeFrameLocation {
+        start: Location {
+            line: 1,
+            column: None,
+        },
+        end: None,
+    };
+    let options = CodeFrameOptions {
+        color: CodeFrameColorMode::Error,
+        highlight_code: true,
+        ..Default::default()
+    };
+    let result = render_code_frame(&source, &location, &options).unwrap();
+    assert!(result.is_some());
+}
+
+#[test]
+fn test_multibyte_regex_literal_beyond_window_does_not_panic() {
+    // A regex literal whose match end exceeds the visible window: the clamp
+    // to the window end must not produce a mid-character span end.
+    let source = format!("const re = /{}\u{3042}x/;", "\u{3042}".repeat(40));
+    let location = CodeFrameLocation {
+        start: Location {
+            line: 1,
+            column: None,
+        },
+        end: None,
+    };
+    let options = CodeFrameOptions {
+        color: CodeFrameColorMode::Error,
+        highlight_code: true,
+        ..Default::default()
+    };
+    let result = render_code_frame(&source, &location, &options).unwrap();
+    assert!(result.is_some());
+}
+
+#[test]
+fn test_highlight_matches_plain_for_multibyte_content() {
+    // Rendering with highlighting must produce the same text as plain
+    // rendering once ANSI codes are stripped, even when the visible window
+    // truncates multi-byte template/regex content mid-token.
+    for source in [
+        format!("const t = `{}`", "\u{3042}".repeat(200)),
+        format!("const re = /{}\u{3042}/;", "a".repeat(90)),
+        format!("const s = \"{}\";", "\u{3042}\u{0301}".repeat(80)),
+    ] {
+        let location = CodeFrameLocation {
+            start: Location {
+                line: 1,
+                column: None,
+            },
+            end: None,
+        };
+        let highlighted = render_code_frame(
+            &source,
+            &location,
+            &CodeFrameOptions {
+                color: CodeFrameColorMode::Error,
+                highlight_code: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .map(|s| strip_ansi_codes(&s));
+        let plain = render_code_frame(&source, &location, &CodeFrameOptions::default()).unwrap();
+        assert_eq!(highlighted, plain, "mismatch for source: {source:?}");
+    }
+}


### PR DESCRIPTION
## What

`render_code_frame` computes the per-line visible window as raw byte offsets — `line_start + truncation_offset + available_width` — without snapping to UTF-8 char boundaries. Two tokenizer paths then emit that raw scan end **verbatim as a span end**:

1. the template-literal scanner's unterminated branch (any template whose closing backtick lies beyond the visible window — e.g. a long line),
2. the regex-literal clamp (`re_end = re_match.end().min(scan_end)`).

`apply_line_highlights` later uses span offsets as byte indices into the visible line content: `&visible_content[display_start..display_end]`. Slicing a `str` at a mid-character index panics with `byte index N is not a char boundary`.

Reproducer (panics before this fix at highlight.rs:1021):

```rust
let source = format!("const t = `{}`", "\u{3042}".repeat(200));
// render_code_frame(&source, loc, &CodeFrameOptions {
//     color: CodeFrameColorMode::Error, highlight_code: true, ..
// })
```

Impact: the panic unwinds out of the `#[napi]` binding (`crates/next-napi-bindings/src/code_frame.rs`), which has no `catch_unwind`, so it **aborts the Node process** — turning an ordinary build/dev diagnostic into a hard crash exactly while reporting the original error. It is also reachable from the dev-only `POST /__nextjs_original-stack-frames` endpoint, whose caller controls line/column (and therefore the truncation offset) for any project file.

## Fix

- **Root cause:** snap the `output_ranges` window to char boundaries — `ceil_char_boundary` for the start (matching `truncate_line`'s existing forward snapping) and `floor_char_boundary` for the end — so `scan_end` is always boundary-aligned and every emitted span end lands on a boundary.
- **Defense in depth:** snap the display offsets (`ceil` start / `floor` end) in `apply_line_highlights` immediately before slicing, so no future invariant violation can panic.

## Tests

- Two regression tests (template-literal and regex-literal beyond the window), each **verified to panic without this fix** and pass with it.
- A property-style test asserting `strip_ansi(render(highlighted)) == render(plain)` for multi-byte template/regex/string content, proving highlighting doesn't alter visible output.
- All 55 `next-code-frame` tests pass; `cargo clippy`/`fmt` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.