### PR TITLE
fix(next-custom-transforms): keep require bindings used in computed member props

### DIFF
--- a/crates/next-custom-transforms/src/transforms/cjs_optimizer.rs
+++ b/crates/next-custom-transforms/src/transforms/cjs_optimizer.rs
@@ -277,9 +277,25 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_member_expr(&mut self, e: &MemberExpr) {
-        self.in_member_or_var = true;
-        e.visit_children_with(self);
-        self.in_member_or_var = false;
+        // Only a plain identifier in the object position of a member
+        // expression can be rewritten by the main pass (`server.Response`), so
+        // it is not force-kept here. Everything else — including computed
+        // props and any nested expressions — is never rewritten and must keep
+        // its bindings, so it is visited with the flag cleared. Setting the
+        // flag for the whole subtree would leak it into computed props (e.g.
+        // `handlers[server]`), dropping bindings whose uses remain.
+        if e.obj.is_ident() {
+            self.in_member_or_var = true;
+            e.obj.visit_with(self);
+            self.in_member_or_var = false;
+        } else {
+            e.obj.visit_with(self);
+        }
+
+        // Non-computed props are property names, not bindings — skip them.
+        if let MemberProp::Computed(computed) = &e.prop {
+            computed.visit_with(self);
+        }
 
         if let (Expr::Ident(obj), MemberProp::Computed(..)) = (&*e.obj, &e.prop) {
             self.data.ignored.insert(obj.to_id());

--- a/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-call-arg/input.js
+++ b/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-call-arg/input.js
@@ -1,0 +1,3 @@
+const server = require('next/server')
+
+console.log(Object.keys(server).length)

--- a/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-call-arg/output.js
+++ b/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-call-arg/output.js
@@ -1,0 +1,2 @@
+const server = require('next/server');
+console.log(Object.keys(server).length);

--- a/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed-nested/input.js
+++ b/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed-nested/input.js
@@ -1,0 +1,3 @@
+const server = require('next/server')
+
+const h = x[server].y

--- a/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed-nested/output.js
+++ b/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed-nested/output.js
@@ -1,0 +1,2 @@
+const server = require('next/server');
+const h = x[server].y;

--- a/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed/input.js
+++ b/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed/input.js
@@ -1,0 +1,3 @@
+const server = require('next/server')
+
+const h = handlers[server]

--- a/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed/output.js
+++ b/crates/next-custom-transforms/tests/fixture/cjs-optimize/not-processed-computed/output.js
@@ -1,0 +1,2 @@
+const server = require('next/server');
+const h = handlers[server];


### PR DESCRIPTION
## What

The CJS optimizer (`cjs_optimizer.rs`, configured internally with `next/server`) rewrites whitelisted member uses (`server.Response` → `require("next/server/response").Response`) and drops the original `const x = require(...)` declarator when the binding is not in `State::ignored`.

`ignored` is populated by an Analyzer prepass that only marks identifiers visited with `in_member_or_var == false`, plus a main pass that marks member-object identifiers whose prop wasn't rewritten. **Analyzer::visit_member_expr set the flag for the entire member-expression subtree**, so an identifier inside a **computed prop** was never marked — and the main pass only handles `MemberProp::Ident`, never computed props. As a result:

```js
const server = require('next/server')
const h = handlers[server]
```

compiled to:

```js
;
const h = handlers[server];
```

— the binding was deleted while the use survived, producing `ReferenceError: server is not defined` at runtime. Verified with fixture repros before the fix (same for the nested `x[server].y` shape).

## Fix

In `Analyzer::visit_member_expr`:

- set `in_member_or_var` only around a **plain-identifier object position** — the only position the main pass can rewrite,
- visit **computed props with the flag cleared** (they're real expressions with bindings),
- **skip non-computed props** entirely (property names are not bindings).

The intended-rewrite fixtures (1/2/3 — whitelisted `server.Response` rewrites that correctly drop the require) are unaffected, as is the existing `Object.keys(server).length` behavior (already safe: the nested member expression resets the flag for the call arguments — kept as a guard fixture).

## Tests

Three new fixtures: `not-processed-computed` and `not-processed-computed-nested` (both miscompiled before this fix, binding now kept), and `not-processed-call-arg` (guard). All 309 cjs-optimize/named-import fixture tests + the full `next-custom-transforms` suite pass; `cargo clippy`/`fmt` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.