### PR TITLE
fix(lightningcss-loader): leave fragment-only url(#id) references untouched

### DIFF
--- a/packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.test.ts
+++ b/packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.test.ts
@@ -1,0 +1,62 @@
+import { LightningCssLoader as loader } from './loader'
+
+function runLoader(
+  source: string,
+  resolveImpl?: (context: any, request: any) => Promise<string>
+) {
+  const calls: Array<[any, any]> = []
+  return new Promise<{ error: any; content: any; calls: Array<[any, any]> }>(
+    (resolve) => {
+      const ctx = {
+        async: () => (error: any, content?: any) =>
+          resolve({ error, content, calls }),
+        getOptions: () => ({ url: true, import: true }),
+        getResolve: () => async (context: any, request: any) => {
+          calls.push([context, request])
+          if (resolveImpl) {
+            return resolveImpl(context, request)
+          }
+          return `/resolved/${request}`
+        },
+        context: '/project',
+        rootContext: '/project',
+        resourcePath: '/project/style.css',
+        sourceMap: false,
+        utils: { contextify: (_context: any, request: any) => request },
+      }
+      // @ts-expect-error -- partial loader context mock
+      loader.call(ctx, source, null, null)
+    }
+  )
+}
+
+describe('lightningcss-loader url() handling', () => {
+  it('leaves fragment-only url(#id) references untouched instead of resolving them', async () => {
+    const { error, content, calls } = await runLoader(
+      'svg { fill: url(#gradient) }',
+      async () => {
+        throw new Error('cannot resolve')
+      }
+    )
+    expect(error).toBeNull()
+    // The fragment reference is left in the CSS (lightningcss serializes it
+    // with quotes) instead of being rewritten to a module placeholder.
+    expect(content).toContain('#gradient')
+    expect(content).not.toContain('__NEXT_LIGHTNINGCSS_LOADER_URL_REPLACE')
+    // No module resolution should be attempted for fragment URLs.
+    expect(calls).toEqual([])
+  })
+
+  it('still processes regular url() references as module requests', async () => {
+    // When handleUrl processes a regular url it pushes a getUrl runtime
+    // import, resolving require.resolve('../../css-loader/src/runtime/getUrl.js').
+    // In jest that resolution fails because the repo only contains getUrl.ts
+    // (the .js exists in built output), so reaching it proves './img.png' was
+    // processed as a module request — i.e. the fragment guard above does not
+    // over-block real urls. (Verified: jest.mock(virtual) does not affect
+    // require.resolve, and we intentionally avoid writing shims into src.)
+    const { error } = await runLoader('.a { background: url(./img.png) }')
+    expect(error).not.toBeNull()
+    expect(String(error?.message)).toContain('getUrl.js')
+  })
+})

--- a/packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.ts
+++ b/packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.ts
@@ -52,6 +52,14 @@ function createUrlAndImportVisitor(
       return u
     }
 
+    // Leave fragment-only references (e.g. `url(#gradient)`), empty URLs and
+    // other non-requestable URLs untouched - mirroring upstream css-loader's
+    // shouldHandleURL guard. Turning them into module requests would fail to
+    // resolve (empty pathname) and break the build.
+    if (url.length === 0 || !isUrlRequestable(url)) {
+      return u
+    }
+
     urlIndex++
 
     replacedUrls.set(urlIndex, url)


### PR DESCRIPTION
## What

`handleUrl` (packages/next/src/build/webpack/loaders/lightningcss-loader/src/loader.ts, used when `experimental.useLightningcss` is enabled) only checks `urlFilter` and `isDataUrl` before turning a CSS url into a webpack module request. Next's configured filter (`cssFileResolve`) only rejects `/`-prefixed and scheme URLs, so **same-document SVG fragment references** — extremely common in real-world CSS:

```css
.icon { fill: url(#gradient) }
.blur { filter: url(#blur) }
.mask { clip-path: url(#c) }
```

were converted into module imports: `'#gradient'.split(/(\?)?#/, 3)` yields an **empty pathname**, `resolveRequests(['', '#gradient'])` fails for both candidates and rethrows, and the loader reports a hard compilation error instead of leaving the fragment untouched. Upstream css-loader gates this via `shouldHandleURL()`/`isUrlRequestable()` (rejecting empty, protocol-relative, and `#`-prefixed URLs) — that guard was missing here.

## Fix

Use the already-imported `isUrlRequestable` to mirror the upstream guard in `handleUrl`:

```ts
if (url.length === 0 || !isUrlRequestable(url)) {
  return u
}
```

## Tests

New `loader.test.ts` drives `LightningCssLoader` with a mocked webpack loader context and the **real native lightningcss transform**:

1. `svg { fill: url(#gradient) }` with an always-throwing resolver — **fails before this fix** (`Error: cannot resolve`, the reported build failure); after the fix the fragment reference is left untouched in the CSS, no module placeholder is emitted, and the resolver is never called.
2. `.a { background: url(./img.png) }` — proves the guard doesn't over-block real urls: the loader reaches the `getUrl.js` runtime-import resolution (which deterministically fails in jest since the repo only ships `getUrl.ts`; `jest.mock(virtual)` was verified not to affect `require.resolve`, so the test asserts that resolution attempt without any filesystem shims).

`jest`/`tsc`/`eslint` all pass.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
