### PR TITLE
Turbopack: serialize moduleLoading.crossOrigin as null instead of "none" in client reference manifest

### DIFF
--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -70,9 +70,8 @@ pub struct CssResource {
 #[serde(rename_all = "camelCase")]
 pub struct ModuleLoading {
     pub prefix: RcStr,
-    /// React Flight treats any string as CORS-enabled (normalizing everything
-    /// but "use-credentials" to anonymous), so `CrossOrigin::None` must
-    /// serialize as `null`, not as the string "none".
+    /// React treats any string here as CORS-enabled, so `CrossOrigin::None`
+    /// must serialize as `null`, not `"none"`.
     #[serde(serialize_with = "serialize_cross_origin")]
     pub cross_origin: CrossOrigin,
 }

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -70,7 +70,21 @@ pub struct CssResource {
 #[serde(rename_all = "camelCase")]
 pub struct ModuleLoading {
     pub prefix: RcStr,
+    /// React Flight treats any string as CORS-enabled (normalizing everything
+    /// but "use-credentials" to anonymous), so `CrossOrigin::None` must
+    /// serialize as `null`, not as the string "none".
+    #[serde(serialize_with = "serialize_cross_origin")]
     pub cross_origin: CrossOrigin,
+}
+
+fn serialize_cross_origin<S>(
+    cross_origin: &CrossOrigin,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    cross_origin.as_str().serialize(serializer)
 }
 
 #[derive(Serialize, Default, Debug, Clone)]
@@ -608,5 +622,33 @@ pub fn get_client_reference_module_key(server_path: &str, export_name: &str) -> 
         server_path.into()
     } else {
         format!("{server_path}#{export_name}").into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_loading_cross_origin_serialization() {
+        let json = |cross_origin| {
+            serde_json::to_string(&ModuleLoading {
+                prefix: rcstr!(""),
+                cross_origin,
+            })
+            .unwrap()
+        };
+        assert_eq!(
+            json(CrossOrigin::None),
+            r#"{"prefix":"","crossOrigin":null}"#
+        );
+        assert_eq!(
+            json(CrossOrigin::Anonymous),
+            r#"{"prefix":"","crossOrigin":"anonymous"}"#
+        );
+        assert_eq!(
+            json(CrossOrigin::UseCredentials),
+            r#"{"prefix":"","crossOrigin":"use-credentials"}"#
+        );
     }
 }


### PR DESCRIPTION
Fixes #96831

### What?

Since 16.3.0, the Turbopack-generated client reference manifest serializes `moduleLoading.crossOrigin` as the string `"none"` when `crossOrigin` is not configured:

```
16.2.12: "moduleLoading":{"prefix":"","crossOrigin":null}
16.3.0:  "moduleLoading":{"prefix":"","crossOrigin":"none"}
```

`CrossOrigin::None` (the `#[default]` variant) goes through the enum's kebab-case serde derive and comes out as `"none"`.

### Why is that a problem?

React Flight only checks `typeof crossOrigin === "string"` and normalizes any string other than `"use-credentials"` to `""` (anonymous). So every SSR-preinited client component chunk `<script>` is emitted with an unexpected `crossorigin=""`, and browsers fetch those chunks in CORS mode.

For apps with a cross-origin `assetPrefix` (CDN), this newly requires `Access-Control-Allow-Origin` on chunk responses. Worse, other references to the same chunk URLs (layout/page script tags, bootstrap, dynamic imports) still load in no-cors mode, so CDNs whose cache key does not include the `Origin` header end up serving no-cors-cached copies (without ACAO) to the CORS-mode loads, which the browser then blocks:

```
Access to script at 'https://cdn.example.com/_next/static/chunks/xxx.js' from origin
'https://www.example.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin'
header is present on the requested resource.
```

This took down our production frontend (www + CDN on separate origins) after upgrading to 16.3.0 and we had to roll back. Reproduction: https://github.com/banqinghe/next-16-3-crossorigin-none-repro

### How?

Serialize the field through the existing `CrossOrigin::as_str()` (`None` → `null`, `Anonymous` → `"anonymous"`, `UseCredentials` → `"use-credentials"`), restoring the 16.2.x manifest shape. Added a unit test covering all three variants.
