### PR TITLE
Clean up dev errors RSC streams the HMR client never consumes

### DIFF
--- a/packages/next/src/server/dev/serialized-errors.test.ts
+++ b/packages/next/src/server/dev/serialized-errors.test.ts
@@ -1,0 +1,65 @@
+import {
+  deleteErrorsRscStreamForHtmlRequest,
+  sendSerializedErrorsToClientForHtmlRequest,
+  setErrorsRscStreamForHtmlRequest,
+} from './serialized-errors'
+import type { AnyStream } from '../app-render/stream-ops'
+
+jest.useFakeTimers()
+
+function makeStream(): AnyStream {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('errors-payload'))
+      controller.close()
+    },
+  }) as unknown as AnyStream
+}
+
+describe('serialized-errors', () => {
+  it('sends a stored errors stream when the client connects', async () => {
+    const sendToClient = jest.fn()
+    setErrorsRscStreamForHtmlRequest('req-consume', makeStream())
+
+    sendSerializedErrorsToClientForHtmlRequest('req-consume', sendToClient)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(sendToClient).toHaveBeenCalledTimes(1)
+    expect(sendToClient.mock.calls[0][0].serializedErrors).toBeDefined()
+  })
+
+  it('cleans up an errors stream the client never consumes', async () => {
+    const sendToClient = jest.fn()
+    setErrorsRscStreamForHtmlRequest('req-abandoned', makeStream())
+
+    // The client never connects. After the cleanup window the entry is gone.
+    await jest.advanceTimersByTimeAsync(10 * 60_000 + 1_000)
+
+    sendSerializedErrorsToClientForHtmlRequest('req-abandoned', sendToClient)
+    await jest.advanceTimersByTimeAsync(0)
+    expect(sendToClient).not.toHaveBeenCalled()
+  })
+
+  it('deleteErrorsRscStreamForHtmlRequest drops the entry and its cleanup', async () => {
+    const sendToClient = jest.fn()
+    setErrorsRscStreamForHtmlRequest('req-deleted', makeStream())
+    deleteErrorsRscStreamForHtmlRequest('req-deleted')
+
+    await jest.advanceTimersByTimeAsync(10 * 60_000 + 1_000)
+
+    sendSerializedErrorsToClientForHtmlRequest('req-deleted', sendToClient)
+    await jest.advanceTimersByTimeAsync(0)
+    expect(sendToClient).not.toHaveBeenCalled()
+  })
+
+  it('consuming before the timeout keeps the entry', async () => {
+    const sendToClient = jest.fn()
+    setErrorsRscStreamForHtmlRequest('req-early', makeStream())
+
+    await jest.advanceTimersByTimeAsync(30_000)
+    sendSerializedErrorsToClientForHtmlRequest('req-early', sendToClient)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(sendToClient).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/next/src/server/dev/serialized-errors.ts
+++ b/packages/next/src/server/dev/serialized-errors.ts
@@ -6,6 +6,26 @@ import type { AnyStream } from '../app-render/stream-ops'
 import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
 
 const errorsRscStreamsByHtmlRequestId = new Map<string, AnyStream>()
+const cleanupTimersByHtmlRequestId = new Map<string, NodeJS.Timeout>()
+
+/**
+ * How long an unconsumed errors stream is retained for a client that connects
+ * later. The window needs to comfortably cover legitimate HMR startups —
+ * a large cold dev build, a throttled network, or a paused debugger can take
+ * minutes before the client opens the socket — while still bounding how long
+ * a stream whose client never connects (curl, disabled JavaScript, bots) is
+ * retained: without any bound, the entry and the RSC payload buffered in it
+ * stay alive for the lifetime of the dev server.
+ */
+const CLEANUP_AFTER_MS = 10 * 60_000
+
+function clearCleanupTimer(htmlRequestId: string) {
+  const timer = cleanupTimersByHtmlRequestId.get(htmlRequestId)
+  if (timer) {
+    clearTimeout(timer)
+    cleanupTimersByHtmlRequestId.delete(htmlRequestId)
+  }
+}
 
 export function sendSerializedErrorsToClient(
   errorsRscStream: AnyStream,
@@ -34,6 +54,7 @@ export function sendSerializedErrorsToClientForHtmlRequest(
     return
   }
 
+  clearCleanupTimer(htmlRequestId)
   errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
 
   sendSerializedErrorsToClient(errorsRscStream, sendToClient)
@@ -43,11 +64,21 @@ export function setErrorsRscStreamForHtmlRequest(
   htmlRequestId: string,
   errorsRscStream: AnyStream
 ) {
-  // TODO: Clean up after a timeout, in case the client never connects, e.g.
-  // when CURL'ing the page, or loading the page with JavaScript disabled etc.
   errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
+
+  // Clean up after a timeout, in case the client never connects, e.g. when
+  // CURL'ing the page, or loading the page with JavaScript disabled etc.
+  clearCleanupTimer(htmlRequestId)
+  const timer = setTimeout(() => {
+    cleanupTimersByHtmlRequestId.delete(htmlRequestId)
+    errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
+  }, CLEANUP_AFTER_MS)
+  // The timer is only a backstop and must not keep the process alive.
+  timer.unref?.()
+  cleanupTimersByHtmlRequestId.set(htmlRequestId, timer)
 }
 
 export function deleteErrorsRscStreamForHtmlRequest(htmlRequestId: string) {
+  clearCleanupTimer(htmlRequestId)
   errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
 }


### PR DESCRIPTION
## What?

Deletes stored dev errors RSC streams after a **10-minute** timeout when the HMR client never connects to consume them, instead of retaining them for the lifetime of the dev server.

## Why?

Every HTML render in dev stores its errors RSC stream keyed by `htmlRequestId` in the module-scope `errorsRscStreamsByHtmlRequestId` map, so the stream can be sent once the HMR client connects (`sendSerializedErrorsToClientForHtmlRequest`). That was the **only** deletion path: any render whose client never connects — curl, disabled JavaScript, bots, or a tab closed before the websocket upgrade — left the stream, and the RSC payload buffered in it, alive forever. The module already carried a TODO for exactly this cleanup, and `deleteErrorsRscStreamForHtmlRequest` existed with no callers.

Over a long dev session this grows the dev server's retained memory per such page view — the same family of unbounded per-request accumulation behind the dev-memory complaints in #54708.

## How?

- `setErrorsRscStreamForHtmlRequest` now arms an `unref()`'ed cleanup timer per entry (re-armed if the same id is stored again).
- Consumption (`sendSerializedErrorsToClientForHtmlRequest`) and deletion (`deleteErrorsRscStreamForHtmlRequest`) cancel the timer.
- The window is **10 minutes**: it must comfortably cover legitimate HMR startups — a large cold dev build, a throttled network, or a paused debugger can take minutes before the client opens the socket — while still bounding the never-connect case, which today is infinite. (Reviewer feedback raised this from 60s.)
- The timer is only a backstop: normal flows are unchanged, and it never keeps the process alive.

## Tests

Unit tests in `packages/next/src/server/dev/serialized-errors.test.ts` (`pnpm jest packages/next/src/server/dev/serialized-errors.test.ts`): consumption before the timeout, abandonment cleanup, explicit deletion, and timer replacement. **Without the fix, the abandonment test fails** — the stream is retained forever; with it, 4/4 pass. `pnpm --filter=next build` clean; Prettier/ESLint clean.