### PR TITLE
fix(turbopack): don't discard JSX transform defaults on empty/unparsable tsconfig

### DIFF
--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -223,7 +223,9 @@ pub async fn get_jsx_transform_options(
             })
         })
         .await?
-        .unwrap_or_default()
+        // An empty/missing/unparsable tsconfig must not discard the computed
+        // defaults (automatic runtime, Fast Refresh, development flag).
+        .unwrap_or(react_transform_options)
     } else {
         react_transform_options
     };


### PR DESCRIPTION
## What

`get_jsx_transform_options` (crates/next-core/src/transform_options.rs) carefully computes `react_transform_options` — automatic JSX runtime, development flag, Fast Refresh, emotion `import_source` — and then **discards all of it** whenever the tsconfig config list is empty:

```rust
read_from_tsconfigs(&tsconfig, |json, _| { ... }).await?.unwrap_or_default()
```

`read_tsconfigs` returns an empty `Vec` (and `get_typescript_options` wraps it as `Some(vec![])`) in three reachable situations:

1. **tsconfig.json exists but is zero-length** — `read_tsconfigs` explicitly ignores empty config files (`file.content().is_empty() -> break`),
2. **`typescript.tsconfigPath` points at a not-yet-created file** (`FileJsonContent::NotFound`),
3. **tsconfig.json is temporarily unparsable** while the user edits it (`FileJsonContent::Unparsable`).

In all three, `read_from_tsconfigs` returns `Ok(None)` and `unwrap_or_default()` resets the options to `JsxTransformOptions::default()` = `{ development: false, react_refresh: false, import_source: None, runtime: None }`. That compiles JSX with the **classic runtime** — `React.createElement` with no auto `React` import — producing app-wide `React is not defined` failures, silently disabling Fast Refresh, and dropping dev JSX info. The other three functions in the same file correctly fall back per-field (`.unwrap_or(false)`); only this one collapsed wholesale.

## Fix

`unwrap_or(react_transform_options)`: an empty/missing/unparsable tsconfig now behaves **exactly like having no tsconfig at all** (the `else` branch — the well-trodden path every non-TS project already runs). Configs with content behave identically to before (the closure always returns `Some`).

This restores webpack parity: `getLoaderSWCOptions` (packages/next/src/build/swc/options.ts) hardcodes `runtime: 'automatic'`, `development`, and `refresh`, letting only `jsxImportSource` through from jsconfig.

## Tests

Verified with `cargo check`/`clippy`/`fmt` on canary. No new test added: the function is a `turbo-tasks` fn requiring a full project context (mode/next_config/sources); the semantic change is a single fallback expression with the no-tsconfig equivalence above — a build-level e2e covering the empty-tsconfig case would be a good follow-up.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.