### PR TITLE
Trace route matching and compilation phases

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -70,6 +70,11 @@ import {
 } from '../lib/router-utils/setup-dev-bundler'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
+import {
+  traceCompileRoutePhase,
+  traceCompileRouteResolution,
+} from './route-compilation-tracing'
+import { DevBundlerServiceSpan } from '../lib/trace/constants'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import {
   type EntryKey,
@@ -1811,7 +1816,11 @@ export async function createHotReloaderTurbopack(
             return
           }
 
-          await currentEntriesHandling
+          await traceCompileRoutePhase(
+            DevBundlerServiceSpan.waitForEntrypoints,
+            'wait for route entrypoints',
+            () => currentEntriesHandling
+          )
 
           // TODO We shouldn't look into the filesystem again. This should use the information from entrypoints
           let routeDef: Pick<
@@ -1819,13 +1828,15 @@ export async function createHotReloaderTurbopack(
             'filename' | 'bundlePath' | 'page'
           > =
             definition ??
-            (await findPagePathData(
-              projectPath,
-              inputPage,
-              nextConfig.pageExtensions,
-              opts.pagesDir,
-              opts.appDir,
-              !!nextConfig.experimental.globalNotFound
+            (await traceCompileRouteResolution(() =>
+              findPagePathData(
+                projectPath,
+                inputPage,
+                nextConfig.pageExtensions,
+                opts.pagesDir,
+                opts.appDir,
+                !!nextConfig.experimental.globalNotFound
+              )
             ))
 
           // If the route is actually an app page route, then we should have access
@@ -1866,24 +1877,29 @@ export async function createHotReloaderTurbopack(
           if (page === '/_error') {
             let finishBuilding = startBuilding(pathname, requestUrl, false)
             try {
-              await handlePagesErrorRoute({
-                currentEntryIssues,
-                entrypoints: currentEntrypoints,
-                manifestLoader,
-                devRewrites: opts.fsChecker.rewrites,
-                productionRewrites: undefined,
-                logErrors: true,
-                hooks: {
-                  subscribeToChanges: subscribeToClientChanges,
-                  handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-                    currentWrittenEntrypoints.set(id, result)
-                    assetMapper.setPathsForKey(id, result.clientPaths)
-                    return clearRequireCache(id, result, {
-                      force: forceDeleteCache,
-                    })
-                  },
-                },
-              })
+              await traceCompileRoutePhase(
+                DevBundlerServiceSpan.buildRoute,
+                'build route',
+                () =>
+                  handlePagesErrorRoute({
+                    currentEntryIssues,
+                    entrypoints: currentEntrypoints,
+                    manifestLoader,
+                    devRewrites: opts.fsChecker.rewrites,
+                    productionRewrites: undefined,
+                    logErrors: true,
+                    hooks: {
+                      subscribeToChanges: subscribeToClientChanges,
+                      handleWrittenEndpoint: (id, result, forceDeleteCache) => {
+                        currentWrittenEntrypoints.set(id, result)
+                        assetMapper.setPathsForKey(id, result.clientPaths)
+                        return clearRequireCache(id, result, {
+                          force: forceDeleteCache,
+                        })
+                      },
+                    },
+                  })
+              )
             } finally {
               finishBuilding()
             }
@@ -1928,36 +1944,41 @@ export async function createHotReloaderTurbopack(
 
           const finishBuilding = startBuilding(pathname, requestUrl, false)
           try {
-            await handleRouteType({
-              dev,
-              page,
-              pathname,
-              route,
-              currentEntryIssues,
-              entrypoints: currentEntrypoints,
-              manifestLoader,
-              readyIds,
-              devRewrites: opts.fsChecker.rewrites,
-              productionRewrites: undefined,
-              logErrors: true,
+            await traceCompileRoutePhase(
+              DevBundlerServiceSpan.buildRoute,
+              'build route',
+              () =>
+                handleRouteType({
+                  dev,
+                  page,
+                  pathname,
+                  route,
+                  currentEntryIssues,
+                  entrypoints: currentEntrypoints,
+                  manifestLoader,
+                  readyIds,
+                  devRewrites: opts.fsChecker.rewrites,
+                  productionRewrites: undefined,
+                  logErrors: true,
 
-              hooks: {
-                // Pass a no-o subscribeToChanges to skip wiring HMR subscriptions for
-                // one-shot compilations (e.g. compile_route MCP tool).
-                subscribeToChanges: subscribeToChanges
-                  ? subscribeToClientChanges
-                  : ((async () => {}) as StartChangeSubscription),
-                handleServerComponentChanges,
-                handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-                  currentWrittenEntrypoints.set(id, result)
-                  assetMapper.setPathsForKey(id, result.clientPaths)
-                  return clearRequireCache(id, result, {
-                    force: forceDeleteCache,
-                  })
-                },
-                serverFastRefresh,
-              },
-            })
+                  hooks: {
+                    // Pass a no-o subscribeToChanges to skip wiring HMR subscriptions for
+                    // one-shot compilations (e.g. compile_route MCP tool).
+                    subscribeToChanges: subscribeToChanges
+                      ? subscribeToClientChanges
+                      : ((async () => {}) as StartChangeSubscription),
+                    handleServerComponentChanges,
+                    handleWrittenEndpoint: (id, result, forceDeleteCache) => {
+                      currentWrittenEntrypoints.set(id, result)
+                      assetMapper.setPathsForKey(id, result.clientPaths)
+                      return clearRequireCache(id, result, {
+                        force: forceDeleteCache,
+                      })
+                    },
+                    serverFastRefresh,
+                  },
+                })
+            )
           } finally {
             finishBuilding()
             // Remove non-deferred entry from building set

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -48,6 +48,11 @@ import { PAGE_TYPES } from '../../lib/page-types'
 import { getNextFlightSegmentPath } from '../../client/flight-data-helpers'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
+import {
+  traceCompileRoutePhase,
+  traceCompileRouteResolution,
+} from './route-compilation-tracing'
+import { DevBundlerServiceSpan } from '../lib/trace/constants'
 
 const debug = createDebug('next:on-demand-entry-handler')
 
@@ -831,19 +836,18 @@ export function onDemandEntryHandler({
     }, stalledTime * 1000)
 
     try {
-      let route: Pick<RouteDefinition, 'filename' | 'bundlePath' | 'page'>
-      if (definition) {
-        route = definition
-      } else {
-        route = await findPagePathData(
-          rootDir,
-          page,
-          nextConfig.pageExtensions,
-          pagesDir,
-          appDir,
-          !!nextConfig.experimental.globalNotFound
-        )
-      }
+      const route: Pick<RouteDefinition, 'filename' | 'bundlePath' | 'page'> =
+        definition ??
+        (await traceCompileRouteResolution(() =>
+          findPagePathData(
+            rootDir,
+            page,
+            nextConfig.pageExtensions,
+            pagesDir,
+            appDir,
+            !!nextConfig.experimental.globalNotFound
+          )
+        ))
 
       const isInsideAppDir = !!appDir && route.filename.startsWith(appDir)
 
@@ -916,15 +920,20 @@ export function onDemandEntryHandler({
         }
       }
 
-      const staticInfo = await getStaticInfoIncludingLayouts({
-        page,
-        pageFilePath: route.filename,
-        isInsideAppDir,
-        pageExtensions: nextConfig.pageExtensions,
-        isDev: true,
-        config: nextConfig,
-        appDir,
-      })
+      const staticInfo = await traceCompileRoutePhase(
+        DevBundlerServiceSpan.analyzeRoute,
+        'analyze route',
+        () =>
+          getStaticInfoIncludingLayouts({
+            page,
+            pageFilePath: route.filename,
+            isInsideAppDir,
+            pageExtensions: nextConfig.pageExtensions,
+            isDev: true,
+            config: nextConfig,
+            appDir,
+          })
+      )
 
       const added = new Map<CompilerNameValues, ReturnType<typeof addEntry>>()
       const isServerComponent =
@@ -1020,8 +1029,14 @@ export function onDemandEntryHandler({
           })
         )
 
-        curInvalidator.invalidate([...added.keys()])
-        await invalidatePromise
+        await traceCompileRoutePhase(
+          DevBundlerServiceSpan.buildRoute,
+          'build route',
+          async () => {
+            curInvalidator.invalidate([...added.keys()])
+            await invalidatePromise
+          }
+        )
       }
     } finally {
       clearTimeout(stalledEnsureTimeout)

--- a/packages/next/src/server/dev/route-compilation-tracing.ts
+++ b/packages/next/src/server/dev/route-compilation-tracing.ts
@@ -8,17 +8,19 @@ import {
 } from '../lib/trace/phase'
 import { getTracer } from '../lib/trace/tracer'
 
-let compileRouteAsyncStorage: AsyncLocalStorage<Span> | undefined
-
-class ExpectedRouteResolutionMiss {
-  constructor(readonly error: PageNotFoundError) {}
+type CompileRouteContext = {
+  span: Span
+  expectedResolutionMisses: WeakSet<PageNotFoundError>
+  active: boolean
 }
+
+let compileRouteAsyncStorage: AsyncLocalStorage<CompileRouteContext> | undefined
 
 type CompileRouteOutcome<T> =
   | { kind: 'result'; value: T }
   | { kind: 'resolution-miss'; error: PageNotFoundError }
 
-function getCompileRouteAsyncStorage(): AsyncLocalStorage<Span> {
+function getCompileRouteAsyncStorage(): AsyncLocalStorage<CompileRouteContext> {
   if (!compileRouteAsyncStorage) {
     const { createAsyncLocalStorage } =
       require('../app-render/async-local-storage') as typeof import('../app-render/async-local-storage')
@@ -28,15 +30,23 @@ function getCompileRouteAsyncStorage(): AsyncLocalStorage<Span> {
 }
 
 async function runCompileRouteOperation<T>(
-  operation: () => Promise<T>
+  operation: () => Promise<T>,
+  compileRouteContext?: CompileRouteContext
 ): Promise<CompileRouteOutcome<T>> {
   try {
     return { kind: 'result', value: await operation() }
   } catch (error) {
-    if (error instanceof ExpectedRouteResolutionMiss) {
-      return { kind: 'resolution-miss', error: error.error }
+    if (
+      error instanceof PageNotFoundError &&
+      compileRouteContext?.expectedResolutionMisses.delete(error)
+    ) {
+      return { kind: 'resolution-miss', error }
     }
     throw error
+  } finally {
+    if (compileRouteContext) {
+      compileRouteContext.active = false
+    }
   }
 }
 
@@ -50,12 +60,20 @@ export async function traceCompileRoute<T>(
   const outcome = await getTracer().trace(
     DevBundlerServiceSpan.ensurePage,
     { spanName: 'compile route' },
-    (compileRouteSpan) =>
-      compileRouteSpan
-        ? getCompileRouteAsyncStorage().run(compileRouteSpan, () =>
-            runCompileRouteOperation(operation)
-          )
-        : runCompileRouteOperation(operation)
+    (compileRouteSpan) => {
+      if (!compileRouteSpan) {
+        return runCompileRouteOperation(operation)
+      }
+
+      const compileRouteContext: CompileRouteContext = {
+        span: compileRouteSpan,
+        expectedResolutionMisses: new WeakSet(),
+        active: true,
+      }
+      return getCompileRouteAsyncStorage().run(compileRouteContext, () =>
+        runCompileRouteOperation(operation, compileRouteContext)
+      )
+    }
   )
 
   if (outcome.kind === 'resolution-miss') {
@@ -64,23 +82,28 @@ export async function traceCompileRoute<T>(
   return outcome.value
 }
 
-function getCompileRouteParentSpan() {
+function getCompileRouteContext() {
   if (!isInternalTracingEnabled()) {
     return undefined
   }
 
-  const compileRouteSpan = compileRouteAsyncStorage?.getStore()
+  const compileRouteContext = compileRouteAsyncStorage?.getStore()
   const activeSpan = getTracer().getActiveScopeSpan()
-  if (!compileRouteSpan || !activeSpan) {
+  if (!compileRouteContext?.active || !activeSpan) {
     return undefined
   }
 
-  const compileRouteContext = compileRouteSpan.spanContext()
+  const compileRouteSpan = compileRouteContext.span
+  const compileRouteSpanContext = compileRouteSpan.spanContext()
   const activeContext = activeSpan.spanContext()
-  return compileRouteContext.traceId === activeContext.traceId &&
-    compileRouteContext.spanId === activeContext.spanId
-    ? compileRouteSpan
+  return compileRouteSpanContext.traceId === activeContext.traceId &&
+    compileRouteSpanContext.spanId === activeContext.spanId
+    ? compileRouteContext
     : undefined
+}
+
+function getCompileRouteParentSpan() {
+  return getCompileRouteContext()?.span
 }
 
 export async function traceCompileRoutePhase<T>(
@@ -102,7 +125,8 @@ export async function traceCompileRoutePhase<T>(
 export async function traceCompileRouteResolution<T>(
   operation: () => Promise<T>
 ): Promise<T> {
-  if (!getCompileRouteParentSpan()) {
+  const compileRouteContext = getCompileRouteContext()
+  if (!compileRouteContext) {
     return await operation()
   }
 
@@ -120,7 +144,10 @@ export async function traceCompileRouteResolution<T>(
     // failed child for a probe that its caller is expected to catch.
     if (error instanceof PageNotFoundError) {
       finishResolution()
-      throw new ExpectedRouteResolutionMiss(error)
+      if (compileRouteContext.active) {
+        compileRouteContext.expectedResolutionMisses.add(error)
+      }
+      throw error
     } else {
       finishResolution({ error })
       throw error

--- a/packages/next/src/server/dev/route-compilation-tracing.ts
+++ b/packages/next/src/server/dev/route-compilation-tracing.ts
@@ -1,0 +1,129 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+import type { Span } from 'next/dist/compiled/@opentelemetry/api'
+import { PageNotFoundError } from '../../shared/lib/utils'
+import { DevBundlerServiceSpan, type SpanTypes } from '../lib/trace/constants'
+import {
+  createOneShotTracePhase,
+  isInternalTracingEnabled,
+} from '../lib/trace/phase'
+import { getTracer } from '../lib/trace/tracer'
+
+let compileRouteAsyncStorage: AsyncLocalStorage<Span> | undefined
+
+class ExpectedRouteResolutionMiss {
+  constructor(readonly error: PageNotFoundError) {}
+}
+
+type CompileRouteOutcome<T> =
+  | { kind: 'result'; value: T }
+  | { kind: 'resolution-miss'; error: PageNotFoundError }
+
+function getCompileRouteAsyncStorage(): AsyncLocalStorage<Span> {
+  if (!compileRouteAsyncStorage) {
+    const { createAsyncLocalStorage } =
+      require('../app-render/async-local-storage') as typeof import('../app-render/async-local-storage')
+    compileRouteAsyncStorage = createAsyncLocalStorage()
+  }
+  return compileRouteAsyncStorage
+}
+
+async function runCompileRouteOperation<T>(
+  operation: () => Promise<T>
+): Promise<CompileRouteOutcome<T>> {
+  try {
+    return { kind: 'result', value: await operation() }
+  } catch (error) {
+    if (error instanceof ExpectedRouteResolutionMiss) {
+      return { kind: 'resolution-miss', error: error.error }
+    }
+    throw error
+  }
+}
+
+export async function traceCompileRoute<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  if (!isInternalTracingEnabled()) {
+    return await operation()
+  }
+
+  const outcome = await getTracer().trace(
+    DevBundlerServiceSpan.ensurePage,
+    { spanName: 'compile route' },
+    (compileRouteSpan) =>
+      compileRouteSpan
+        ? getCompileRouteAsyncStorage().run(compileRouteSpan, () =>
+            runCompileRouteOperation(operation)
+          )
+        : runCompileRouteOperation(operation)
+  )
+
+  if (outcome.kind === 'resolution-miss') {
+    throw outcome.error
+  }
+  return outcome.value
+}
+
+function getCompileRouteParentSpan() {
+  if (!isInternalTracingEnabled()) {
+    return undefined
+  }
+
+  const compileRouteSpan = compileRouteAsyncStorage?.getStore()
+  const activeSpan = getTracer().getActiveScopeSpan()
+  if (!compileRouteSpan || !activeSpan) {
+    return undefined
+  }
+
+  const compileRouteContext = compileRouteSpan.spanContext()
+  const activeContext = activeSpan.spanContext()
+  return compileRouteContext.traceId === activeContext.traceId &&
+    compileRouteContext.spanId === activeContext.spanId
+    ? compileRouteSpan
+    : undefined
+}
+
+export async function traceCompileRoutePhase<T>(
+  type: SpanTypes,
+  spanName: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const parentSpan = getCompileRouteParentSpan()
+
+  // These phases describe work within `compile route`. An unrelated active
+  // span or direct route probe must not become their owner.
+  if (!parentSpan) {
+    return await operation()
+  }
+
+  return await getTracer().trace(type, { spanName, parentSpan }, operation)
+}
+
+export async function traceCompileRouteResolution<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  if (!getCompileRouteParentSpan()) {
+    return await operation()
+  }
+
+  const finishResolution = createOneShotTracePhase(
+    DevBundlerServiceSpan.resolveRoute,
+    'resolve route'
+  )
+
+  try {
+    const result = await operation()
+    finishResolution()
+    return result
+  } catch (error) {
+    // Candidate-route misses are normal dev-server control flow. Do not emit a
+    // failed child for a probe that its caller is expected to catch.
+    if (error instanceof PageNotFoundError) {
+      finishResolution()
+      throw new ExpectedRouteResolutionMiss(error)
+    } else {
+      finishResolution({ error })
+      throw error
+    }
+  }
+}

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -9,9 +9,8 @@ import {
   type HmrMessageSentToBrowser,
   type NextJsHotReloaderInterface,
 } from '../dev/hot-reloader-types'
-import { DevBundlerServiceSpan } from './trace/constants'
 import { subscribeRequestInsights } from './trace/request-insights'
-import { getTracer } from './trace/tracer'
+import { traceCompileRoute } from '../dev/route-compilation-tracing'
 
 /**
  * The DevBundlerService provides an interface to perform tasks with the
@@ -63,10 +62,8 @@ export class DevBundlerService {
     definition
   ) => {
     // TODO: remove after ensure is pulled out of server
-    return await getTracer().trace(
-      DevBundlerServiceSpan.ensurePage,
-      { spanName: 'compile route' },
-      () => this.bundler.hotReloader.ensurePage(definition)
+    return await traceCompileRoute(() =>
+      this.bundler.hotReloader.ensurePage(definition)
     )
   }
 

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -61,6 +61,7 @@ enum NextNodeServerSpan {
   renderError = 'NextNodeServer.renderError',
   renderErrorToHTML = 'NextNodeServer.renderErrorToHTML',
   render404 = 'NextNodeServer.render404',
+  matchRoute = 'NextNodeServer.matchRoute',
   startResponse = 'NextNodeServer.startResponse',
 
   // nested inner span, does not require parent scope name
@@ -105,6 +106,10 @@ enum DevRouteMatcherManagerSpan {
 
 enum DevBundlerServiceSpan {
   ensurePage = 'DevBundlerService.ensurePage',
+  waitForEntrypoints = 'DevBundlerService.waitForEntrypoints',
+  resolveRoute = 'DevBundlerService.resolveRoute',
+  analyzeRoute = 'DevBundlerService.analyzeRoute',
+  buildRoute = 'DevBundlerService.buildRoute',
 }
 
 enum RouterSpan {

--- a/packages/next/src/server/lib/trace/phase.ts
+++ b/packages/next/src/server/lib/trace/phase.ts
@@ -1,17 +1,19 @@
 import type { SpanTypes } from './constants'
 import { getTracer, SpanStatusCode } from './tracer'
+import { isRequestInsightsEnabled } from './span-store'
 
 export type TracePhaseCompletion = { error: unknown }
 export type FinishTracePhase = (completion?: TracePhaseCompletion) => void
+
+export function isInternalTracingEnabled(): boolean {
+  return isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1'
+}
 
 export function createOneShotTracePhase(
   type: SpanTypes,
   spanName: string
 ): FinishTracePhase {
-  if (
-    !process.env.__NEXT_REQUEST_INSIGHTS &&
-    process.env.NEXT_OTEL_VERBOSE !== '1'
-  ) {
+  if (!isInternalTracingEnabled()) {
     return () => {}
   }
 

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -27,8 +27,10 @@ import {
 import {
   AppRenderSpan,
   BaseServerSpan,
+  DevBundlerServiceSpan,
   LoadComponentsSpan,
   NextNodeServerSpan,
+  NextVanillaSpanAllowlist,
   NodeSpan,
 } from './constants'
 import { createOneShotTracePhase } from './phase'
@@ -38,6 +40,12 @@ import {
   ReactServerResult,
   type AnyStream,
 } from '../../app-render/app-render-prerender-utils'
+import { PageNotFoundError } from '../../../shared/lib/utils'
+import {
+  traceCompileRoute,
+  traceCompileRoutePhase,
+  traceCompileRouteResolution,
+} from '../../dev/route-compilation-tracing'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
@@ -294,6 +302,140 @@ describe('local span recording', () => {
     )
   })
 
+  it('records a successful route compilation phase under its compile owner', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const result = await traceCompileRoute(() =>
+      traceCompileRoutePhase(
+        DevBundlerServiceSpan.analyzeRoute,
+        'analyze route',
+        async () => 'analyzed'
+      )
+    )
+
+    expect(result).toBe('analyzed')
+    const compileSpan = getSpanRecords({ name: 'compile route' })[0]
+    expect(getSpanRecords({ name: 'analyze route' })).toEqual([
+      expect.objectContaining({
+        parentSpanId: compileSpan.spanId,
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_type': DevBundlerServiceSpan.analyzeRoute,
+        }),
+      }),
+    ])
+  })
+
+  it('records candidate route misses as successful resolution work', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const miss = new PageNotFoundError('candidate route')
+
+    await expect(
+      traceCompileRoute(() =>
+        traceCompileRouteResolution(async () => {
+          throw miss
+        })
+      )
+    ).rejects.toBe(miss)
+
+    expect(getSpanRecords({ name: 'resolve route' })).toEqual([
+      expect.objectContaining({
+        status: 'ok',
+        error: undefined,
+        attributes: expect.objectContaining({
+          'next.span_type': DevBundlerServiceSpan.resolveRoute,
+        }),
+      }),
+    ])
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({
+        status: 'ok',
+        error: undefined,
+      }),
+    ])
+  })
+
+  it('records genuine route resolution failures as errors', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const failure = new TypeError('route analysis failed')
+
+    await expect(
+      traceCompileRoute(() =>
+        traceCompileRouteResolution(async () => {
+          throw failure
+        })
+      )
+    ).rejects.toBe(failure)
+
+    expect(getSpanRecords({ name: 'resolve route' })).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: {
+          type: 'TypeError',
+          message: 'route analysis failed',
+        },
+      }),
+    ])
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({
+        status: 'error',
+      }),
+    ])
+  })
+
+  it('keeps terminal page-not-found failures outside resolution probes failed', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const failure = new PageNotFoundError('terminal route')
+
+    await expect(
+      traceCompileRoute(async () => {
+        throw failure
+      })
+    ).rejects.toBe(failure)
+
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: {
+          type: 'PageNotFoundError',
+          message: 'Cannot find module for page: terminal route',
+        },
+      }),
+    ])
+  })
+
+  it('does not record route phases without a compile owner', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    await traceCompileRoutePhase(
+      DevBundlerServiceSpan.buildRoute,
+      'build route',
+      async () => undefined
+    )
+    await traceCompileRouteResolution(async () => undefined)
+
+    expect(getSpanRecords({ name: 'build route' })).toEqual([])
+    expect(getSpanRecords({ name: 'resolve route' })).toEqual([])
+  })
+
+  it('does not assign route phases to a different active parent', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    await traceCompileRoute(() =>
+      getTracer().trace(BaseServerSpan.render, () =>
+        traceCompileRoutePhase(
+          DevBundlerServiceSpan.buildRoute,
+          'build route',
+          async () => undefined
+        )
+      )
+    )
+
+    expect(getSpanRecords({ name: 'compile route' })).toHaveLength(1)
+    expect(getSpanRecords({ name: BaseServerSpan.render })).toHaveLength(1)
+    expect(getSpanRecords({ name: 'build route' })).toEqual([])
+  })
+
   async function createTrackedReactServerResult(
     createStream: () => AnyStream | Promise<AnyStream>
   ) {
@@ -419,6 +561,66 @@ describe('local span recording', () => {
     process.env.NEXT_OTEL_VERBOSE = '1'
     getTracer().trace(BaseServerSpan.render, () => undefined)
     expect(exportedSpans).toEqual([NodeSpan.runHandler, BaseServerSpan.render])
+  })
+
+  it('keeps route phases out of default public OTel while preserving verbose tracing', async () => {
+    const routeSpanTypes = [
+      NextNodeServerSpan.matchRoute,
+      DevBundlerServiceSpan.waitForEntrypoints,
+      DevBundlerServiceSpan.resolveRoute,
+      DevBundlerServiceSpan.analyzeRoute,
+      DevBundlerServiceSpan.buildRoute,
+    ]
+    for (const spanType of routeSpanTypes) {
+      expect(NextVanillaSpanAllowlist.has(spanType)).toBe(false)
+    }
+
+    context.disable()
+    context.setGlobalContextManager(new TestContextManager())
+    const exportedSpans: string[] = []
+    const delegateSpan = trace.wrapSpanContext({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    })
+    trace.setGlobalTracerProvider({
+      getTracer() {
+        return {
+          startSpan: () => delegateSpan,
+          startActiveSpan(...args: unknown[]) {
+            exportedSpans.push(args[0] as string)
+            const callback = args.at(-1) as (
+              span: typeof delegateSpan
+            ) => unknown
+            return context.with(
+              trace.setSpan(context.active(), delegateSpan),
+              callback,
+              undefined,
+              delegateSpan
+            )
+          },
+        }
+      },
+    })
+
+    await traceCompileRoute(() =>
+      traceCompileRoutePhase(
+        DevBundlerServiceSpan.buildRoute,
+        'build route',
+        async () => undefined
+      )
+    )
+    expect(exportedSpans).toEqual([])
+
+    process.env.NEXT_OTEL_VERBOSE = '1'
+    await traceCompileRoute(() =>
+      traceCompileRoutePhase(
+        DevBundlerServiceSpan.buildRoute,
+        'build route',
+        async () => undefined
+      )
+    )
+    expect(exportedSpans).toEqual(['compile route', 'build route'])
   })
 
   it('does not record or export hidden spans', () => {

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -41,6 +41,7 @@ import {
   type AnyStream,
 } from '../../app-render/app-render-prerender-utils'
 import { PageNotFoundError } from '../../../shared/lib/utils'
+import { Batcher } from '../../../lib/batcher'
 import {
   traceCompileRoute,
   traceCompileRoutePhase,
@@ -353,6 +354,128 @@ describe('local span recording', () => {
         error: undefined,
       }),
     ])
+  })
+
+  it('does not wrap candidate misses shared with an untraced caller', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const miss = new PageNotFoundError('shared candidate route')
+    const batcher = Batcher.create<string, void>()
+    let rejectSharedOperation!: (error: PageNotFoundError) => void
+    const sharedOperation = new Promise<void>((_, reject) => {
+      rejectSharedOperation = reject
+    })
+
+    const traced = traceCompileRoute(() =>
+      batcher.batch('candidate route', async () =>
+        traceCompileRouteResolution(() => sharedOperation)
+      )
+    )
+    const untraced = batcher.batch('candidate route', async () => {
+      throw new Error('deduplicated work unexpectedly ran twice')
+    })
+
+    rejectSharedOperation(miss)
+
+    const [tracedResult, untracedResult] = await Promise.allSettled([
+      traced,
+      untraced,
+    ])
+    expect(tracedResult.status).toBe('rejected')
+    expect(untracedResult.status).toBe('rejected')
+    if (
+      tracedResult.status !== 'rejected' ||
+      untracedResult.status !== 'rejected'
+    ) {
+      throw new Error('expected both callers to reject')
+    }
+    expect(tracedResult.reason).toBe(miss)
+    expect(untracedResult.reason).toBe(miss)
+    expect(getSpanRecords({ name: 'resolve route' })[0]).toEqual(
+      expect.objectContaining({ status: 'ok', error: undefined })
+    )
+    expect(getSpanRecords({ name: 'compile route' })[0]).toEqual(
+      expect.objectContaining({ status: 'ok', error: undefined })
+    )
+  })
+
+  it('only lets the traced work owner consume a shared candidate miss', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const miss = new PageNotFoundError('shared traced candidate route')
+    const batcher = Batcher.create<string, void>()
+    let rejectSharedOperation!: (error: PageNotFoundError) => void
+    const sharedOperation = new Promise<void>((_, reject) => {
+      rejectSharedOperation = reject
+    })
+
+    const workOwner = traceCompileRoute(() =>
+      batcher.batch('candidate route', async () =>
+        traceCompileRouteResolution(() => sharedOperation)
+      )
+    )
+    const joiningOwner = traceCompileRoute(() =>
+      batcher.batch('candidate route', async () => {
+        throw new Error('deduplicated work unexpectedly ran twice')
+      })
+    )
+
+    rejectSharedOperation(miss)
+
+    const [workOwnerResult, joiningOwnerResult] = await Promise.allSettled([
+      workOwner,
+      joiningOwner,
+    ])
+    expect(workOwnerResult.status).toBe('rejected')
+    expect(joiningOwnerResult.status).toBe('rejected')
+    if (
+      workOwnerResult.status !== 'rejected' ||
+      joiningOwnerResult.status !== 'rejected'
+    ) {
+      throw new Error('expected both callers to reject')
+    }
+    expect(workOwnerResult.reason).toBe(miss)
+    expect(joiningOwnerResult.reason).toBe(miss)
+
+    const resolutionSpan = getSpanRecords({ name: 'resolve route' })[0]
+    const compileSpans = getSpanRecords({ name: 'compile route' })
+    expect(compileSpans).toHaveLength(2)
+    expect(
+      compileSpans.find((span) => span.spanId === resolutionSpan.parentSpanId)
+    ).toEqual(expect.objectContaining({ status: 'ok', error: undefined }))
+    expect(
+      compileSpans.find((span) => span.spanId !== resolutionSpan.parentSpanId)
+    ).toEqual(expect.objectContaining({ status: 'error' }))
+  })
+
+  it('does not attach late async descendants to a completed compile owner', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    let resumeDescendant!: () => void
+    const descendantCanResume = new Promise<void>((resolve) => {
+      resumeDescendant = resolve
+    })
+    let descendant!: Promise<void>
+    let descendantRan = false
+
+    await traceCompileRoute(async () => {
+      descendant = (async () => {
+        await descendantCanResume
+        await traceCompileRoutePhase(
+          DevBundlerServiceSpan.buildRoute,
+          'late build route',
+          async () => {
+            descendantRan = true
+          }
+        )
+      })()
+    })
+
+    resumeDescendant()
+    await descendant
+
+    expect(descendantRan).toBe(true)
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({ status: 'ok' }),
+    ])
+    expect(getSpanRecords({ name: 'late build route' })).toEqual([])
   })
 
   it('records genuine route resolution failures as errors', async () => {

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -571,8 +571,9 @@ describe('local span recording', () => {
       DevBundlerServiceSpan.analyzeRoute,
       DevBundlerServiceSpan.buildRoute,
     ]
+    const vanillaSpanAllowlist = NextVanillaSpanAllowlist as ReadonlySet<string>
     for (const spanType of routeSpanTypes) {
-      expect(NextVanillaSpanAllowlist.has(spanType)).toBe(false)
+      expect(vanillaSpanAllowlist.has(spanType)).toBe(false)
     }
 
     context.disable()

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -98,6 +98,7 @@ import type { PagesAPIRouteMatch } from './route-matches/pages-api-route-match'
 import type { MatchOptions } from './route-matcher-managers/route-matcher-manager'
 import { BubbledError, getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { isInternalTracingEnabled } from './lib/trace/phase'
 import { nodeFs } from './lib/node-fs-methods'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { pipeToNodeResponse } from './pipe-readable'
@@ -1128,7 +1129,14 @@ export default class NextNodeServer extends BaseServer<
       const options: MatchOptions = {
         i18n: this.i18nProvider?.fromRequest(req, pathname),
       }
-      const match = await this.matchers.match(pathname, options)
+      const matchPathname = pathname
+      const match = isInternalTracingEnabled()
+        ? await getTracer().trace(
+            NextNodeServerSpan.matchRoute,
+            { spanName: 'match route' },
+            () => this.matchers.match(matchPathname, options)
+          )
+        : await this.matchers.match(matchPathname, options)
 
       // If we don't have a match, try to render it anyways.
       if (!match) {

--- a/test/development/app-dir/request-insights/app/route-phases-r4/page.tsx
+++ b/test/development/app-dir/request-insights/app/route-phases-r4/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>route phases</p>
+}

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -12,12 +12,16 @@ type RequestInsight = {
   kind?: 'request' | 'instant-insights'
   htmlRequestId: string
   route: string
+  url?: string
   startTime: number
   status: 'ok'
   spans: Array<{
     name?: string
     spanId?: string
     parentSpanId?: string
+    startTime?: number
+    durationMs?: number
+    status?: 'ok' | 'error'
     attributes?: Record<string, string | number | boolean>
   }>
   fetches: Array<{
@@ -30,7 +34,7 @@ type RequestInsight = {
 }
 
 describe('request insights', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
 
@@ -93,6 +97,191 @@ describe('request insights', () => {
       verbose: false,
     })
     shouldResetRequestInsightsConfig = false
+  })
+
+  describe('cold route resolution and compilation phases', () => {
+    // These spans only appear together on the first request, so both ownership
+    // assertions share one settled cold render.
+    let coldRenderRequestId: Promise<string> | undefined
+
+    function recordColdRender(): Promise<string> {
+      coldRenderRequestId ??= (async () => {
+        const existingRequestIds = new Set(
+          (
+            (await next
+              .fetch('/_next/development/request-insights')
+              .then((response) => response.json())) as {
+              requests: RequestInsight[]
+            }
+          ).requests.map((request) => request.requestId)
+        )
+
+        await next.render('/route-phases-r4')
+
+        let requestId: string
+        await retry(async () => {
+          const snapshot = (await next
+            .fetch('/_next/development/request-insights')
+            .then((response) => response.json())) as {
+            requests: RequestInsight[]
+          }
+          const request = snapshot.requests.find(
+            (candidate) =>
+              candidate.route === '/route-phases-r4' &&
+              !existingRequestIds.has(candidate.requestId)
+          )
+
+          expect(request).toBeDefined()
+          expect(request!.status).toBe('ok')
+          expect(
+            request!.spans.filter((span) => span.status === 'error')
+          ).toEqual([])
+          requestId = request!.requestId
+        })
+        return requestId!
+      })().catch((error) => {
+        coldRenderRequestId = undefined
+        throw error
+      })
+      return coldRenderRequestId
+    }
+
+    async function getColdRenderSpans(): Promise<RequestInsight['spans']> {
+      const requestId = await recordColdRender()
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) => candidate.requestId === requestId
+      )
+      expect(request).toBeDefined()
+      return request!.spans
+    }
+
+    it('records route matching with route preparation ownership', async () => {
+      await retry(async () => {
+        const spans = await getColdRenderSpans()
+        const matchSpan = spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] === 'NextNodeServer.matchRoute'
+        )
+        expect(matchSpan).toBeDefined()
+        expect(
+          spans.some(
+            (span) =>
+              span.parentSpanId === matchSpan?.spanId &&
+              span.attributes?.['next.span_type'] ===
+                'DevRouteMatcherManager.ensureRoute'
+          )
+        ).toBe(true)
+      })
+    })
+
+    it('records bundler phases inside the compile route span', async () => {
+      await retry(async () => {
+        const spans = await getColdRenderSpans()
+        const compileSpan = spans.find(
+          (candidate) =>
+            candidate.attributes?.['next.span_type'] ===
+              'DevBundlerService.ensurePage' &&
+            spans.some(
+              (child) =>
+                child.parentSpanId === candidate.spanId &&
+                child.attributes?.['next.span_type'] ===
+                  'DevBundlerService.buildRoute'
+            )
+        )
+
+        expect(compileSpan).toBeDefined()
+        const compileChildren = spans.filter(
+          (span) => span.parentSpanId === compileSpan?.spanId
+        )
+        const expectedCompilePhases = isTurbopack
+          ? [
+              'DevBundlerService.waitForEntrypoints',
+              'DevBundlerService.buildRoute',
+            ]
+          : ['DevBundlerService.analyzeRoute', 'DevBundlerService.buildRoute']
+
+        expect(
+          compileChildren.map(
+            (span) => span.attributes?.['next.span_type'] as string
+          )
+        ).toEqual(expect.arrayContaining(expectedCompilePhases))
+
+        const compileStart = compileSpan!.startTime!
+        const compileEnd = compileStart + compileSpan!.durationMs!
+        for (const child of compileChildren) {
+          expect(child.startTime).toBeGreaterThanOrEqual(compileStart - 1)
+          expect(child.startTime! + child.durationMs!).toBeLessThanOrEqual(
+            compileEnd + 1
+          )
+        }
+      })
+    })
+
+    it('records definition-less resolution for a missing route', async () => {
+      const missingRoute = '/route-phases-r4-missing'
+      const existingRequestIds = new Set(
+        (
+          (await next
+            .fetch('/_next/development/request-insights')
+            .then((response) => response.json())) as {
+            requests: RequestInsight[]
+          }
+        ).requests.map((request) => request.requestId)
+      )
+
+      const response = await next.fetch(missingRoute)
+      expect(response.status).toBe(404)
+
+      await retry(async () => {
+        const snapshot = (await next
+          .fetch('/_next/development/request-insights')
+          .then((result) => result.json())) as {
+          requests: RequestInsight[]
+        }
+        const request = snapshot.requests.find(
+          (candidate) =>
+            candidate.url === missingRoute &&
+            !existingRequestIds.has(candidate.requestId)
+        )
+        expect(request).toBeDefined()
+        expect(request!.status).toBe('ok')
+
+        const compileSpan = request!.spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] ===
+              'DevBundlerService.ensurePage' &&
+            request!.spans.some(
+              (child) =>
+                child.parentSpanId === span.spanId &&
+                child.attributes?.['next.span_type'] ===
+                  'DevBundlerService.resolveRoute'
+            )
+        )
+        const resolutionSpan = request!.spans.find(
+          (span) =>
+            span.parentSpanId === compileSpan?.spanId &&
+            span.attributes?.['next.span_type'] ===
+              'DevBundlerService.resolveRoute'
+        )
+
+        expect(compileSpan).toBeDefined()
+        expect(resolutionSpan).toBeDefined()
+        expect(resolutionSpan!.status).toBe('ok')
+        expect(resolutionSpan!.startTime).toBeGreaterThanOrEqual(
+          compileSpan!.startTime! - 1
+        )
+        expect(
+          resolutionSpan!.startTime! + resolutionSpan!.durationMs!
+        ).toBeLessThanOrEqual(
+          compileSpan!.startTime! + compileSpan!.durationMs! + 1
+        )
+      })
+    })
   })
 
   async function runWithResponse(body: unknown, args: string[] = []) {


### PR DESCRIPTION
## Summary

- record internal route matching plus Turbopack and webpack compilation phases for Request Insights
- keep expected missing-route probes successful while preserving genuine compilation failures and original errors
- keep the new spans internal by default without changing the public OpenTelemetry contract

## Verification

- pnpm --filter=next types
- pnpm --filter=next build
- focused tracer unit tests (29 passed)
- Request Insights development tests with Turbopack (3 passed)
- Request Insights development tests with webpack (3 passed)
- changed-file Prettier, ESLint, and git diff checks