### PR TITLE
[ci] Reset the turbopack deploy test project in the weekly cron

### DIFF
--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -12,6 +12,9 @@ env:
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
   VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
   VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
+  VERCEL_TURBOPACK_TEST_TEAM: vtest314-next-turbo-e2e-tests
+  VERCEL_TURBOPACK_TEST_TOKEN: ${{ secrets.VERCEL_TURBOPACK_TEST_TOKEN }}
+  # Unrelated to the teams above: this is the Turborepo remote cache team.
   TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.

--- a/bench/vercel/project-utils.js
+++ b/bench/vercel/project-utils.js
@@ -38,6 +38,7 @@ export async function generateProjects() {
                 task: async () => {
                   await resetProject({
                     teamId: TEST_TEAM_NAME,
+                    token: TEST_TOKEN,
                     projectName: ORIGIN_PROJECT_NAME,
                     disableDeploymentProtection: true,
                   })
@@ -79,6 +80,7 @@ export async function generateProjects() {
                 task: async () => {
                   await resetProject({
                     teamId: TEST_TEAM_NAME,
+                    token: TEST_TOKEN,
                     projectName: HEAD_PROJECT_NAME,
                     disableDeploymentProtection: true,
                   })

--- a/scripts/reset-project.mjs
+++ b/scripts/reset-project.mjs
@@ -11,6 +11,17 @@ export const TURBOPACK_TEST_TEAM_NAME = process.env.VERCEL_TURBOPACK_TEST_TEAM
 export const TURBOPACK_TEST_TOKEN = process.env.VERCEL_TURBOPACK_TEST_TOKEN
 
 /**
+ * Whether a value read from the environment carries no usable value. An unset
+ * variable reads as `undefined`, while one set to an empty value reads as `''`;
+ * neither can identify a team or authenticate against one.
+ * @param {string | null | undefined} value
+ * @returns {boolean}
+ */
+function isAbsent(value) {
+  return value === undefined || value === null || value === ''
+}
+
+/**
  * Retry a fetch request with exponential backoff
  * @param {string} url - The URL to fetch
  * @param {object} options - Fetch options
@@ -59,11 +70,25 @@ async function fetchWithRetry(
 }
 
 export async function resetProject({
-  teamId = TEST_TEAM_NAME,
-  projectName = TEST_PROJECT_NAME,
-  token = TEST_TOKEN,
+  teamId,
+  projectName,
+  token,
   disableDeploymentProtection = true,
 }) {
+  // `teamId`, `projectName` and `token` together decide which project gets
+  // deleted and recreated, so all three are deliberately required. Defaulting
+  // any of them meant a caller passing an unset value silently destroyed some
+  // other project instead of the one it meant to reset.
+  if (isAbsent(teamId)) {
+    throw new Error('resetProject requires a teamId.')
+  }
+  if (isAbsent(projectName)) {
+    throw new Error(`resetProject requires a projectName for team ${teamId}.`)
+  }
+  if (isAbsent(token)) {
+    throw new Error(`resetProject requires a token for team ${teamId}.`)
+  }
+
   console.log(`Resetting project ${teamId}/${projectName}`)
   // TODO: error/bail if existing deployments are pending
   await fetchWithRetry(

--- a/scripts/run-e2e-test-project-reset.mjs
+++ b/scripts/run-e2e-test-project-reset.mjs
@@ -9,14 +9,40 @@ import {
   TEST_TOKEN,
 } from './reset-project.mjs'
 
+/**
+ * Every team hosting a `TEST_PROJECT_NAME` project that deploy tests deploy
+ * into. Each entry records the environment variables it was read from, so that
+ * a failure can point at the variables to check rather than just reporting that
+ * some team could not be reset.
+ */
+const TEST_TEAMS = [
+  {
+    teamEnvVar: 'VERCEL_TEST_TEAM',
+    teamId: TEST_TEAM_NAME,
+    tokenEnvVar: 'VERCEL_TEST_TOKEN',
+    token: TEST_TOKEN,
+  },
+  {
+    teamEnvVar: 'VERCEL_ADAPTER_TEST_TEAM',
+    teamId: ADAPTER_TEST_TEAM_NAME,
+    tokenEnvVar: 'VERCEL_ADAPTER_TEST_TOKEN',
+    token: ADAPTER_TEST_TOKEN,
+  },
+  {
+    teamEnvVar: 'VERCEL_TURBOPACK_TEST_TEAM',
+    teamId: TURBOPACK_TEST_TEAM_NAME,
+    tokenEnvVar: 'VERCEL_TURBOPACK_TEST_TOKEN',
+    token: TURBOPACK_TEST_TOKEN,
+  },
+]
+
 async function main() {
   let hadFailure = false
 
-  for (const { teamId, token } of [
-    { teamId: TEST_TEAM_NAME, token: TEST_TOKEN },
-    { teamId: ADAPTER_TEST_TEAM_NAME, token: ADAPTER_TEST_TOKEN },
-    { teamId: TURBOPACK_TEST_TEAM_NAME, token: TURBOPACK_TEST_TOKEN },
-  ]) {
+  // Keep going after a failure so that one misconfigured or unreachable team
+  // does not stop the others from being reset. `resetProject` rejects an absent
+  // teamId or token itself, so this only has to say which variables to check.
+  for (const { teamEnvVar, teamId, tokenEnvVar, token } of TEST_TEAMS) {
     try {
       await resetProject({
         projectName: TEST_PROJECT_NAME,
@@ -25,7 +51,12 @@ async function main() {
         disableDeploymentProtection: true,
       })
     } catch (err) {
-      console.error(err)
+      console.error(
+        new Error(
+          `Failed to reset the ${TEST_PROJECT_NAME} project for ${teamEnvVar}. Verify that ${teamEnvVar} and ${tokenEnvVar} are set correctly.`,
+          { cause: err }
+        )
+      )
       hadFailure = true
     }
   }


### PR DESCRIPTION

The weekly `test-e2e-project-reset-cron` workflow never defined `VERCEL_TURBOPACK_TEST_TEAM` or `VERCEL_TURBOPACK_TEST_TOKEN`, even though `run-e2e-test-project-reset.mjs` iterates over all three deploy test teams. Because `resetProject` defaulted `teamId` and `token` to the base team, and a destructuring default fires on an explicit `undefined`, the turbopack iteration silently resolved to `vtest314-next-e2e-tests`.

The cron has therefore been deleting and recreating the base team's project twice per run while never resetting the turbopack team's project, and reporting success throughout. This dates back to #89458, which wired the env pair into `build_reusable.yml` and `test_e2e_deploy_release.yml` but missed the cron.

This drops the defaults in favor of explicitly passing the team.
