### PR TITLE
feat(turbopack): defer dynamic import chunks in development

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -39,8 +39,8 @@ use next_core::{
 use tracing::{Instrument, field::Empty};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexMap, NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
-    fxindexset, trace::TraceRawVcs,
+    Completion, FxIndexMap, NonLocalValue, OperationVc, ResolvedVc, TryJoinIterExt, ValueToString,
+    Vc, fxindexset, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack::{
@@ -52,13 +52,13 @@ use turbopack_core::{
     asset::AssetContent,
     chunk::{
         ChunkGroupResult, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssets,
-        availability_info::AvailabilityInfo,
+        HmrChunkListSource, availability_info::AvailabilityInfo,
     },
     file_source::FileSource,
     ident::{AssetIdent, Layer},
     module::Module,
     module_graph::{
-        GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
+        DeferAsyncLayers, GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
         binding_usage_info::compute_binding_usage_info,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry, EntryHeuristics},
     },
@@ -90,6 +90,32 @@ use crate::{
     service_worker::service_worker_output_assets,
     sri_manifest::get_sri_manifest_asset,
 };
+
+fn new_app_single_module_graph(
+    entries: GraphEntries,
+    visited_modules: OperationVc<VisitedModules>,
+    include_traced: bool,
+    include_binding_usage: bool,
+    defer_async: bool,
+) -> OperationVc<SingleModuleGraph> {
+    if defer_async {
+        SingleModuleGraph::new_with_entries_visited_intern_defer_layers(
+            entries,
+            visited_modules,
+            include_traced,
+            include_binding_usage,
+            DeferAsyncLayers(vec![rcstr!("app-client"), rcstr!("client")]),
+        )
+    } else {
+        SingleModuleGraph::new_with_entries_visited_intern(
+            entries,
+            visited_modules,
+            include_traced,
+            include_binding_usage,
+            /* defer_async */ false,
+        )
+    }
+}
 
 #[turbo_tasks::value]
 pub struct AppProject {
@@ -890,6 +916,7 @@ impl AppProject {
             let next_mode_ref = next_mode.await?;
             let should_trace = *self.project.should_write_nft_manifests().await?;
             let should_read_binding_usage = next_mode_ref.is_production();
+            let defer_async = *self.project.defer_async_graph().await?;
 
             // Implements layout segment optimization to compute a graph "chain" for each layout
             // segment
@@ -920,7 +947,7 @@ impl AppProject {
 
                     // SEGMENT: client_shared_entries and server utils shared by the layout segments
                     // and the page
-                    let graph = SingleModuleGraph::new_with_entries_visited_intern(
+                    let graph = new_app_single_module_graph(
                         GraphEntries::from_chunk_groups(vec![
                             ChunkGroupEntry::Entry {
                                 modules: client_shared_entries,
@@ -937,6 +964,7 @@ impl AppProject {
                         visited_modules,
                         should_trace,
                         should_read_binding_usage,
+                        defer_async,
                     );
                     graphs.push(graph);
                     visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -949,13 +977,14 @@ impl AppProject {
                         .take(server_component_entries.len().saturating_sub(1))
                     {
                         // SEGMENT: layout segment
-                        let graph = SingleModuleGraph::new_with_entries_visited_intern(
+                        let graph = new_app_single_module_graph(
                             GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Shared(
                                 ResolvedVc::upcast(*module),
                             )]),
                             visited_modules,
                             should_trace,
                             should_read_binding_usage,
+                            /* defer_async */ false,
                         );
                         graphs.push(graph);
                         let is_layout = module.server_path().await?.file_stem() == Some("layout");
@@ -974,22 +1003,24 @@ impl AppProject {
                 }
 
                 // SEGMENT: rsc entry chunk group
-                let graph = SingleModuleGraph::new_with_entries_visited_intern(
+                let graph = new_app_single_module_graph(
                     GraphEntries::from_chunk_groups(vec![rsc_entry_chunk_group]),
                     visited_modules,
                     should_trace,
                     should_read_binding_usage,
+                    defer_async,
                 );
                 graphs.push(graph);
                 visited_modules = VisitedModules::concatenate(visited_modules, graph);
 
                 let base = ModuleGraph::from_graphs(graphs.clone(), None);
                 let additional_entries = endpoint.additional_entries(base.connect());
-                let additional_module_graph = SingleModuleGraph::new_with_entries_visited_intern(
+                let additional_module_graph = new_app_single_module_graph(
                     additional_entries.owned().await?,
                     visited_modules,
                     should_trace,
                     should_read_binding_usage,
+                    defer_async,
                 );
                 graphs.push(additional_module_graph);
 
@@ -1427,7 +1458,11 @@ impl AppEndpoint {
             let client_reference_chunks =
                 get_client_references_chunks_for_hmr(*client_references_chunks);
             client_chunking_context
-                .hmr_chunk_list(client_components_chunks_ident, client_reference_chunks)
+                .hmr_chunk_list(
+                    client_components_chunks_ident,
+                    client_reference_chunks,
+                    HmrChunkListSource::Entry,
+                )
                 .await?
                 .iter()
                 .copied()

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -110,6 +110,7 @@ impl Asset for ServerNftJsonAsset {
                 GraphEntries::new(vec![], self.entries().owned().await?).resolved_cell(),
                 true,
                 false,
+                /* defer_async */ false,
             )],
             None,
         )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -728,7 +728,6 @@ impl PageEndpoint {
             let next_mode_ref = next_mode.await?;
             let should_trace = *project.should_write_nft_manifests().await?;
             let should_read_binding_usage = next_mode_ref.is_production();
-
             let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
             // Implements layout segment optimization to compute a graph "chain" for document, app,
             // page
@@ -746,6 +745,7 @@ impl PageEndpoint {
                     visited_modules,
                     should_trace,
                     should_read_binding_usage,
+                    /* defer_async */ false,
                 );
                 graphs.push(graph);
                 visited_modules = VisitedModules::concatenate(visited_modules, graph);
@@ -759,6 +759,7 @@ impl PageEndpoint {
                 visited_modules,
                 should_trace,
                 should_read_binding_usage,
+                /* defer_async */ false,
             );
             graphs.push(graph);
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -909,6 +909,26 @@ impl ProjectContainer {
             FileContent::NotFound.cell()
         }
     }
+
+    /// Materializes a lazy dynamic-import boundary and returns its client-relative output paths.
+    #[turbo_tasks::function]
+    pub async fn materialize_lazy_chunk(
+        self: Vc<Self>,
+        client_path: FileSystemPath,
+    ) -> Result<Vc<Vec<RcStr>>> {
+        let Some(map) = self.await?.versioned_content_map else {
+            return Ok(Vc::cell(vec![]));
+        };
+        let project = self.project();
+        let node_root = project.node_root().owned().await?;
+        let client_relative_path = project.client_relative_path().owned().await?;
+        Ok(map.materialize_lazy_boundary(
+            client_path,
+            node_root.clone(),
+            client_relative_path,
+            node_root,
+        ))
+    }
 }
 
 #[derive(Clone)]
@@ -1233,6 +1253,21 @@ impl Project {
         Ok(Vc::cell(*self.mode.await? == NextMode::Development))
     }
 
+    /// Whether dynamic import subgraphs are deferred in development.
+    #[turbo_tasks::function]
+    pub(super) async fn defer_async_graph(self: Vc<Self>) -> Result<Vc<bool>> {
+        let this = self.await?;
+        Ok(Vc::cell(
+            *this.mode.await? == NextMode::Development
+                && *this
+                    .next_config
+                    .turbopack_lazy_dynamic_imports()
+                    .await?
+                // NFT tracing requires complete graphs.
+                && !*self.should_write_nft_manifests().await?,
+        ))
+    }
+
     #[turbo_tasks::function]
     pub(super) fn encryption_key(&self) -> Vc<RcStr> {
         Vc::cell(self.encryption_key.clone())
@@ -1489,6 +1524,7 @@ impl Project {
                     },
                     /* include_traced */ *self.should_write_nft_manifests().await?,
                     /* include_binding_usage */ self.next_mode().await?.is_production(),
+                    /* defer_async */ false,
                 )],
                 None,
             )
@@ -1519,6 +1555,7 @@ impl Project {
                     .resolved_cell(),
                     /* include_traced */ *self.should_write_nft_manifests().await?,
                     /* include_binding_usage */ self.next_mode().await?.is_production(),
+                    /* defer_async */ *self.defer_async_graph().await?,
                 )],
                 None,
             )
@@ -1629,6 +1666,7 @@ impl Project {
                 .turbo_nested_async_chunking(self.next_mode(), true),
             shared_runtime: self.next_config().turbo_shared_runtime(self.next_mode()),
             per_page_module_graph: self.per_page_module_graph(),
+            lazy_dynamic_imports: self.next_config().turbopack_lazy_dynamic_imports(),
             debug_ids: self.next_config().turbopack_debug_ids(),
             worker_asset_prefix: self.next_config().turbopack_worker_asset_prefix(),
             should_use_absolute_url_references: self.next_config().inline_css(),
@@ -1716,6 +1754,7 @@ impl Project {
             nested_async_chunking: self
                 .next_config()
                 .turbo_nested_async_chunking(self.next_mode(), false),
+            defer_async_graph: Vc::cell(false),
             debug_ids: self.next_config().turbopack_debug_ids(),
             client_root: self.client_relative_path().owned().await?,
             client_static_folder_name: self
@@ -2867,10 +2906,12 @@ async fn whole_app_module_graph_operation(
         let next_mode = project.next_mode();
         let should_trace = *project.should_write_nft_manifests().await?;
         let should_read_binding_usage = next_mode.await?.is_production();
+        let defer_async = *project.defer_async_graph().await?;
         let base_single_module_graph = SingleModuleGraph::new_with_entries(
             project.get_all_entries().to_resolved().await?,
             should_trace,
             should_read_binding_usage,
+            defer_async,
         );
         let base_visited_modules = VisitedModules::from_graph(base_single_module_graph);
 
@@ -2900,6 +2941,7 @@ async fn whole_app_module_graph_operation(
             base_visited_modules,
             should_trace,
             should_read_binding_usage,
+            defer_async,
         );
 
         if !span.is_disabled() {

--- a/crates/next-api/src/service_worker.rs
+++ b/crates/next-api/src/service_worker.rs
@@ -115,6 +115,7 @@ async fn service_worker_chunk(
             },
             /* include_traced */ *project.should_write_nft_manifests().await?,
             /* include_binding_usage */ is_production,
+            /* defer_async */ false,
         )],
         /* binding_usage */ None,
     )

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -10,7 +10,8 @@ use turbo_tasks::{
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    output::{ExpandedOutputAssets, OptionOutputAsset, OutputAsset},
+    lazy_output_asset::LazyOutputAsset,
+    output::{ExpandedOutputAssets, OptionOutputAsset, OutputAsset, OutputAssetsReference},
     source_map::GenerateSourceMap,
     version::OptionVersionedContent,
 };
@@ -289,6 +290,80 @@ impl VersionedContentMap {
         Ok(Vc::cell(None))
     }
 
+    /// Materializes the lazy boundary at `path` and returns its client-relative output paths.
+    #[turbo_tasks::function]
+    pub async fn materialize_lazy_boundary(
+        self: Vc<Self>,
+        path: FileSystemPath,
+        node_root: FileSystemPath,
+        client_relative_path: FileSystemPath,
+        client_output_path: FileSystemPath,
+    ) -> Result<Vc<Vec<RcStr>>> {
+        let result = self.raw_get(path.clone()).await?;
+        let Some(entry) = &*result else {
+            return Ok(Vc::cell(vec![]));
+        };
+        let Some(&asset) = entry.path_to_asset.get(&path) else {
+            return Ok(Vc::cell(vec![]));
+        };
+        let Some(asset) = ResolvedVc::try_downcast_type::<LazyOutputAsset>(asset) else {
+            return Ok(Vc::cell(vec![]));
+        };
+
+        LazyOutputAsset::materialize(asset).await?;
+
+        let owner_entries = {
+            let this = self.await?;
+            let owners = this
+                .map_path_to_op
+                .get()
+                .0
+                .get(&path)
+                .map(|owners| owners.0.iter().copied().collect::<Vec<_>>())
+                .unwrap_or_default();
+            let entries = this.map_op_to_compute_entry.get();
+            owners
+                .into_iter()
+                .filter_map(|owner| entries.get(&owner).copied())
+                .collect::<Vec<_>>()
+        };
+        for entry in owner_entries {
+            entry.connect().await?;
+        }
+
+        let result = self.raw_get(path.clone()).await?;
+        let Some(entry) = &*result else {
+            return Ok(Vc::cell(vec![]));
+        };
+        let Some(&asset) = entry.path_to_asset.get(&path) else {
+            return Ok(Vc::cell(vec![]));
+        };
+
+        let assets_operation = lazy_asset_references_operation(asset);
+        let compute_entry = compute_entry_operation(
+            self.to_resolved().await?,
+            assets_operation,
+            node_root,
+            client_relative_path.clone(),
+            client_output_path,
+        );
+        self.await?
+            .map_op_to_compute_entry
+            .update_conditionally(|map| {
+                map.insert(assets_operation, compute_entry) != Some(compute_entry)
+            });
+        let Some(materialized) = &*compute_entry.connect().await? else {
+            return Ok(Vc::cell(vec![]));
+        };
+        Ok(Vc::cell(
+            materialized
+                .path_to_asset
+                .keys()
+                .filter_map(|path| client_relative_path.get_path_to(path).map(RcStr::from))
+                .collect(),
+        ))
+    }
+
     #[turbo_tasks::function]
     pub async fn keys_in_path(&self, root: FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
@@ -333,6 +408,13 @@ type GetEntriesResultT = Vec<(FileSystemPath, ResolvedVc<Box<dyn OutputAsset>>)>
 
 #[turbo_tasks::value(transparent)]
 struct GetEntriesResult(GetEntriesResultT);
+
+#[turbo_tasks::function(operation, root)]
+fn lazy_asset_references_operation(
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
+) -> Vc<ExpandedOutputAssets> {
+    asset.references().expand_all_assets()
+}
 
 #[turbo_tasks::function(operation, root)]
 async fn get_entries(assets: OperationVc<ExpandedOutputAssets>) -> Result<Vc<GetEntriesResult>> {

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -12,6 +12,7 @@ use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
+    lazy_output_asset::LazyOutputAsset,
     output::{ExpandedOutputAssets, OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
 };
@@ -60,6 +61,9 @@ pub async fn emit_assets(
         .iter()
         .copied()
         .map(async |asset| {
+            if LazyOutputAsset::is_lazy(asset) {
+                return Ok(None);
+            }
             let path = asset.path().owned().await?;
             let location = if path.is_inside_ref(&node_root) {
                 Location::Node

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -483,6 +483,7 @@ pub struct ClientChunkingContextOptions {
     pub nested_async_chunking: Vc<bool>,
     pub shared_runtime: Vc<bool>,
     pub per_page_module_graph: Vc<bool>,
+    pub lazy_dynamic_imports: Vc<bool>,
     pub debug_ids: Vc<bool>,
     pub worker_asset_prefix: Vc<Option<RcStr>>,
     pub should_use_absolute_url_references: Vc<bool>,
@@ -532,6 +533,7 @@ pub async fn get_client_chunking_context(
         nested_async_chunking,
         shared_runtime,
         per_page_module_graph,
+        lazy_dynamic_imports,
         debug_ids,
         worker_asset_prefix,
         should_use_absolute_url_references,
@@ -607,6 +609,8 @@ pub async fn get_client_chunking_context(
 
     if next_mode.is_development() {
         builder = builder
+            .manifest_chunks(*lazy_dynamic_imports.await?)
+            .defer_async_graph(*lazy_dynamic_imports.await?)
             .hot_module_replacement()
             .source_map_source_type(SourceMapSourceType::AbsoluteFileUri)
             .dynamic_chunk_content_loading(true);

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1406,6 +1406,10 @@ pub struct ExperimentalConfig {
     turbopack_worker_asset_prefix: Option<RcStr>,
     turbopack_client_side_nested_async_chunking: Option<bool>,
     turbopack_server_side_nested_async_chunking: Option<bool>,
+    /// Defer the chunk-group computation for a dynamic `import()` behind its manifest chunk, so it
+    /// runs when the browser first requests the chunk instead of while compiling the route.
+    /// Development only.
+    turbopack_lazy_dynamic_imports: Option<bool>,
     turbopack_import_type_bytes: Option<bool>,
     /// Disable automatic configuration of the sass loader.
     #[serde(default)]
@@ -2587,6 +2591,17 @@ impl NextConfig {
                 NextMode::Build => client_side,
             }
         }))
+    }
+
+    /// Whether the chunk group behind a dynamic `import()` is computed lazily. Only ever enabled in
+    /// development, where the caller applies it.
+    #[turbo_tasks::function]
+    pub fn turbopack_lazy_dynamic_imports(&self) -> Vc<bool> {
+        Vc::cell(
+            self.experimental
+                .turbopack_lazy_dynamic_imports
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -739,6 +739,7 @@ async fn get_mock_stylesheet(
             entries.graph_entries().to_resolved().await?,
             false,
             false,
+            /* defer_async */ false,
         )],
         None,
     );

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1026,6 +1026,7 @@ pub struct ServerChunkingContextOptions {
     pub no_mangling: Vc<bool>,
     pub scope_hoisting: Vc<bool>,
     pub nested_async_chunking: Vc<bool>,
+    pub defer_async_graph: Vc<bool>,
     pub debug_ids: Vc<bool>,
     pub client_root: FileSystemPath,
     pub client_static_folder_name: RcStr,
@@ -1055,6 +1056,7 @@ pub async fn get_server_chunking_context_with_client_assets(
         no_mangling,
         scope_hoisting,
         nested_async_chunking,
+        defer_async_graph,
         debug_ids,
         client_root,
         client_static_folder_name,
@@ -1119,6 +1121,9 @@ pub async fn get_server_chunking_context_with_client_assets(
     } else {
         SourceMapSourceType::RelativeUri
     });
+    if next_mode.is_development() {
+        builder = builder.defer_async_graph(*defer_async_graph.await?);
+    }
     if next_mode.is_production() {
         builder = builder
             .chunking_config(
@@ -1163,6 +1168,7 @@ pub async fn get_server_chunking_context(
         no_mangling,
         scope_hoisting,
         nested_async_chunking,
+        defer_async_graph,
         debug_ids,
         client_root,
         client_static_folder_name,
@@ -1226,7 +1232,9 @@ pub async fn get_server_chunking_context(
     .worker_forwarded_globals(worker_forwarded_globals());
 
     if next_mode.is_development() {
-        builder = builder.source_map_source_type(SourceMapSourceType::AbsoluteFileUri);
+        builder = builder
+            .source_map_source_type(SourceMapSourceType::AbsoluteFileUri)
+            .defer_async_graph(*defer_async_graph.await?);
     } else {
         builder = builder
             .source_map_source_type(SourceMapSourceType::RelativeUri)

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -290,7 +290,8 @@ impl VisitMut for NextDynamicPatcher {
             let should_skip_ssr_compile = has_ssr_false
                 && self.is_server_compiler
                 && !self.is_react_server_layer
-                && self.prefer_esm;
+                && (self.prefer_esm
+                    || matches!(self.state, NextDynamicPatcherState::Turbopack { .. }));
 
             match &self.state {
                 NextDynamicPatcherState::Webpack => {
@@ -375,6 +376,7 @@ impl VisitMut for NextDynamicPatcher {
                         // Add `{with:{turbopack-transition: ...}}` to the dynamic import
                         let mut visitor = DynamicImportTransitionAdder {
                             transition_name: dynamic_transition_name,
+                            chunking_type: self.is_server_compiler.then_some("parallel"),
                         };
                         expr.args[0].visit_mut_with(&mut visitor);
                     }
@@ -400,18 +402,25 @@ impl VisitMut for NextDynamicPatcher {
 
 struct DynamicImportTransitionAdder<'a> {
     transition_name: &'a str,
+    chunking_type: Option<&'a str>,
 }
-// Add `{with:{turbopack-transition: <self.transition_name>}}` to any dynamic imports
+// Add Turbopack transition and optional chunking annotations to any dynamic imports.
 impl VisitMut for DynamicImportTransitionAdder<'_> {
     fn visit_mut_call_expr(&mut self, expr: &mut CallExpr) {
         if let Callee::Import(..) = &expr.callee {
+            let with = match self.chunking_type {
+                Some(chunking_type) => {
+                    *with_transition_chunking_type(self.transition_name, chunking_type)
+                }
+                None => with_transition(self.transition_name),
+            };
             let options = ExprOrSpread {
                 expr: Box::new(
                     ObjectLit {
                         span: DUMMY_SP,
                         props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                             key: PropName::Ident(IdentName::new(atom!("with"), DUMMY_SP)),
-                            value: with_transition(self.transition_name).into(),
+                            value: with.into(),
                         })))],
                     }
                     .into(),

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
@@ -3,11 +3,7 @@ import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" wi
     "turbopack-chunking-type": "none"
 };
 import dynamic from 'next/dynamic';
-export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
-        with: {
-            "turbopack-transition": "next-dynamic"
-        }
-    }), {
+export const NextDynamicNoSSRServerComponent = dynamic(async ()=>{}, {
     loadableGenerated: {
         modules: [
             id

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
@@ -5,7 +5,8 @@ import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" wi
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
@@ -10,7 +10,8 @@ import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';
 const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {
@@ -21,7 +22,8 @@ const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
 });
 const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
@@ -3,11 +3,7 @@ import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" wi
     "turbopack-chunking-type": "none"
 };
 import dynamic from 'next/dynamic';
-export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
-        with: {
-            "turbopack-transition": "next-dynamic"
-        }
-    }), {
+export const NextDynamicNoSSRServerComponent = dynamic(async ()=>{}, {
     loadableGenerated: {
         modules: [
             id

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
@@ -6,7 +6,8 @@ import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
@@ -5,7 +5,8 @@ import { __turbopack_module_id__ as id } from "../components/hello" with {
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
@@ -5,7 +5,8 @@ import { __turbopack_module_id__ as id } from "../components/hello" with {
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
@@ -13,7 +13,8 @@ import { __turbopack_module_id__ as id2 } from "../components/hello" with {
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }), {
     loadableGenerated: {
@@ -23,11 +24,7 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hell
     },
     loading: ()=><p>...</p>
 });
-const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
-        with: {
-            "turbopack-transition": "next-dynamic"
-        }
-    }), {
+const DynamicClientOnlyComponent = dynamic(async ()=>{}, {
     loadableGenerated: {
         modules: [
             id1
@@ -35,11 +32,7 @@ const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
     },
     ssr: false
 });
-const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
-        with: {
-            "turbopack-transition": "next-dynamic"
-        }
-    }), {
+const DynamicClientOnlyComponentWithSuspense = dynamic(async ()=>{}, {
     loadableGenerated: {
         modules: [
             id2

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
@@ -7,11 +7,7 @@ import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
     "turbopack-chunking-type": "none"
 };
 import dynamic from 'next/dynamic';
-const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
-        with: {
-            "turbopack-transition": "next-dynamic"
-        }
-    })), {
+const DynamicComponent1 = dynamic(async ()=>{}, {
     loadableGenerated: {
         modules: [
             id
@@ -22,7 +18,8 @@ const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1',
 });
 const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopack-transition": "next-dynamic",
+            "turbopack-chunking-type": "parallel"
         }
     }).then((mod)=>{
         return mod.Button;

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2676,6 +2676,88 @@ pub fn project_get_source_map_sync(
     })
 }
 
+#[napi(object)]
+pub struct NapiMaterializedLazyChunk {
+    /// Paths contributed by the boundary, relative to the client root.
+    pub client_paths: Vec<String>,
+}
+
+#[turbo_tasks::value(serialization = "skip")]
+struct MaterializedLazyChunk {
+    client_paths: Option<ReadRef<Vec<RcStr>>>,
+    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    effects: Arc<Effects>,
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn materialize_lazy_chunk_operation(
+    container: ResolvedVc<ProjectContainer>,
+    chunk_url_path: RcStr,
+) -> Result<Vc<MaterializedLazyChunk>> {
+    let inner_op = materialize_lazy_chunk_inner_operation(container, chunk_url_path);
+    let filter = container.project().issue_filter().await?;
+    let (client_paths, issues, effects) =
+        strongly_consistent_catch_collectables(inner_op, &filter).await?;
+    Ok(MaterializedLazyChunk {
+        client_paths,
+        issues,
+        effects,
+    }
+    .cell())
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn materialize_lazy_chunk_inner_operation(
+    container: ResolvedVc<ProjectContainer>,
+    chunk_url_path: RcStr,
+) -> Result<Vc<Vec<RcStr>>> {
+    let project = container.project();
+    let path = chunk_url_path
+        .split_once('?')
+        .map_or(&*chunk_url_path, |(path, _)| path);
+    let rel = path.strip_prefix("/_next/").unwrap_or(path);
+    let rel = urlencoding::decode(rel)
+        .map(|s| s.into_owned())
+        .unwrap_or_else(|_| rel.to_string());
+    let client_path = project.client_relative_path().await?.join(&rel)?;
+    Ok(container.materialize_lazy_chunk(client_path))
+}
+
+#[tracing::instrument(level = "info", name = "materialize lazy chunk", skip_all)]
+#[napi]
+pub async fn project_materialize_lazy_chunk(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    chunk_url_path: RcStr,
+) -> napi::Result<TurbopackResult<NapiMaterializedLazyChunk>> {
+    let container = project.container;
+    let (client_paths, issues) = project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run(async move {
+            let op = materialize_lazy_chunk_operation(container, chunk_url_path);
+            let read = read_strongly_consistent_and_apply_effects(op, |v| &v.effects).await?;
+            let MaterializedLazyChunk {
+                client_paths,
+                issues,
+                ..
+            } = &*read;
+            Ok((
+                client_paths
+                    .iter()
+                    .flat_map(|paths| paths.iter().map(|path| path.to_string()))
+                    .collect::<Vec<_>>(),
+                issues.clone(),
+            ))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: NapiMaterializedLazyChunk { client_paths },
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+    })
+}
+
 #[napi]
 pub async fn project_write_analyze_data(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -489,6 +489,14 @@ export declare function projectGetSourceMapSync(
   project: { __napiType: 'Project' },
   filePath: RcStr
 ): string | null
+export interface NapiMaterializedLazyChunk {
+  /** Paths contributed by the boundary, relative to the client root. */
+  clientPaths: Array<string>
+}
+export declare function projectMaterializeLazyChunk(
+  project: { __napiType: 'Project' },
+  chunkUrlPath: RcStr
+): Promise<TurbopackResult>
 export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -831,6 +831,16 @@ function bindingToApi(
       return binding.projectGetSourceMapSync(this._nativeProject, filePath)
     }
 
+    async materializeLazyChunk(
+      chunkUrlPath: string
+    ): Promise<TurbopackResult<{ clientPaths: string[] }>> {
+      const napiResult = (await binding.projectMaterializeLazyChunk(
+        this._nativeProject,
+        chunkUrlPath
+      )) as TurbopackResult<{ clientPaths: string[] }>
+      return napiResult
+    }
+
     updateInfoSubscribe(aggregationMs: number) {
       return subscribe<TurbopackResult<UpdateMessage>>(true, async (callback) =>
         binding.projectUpdateInfoSubscribe(

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -358,6 +358,11 @@ export interface Project {
   getSourceMap(filePath: string): Promise<string | null>
   getSourceMapSync(filePath: string): string | null
 
+  /** Materialize a lazy dynamic-import boundary. */
+  materializeLazyChunk(
+    chunkUrlPath: string
+  ): Promise<TurbopackResult<{ clientPaths: string[] }>>
+
   traceSource(
     stackFrame: TurbopackStackFrame,
     currentDirectoryFileUrl: string

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -399,6 +399,7 @@ export const experimentalSchema = {
   turbopackWorkerAssetPrefix: z.string().optional(),
   turbopackClientSideNestedAsyncChunking: z.boolean().optional(),
   turbopackServerSideNestedAsyncChunking: z.boolean().optional(),
+  turbopackLazyDynamicImports: z.boolean().optional(),
   turbopackImportTypeBytes: z.boolean().optional(),
   turbopackUseBuiltinBabel: z.boolean().optional(),
   turbopackUseBuiltinSass: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -870,6 +870,14 @@ export interface ExperimentalConfig {
   turbopackServerSideNestedAsyncChunking?: boolean
 
   /**
+   * Defer the chunk-group computation for a dynamic `import()` until the browser first requests it,
+   * instead of performing it while compiling the route. Development only.
+   *
+   * Defaults to `false`.
+   */
+  turbopackLazyDynamicImports?: boolean
+
+  /**
    * Enable filesystem cache for the turbopack dev server.
    *
    * Defaults to `true`.

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1357,6 +1357,63 @@ export async function createHotReloaderTurbopack(
         }
       }
 
+      if (req.url?.startsWith('/_next/static/chunks/')) {
+        // Dev chunk names are stable across edits, so materialize on every request.
+        try {
+          const boundaryPath = decodeURIComponent(
+            req.url.split('?')[0].replace(/^\/_next\//, '')
+          )
+          const ownerKeys = assetMapper.getKeysByAsset(boundaryPath)
+          const { clientPaths, issues } = await project.materializeLazyChunk(
+            req.url
+          )
+
+          for (const issue of issues) {
+            if (issue.severity === 'warning') {
+              printNonFatalIssue(issue)
+            } else if (
+              issue.severity === 'error' ||
+              issue.severity === 'fatal'
+            ) {
+              Log.error(formatIssue(issue))
+            }
+          }
+
+          if (clientPaths.length > 0) {
+            // HMR subscriptions require the materialized paths to have an owning entry.
+            for (const key of ownerKeys) {
+              assetMapper.setPathsForKey(key, [
+                ...assetMapper.getAssetPathsByKey(key),
+                ...clientPaths,
+              ])
+            }
+
+            let actionManifestChanged = false
+            for (const key of ownerKeys) {
+              const { type, side, page } = splitEntryKey(key)
+              if (type !== 'app' || side !== 'server') continue
+
+              manifestLoader.loadActionManifest(page)
+              actionManifestChanged = true
+
+              const writtenEndpoint = currentWrittenEntrypoints.get(key)
+              if (writtenEndpoint) {
+                clearRequireCache(key, writtenEndpoint, { force: true })
+              }
+            }
+            if (actionManifestChanged) {
+              manifestLoader.writeManifests({
+                devRewrites: opts.fsChecker.rewrites,
+                productionRewrites: undefined,
+                entrypoints: currentEntrypoints,
+              })
+            }
+          }
+        } catch (err) {
+          console.error(err)
+        }
+      }
+
       for (const middleware of middlewares) {
         let calledNext = false
 

--- a/test/development/app-dir/lazy-dynamic-chunks/app/demo.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/demo.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+import { EAGER_MARKER } from './eager-dep'
+
+const LazyTarget = dynamic(
+  () => import('./lazy-target').then((mod) => mod.LazyTarget),
+  {
+    ssr: false,
+    loading: () => <p id="loading">loading</p>,
+  }
+)
+
+export function Demo() {
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      <p id="eager">{EAGER_MARKER}</p>
+      <button id="render-target" onClick={() => setShow(true)}>
+        render target
+      </button>
+      {show ? <LazyTarget /> : <p id="idle">idle</p>}
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/eager-dep.ts
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/eager-dep.ts
@@ -1,0 +1,1 @@
+export const EAGER_MARKER = 'eager-chunk-marker-4c1d'

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/demo.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/demo.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+import { EAGER_MARKER } from '../eager-dep'
+
+const InteractiveTarget = dynamic(
+  () => import('./target').then((mod) => mod.InteractiveTarget),
+  {
+    ssr: false,
+    loading: () => <p id="loading">loading</p>,
+  }
+)
+
+export function InteractiveDemo() {
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      <p id="eager">{EAGER_MARKER}</p>
+      <button id="render-target" onClick={() => setShow(true)}>
+        render target
+      </button>
+      {show ? <InteractiveTarget /> : <p id="idle">idle</p>}
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/page.tsx
@@ -1,0 +1,9 @@
+import { InteractiveDemo } from './demo'
+
+export default function InteractivePage() {
+  return (
+    <main>
+      <InteractiveDemo />
+    </main>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.module.css
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.module.css
@@ -1,0 +1,4 @@
+.target {
+  --interactive-css-marker-5d1c: 1;
+  color: rgb(0, 128, 0);
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/interactive/target.tsx
@@ -1,0 +1,11 @@
+import styles from './target.module.css'
+
+export const INTERACTIVE_MARKER = 'interactive-chunk-marker-2e8b'
+
+export function InteractiveTarget() {
+  return (
+    <p id="target" className={styles.target}>
+      {INTERACTIVE_MARKER}
+    </p>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/layout.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.module.css
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.module.css
@@ -1,0 +1,4 @@
+.target {
+  --lazy-css-marker-7b2e: 1;
+  color: rgb(0, 128, 0);
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/lazy-target.tsx
@@ -1,0 +1,11 @@
+import styles from './lazy-target.module.css'
+
+export const LAZY_MARKER = 'lazy-chunk-marker-9f3a'
+
+export function LazyTarget() {
+  return (
+    <p id="target" className={styles.target}>
+      {LAZY_MARKER}
+    </p>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/page.tsx
@@ -1,0 +1,9 @@
+import { Demo } from './demo'
+
+export default function Page() {
+  return (
+    <main>
+      <Demo />
+    </main>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/server-import/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/server-import/page.tsx
@@ -1,0 +1,4 @@
+export default async function Page() {
+  const { value } = await import('./value')
+  return <p id="server-value">{value}</p>
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/server-import/value.ts
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/server-import/value.ts
@@ -1,0 +1,1 @@
+export const value = 'server-dynamic-import'

--- a/test/development/app-dir/lazy-dynamic-chunks/app/server-next-dynamic/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/server-next-dynamic/page.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic'
+
+const DynamicValue = dynamic(() => import('./value'))
+
+export default function Page() {
+  return <DynamicValue />
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/app/server-next-dynamic/value.tsx
+++ b/test/development/app-dir/lazy-dynamic-chunks/app/server-next-dynamic/value.tsx
@@ -1,0 +1,3 @@
+export default function DynamicValue() {
+  return <p id="server-dynamic-value">server-next-dynamic</p>
+}

--- a/test/development/app-dir/lazy-dynamic-chunks/lazy-dynamic-chunks.test.ts
+++ b/test/development/app-dir/lazy-dynamic-chunks/lazy-dynamic-chunks.test.ts
@@ -1,0 +1,226 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+const EAGER_MARKER = 'eager-chunk-marker-4c1d'
+const LAZY_MARKER = 'lazy-chunk-marker-9f3a'
+const LAZY_CSS_MARKER = 'lazy-css-marker-7b2e'
+const INTERACTIVE_MARKER = 'interactive-chunk-marker-2e8b'
+const INTERACTIVE_CSS_MARKER = 'interactive-css-marker-5d1c'
+
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'lazy-dynamic-chunks',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      patchFileDelay: 500,
+    })
+
+    async function clientAssets(): Promise<string[]> {
+      const root = path.join(next.testDir, next.distDir, 'static')
+      const found: string[] = []
+
+      async function walk(dir: string) {
+        let entries
+        try {
+          entries = await fs.readdir(dir, { withFileTypes: true })
+        } catch {
+          return
+        }
+        for (const entry of entries) {
+          const entryPath = path.join(dir, entry.name)
+          if (entry.isDirectory()) {
+            await walk(entryPath)
+          } else {
+            found.push(entryPath)
+          }
+        }
+      }
+
+      await walk(root)
+      return found
+    }
+
+    async function assetsContaining(marker: string): Promise<string[]> {
+      const assets = await clientAssets()
+      const matches = await Promise.all(
+        assets.map(async (asset) => {
+          const contents = await fs.readFile(asset, 'utf8').catch(() => '')
+          return contents.includes(marker) ? asset : null
+        })
+      )
+      return matches.filter((asset): asset is string => asset !== null)
+    }
+
+    async function loadableManifestFiles(route: string): Promise<string[]> {
+      const manifestPath = path.join(
+        next.testDir,
+        next.distDir,
+        'server/app',
+        route,
+        'react-loadable-manifest.json'
+      )
+      const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+      return Object.values(manifest).flatMap(
+        (entry: { files: string[] }) => entry.files
+      )
+    }
+
+    it('keeps server dynamic imports available during the initial render', async () => {
+      const res = await next.fetch('/server-import')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('server-dynamic-import')
+    })
+
+    it('renders server next/dynamic imports during the initial render', async () => {
+      const res = await next.fetch('/server-next-dynamic')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('server-next-dynamic')
+    })
+
+    it('does not emit the dynamic import chunk while compiling the route', async () => {
+      const res = await next.fetch('/')
+      expect(res.status).toBe(200)
+
+      await retry(async () => {
+        expect(await assetsContaining(EAGER_MARKER)).not.toHaveLength(0)
+      })
+
+      expect(await assetsContaining(LAZY_MARKER)).toHaveLength(0)
+      expect(await assetsContaining(LAZY_CSS_MARKER)).toHaveLength(0)
+    })
+
+    it('resolves the dynamic import to a boundary chunk rather than its target group', async () => {
+      expect(await next.fetch('/').then((res) => res.status)).toBe(200)
+
+      let files: string[]
+      await retry(async () => {
+        files = await loadableManifestFiles('page')
+        expect(files).not.toHaveLength(0)
+      })
+
+      expect(files.filter((file) => file.endsWith('.css'))).toHaveLength(0)
+      expect(files.every((file) => file.endsWith('.js'))).toBe(true)
+    })
+
+    it('emits and serves the dynamic import chunk when the browser requests it', async () => {
+      const browser = await next.browser('/interactive')
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#eager').text()).toBe(EAGER_MARKER)
+      })
+
+      const requestedUrls = async (): Promise<string[]> =>
+        (await browser.eval(
+          `performance.getEntriesByType('resource').map((entry) => entry.name)`
+        )) as string[]
+
+      const requestedBefore = new Set(await requestedUrls())
+      const emittedBefore = new Set(await clientAssets())
+
+      await browser.elementByCss('#render-target').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#target').text()).toBe(
+          INTERACTIVE_MARKER
+        )
+      })
+
+      expect(
+        await browser.eval(
+          `getComputedStyle(document.querySelector('#target')).color`
+        )
+      ).toBe('rgb(0, 128, 0)')
+
+      await retry(async () => {
+        expect(await assetsContaining(INTERACTIVE_MARKER)).not.toHaveLength(0)
+        expect(await assetsContaining(INTERACTIVE_CSS_MARKER)).not.toHaveLength(
+          0
+        )
+      })
+
+      const newAssets = (await clientAssets()).filter(
+        (asset) => !emittedBefore.has(asset)
+      )
+      expect(newAssets).not.toHaveLength(0)
+
+      const newChunkUrls = (await requestedUrls())
+        .filter((url) => !requestedBefore.has(url))
+        .filter((url) => url.includes('/_next/static/chunks/'))
+      expect(newChunkUrls).not.toHaveLength(0)
+
+      const bodies = await Promise.all(
+        newChunkUrls.map(async (url) => {
+          const { pathname, search } = new URL(url)
+          const res = await next.fetch(pathname + search)
+          expect(res.status).toBe(200)
+          return { url, body: await res.text() }
+        })
+      )
+
+      expect(
+        bodies.filter(({ body }) => body.includes(INTERACTIVE_MARKER))
+      ).not.toHaveLength(0)
+      expect(
+        bodies.filter(({ body }) => body.includes(INTERACTIVE_CSS_MARKER))
+      ).not.toHaveLength(0)
+    })
+
+    it('resolves a source map for the boundary chunk', async () => {
+      const boundaryChunk = (await loadableManifestFiles('interactive/page'))[0]
+      expect(boundaryChunk).toMatch(/\.js$/)
+
+      const filename = path.join(next.testDir, next.distDir, boundaryChunk)
+      const res = await next.fetch(
+        `/__nextjs_source-map?filename=${encodeURIComponent(filename)}`
+      )
+      expect(res.status).toBe(200)
+      expect(await res.json()).toHaveProperty('version', 3)
+    })
+
+    it('applies an edit to a mounted dynamic component over HMR', async () => {
+      const targetPath = path.join('app', 'interactive', 'target.tsx')
+      const originalContent = await next.readFile(targetPath)
+      try {
+        const browser = await next.browser('/interactive')
+        await browser.elementByCss('#render-target').click()
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#target').text()).toBe(
+            INTERACTIVE_MARKER
+          )
+        })
+
+        const timeOrigin = await browser.eval('performance.timeOrigin')
+
+        await next.patchFile(
+          targetPath,
+          originalContent.replace(INTERACTIVE_MARKER, 'updated-marker')
+        )
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#target').text()).toBe(
+            'updated-marker'
+          )
+        }, 10000)
+
+        expect(await browser.eval('performance.timeOrigin')).toEqual(timeOrigin)
+      } finally {
+        await next.patchFile(targetPath, originalContent)
+      }
+    })
+
+    it('keeps the lazy chunk of an untouched route unmaterialized', async () => {
+      const res = await next.fetch('/')
+      expect(res.status).toBe(200)
+
+      await retry(async () => {
+        expect(await assetsContaining(EAGER_MARKER)).not.toHaveLength(0)
+      })
+
+      expect(await assetsContaining(LAZY_MARKER)).toHaveLength(0)
+      expect(await assetsContaining(LAZY_CSS_MARKER)).toHaveLength(0)
+    })
+  }
+)

--- a/test/development/app-dir/lazy-dynamic-chunks/next.config.js
+++ b/test/development/app-dir/lazy-dynamic-chunks/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbopackLazyDynamicImports: true,
+  },
+}
+
+module.exports = nextConfig

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -12,9 +12,9 @@ use turbopack_core::{
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkLoadRetry, ChunkType,
         ChunkableModule, ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing,
-        CrossOrigin, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets, MinifyType,
-        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
-        WorkerConfigurationOptions,
+        CrossOrigin, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
+        HmrChunkListSource, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences,
+        UrlBehavior, WorkerConfigurationOptions,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         chunk_id_strategy::ModuleIdStrategy,
@@ -131,6 +131,11 @@ impl BrowserChunkingContextBuilder {
 
     pub fn manifest_chunks(mut self, manifest_chunks: bool) -> Self {
         self.chunking_context.manifest_chunks = manifest_chunks;
+        self
+    }
+
+    pub fn defer_async_graph(mut self, defer_async_graph: bool) -> Self {
+        self.chunking_context.defer_async_graph = defer_async_graph;
         self
     }
 
@@ -381,6 +386,7 @@ pub struct BrowserChunkingContext {
     current_chunk_method: CurrentChunkMethod,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    defer_async_graph: bool,
     /// The module id strategy to use
     module_id_strategy: Option<ResolvedVc<ModuleIdStrategy>>,
     /// The module export usage info, if available.
@@ -453,6 +459,7 @@ impl BrowserChunkingContext {
                 source_maps_type: SourceMapsType::Full,
                 current_chunk_method: CurrentChunkMethod::StringLiteral,
                 manifest_chunks: false,
+                defer_async_graph: false,
                 module_id_strategy: None,
                 export_usage: None,
                 unused_references: None,
@@ -862,6 +869,16 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
+    fn is_hot_module_replacement_enabled(&self) -> Vc<bool> {
+        Vc::cell(self.enable_hot_module_replacement)
+    }
+
+    #[turbo_tasks::function]
+    fn is_async_graph_deferral_enabled(&self) -> Vc<bool> {
+        Vc::cell(self.defer_async_graph)
+    }
+
+    #[turbo_tasks::function]
     pub fn minify_type(&self) -> Vc<MinifyType> {
         self.minify_type.cell()
     }
@@ -1075,6 +1092,7 @@ impl ChunkingContext for BrowserChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         chunks: Vc<OutputAssets>,
+        source: HmrChunkListSource,
     ) -> Result<Vc<OutputAssets>> {
         let this = self.await?;
         if !this.enable_hot_module_replacement {
@@ -1088,7 +1106,10 @@ impl ChunkingContext for BrowserChunkingContext {
                 ident,
                 EvaluatableAssets::empty(),
                 chunks,
-                EcmascriptDevChunkListSource::Entry,
+                match source {
+                    HmrChunkListSource::Entry => EcmascriptDevChunkListSource::Entry,
+                    HmrChunkListSource::Dynamic => EcmascriptDevChunkListSource::Dynamic,
+                },
             )
             .to_resolved()
             .await?,

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -326,6 +326,7 @@ async fn build_internal(
         .resolved_cell(),
         false,
         true,
+        /* defer_async */ false,
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
     let binding_usage = compute_binding_usage_info(module_graph, true);

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -176,6 +176,7 @@ pub async fn create_web_entry_source(
             .resolved_cell(),
             false,
             false,
+            /* defer_async */ false,
         )],
         None,
     );

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -293,6 +293,16 @@ pub struct ChunkingConfig {
 #[turbo_tasks::value(transparent)]
 pub struct ChunkingConfigs(FxHashMap<ResolvedVc<Box<dyn ChunkType>>, ChunkingConfig>);
 
+/// The owner of a standalone HMR chunk list.
+#[turbo_tasks::task_input]
+#[derive(
+    Eq, PartialEq, Debug, Clone, Copy, Hash, TraceRawVcs, Serialize, Deserialize, Encode, Decode,
+)]
+pub enum HmrChunkListSource {
+    Entry,
+    Dynamic,
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone, Copy, Hash, Default, Deserialize)]
 pub enum SourceMapSourceType {
@@ -443,6 +453,16 @@ pub trait ChunkingContext {
     }
 
     #[turbo_tasks::function]
+    fn is_hot_module_replacement_enabled(self: Vc<Self>) -> Vc<bool> {
+        Vc::cell(false)
+    }
+
+    #[turbo_tasks::function]
+    fn is_async_graph_deferral_enabled(self: Vc<Self>) -> Vc<bool> {
+        Vc::cell(false)
+    }
+
+    #[turbo_tasks::function]
     fn minify_type(self: Vc<Self>) -> Vc<MinifyType> {
         MinifyType::NoMinify.cell()
     }
@@ -490,16 +510,13 @@ pub trait ChunkingContext {
         availability_info: AvailabilityInfo,
     ) -> Vc<ChunkGroupResult>;
 
-    /// In development, produces a standalone HMR chunk-list register chunk
-    /// that tracks `chunks` for hot-module-replacement without producing an
-    /// evaluate chunk. Returns `None` (empty vec) outside dev or when HMR is
-    /// disabled. Used to register a page-specific chunk list that covers
-    /// client-reference chunks built outside the shared module graph.
+    /// Produces a standalone HMR chunk list without an evaluate chunk.
     #[turbo_tasks::function]
     fn hmr_chunk_list(
         self: Vc<Self>,
         _ident: Vc<AssetIdent>,
         _chunks: Vc<OutputAssets>,
+        _source: HmrChunkListSource,
     ) -> Vc<OutputAssets> {
         OutputAssets::empty()
     }

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -28,8 +28,8 @@ pub use crate::chunk::{
     },
     chunking_context::{
         AssetSuffix, ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs,
-        ChunkingContext, ChunkingContextExt, EntryChunkGroupResult, MangleType, MinifyType,
-        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        ChunkingContext, ChunkingContextExt, EntryChunkGroupResult, HmrChunkListSource, MangleType,
+        MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
         WorkerConfigurationOptions,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},

--- a/turbopack/crates/turbopack-core/src/lazy_output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/lazy_output_asset.rs
@@ -1,0 +1,105 @@
+use anyhow::Result;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{FileContent, FileSystemPath};
+
+use crate::{
+    asset::{Asset, AssetContent},
+    chunk::{OutputChunk, OutputChunkRuntimeInfo},
+    module_graph::AsyncGraphMaterialization,
+    output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
+    source_map::GenerateSourceMap,
+    version::VersionedContent,
+};
+
+/// An [`OutputAsset`] whose references are not traversed until it is materialized.
+#[turbo_tasks::value]
+pub struct LazyOutputAsset {
+    inner: ResolvedVc<Box<dyn OutputAsset>>,
+    materialization: ResolvedVc<AsyncGraphMaterialization>,
+}
+
+#[turbo_tasks::value_impl]
+impl LazyOutputAsset {
+    #[turbo_tasks::function]
+    pub fn new(
+        inner: ResolvedVc<Box<dyn OutputAsset>>,
+        materialization: ResolvedVc<AsyncGraphMaterialization>,
+    ) -> Vc<Self> {
+        LazyOutputAsset {
+            inner,
+            materialization,
+        }
+        .cell()
+    }
+}
+
+impl LazyOutputAsset {
+    pub fn is_lazy(asset: ResolvedVc<Box<dyn OutputAsset>>) -> bool {
+        ResolvedVc::try_downcast_type::<LazyOutputAsset>(asset).is_some()
+    }
+
+    pub async fn materialize(asset: ResolvedVc<LazyOutputAsset>) -> Result<()> {
+        asset.await?.materialization.await?.materialize();
+        Ok(())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.inner.content()
+    }
+
+    #[turbo_tasks::function]
+    fn versioned_content(&self) -> Vc<Box<dyn VersionedContent>> {
+        self.inner.versioned_content()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsReference for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn references(&self) -> Vc<OutputAssetsWithReferenced> {
+        self.inner.references().concatenate_asset(*self.inner)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAsset for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.inner.path()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl GenerateSourceMap for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn generate_source_map(&self) -> Vc<FileContent> {
+        match ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.inner) {
+            Some(inner) => inner.generate_source_map(),
+            None => FileContent::NotFound.cell(),
+        }
+    }
+
+    #[turbo_tasks::function]
+    fn by_section(&self, section: RcStr) -> Vc<FileContent> {
+        match ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.inner) {
+            Some(inner) => inner.by_section(section),
+            None => FileContent::NotFound.cell(),
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputChunk for LazyOutputAsset {
+    #[turbo_tasks::function]
+    fn runtime_info(&self) -> Vc<OutputChunkRuntimeInfo> {
+        match ResolvedVc::try_sidecast::<Box<dyn OutputChunk>>(self.inner) {
+            Some(inner) => inner.runtime_info(),
+            None => OutputChunkRuntimeInfo::empty(),
+        }
+    }
+}

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod generated_code_source;
 pub mod ident;
 pub mod introspect;
 pub mod issue;
+pub mod lazy_output_asset;
 pub mod loader;
 pub mod module;
 pub mod module_graph;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level, Span};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    CollectiblesSource, FxIndexMap, NonLocalValue, OperationVc, ReadRef, ResolvedVc,
+    CollectiblesSource, FxIndexMap, NonLocalValue, OperationVc, ReadRef, ResolvedVc, State,
     TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
     debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
@@ -60,6 +60,32 @@ pub mod style_groups_loose;
 mod traced_di_graph;
 
 pub use self::module_batches::BatchingConfig;
+
+#[turbo_tasks::value]
+pub struct AsyncGraphMaterialization {
+    materialized: State<bool>,
+}
+
+impl AsyncGraphMaterialization {
+    pub fn is_materialized(&self) -> bool {
+        *self.materialized.get()
+    }
+
+    pub fn materialize(&self) {
+        self.materialized.set(true);
+    }
+}
+
+/// Returns the materialization state associated with an async module graph.
+#[turbo_tasks::function]
+pub fn async_graph_materialization(
+    _module: ResolvedVc<Box<dyn Module>>,
+) -> Vc<AsyncGraphMaterialization> {
+    AsyncGraphMaterialization {
+        materialized: State::new(false),
+    }
+    .cell()
+}
 
 #[derive(
     Debug,
@@ -229,6 +255,11 @@ pub struct GraphEntries {
     traced_modules: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
+/// Limits async graph deferral to modules in the named layers.
+#[turbo_tasks::task_input]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, TraceRawVcs, Encode, Decode)]
+pub struct DeferAsyncLayers(pub Vec<RcStr>);
+
 #[turbo_tasks::value_impl]
 impl GraphEntries {
     #[turbo_tasks::function]
@@ -338,12 +369,14 @@ impl SingleModuleGraph {
         visited_modules: &FxIndexMap<ResolvedVc<Box<dyn Module>>, GraphNodeIndex>,
         include_traced: bool,
         include_binding_usage: bool,
+        defer_async: bool,
+        defer_async_layers: Option<&DeferAsyncLayers>,
     ) -> Result<Vc<Self>> {
         let emit_spans = tracing::enabled!(Level::INFO);
         let root_nodes = entries
             .all_modules_with_is_traced()
             .map(|(e, is_traced)| {
-                SingleModuleGraphBuilderNode::new_module(emit_spans, e, is_traced)
+                SingleModuleGraphBuilderNode::new_module(emit_spans, e, is_traced, false)
             })
             .try_join()
             .await?;
@@ -356,6 +389,8 @@ impl SingleModuleGraph {
                     emit_spans,
                     include_traced,
                     include_binding_usage,
+                    defer_async,
+                    defer_async_layers: defer_async_layers.map(|layers| layers.0.as_slice()),
                 },
             )
             .await
@@ -380,6 +415,7 @@ impl SingleModuleGraph {
                         module,
                         is_traced: _,
                         ident: _,
+                        defer_children: _,
                     } => (module, SingleModuleGraphNode::Module(module), 1),
                     SingleModuleGraphBuilderNode::VisitedModule { module, idx } => (
                         module,
@@ -807,11 +843,76 @@ impl ModuleGraph {
                 graphs: graphs.iter().map(|g| g.connect()).try_join().await?,
                 skip_visited_module_children: false,
                 graph_idx_override: None,
+                entry_override: None,
                 binding_usage: if let Some(binding_usage) = binding_usage {
                     Some(binding_usage.connect().await?)
                 } else {
                     None
                 },
+            },
+        }
+        .cell())
+    }
+
+    /// A graph containing nothing but `entry` and whatever it references, as an async chunk group
+    /// entry.
+    #[turbo_tasks::function]
+    pub fn isolated_async_entry(entry: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
+        Self::from_graphs(
+            vec![SingleModuleGraph::new_with_entry(
+                ChunkGroupEntry::Async(entry),
+                false,
+                false,
+                /* defer_async */ false,
+            )],
+            None,
+        )
+        .connect()
+    }
+
+    /// Like [`Self::isolated_async_entry`], seeded with modules from `parent`.
+    #[turbo_tasks::function]
+    pub async fn isolated_async_entry_seeded(
+        entry: ResolvedVc<Box<dyn Module>>,
+        parent: Vc<ModuleGraph>,
+    ) -> Result<Vc<Self>> {
+        let parent_graphs = parent.await?.input_graphs.clone();
+        let mut visited = VisitedModules::empty();
+        for graph in &parent_graphs {
+            visited = VisitedModules::concatenate(visited, *graph);
+        }
+        let isolated = SingleModuleGraph::new_with_entries_visited(
+            GraphEntries::from_chunk_groups(vec![ChunkGroupEntry::Async(entry)]).resolved_cell(),
+            visited,
+            false,
+            false,
+            /* defer_async */ false,
+        );
+        let isolated_graph_idx = parent_graphs.len();
+        let mut graphs = parent_graphs;
+        graphs.push(isolated);
+        let snapshot_graphs = graphs.iter().map(|g| g.connect()).try_join().await?;
+        let node_idx = *snapshot_graphs[isolated_graph_idx]
+            .modules
+            .get(&entry)
+            .context("Expected isolated graph entry")?;
+        Ok(Self {
+            input_graphs: graphs,
+            input_binding_usage: None,
+            snapshot: ModuleGraphSnapshot {
+                graphs: snapshot_graphs,
+                skip_visited_module_children: false,
+                graph_idx_override: None,
+                // The parent contains a deferred copy of `entry`; chunking must start from the
+                // complete copy in the isolated graph while all other lookups retain normal order.
+                entry_override: Some((
+                    entry,
+                    GraphNodeIndex {
+                        graph_idx: isolated_graph_idx as u32,
+                        node_idx,
+                    },
+                )),
+                binding_usage: None,
             },
         }
         .cell())
@@ -942,6 +1043,7 @@ impl ModuleGraphLayer {
                 graphs: vec![graph.connect().await?],
                 skip_visited_module_children: true,
                 graph_idx_override: Some(graph_idx),
+                entry_override: None,
                 binding_usage: if let Some(binding_usage) = binding_usage {
                     Some(binding_usage.connect().await?)
                 } else {
@@ -984,6 +1086,9 @@ pub struct ModuleGraphSnapshot {
 
     graph_idx_override: Option<u32>,
 
+    /// Selects a specific graph when the same entry module has both deferred and complete nodes.
+    entry_override: Option<(ResolvedVc<Box<dyn Module>>, GraphNodeIndex)>,
+
     binding_usage: Option<ReadRef<BindingUsageInfo>>,
 }
 
@@ -991,6 +1096,12 @@ impl ModuleGraphSnapshot {
     fn get_entry(&self, entry: ResolvedVc<Box<dyn Module>>) -> Result<GraphNodeIndex> {
         if self.graph_idx_override.is_some() {
             debug_assert_eq!(self.graphs.len(), 1,);
+        }
+
+        if let Some((override_entry, idx)) = self.entry_override
+            && override_entry == entry
+        {
+            return Ok(idx);
         }
 
         let Some(idx) = self
@@ -1642,12 +1753,15 @@ impl SingleModuleGraph {
         entry: ChunkGroupEntry,
         include_traced: bool,
         include_binding_usage: bool,
+        defer_async: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &GraphEntries::from_chunk_groups(vec![entry]),
             &Default::default(),
             include_traced,
             include_binding_usage,
+            defer_async,
+            None,
         )
         .await
     }
@@ -1657,12 +1771,15 @@ impl SingleModuleGraph {
         entries: ResolvedVc<GraphEntries>,
         include_traced: bool,
         include_binding_usage: bool,
+        defer_async: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &*entries.await?,
             &Default::default(),
             include_traced,
             include_binding_usage,
+            defer_async,
+            None,
         )
         .await
     }
@@ -1673,12 +1790,15 @@ impl SingleModuleGraph {
         visited_modules: OperationVc<VisitedModules>,
         include_traced: bool,
         include_binding_usage: bool,
+        defer_async: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &*entries.await?,
             &visited_modules.connect().await?.modules,
             include_traced,
             include_binding_usage,
+            defer_async,
+            None,
         )
         .await
     }
@@ -1690,12 +1810,34 @@ impl SingleModuleGraph {
         visited_modules: OperationVc<VisitedModules>,
         include_traced: bool,
         include_binding_usage: bool,
+        defer_async: bool,
     ) -> Result<Vc<Self>> {
         SingleModuleGraph::new_inner(
             &entries,
             &visited_modules.connect().await?.modules,
             include_traced,
             include_binding_usage,
+            defer_async,
+            None,
+        )
+        .await
+    }
+
+    #[turbo_tasks::function(operation)]
+    pub async fn new_with_entries_visited_intern_defer_layers(
+        entries: GraphEntries,
+        visited_modules: OperationVc<VisitedModules>,
+        include_traced: bool,
+        include_binding_usage: bool,
+        defer_async_layers: DeferAsyncLayers,
+    ) -> Result<Vc<Self>> {
+        SingleModuleGraph::new_inner(
+            &entries,
+            &visited_modules.connect().await?.modules,
+            include_traced,
+            include_binding_usage,
+            true,
+            Some(&defer_async_layers),
         )
         .await
     }
@@ -1760,6 +1902,7 @@ enum SingleModuleGraphBuilderNode {
         ident: Option<ReadRef<RcStr>>,
         /// whether this module is a tracing context
         is_traced: bool,
+        defer_children: bool,
     },
     /// A reference to a module that is already listed in visited_modules
     VisitedModule {
@@ -1773,6 +1916,7 @@ impl SingleModuleGraphBuilderNode {
         emit_spans: bool,
         module: ResolvedVc<Box<dyn Module>>,
         is_traced: bool,
+        defer_children: bool,
     ) -> Result<Self> {
         Ok(Self::Module {
             module,
@@ -1783,6 +1927,7 @@ impl SingleModuleGraphBuilderNode {
                 None
             },
             is_traced,
+            defer_children,
         })
     }
     fn new_visited_module(module: ResolvedVc<Box<dyn Module>>, idx: GraphNodeIndex) -> Self {
@@ -1798,6 +1943,12 @@ struct SingleModuleGraphBuilder<'a> {
     /// Whether to walk ChunkingType::Traced references
     include_traced: bool,
 
+    /// Whether to defer traversal below async references.
+    defer_async: bool,
+
+    /// When set, only defer async targets whose asset layer has one of these names.
+    defer_async_layers: Option<&'a [RcStr]>,
+
     /// Whether to read ModuleReference::binding_usage()
     include_binding_usage: bool,
 }
@@ -1811,6 +1962,10 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
         _edge: Option<&RefData>,
     ) -> VisitControlFlow {
         match node {
+            SingleModuleGraphBuilderNode::Module {
+                defer_children: true,
+                ..
+            } => VisitControlFlow::Skip,
             SingleModuleGraphBuilderNode::Module { .. } => VisitControlFlow::Continue,
             // Module was already visited previously
             SingleModuleGraphBuilderNode::VisitedModule { .. } => VisitControlFlow::Skip,
@@ -1830,6 +1985,8 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
         let emit_spans = self.emit_spans;
         let include_traced = self.include_traced;
         let include_binding_usage = self.include_binding_usage;
+        let defer_async = self.defer_async;
+        let defer_async_layers = self.defer_async_layers.map(<[RcStr]>::to_vec);
         async move {
             let refs_cell = if !is_traced {
                 primary_chunkable_referenced_modules(*module, include_traced, include_binding_usage)
@@ -1872,6 +2029,22 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                     ) || is_traced
                 })
                 .map(async |(reference, ty, binding_usage, target)| {
+                    let layer_matches = if let Some(layers) = &defer_async_layers {
+                        target
+                            .ident()
+                            .await?
+                            .layer
+                            .as_ref()
+                            .is_some_and(|layer| layers.contains(layer.name()))
+                    } else {
+                        true
+                    };
+                    let defer_children = defer_async
+                        && matches!(ty, ChunkingType::Async)
+                        && layer_matches
+                        && !async_graph_materialization(*target)
+                            .await?
+                            .is_materialized();
                     let to = if let Some(idx) = visited_modules.get(&target) {
                         SingleModuleGraphBuilderNode::new_visited_module(target, *idx)
                     } else {
@@ -1879,6 +2052,7 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                             emit_spans,
                             target,
                             is_traced || ty.is_traced(),
+                            defer_children,
                         )
                         .await?
                     };
@@ -2296,6 +2470,7 @@ pub mod tests {
                     .resolved_cell(),
                     false,
                     false,
+                    /* defer_async */ false,
                 );
 
                 let module_graph = ModuleGraph::from_graphs(
@@ -2310,6 +2485,7 @@ pub mod tests {
                             VisitedModules::from_graph(parent_graph),
                             false,
                             false,
+                            /* defer_async */ false,
                         ),
                     ],
                     None,
@@ -2477,6 +2653,7 @@ pub mod tests {
                     .resolved_cell(),
                     true,
                     false,
+                    /* defer_async */ false,
                 );
 
                 let module_graph = ModuleGraph::from_graphs(
@@ -2491,6 +2668,7 @@ pub mod tests {
                             VisitedModules::from_graph(parent_graph),
                             true,
                             false,
+                            /* defer_async */ false,
                         ),
                     ],
                     None,
@@ -2844,6 +3022,7 @@ pub mod tests {
                 )),
                 false,
                 false,
+                /* defer_async */ false,
             );
 
             // Create a simple name mapping to make analyzing the visitors easier.

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 
-use crate::asset::Asset;
+use crate::{asset::Asset, lazy_output_asset::LazyOutputAsset};
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionOutputAsset(Option<ResolvedVc<Box<dyn OutputAsset>>>);
@@ -245,7 +245,7 @@ async fn get_referenced_assets(
 ) -> Result<impl Iterator<Item = ExpandOutputAssetsInput>> {
     let refs = match input {
         ExpandOutputAssetsInput::Asset(output_asset) => {
-            if !inner_output_assets {
+            if !inner_output_assets || LazyOutputAsset::is_lazy(output_asset) {
                 return Ok(Either::Left(std::iter::empty()));
             }
             output_asset.references().await?

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -11,7 +11,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
     atoms::Wtf8Atom,
-    common::{BytePos, GLOBALS, Mark, Span, Spanned, SyntaxContext, comments::Comments},
+    common::{BytePos, DUMMY_SP, GLOBALS, Mark, Span, Spanned, SyntaxContext, comments::Comments},
     ecma::{
         ast::*,
         atoms::{Atom, atom},
@@ -168,6 +168,7 @@ impl ImportAnnotations {
 
     pub fn parse_dynamic(with: &JsValue<'_>) -> Option<ImportAnnotations> {
         let mut map = BTreeMap::new();
+        let mut chunking_type = None;
 
         let JsValue::Object { parts, .. } = with else {
             return None;
@@ -185,19 +186,23 @@ impl ImportAnnotations {
                 continue;
             };
 
-            map.insert(
-                key.as_atom().into_owned().into(),
-                value.as_atom().into_owned().into(),
-            );
+            let key = key.as_atom().into_owned();
+            let value = value.as_atom().into_owned();
+            if key == "turbopack-chunking-type" {
+                chunking_type = parse_chunking_type_annotation(DUMMY_SP, value.as_str())
+                    .filter(|chunking_type| *chunking_type != SpecifiedChunkingType::None);
+            } else {
+                map.insert(key.into(), value.into());
+            }
         }
 
-        if !map.is_empty() {
+        if !map.is_empty() || chunking_type.is_some() {
             Some(ImportAnnotations {
                 map,
                 turbopack_loader: None,
                 turbopack_rename_as: None,
                 turbopack_module_type: None,
-                chunking_type: None,
+                chunking_type,
             })
         } else {
             None

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -83,6 +83,15 @@ impl AsyncLoaderModule {
                 .cell());
             }
         }
+        let module_graph = if *self
+            .chunking_context
+            .is_async_graph_deferral_enabled()
+            .await?
+        {
+            ModuleGraph::isolated_async_entry_seeded(Vc::upcast(*self.inner), module_graph)
+        } else {
+            module_graph
+        };
         Ok(self.chunking_context.chunk_group_assets(
             self.inner.ident(),
             ChunkGroup::Async(ResolvedVc::upcast(self.inner)),

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -5,14 +5,16 @@ use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkData, ChunkableModule, ChunkingContext, ChunkingContextExt,
-        ChunksData, availability_info::AvailabilityInfo,
+        ChunksData, HmrChunkListSource, availability_info::AvailabilityInfo,
     },
     ident::AssetIdent,
+    lazy_output_asset::LazyOutputAsset,
     module::{Module, ModuleSideEffects},
     module_graph::{
-        ModuleGraph, chunk_group_info::ChunkGroup, module_batch::ChunkableModuleOrBatch,
+        ModuleGraph, async_graph_materialization, chunk_group_info::ChunkGroup,
+        module_batch::ChunkableModuleOrBatch,
     },
-    output::OutputAssetsWithReferenced,
+    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
 };
 
 use crate::{
@@ -61,13 +63,40 @@ impl ManifestAsyncModule {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn chunk_group(&self) -> Vc<OutputAssetsWithReferenced> {
-        self.chunking_context.chunk_group_assets(
+    pub(super) async fn chunk_group(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
+        let module_graph = if *self
+            .chunking_context
+            .is_async_graph_deferral_enabled()
+            .await?
+        {
+            ModuleGraph::isolated_async_entry_seeded(Vc::upcast(*self.inner), *self.module_graph)
+        } else {
+            *self.module_graph
+        };
+        Ok(self.chunking_context.chunk_group_assets(
             self.inner.ident(),
             ChunkGroup::Async(ResolvedVc::upcast(self.inner)),
-            *self.module_graph,
+            module_graph,
             self.availability_info,
-        )
+        ))
+    }
+
+    /// Returns the dynamic import's HMR chunk list.
+    #[turbo_tasks::function]
+    async fn hmr_chunk_list(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
+        let this = self.await?;
+        if !*this
+            .chunking_context
+            .is_hot_module_replacement_enabled()
+            .await?
+        {
+            return Ok(OutputAssets::empty());
+        }
+        Ok(this.chunking_context.hmr_chunk_list(
+            self.ident(),
+            *self.chunk_group().await?.assets,
+            HmrChunkListSource::Dynamic,
+        ))
     }
 
     #[turbo_tasks::function]
@@ -94,12 +123,46 @@ impl ManifestAsyncModule {
                 .cell());
             }
         }
-        Ok(this.chunking_context.chunk_group_assets(
-            self.ident(),
-            ChunkGroup::Async(ResolvedVc::upcast(self)),
-            *this.module_graph,
-            this.availability_info,
-        ))
+        let module_graph = ModuleGraph::isolated_async_entry(*ResolvedVc::upcast(self));
+        let manifest_group = this
+            .chunking_context
+            .chunk_group_assets(
+                self.ident(),
+                ChunkGroup::Async(ResolvedVc::upcast(self)),
+                module_graph,
+                this.availability_info,
+            )
+            .await?;
+
+        // Group-level references would bypass the lazy asset boundary.
+        debug_assert!(
+            manifest_group.referenced_assets.await?.is_empty()
+                && manifest_group.references.await?.is_empty(),
+            "manifest chunk groups must not have group-level references"
+        );
+
+        let assets = manifest_group
+            .assets
+            .await?
+            .iter()
+            .map(async |asset| {
+                Ok(ResolvedVc::upcast::<Box<dyn OutputAsset>>(
+                    LazyOutputAsset::new(
+                        **asset,
+                        async_graph_materialization(*ResolvedVc::upcast(this.inner)),
+                    )
+                    .to_resolved()
+                    .await?,
+                ))
+            })
+            .try_join()
+            .await?;
+        Ok(OutputAssetsWithReferenced {
+            assets: ResolvedVc::cell(assets),
+            referenced_assets: manifest_group.referenced_assets,
+            references: manifest_group.references,
+        }
+        .cell())
     }
 
     #[turbo_tasks::function]
@@ -128,7 +191,10 @@ impl ManifestAsyncModule {
         let this = self.await?;
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root().owned().await?,
-            *self.chunk_group().await?.assets,
+            self.chunk_group()
+                .await?
+                .assets
+                .concatenate(self.hmr_chunk_list()),
         ))
     }
 }
@@ -186,8 +252,22 @@ impl EcmascriptChunkPlaceable for ManifestAsyncModule {
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
         _module_graph: Vc<ModuleGraph>,
         _async_module_info: Option<Vc<AsyncModuleInfo>>,
-        _estimated: bool,
+        estimated: bool,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        if estimated {
+            let code = formatdoc! {
+                r#"
+                    {TURBOPACK_EXPORT_VALUE}({:#});
+                "#,
+                StringifyJs(&Vec::<EcmascriptChunkData<'_>>::new())
+            };
+            return Ok(EcmascriptChunkItemContent {
+                inner_code: code.into(),
+                ..Default::default()
+            }
+            .cell());
+        }
+
         let chunks_data = self.chunks_data().await?;
         let chunks_data = chunks_data.iter().try_join().await?;
         let chunks_data: Vec<_> = chunks_data
@@ -219,11 +299,28 @@ impl EcmascriptChunkPlaceable for ManifestAsyncModule {
     }
 
     #[turbo_tasks::function]
-    fn chunk_item_output_assets(
+    async fn chunk_item_output_assets(
         self: Vc<Self>,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
         _module_graph: Vc<ModuleGraph>,
-    ) -> Vc<OutputAssetsWithReferenced> {
-        self.chunk_group()
+    ) -> Result<Vc<OutputAssetsWithReferenced>> {
+        let this = self.await?;
+        if *this
+            .chunking_context
+            .is_async_graph_deferral_enabled()
+            .await?
+            && !async_graph_materialization(*ResolvedVc::upcast(this.inner))
+                .await?
+                .is_materialized()
+        {
+            return Ok(OutputAssetsWithReferenced::from_assets(
+                OutputAssets::empty(),
+            ));
+        }
+        Ok(self
+            .chunk_group()
+            .concatenate(OutputAssetsWithReferenced::from_assets(
+                self.hmr_chunk_list(),
+            )))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -29,6 +29,7 @@ use crate::{
     references::{
         AstPath,
         pattern_mapping::{PatternMapping, ResolveType},
+        util::SpecifiedChunkingType,
     },
 };
 
@@ -46,6 +47,7 @@ pub struct EsmAsyncAssetReference {
     /// callback destructuring, or webpackExports/turbopackExports comments.
     pub export_usage: ExportUsage,
     pub resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
+    pub chunking_type: Option<SpecifiedChunkingType>,
 }
 
 impl EsmAsyncAssetReference {
@@ -60,8 +62,8 @@ impl EsmAsyncAssetReference {
         export_usage: ExportUsage,
         resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
     ) -> Result<Self> {
-        // Apply any annotation-driven transition eagerly so the stored origin is final and the
-        // `annotations` don't need to be retained on the reference.
+        let chunking_type = annotations.chunking_type();
+        // Apply any annotation-driven transition eagerly so the stored origin is final.
         let origin = if let Some(transition) = annotations.transition() {
             origin
                 .with_transition(transition.into())
@@ -79,6 +81,7 @@ impl EsmAsyncAssetReference {
             import_externals,
             export_usage,
             resolve_override,
+            chunking_type,
         })
     }
 }
@@ -102,7 +105,10 @@ impl ModuleReference for EsmAsyncAssetReference {
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {
-        Some(ChunkingType::Async)
+        self.chunking_type
+            .map_or(Some(ChunkingType::Async), |chunking_type| {
+                chunking_type.as_chunking_type(false, false)
+            })
     }
 
     fn binding_usage(&self) -> BindingUsage {
@@ -153,7 +159,9 @@ impl EsmAsyncAssetReferenceCodeGen {
             *reference.origin,
             chunking_context,
             self.reference.resolve_reference(),
-            if chunking_context.chunk_loading().await?.can_split_async() {
+            if reference.chunking_type.is_none()
+                && chunking_context.chunk_loading().await?.can_split_async()
+            {
                 ResolveType::AsyncChunkLoader
             } else {
                 ResolveType::ChunkItem

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -533,6 +533,7 @@ impl PostCssTransformedAsset {
                 entries.graph_entries().to_resolved().await?,
                 false,
                 false,
+                /* defer_async */ false,
             )],
             None,
         )

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -285,6 +285,7 @@ impl WebpackLoadersProcessedAsset {
                     entries.graph_entries().to_resolved().await?,
                     false,
                     false,
+                    /* defer_async */ false,
                 )],
                 None,
             )
@@ -759,6 +760,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     },
                     false,
                     false,
+                    /* defer_async */ false,
                 );
                 let import_module_graph = ModuleGraph::from_graphs(vec![single_graph], None)
                     .connect()

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -114,6 +114,11 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
+    pub fn defer_async_graph(mut self, defer_async_graph: bool) -> Self {
+        self.chunking_context.defer_async_graph = defer_async_graph;
+        self
+    }
+
     pub fn source_map_source_type(mut self, source_map_source_type: SourceMapSourceType) -> Self {
         self.chunking_context.source_map_source_type = source_map_source_type;
         self
@@ -232,6 +237,7 @@ pub struct NodeJsChunkingContext {
     source_maps_type: SourceMapsType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    defer_async_graph: bool,
     /// The strategy to use for generating module ids
     module_id_strategy: Option<ResolvedVc<ModuleIdStrategy>>,
     /// The module export usage info, if available.
@@ -289,6 +295,7 @@ impl NodeJsChunkingContext {
                 minify_type: MinifyType::NoMinify,
                 source_maps_type: SourceMapsType::Full,
                 manifest_chunks: false,
+                defer_async_graph: false,
                 source_map_source_type: SourceMapSourceType::TurbopackUri,
                 module_id_strategy: None,
                 export_usage: None,
@@ -429,6 +436,11 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     fn is_dynamic_chunk_content_loading_enabled(&self) -> Vc<bool> {
         Vc::cell(self.enable_dynamic_chunk_content_loading)
+    }
+
+    #[turbo_tasks::function]
+    fn is_async_graph_deferral_enabled(&self) -> Vc<bool> {
+        Vc::cell(self.defer_async_graph)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -539,6 +539,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         entries.graph_entries().to_resolved().await?,
         false,
         true,
+        /* defer_async */ false,
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -486,6 +486,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .resolved_cell(),
         false,
         true,
+        /* defer_async */ false,
     );
     let mut module_graph = ModuleGraph::from_graphs(vec![single_graph], None);
 


### PR DESCRIPTION
## Summary

Defer Turbopack development-mode dynamic import subgraphs until their boundary chunks are requested. Materialized chunks integrate with normal emission, source maps, HMR subscriptions, and server action manifest updates.

## Verification

- `pnpm build-all`
- `HEADLESS=true pnpm test-dev-turbo test/development/app-dir/lazy-dynamic-chunks/lazy-dynamic-chunks.test.ts`

<!-- NEXT_JS_LLM -->