### PR TITLE
fix(build): share one proxy install between concurrent turborepo access traces

### DIFF
--- a/packages/next/src/build/turborepo-access-trace/helpers.test.ts
+++ b/packages/next/src/build/turborepo-access-trace/helpers.test.ts
@@ -1,0 +1,76 @@
+import net from 'net'
+import { turborepoTraceAccess } from './helpers'
+import { TurborepoAccessTraceResult } from './result'
+
+describe('turborepoTraceAccess', () => {
+  const TRACE_FILE = process.env.TURBOREPO_TRACE_FILE
+
+  beforeEach(() => {
+    process.env.TURBOREPO_TRACE_FILE = '/tmp/next-test-trace.json'
+  })
+
+  afterEach(() => {
+    if (TRACE_FILE === undefined) {
+      delete process.env.TURBOREPO_TRACE_FILE
+    } else {
+      process.env.TURBOREPO_TRACE_FILE = TRACE_FILE
+    }
+  })
+
+  it('does not trace when TURBOREPO_TRACE_FILE is not set', async () => {
+    delete process.env.TURBOREPO_TRACE_FILE
+    const parent = new TurborepoAccessTraceResult()
+    const result = await turborepoTraceAccess(async () => {
+      const read = process.env.SOME_UNTRACKED_VAR
+      expect(read).toBeUndefined()
+      return 42
+    }, parent)
+    expect(result).toBe(42)
+    expect(parent.toPublicTrace().envVarKeys).toEqual([])
+  })
+
+  it('records accesses from overlapping traces and fully restores globals', async () => {
+    const originalEnv = process.env
+    const originalConnect = net.Socket.prototype.connect
+
+    const parent1 = new TurborepoAccessTraceResult()
+    const parent2 = new TurborepoAccessTraceResult()
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+
+    // First trace starts and completes while the second is still running.
+    const trace1 = turborepoTraceAccess(async () => {
+      const read = process.env.DEEPSEC_TEST_VAR_1
+      expect(read).toBeUndefined()
+    }, parent1)
+
+    const trace2 = turborepoTraceAccess(async () => {
+      const read2 = process.env.DEEPSEC_TEST_VAR_2
+      expect(read2).toBeUndefined()
+      // Hold this trace open until trace1 has fully completed (including its
+      // proxy restore).
+      await gate
+      // Read after trace1 finished: previously this read was invisible
+      // because trace1's restore removed this trace's instrumentation.
+      const read3 = process.env.DEEPSEC_TEST_VAR_3
+      expect(read3).toBeUndefined()
+    }, parent2)
+
+    await trace1
+    release()
+    await trace2
+
+    // Globals must be fully restored — no stale proxy left installed.
+    expect(process.env).toBe(originalEnv)
+    expect(net.Socket.prototype.connect).toBe(originalConnect)
+
+    const merged = new TurborepoAccessTraceResult()
+    merged.merge(parent1)
+    merged.merge(parent2)
+    const { envVarKeys } = merged.toPublicTrace()
+    expect(envVarKeys).toContain('DEEPSEC_TEST_VAR_1')
+    expect(envVarKeys).toContain('DEEPSEC_TEST_VAR_2')
+    expect(envVarKeys).toContain('DEEPSEC_TEST_VAR_3')
+  })
+})

--- a/packages/next/src/build/turborepo-access-trace/helpers.ts
+++ b/packages/next/src/build/turborepo-access-trace/helpers.ts
@@ -1,6 +1,11 @@
 import fs from 'fs/promises'
 import path from 'path'
-import type { FS, Addresses, EnvVars } from './types'
+import type {
+  FS,
+  Addresses,
+  EnvVars,
+  RestoreOriginalFunction,
+} from './types'
 import { envProxy } from './env'
 import { tcpProxy } from './tcp'
 import { TurborepoAccessTraceResult } from './result'
@@ -74,18 +79,38 @@ export async function writeTurborepoAccessTraceResult({
   }
 }
 
