### PR TITLE
fix(turbopack): only emit numeric fontWeight in the generated localFont module

### DIFF
--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -148,7 +148,7 @@ impl ImportMappingReplacement for NextFontLocalReplacer {
                 .weight
                 .await?
                 .as_ref()
-                .map(|w| format!("fontWeight: {w},\n"))
+                .and_then(font_weight_js_property)
                 .unwrap_or_else(|| "".to_owned()),
             properties
                 .style
@@ -323,6 +323,22 @@ impl ImportMappingReplacement for NextFontLocalFontFileReplacer {
     }
 }
 
+/// Formats the `fontWeight` entry for the generated JS module, mirroring the
+/// webpack implementation (postcss-next-font.ts): only numeric weights are
+/// included. A CSS keyword like `normal` would otherwise be emitted as a bare
+/// (unbound) identifier and throw a `ReferenceError` when the module is
+/// evaluated. The parsed number is emitted rather than the raw string so the
+/// output is always a valid JS numeric literal.
+fn font_weight_js_property(weight: &RcStr) -> Option<String> {
+    weight
+        .parse::<f64>()
+        .ok()
+        // Rust's float parser also accepts `inf`/`Infinity`/`NaN`, which would
+        // be emitted as bare identifiers (`fontWeight: inf`) — guard them out.
+        .filter(|n| n.is_finite())
+        .map(|n| format!("fontWeight: {n},\n"))
+}
+
 #[turbo_tasks::function]
 async fn get_font_css_properties(
     options_vc: Vc<NextFontLocalOptions>,
@@ -382,5 +398,38 @@ impl Issue for FontResolvingIssue {
             StyledString::Code(self.font_path.owned().await?),
             StyledString::Text(rcstr!("'")),
         ]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn font_weight_js_property_emits_numeric_weights() {
+        assert_eq!(
+            font_weight_js_property(&"400".into()),
+            Some("fontWeight: 400,\n".to_owned())
+        );
+        // Emitted as a canonical numeric literal, not verbatim.
+        assert_eq!(
+            font_weight_js_property(&"0400".into()),
+            Some("fontWeight: 400,\n".to_owned())
+        );
+    }
+
+    #[test]
+    fn font_weight_js_property_omits_non_numeric_weights() {
+        // CSS keywords would be emitted as bare (unbound) identifiers in the
+        // generated module, throwing a ReferenceError on evaluation.
+        for keyword in ["normal", "bold", "bolder", "lighter", "inherit"] {
+            assert_eq!(font_weight_js_property(&keyword.into()), None);
+        }
+        // Rust's float parser accepts these, but emitting them would produce
+        // `fontWeight: inf` / `fontWeight: NaN` — bare identifier output in
+        // the `inf` case, and neither is a valid CSS font weight.
+        for special in ["inf", "Infinity", "-inf", "NaN", "nan"] {
+            assert_eq!(font_weight_js_property(&special.into()), None);
+        }
     }
 }


### PR DESCRIPTION
## What

The generated JS module for `next/font/local` interpolated the font weight verbatim:

```js
style: { fontFamily: "...", fontWeight: normal, }
```

CSS keyword weights like `weight: 'normal'` or `'bold'` are accepted by the option validation (`validateLocalFontFunctionCall` doesn't restrict `weight`, and Rust's `FontWeight::from_str` produces `Fixed("normal")`), so the emitted module references a bare unbound identifier and evaluating it throws `ReferenceError: normal is not defined` — every page importing the font crashes (500 on the server, hydration failure on the client). Turbopack-only: the webpack implementation (`postcss-next-font.ts`) only emits `fontWeight` when `Number(weight)` is not `NaN`, so the same app works under webpack.

## Fix

Mirror the webpack behavior in the JS emission: a new pure helper `font_weight_js_property` parses the weight as a number, emits the canonical numeric literal when finite, and omits the property otherwise. The parsed number (not the raw string) is emitted so the output is always a valid JS numeric literal (`'0400'` → `fontWeight: 400`), and non-finite parses (`inf`/`Infinity`/`NaN`, which Rust's float parser accepts) are filtered out so no bare identifier can ever be produced.

`FontCssProperties.weight`'s other consumer — the CSS class rules (`font-weight: normal` is valid CSS) — is intentionally unaffected; the filter is scoped to the JS module emission only. The Google-fonts path has the same emission pattern but is unreachable (weights are validated against the font's metadata).

## Tests

Unit tests for the helper: numeric weights are emitted as canonical numeric literals; CSS keywords and non-finite specials are omitted. Verified on latest canary: `cargo test -p next-core` (87 pass), `clippy`/`fmt` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.