### PR TITLE
Fix fallback notFound navigation with middleware

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -2093,7 +2093,7 @@ export default class Router implements BaseRouter {
       const isBackground = isQueryUpdating
       const fetchNextDataParams: FetchNextDataParams = {
         dataHref: this.pageLoader.getDataHref({
-          href: formatWithValidation({ pathname, query }),
+          href: isNotFound ? '/404' : formatWithValidation({ pathname, query }),
           skipInterpolation: true,
           asPath: isNotFound ? '/404' : resolvedAs,
           locale,
@@ -2113,7 +2113,7 @@ export default class Router implements BaseRouter {
         | (Pick<WithMiddlewareEffectsOutput, 'json'> &
             Omit<Partial<WithMiddlewareEffectsOutput>, 'json'>)
         | null =
-        isQueryUpdating && !isMiddlewareRewrite
+        isNotFound || (isQueryUpdating && !isMiddlewareRewrite)
           ? null
           : await withMiddlewareEffects({
               fetchData: () => fetchNextData(fetchNextDataParams),
@@ -2231,8 +2231,10 @@ export default class Router implements BaseRouter {
           const dataHref = data?.dataHref
             ? data.dataHref
             : this.pageLoader.getDataHref({
-                href: formatWithValidation({ pathname, query }),
-                asPath: resolvedAs,
+                href: isNotFound
+                  ? '/404'
+                  : formatWithValidation({ pathname, query }),
+                asPath: isNotFound ? '/404' : resolvedAs,
                 locale,
               })
 

--- a/test/e2e/middleware-rewrites/app/pages/fallback-true-blog/[slug].js
+++ b/test/e2e/middleware-rewrites/app/pages/fallback-true-blog/[slug].js
@@ -39,6 +39,10 @@ export function getStaticPaths() {
 }
 
 export function getStaticProps({ params }) {
+  if (params.slug === 'not-found') {
+    return { notFound: true }
+  }
+
   return {
     props: {
       params,

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -237,6 +237,20 @@ describe('Middleware Rewrite', () => {
       expect(await browser.eval('window.beforeNav')).not.toBe(1)
     })
 
+    it('should render the 404 page when fallback getStaticProps returns notFound', async () => {
+      const browser = await next.browser('/')
+      await browser.eval(`next.router.push('/fallback-true-blog/not-found')`)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain(
+          'custom 404 page'
+        )
+      })
+      expect(await browser.eval('location.pathname')).toBe(
+        '/fallback-true-blog/not-found'
+      )
+    })
+
     // TODO: middleware effect headers aren't available here
     it.skip('includes the locale in rewrites by default', async () => {
       const res = await fetchViaHTTP(next.url, `/rewrite-me-to-about`)


### PR DESCRIPTION
### What?

- Skip middleware data fetching when the Pages Router switches a client transition to the 404 page after `getStaticProps` returns `notFound`.
- Generate internal data URLs from `/404` for static 404 pages while preserving the requested URL and router query.
- Add an end-to-end regression test for a `fallback: true` dynamic route with active middleware.

### Why?

For a fallback SSG route, a client navigation can receive the expected `notFound` data response and then transition internally to the custom 404 page. With middleware enabled, the router performed another middleware-aware data request for that error route. Since a static custom 404 response has HTTP status 404 by design, the data loader treated it as a fatal `Failed to load static props` error instead of rendering the page.

Fixes #74276.

### How?

Treat the internal `isNotFound` transition as an already-resolved error route and bypass the extra middleware-effects request. If the custom 404 page itself needs static data, its normal data fetch and background revalidation now use `/404` rather than the original dynamic route and query.

### Verification

- `pnpm test-dev-turbo test/e2e/middleware-rewrites/test/index.test.ts -t 'should render the 404 page when fallback getStaticProps returns notFound'`
- `pnpm test-dev-webpack test/e2e/middleware-rewrites/test/index.test.ts -t 'should render the 404 page when fallback getStaticProps returns notFound'`
- `pnpm test-start-turbo test/e2e/middleware-rewrites/test/index.test.ts -t 'should render the 404 page when fallback getStaticProps returns notFound'`
- `pnpm --filter=next build`
- Prettier and ESLint passed for all changed files, including the commit hook checks.

The regression test failed before the fix with a second `/404.json?slug=not-found` request and `Failed to load static props`; it passes after the fix without the extra 404 data request.

### Risk and rollout

- Risk: Low and scoped to Pages Router client transitions that have already resolved to `notFound`. The requested browser URL and router query remain unchanged.
- Rollback: Revert this commit to restore the previous middleware-effects request.

### Notes for reviewers

- Duplicate audit covered open, closed, and merged PRs plus open and closed issues using `#74276`, `Failed to load static props` + middleware, `404.json` + `getStaticProps` + middleware, and `notFound` + `fallback: true` + middleware.
- No PR currently references or implements #74276. The older #42305 reports the same symptom but was stale-closed without a linked fix; the PR search result #42589 is unrelated to this behavior.

<!-- NEXT_JS_LLM_PR -->