+// Access is traced through process-global proxies (process.env and
+// net.Socket.prototype.connect), so overlapping traces must share a single
+// set of proxies. Installing and restoring them per invocation is racy:
+// restores happen in completion order rather than LIFO, so an earlier
+// restore removes a still-active trace's instrumentation (silently dropping
+// its accesses) and a later restore reinstalls a stale proxy for the rest of
+// the process lifetime. Since every consumer ultimately merges all traces
+// into a single union (writeTurborepoAccessTraceResult), sharing one install
+// between concurrent traces yields the same final result without the race.
+let activeTraceCount = 0
+let sharedEnvVars: EnvVars | null = null
+let sharedAddresses: Addresses | null = null
+let sharedFsPaths: FS | null = null
+let restoreProxies: RestoreOriginalFunction[] = []
+
 async function withTurborepoTraceAccess<T>(
   f: () => T | Promise<T>
 ): Promise<[T, TurborepoAccessTraceResult]> {
-  const envVars: EnvVars = new Set([])
-  // addresses is an array of objects, so a set is useless
-  const addresses: Addresses = []
-  // TODO: watch fsPaths (removed from this implementation for now)
-  const fsPaths: FS = new Set<string>()
+  if (activeTraceCount === 0) {
+    // First trace installs the proxies; nested/concurrent traces share them.
+    sharedEnvVars = new Set([])
+    sharedAddresses = []
+    sharedFsPaths = new Set<string>()
+    restoreProxies = [tcpProxy(sharedAddresses), envProxy(sharedEnvVars)]
+  }
+  activeTraceCount++
 
-  // setup proxies
-  const restoreTCP = tcpProxy(addresses)
-  const restoreEnv = envProxy(envVars)
+  // Non-null by construction: a trace is active (count > 0) exactly while
+  // the shared proxies are installed.
+  const envVars = sharedEnvVars!
+  const addresses = sharedAddresses!
+  const fsPaths = sharedFsPaths!
 
   let functionResult
 
@@ -94,9 +119,20 @@ async function withTurborepoTraceAccess<T>(
     // call the wrapped function
     functionResult = await f()
   } finally {
-    // remove proxies
-    restoreTCP()
-    restoreEnv()
+    // The last concurrent trace to finish removes the proxies. The
+    // count/check/restore sequence is synchronous, so it can't interleave
+    // with another trace installing or restoring.
+    activeTraceCount--
+    if (activeTraceCount === 0) {
+      const restore = restoreProxies
+      restoreProxies = []
+      sharedEnvVars = null
+      sharedAddresses = null
+      sharedFsPaths = null
+      for (const r of restore) {
+        r()
+      }
+    }
   }
 
   const traceResult = new TurborepoAccessTraceResult(


### PR DESCRIPTION
## What

`withTurborepoTraceAccess` installs two process-global patches — a `process.env` `Proxy` and a `net.Socket.prototype.connect` wrapper — and removes them in a `finally` block. This is only safe if traces never overlap, but they do: `exportPages()` runs up to `staticGenerationMaxConcurrency` (default 8) page exports concurrently via `Promise.all` in the same worker process, each wrapped in its own trace.

Restores happen in **completion order, not LIFO**:

1. The first-installed trace to finish removes a **still-active** trace's instrumentation — every env var read / socket opened by the still-running trace after that point is invisible. The resulting under-reported `envVarKeys` is exactly the condition this module warns can cause **incorrect turborepo cache hits** (e.g. stale inlined `NEXT_PUBLIC_*` values in client bundles).
2. The later trace then restores **its** captured "originals" — which are the first trace's wrapper/Proxy — reinstalling a stale global patch for the rest of the process lifetime (a dead Proxy that keeps recording into abandoned sets — unbounded growth — and cross-attributing accesses between traces).

## Fix

Every consumer ultimately merges **all** traces into a single union (`writeTurborepoAccessTraceResult`), so per-installation isolation is unnecessary. Concurrent traces now **share one proxy install**: the first trace installs, the last to finish restores, and all of them record into the same collections. The count/check/restore sequence contains no `await`, so installs and restores can't interleave. The final merged trace is identical to a race-free per-page implementation — `serialize()` snapshots arrays at each page's completion and `merge()` copies into fresh sets.

## Tests

New `helpers.test.ts` drives two overlapping traces where the first-installed trace completes first (the failing interleaving), asserting:

- a read made by the still-open trace **after** the other completed is recorded (previously invisible),
- `process.env` and `net.Socket.prototype.connect` are pristine afterwards (previously left as a stale proxy/wrapper — verified: this test fails on the old code with `Received: serializes to the same string`),
- tracing stays disabled without `TURBOREPO_TRACE_FILE`.

`jest`, `tsc`, and `eslint` all pass.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.