### PR TITLE
fix(css-loader): don't spread the 'needQuotes: true' string into URL import options

### DIFF
--- a/packages/next/src/build/webpack/loaders/css-loader/src/utils.test.ts
+++ b/packages/next/src/build/webpack/loaders/css-loader/src/utils.test.ts
@@ -1,0 +1,67 @@
+import { getModuleCode } from './utils'
+
+describe('css-loader getModuleCode', () => {
+  it('emits valid JS options for url() replacements needing quotes (image-set string args)', () => {
+    // `image-set("a.png" 1x)` produces a replacement item with
+    // `needQuotes: true` and no localName. The emitted getUrl options must be
+    // a single `needQuotes: true` entry — spreading the string would emit one
+    // entry per character and produce unparsable module code.
+    const code = getModuleCode(
+      { map: null, css: 'body { background: image-set("a.png" 1x) }' },
+      [],
+      [
+        {
+          replacementName: '___CSS_LOADER_URL_REPLACEMENT_0___',
+          importName: '___CSS_LOADER_URL_IMPORT_0___',
+          localName: undefined,
+          hash: undefined,
+          needQuotes: true,
+        },
+      ],
+      {
+        modules: { exportOnlyLocals: false, namedExport: true },
+        sourceMap: false,
+      },
+      {}
+    )
+
+    expect(code).toContain(
+      '___CSS_LOADER_GET_URL_IMPORT___(___CSS_LOADER_URL_IMPORT_0___, { needQuotes: true })'
+    )
+
+    // The emitted module code must be syntactically valid JavaScript.
+    expect(() => {
+      // eslint-disable-next-line no-new-func -- used as a syntax-only parse check
+      new Function('module', code)
+    }).not.toThrow()
+  })
+
+  it('emits hash and needQuotes together as valid options', () => {
+    const code = getModuleCode(
+      { map: null, css: '.a { content: url(a.png) }' },
+      [],
+      [
+        {
+          replacementName: '___CSS_LOADER_URL_REPLACEMENT_0___',
+          importName: '___CSS_LOADER_URL_IMPORT_0___',
+          localName: undefined,
+          hash: 'abc123',
+          needQuotes: true,
+        },
+      ],
+      {
+        modules: { exportOnlyLocals: false, namedExport: true },
+        sourceMap: false,
+      },
+      {}
+    )
+
+    expect(code).toContain(
+      '{ hash: "abc123", needQuotes: true }'
+    )
+    expect(() => {
+      // eslint-disable-next-line no-new-func -- used as a syntax-only parse check
+      new Function('module', code)
+    }).not.toThrow()
+  })
+})

--- a/packages/next/src/build/webpack/loaders/css-loader/src/utils.ts
+++ b/packages/next/src/build/webpack/loaders/css-loader/src/utils.ts
@@ -361,7 +361,7 @@ function getModuleCode(
       const { hash, needQuotes } = item
       const getUrlOptions = [
         ...(hash ? [`hash: ${JSON.stringify(hash)}`] : []),
-        ...(needQuotes ? 'needQuotes: true' : []),
+        ...(needQuotes ? ['needQuotes: true'] : []),
       ]
       const preparedOptions =
         getUrlOptions.length > 0 ? `, { ${getUrlOptions.join(', ')} }` : ''

--- a/packages/next/src/build/webpack/loaders/lightningcss-loader/src/codegen.ts
+++ b/packages/next/src/build/webpack/loaders/lightningcss-loader/src/codegen.ts
@@ -105,7 +105,7 @@ export function getModuleCode(
       const { hash, needQuotes } = item
       const getUrlOptions = [
         ...(hash ? [`hash: ${JSON.stringify(hash)}`] : []),
-        ...(needQuotes ? 'needQuotes: true' : []),
+        ...(needQuotes ? ['needQuotes: true'] : []),
       ]
       const preparedOptions =
         getUrlOptions.length > 0 ? `, { ${getUrlOptions.join(', ')} }` : ''


### PR DESCRIPTION
## What

`getModuleCode` (vendored css-loader, packages/next/src/build/webpack/loaders/css-loader/src/utils.ts) builds the `getUrl` options array as:

```js
const getUrlOptions = [
  ...(hash ? [`hash: ${JSON.stringify(hash)}`] : []),
  ...(needQuotes ? 'needQuotes: true' : []),
]
```

The second spread **iterates the string's characters**, so with `needQuotes` set the emitted options become 16 single-character entries:

```
, { n, e, e, d, Q, u, o, t, e, s, :,  , t, r, u, e }
```

— a JavaScript syntax error (`Unexpected token ':'`, verified with Node) that makes webpack fail parsing the generated CSS module.

Reachability: `postcss-url-parser` sets `needQuotes: true` for string arguments inside `image-set()`/`-webkit-image-set()`, so ordinary valid CSS like

```css
background-image: image-set("a.png" 1x, "a2x.png" 2x);
```

breaks the build. Upstream css-loader used `[].concat(needQuotes ? "needQuotes: true" : [])`, which appends the string as a single element.

## Fix

Wrap the value in an array so a single element is added: `...(needQuotes ? ['needQuotes: true'] : [])`.

The identical mistake existed in `lightningcss-loader/src/codegen.ts` (currently masked only because its loader hardcodes `needQuotes = false`) — fixed for consistency. As a bonus, `needQuotes` now actually reaches `runtime/getUrl.ts`, which reads `options.needQuotes` to wrap the URL in quotes.

## Tests

New `utils.test.ts` drives `getModuleCode` with `needQuotes: true` (the image-set string-arg shape) and with `hash + needQuotes`, asserting the emitted options are exactly `{ needQuotes: true }` / `{ hash: "abc123", needQuotes: true }` and that the full generated module code parses as JavaScript. Both tests fail before this fix and pass after; `jest`/`tsc`/`eslint` green.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
