### PR TITLE
Bound Request Insights capture with honest omission metadata

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.test.ts
@@ -1,0 +1,60 @@
+import { getFetchUrlPresentation, truncateMiddle } from './fetch-label'
+
+describe('request insight fetch labels', () => {
+  it('classifies same-origin and external fetches by full web origin', () => {
+    expect(
+      getFetchUrlPresentation('/api/items?token=redacted', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'https://app.test/api/items?token=redacted',
+      path: '/api/items?token=redacted',
+      originKind: 'same-origin',
+      originLabel: 'Same origin',
+    })
+    expect(
+      getFetchUrlPresentation('https://api.test:445/items', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'https://api.test:445/items',
+      path: '/items',
+      originKind: 'external',
+      originLabel: 'External origin · api.test:445',
+    })
+    expect(
+      getFetchUrlPresentation('http://app.test/items', 'https://app.test')
+    ).toEqual({
+      fullUrl: 'http://app.test/items',
+      path: '/items',
+      originKind: 'external',
+      originLabel: 'External origin · http://app.test',
+    })
+  })
+
+  it('does not guess origin semantics without a usable browser origin', () => {
+    expect(
+      getFetchUrlPresentation('https://api.test/items', undefined)
+    ).toEqual({
+      fullUrl: 'https://api.test/items',
+      path: '/items',
+      originKind: 'unknown',
+      originLabel: 'https://api.test',
+    })
+    expect(getFetchUrlPresentation('/api/items', undefined)).toEqual({
+      fullUrl: '/api/items',
+      path: '/api/items',
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    })
+  })
+
+  it('middle-truncates labels while retaining their distinguishing suffix', () => {
+    const value = '/api/a/very/long/path/to/tail-marker?token=redacted'
+    const truncated = truncateMiddle(value, 28)
+
+    expect(truncated).toHaveLength(28)
+    expect(truncated).toContain('…')
+    expect(truncated).toMatch(/token=redacted$/)
+
+    expect(truncateMiddle('😀abc', 3)).toBe('😀…c')
+    expect(truncateMiddle('secret', 1)).toBe('…')
+    expect(truncateMiddle('secret', 0)).toBe('')
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/fetch-label.ts
@@ -1,0 +1,111 @@
+export type FetchOriginKind = 'same-origin' | 'external' | 'unknown'
+
+export type FetchUrlPresentation = {
+  fullUrl: string
+  path: string
+  originKind: FetchOriginKind
+  originLabel: string
+}
+
+const DEFAULT_PATH_LENGTH = 48
+const DEFAULT_ORIGIN_LENGTH = 36
+
+export function getFetchUrlPresentation(
+  url: string | undefined,
+  currentOrigin: string | undefined,
+  pathLength = DEFAULT_PATH_LENGTH,
+  originLength = DEFAULT_ORIGIN_LENGTH
+): FetchUrlPresentation {
+  if (!url) {
+    return {
+      fullUrl: 'Unknown URL',
+      path: 'Unknown URL',
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    }
+  }
+
+  const baseUrl = parseHttpUrl(currentOrigin)
+
+  try {
+    const parsedUrl = baseUrl ? new URL(url, baseUrl) : new URL(url)
+    if (!isHttpUrl(parsedUrl)) {
+      return {
+        fullUrl: url,
+        path: truncateMiddle(url, pathLength),
+        originKind: 'unknown',
+        originLabel: 'Origin unavailable',
+      }
+    }
+
+    const sameOrigin = baseUrl?.origin === parsedUrl.origin
+    const originKind = baseUrl
+      ? sameOrigin
+        ? 'same-origin'
+        : 'external'
+      : 'unknown'
+    const compactOrigin =
+      baseUrl?.protocol === parsedUrl.protocol
+        ? parsedUrl.host
+        : parsedUrl.origin
+
+    return {
+      fullUrl: parsedUrl.href,
+      path: truncateMiddle(
+        `${parsedUrl.pathname}${parsedUrl.search}`,
+        pathLength
+      ),
+      originKind,
+      originLabel:
+        originKind === 'same-origin'
+          ? 'Same origin'
+          : originKind === 'external'
+            ? `External origin · ${truncateMiddle(compactOrigin, originLength)}`
+            : truncateMiddle(parsedUrl.origin, originLength),
+    }
+  } catch {
+    return {
+      fullUrl: url,
+      path: truncateMiddle(url, pathLength),
+      originKind: 'unknown',
+      originLabel: 'Origin unavailable',
+    }
+  }
+}
+
+export function truncateMiddle(value: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return ''
+  }
+  const characters = Array.from(value)
+  if (characters.length <= maxLength) {
+    return value
+  }
+  if (maxLength === 1) {
+    return '…'
+  }
+
+  const availableLength = maxLength - 1
+  const prefixLength = Math.floor(availableLength / 2)
+  const suffixLength = availableLength - prefixLength
+  return `${characters.slice(0, prefixLength).join('')}…${characters
+    .slice(-suffixLength)
+    .join('')}`
+}
+
+function parseHttpUrl(value: string | undefined): URL | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(value)
+    return isHttpUrl(url) ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:'
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -1,0 +1,285 @@
+import {
+  getRequestInsightKind,
+  getRequestInsightSource,
+  type RequestInsight,
+} from '../../../shared/request-insights'
+import {
+  getRequestInsightRepresentation,
+  getRequestInsightRouterActivity,
+  getRequestInsightStatusCode,
+  hasRequestInsightProxyActivity,
+} from './request-list'
+
+export type RequestInsightFilter =
+  | 'source:page'
+  | 'source:action'
+  | 'source:api'
+  | 'source:image'
+  | 'source:asset'
+  | 'source:unknown'
+  | 'representation:html'
+  | 'representation:rsc'
+  | 'representation:unknown'
+  | 'activity:proxy'
+  | 'activity:instant-insights'
+  | 'activity:prefetch'
+  | 'activity:segment-prefetch'
+  | 'activity:hmr-refresh'
+  | 'status:error'
+  | 'status:http-4xx'
+  | 'status:http-5xx'
+  | 'fetches:present'
+  | 'fetches:none'
+  | 'cache:hit'
+  | 'cache:miss'
+  | 'cache:skip'
+  | 'cache:none'
+
+export type RequestInsightFilterGroup = Readonly<{
+  label: string
+  options: ReadonlyArray<{
+    value: RequestInsightFilter
+    label: string
+  }>
+}>
+
+export const REQUEST_INSIGHT_FILTER_GROUPS: readonly RequestInsightFilterGroup[] =
+  [
+    {
+      label: 'Request type',
+      options: [
+        { value: 'source:page', label: 'Page or navigation' },
+        { value: 'source:action', label: 'Server Action' },
+        { value: 'source:api', label: 'API' },
+        { value: 'source:image', label: 'Image optimization' },
+        { value: 'source:asset', label: 'Static asset' },
+        { value: 'source:unknown', label: 'Unknown type' },
+      ],
+    },
+    {
+      label: 'Page response',
+      options: [
+        { value: 'representation:html', label: 'HTML' },
+        { value: 'representation:rsc', label: 'RSC' },
+        { value: 'representation:unknown', label: 'Unavailable' },
+      ],
+    },
+    {
+      label: 'Activity',
+      options: [
+        { value: 'activity:proxy', label: 'Matched proxy' },
+        { value: 'activity:prefetch', label: 'App Router prefetch' },
+        { value: 'activity:segment-prefetch', label: 'Segment prefetch' },
+        { value: 'activity:hmr-refresh', label: 'HMR refresh' },
+        { value: 'activity:instant-insights', label: 'Instant Insights' },
+      ],
+    },
+    {
+      label: 'Status',
+      options: [
+        { value: 'status:error', label: 'Recorded error' },
+        { value: 'status:http-4xx', label: 'HTTP 4xx' },
+        { value: 'status:http-5xx', label: 'HTTP 5xx' },
+      ],
+    },
+    {
+      label: 'Fetches',
+      options: [
+        { value: 'fetches:present', label: 'Has fetches' },
+        { value: 'fetches:none', label: 'No fetches' },
+      ],
+    },
+    {
+      label: 'Fetch cache',
+      options: [
+        { value: 'cache:hit', label: 'Hit' },
+        { value: 'cache:miss', label: 'Miss' },
+        { value: 'cache:skip', label: 'Skip' },
+        { value: 'cache:none', label: 'No cache activity' },
+      ],
+    },
+  ]
+
+const ALL_FILTERS = REQUEST_INSIGHT_FILTER_GROUPS.flatMap((group) =>
+  group.options.map((option) => option.value)
+)
+
+type RequestInsightFilterResult = Readonly<{
+  requests: RequestInsight[]
+  matchingRequestCount: number
+  totalRequestCount: number
+  optionCounts: Readonly<Record<RequestInsightFilter, number>>
+}>
+
+export function getRequestInsightFilterResult(
+  requests: readonly RequestInsight[],
+  activeFilters: readonly RequestInsightFilter[],
+  showInternal = false
+): RequestInsightFilterResult {
+  const revealInternal =
+    showInternal || activeFilters.includes('activity:instant-insights')
+  const visibleRequests = requests.filter(
+    (request) => getRequestInsightKind(request) === 'request' || revealInternal
+  )
+  const activeFiltersByFacet = groupFiltersByFacet(activeFilters)
+  const optionCounts = Object.fromEntries(
+    ALL_FILTERS.map((filter) => [filter, 0])
+  ) as Record<RequestInsightFilter, number>
+
+  for (const request of requests) {
+    const tags = getRequestInsightTags(request)
+    if (getRequestInsightKind(request) === 'request' || showInternal) {
+      for (const tag of tags) {
+        optionCounts[tag] += 1
+      }
+    } else if (tags.has('activity:instant-insights')) {
+      optionCounts['activity:instant-insights'] += 1
+    }
+  }
+
+  const matchingRequests = visibleRequests.filter((request) =>
+    matchesActiveFilters(getRequestInsightTags(request), activeFiltersByFacet)
+  )
+
+  return {
+    requests: matchingRequests,
+    matchingRequestCount: matchingRequests.length,
+    totalRequestCount: visibleRequests.length,
+    optionCounts,
+  }
+}
+
+export function toggleRequestInsightFilter(
+  activeFilters: readonly RequestInsightFilter[],
+  filter: RequestInsightFilter
+): RequestInsightFilter[] {
+  return activeFilters.includes(filter)
+    ? activeFilters.filter((activeFilter) => activeFilter !== filter)
+    : [...activeFilters, filter]
+}
+
+function getRequestInsightTags(
+  request: RequestInsight
+): Set<RequestInsightFilter> {
+  const tags = new Set<RequestInsightFilter>()
+  const source = getRequestSourceFilter(request)
+  if (source) {
+    tags.add(source)
+  }
+
+  switch (getRequestInsightRepresentation(request)) {
+    case 'html':
+      tags.add('representation:html')
+      break
+    case 'rsc':
+      tags.add('representation:rsc')
+      break
+    case 'unknown':
+      tags.add('representation:unknown')
+      break
+    case 'not-applicable':
+      break
+  }
+
+  if (hasRequestInsightProxyActivity(request)) {
+    tags.add('activity:proxy')
+  }
+  const routerActivity = getRequestInsightRouterActivity(request)
+  if (routerActivity) {
+    tags.add(`activity:${routerActivity}`)
+  }
+  if (getRequestInsightKind(request) === 'instant-insights') {
+    tags.add('activity:instant-insights')
+  }
+
+  if (
+    request.status === 'error' ||
+    request.spans.some((span) => span.status === 'error' || span.error)
+  ) {
+    tags.add('status:error')
+  }
+  const statusCode = getRequestInsightStatusCode(request)
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+    tags.add('status:http-4xx')
+  } else if (
+    statusCode !== undefined &&
+    statusCode >= 500 &&
+    statusCode < 600
+  ) {
+    tags.add('status:http-5xx')
+  }
+
+  if (request.fetches.length === 0) {
+    tags.add('fetches:none')
+    tags.add('cache:none')
+  } else {
+    tags.add('fetches:present')
+    for (const fetch of request.fetches) {
+      if (
+        fetch.cacheStatus === 'hit' ||
+        fetch.cacheStatus === 'miss' ||
+        fetch.cacheStatus === 'skip'
+      ) {
+        tags.add(`cache:${fetch.cacheStatus}`)
+      }
+    }
+  }
+
+  return tags
+}
+
+function getRequestSourceFilter(
+  request: RequestInsight
+): RequestInsightFilter | undefined {
+  const source = getRequestInsightSource(request)
+  if (source === 'page' && request.serverAction) {
+    return 'source:action'
+  }
+
+  switch (source) {
+    case 'page':
+      return 'source:page'
+    case 'app-route':
+    case 'pages-api':
+      return 'source:api'
+    case 'image':
+      return 'source:image'
+    case 'asset':
+      return 'source:asset'
+    case 'proxy':
+    case 'instant-insights':
+      return undefined
+    case 'unknown':
+      return 'source:unknown'
+  }
+}
+
+function groupFiltersByFacet(
+  filters: readonly RequestInsightFilter[]
+): Map<string, RequestInsightFilter[]> {
+  const filtersByFacet = new Map<string, RequestInsightFilter[]>()
+
+  for (const filter of filters) {
+    const facet = filter.slice(0, filter.indexOf(':'))
+    const facetFilters = filtersByFacet.get(facet)
+    if (facetFilters) {
+      facetFilters.push(filter)
+    } else {
+      filtersByFacet.set(facet, [filter])
+    }
+  }
+
+  return filtersByFacet
+}
+
+function matchesActiveFilters(
+  tags: ReadonlySet<RequestInsightFilter>,
+  activeFiltersByFacet: ReadonlyMap<string, RequestInsightFilter[]>
+): boolean {
+  for (const facetFilters of activeFiltersByFacet.values()) {
+    if (!facetFilters.some((filter) => tags.has(filter))) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -8,6 +8,7 @@ import {
   getRequestInsightRouterActivity,
   getRequestInsightStatusCode,
   hasRequestInsightProxyActivity,
+  type RequestListEntry,
 } from './request-list'
 
 export type RequestInsightFilter =
@@ -105,46 +106,37 @@ const ALL_FILTERS = REQUEST_INSIGHT_FILTER_GROUPS.flatMap((group) =>
 )
 
 type RequestInsightFilterResult = Readonly<{
-  requests: RequestInsight[]
+  entries: RequestListEntry[]
   matchingRequestCount: number
   totalRequestCount: number
   optionCounts: Readonly<Record<RequestInsightFilter, number>>
 }>
 
 export function getRequestInsightFilterResult(
-  requests: readonly RequestInsight[],
-  activeFilters: readonly RequestInsightFilter[],
-  showInternal = false
+  entries: readonly RequestListEntry[],
+  activeFilters: readonly RequestInsightFilter[]
 ): RequestInsightFilterResult {
-  const revealInternal =
-    showInternal || activeFilters.includes('activity:instant-insights')
-  const visibleRequests = requests.filter(
-    (request) => getRequestInsightKind(request) === 'request' || revealInternal
-  )
   const activeFiltersByFacet = groupFiltersByFacet(activeFilters)
   const optionCounts = Object.fromEntries(
     ALL_FILTERS.map((filter) => [filter, 0])
   ) as Record<RequestInsightFilter, number>
 
-  for (const request of requests) {
-    const tags = getRequestInsightTags(request)
-    if (getRequestInsightKind(request) === 'request' || showInternal) {
-      for (const tag of tags) {
-        optionCounts[tag] += 1
-      }
-    } else if (tags.has('activity:instant-insights')) {
-      optionCounts['activity:instant-insights'] += 1
+  for (const entry of entries) {
+    const tags = getRequestInsightTags(entry)
+    for (const tag of tags) {
+      optionCounts[tag] += 1
     }
   }
 
-  const matchingRequests = visibleRequests.filter((request) =>
-    matchesActiveFilters(getRequestInsightTags(request), activeFiltersByFacet)
-  )
+  const matchingEntries = entries.filter((entry) => {
+    const tags = getRequestInsightTags(entry)
+    return matchesActiveFilters(tags, activeFiltersByFacet)
+  })
 
   return {
-    requests: matchingRequests,
-    matchingRequestCount: matchingRequests.length,
-    totalRequestCount: visibleRequests.length,
+    entries: matchingEntries,
+    matchingRequestCount: matchingEntries.length,
+    totalRequestCount: entries.length,
     optionCounts,
   }
 }
@@ -159,8 +151,9 @@ export function toggleRequestInsightFilter(
 }
 
 function getRequestInsightTags(
-  request: RequestInsight
+  entry: RequestListEntry
 ): Set<RequestInsightFilter> {
+  const { request } = entry
   const tags = new Set<RequestInsightFilter>()
   const source = getRequestSourceFilter(request)
   if (source) {
@@ -188,13 +181,19 @@ function getRequestInsightTags(
   if (routerActivity) {
     tags.add(`activity:${routerActivity}`)
   }
-  if (getRequestInsightKind(request) === 'instant-insights') {
+  if (
+    entry.instantInsights.length > 0 ||
+    getRequestInsightKind(request) === 'instant-insights'
+  ) {
     tags.add('activity:instant-insights')
   }
 
   if (
-    request.status === 'error' ||
-    request.spans.some((span) => span.status === 'error' || span.error)
+    [request, ...entry.instantInsights].some(
+      (item) =>
+        item.status === 'error' ||
+        item.spans.some((span) => span.status === 'error' || span.error)
+    )
   ) {
     tags.add('status:error')
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -1,3 +1,9 @@
+.request-insights-panel-container {
+  container-type: inline-size;
+  height: 100%;
+  min-height: 0;
+}
+
 .request-insights-panel {
   display: grid;
   grid-template-columns: minmax(210px, 320px) minmax(420px, 1fr);
@@ -462,13 +468,61 @@
 }
 
 .request-insights-overview span {
+  overflow: hidden;
+  max-width: 100%;
   min-width: 0;
   border: 1px solid var(--color-gray-400);
   border-radius: 4px;
   padding: 2px 6px;
   color: var(--color-gray-900);
   font-size: var(--size-12);
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-overview .request-insights-route-template {
+  border-style: dashed;
+  font-family: var(--font-mono);
+}
+
+.request-insights-params-trigger {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: help;
+  font: inherit;
+}
+
+.request-insights-params-trigger:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.request-insights-params-tooltip,
+.request-insights-fetch-tooltip,
+.request-insights-trace-tooltip {
+  --tooltip-background: var(--color-background-100);
+
+  border: 1px solid var(--color-gray-alpha-400);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 16%);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-params-tooltip {
+  max-width: min(420px, calc(100vw - 32px));
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: pre-wrap;
+}
+
+.request-insights-fetch-tooltip,
+.request-insights-trace-tooltip {
+  max-width: min(640px, calc(100vw - 32px));
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .request-insights-error {
@@ -596,9 +650,18 @@
   flex-direction: column;
 }
 
+.request-insights-trace-rows:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -1px;
+}
+
 .request-insights-span-row {
   min-height: 28px;
   border-bottom: 1px solid var(--color-gray-300);
+}
+
+.request-insights-span-row[data-active='true'] {
+  background: var(--color-gray-200);
 }
 
 .request-insights-span-row:last-child {
@@ -642,7 +705,6 @@
   background: var(--color-red-800);
 }
 
-.request-insights-fetch-host,
 .request-insights-cache-reason {
   min-width: 0;
   overflow: hidden;
@@ -720,7 +782,52 @@
   gap: 8px;
 }
 
-@media (max-width: 900px) {
+.request-insights-fetch-url-trigger {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  cursor: help;
+}
+
+.request-insights-fetch-path,
+.request-insights-fetch-origin {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.request-insights-fetch-path {
+  color: var(--color-gray-1000);
+  text-overflow: ellipsis;
+}
+
+.request-insights-fetch-origin {
+  max-width: 240px;
+  flex-shrink: 0;
+  border: 1px solid var(--color-gray-400);
+  border-radius: 999px;
+  padding: 0 5px;
+  color: var(--color-gray-800);
+  font-family: inherit;
+  font-size: var(--size-10);
+  text-overflow: ellipsis;
+}
+
+.request-insights-fetch-origin[data-origin='external'] {
+  border-color: var(--color-purple-500);
+  color: var(--color-purple-900);
+}
+
+@media (forced-colors: active) {
+  .request-insights-trace-rows:focus-visible,
+  .request-insights-span-row[data-active='true'] {
+    outline: 1px solid Highlight;
+    outline-offset: -1px;
+  }
+}
+
+@container (width <= 900px) {
   .request-insights-summary {
     align-items: flex-start;
   }
@@ -730,7 +837,7 @@
   }
 }
 
-@media (max-width: 700px) {
+@container (width < 630px) {
   .request-insights-panel {
     grid-template-columns: 1fr;
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -28,6 +28,7 @@
 .request-insights-list {
   border-right: 1px solid var(--color-gray-400);
   overflow: auto;
+  overscroll-behavior: contain;
   min-width: 0;
 }
 
@@ -54,8 +55,50 @@
   gap: 6px;
 }
 
+.request-insights-scope-switcher {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--color-gray-400);
+  background: var(--color-background-100);
+}
+
+.request-insights-scope-switcher button {
+  min-height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-gray-900);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--size-11);
+}
+
+.request-insights-scope-switcher button:focus-visible,
+.request-insights-row:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.request-insights-scope-switcher button:hover:not(:disabled) {
+  background: var(--color-gray-200);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-scope-switcher button[aria-pressed='true'] {
+  background: var(--color-gray-300);
+  color: var(--color-gray-1000);
+  font-weight: 500;
+}
+
+.request-insights-scope-switcher button:disabled {
+  color: var(--color-gray-600);
+  cursor: default;
+}
+
 .request-insights-update-status {
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-11);
   white-space: nowrap;
 }
@@ -95,7 +138,7 @@
   border-radius: 999px;
   padding: 0 4px;
   background: var(--color-blue-800);
-  color: var(--color-background-100);
+  color: white;
   font-size: var(--size-10);
   line-height: 16px;
   text-align: center;
@@ -121,7 +164,7 @@
 
 .request-insights-filter-group-label {
   padding: 8px 8px 3px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-10);
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -157,7 +200,7 @@
 
 .request-insights-filter-option-count {
   min-width: 20px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-family: var(--font-mono);
   font-size: var(--size-11);
   text-align: right;
@@ -393,6 +436,20 @@
   color: var(--color-gray-800);
 }
 
+.request-insights-request-error {
+  flex-shrink: 0;
+  color: var(--color-red-900);
+  font-size: var(--size-11);
+}
+
+.request-insights-request-activity[data-activity='instant-insights'] {
+  color: var(--color-blue-900);
+}
+
+.request-insights-request-activity[data-activity='instant-insights'][data-status='error'] {
+  color: var(--color-red-900);
+}
+
 .request-insights-duration,
 .request-insights-meta {
   color: var(--color-gray-900);
@@ -418,6 +475,69 @@
   min-width: 0;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.request-insights-instant-section {
+  border-top: 1px solid var(--color-gray-400);
+}
+
+.request-insights-instant-section > summary {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  font-size: var(--size-12);
+  font-weight: 600;
+  list-style: none;
+}
+
+.request-insights-instant-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+.request-insights-instant-section > summary::before {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  content: '';
+  transform-origin: 2px 50%;
+}
+
+.request-insights-instant-section[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.request-insights-instant-section > summary > :first-child {
+  flex: 1;
+}
+
+.request-insights-instant-section > summary:hover {
+  background: var(--color-gray-100);
+}
+
+.request-insights-instant-section > summary:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.request-insights-instant-record {
+  border-top: 1px solid var(--color-gray-400);
+}
+
+.request-insights-instant-record-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
 }
 
 .request-insights-summary {
@@ -565,7 +685,7 @@
 }
 
 .request-insights-section-note {
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-size: var(--size-11);
 }
 
@@ -747,6 +867,8 @@
 .request-insights-fetch-table {
   display: flex;
   flex-direction: column;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
   border-top: 1px solid var(--color-gray-400);
 }
 
@@ -760,6 +882,7 @@
   color: var(--color-gray-900);
   font-family: var(--font-mono);
   font-size: var(--size-12);
+  min-width: 640px;
 }
 
 .request-insights-fetch-header {
@@ -808,7 +931,7 @@
   border: 1px solid var(--color-gray-400);
   border-radius: 999px;
   padding: 0 5px;
-  color: var(--color-gray-800);
+  color: var(--color-gray-900);
   font-family: inherit;
   font-size: var(--size-10);
   text-overflow: ellipsis;
@@ -846,13 +969,5 @@
     max-height: 180px;
     border-right: 0;
     border-bottom: 1px solid var(--color-gray-400);
-  }
-
-  .request-insights-fetch {
-    grid-template-columns: 44px minmax(0, 1fr) 56px;
-  }
-
-  .request-insights-fetch > span:nth-child(n + 4) {
-    display: none;
   }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.css
@@ -40,6 +40,162 @@
   font-size: var(--size-12);
 }
 
+.request-insights-list-controls,
+.request-insights-update-status {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.request-insights-update-status {
+  color: var(--color-gray-800);
+  font-size: var(--size-11);
+  white-space: nowrap;
+}
+
+.request-insights-paused-state::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 4px;
+  border-radius: 999px;
+  background: var(--color-amber-800);
+  content: '';
+}
+
+.request-insights-filter-trigger {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--color-gray-400);
+  border-radius: 4px;
+  padding: 2px 6px;
+  background: transparent;
+  color: var(--color-gray-900);
+  cursor: pointer;
+  font: inherit;
+}
+
+.request-insights-filter-trigger:hover,
+.request-insights-filter-trigger[aria-expanded='true'] {
+  background: var(--color-gray-200);
+  color: var(--color-gray-1000);
+}
+
+.request-insights-filter-active-count {
+  min-width: 16px;
+  border-radius: 999px;
+  padding: 0 4px;
+  background: var(--color-blue-800);
+  color: var(--color-background-100);
+  font-size: var(--size-10);
+  line-height: 16px;
+  text-align: center;
+}
+
+.request-insights-filter-positioner {
+  z-index: var(--top-z-index);
+}
+
+.request-insights-filter-menu {
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  width: min(280px, calc(100vw - 24px));
+  max-height: min(560px, calc(100vh - 48px));
+  border: 1px solid var(--color-gray-400);
+  border-radius: 8px;
+  background: var(--color-background-100);
+  box-shadow: 0px 4px 8px -4px
+    color-mix(in srgb, var(--color-gray-900) 4%, transparent);
+  padding: 4px;
+  user-select: none;
+}
+
+.request-insights-filter-group-label {
+  padding: 8px 8px 3px;
+  color: var(--color-gray-800);
+  font-size: var(--size-10);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.request-insights-filter-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: var(--color-gray-1000);
+  cursor: pointer;
+  font-size: var(--size-12);
+}
+
+.request-insights-filter-item[data-highlighted] {
+  background: var(--color-gray-200);
+}
+
+.request-insights-filter-item[data-disabled] {
+  color: var(--color-gray-700);
+  cursor: default;
+}
+
+.request-insights-filter-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.request-insights-filter-option-count {
+  min-width: 20px;
+  color: var(--color-gray-800);
+  font-family: var(--font-mono);
+  font-size: var(--size-11);
+  text-align: right;
+}
+
+.request-insights-filter-reset {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  margin-top: 4px;
+  border-top: 1px solid var(--color-gray-400);
+  padding: 6px 8px 2px;
+  color: var(--color-blue-900);
+  cursor: pointer;
+  font-size: var(--size-12);
+}
+
+.request-insights-filter-reset[data-disabled] {
+  color: var(--color-gray-700);
+  cursor: default;
+}
+
+.request-insights-filter-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--color-gray-400);
+  background: var(--color-gray-100);
+  color: var(--color-gray-900);
+  font-size: var(--size-11);
+}
+
+.request-insights-filter-status button,
+.request-insights-list-empty button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-blue-900);
+  cursor: pointer;
+  font: inherit;
+}
+
 .request-insights-settings {
   position: relative;
   display: inline-flex;
@@ -186,48 +342,49 @@
   font-weight: 400;
 }
 
-.request-insights-row[data-nested='true'] .request-insights-route {
-  padding-left: 18px;
-}
-
-.request-insights-nested-arrow {
-  flex-shrink: 0;
-  color: var(--color-gray-700);
-}
-
-.request-insights-internal-badge {
-  flex-shrink: 0;
-  margin-right: 6px;
-  border: 1px solid var(--color-gray-500);
-  border-radius: 999px;
-  padding: 1px 6px;
-  color: var(--color-gray-800);
-  font-size: var(--size-10);
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.request-insights-page-load {
-  flex-shrink: 0;
-  border-radius: 999px;
-  padding: 1px 5px;
-  background: var(--color-blue-100);
-  color: var(--color-blue-900);
-  font-size: var(--size-10);
-  font-weight: 600;
-  line-height: 16px;
-  white-space: nowrap;
-}
-
-.request-insights-item-context {
+.request-insights-row-metadata {
+  display: flex;
   min-width: 0;
   overflow: hidden;
+  align-items: center;
+  gap: 5px;
+  grid-column: 2;
+  grid-row: 2;
+  text-overflow: ellipsis;
+}
+
+.request-insights-request-type,
+.request-insights-request-activity {
+  flex-shrink: 0;
   color: var(--color-gray-900);
   font-size: var(--size-11);
-  font-weight: 400;
-  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-insights-request-type[data-type='page-load'],
+.request-insights-request-type[data-type='rsc'],
+.request-insights-request-type[data-type='prefetch'],
+.request-insights-request-type[data-type='segment-prefetch'],
+.request-insights-request-type[data-type='hmr-refresh'] {
+  color: var(--color-blue-900);
+}
+
+.request-insights-request-type[data-type='action'] {
+  color: var(--color-amber-900);
+}
+
+.request-insights-request-type[data-type='api'] {
+  color: var(--color-purple-900);
+}
+
+.request-insights-request-type[data-type='image'],
+.request-insights-request-type[data-type='asset'],
+.request-insights-request-type[data-type='proxy'] {
+  color: var(--color-green-900);
+}
+
+.request-insights-request-activity {
+  color: var(--color-gray-800);
 }
 
 .request-insights-duration,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -13,7 +13,16 @@ import { CopyButton } from '../copy-button'
 import GearIcon from '../../icons/gear-icon'
 import { formatDuration } from './format-duration'
 import {
+  getRequestInsightFilterResult,
+  REQUEST_INSIGHT_FILTER_GROUPS,
+  toggleRequestInsightFilter,
+  type RequestInsightFilter,
+} from './request-filters'
+import {
   getActiveRequestKey,
+  getRequestInsightRowType,
+  getRequestInsightStatusCode,
+  getRequestInsightSummaryTypeLabel,
   getRequestListEntries,
   isInternalRequestInsight,
   isPageLoadRequest,
@@ -30,10 +39,18 @@ const TRACE_TICK_COUNT = 5
 
 export function RequestInsightsPanel() {
   const { dispatch, state, shadowRoot } = useDevOverlayContext()
+  const [activeFilters, setActiveFilters] = useState<
+    readonly RequestInsightFilter[]
+  >([])
+  const [pausedRequests, setPausedRequests] = useState<
+    readonly RequestInsight[] | null
+  >(null)
+  const displayedRequests = pausedRequests ?? state.requestInsights
   const requests = useMemo(
-    () => [...state.requestInsights].reverse(),
-    [state.requestInsights]
+    () => [...displayedRequests].reverse(),
+    [displayedRequests]
   )
+  const isPaused = pausedRequests !== null
   const { showInternal, verbose } = state.requestInsightsConfig
   const setRequestInsightsConfig = (patch: {
     showInternal?: boolean
@@ -45,9 +62,15 @@ export function RequestInsightsPanel() {
     })
     saveDevToolsConfig({ requestInsights: patch })
   }
+  const filterResult = useMemo(
+    () => getRequestInsightFilterResult(requests, activeFilters, showInternal),
+    [activeFilters, requests, showInternal]
+  )
+  const showInternalInList =
+    showInternal || activeFilters.includes('activity:instant-insights')
   const listEntries = useMemo(
-    () => getRequestListEntries(requests, showInternal),
-    [requests, showInternal]
+    () => getRequestListEntries(filterResult.requests, showInternalInList),
+    [filterResult.requests, showInternalInList]
   )
   const visibleRequests = useMemo(
     () => listEntries.map((entry) => entry.request),
@@ -76,7 +99,7 @@ export function RequestInsightsPanel() {
   // internal activity to reveal.
   const showInternalToggle = internalRequests.length > 0
 
-  if (requests.length === 0) {
+  if (displayedRequests.length === 0) {
     return (
       <div className="request-insights-empty">
         Request insights will appear after the next App Router request.
@@ -89,81 +112,143 @@ export function RequestInsightsPanel() {
       <div className="request-insights-list">
         <div className="request-insights-list-toolbar">
           <strong>Requests</strong>
-          <div className="request-insights-settings">
-            {hiddenInternalErrorCount > 0 ? (
-              <span
-                aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
-                className="request-insights-settings-dot"
-                role="img"
-              />
-            ) : null}
-            <Menu.Root delay={0} modal={false}>
-              <Menu.Trigger
-                aria-label="Request list settings"
-                className="request-insights-settings-trigger"
+          <div className="request-insights-list-controls">
+            {isPaused ? (
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                className="request-insights-update-status"
+                role="status"
               >
-                <GearIcon />
-              </Menu.Trigger>
-              <Menu.Portal container={shadowRoot}>
-                <Menu.Positioner
-                  align="end"
-                  className="request-insights-settings-positioner"
-                  side="bottom"
-                  sideOffset={4}
+                <span className="request-insights-paused-state">Paused</span>
+              </div>
+            ) : null}
+            <RequestFiltersMenu
+              activeFilters={activeFilters}
+              onReset={() => setActiveFilters([])}
+              onToggle={(filter) =>
+                setActiveFilters((filters) =>
+                  toggleRequestInsightFilter(filters, filter)
+                )
+              }
+              optionCounts={filterResult.optionCounts}
+              shadowRoot={shadowRoot}
+            />
+            <div className="request-insights-settings">
+              {hiddenInternalErrorCount > 0 ? (
+                <span
+                  aria-label={`${hiddenInternalErrorCount} hidden internal error${hiddenInternalErrorCount === 1 ? '' : 's'}`}
+                  className="request-insights-settings-dot"
+                  role="img"
+                />
+              ) : null}
+              <Menu.Root delay={0} modal={false}>
+                <Menu.Trigger
+                  aria-label="Request list settings"
+                  className="request-insights-settings-trigger"
                 >
-                  <Menu.Popup className="request-insights-settings-menu">
-                    {showInternalToggle ? (
+                  <GearIcon />
+                </Menu.Trigger>
+                <Menu.Portal container={shadowRoot}>
+                  <Menu.Positioner
+                    align="end"
+                    className="request-insights-settings-positioner"
+                    side="bottom"
+                    sideOffset={4}
+                  >
+                    <Menu.Popup className="request-insights-settings-menu">
                       <Menu.CheckboxItem
-                        checked={showInternal}
+                        checked={isPaused}
                         className="request-insights-settings-item"
                         closeOnClick={false}
                         onCheckedChange={(checked) =>
-                          setRequestInsightsConfig({ showInternal: checked })
+                          setPausedRequests(
+                            checked ? [...state.requestInsights] : null
+                          )
                         }
                       >
                         <span
                           className="request-insights-settings-checkbox"
-                          data-checked={showInternal || undefined}
+                          data-checked={isPaused || undefined}
                         >
-                          {showInternal ? <CheckIcon /> : null}
+                          {isPaused ? <CheckIcon /> : null}
                         </span>
-                        Internal activity
+                        Pause updates
                       </Menu.CheckboxItem>
-                    ) : null}
-                    <Menu.CheckboxItem
-                      checked={verbose}
-                      className="request-insights-settings-item"
-                      closeOnClick={false}
-                      onCheckedChange={(checked) =>
-                        setRequestInsightsConfig({ verbose: checked })
-                      }
-                    >
-                      <span
-                        className="request-insights-settings-checkbox"
-                        data-checked={verbose || undefined}
+                      {showInternalToggle ? (
+                        <Menu.CheckboxItem
+                          checked={showInternal}
+                          className="request-insights-settings-item"
+                          closeOnClick={false}
+                          onCheckedChange={(checked) =>
+                            setRequestInsightsConfig({ showInternal: checked })
+                          }
+                        >
+                          <span
+                            className="request-insights-settings-checkbox"
+                            data-checked={showInternal || undefined}
+                          >
+                            {showInternal ? <CheckIcon /> : null}
+                          </span>
+                          Internal activity
+                        </Menu.CheckboxItem>
+                      ) : null}
+                      <Menu.CheckboxItem
+                        checked={verbose}
+                        className="request-insights-settings-item"
+                        closeOnClick={false}
+                        onCheckedChange={(checked) =>
+                          setRequestInsightsConfig({ verbose: checked })
+                        }
                       >
-                        {verbose ? <CheckIcon /> : null}
-                      </span>
-                      Verbose traces
-                    </Menu.CheckboxItem>
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
+                        <span
+                          className="request-insights-settings-checkbox"
+                          data-checked={verbose || undefined}
+                        >
+                          {verbose ? <CheckIcon /> : null}
+                        </span>
+                        Verbose traces
+                      </Menu.CheckboxItem>
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            </div>
           </div>
         </div>
+        {activeFilters.length > 0 ? (
+          <div className="request-insights-filter-status">
+            <span>
+              {filterResult.matchingRequestCount} of{' '}
+              {filterResult.totalRequestCount} requests
+            </span>
+            <button onClick={() => setActiveFilters([])} type="button">
+              Reset
+            </button>
+          </div>
+        ) : null}
         {listEntries.length === 0 ? (
           <div className="request-insights-list-empty">
-            Only internal activity has been captured. Enable “Internal activity”
-            to view it.
+            {activeFilters.length > 0 ? (
+              <>
+                No requests match the active filters.{' '}
+                <button onClick={() => setActiveFilters([])} type="button">
+                  Reset filters
+                </button>
+              </>
+            ) : (
+              <>
+                Only internal activity has been captured. Enable “Internal
+                activity” to view it.
+              </>
+            )}
           </div>
         ) : (
-          listEntries.map(({ request, nested }) => {
+          listEntries.map(({ request }) => {
             const requestKey = getRequestInsightKey(request)
             return (
               <RequestRow
                 key={requestKey}
-                nested={nested}
                 request={request}
                 pageLoad={isPageLoadRequest(request, initialRequestId)}
                 selected={requestKey === activeRequestKey}
@@ -181,15 +266,99 @@ export function RequestInsightsPanel() {
   )
 }
 
+function RequestFiltersMenu({
+  activeFilters,
+  onReset,
+  onToggle,
+  optionCounts,
+  shadowRoot,
+}: {
+  activeFilters: readonly RequestInsightFilter[]
+  onReset: () => void
+  onToggle: (filter: RequestInsightFilter) => void
+  optionCounts: Readonly<Record<RequestInsightFilter, number>>
+  shadowRoot: ShadowRoot
+}) {
+  return (
+    <Menu.Root delay={0} modal={false}>
+      <Menu.Trigger
+        aria-label={`Filter requests${activeFilters.length > 0 ? `, ${activeFilters.length} active` : ''}`}
+        className="request-insights-filter-trigger"
+      >
+        Filter
+        {activeFilters.length > 0 ? (
+          <span className="request-insights-filter-active-count">
+            {activeFilters.length}
+          </span>
+        ) : null}
+      </Menu.Trigger>
+      <Menu.Portal container={shadowRoot}>
+        <Menu.Positioner
+          align="end"
+          className="request-insights-filter-positioner"
+          side="bottom"
+          sideOffset={4}
+        >
+          <Menu.Popup
+            aria-label="Request filters"
+            className="request-insights-filter-menu"
+          >
+            {REQUEST_INSIGHT_FILTER_GROUPS.map((group) => (
+              <Menu.Group key={group.label}>
+                <Menu.GroupLabel className="request-insights-filter-group-label">
+                  {group.label}
+                </Menu.GroupLabel>
+                {group.options.map((option) => {
+                  const checked = activeFilters.includes(option.value)
+                  const count = optionCounts[option.value]
+                  return (
+                    <Menu.CheckboxItem
+                      key={option.value}
+                      checked={checked}
+                      className="request-insights-filter-item"
+                      closeOnClick={false}
+                      data-filter-value={option.value}
+                      disabled={!checked && count === 0}
+                      onCheckedChange={() => onToggle(option.value)}
+                    >
+                      <span
+                        className="request-insights-settings-checkbox"
+                        data-checked={checked || undefined}
+                      >
+                        {checked ? <CheckIcon /> : null}
+                      </span>
+                      <span className="request-insights-filter-option-label">
+                        {option.label}
+                      </span>
+                      <span className="request-insights-filter-option-count">
+                        {count}
+                      </span>
+                    </Menu.CheckboxItem>
+                  )
+                })}
+              </Menu.Group>
+            ))}
+            <Menu.Item
+              className="request-insights-filter-reset"
+              disabled={activeFilters.length === 0}
+              onClick={onReset}
+            >
+              Reset filters
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  )
+}
+
 function RequestRow({
   request,
-  nested,
   pageLoad,
   selected,
   onSelect,
 }: {
   request: RequestInsight
-  nested: boolean
   pageLoad: boolean
   selected: boolean
   onSelect: () => void
@@ -197,12 +366,15 @@ function RequestRow({
   const isInstantInsights =
     getRequestInsightKind(request) === 'instant-insights'
   const route = request.route ?? request.url ?? 'Unknown route'
+  const requestType = getRequestInsightRowType(request, pageLoad)
+  const clockTime = formatClockTime(request.startTime)
+  const bypassesProxy = request.proxyStatus === 'bypassed'
 
   return (
     <button
+      aria-label={`${isInstantInsights ? `Instant Insights for ${route}` : route}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
-      data-nested={nested || undefined}
       data-page-load={pageLoad}
       data-selected={selected}
       onClick={onSelect}
@@ -210,24 +382,30 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        {nested ? <NestedArrowIcon /> : null}
-        {isInstantInsights && !nested ? (
-          <span className="request-insights-internal-badge">Internal</span>
-        ) : null}
         <span className="request-insights-route-label">
           {isInstantInsights ? 'Instant Insights' : route}
         </span>
-        {isInstantInsights && !nested ? (
-          <span className="request-insights-item-context">{route}</span>
-        ) : pageLoad ? (
-          <span className="request-insights-page-load">Page load</span>
-        ) : null}
       </span>
       <span className="request-insights-duration">
         {formatDuration(request.durationMs)}
       </span>
-      <span className="request-insights-meta">
-        {formatClockTime(request.startTime)}
+      <span className="request-insights-meta request-insights-row-metadata">
+        <span
+          className="request-insights-request-type"
+          data-type={requestType.type}
+          title={requestType.accessibleLabel}
+        >
+          {requestType.label}
+        </span>
+        {bypassesProxy ? (
+          <span
+            className="request-insights-request-activity"
+            title="This request did not match the configured proxy"
+          >
+            No proxy
+          </span>
+        ) : null}
+        <span>{clockTime}</span>
       </span>
       <span className="request-insights-meta request-insights-fetch-summary">
         {request.fetches.length
@@ -235,25 +413,6 @@ function RequestRow({
           : 'No fetches'}
       </span>
     </button>
-  )
-}
-
-function NestedArrowIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      className="request-insights-nested-arrow"
-      fill="none"
-      height="12"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.5"
-      viewBox="0 0 16 16"
-      width="12"
-    >
-      <path d="M4 3v5.5A2.5 2.5 0 0 0 6.5 11H12M12 11l-3-3m3 3-3 3" />
-    </svg>
   )
 }
 
@@ -492,8 +651,7 @@ function getRequestOverview(request: RequestInsight) {
     : (getFirstStringAttribute(request, 'http.method') ??
       getMethodFromName(request.spans[0]?.name) ??
       'GET')
-  const statusCode = getFirstNumberAttribute(request, 'http.status_code')
-  const isRsc = getFirstBooleanAttribute(request, 'next.rsc')
+  const statusCode = getRequestInsightStatusCode(request)
   const erroredSpan = request.spans.find(
     (span) => span.status === 'error' || span.error
   )
@@ -516,11 +674,7 @@ function getRequestOverview(request: RequestInsight) {
     method,
     statusCode,
     statusLabel: statusCode ?? request.status,
-    kind: isInstantInsights
-      ? 'Instant Insights'
-      : isRsc
-        ? 'RSC request'
-        : 'HTML request',
+    kind: getRequestInsightSummaryTypeLabel(request),
     fetchSummary: request.fetches.length
       ? `${request.fetches.length} fetch${request.fetches.length === 1 ? '' : 'es'}`
       : 'No fetches',
@@ -592,30 +746,6 @@ function getFirstStringAttribute(
   for (const span of request.spans) {
     const value = span.attributes?.[key]
     if (typeof value === 'string') {
-      return value
-    }
-  }
-}
-
-function getFirstNumberAttribute(
-  request: RequestInsight,
-  key: string
-): number | undefined {
-  for (const span of request.spans) {
-    const value = span.attributes?.[key]
-    if (typeof value === 'number') {
-      return value
-    }
-  }
-}
-
-function getFirstBooleanAttribute(
-  request: RequestInsight,
-  key: string
-): boolean | undefined {
-  for (const span of request.spans) {
-    const value = span.attributes?.[key]
-    if (typeof value === 'boolean') {
       return value
     }
   }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -41,6 +41,7 @@ import {
   getRequestInsightStatusCode,
   getRequestInsightSummaryTypeLabel,
   getRequestListEntries,
+  getRequestListEntriesForPage,
   isInternalRequestInsight,
   isPageLoadRequest,
 } from './request-list'
@@ -54,6 +55,7 @@ import {
 import './request-insights-panel.css'
 
 const TRACE_TICK_COUNT = 5
+type RequestScope = 'all' | 'page'
 
 export function RequestInsightsPanel() {
   const { dispatch, state, shadowRoot } = useDevOverlayContext()
@@ -63,11 +65,13 @@ export function RequestInsightsPanel() {
   const [pausedRequests, setPausedRequests] = useState<
     readonly RequestInsight[] | null
   >(null)
+  const [requestScope, setRequestScope] = useState<RequestScope>('all')
   const displayedRequests = pausedRequests ?? state.requestInsights
   const requests = useMemo(
     () => [...displayedRequests].reverse(),
     [displayedRequests]
   )
+  const initialRequestId = self.__next_r
   const isPaused = pausedRequests !== null
   const { showInternal, verbose } = state.requestInsightsConfig
   const setRequestInsightsConfig = (patch: {
@@ -80,16 +84,30 @@ export function RequestInsightsPanel() {
     })
     saveDevToolsConfig({ requestInsights: patch })
   }
+  const retainedEntries = useMemo(
+    () => getRequestListEntries(requests, true),
+    [requests]
+  )
+  const allListEntries = useMemo(
+    () =>
+      showInternal
+        ? retainedEntries
+        : retainedEntries.filter(
+            ({ request }) => !isInternalRequestInsight(request)
+          ),
+    [retainedEntries, showInternal]
+  )
+  const currentPageEntries = useMemo(
+    () => getRequestListEntriesForPage(allListEntries, initialRequestId),
+    [allListEntries, initialRequestId]
+  )
+  const scopedEntries =
+    requestScope === 'page' ? currentPageEntries : allListEntries
   const filterResult = useMemo(
-    () => getRequestInsightFilterResult(requests, activeFilters, showInternal),
-    [activeFilters, requests, showInternal]
+    () => getRequestInsightFilterResult(scopedEntries, activeFilters),
+    [activeFilters, scopedEntries]
   )
-  const showInternalInList =
-    showInternal || activeFilters.includes('activity:instant-insights')
-  const listEntries = useMemo(
-    () => getRequestListEntries(filterResult.requests, showInternalInList),
-    [filterResult.requests, showInternalInList]
-  )
+  const listEntries = filterResult.entries
   const visibleRequests = useMemo(
     () => listEntries.map((entry) => entry.request),
     [listEntries]
@@ -101,21 +119,23 @@ export function RequestInsightsPanel() {
     visibleRequests,
     selectedRequestKey
   )
-  const selectedRequest =
-    visibleRequests.find(
-      (request) => getRequestInsightKey(request) === activeRequestKey
+  const selectedEntry =
+    listEntries.find(
+      ({ request }) => getRequestInsightKey(request) === activeRequestKey
     ) ?? null
-  const initialRequestId = self.__next_r
-  const internalRequests = useMemo(
-    () => requests.filter((request) => isInternalRequestInsight(request)),
-    [requests]
+  const selectedRequest = selectedEntry?.request ?? null
+  const orphanedInternalRequests = useMemo(
+    () =>
+      retainedEntries
+        .filter(({ request }) => isInternalRequestInsight(request))
+        .map(({ request }) => request),
+    [retainedEntries]
   )
   const hiddenInternalErrorCount = showInternal
     ? 0
-    : internalRequests.filter((request) => request.status === 'error').length
-  // Only offer the internal-activity toggle once the session has captured
-  // internal activity to reveal.
-  const showInternalToggle = internalRequests.length > 0
+    : orphanedInternalRequests.filter((request) => request.status === 'error')
+        .length
+  const showInternalToggle = orphanedInternalRequests.length > 0
 
   if (displayedRequests.length === 0) {
     return (
@@ -236,6 +256,28 @@ export function RequestInsightsPanel() {
             </div>
           </div>
         </div>
+        <div
+          aria-label="Request scope"
+          className="request-insights-scope-switcher"
+          role="group"
+        >
+          <button
+            aria-pressed={requestScope === 'all'}
+            onClick={() => setRequestScope('all')}
+            type="button"
+          >
+            All
+          </button>
+          <button
+            aria-pressed={requestScope === 'page'}
+            disabled={currentPageEntries.length === 0}
+            onClick={() => setRequestScope('page')}
+            title="Show requests correlated to this browser document"
+            type="button"
+          >
+            This page
+          </button>
+        </div>
         {activeFilters.length > 0 ? (
           <div className="request-insights-filter-status">
             <span>
@@ -256,6 +298,8 @@ export function RequestInsightsPanel() {
                   Reset filters
                 </button>
               </>
+            ) : requestScope === 'page' ? (
+              <>No requests are correlated to this browser document.</>
             ) : (
               <>
                 Only internal activity has been captured. Enable “Internal
@@ -264,10 +308,11 @@ export function RequestInsightsPanel() {
             )}
           </div>
         ) : (
-          listEntries.map(({ request }) => {
+          listEntries.map(({ request, instantInsights }) => {
             const requestKey = getRequestInsightKey(request)
             return (
               <RequestRow
+                instantInsights={instantInsights}
                 key={requestKey}
                 request={request}
                 pageLoad={isPageLoadRequest(request, initialRequestId)}
@@ -280,7 +325,11 @@ export function RequestInsightsPanel() {
       </div>
 
       {selectedRequest && (
-        <RequestDetails request={selectedRequest} verbose={verbose} />
+        <RequestDetails
+          instantInsights={selectedEntry?.instantInsights ?? []}
+          request={selectedRequest}
+          verbose={verbose}
+        />
       )}
     </div>
   )
@@ -373,11 +422,13 @@ function RequestFiltersMenu({
 }
 
 function RequestRow({
+  instantInsights,
   request,
   pageLoad,
   selected,
   onSelect,
 }: {
+  instantInsights: readonly RequestInsight[]
   request: RequestInsight
   pageLoad: boolean
   selected: boolean
@@ -392,10 +443,21 @@ function RequestRow({
   )
   const clockTime = formatClockTime(request.startTime)
   const bypassesProxy = request.proxyStatus === 'bypassed'
+  const hasInstantInsightsError = instantInsights.some(
+    (item) =>
+      item.status === 'error' ||
+      item.spans.some((span) => span.status === 'error' || span.error)
+  )
+  const hasRequestError =
+    request.status === 'error' ||
+    request.spans.some((span) => span.status === 'error' || span.error)
+  const hasVisibleError = hasRequestError || hasInstantInsightsError
+  const statusLabel = getRequestInsightStatusCode(request) ?? request.status
 
   return (
     <button
-      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, Status ${statusLabel}, ${instantInsights.length > 0 ? `Includes Instant Insights${hasInstantInsightsError ? ' with errors' : ''}, ` : ''}${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-pressed={selected}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
       data-page-load={pageLoad}
@@ -405,7 +467,7 @@ function RequestRow({
     >
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
-        <span className="request-insights-route-label">
+        <span className="request-insights-route-label" title={requestUrl}>
           {isInstantInsights ? 'Instant Insights' : requestUrl}
         </span>
       </span>
@@ -420,6 +482,16 @@ function RequestRow({
         >
           {requestType.label}
         </span>
+        {instantInsights.length > 0 ? (
+          <span
+            className="request-insights-request-activity"
+            data-activity="instant-insights"
+            data-status={hasInstantInsightsError ? 'error' : 'ok'}
+            title={`${instantInsights.length} Instant Insights record${instantInsights.length === 1 ? '' : 's'}${hasInstantInsightsError ? ' with errors' : ''}`}
+          >
+            Instant
+          </span>
+        ) : null}
         {bypassesProxy ? (
           <span
             className="request-insights-request-activity"
@@ -427,6 +499,9 @@ function RequestRow({
           >
             No proxy
           </span>
+        ) : null}
+        {hasVisibleError ? (
+          <span className="request-insights-request-error">Error</span>
         ) : null}
         <span>{clockTime}</span>
       </span>
@@ -454,9 +529,11 @@ function CheckIcon() {
 }
 
 function RequestDetails({
+  instantInsights,
   request,
   verbose,
 }: {
+  instantInsights: readonly RequestInsight[]
   request: RequestInsight
   verbose: boolean
 }) {
@@ -478,7 +555,7 @@ function RequestDetails({
       <div className="request-insights-summary">
         <div className="request-insights-heading">
           <div className="request-insights-title-row">
-            <div className="request-insights-title">
+            <div className="request-insights-title" title={requestUrl}>
               {getRequestInsightKind(request) === 'instant-insights'
                 ? `Instant Insights · ${requestUrl}`
                 : requestUrl}
@@ -508,6 +585,65 @@ function RequestDetails({
         request={request}
       />
 
+      <FetchTable fetches={request.fetches} />
+
+      {instantInsights.length > 0 ? (
+        <InstantInsightsSection requests={instantInsights} verbose={verbose} />
+      ) : null}
+    </div>
+  )
+}
+
+function InstantInsightsSection({
+  requests,
+  verbose,
+}: {
+  requests: readonly RequestInsight[]
+  verbose: boolean
+}) {
+  return (
+    <details className="request-insights-instant-section">
+      <summary>
+        <span>Instant Insights</span>
+        <span className="request-insights-section-note">
+          {requests.length} record{requests.length === 1 ? '' : 's'}
+        </span>
+      </summary>
+      {requests.map((request) => (
+        <InstantInsightsRecord
+          key={getRequestInsightKey(request)}
+          request={request}
+          verbose={verbose}
+        />
+      ))}
+    </details>
+  )
+}
+
+function InstantInsightsRecord({
+  request,
+  verbose,
+}: {
+  request: RequestInsight
+  verbose: boolean
+}) {
+  const traceItems = useMemo(
+    () =>
+      getTraceItems(
+        request,
+        verbose,
+        typeof window === 'undefined' ? undefined : window.location.origin
+      ),
+    [request, verbose]
+  )
+
+  return (
+    <div className="request-insights-instant-record">
+      <div className="request-insights-instant-record-summary">
+        <span>Status {request.status}</span>
+        <span>{formatDuration(request.durationMs)}</span>
+      </div>
+      <Trace items={traceItems} request={request} />
       <FetchTable fetches={request.fetches} />
     </div>
   )
@@ -782,14 +918,17 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
           No server fetches captured.
         </div>
       ) : (
-        <div className="request-insights-fetch-table">
-          <div className="request-insights-fetch request-insights-fetch-header">
-            <span>Method</span>
-            <span>URL</span>
-            <span>Duration</span>
-            <span>Status</span>
-            <span>Cache</span>
-            <span>Reason</span>
+        <div className="request-insights-fetch-table" role="table">
+          <div
+            className="request-insights-fetch request-insights-fetch-header"
+            role="row"
+          >
+            <span role="columnheader">Method</span>
+            <span role="columnheader">URL</span>
+            <span role="columnheader">Duration</span>
+            <span role="columnheader">Status</span>
+            <span role="columnheader">Cache</span>
+            <span role="columnheader">Reason</span>
           </div>
           {fetches.map((fetch, index) => {
             const url = getFetchUrlPresentation(fetch.url, currentOrigin)
@@ -798,11 +937,12 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
                 className="request-insights-fetch"
                 data-origin={url.originKind}
                 key={index}
+                role="row"
               >
-                <span className="request-insights-method">
+                <span className="request-insights-method" role="cell">
                   {fetch.method ?? 'GET'}
                 </span>
-                <span className="request-insights-fetch-url">
+                <span className="request-insights-fetch-url" role="cell">
                   <Tooltip
                     className="request-insights-fetch-tooltip"
                     title={url.fullUrl}
@@ -820,10 +960,10 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
                     </span>
                   </Tooltip>
                 </span>
-                <span>{formatDuration(fetch.durationMs)}</span>
-                <span>{fetch.statusCode ?? '-'}</span>
-                <span>{fetch.cacheStatus ?? 'unknown'}</span>
-                <span className="request-insights-cache-reason">
+                <span role="cell">{formatDuration(fetch.durationMs)}</span>
+                <span role="cell">{fetch.statusCode ?? '-'}</span>
+                <span role="cell">{fetch.cacheStatus ?? 'unknown'}</span>
+                <span className="request-insights-cache-reason" role="cell">
                   {fetch.cacheReason ?? '-'}
                 </span>
               </div>

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -1,4 +1,13 @@
-import { useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react'
 import { Menu } from '@base-ui-components/react/menu'
 import {
   getRequestInsightKey,
@@ -10,7 +19,9 @@ import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { ACTION_DEVTOOLS_CONFIG } from '../../shared'
 import { saveDevToolsConfig } from '../../utils/save-devtools-config'
 import { CopyButton } from '../copy-button'
+import { Tooltip } from '../tooltip/tooltip'
 import GearIcon from '../../icons/gear-icon'
+import { getFetchUrlPresentation } from './fetch-label'
 import { formatDuration } from './format-duration'
 import {
   getRequestInsightFilterResult,
@@ -18,6 +29,12 @@ import {
   toggleRequestInsightFilter,
   type RequestInsightFilter,
 } from './request-filters'
+import {
+  formatRequestRouteParams,
+  getRequestDisplayUrl,
+  getRequestListDisplayUrl,
+  getRequestRouteParams,
+} from './request-label'
 import {
   getActiveRequestKey,
   getRequestInsightRowType,
@@ -29,6 +46,7 @@ import {
 } from './request-list'
 import {
   getTraceItems,
+  getTraceNavigationIndex,
   getTracePosition,
   getTraceRange,
   type TraceItem,
@@ -181,7 +199,9 @@ export function RequestInsightsPanel() {
                           className="request-insights-settings-item"
                           closeOnClick={false}
                           onCheckedChange={(checked) =>
-                            setRequestInsightsConfig({ showInternal: checked })
+                            setRequestInsightsConfig({
+                              showInternal: checked,
+                            })
                           }
                         >
                           <span
@@ -365,14 +385,17 @@ function RequestRow({
 }) {
   const isInstantInsights =
     getRequestInsightKind(request) === 'instant-insights'
-  const route = request.route ?? request.url ?? 'Unknown route'
   const requestType = getRequestInsightRowType(request, pageLoad)
+  const requestUrl = getRequestListDisplayUrl(
+    request,
+    requestType.type === 'rsc'
+  )
   const clockTime = formatClockTime(request.startTime)
   const bypassesProxy = request.proxyStatus === 'bypassed'
 
   return (
     <button
-      aria-label={`${isInstantInsights ? `Instant Insights for ${route}` : route}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
+      aria-label={`${isInstantInsights ? `Instant Insights for ${requestUrl}` : requestUrl}, ${requestType.accessibleLabel}, ${bypassesProxy ? 'Did not match the configured proxy, ' : ''}${formatDuration(request.durationMs)}, ${clockTime}`}
       className="request-insights-row"
       data-internal={isInstantInsights || undefined}
       data-page-load={pageLoad}
@@ -383,7 +406,7 @@ function RequestRow({
       <span className="request-insights-status" data-status={request.status} />
       <span className="request-insights-route">
         <span className="request-insights-route-label">
-          {isInstantInsights ? 'Instant Insights' : route}
+          {isInstantInsights ? 'Instant Insights' : requestUrl}
         </span>
       </span>
       <span className="request-insights-duration">
@@ -438,11 +461,17 @@ function RequestDetails({
   verbose: boolean
 }) {
   const traceItems = useMemo(
-    () => getTraceItems(request, verbose),
+    () =>
+      getTraceItems(
+        request,
+        verbose,
+        typeof window === 'undefined' ? undefined : window.location.origin
+      ),
     [request, verbose]
   )
   const overview = useMemo(() => getRequestOverview(request), [request])
   const diagnosis = getDiagnosis(request, traceItems)
+  const requestUrl = getRequestDisplayUrl(request)
 
   return (
     <div className="request-insights-details">
@@ -451,8 +480,8 @@ function RequestDetails({
           <div className="request-insights-title-row">
             <div className="request-insights-title">
               {getRequestInsightKind(request) === 'instant-insights'
-                ? `Instant Insights · ${request.route ?? request.url ?? request.requestId}`
-                : (request.route ?? request.url ?? request.requestId)}
+                ? `Instant Insights · ${requestUrl}`
+                : requestUrl}
             </div>
             <CopyButton
               actionLabel="Copy request JSON"
@@ -473,7 +502,11 @@ function RequestDetails({
       ) : null}
       <div className="request-insights-diagnosis">{diagnosis}</div>
 
-      <Trace items={traceItems} request={request} />
+      <Trace
+        items={traceItems}
+        key={getRequestInsightKey(request)}
+        request={request}
+      />
 
       <FetchTable fetches={request.fetches} />
     </div>
@@ -493,6 +526,27 @@ function RequestOverview({
       <span>{overview.fetchSummary}</span>
       <span>{overview.cacheSummary}</span>
       <span>{overview.spanSummary}</span>
+      {overview.route ? (
+        <span className="request-insights-route-template">
+          Route {overview.route}
+        </span>
+      ) : null}
+      {overview.routeParams?.length ? (
+        <Tooltip
+          className="request-insights-params-tooltip"
+          title={formatRequestRouteParams(overview.routeParams)}
+        >
+          <button
+            aria-label={`Route parameters: ${overview.routeParams
+              .map(({ name }) => name)
+              .join(', ')}`}
+            className="request-insights-params-trigger"
+            type="button"
+          >
+            Params {overview.routeParams.map(({ name }) => name).join(', ')}
+          </button>
+        </Tooltip>
+      ) : null}
     </div>
   )
 }
@@ -504,7 +558,41 @@ function Trace({
   request: RequestInsight
   items: TraceItem[]
 }) {
+  const [activeItemId, setActiveItemId] = useState<string | null>(
+    items[0]?.id ?? null
+  )
+  const [activeTraceRow, setActiveTraceRow] = useState<HTMLElement | null>(null)
+  const traceRowsRef = useRef<HTMLDivElement>(null)
+  const shouldScrollActiveItemIntoViewRef = useRef(false)
+  const traceId = useId()
   const range = getTraceRange(request)
+  const activeItemIndex = items.findIndex((item) => item.id === activeItemId)
+  const safeActiveItemIndex =
+    items.length === 0 ? -1 : Math.max(activeItemIndex, 0)
+  const activeItem = items[safeActiveItemIndex]
+  const activeItemDescription = activeItem
+    ? getTraceItemDescription(activeItem, range)
+    : null
+
+  useEffect(() => {
+    if (
+      !shouldScrollActiveItemIntoViewRef.current ||
+      safeActiveItemIndex === -1
+    ) {
+      return
+    }
+
+    shouldScrollActiveItemIntoViewRef.current = false
+    const activeOption =
+      traceRowsRef.current?.children.item(safeActiveItemIndex)
+    if (activeOption instanceof HTMLElement) {
+      activeOption.scrollIntoView({
+        block: 'nearest',
+        inline: 'nearest',
+      })
+    }
+  }, [safeActiveItemIndex])
+
   const ticks = Array.from({ length: TRACE_TICK_COUNT }, (_, index) => {
     const position = index / (TRACE_TICK_COUNT - 1)
     return {
@@ -512,6 +600,52 @@ function Trace({
       position: position * 100,
     }
   })
+  const handleTraceKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return
+      }
+
+      const nextIndex = getTraceNavigationIndex(
+        activeItemIndex,
+        items.length,
+        event.key
+      )
+      if (nextIndex === undefined) {
+        return
+      }
+
+      event.preventDefault()
+      shouldScrollActiveItemIntoViewRef.current = true
+      setActiveItemId(items[nextIndex]?.id ?? null)
+    },
+    [activeItemIndex, items]
+  )
+  const handleTracePointerOver = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+
+      const row = target.closest<HTMLElement>('[data-trace-index]')
+      if (row === null || !event.currentTarget.contains(row)) {
+        return
+      }
+
+      const index = Number(row.dataset.traceIndex)
+      if (Number.isSafeInteger(index)) {
+        shouldScrollActiveItemIntoViewRef.current = false
+        const itemId = items[index]?.id
+        if (itemId !== undefined) {
+          setActiveItemId((currentItemId) =>
+            currentItemId === itemId ? currentItemId : itemId
+          )
+        }
+      }
+    },
+    [items]
+  )
 
   return (
     <div className="request-insights-section">
@@ -548,54 +682,98 @@ function Trace({
               Duration
             </span>
           </div>
-          <div className="request-insights-trace-rows">
-            {items.map((item) => {
-              const position = getTracePosition(item, range)
+          <Tooltip
+            anchor={activeTraceRow}
+            asChild
+            className="request-insights-trace-tooltip"
+            direction="top"
+            title={activeItemDescription}
+          >
+            <div
+              aria-activedescendant={
+                safeActiveItemIndex === -1
+                  ? undefined
+                  : `${traceId}-item-${safeActiveItemIndex}`
+              }
+              aria-label={`Trace spans, ${items.length} item${items.length === 1 ? '' : 's'}. Use arrow keys to inspect timing.`}
+              className="request-insights-trace-rows"
+              onKeyDown={handleTraceKeyDown}
+              onPointerOver={handleTracePointerOver}
+              ref={traceRowsRef}
+              role="listbox"
+              tabIndex={items.length === 0 ? undefined : 0}
+            >
+              {items.map((item, index) => {
+                const position = getTracePosition(item, range)
+                const description = getTraceItemDescription(item, range)
 
-              return (
-                <div
-                  className="request-insights-span-row"
-                  data-kind={item.kind}
-                  key={item.id}
-                  title={`${item.label} · +${formatDuration(position.offsetMs)} · ${formatDuration(item.durationMs)}`}
-                >
-                  <span
-                    className="request-insights-span-name"
-                    style={{ paddingLeft: `${item.depth * 14 + 4}px` }}
+                return (
+                  <div
+                    aria-label={description}
+                    aria-selected={index === safeActiveItemIndex}
+                    className="request-insights-span-row"
+                    data-active={index === safeActiveItemIndex || undefined}
+                    data-kind={item.kind}
+                    data-trace-item-id={item.id}
+                    data-trace-index={index}
+                    id={`${traceId}-item-${index}`}
+                    key={item.id}
+                    ref={
+                      index === safeActiveItemIndex
+                        ? setActiveTraceRow
+                        : undefined
+                    }
+                    role="option"
                   >
-                    <span className="request-insights-span-label">
-                      <span
-                        className="request-insights-span-marker"
-                        data-kind={item.kind}
-                        data-status={item.status}
-                      />
-                      <span>{item.label}</span>
-                    </span>
-                  </span>
-                  <span className="request-insights-span-track">
                     <span
-                      className="request-insights-span-bar"
-                      data-status={item.status}
-                      style={{
-                        left: `${position.left}%`,
-                        width: `${position.width}%`,
-                      }}
-                    />
-                  </span>
-                  <span className="request-insights-span-duration">
-                    {formatDuration(item.durationMs)}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
+                      className="request-insights-span-name"
+                      style={{ paddingLeft: `${item.depth * 14 + 4}px` }}
+                    >
+                      <span className="request-insights-span-label">
+                        <span
+                          className="request-insights-span-marker"
+                          data-kind={item.kind}
+                          data-status={item.status}
+                        />
+                        <span>{item.label}</span>
+                      </span>
+                    </span>
+                    <span className="request-insights-span-track">
+                      <span
+                        className="request-insights-span-bar"
+                        data-status={item.status}
+                        style={{
+                          left: `${position.left}%`,
+                          width: `${position.width}%`,
+                        }}
+                      />
+                    </span>
+                    <span className="request-insights-span-duration">
+                      {formatDuration(item.durationMs)}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </Tooltip>
         </div>
       </div>
     </div>
   )
 }
 
+function getTraceItemDescription(
+  item: TraceItem,
+  range: ReturnType<typeof getTraceRange>
+): string {
+  const position = getTracePosition(item, range)
+  return `${item.fullLabel ?? item.label} · +${formatDuration(position.offsetMs)} · ${formatDuration(item.durationMs)}`
+}
+
 function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
+  const currentOrigin =
+    typeof window === 'undefined' ? undefined : window.location.origin
+
   return (
     <div className="request-insights-section">
       <div className="request-insights-section-title">Fetches</div>
@@ -614,19 +792,33 @@ function FetchTable({ fetches }: { fetches: RequestInsightFetch[] }) {
             <span>Reason</span>
           </div>
           {fetches.map((fetch, index) => {
-            const urlParts = formatUrl(fetch.url)
+            const url = getFetchUrlPresentation(fetch.url, currentOrigin)
             return (
-              <div className="request-insights-fetch" key={index}>
+              <div
+                className="request-insights-fetch"
+                data-origin={url.originKind}
+                key={index}
+              >
                 <span className="request-insights-method">
                   {fetch.method ?? 'GET'}
                 </span>
                 <span className="request-insights-fetch-url">
-                  <span>{urlParts.path}</span>
-                  {urlParts.host ? (
-                    <span className="request-insights-fetch-host">
-                      {urlParts.host}
+                  <Tooltip
+                    className="request-insights-fetch-tooltip"
+                    title={url.fullUrl}
+                  >
+                    <span className="request-insights-fetch-url-trigger">
+                      <span className="request-insights-fetch-path">
+                        {url.path}
+                      </span>
+                      <span
+                        className="request-insights-fetch-origin"
+                        data-origin={url.originKind}
+                      >
+                        {url.originLabel}
+                      </span>
                     </span>
-                  ) : null}
+                  </Tooltip>
                 </span>
                 <span>{formatDuration(fetch.durationMs)}</span>
                 <span>{fetch.statusCode ?? '-'}</span>
@@ -687,6 +879,8 @@ function getRequestOverview(request: RequestInsight) {
               cacheCounts.unknown ? `, ${cacheCounts.unknown} unknown` : ''
             }`,
     spanSummary: `${request.spans.length} span${request.spans.length === 1 ? '' : 's'}`,
+    route: request.route,
+    routeParams: getRequestRouteParams(request),
     errorSummary,
   }
 }
@@ -719,8 +913,11 @@ function getDiagnosis(
     (!criticalItem ||
       (slowestFetch.durationMs ?? 0) >= (criticalItem.durationMs ?? 0))
   ) {
-    const urlParts = formatUrl(slowestFetch.url)
-    return `Slowest recorded operation: ${urlParts.path} · ${formatDuration(slowestFetch.durationMs)}${getCacheSummary(slowestFetch)}.`
+    const url = getFetchUrlPresentation(
+      slowestFetch.url,
+      typeof window === 'undefined' ? undefined : window.location.origin
+    )
+    return `Slowest recorded operation: ${url.path} · ${formatDuration(slowestFetch.durationMs)}${getCacheSummary(slowestFetch)}.`
   }
 
   if (criticalItem) {
@@ -756,24 +953,6 @@ function getMethodFromName(name: string | undefined): string | undefined {
     /^(?:RSC )?(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)\b/
   )
   return match?.[1]
-}
-
-function formatUrl(url: string | undefined): { path: string; host?: string } {
-  if (!url) {
-    return { path: 'Unknown URL' }
-  }
-
-  try {
-    const parsedUrl = new URL(url, window.location.origin)
-    const path = `${parsedUrl.pathname}${parsedUrl.search}`
-    const sameHost = parsedUrl.host === window.location.host
-    return {
-      path,
-      host: sameHost ? undefined : parsedUrl.host,
-    }
-  } catch {
-    return { path: url }
-  }
 }
 
 function formatClockTime(timestamp: number): string {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.test.ts
@@ -1,0 +1,87 @@
+import {
+  formatRequestRouteParams,
+  getRequestDisplayUrl,
+  getRequestListDisplayUrl,
+  getRequestRouteParams,
+} from './request-label'
+
+describe('request insight request labels', () => {
+  it('prefers the concrete URL and hides the transport-only RSC query', () => {
+    const request = {
+      requestId: 'request-1',
+      route: '/products/[id]',
+      url: '/products/blue?tab=details&_rsc=redacted#summary',
+    }
+
+    expect(getRequestDisplayUrl(request)).toBe(
+      '/products/blue?tab=details&_rsc=redacted#summary'
+    )
+    expect(getRequestListDisplayUrl(request, true)).toBe(
+      '/products/blue?tab=details#summary'
+    )
+    expect(getRequestListDisplayUrl(request, false)).toBe(
+      '/products/blue?tab=details&_rsc=redacted#summary'
+    )
+    expect(
+      getRequestListDisplayUrl(
+        {
+          requestId: 'request-2',
+          route: '/products/[id]',
+          url: '//example.test/products/blue?_rsc=redacted',
+        },
+        true
+      )
+    ).toBe('//example.test/products/blue')
+  })
+
+  it('extracts dynamic, catch-all, and optional catch-all parameters', () => {
+    expect(
+      getRequestRouteParams({
+        route: '/products/[category]/[...slug]',
+        url: '/products/widgets/blue/large?sort=redacted',
+      })
+    ).toEqual([
+      { name: 'category', value: 'widgets' },
+      { name: 'slug', value: ['blue', 'large'] },
+    ])
+    expect(
+      getRequestRouteParams({
+        route: '/docs/[[...slug]]',
+        url: '/docs',
+      })
+    ).toEqual([{ name: 'slug', value: [] }])
+  })
+
+  it('handles base paths and encoded route values', () => {
+    const params = getRequestRouteParams(
+      {
+        route: '/products/[category]/[...slug]',
+        url: '/shop/products/home%20goods/blue%2Flarge',
+      },
+      '/shop'
+    )
+
+    expect(params).toEqual([
+      { name: 'category', value: 'home goods' },
+      { name: 'slug', value: ['blue/large'] },
+    ])
+    expect(formatRequestRouteParams(params!)).toBe(
+      '{\n  "category": "home goods",\n  "slug": [\n    "blue/large"\n  ]\n}'
+    )
+  })
+
+  it('does not guess parameters from malformed or mismatched routes', () => {
+    expect(
+      getRequestRouteParams({ route: '/products/[id]', url: '/users/1' })
+    ).toBeUndefined()
+    expect(
+      getRequestRouteParams({ route: '/products/[id]', url: '/products/%zz' })
+    ).toBeUndefined()
+    expect(
+      getRequestRouteParams({
+        route: '/products/[id]/[id]',
+        url: '/products/one/two',
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-label.ts
@@ -1,0 +1,180 @@
+import type { RequestInsight } from '../../../shared/request-insights'
+import { removePathPrefix } from '../../../../shared/lib/router/utils/remove-path-prefix'
+
+type RequestIdentity = Pick<RequestInsight, 'requestId' | 'route' | 'url'>
+
+export type RequestRouteParam = {
+  name: string
+  value: string | string[]
+}
+
+export function getRequestDisplayUrl(request: RequestIdentity): string {
+  return request.url ?? request.route ?? request.requestId
+}
+
+export function getRequestListDisplayUrl(
+  request: RequestIdentity,
+  rscRequest: boolean
+): string {
+  const displayUrl = getRequestDisplayUrl(request)
+  if (!rscRequest) {
+    return displayUrl
+  }
+
+  try {
+    const protocolRelative = displayUrl.startsWith('//')
+    const rootRelative = !protocolRelative && displayUrl.startsWith('/')
+    const parsed = new URL(displayUrl, 'http://next.local')
+    if (!parsed.searchParams.has('_rsc')) {
+      return displayUrl
+    }
+
+    parsed.searchParams.delete('_rsc')
+    return protocolRelative
+      ? `//${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`
+      : rootRelative
+        ? `${parsed.pathname}${parsed.search}${parsed.hash}`
+        : parsed.toString()
+  } catch {
+    return displayUrl
+  }
+}
+
+export function getRequestRouteParams(
+  request: Pick<RequestIdentity, 'route' | 'url'>,
+  basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+): RequestRouteParam[] | undefined {
+  if (!request.route || !request.url) {
+    return undefined
+  }
+
+  const pathname = getPathname(request.url)
+  if (!pathname) {
+    return undefined
+  }
+
+  const routeSegments = splitPathname(request.route)
+  const pathnameSegments = splitPathname(removePathPrefix(pathname, basePath))
+  if (!routeSegments || !pathnameSegments) {
+    return undefined
+  }
+
+  const params: RequestRouteParam[] = []
+  const names = new Set<string>()
+  let pathnameIndex = 0
+
+  for (const routeSegment of routeSegments) {
+    const dynamicSegment = parseDynamicSegment(routeSegment)
+
+    if (!dynamicSegment) {
+      if (
+        routeSegment.includes('[') ||
+        routeSegment.includes(']') ||
+        pathnameSegments[pathnameIndex] !== routeSegment
+      ) {
+        return undefined
+      }
+      pathnameIndex += 1
+      continue
+    }
+
+    if (names.has(dynamicSegment.name)) {
+      return undefined
+    }
+    names.add(dynamicSegment.name)
+
+    if (dynamicSegment.catchAll) {
+      const value = pathnameSegments.slice(pathnameIndex)
+      if (value.length === 0 && !dynamicSegment.optional) {
+        return undefined
+      }
+      params.push({ name: dynamicSegment.name, value })
+      pathnameIndex = pathnameSegments.length
+      continue
+    }
+
+    const value = pathnameSegments[pathnameIndex]
+    if (value === undefined) {
+      return undefined
+    }
+    params.push({ name: dynamicSegment.name, value })
+    pathnameIndex += 1
+  }
+
+  return pathnameIndex === pathnameSegments.length ? params : undefined
+}
+
+export function formatRequestRouteParams(params: RequestRouteParam[]): string {
+  return JSON.stringify(
+    Object.fromEntries(params.map(({ name, value }) => [name, value])),
+    null,
+    2
+  )
+}
+
+function getPathname(url: string): string | undefined {
+  try {
+    if (url.startsWith('/')) {
+      return new URL(url, 'http://next.local').pathname
+    }
+
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.pathname
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function splitPathname(pathname: string): string[] | undefined {
+  if (!pathname.startsWith('/')) {
+    return undefined
+  }
+
+  const segments = pathname.split('/').slice(1)
+  if (segments.at(-1) === '') {
+    segments.pop()
+  }
+
+  const decoded: string[] = []
+  for (const segment of segments) {
+    const value = decodeSegment(segment)
+    if (value === undefined) {
+      return undefined
+    }
+    decoded.push(value)
+  }
+  return decoded
+}
+
+function decodeSegment(segment: string): string | undefined {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return undefined
+  }
+}
+
+function parseDynamicSegment(segment: string):
+  | {
+      name: string
+      catchAll: boolean
+      optional: boolean
+    }
+  | undefined {
+  const optionalCatchAll = segment.match(/^\[\[\.\.\.([^[/\]]+)\]\]$/)
+  const catchAll = segment.match(/^\[\.\.\.([^[/\]]+)\]$/)
+  const dynamic = segment.match(/^\[([^[/\]]+)\]$/)
+  const match = optionalCatchAll ?? catchAll ?? dynamic
+
+  if (!match) {
+    return undefined
+  }
+
+  return {
+    name: match[1],
+    catchAll: optionalCatchAll !== null || catchAll !== null,
+    optional: optionalCatchAll !== null,
+  }
+}

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -1,7 +1,11 @@
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsight,
+  type RequestInsightSpan,
 } from '../../../shared/request-insights'
 
 export function getActiveRequestKey(
@@ -30,65 +34,291 @@ export function isInternalRequestInsight(
 
 export type RequestListEntry = {
   request: RequestInsight
-  nested: boolean
 }
 
 export function getRequestListEntries(
   requests: readonly RequestInsight[],
   showInternal: boolean
 ): RequestListEntry[] {
-  if (!showInternal) {
-    return requests
-      .filter((request) => !isInternalRequestInsight(request))
-      .map((request) => ({ request, nested: false }))
-  }
+  return requests
+    .filter((request) => showInternal || !isInternalRequestInsight(request))
+    .map((request) => ({ request }))
+}
 
-  // Group internal records by the request they belong to, and record which
-  // request ids have a parent (non-internal) record present, both in one pass.
-  const internalByRequestId = new Map<string, RequestInsight[]>()
-  const parentRequestIds = new Set<string>()
-  for (const request of requests) {
-    if (isInternalRequestInsight(request)) {
-      const group = internalByRequestId.get(request.requestId)
-      if (group) {
-        group.push(request)
-      } else {
-        internalByRequestId.set(request.requestId, [request])
+export type RequestInsightRowType =
+  | 'page'
+  | 'page-load'
+  | 'rsc'
+  | 'action'
+  | 'prefetch'
+  | 'segment-prefetch'
+  | 'hmr-refresh'
+  | 'api'
+  | 'image'
+  | 'asset'
+  | 'proxy'
+  | 'instant-insights'
+  | 'unknown'
+
+export type RequestInsightRowTypePresentation = Readonly<{
+  type: RequestInsightRowType
+  label: string
+  accessibleLabel: string
+}>
+
+const REQUEST_INSIGHT_ROW_TYPES: Readonly<
+  Record<RequestInsightRowType, RequestInsightRowTypePresentation>
+> = {
+  page: { type: 'page', label: 'Page', accessibleLabel: 'Page request' },
+  'page-load': {
+    type: 'page-load',
+    label: 'Page load',
+    accessibleLabel: 'Page load',
+  },
+  rsc: {
+    type: 'rsc',
+    label: 'RSC',
+    accessibleLabel: 'React Server Component request',
+  },
+  action: {
+    type: 'action',
+    label: 'Action',
+    accessibleLabel: 'Server Action request',
+  },
+  prefetch: {
+    type: 'prefetch',
+    label: 'Prefetch',
+    accessibleLabel: 'App Router prefetch request',
+  },
+  'segment-prefetch': {
+    type: 'segment-prefetch',
+    label: 'Segment',
+    accessibleLabel: 'App Router segment prefetch request',
+  },
+  'hmr-refresh': {
+    type: 'hmr-refresh',
+    label: 'HMR',
+    accessibleLabel: 'Hot Module Replacement refresh request',
+  },
+  api: { type: 'api', label: 'API', accessibleLabel: 'API request' },
+  image: {
+    type: 'image',
+    label: 'Image',
+    accessibleLabel: 'Image optimization request',
+  },
+  asset: {
+    type: 'asset',
+    label: 'Asset',
+    accessibleLabel: 'Static asset request',
+  },
+  proxy: { type: 'proxy', label: 'Proxy', accessibleLabel: 'Proxy request' },
+  'instant-insights': {
+    type: 'instant-insights',
+    label: 'Instant',
+    accessibleLabel: 'Instant Insights activity',
+  },
+  unknown: {
+    type: 'unknown',
+    label: 'Unknown',
+    accessibleLabel: 'Unclassified request',
+  },
+}
+
+export function getRequestInsightRowType(
+  request: RequestInsight,
+  pageLoad = false
+): RequestInsightRowTypePresentation {
+  switch (getRequestInsightSource(request)) {
+    case 'page': {
+      if (request.serverAction) {
+        return REQUEST_INSIGHT_ROW_TYPES.action
       }
-    } else {
-      parentRequestIds.add(request.requestId)
+      const routerActivity = getRequestInsightRouterActivity(request)
+      if (routerActivity) {
+        return REQUEST_INSIGHT_ROW_TYPES[routerActivity]
+      }
+      if (getRequestInsightIsRsc(request) === true) {
+        return REQUEST_INSIGHT_ROW_TYPES.rsc
+      }
+      return REQUEST_INSIGHT_ROW_TYPES[pageLoad ? 'page-load' : 'page']
     }
+    case 'app-route':
+    case 'pages-api':
+      return REQUEST_INSIGHT_ROW_TYPES.api
+    case 'image':
+      return REQUEST_INSIGHT_ROW_TYPES.image
+    case 'asset':
+      return REQUEST_INSIGHT_ROW_TYPES.asset
+    case 'proxy':
+      return REQUEST_INSIGHT_ROW_TYPES.proxy
+    case 'instant-insights':
+      return REQUEST_INSIGHT_ROW_TYPES['instant-insights']
+    case 'unknown':
+      return REQUEST_INSIGHT_ROW_TYPES.unknown
   }
+}
 
-  const entries: RequestListEntry[] = []
-  for (const request of requests) {
-    if (isInternalRequestInsight(request)) {
-      // Orphans (no parent request in the list) remain top-level and preserve
-      // their ordering relative to other top-level records. Nested internal
-      // records are emitted under their request below.
-      if (!parentRequestIds.has(request.requestId)) {
-        entries.push({ request, nested: false })
-      }
+export function hasRequestInsightProxyActivity(
+  request: RequestInsight
+): boolean {
+  return (
+    getRequestInsightSource(request) === 'proxy' ||
+    request.proxyStatus === 'matched' ||
+    request.spans.some(
+      (span) =>
+        span.attributes?.['next.span_type'] === REQUEST_INSIGHT_PROXY_SPAN_TYPE
+    )
+  )
+}
+
+export function getCanonicalRequestSpan(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): RequestInsightSpan | undefined {
+  let latestRequestSpan: RequestInsightSpan | undefined
+  let latestMatchedRouteSpan: RequestInsightSpan | undefined
+
+  for (const span of request.spans) {
+    if (
+      span.attributes?.['next.span_type'] !== REQUEST_INSIGHT_REQUEST_SPAN_TYPE
+    ) {
       continue
     }
-
-    entries.push({ request, nested: false })
-    const nested = internalByRequestId.get(request.requestId)
-    if (nested) {
-      for (const internalRequest of nested) {
-        entries.push({ request: internalRequest, nested: true })
-      }
+    if (!latestRequestSpan || span.startTime >= latestRequestSpan.startTime) {
+      latestRequestSpan = span
+    }
+    if (
+      request.route &&
+      span.attributes?.['next.route'] === request.route &&
+      (!latestMatchedRouteSpan ||
+        span.startTime >= latestMatchedRouteSpan.startTime)
+    ) {
+      latestMatchedRouteSpan = span
     }
   }
-  return entries
+
+  return latestMatchedRouteSpan ?? latestRequestSpan
+}
+
+export function getRequestInsightStatusCode(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): number | undefined {
+  return getCanonicalThenAnySpanAttribute(
+    request,
+    'http.status_code',
+    (value): value is number => typeof value === 'number'
+  )
+}
+
+export function getRequestInsightIsRsc(
+  request: Pick<RequestInsight, 'route' | 'spans'>
+): boolean | undefined {
+  return getCanonicalThenAnySpanAttribute(
+    request,
+    'next.rsc',
+    (value): value is boolean => typeof value === 'boolean'
+  )
+}
+
+export type RequestInsightRepresentation =
+  | 'html'
+  | 'rsc'
+  | 'not-applicable'
+  | 'unknown'
+
+export function getRequestInsightRepresentation(
+  request: Pick<
+    RequestInsight,
+    'kind' | 'source' | 'serverAction' | 'route' | 'spans'
+  >
+): RequestInsightRepresentation {
+  if (request.serverAction) {
+    return 'not-applicable'
+  }
+
+  switch (getRequestInsightSource(request)) {
+    case 'page': {
+      const isRsc = getRequestInsightIsRsc(request)
+      return isRsc === true ? 'rsc' : isRsc === false ? 'html' : 'unknown'
+    }
+    case 'unknown':
+      return 'unknown'
+    case 'app-route':
+    case 'pages-api':
+    case 'image':
+    case 'asset':
+    case 'proxy':
+    case 'instant-insights':
+      return 'not-applicable'
+  }
+}
+
+export function getRequestInsightRouterActivity(
+  request: Pick<RequestInsight, 'routerActivity'>
+): RequestInsight['routerActivity'] {
+  switch (request.routerActivity) {
+    case 'prefetch':
+    case 'segment-prefetch':
+    case 'hmr-refresh':
+      return request.routerActivity
+    case undefined:
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+export function getRequestInsightSummaryTypeLabel(
+  request: RequestInsight
+): string {
+  const rowType = getRequestInsightRowType(request)
+  if (
+    rowType.type === 'instant-insights' ||
+    rowType.type === 'action' ||
+    rowType.type === 'prefetch' ||
+    rowType.type === 'segment-prefetch' ||
+    rowType.type === 'hmr-refresh'
+  ) {
+    return rowType.accessibleLabel
+  }
+
+  switch (getRequestInsightRepresentation(request)) {
+    case 'html':
+      return 'HTML request'
+    case 'rsc':
+      return 'RSC request'
+    case 'not-applicable':
+    case 'unknown':
+      return rowType.accessibleLabel
+  }
+}
+
+function getCanonicalThenAnySpanAttribute<T>(
+  request: Pick<RequestInsight, 'route' | 'spans'>,
+  key: string,
+  isValue: (value: unknown) => value is T
+): T | undefined {
+  const canonicalValue = getCanonicalRequestSpan(request)?.attributes?.[key]
+  if (isValue(canonicalValue)) {
+    return canonicalValue
+  }
+
+  for (const span of request.spans) {
+    const value = span.attributes?.[key]
+    if (isValue(value)) {
+      return value
+    }
+  }
 }
 
 export function isPageLoadRequest(
-  request: Pick<RequestInsight, 'requestId' | 'kind'>,
+  request: RequestInsight,
   initialRequestId: string | undefined
 ): boolean {
   return (
     getRequestInsightKind(request) === 'request' &&
-    request.requestId === initialRequestId
+    getRequestInsightSource(request) === 'page' &&
+    !request.serverAction &&
+    getRequestInsightIsRsc(request) === false &&
+    request.htmlRequestId === initialRequestId
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-list.ts
@@ -32,17 +32,60 @@ export function isInternalRequestInsight(
   return getRequestInsightKind(request) !== 'request'
 }
 
-export type RequestListEntry = {
+export type RequestListEntry = Readonly<{
   request: RequestInsight
-}
+  instantInsights: readonly RequestInsight[]
+}>
 
 export function getRequestListEntries(
   requests: readonly RequestInsight[],
   showInternal: boolean
 ): RequestListEntry[] {
-  return requests
-    .filter((request) => showInternal || !isInternalRequestInsight(request))
-    .map((request) => ({ request }))
+  const requestIds = new Set(
+    requests
+      .filter((request) => !isInternalRequestInsight(request))
+      .map((request) => request.requestId)
+  )
+  const instantInsightsByOwner = new Map<string, RequestInsight[]>()
+  for (const request of requests) {
+    if (getRequestInsightKind(request) !== 'instant-insights') {
+      continue
+    }
+    const owned = instantInsightsByOwner.get(request.requestId)
+    if (owned) {
+      owned.push(request)
+    } else {
+      instantInsightsByOwner.set(request.requestId, [request])
+    }
+  }
+
+  return requests.flatMap((request) => {
+    if (isInternalRequestInsight(request)) {
+      return showInternal && !requestIds.has(request.requestId)
+        ? [{ request, instantInsights: [] }]
+        : []
+    }
+
+    return [
+      {
+        request,
+        instantInsights: instantInsightsByOwner.get(request.requestId) ?? [],
+      },
+    ]
+  })
+}
+
+export function getRequestListEntriesForPage(
+  entries: readonly RequestListEntry[],
+  htmlRequestId: string | undefined
+): RequestListEntry[] {
+  if (!htmlRequestId) {
+    return []
+  }
+
+  return entries.filter(
+    (entry) => entry.request.htmlRequestId === htmlRequestId
+  )
 }
 
 export type RequestInsightRowType =

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -11,6 +11,7 @@ function createRequest(
 ): RequestInsight {
   return {
     requestId: 'request-1',
+    source: 'unknown',
     htmlRequestId: 'html-1',
     startTime: 100,
     durationMs: 100,

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -9,7 +9,12 @@ import {
   getRequestListEntries,
   isPageLoadRequest,
 } from './request-list'
-import { getTraceItems, getTracePosition, getTraceRange } from './trace-viewer'
+import {
+  getTraceItems,
+  getTraceNavigationIndex,
+  getTracePosition,
+  getTraceRange,
+} from './trace-viewer'
 
 function createRequest(
   overrides: Partial<RequestInsight> = {}
@@ -28,6 +33,18 @@ function createRequest(
 }
 
 describe('request insights trace viewer', () => {
+  it('moves the active trace row without leaving the listbox', () => {
+    expect(getTraceNavigationIndex(0, 3, 'ArrowDown')).toBe(1)
+    expect(getTraceNavigationIndex(2, 3, 'ArrowDown')).toBe(2)
+    expect(getTraceNavigationIndex(2, 3, 'ArrowUp')).toBe(1)
+    expect(getTraceNavigationIndex(1, 3, 'Home')).toBe(0)
+    expect(getTraceNavigationIndex(1, 3, 'End')).toBe(2)
+    expect(getTraceNavigationIndex(1, 3, 'ArrowRight')).toBeUndefined()
+    expect(getTraceNavigationIndex(1, 3, 'ArrowLeft')).toBeUndefined()
+    expect(getTraceNavigationIndex(0, 0, 'ArrowDown')).toBeUndefined()
+    expect(getTraceNavigationIndex(0, 3, 'Enter')).toBeUndefined()
+  })
+
   it('keeps the active request selected when newer requests arrive', () => {
     const selectedRequest = createRequest({ requestId: 'selected' })
     const newerRequest = createRequest({ requestId: 'newer' })
@@ -272,6 +289,40 @@ describe('request insights trace viewer', () => {
         }),
       })
     )
+  })
+
+  it('distinguishes same-origin and external fetches in the trace', () => {
+    const request = createRequest({
+      fetches: [
+        {
+          method: 'GET',
+          url: 'https://app.test/api/data?token=%3Credacted%3E',
+          startTime: 110,
+          durationMs: 10,
+        },
+        {
+          method: 'POST',
+          url: 'https://api.example.test/api/data',
+          startTime: 120,
+          durationMs: 20,
+        },
+      ],
+    })
+
+    expect(
+      getTraceItems(request, true, 'https://app.test').map(
+        ({ label, fullLabel }) => ({ label, fullLabel })
+      )
+    ).toEqual([
+      {
+        label: 'GET /api/data?token=%3Credacted%3E · Same origin',
+        fullLabel: 'GET https://app.test/api/data?token=%3Credacted%3E',
+      },
+      {
+        label: 'POST /api/data · External origin · api.example.test',
+        fullLabel: 'POST https://api.example.test/api/data',
+      },
+    ])
   })
 
   it('orders spans by their recorded parent-child hierarchy', () => {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -199,6 +199,31 @@ describe('request insights trace viewer', () => {
     ])
   })
 
+  it('uses Proxy terminology without changing the recorded OTel span', () => {
+    const middlewareSpan = {
+      name: 'middleware POST',
+      startTime: 100,
+      durationMs: 10,
+      attributes: {
+        'http.method': 'POST',
+        'next.span_name': 'middleware POST',
+        'next.span_type': 'Middleware.execute',
+      },
+    }
+    const request = createRequest({ spans: [middlewareSpan] })
+
+    expect(getTraceItems(request, false)[0]?.label).toBe('proxy POST')
+    expect(middlewareSpan).toEqual(
+      expect.objectContaining({
+        name: 'middleware POST',
+        attributes: expect.objectContaining({
+          'next.span_name': 'middleware POST',
+          'next.span_type': 'Middleware.execute',
+        }),
+      })
+    )
+  })
+
   it('orders spans by their recorded parent-child hierarchy', () => {
     const request = createRequest({
       spans: [

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -7,6 +7,7 @@ import {
   getActiveRequestKey,
   getRequestInsightRowType,
   getRequestListEntries,
+  getRequestListEntriesForPage,
   isPageLoadRequest,
 } from './request-list'
 import {
@@ -80,11 +81,12 @@ describe('request insights trace viewer', () => {
     })
 
     expect(getRequestListEntries([instantInsights, request], false)).toEqual([
-      { request },
+      { request, instantInsights: [instantInsights] },
     ])
+    expect(getRequestListEntries([instantInsights], false)).toEqual([])
   })
 
-  it('keeps internal records flat and in capture order', () => {
+  it('keeps owned internal activity off the list and reveals only orphans', () => {
     const newerRequest = createRequest({ requestId: 'newer' })
     const olderRequest = createRequest({ requestId: 'older' })
     const newerInstantInsights = createRequest({
@@ -95,6 +97,10 @@ describe('request insights trace viewer', () => {
       requestId: 'older',
       kind: 'instant-insights',
     })
+    const orphanedInstantInsights = createRequest({
+      requestId: 'orphaned',
+      kind: 'instant-insights',
+    })
 
     expect(
       getRequestListEntries(
@@ -103,15 +109,51 @@ describe('request insights trace viewer', () => {
           newerRequest,
           olderInstantInsights,
           olderRequest,
+          orphanedInstantInsights,
         ],
         true
       )
     ).toEqual([
-      { request: newerInstantInsights },
-      { request: newerRequest },
-      { request: olderInstantInsights },
-      { request: olderRequest },
+      { request: newerRequest, instantInsights: [newerInstantInsights] },
+      { request: olderRequest, instantInsights: [olderInstantInsights] },
+      { request: orphanedInstantInsights, instantInsights: [] },
     ])
+  })
+
+  it('scopes requests to an exact document identity', () => {
+    const currentPage = createRequest({
+      requestId: 'current-page',
+      htmlRequestId: 'current-document',
+    })
+    const currentNavigation = createRequest({
+      requestId: 'current-navigation',
+      htmlRequestId: 'current-document',
+    })
+    const earlierPage = createRequest({
+      requestId: 'earlier-page',
+      htmlRequestId: 'earlier-document',
+    })
+    const currentPageInstantInsights = createRequest({
+      requestId: 'current-page',
+      kind: 'instant-insights',
+      htmlRequestId: 'different-correlation-metadata',
+    })
+    const entries = getRequestListEntries(
+      [currentNavigation, earlierPage, currentPageInstantInsights, currentPage],
+      true
+    )
+
+    expect(getRequestListEntriesForPage(entries, 'current-document')).toEqual([
+      { request: currentNavigation, instantInsights: [] },
+      {
+        request: currentPage,
+        instantInsights: [currentPageInstantInsights],
+      },
+    ])
+    expect(getRequestListEntriesForPage(entries, 'missing-document')).toEqual(
+      []
+    )
+    expect(getRequestListEntriesForPage(entries, undefined)).toEqual([])
   })
 
   it('labels and filters normalized request activity', () => {
@@ -142,6 +184,29 @@ describe('request insights trace viewer', () => {
     })
     const api = createRequest({ requestId: 'api', source: 'app-route' })
     const asset = createRequest({ requestId: 'asset', source: 'asset' })
+    const instantInsights = createRequest({
+      requestId: 'page',
+      kind: 'instant-insights',
+      source: 'instant-insights',
+      status: 'error',
+    })
+    const entries = getRequestListEntries(
+      [page, instantInsights, rsc, action, api, asset],
+      false
+    )
+    const orphanedInstantInsights = createRequest({
+      requestId: 'orphaned',
+      kind: 'instant-insights',
+      source: 'instant-insights',
+    })
+    const entriesWithOrphan = getRequestListEntries(
+      [page, instantInsights, orphanedInstantInsights, rsc, action, api, asset],
+      true
+    )
+    const entriesWithHiddenOrphan = getRequestListEntries(
+      [page, instantInsights, orphanedInstantInsights, rsc, action, api, asset],
+      false
+    )
 
     expect(getRequestInsightRowType(page, true).label).toBe('Page load')
     expect(getRequestInsightRowType(rsc).label).toBe('RSC')
@@ -149,23 +214,37 @@ describe('request insights trace viewer', () => {
     expect(getRequestInsightRowType(api).label).toBe('API')
     expect(getRequestInsightRowType(asset).label).toBe('Asset')
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api],
-        ['source:page', 'cache:miss']
-      ).requests
+      getRequestInsightFilterResult(entries, [
+        'source:page',
+        'cache:miss',
+      ]).entries.map(({ request }) => request)
     ).toEqual([page])
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api, asset],
-        ['source:action', 'source:api']
-      ).requests
+      getRequestInsightFilterResult(entries, [
+        'source:action',
+        'source:api',
+      ]).entries.map(({ request }) => request)
     ).toEqual([action, api])
     expect(
-      getRequestInsightFilterResult(
-        [page, rsc, action, api, asset],
-        ['source:asset']
-      ).requests
+      getRequestInsightFilterResult(entries, ['source:asset']).entries.map(
+        ({ request }) => request
+      )
     ).toEqual([asset])
+    expect(
+      getRequestInsightFilterResult(entriesWithHiddenOrphan, [
+        'activity:instant-insights',
+      ]).entries.map(({ request }) => request)
+    ).toEqual([page])
+    expect(
+      getRequestInsightFilterResult(entriesWithOrphan, [
+        'activity:instant-insights',
+      ]).entries.map(({ request }) => request)
+    ).toEqual([page, orphanedInstantInsights])
+    expect(
+      getRequestInsightFilterResult(entries, ['status:error']).entries.map(
+        ({ request }) => request
+      )
+    ).toEqual([page])
   })
 
   it('only marks the exact initial document request as the page load', () => {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -1,6 +1,11 @@
-import type { RequestInsight } from '../../../shared/request-insights'
+import {
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  type RequestInsight,
+} from '../../../shared/request-insights'
+import { getRequestInsightFilterResult } from './request-filters'
 import {
   getActiveRequestKey,
+  getRequestInsightRowType,
   getRequestListEntries,
   isPageLoadRequest,
 } from './request-list'
@@ -58,11 +63,11 @@ describe('request insights trace viewer', () => {
     })
 
     expect(getRequestListEntries([instantInsights, request], false)).toEqual([
-      { request, nested: false },
+      { request },
     ])
   })
 
-  it('nests internal records directly after their request row', () => {
+  it('keeps internal records flat and in capture order', () => {
     const newerRequest = createRequest({ requestId: 'newer' })
     const olderRequest = createRequest({ requestId: 'older' })
     const newerInstantInsights = createRequest({
@@ -85,49 +90,89 @@ describe('request insights trace viewer', () => {
         true
       )
     ).toEqual([
-      { request: newerRequest, nested: false },
-      { request: newerInstantInsights, nested: true },
-      { request: olderRequest, nested: false },
-      { request: olderInstantInsights, nested: true },
+      { request: newerInstantInsights },
+      { request: newerRequest },
+      { request: olderInstantInsights },
+      { request: olderRequest },
     ])
   })
 
-  it('keeps orphaned internal records top-level and in root ordering', () => {
-    const request = createRequest({ requestId: 'present' })
-    const presentInstantInsights = createRequest({
-      requestId: 'present',
-      kind: 'instant-insights',
+  it('labels and filters normalized request activity', () => {
+    const requestSpan = (rsc: boolean) => ({
+      name: 'GET',
+      startTime: 100,
+      attributes: {
+        'next.span_type': REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+        'next.rsc': rsc,
+      },
     })
-    const orphanInstantInsights = createRequest({
-      requestId: 'evicted',
-      kind: 'instant-insights',
+    const page = createRequest({
+      requestId: 'page',
+      source: 'page',
+      spans: [requestSpan(false)],
+      fetches: [{ cacheStatus: 'miss' }],
     })
+    const rsc = createRequest({
+      requestId: 'rsc',
+      source: 'page',
+      spans: [requestSpan(true)],
+    })
+    const action = createRequest({
+      requestId: 'action',
+      source: 'page',
+      serverAction: true,
+      spans: [requestSpan(true)],
+    })
+    const api = createRequest({ requestId: 'api', source: 'app-route' })
+    const asset = createRequest({ requestId: 'asset', source: 'asset' })
 
-    const entries = getRequestListEntries(
-      [presentInstantInsights, orphanInstantInsights, request],
-      true
-    )
-
-    expect(entries).toEqual([
-      { request: orphanInstantInsights, nested: false },
-      { request, nested: false },
-      { request: presentInstantInsights, nested: true },
-    ])
-    // Every record appears exactly once.
-    expect(new Set(entries.map((entry) => entry.request)).size).toBe(
-      entries.length
-    )
-    expect(entries).toHaveLength(3)
+    expect(getRequestInsightRowType(page, true).label).toBe('Page load')
+    expect(getRequestInsightRowType(rsc).label).toBe('RSC')
+    expect(getRequestInsightRowType(action).label).toBe('Action')
+    expect(getRequestInsightRowType(api).label).toBe('API')
+    expect(getRequestInsightRowType(asset).label).toBe('Asset')
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api],
+        ['source:page', 'cache:miss']
+      ).requests
+    ).toEqual([page])
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api, asset],
+        ['source:action', 'source:api']
+      ).requests
+    ).toEqual([action, api])
+    expect(
+      getRequestInsightFilterResult(
+        [page, rsc, action, api, asset],
+        ['source:asset']
+      ).requests
+    ).toEqual([asset])
   })
 
   it('only marks the exact initial document request as the page load', () => {
     const initialRequestId = 'document-request'
+    const htmlSpan = {
+      name: 'GET',
+      startTime: 100,
+      attributes: {
+        'next.span_type': REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+        'next.rsc': false,
+      },
+    }
+    const rscSpan = {
+      ...htmlSpan,
+      attributes: { ...htmlSpan.attributes, 'next.rsc': true },
+    }
 
     expect(
       isPageLoadRequest(
         createRequest({
-          requestId: initialRequestId,
+          requestId: 'server-owned-request',
+          source: 'page',
           htmlRequestId: initialRequestId,
+          spans: [htmlSpan],
         }),
         initialRequestId
       )
@@ -136,7 +181,9 @@ describe('request insights trace viewer', () => {
       isPageLoadRequest(
         createRequest({
           requestId: 'related-rsc-request',
+          source: 'page',
           htmlRequestId: initialRequestId,
+          spans: [rscSpan],
         }),
         initialRequestId
       )
@@ -145,7 +192,9 @@ describe('request insights trace viewer', () => {
       isPageLoadRequest(
         createRequest({
           requestId: initialRequestId,
+          source: 'instant-insights',
           kind: 'instant-insights',
+          spans: [htmlSpan],
         }),
         initialRequestId
       )

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -3,6 +3,7 @@ import type {
   RequestInsightFetch,
   RequestInsightSpan,
 } from '../../../shared/request-insights'
+import { getFetchUrlPresentation } from './fetch-label'
 
 export type TraceItem = {
   id: string
@@ -11,6 +12,7 @@ export type TraceItem = {
   spanType?: string
   category: 'nextjs' | 'application'
   label: string
+  fullLabel?: string
   startTime: number
   durationMs?: number
   status: 'ok' | 'error' | 'pending'
@@ -21,6 +23,32 @@ export type TraceItem = {
 export type TraceRange = {
   startTime: number
   durationMs: number
+}
+
+export function getTraceNavigationIndex(
+  currentIndex: number,
+  itemCount: number,
+  key: string
+): number | undefined {
+  if (itemCount <= 0) {
+    return undefined
+  }
+
+  const lastIndex = itemCount - 1
+  const safeCurrentIndex = Math.min(Math.max(currentIndex, 0), lastIndex)
+
+  switch (key) {
+    case 'ArrowDown':
+      return Math.min(safeCurrentIndex + 1, lastIndex)
+    case 'ArrowUp':
+      return Math.max(safeCurrentIndex - 1, 0)
+    case 'Home':
+      return 0
+    case 'End':
+      return lastIndex
+    default:
+      return undefined
+  }
 }
 
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
@@ -74,7 +102,8 @@ const SPAN_WORD_CASE: Record<string, string> = {
 
 export function getTraceItems(
   request: RequestInsight,
-  verbose: boolean
+  verbose: boolean,
+  currentOrigin?: string
 ): TraceItem[] {
   const fetchSpansByIndex = new Map<number, RequestInsightSpan>()
 
@@ -108,7 +137,7 @@ export function getTraceItems(
   request.fetches.forEach((fetch, index) => {
     const matchingSpan =
       fetch.index === undefined ? undefined : fetchSpansByIndex.get(fetch.index)
-    const item = getFetchTraceItem(fetch, index, matchingSpan)
+    const item = getFetchTraceItem(fetch, index, matchingSpan, currentOrigin)
     if (item) {
       items.push(item)
     }
@@ -171,12 +200,16 @@ function getSpanTraceItem(
 function getFetchTraceItem(
   fetch: RequestInsightFetch,
   index: number,
-  matchingSpan: RequestInsightSpan | undefined
+  matchingSpan: RequestInsightSpan | undefined,
+  currentOrigin: string | undefined
 ): UnnestedTraceItem | null {
   const startTime = fetch.startTime ?? matchingSpan?.startTime
   if (startTime === undefined) {
     return null
   }
+
+  const method = fetch.method ?? 'GET'
+  const url = getFetchUrlPresentation(fetch.url, currentOrigin)
 
   return {
     id: `fetch:${matchingSpan?.spanId ?? fetch.index ?? index}:${startTime}`,
@@ -184,7 +217,8 @@ function getFetchTraceItem(
     parentSpanId: matchingSpan?.parentSpanId,
     spanType: FETCH_SPAN_TYPE,
     category: matchingSpan ? getSpanCategory(matchingSpan) : 'application',
-    label: `${fetch.method ?? 'GET'} ${getUrlPath(fetch.url)}`,
+    label: `${method} ${url.path}${currentOrigin ? ` · ${url.originLabel}` : ''}`,
+    fullLabel: `${method} ${url.fullUrl}`,
     startTime,
     durationMs: fetch.durationMs ?? matchingSpan?.durationMs,
     status:
@@ -391,17 +425,4 @@ function getSpanLabel(span: RequestInsightSpan): string {
   }
 
   return words.join(' ')
-}
-
-function getUrlPath(url: string | undefined): string {
-  if (!url) {
-    return 'Unknown URL'
-  }
-
-  try {
-    const parsedUrl = new URL(url, 'http://localhost')
-    return `${parsedUrl.pathname}${parsedUrl.search}`
-  } catch {
-    return url
-  }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.ts
@@ -26,9 +26,10 @@ export type TraceRange = {
 type UnnestedTraceItem = Omit<TraceItem, 'depth'>
 
 const FETCH_SPAN_TYPE = 'AppRender.fetch'
+const MIDDLEWARE_SPAN_TYPE = 'Middleware.execute'
 const DEFAULT_VISIBLE_SPAN_TYPES = new Set([
   'BaseServer.handleRequest',
-  'Middleware.execute',
+  MIDDLEWARE_SPAN_TYPE,
   'NextNodeServer.matchRoute',
   'DevRouteMatcherManager.ensureRoute',
   'BaseServer.render',
@@ -349,6 +350,13 @@ function getSpanLabel(span: RequestInsightSpan): string {
   const displayName = name
     .replace(FIZZ_WORD, 'HTML')
     .replace(FLIGHT_WORD, 'RSC')
+
+  if (span.attributes?.['next.span_type'] === MIDDLEWARE_SPAN_TYPE) {
+    const method = span.attributes['http.method']
+    return typeof method === 'string' && method.length > 0
+      ? `proxy ${method}`
+      : displayName.replace(/^middleware\b/i, 'proxy')
+  }
 
   if (displayName === 'resolve segment modules') {
     return 'resolve segment'

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.css
@@ -5,6 +5,8 @@
 }
 
 .tooltip {
+  --tooltip-background: var(--color-gray-1000);
+
   position: relative;
   padding: 6px 12px;
   border-radius: 8px;
@@ -12,7 +14,7 @@
   line-height: 1.4;
   pointer-events: none;
   color: var(--color-gray-100);
-  background-color: var(--color-gray-1000);
+  background-color: var(--tooltip-background);
 }
 
 .tooltip-arrow {
@@ -27,7 +29,7 @@
 .tooltip-arrow--top {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px) 0
     var(--arrow-size, 6px);
-  border-top-color: var(--color-gray-1000);
+  border-top-color: var(--tooltip-background);
   bottom: 0;
   transform: translateY(100%);
 }
@@ -35,7 +37,7 @@
 .tooltip-arrow--bottom {
   border-width: 0 var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-bottom-color: var(--color-gray-1000);
+  border-bottom-color: var(--tooltip-background);
   top: 0;
   transform: translateY(-100%);
 }
@@ -43,7 +45,7 @@
 .tooltip-arrow--left {
   border-width: var(--arrow-size, 6px) 0 var(--arrow-size, 6px)
     var(--arrow-size, 6px);
-  border-left-color: var(--color-gray-1000);
+  border-left-color: var(--tooltip-background);
   right: 0;
   transform: translateX(100%);
 }
@@ -51,7 +53,7 @@
 .tooltip-arrow--right {
   border-width: var(--arrow-size, 6px) var(--arrow-size, 6px)
     var(--arrow-size, 6px) 0;
-  border-right-color: var(--color-gray-1000);
+  border-right-color: var(--tooltip-background);
   left: 0;
   transform: translateX(-100%);
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, isValidElement } from 'react'
 import { Tooltip as BaseTooltip } from '@base-ui-components/react/tooltip'
 import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { cx } from '../../utils/cx'
@@ -9,72 +9,80 @@ type TooltipDirection = 'top' | 'bottom' | 'left' | 'right'
 interface TooltipProps {
   children: React.ReactNode
   title: string | null
+  anchor?: React.ComponentProps<typeof BaseTooltip.Positioner>['anchor']
+  asChild?: boolean
   direction?: TooltipDirection
   arrowSize?: number
   offset?: number
   className?: string
 }
 
-export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
-  function Tooltip(
-    {
-      className,
-      children,
-      title,
-      direction = 'top',
-      arrowSize = 6,
-      offset = 8,
-    },
-    ref
-  ) {
-    const { shadowRoot } = useDevOverlayContext()
-    if (!title) {
-      return children
-    }
-    return (
-      <BaseTooltip.Provider>
-        <BaseTooltip.Root delay={400}>
-          <BaseTooltip.Trigger
-            ref={ref}
-            render={(triggerProps) => {
-              return <span {...triggerProps}>{children}</span>
-            }}
-          />
+export const Tooltip = forwardRef<HTMLElement, TooltipProps>(function Tooltip(
+  {
+    className,
+    children,
+    title,
+    anchor,
+    asChild = false,
+    direction = 'top',
+    arrowSize = 6,
+    offset = 8,
+  },
+  ref
+) {
+  const { shadowRoot } = useDevOverlayContext()
+  if (!title) {
+    return children
+  }
+  return (
+    <BaseTooltip.Provider>
+      <BaseTooltip.Root delay={400}>
+        <BaseTooltip.Trigger
+          ref={ref}
+          render={
+            asChild && isValidElement<Record<string, unknown>>(children)
+              ? children
+              : (triggerProps) => {
+                  return <span {...triggerProps}>{children}</span>
+                }
+          }
+        />
 
-          <BaseTooltip.Portal container={shadowRoot}>
-            <BaseTooltip.Positioner
-              side={direction}
-              sideOffset={offset + arrowSize}
-              className="tooltip-positioner"
+        <BaseTooltip.Portal container={shadowRoot}>
+          <BaseTooltip.Positioner
+            anchor={anchor}
+            positionMethod={anchor ? 'fixed' : undefined}
+            side={direction}
+            sideOffset={offset + arrowSize}
+            className="tooltip-positioner"
+            style={
+              {
+                '--anchor-width': `${arrowSize}px`,
+                '--anchor-height': `${arrowSize}px`,
+              } as React.CSSProperties
+            }
+          >
+            <BaseTooltip.Popup
+              className={cx('tooltip', className)}
               style={
                 {
-                  '--anchor-width': `${arrowSize}px`,
-                  '--anchor-height': `${arrowSize}px`,
+                  '--arrow-size': `${arrowSize}px`,
                 } as React.CSSProperties
               }
             >
-              <BaseTooltip.Popup
-                className={cx('tooltip', className)}
+              {title}
+              <BaseTooltip.Arrow
+                className={cx('tooltip-arrow', `tooltip-arrow--${direction}`)}
                 style={
                   {
                     '--arrow-size': `${arrowSize}px`,
                   } as React.CSSProperties
                 }
-              >
-                {title}
-                <BaseTooltip.Arrow
-                  className={cx('tooltip-arrow', `tooltip-arrow--${direction}`)}
-                  style={
-                    {
-                      '--arrow-size': `${arrowSize}px`,
-                    } as React.CSSProperties
-                  }
-                />
-              </BaseTooltip.Popup>
-            </BaseTooltip.Positioner>
-          </BaseTooltip.Portal>
-        </BaseTooltip.Root>
-      </BaseTooltip.Provider>
-    )
-  }
-)
+              />
+            </BaseTooltip.Popup>
+          </BaseTooltip.Positioner>
+        </BaseTooltip.Portal>
+      </BaseTooltip.Root>
+    </BaseTooltip.Provider>
+  )
+})

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -374,6 +374,7 @@ export const PanelRouter = () => {
       {isAppRouter && !!process.env.__NEXT_REQUEST_INSIGHTS && (
         <PanelRoute name="request-insights">
           <DynamicPanel
+            containerProps={{ className: 'request-insights-panel-container' }}
             sharePanelSizeGlobally={false}
             sharePanelPositionGlobally={false}
             draggable

--- a/packages/next/src/next-devtools/dev-overlay/shared.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.test.ts
@@ -23,6 +23,7 @@ function createRequestInsight(
   return {
     requestId: 'shared-request',
     kind,
+    source: kind === 'instant-insights' ? 'instant-insights' : 'page',
     htmlRequestId: 'shared-html',
     route: '/dashboard',
     startTime: 100,

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
+type DevToolsWindow = Window & {
+  [PAGEHIDE_LISTENER_KEY]?: () => void
+}
+
+const originalFetch = global.fetch
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function removePagehideListener() {
+  const devToolsWindow = window as DevToolsWindow
+  const listener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+
+  if (listener) {
+    window.removeEventListener('pagehide', listener)
+    delete devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  }
+}
+
+describe('saveDevToolsConfig', () => {
+  let fetchMock: jest.Mock
+  let warnMock: jest.SpyInstance
+
+  beforeEach(() => {
+    removePagehideListener()
+    jest.resetModules()
+    jest.useFakeTimers()
+    fetchMock = jest.fn()
+    global.fetch = fetchMock
+    warnMock = jest.spyOn(console, 'warn').mockImplementation()
+  })
+
+  afterEach(async () => {
+    await flushMicrotasks()
+    removePagehideListener()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    global.fetch = originalFetch
+    warnMock.mockRestore()
+  })
+
+  it('serializes writes and retries a merged patch after a failed response', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let activeRequests = 0
+    let maximumActiveRequests = 0
+
+    fetchMock
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return new Promise<{ ok: boolean }>((resolve) => {
+          resolveFirstRequest = resolve
+        }).finally(() => {
+          activeRequests--
+        })
+      })
+      .mockImplementationOnce(() => {
+        activeRequests++
+        maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+
+        return Promise.resolve({ ok: true }).finally(() => {
+          activeRequests--
+        })
+      })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({
+      requestInsights: { showInternal: true, verbose: false },
+    })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    jest.advanceTimersByTime(120)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveFirstRequest!({ ok: false })
+    await jest.advanceTimersByTimeAsync(0)
+
+    await jest.advanceTimersByTimeAsync(239)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await jest.advanceTimersByTimeAsync(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    expect(maximumActiveRequests).toBe(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: false },
+      }
+    )
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toStrictEqual(
+      {
+        requestInsights: { showInternal: true, verbose: true },
+      }
+    )
+  })
+
+  it('retries a patch when fetch throws synchronously without logging it', async () => {
+    fetchMock
+      .mockImplementationOnce(() => {
+        throw new Error('sensitive value: dark')
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ theme: 'dark' })
+    jest.advanceTimersByTime(120)
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('dark')
+    expect(JSON.stringify(warnMock.mock.calls)).not.toContain('sensitive')
+
+    await jest.advanceTimersByTimeAsync(240)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({ theme: 'dark' }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a pending patch immediately on pagehide with keepalive', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/__nextjs_devtools_config',
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: { showInternal: true },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('flushes a queued patch on pagehide while a save is in flight', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(
+      fetchMock.mock.calls.map((call) => JSON.parse(call[1].body))
+    ).toEqual([
+      { requestInsights: { showInternal: true } },
+      {
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      },
+    ])
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ keepalive: true })
+    )
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+  })
+
+  it('retries a failed pagehide flush after the in-flight save completes', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    let rejectPagehideRequest: (error: Error) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((_resolve, reject) => {
+            rejectPagehideRequest = reject
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { showInternal: true } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    resolveFirstRequest!({ ok: true })
+    await flushMicrotasks()
+    rejectPagehideRequest!(new Error('page was hidden'))
+    await flushMicrotasks()
+
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          requestInsights: {
+            showInternal: true,
+            verbose: true,
+          },
+        }),
+        keepalive: true,
+      })
+    )
+  })
+
+  it('does not restore an older failed patch after a newer pagehide flush succeeds', async () => {
+    let resolveFirstRequest: (response: { ok: boolean }) => void
+    fetchMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirstRequest = resolve
+          })
+      )
+      .mockResolvedValueOnce({ ok: true })
+
+    const { saveDevToolsConfig } = await import('./save-devtools-config')
+
+    saveDevToolsConfig({ requestInsights: { verbose: false } })
+    jest.advanceTimersByTime(120)
+    saveDevToolsConfig({ requestInsights: { verbose: true } })
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      requestInsights: { verbose: true },
+    })
+
+    resolveFirstRequest!({ ok: false })
+    await flushMicrotasks()
+    await jest.advanceTimersByTimeAsync(5_000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(warnMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
+++ b/packages/next/src/next-devtools/dev-overlay/utils/save-devtools-config.ts
@@ -2,29 +2,124 @@ import type { DevToolsConfig } from '../shared'
 import { devToolsConfigSchema } from '../../shared/devtools-config-schema'
 import { deepMerge } from '../../shared/deepmerge'
 
+const SAVE_DEBOUNCE_DELAY = 120
+const INITIAL_RETRY_DELAY = 240
+const MAX_RETRY_DELAY = 5_000
+const PAGEHIDE_LISTENER_KEY = '__nextDevToolsConfigPagehideListener'
+
 let queuedConfigPatch: DevToolsConfig = {}
 let timer: ReturnType<typeof setTimeout> | null = null
+let flushInFlight: Promise<void> | null = null
+let inFlightFlush:
+  | {
+      patch: DevToolsConfig
+      supersedingPatch?: DevToolsConfig
+      supersedingFlush?: Promise<void>
+      supersedingVersion: number
+    }
+  | undefined
+let flushImmediatelyAfterInFlight = false
+let retryDelay = INITIAL_RETRY_DELAY
 
-function flushPatch() {
-  if (Object.keys(queuedConfigPatch).length === 0) {
-    return
+function hasQueuedPatch() {
+  return Object.keys(queuedConfigPatch).length > 0
+}
+
+function scheduleFlush(delay: number) {
+  if (timer) {
+    clearTimeout(timer)
   }
 
-  const body = JSON.stringify(queuedConfigPatch)
-  queuedConfigPatch = {}
+  timer = setTimeout(flushPatch, delay)
+}
 
-  fetch('/__nextjs_devtools_config', {
+async function sendConfigPatch(body: string) {
+  const response = await fetch('/__nextjs_devtools_config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body,
     // keepalive in case of fetch interrupted, e.g. navigation or reload
     keepalive: true,
-  }).catch((error) => {
-    console.warn('[Next.js DevTools] Failed to save config:', {
-      data: body,
-      error,
-    })
   })
+
+  if (!response.ok) {
+    throw new Error('Failed to save DevTools config')
+  }
+}
+
+function flushPatch(immediatelyAfterInFlight = false) {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+
+  if (flushInFlight) {
+    flushImmediatelyAfterInFlight ||= immediatelyAfterInFlight
+    return
+  }
+
+  if (!hasQueuedPatch()) {
+    return
+  }
+
+  const patch = queuedConfigPatch
+  const body = JSON.stringify(patch)
+  queuedConfigPatch = {}
+
+  const currentFlush: NonNullable<typeof inFlightFlush> = {
+    patch,
+    supersedingVersion: 0,
+  }
+  inFlightFlush = currentFlush
+  const request = sendConfigPatch(body)
+
+  flushInFlight = request
+    .then(() => {
+      retryDelay = INITIAL_RETRY_DELAY
+    })
+    .catch(async () => {
+      // A pagehide write contains this patch plus everything queued after it.
+      // Let that newer write own restoration so an older failed request can
+      // never overwrite a successful newer one.
+      if (currentFlush.supersedingFlush) {
+        await currentFlush.supersedingFlush
+        return
+      }
+
+      // Restore the failed patch without overwriting changes queued while the
+      // request was in flight.
+      queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+
+      const delay = retryDelay
+      retryDelay = Math.min(retryDelay * 2, MAX_RETRY_DELAY)
+      scheduleFlush(delay)
+
+      // Do not include the request body or error details here. Config patches
+      // can contain user-defined shortcut values.
+      console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+    })
+    .finally(() => {
+      if (inFlightFlush === currentFlush) {
+        inFlightFlush = undefined
+      }
+      flushInFlight = null
+
+      if (!hasQueuedPatch()) {
+        flushImmediatelyAfterInFlight = false
+        return
+      }
+
+      if (flushImmediatelyAfterInFlight) {
+        flushImmediatelyAfterInFlight = false
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        flushPatch(true)
+      } else if (!timer) {
+        scheduleFlush(0)
+      }
+    })
 }
 
 export function saveDevToolsConfig(patch: DevToolsConfig) {
@@ -43,5 +138,59 @@ export function saveDevToolsConfig(patch: DevToolsConfig) {
     clearTimeout(timer)
   }
 
-  timer = setTimeout(flushPatch, 120)
+  timer = setTimeout(flushPatch, SAVE_DEBOUNCE_DELAY)
+}
+
+if (typeof window !== 'undefined') {
+  const devToolsWindow = window as Window & {
+    [PAGEHIDE_LISTENER_KEY]?: () => void
+  }
+  const previousListener = devToolsWindow[PAGEHIDE_LISTENER_KEY]
+  if (typeof previousListener === 'function') {
+    previousListener()
+    window.removeEventListener('pagehide', previousListener)
+  }
+
+  // A reload can happen before the debounced write starts. Flush the pending
+  // patch while the page is still alive; keepalive lets the request finish
+  // during page teardown.
+  const flushPatchOnPagehide = () => {
+    if (flushInFlight && inFlightFlush && hasQueuedPatch()) {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      const currentFlush = inFlightFlush
+      const patch = deepMerge(
+        currentFlush.supersedingPatch ?? currentFlush.patch,
+        queuedConfigPatch
+      )
+      queuedConfigPatch = {}
+      const version = ++currentFlush.supersedingVersion
+      currentFlush.supersedingPatch = patch
+      currentFlush.supersedingFlush = sendConfigPatch(JSON.stringify(patch))
+        .then(() => {
+          retryDelay = INITIAL_RETRY_DELAY
+        })
+        .catch(() => {
+          // Ignore an older pagehide failure when a newer cumulative write is
+          // already responsible for the same data.
+          if (version !== currentFlush.supersedingVersion) {
+            return
+          }
+
+          // The document may survive through the back-forward cache. Restore
+          // the complete superseding patch and retry it without logging user
+          // config values.
+          queuedConfigPatch = deepMerge(patch, queuedConfigPatch)
+          scheduleFlush(0)
+          console.warn('[Next.js DevTools] Failed to save config. Retrying.')
+        })
+      return
+    }
+
+    flushPatch(true)
+  }
+  window.addEventListener('pagehide', flushPatchOnPagehide)
+  devToolsWindow[PAGEHIDE_LISTENER_KEY] = flushPatchOnPagehide
 }

--- a/packages/next/src/next-devtools/server/devtools-config-middleware.ts
+++ b/packages/next/src/next-devtools/server/devtools-config-middleware.ts
@@ -1,9 +1,9 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { DevToolsConfig } from '../dev-overlay/shared'
 
-import { existsSync } from 'fs'
-import { readFile, writeFile, mkdir } from 'fs/promises'
-import { dirname, join } from 'path'
+import * as fsPromises from 'fs/promises'
+import { randomUUID } from 'crypto'
+import { basename, dirname, join } from 'path'
 
 import { middlewareResponse } from './middleware-response'
 import { devToolsConfigSchema } from '../shared/devtools-config-schema'
@@ -11,6 +11,8 @@ import { deepMerge } from '../shared/deepmerge'
 
 const DEVTOOLS_CONFIG_FILENAME = 'next-devtools-config.json'
 const DEVTOOLS_CONFIG_MIDDLEWARE_ENDPOINT = '/__nextjs_devtools_config'
+const DEVTOOLS_CONFIG_BODY_LIMIT = 64 * 1024
+const configUpdateQueues = new Map<string, Promise<void>>()
 
 export function devToolsConfigMiddleware({
   distDir,
@@ -36,36 +38,63 @@ export function devToolsConfigMiddleware({
       return middlewareResponse.methodNotAllowed(res)
     }
 
-    const currentConfig = await getDevToolsConfig(distDir)
+    const previousUpdate = (
+      configUpdateQueues.get(configPath) ?? Promise.resolve()
+    ).catch(() => {})
+    let releaseUpdate!: () => void
+    const updateCompleted = new Promise<void>((resolve) => {
+      releaseUpdate = resolve
+    })
+    const queueTail = previousUpdate.then(() => updateCompleted)
+    configUpdateQueues.set(configPath, queueTail)
+    void queueTail.then(() => {
+      if (configUpdateQueues.get(configPath) === queueTail) {
+        configUpdateQueues.delete(configPath)
+      }
+    })
 
-    const chunks: Buffer[] = []
-    for await (const chunk of req) {
-      chunks.push(Buffer.from(chunk))
-    }
-
-    let body = Buffer.concat(chunks).toString('utf8')
     try {
-      body = JSON.parse(body)
-    } catch (error) {
-      console.error('[Next.js DevTools] Invalid config body passed:', error)
-      return middlewareResponse.badRequest(res)
-    }
+      const chunks: Buffer[] = []
+      let bodySize = 0
+      for await (const chunk of req) {
+        const buffer = Buffer.from(chunk)
+        bodySize += buffer.byteLength
+        if (bodySize > DEVTOOLS_CONFIG_BODY_LIMIT) {
+          return middlewareResponse.payloadTooLarge(res)
+        }
+        chunks.push(buffer)
+      }
 
-    const validation = devToolsConfigSchema.safeParse(body)
-    if (!validation.success) {
-      console.error(
-        '[Next.js DevTools] Invalid config passed:',
-        validation.error.message
+      let body = Buffer.concat(chunks).toString('utf8')
+      try {
+        body = JSON.parse(body)
+      } catch (error) {
+        console.error('[Next.js DevTools] Invalid config body passed:', error)
+        return middlewareResponse.badRequest(res)
+      }
+
+      const validation = devToolsConfigSchema.safeParse(body)
+      if (!validation.success) {
+        console.error(
+          '[Next.js DevTools] Invalid config passed:',
+          validation.error.message
+        )
+        return middlewareResponse.badRequest(res)
+      }
+
+      await previousUpdate
+      const currentConfig = await getDevToolsConfig(distDir)
+      const newConfig = deepMerge(currentConfig, validation.data)
+      await writeDevToolsConfigAtomically(
+        configPath,
+        JSON.stringify(newConfig, null, 2)
       )
-      return middlewareResponse.badRequest(res)
+      sendUpdateSignal(newConfig)
+
+      return middlewareResponse.noContent(res)
+    } finally {
+      releaseUpdate()
     }
-
-    const newConfig = deepMerge(currentConfig, validation.data)
-    await writeFile(configPath, JSON.stringify(newConfig, null, 2))
-
-    sendUpdateSignal(newConfig)
-
-    return middlewareResponse.noContent(res)
   }
 }
 
@@ -74,11 +103,41 @@ export async function getDevToolsConfig(
 ): Promise<DevToolsConfig> {
   const configPath = join(distDir, 'cache', DEVTOOLS_CONFIG_FILENAME)
 
-  if (!existsSync(configPath)) {
-    await mkdir(dirname(configPath), { recursive: true })
-    await writeFile(configPath, JSON.stringify({}))
-    return {}
+  try {
+    const parsed = JSON.parse(await fsPromises.readFile(configPath, 'utf8'))
+    const validation = devToolsConfigSchema.safeParse(parsed)
+    return validation.success ? validation.data : {}
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return {}
+    }
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return {}
+    }
+    throw error
   }
+}
 
-  return JSON.parse(await readFile(configPath, 'utf8'))
+async function writeDevToolsConfigAtomically(
+  configPath: string,
+  contents: string
+): Promise<void> {
+  const temporaryPath = join(
+    dirname(configPath),
+    `.${basename(configPath)}.${process.pid}.${randomUUID()}.tmp`
+  )
+
+  try {
+    await fsPromises.mkdir(dirname(configPath), { recursive: true })
+    await fsPromises.writeFile(temporaryPath, contents)
+    await fsPromises.rename(temporaryPath, configPath)
+  } catch (error) {
+    await fsPromises.unlink(temporaryPath).catch(() => {})
+    throw error
+  }
 }

--- a/packages/next/src/next-devtools/server/middleware-response.ts
+++ b/packages/next/src/next-devtools/server/middleware-response.ts
@@ -23,6 +23,10 @@ export const middlewareResponse = {
     res.statusCode = 405
     res.end('Method Not Allowed')
   },
+  payloadTooLarge(res: ServerResponse) {
+    res.statusCode = 413
+    res.end('Payload Too Large')
+  },
   internalServerError(res: ServerResponse, error?: unknown) {
     res.statusCode = 500
     res.setHeader('Content-Type', 'text/plain')

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -1,10 +1,19 @@
-import type { RequestInsightKind } from '../../shared/lib/request-insights'
+import type {
+  RequestInsightKind,
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../shared/lib/request-insights'
 
 export {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
   type RequestInsightIdentity,
   type RequestInsightKind,
+  type RequestInsightProxyStatus,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../shared/lib/request-insights'
 
 type RequestInsightAttributeValue =
@@ -54,6 +63,10 @@ export type RequestInsightFetch = {
 export type RequestInsight = {
   requestId: string
   kind?: RequestInsightKind
+  source: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId: string
   route?: string
   url?: string

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -9,6 +9,8 @@ export {
   getRequestInsightKey,
   getRequestInsightKind,
   getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsightIdentity,
   type RequestInsightKind,
   type RequestInsightProxyStatus,

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -18,7 +18,7 @@ export {
   type RequestInsightSource,
 } from '../../shared/lib/request-insights'
 
-type RequestInsightAttributeValue =
+export type RequestInsightAttributeValue =
   | string
   | number
   | boolean

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -1,19 +1,41 @@
-import type {
-  RequestInsightKind,
-  RequestInsightProxyStatus,
-  RequestInsightRouterActivity,
-  RequestInsightSource,
+import {
+  getRequestInsightKind,
+  getRequestInsightRootId,
+  getRequestInsightRetentionBucket,
+  REQUEST_INSIGHT_RETENTION_BUCKETS,
+  type RequestInsightKind,
+  type RequestInsightProxyStatus,
+  type RequestInsightRetentionBucket,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../shared/lib/request-insights'
+
+export const REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET = 200
+export const REQUEST_INSIGHTS_MAX_BYTES_PER_RETENTION_BUCKET =
+  18.75 * 1024 * 1024
+export const REQUEST_INSIGHTS_MAX_RETAINED_BYTES = 93.75 * 1024 * 1024
+export const REQUEST_INSIGHTS_MAX_RECORDS_PER_GROUP = 15
+export const REQUEST_INSIGHTS_MAX_SPANS_PER_RECORD = 200
+export const REQUEST_INSIGHTS_MAX_FETCHES_PER_RECORD = 200
+export const REQUEST_INSIGHTS_MAX_BYTES_PER_RECORD = 64 * 1024
+export const REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN = 8 * 1024
+export const REQUEST_INSIGHTS_MAX_EVENTS_PER_SPAN = 16
+export const REQUEST_INSIGHTS_MAX_LINKS_PER_SPAN = 8
+export const REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES = 4 * 1024 * 1024
 
 export {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightRetentionBucket,
+  getRequestInsightRootId,
   getRequestInsightSource,
   REQUEST_INSIGHT_PROXY_SPAN_TYPE,
   REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  REQUEST_INSIGHT_RETENTION_BUCKETS,
   type RequestInsightIdentity,
   type RequestInsightKind,
   type RequestInsightProxyStatus,
+  type RequestInsightRetentionBucket,
   type RequestInsightRouterActivity,
   type RequestInsightSource,
 } from '../../shared/lib/request-insights'
@@ -49,6 +71,9 @@ export type RequestInsightSpan = {
     type?: string
     message?: string
   }
+  truncatedMetadataValueCount?: number
+  truncatedEventCount?: number
+  truncatedLinkCount?: number
 }
 
 export type RequestInsightFetch = {
@@ -64,6 +89,7 @@ export type RequestInsightFetch = {
 
 export type RequestInsight = {
   requestId: string
+  rootRequestId?: string
   kind?: RequestInsightKind
   source: RequestInsightSource
   proxyStatus?: RequestInsightProxyStatus
@@ -77,8 +103,303 @@ export type RequestInsight = {
   status: 'ok' | 'error' | 'pending'
   spans: RequestInsightSpan[]
   fetches: RequestInsightFetch[]
+  truncatedSpanCount?: number
+  truncatedFetchCount?: number
+  omittedRequestCount?: number
+}
+
+export type RequestInsightsCaptureState = {
+  limits: {
+    maxRequestGroupsPerBucket: number
+    maxBytesPerBucket: number
+    maxRetainedBytes: number
+    maxRecordsPerGroup: number
+    maxSpansPerRecord: number
+    maxFetchesPerRecord: number
+    maxBytesPerRecord: number
+    maxBytesPerSpan: number
+    maxEventsPerSpan: number
+    maxLinksPerSpan: number
+    maxSnapshotBytes: number
+  }
+  usage: {
+    retainedRequestGroupCount: number
+    retainedRequestCount: number
+    retainedBytes: number
+    buckets: Array<{
+      bucket: RequestInsightRetentionBucket
+      retainedRequestGroupCount: number
+      retainedRequestCount: number
+      retainedBytes: number
+      evictedRequestGroupCount: number
+    }>
+  }
 }
 
 export type RequestInsightsSnapshot = {
   requests: RequestInsight[]
+  capture?: RequestInsightsCaptureState
+  projection?: {
+    omittedRequestGroupCount: number
+    buckets: Array<{
+      bucket: RequestInsightRetentionBucket
+      omittedRequestGroupCount: number
+    }>
+  }
+}
+
+export type BoundedRequestInsightsSnapshotProjection = {
+  snapshot: RequestInsightsSnapshot
+  snapshotByteLength: number
+}
+
+/**
+ * Selects a bucket-fair set of newest logical roots that fits one serialized
+ * snapshot. A bucket stops at its first root that does not fit, so its result
+ * always remains a newest contiguous suffix.
+ */
+export function createBoundedRequestInsightsSnapshotProjection(
+  groups: readonly (readonly RequestInsight[])[],
+  maxSnapshotBytes: number,
+  capture?: RequestInsightsCaptureState,
+  maxRetainedGroupCount = Number.POSITIVE_INFINITY
+): BoundedRequestInsightsSnapshotProjection {
+  type IndexedGroup = {
+    group: readonly RequestInsight[]
+    index: number
+    byteLength: number
+    bucket: RequestInsightRetentionBucket
+  }
+
+  const groupsByBucket = new Map<
+    RequestInsightRetentionBucket,
+    IndexedGroup[]
+  >()
+  const availableGroupCountByBucket = new Map<
+    RequestInsightRetentionBucket,
+    number
+  >()
+  const indexedGroups: IndexedGroup[] = []
+
+  for (let index = 0; index < groups.length; index++) {
+    const group = groups[index]
+    if (group.length === 0) continue
+    const bucket = getRequestInsightRetentionBucket(
+      getRequestInsightGroupRepresentative(group)
+    )
+    const indexedGroup = {
+      group,
+      index,
+      byteLength: getRequestInsightsSerializedByteLength(group),
+      bucket,
+    }
+    indexedGroups.push(indexedGroup)
+    const bucketGroups = groupsByBucket.get(bucket)
+    if (bucketGroups) {
+      bucketGroups.push(indexedGroup)
+    } else {
+      groupsByBucket.set(bucket, [indexedGroup])
+    }
+    availableGroupCountByBucket.set(
+      bucket,
+      (availableGroupCountByBucket.get(bucket) ?? 0) + 1
+    )
+  }
+
+  const retainedGroups: IndexedGroup[] = []
+  const retainedGroupCountByBucket = new Map<
+    RequestInsightRetentionBucket,
+    number
+  >()
+  const exhaustedBuckets = new Set<RequestInsightRetentionBucket>()
+  let retainedGroupContentsByteLength = 0
+
+  for (let depth = 0; ; depth++) {
+    const candidates: IndexedGroup[] = []
+    for (const [bucket, bucketGroups] of groupsByBucket) {
+      if (exhaustedBuckets.has(bucket)) continue
+      const candidate = bucketGroups[bucketGroups.length - 1 - depth]
+      if (candidate) candidates.push(candidate)
+    }
+    if (candidates.length === 0) break
+
+    candidates.sort((left, right) => right.index - left.index)
+    for (const candidate of candidates) {
+      if (retainedGroups.length >= maxRetainedGroupCount) break
+      const nextRetainedCountByBucket = new Map(retainedGroupCountByBucket)
+      nextRetainedCountByBucket.set(
+        candidate.bucket,
+        (nextRetainedCountByBucket.get(candidate.bucket) ?? 0) + 1
+      )
+      if (
+        getProjectedSnapshotByteLength(
+          retainedGroupContentsByteLength + candidate.byteLength - 2,
+          retainedGroups.length + 1,
+          availableGroupCountByBucket,
+          nextRetainedCountByBucket,
+          capture
+        ) > maxSnapshotBytes
+      ) {
+        exhaustedBuckets.add(candidate.bucket)
+        continue
+      }
+      retainedGroupContentsByteLength += candidate.byteLength - 2
+      retainedGroups.push(candidate)
+      retainedGroupCountByBucket.set(
+        candidate.bucket,
+        (retainedGroupCountByBucket.get(candidate.bucket) ?? 0) + 1
+      )
+    }
+    if (retainedGroups.length >= maxRetainedGroupCount) break
+  }
+
+  const retainedGroupIndexes = new Set(
+    retainedGroups.map((retainedGroup) => retainedGroup.index)
+  )
+  const orderedRetainedGroups = indexedGroups.filter((indexedGroup) =>
+    retainedGroupIndexes.has(indexedGroup.index)
+  )
+  const snapshot = createSnapshot(
+    orderedRetainedGroups,
+    availableGroupCountByBucket,
+    retainedGroupCountByBucket,
+    capture
+  )
+  const snapshotByteLength = getRequestInsightsSerializedByteLength(snapshot)
+
+  return { snapshot, snapshotByteLength }
+}
+
+function getRequestInsightGroupRepresentative(
+  group: readonly RequestInsight[]
+): RequestInsight {
+  const rootRequestId = getRequestInsightRootId(group[0])
+  return (
+    group.find(
+      (request) =>
+        request.requestId === rootRequestId &&
+        getRequestInsightKind(request) === 'request'
+    ) ??
+    group.find((request) => getRequestInsightKind(request) === 'request') ??
+    group[0]
+  )
+}
+
+function getProjectedSnapshotByteLength(
+  retainedGroupContentsByteLength: number,
+  retainedGroupCount: number,
+  availableGroupCountByBucket: ReadonlyMap<
+    RequestInsightRetentionBucket,
+    number
+  >,
+  retainedGroupCountByBucket: ReadonlyMap<
+    RequestInsightRetentionBucket,
+    number
+  >,
+  capture?: RequestInsightsCaptureState
+): number {
+  const requestsByteLength =
+    2 + retainedGroupContentsByteLength + Math.max(0, retainedGroupCount - 1)
+  const emptySnapshot = createSnapshotFromCounts(
+    [],
+    availableGroupCountByBucket,
+    retainedGroupCountByBucket,
+    capture
+  )
+  return (
+    getRequestInsightsSerializedByteLength(emptySnapshot) -
+    getRequestInsightsSerializedByteLength(emptySnapshot.requests) +
+    requestsByteLength
+  )
+}
+
+function createSnapshot(
+  retainedGroups: readonly {
+    group: readonly RequestInsight[]
+    bucket: RequestInsightRetentionBucket
+  }[],
+  availableGroupCountByBucket: ReadonlyMap<
+    RequestInsightRetentionBucket,
+    number
+  >,
+  retainedGroupCountByBucket: ReadonlyMap<
+    RequestInsightRetentionBucket,
+    number
+  >,
+  capture?: RequestInsightsCaptureState
+): RequestInsightsSnapshot {
+  return createSnapshotFromCounts(
+    retainedGroups.flatMap(({ group }) => [...group]),
+    availableGroupCountByBucket,
+    retainedGroupCountByBucket,
+    capture
+  )
+}
+
+function createSnapshotFromCounts(
+  requests: RequestInsight[],
+  availableGroupCountByBucket: ReadonlyMap<
+    RequestInsightRetentionBucket,
+    number
+  >,
+  retainedGroupCountByBucket: ReadonlyMap<
+    RequestInsightRetentionBucket,
+    number
+  >,
+  capture?: RequestInsightsCaptureState
+): RequestInsightsSnapshot {
+  const projectionBuckets = REQUEST_INSIGHT_RETENTION_BUCKETS.flatMap(
+    (bucket) => {
+      const omittedRequestGroupCount = Math.max(
+        0,
+        (availableGroupCountByBucket.get(bucket) ?? 0) -
+          (retainedGroupCountByBucket.get(bucket) ?? 0)
+      )
+      return omittedRequestGroupCount > 0
+        ? [{ bucket, omittedRequestGroupCount }]
+        : []
+    }
+  )
+  const omittedRequestGroupCount = projectionBuckets.reduce(
+    (total, bucket) => total + bucket.omittedRequestGroupCount,
+    0
+  )
+
+  return {
+    requests,
+    ...(capture ? { capture } : undefined),
+    ...(omittedRequestGroupCount > 0
+      ? {
+          projection: {
+            omittedRequestGroupCount,
+            buckets: projectionBuckets,
+          },
+        }
+      : undefined),
+  }
+}
+
+export function getRequestInsightsSerializedByteLength(value: unknown): number {
+  const serialized = JSON.stringify(value) ?? ''
+  let byteLength = 0
+  for (let index = 0; index < serialized.length; index++) {
+    const codeUnit = serialized.charCodeAt(index)
+    if (codeUnit <= 0x7f) {
+      byteLength++
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2
+    } else if (
+      codeUnit >= 0xd800 &&
+      codeUnit <= 0xdbff &&
+      index + 1 < serialized.length &&
+      serialized.charCodeAt(index + 1) >= 0xdc00 &&
+      serialized.charCodeAt(index + 1) <= 0xdfff
+    ) {
+      byteLength += 4
+      index++
+    } else {
+      byteLength += 3
+    }
+  }
+  return byteLength
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -65,6 +65,7 @@ import {
   extractInfoFromServerReferenceId,
   mightBeServerReferenceId,
 } from '../../shared/lib/server-reference-info'
+import { isUseCacheFunction } from '../../lib/client-and-server-references'
 import type { ServerActionLogInfo } from '../dev/server-action-logger'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { synchronizeMutableCookies } from '../async-storage/request-store'
@@ -752,6 +753,9 @@ export async function handleAction({
     // action in the current handler, so we forward the request to a worker that
     // has the action.
     if (forwardedWorker) {
+      if (extractInfoFromServerReferenceId(actionId).type === 'server-action') {
+        markServerActionRequest()
+      }
       return {
         type: 'done',
         result: await createForwardedActionResponse(
@@ -869,6 +873,10 @@ export async function handleAction({
               const action = await decodeAction(formData, serverModuleMap)
               if (typeof action === 'function') {
                 // an MPA action.
+
+                if (!isUseCacheFunction(action)) {
+                  markServerActionRequest()
+                }
 
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
@@ -1079,6 +1087,10 @@ export async function handleAction({
               if (typeof action === 'function') {
                 // an MPA action.
 
+                if (!isUseCacheFunction(action)) {
+                  markServerActionRequest()
+                }
+
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
@@ -1175,6 +1187,9 @@ export async function handleAction({
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
         const { type: actionType } = extractInfoFromServerReferenceId(actionId!)
+        if (actionType !== 'use-cache') {
+          markServerActionRequest()
+        }
         if (
           process.env.NODE_ENV === 'development' &&
           ctx.renderOpts.logServerFunctions &&
@@ -1372,6 +1387,19 @@ export async function handleAction({
  * stack overflow during `action.apply()` from malicious requests.
  */
 const SERVER_ACTION_ARGS_LIMIT = 1000
+
+function markServerActionRequest(): void {
+  if (process.env.__NEXT_DEV_SERVER && process.env.NEXT_RUNTIME !== 'edge') {
+    const { getRequestInsightsIdentity } =
+      require('../lib/trace/request-insights-identity') as typeof import('../lib/trace/request-insights-identity')
+    const identity = getRequestInsightsIdentity()
+    if (identity) {
+      const { recordRequestInsightServerAction } =
+        require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
+      recordRequestInsightServerAction(identity)
+    }
+  }
+}
 
 async function executeActionAndPrepareForRender<
   TFn extends (...args: any[]) => Promise<any>,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1394,9 +1394,9 @@ function markServerActionRequest(): void {
       require('../lib/trace/request-insights-identity') as typeof import('../lib/trace/request-insights-identity')
     const identity = getRequestInsightsIdentity()
     if (identity) {
-      const { recordRequestInsightServerAction } =
-        require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
-      recordRequestInsightServerAction(identity)
+      const { getActiveRequestInsights } =
+        require('../lib/trace/request-insights-runtime') as typeof import('../lib/trace/request-insights-runtime')
+      getActiveRequestInsights()?.recordServerAction(identity)
     }
   }
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -333,6 +333,7 @@ import type { StageEndTimes } from './instant-validation/instant-validation'
 import { hasNonRootStaticParams } from '../lib/params-utils'
 
 type AppRenderRequestInsightsRuntime = {
+  createRequestInsightsRetentionContext: typeof import('../lib/trace/request-insights-identity').createRequestInsightsRetentionContext
   getActiveRequestInsights: typeof import('../lib/trace/request-insights-runtime').getActiveRequestInsights
   getRequestInsightsIdentity: typeof import('../lib/trace/request-insights-identity').getRequestInsightsIdentity
   getRequestInsightRouterActivity: typeof import('../lib/trace/request-insights-router-activity').getRequestInsightRouterActivity
@@ -347,7 +348,11 @@ function getAppRenderRequestInsightsRuntime():
   | undefined {
   if (process.env.__NEXT_DEV_SERVER) {
     if (!appRenderRequestInsightsRuntime) {
-      const { getRequestInsightsIdentity, runWithRequestInsightsIdentity } =
+      const {
+        createRequestInsightsRetentionContext,
+        getRequestInsightsIdentity,
+        runWithRequestInsightsIdentity,
+      } =
         require('../lib/trace/request-insights-identity') as typeof import('../lib/trace/request-insights-identity')
       const { getRequestInsightRouterActivity } =
         require('../lib/trace/request-insights-router-activity') as typeof import('../lib/trace/request-insights-router-activity')
@@ -357,6 +362,7 @@ function getAppRenderRequestInsightsRuntime():
         require('../lib/trace/span-store') as typeof import('../lib/trace/span-store')
 
       appRenderRequestInsightsRuntime = {
+        createRequestInsightsRetentionContext,
         getActiveRequestInsights,
         getRequestInsightsIdentity,
         getRequestInsightRouterActivity,
@@ -4982,11 +4988,15 @@ async function runInstantInsightsWithTracing<T>(
     return fn(runWithoutInstantInsightsSpan)
   }
 
+  const outerIdentity = requestInsightsRuntime.getRequestInsightsIdentity()
+
   return requestInsightsRuntime.runWithRequestInsightsIdentity(
     {
-      requestId:
-        requestInsightsRuntime.getRequestInsightsIdentity()?.requestId ??
-        ctx.requestId,
+      requestId: outerIdentity?.requestId ?? ctx.requestId,
+      rootRequestId: outerIdentity?.rootRequestId ?? ctx.requestId,
+      retention: requestInsightsRuntime.createRequestInsightsRetentionContext(
+        outerIdentity?.retention
+      ),
       kind: 'instant-insights',
       htmlRequestId: ctx.htmlRequestId,
       url: ctx.url.href,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -111,14 +111,8 @@ import {
 import { isRedirectError } from '../../client/components/redirect-error'
 import { getImplicitTags, type ImplicitTags } from '../lib/implicit-tags'
 import { AppRenderSpan, NextNodeServerSpan } from '../lib/trace/constants'
-import {
-  getRequestInsightsIdentity,
-  runWithRequestInsightsIdentity,
-} from '../lib/trace/request-insights-identity'
-import { getRequestInsightRouterActivity } from '../lib/trace/request-insights-router-activity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
-import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
 import {
   createReactServerErrorHandler,
@@ -337,6 +331,43 @@ import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolv
 import { RENDER_STAGES_BY_DATA_KIND } from '../dynamic-rendering-utils'
 import type { StageEndTimes } from './instant-validation/instant-validation'
 import { hasNonRootStaticParams } from '../lib/params-utils'
+
+type AppRenderRequestInsightsRuntime = {
+  getActiveRequestInsights: typeof import('../lib/trace/request-insights-runtime').getActiveRequestInsights
+  getRequestInsightsIdentity: typeof import('../lib/trace/request-insights-identity').getRequestInsightsIdentity
+  getRequestInsightRouterActivity: typeof import('../lib/trace/request-insights-router-activity').getRequestInsightRouterActivity
+  isRequestInsightsEnabled: typeof import('../lib/trace/span-store').isRequestInsightsEnabled
+  runWithRequestInsightsIdentity: typeof import('../lib/trace/request-insights-identity').runWithRequestInsightsIdentity
+}
+
+let appRenderRequestInsightsRuntime: AppRenderRequestInsightsRuntime | undefined
+
+function getAppRenderRequestInsightsRuntime():
+  | AppRenderRequestInsightsRuntime
+  | undefined {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!appRenderRequestInsightsRuntime) {
+      const { getRequestInsightsIdentity, runWithRequestInsightsIdentity } =
+        require('../lib/trace/request-insights-identity') as typeof import('../lib/trace/request-insights-identity')
+      const { getRequestInsightRouterActivity } =
+        require('../lib/trace/request-insights-router-activity') as typeof import('../lib/trace/request-insights-router-activity')
+      const { getActiveRequestInsights } =
+        require('../lib/trace/request-insights-runtime') as typeof import('../lib/trace/request-insights-runtime')
+      const { isRequestInsightsEnabled } =
+        require('../lib/trace/span-store') as typeof import('../lib/trace/span-store')
+
+      appRenderRequestInsightsRuntime = {
+        getActiveRequestInsights,
+        getRequestInsightsIdentity,
+        getRequestInsightRouterActivity,
+        isRequestInsightsEnabled,
+        runWithRequestInsightsIdentity,
+      }
+    }
+    return appRenderRequestInsightsRuntime
+  }
+  return undefined
+}
 
 export type GetDynamicParamFromSegment = (
   // The LoaderTree to extract the dynamic param from
@@ -2756,19 +2787,21 @@ async function prepareAppPageRender(
 
   let requestId: string
   let htmlRequestId: string
-  const requestInsightsIdentity = process.env.__NEXT_REQUEST_INSIGHTS
-    ? getRequestInsightsIdentity()
-    : undefined
+  const requestInsightsRuntime = getAppRenderRequestInsightsRuntime()
+  const requestInsightsIdentity =
+    requestInsightsRuntime?.isRequestInsightsEnabled()
+      ? requestInsightsRuntime.getRequestInsightsIdentity()
+      : undefined
 
   const { flightRouterState, isPrefetchRequest, nonce } = parsedRequestHeaders
 
   const routerActivity = requestInsightsIdentity
-    ? getRequestInsightRouterActivity(req.headers)
+    ? requestInsightsRuntime?.getRequestInsightRouterActivity(req.headers)
     : undefined
-  if (requestInsightsIdentity && routerActivity) {
-    const { recordRequestInsightRouterActivity } =
-      require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
-    recordRequestInsightRouterActivity(requestInsightsIdentity, routerActivity)
+  if (requestInsightsIdentity && routerActivity && requestInsightsRuntime) {
+    requestInsightsRuntime
+      .getActiveRequestInsights()
+      ?.recordRouterActivity(requestInsightsIdentity, routerActivity)
   }
 
   if (requestInsightsIdentity?.debugRequestId) {
@@ -4944,13 +4977,16 @@ async function runInstantInsightsWithTracing<T>(
   ctx: AppRenderContext,
   fn: (runSpan: RunInstantInsightsSpan) => Promise<T>
 ): Promise<T> {
-  if (!isRequestInsightsEnabled()) {
+  const requestInsightsRuntime = getAppRenderRequestInsightsRuntime()
+  if (!requestInsightsRuntime?.isRequestInsightsEnabled()) {
     return fn(runWithoutInstantInsightsSpan)
   }
 
-  return runWithRequestInsightsIdentity(
+  return requestInsightsRuntime.runWithRequestInsightsIdentity(
     {
-      requestId: getRequestInsightsIdentity()?.requestId ?? ctx.requestId,
+      requestId:
+        requestInsightsRuntime.getRequestInsightsIdentity()?.requestId ??
+        ctx.requestId,
       kind: 'instant-insights',
       htmlRequestId: ctx.htmlRequestId,
       url: ctx.url.href,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -115,6 +115,7 @@ import {
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
+import { getRequestInsightRouterActivity } from '../lib/trace/request-insights-router-activity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
@@ -2761,7 +2762,18 @@ async function prepareAppPageRender(
 
   const { flightRouterState, isPrefetchRequest, nonce } = parsedRequestHeaders
 
-  if (parsedRequestHeaders.requestId) {
+  const routerActivity = requestInsightsIdentity
+    ? getRequestInsightRouterActivity(req.headers)
+    : undefined
+  if (requestInsightsIdentity && routerActivity) {
+    const { recordRequestInsightRouterActivity } =
+      require('../lib/trace/request-insights') as typeof import('../lib/trace/request-insights')
+    recordRequestInsightRouterActivity(requestInsightsIdentity, routerActivity)
+  }
+
+  if (requestInsightsIdentity?.debugRequestId) {
+    requestId = requestInsightsIdentity.debugRequestId
+  } else if (parsedRequestHeaders.requestId) {
     // If the client has provided a request ID (in development mode), we use it.
     requestId = parsedRequestHeaders.requestId
   } else if (requestInsightsIdentity) {
@@ -4938,7 +4950,7 @@ async function runInstantInsightsWithTracing<T>(
 
   return runWithRequestInsightsIdentity(
     {
-      requestId: ctx.requestId,
+      requestId: getRequestInsightsIdentity()?.requestId ?? ctx.requestId,
       kind: 'instant-insights',
       htmlRequestId: ctx.htmlRequestId,
       url: ctx.url.href,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -114,7 +114,10 @@ import {
   SpanStatusCode,
 } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
-import { runWithRequestInsightsIdentity } from './lib/trace/request-insights-identity'
+import {
+  resolveRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './lib/trace/request-insights-identity'
 import { isRequestInsightsEnabled } from './lib/trace/span-store'
 import { I18NProvider } from './lib/i18n-provider'
 import { sendResponse } from './send-response'
@@ -1002,25 +1005,33 @@ export default abstract class Server<
       return handleRequest()
     }
 
-    const requestIdHeader = req.headers[NEXT_REQUEST_ID_HEADER]
-    const requestId =
-      typeof requestIdHeader === 'string' ? requestIdHeader : nanoid()
-    const htmlRequestIdHeader = req.headers[NEXT_HTML_REQUEST_ID_HEADER]
+    const requestInsightsIdentity = resolveRequestInsightsIdentity({
+      previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+      requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+      htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+      url: req.url,
+      createRequestId: nanoid,
+    })
+    const isMiddlewareInvoke = getRequestMeta(req, 'middlewareInvoke') === true
+    const sourceBeforeMiddleware = requestInsightsIdentity.source
+    if (isMiddlewareInvoke) {
+      requestInsightsIdentity.source = 'proxy'
+    }
+    addRequestMeta(req, 'requestInsightsIdentity', requestInsightsIdentity)
 
     // The request root and route-matching spans start before App Render creates
     // its workStore. Carry their identity in this outer scope; App Render copies
     // it into the workStore so the complete timeline uses one request ID.
-    return runWithRequestInsightsIdentity(
-      {
-        requestId,
-        htmlRequestId:
-          typeof htmlRequestIdHeader === 'string'
-            ? htmlRequestIdHeader
-            : requestId,
-        url: req.url,
-      },
-      handleRequest
-    )
+    try {
+      return await runWithRequestInsightsIdentity(
+        requestInsightsIdentity,
+        handleRequest
+      )
+    } finally {
+      if (isMiddlewareInvoke && requestInsightsIdentity.source === 'proxy') {
+        requestInsightsIdentity.source = sourceBeforeMiddleware
+      }
+    }
   }
 
   private async handleRequestImpl(

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -114,11 +114,7 @@ import {
   SpanStatusCode,
 } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
-import {
-  resolveRequestInsightsIdentity,
-  runWithRequestInsightsIdentity,
-} from './lib/trace/request-insights-identity'
-import { isRequestInsightsEnabled } from './lib/trace/span-store'
+import type { RequestInsights } from './lib/trace/request-insights'
 import { I18NProvider } from './lib/i18n-provider'
 import { sendResponse } from './send-response'
 import { normalizeNextQueryParam } from './web/utils'
@@ -172,6 +168,41 @@ import {
   computeCacheBustingSearchParam,
   computeLegacyCacheBustingSearchParam,
 } from '../shared/lib/router/utils/cache-busting-search-param'
+
+type BaseServerRequestInsightsRuntime = {
+  RequestInsights: typeof import('./lib/trace/request-insights').RequestInsights
+  resolveRequestInsightsIdentity: typeof import('./lib/trace/request-insights-identity').resolveRequestInsightsIdentity
+  runWithRequestInsights: typeof import('./lib/trace/request-insights-runtime').runWithRequestInsights
+  runWithRequestInsightsIdentity: typeof import('./lib/trace/request-insights-identity').runWithRequestInsightsIdentity
+}
+
+let baseServerRequestInsightsRuntime:
+  | BaseServerRequestInsightsRuntime
+  | undefined
+
+function getBaseServerRequestInsightsRuntime():
+  | BaseServerRequestInsightsRuntime
+  | undefined {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!baseServerRequestInsightsRuntime) {
+      const { RequestInsights } =
+        require('./lib/trace/request-insights') as typeof import('./lib/trace/request-insights')
+      const { resolveRequestInsightsIdentity, runWithRequestInsightsIdentity } =
+        require('./lib/trace/request-insights-identity') as typeof import('./lib/trace/request-insights-identity')
+      const { runWithRequestInsights } =
+        require('./lib/trace/request-insights-runtime') as typeof import('./lib/trace/request-insights-runtime')
+
+      baseServerRequestInsightsRuntime = {
+        RequestInsights,
+        resolveRequestInsightsIdentity,
+        runWithRequestInsights,
+        runWithRequestInsightsIdentity,
+      }
+    }
+    return baseServerRequestInsightsRuntime
+  }
+  return undefined
+}
 
 export type FindComponentsResult<
   NextModule extends GenericComponentMod = GenericComponentMod,
@@ -254,6 +285,10 @@ export interface Options {
    * The HTTP Server that Next.js is running behind
    */
   httpServer?: HTTPServer
+  /** Internal controller shared by one dev server, its bundler, and tools. */
+  requestInsights?: RequestInsights
+  /** Whether this server owns and must dispose the injected controller. */
+  requestInsightsOwner?: boolean
 }
 
 export type RenderOpts = PagesRenderOptsPartial & AppRenderOptsPartial
@@ -346,6 +381,9 @@ export default abstract class Server<
   protected readonly dev: boolean
   protected readonly minimalMode: boolean
   protected readonly renderOpts: BaseRenderOpts
+  protected readonly requestInsights: RequestInsights | undefined
+  /** Whether this server created and therefore owns its controller. */
+  protected readonly ownsRequestInsights: boolean
   protected readonly serverOptions: Readonly<ServerOptions>
   protected readonly appPathRoutes?: Record<string, string[]>
   protected readonly clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
@@ -483,12 +521,17 @@ export default abstract class Server<
     // TODO: should conf be normalized to prevent missing
     // values from causing issues as this can be user provided
     this.nextConfig = conf as NextConfigRuntime
-    if (
-      (dev || process.env.__NEXT_DEV_SERVER) &&
-      this.nextConfig.experimental.requestInsights
-    ) {
-      process.env.__NEXT_REQUEST_INSIGHTS = 'true'
-    }
+    const requestInsightsRuntime = getBaseServerRequestInsightsRuntime()
+    this.requestInsights = requestInsightsRuntime
+      ? (options.requestInsights ??
+        (dev && this.nextConfig.experimental.requestInsights
+          ? new requestInsightsRuntime.RequestInsights()
+          : undefined))
+      : undefined
+    this.ownsRequestInsights =
+      this.requestInsights !== undefined &&
+      (options.requestInsights === undefined ||
+        options.requestInsightsOwner === true)
 
     if (this.nextConfig.experimental.runtimeServerDeploymentId) {
       if (!process.env.NEXT_DEPLOYMENT_ID) {
@@ -1001,17 +1044,26 @@ export default abstract class Server<
         )
       })
 
-    if (!isRequestInsightsEnabled()) {
-      return handleRequest()
+    const requestInsightsRuntime = getBaseServerRequestInsightsRuntime()
+    if (!this.requestInsights || !requestInsightsRuntime) {
+      return requestInsightsRuntime
+        ? requestInsightsRuntime.runWithRequestInsights(undefined, () =>
+            requestInsightsRuntime.runWithRequestInsightsIdentity(
+              undefined,
+              handleRequest
+            )
+          )
+        : handleRequest()
     }
 
-    const requestInsightsIdentity = resolveRequestInsightsIdentity({
-      previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
-      requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
-      htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
-      url: req.url,
-      createRequestId: nanoid,
-    })
+    const requestInsightsIdentity =
+      requestInsightsRuntime.resolveRequestInsightsIdentity({
+        previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+        requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+        htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+        url: req.url,
+        createRequestId: nanoid,
+      })
     const isMiddlewareInvoke = getRequestMeta(req, 'middlewareInvoke') === true
     const sourceBeforeMiddleware = requestInsightsIdentity.source
     if (isMiddlewareInvoke) {
@@ -1023,9 +1075,13 @@ export default abstract class Server<
     // its workStore. Carry their identity in this outer scope; App Render copies
     // it into the workStore so the complete timeline uses one request ID.
     try {
-      return await runWithRequestInsightsIdentity(
-        requestInsightsIdentity,
-        handleRequest
+      return await requestInsightsRuntime.runWithRequestInsights(
+        this.requestInsights,
+        () =>
+          requestInsightsRuntime.runWithRequestInsightsIdentity(
+            requestInsightsIdentity,
+            handleRequest
+          )
       )
     } finally {
       if (isMiddlewareInvoke && requestInsightsIdentity.source === 'proxy') {

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -31,10 +31,7 @@ import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import { devIndicatorServerState } from './dev-indicator-server-state'
 import { createBinaryHmrMessageData } from './messages'
 import type { NextConfigComplete } from '../config-shared'
-import {
-  getRequestInsightsSnapshot,
-  isRequestInsightsEnabled,
-} from '../lib/trace/request-insights'
+import type { RequestInsightsSnapshot } from '../../next-devtools/shared/request-insights'
 
 function isMiddlewareStats(stats: webpack.Stats) {
   for (const key of stats.compilation.entrypoints.keys()) {
@@ -88,7 +85,10 @@ export class WebpackHotMiddleware {
     private versionInfo: VersionInfo,
     private devtoolsFrontendUrl: string | undefined,
     private config: NextConfigComplete,
-    private devToolsConfig: DevToolsConfig
+    private devToolsConfig: DevToolsConfig,
+    private getRequestInsightsSnapshot: () =>
+      | RequestInsightsSnapshot
+      | undefined
   ) {
     compilers[0].hooks.invalid.tap(
       'webpack-hot-middleware',
@@ -211,10 +211,7 @@ export class WebpackHotMiddleware {
         },
         devIndicator: devIndicatorServerState,
         devToolsConfig: this.devToolsConfig,
-        requestInsights:
-          this.config.experimental.requestInsights || isRequestInsightsEnabled()
-            ? getRequestInsightsSnapshot()
-            : undefined,
+        requestInsights: this.getRequestInsightsSnapshot(),
       })
     }
   }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -128,10 +128,6 @@ import {
 } from './hot-reloader-shared-utils'
 import { getMcpMiddleware } from '../mcp/get-mcp-middleware'
 import { formatCompilationIssues } from '../mcp/tools/utils/format-compilation-issues'
-import {
-  getRequestInsightsSnapshot,
-  isRequestInsightsEnabled,
-} from '../lib/trace/request-insights'
 import { resolvePathToRoute } from '../mcp/tools/utils/resolve-path-to-route'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
@@ -1173,6 +1169,7 @@ export async function createHotReloaderTurbopack(
             getActiveConnectionCount: () =>
               clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
             getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
+            getRequestInsights: opts.getRequestInsights,
             getTurbopackProject: () => project,
             compileRoute: async ({ routeSpecifier, path }) => {
               // Resolve the caller's input to a concrete route specifier. The
@@ -1598,11 +1595,7 @@ export async function createHotReloaderTurbopack(
             },
             devIndicator: devIndicatorServerState,
             devToolsConfig,
-            requestInsights:
-              nextConfig.experimental.requestInsights ||
-              isRequestInsightsEnabled()
-                ? getRequestInsightsSnapshot()
-                : undefined,
+            requestInsights: opts.getRequestInsights()?.getSnapshot(),
           }
 
           sendToClient(client, syncMessage)

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -113,6 +113,7 @@ import { recordMcpTelemetry } from '../mcp/mcp-telemetry-tracker'
 import { getFileLogger } from './browser-logs/file-logger'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { Lockfile } from '../../build/lockfile'
+import type { RequestInsights } from '../lib/trace/request-insights'
 import {
   sendSerializedErrorsToClient,
   sendSerializedErrorsToClientForHtmlRequest,
@@ -255,6 +256,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private telemetry: Telemetry
   private resetFetch: () => void
   private lockfile: Lockfile | undefined
+  private getRequestInsights: () => RequestInsights | undefined
   private versionInfo: VersionInfo = {
     staleness: 'unknown',
     installed: '0.0.0',
@@ -287,6 +289,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       resetFetch,
       lockfile,
       onDevServerCleanup,
+      getRequestInsights,
     }: {
       config: NextConfigComplete
       isSrcDir: boolean
@@ -301,6 +304,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       resetFetch: () => void
       lockfile: Lockfile | undefined
       onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
+      getRequestInsights: () => RequestInsights | undefined
     }
   ) {
     this.hasAppRouterEntrypoints = false
@@ -320,6 +324,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.telemetry = telemetry
     this.resetFetch = resetFetch
     this.lockfile = lockfile
+    this.getRequestInsights = getRequestInsights
 
     this.config = config
     this.previewProps = previewProps
@@ -1614,7 +1619,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       this.versionInfo,
       this.devtoolsFrontendUrl,
       this.config,
-      initialDevToolsConfig
+      initialDevToolsConfig,
+      () => this.getRequestInsights()?.getSnapshot()
     )
 
     let booted = false
@@ -1695,6 +1701,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
               getActiveConnectionCount: () =>
                 this.webpackHotMiddleware?.getClientCount() ?? 0,
               getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
+              getRequestInsights: this.getRequestInsights,
               // compile_route is Turbopack-only; intentionally omitted here.
             }),
           ]

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -9,7 +9,7 @@ import {
   type HmrMessageSentToBrowser,
   type NextJsHotReloaderInterface,
 } from '../dev/hot-reloader-types'
-import { subscribeRequestInsights } from './trace/request-insights'
+import type { RequestInsights } from './trace/request-insights'
 
 /**
  * The DevBundlerService provides an interface to perform tasks with the
@@ -25,7 +25,7 @@ export class DevBundlerService {
   constructor(
     private readonly bundler: DevBundler,
     private readonly handler: WorkerRequestHandler,
-    requestInsightsEnabled: boolean
+    public readonly requestInsights: RequestInsights | undefined
   ) {
     this.appIsrManifestInner = new LRUCache(
       8_000,
@@ -42,8 +42,8 @@ export class DevBundlerService {
       hotReloader.setReactDebugChannel.bind(hotReloader)
     this.sendErrorsToBrowser = hotReloader.sendErrorsToBrowser.bind(hotReloader)
 
-    if (requestInsightsEnabled) {
-      this.unsubscribeRequestInsights = subscribeRequestInsights((insight) => {
+    if (requestInsights) {
+      this.unsubscribeRequestInsights = requestInsights.subscribe((insight) => {
         hotReloader.send({
           type: HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_INSIGHTS_UPDATE,
           insight,

--- a/packages/next/src/server/lib/dev-request-id.ts
+++ b/packages/next/src/server/lib/dev-request-id.ts
@@ -1,0 +1,44 @@
+import {
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from '../../client/components/app-router-headers'
+
+type HeaderValue = string | string[] | undefined
+
+const REQUEST_ID_PATTERN = /^[0-9a-f]{1,8}$/
+const HTML_REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
+
+export function getValidatedDevRequestId(
+  value: HeaderValue
+): string | undefined {
+  return typeof value === 'string' && REQUEST_ID_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function getValidatedDevHtmlRequestId(
+  value: HeaderValue
+): string | undefined {
+  return typeof value === 'string' && HTML_REQUEST_ID_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function filterInvalidDevRequestIdHeaders(
+  headers: Record<string, HeaderValue>
+): void {
+  if (
+    headers[NEXT_REQUEST_ID_HEADER] !== undefined &&
+    getValidatedDevRequestId(headers[NEXT_REQUEST_ID_HEADER]) === undefined
+  ) {
+    delete headers[NEXT_REQUEST_ID_HEADER]
+  }
+
+  if (
+    headers[NEXT_HTML_REQUEST_ID_HEADER] !== undefined &&
+    getValidatedDevHtmlRequestId(headers[NEXT_HTML_REQUEST_ID_HEADER]) ===
+      undefined
+  ) {
+    delete headers[NEXT_HTML_REQUEST_ID_HEADER]
+  }
+}

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -4,11 +4,6 @@ import type {
 } from '../app-render/work-async-storage.external'
 
 import { AppRenderSpan, NextNodeServerSpan } from './trace/constants'
-import {
-  isRequestInsightsEnabled,
-  recordRequestInsightFetch,
-} from './trace/request-insights'
-import { getRequestInsightsIdentity } from './trace/request-insights-identity'
 import { getTracer, SpanKind } from './trace/tracer'
 import {
   CACHE_ONE_YEAR_SECONDS,
@@ -41,6 +36,34 @@ import { encodeCacheTag } from './encode-cache-tag'
 import type { Span } from './trace/tracer'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
+
+type PatchFetchRequestInsightsRuntime = {
+  getActiveRequestInsights: typeof import('./trace/request-insights-runtime').getActiveRequestInsights
+  getRequestInsightsIdentity: typeof import('./trace/request-insights-identity').getRequestInsightsIdentity
+}
+
+let patchFetchRequestInsightsRuntime:
+  | PatchFetchRequestInsightsRuntime
+  | undefined
+
+function getPatchFetchRequestInsightsRuntime():
+  | PatchFetchRequestInsightsRuntime
+  | undefined {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!patchFetchRequestInsightsRuntime) {
+      const { getActiveRequestInsights } =
+        require('./trace/request-insights-runtime') as typeof import('./trace/request-insights-runtime')
+      const { getRequestInsightsIdentity } =
+        require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
+      patchFetchRequestInsightsRuntime = {
+        getActiveRequestInsights,
+        getRequestInsightsIdentity,
+      }
+    }
+    return patchFetchRequestInsightsRuntime
+  }
+  return undefined
+}
 
 /**
  * Whether fetch cache configuration needs to be processed for the current work
@@ -187,13 +210,16 @@ function trackFetchMetric(
     'next.fetch.cache_reason': metric.cacheReason,
   })
 
-  if (isRequestInsightsEnabled()) {
-    const requestInsightsIdentity = getRequestInsightsIdentity()
+  const requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
+  const requestInsights = requestInsightsRuntime?.getActiveRequestInsights()
+  if (requestInsights) {
+    const requestInsightsIdentity =
+      requestInsightsRuntime?.getRequestInsightsIdentity()
     const requestInsightsRequestId =
       requestInsightsIdentity?.requestId ?? workStore.requestId
 
     if (requestInsightsRequestId) {
-      recordRequestInsightFetch(
+      requestInsights.recordFetch(
         {
           requestId: requestInsightsRequestId,
           kind: requestInsightsIdentity?.kind,

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -222,6 +222,9 @@ function trackFetchMetric(
       requestInsights.recordFetch(
         {
           requestId: requestInsightsRequestId,
+          rootRequestId:
+            requestInsightsIdentity?.rootRequestId ?? requestInsightsRequestId,
+          retention: requestInsightsIdentity?.retention,
           kind: requestInsightsIdentity?.kind,
           htmlRequestId:
             requestInsightsIdentity?.htmlRequestId ?? workStore.htmlRequestId,

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -9,6 +9,7 @@ import type { OnCacheEntryHandler } from '../request-meta'
 import { interopDefault } from '../../lib/interop-default'
 import { formatDynamicImportPath } from '../../lib/format-dynamic-import-path'
 import type { ConfiguredExperimentalFeature } from '../config'
+import type { RequestInsights } from './trace/request-insights'
 
 export type ServerInitResult = {
   requestHandler: RequestHandler
@@ -101,6 +102,8 @@ async function initializeImpl(opts: {
   _ipcPort?: string
   _ipcKey?: string
   bundlerService: DevBundlerService | undefined
+  requestInsights: RequestInsights | undefined
+  requestInsightsOwner: boolean
   startServerSpan: Span | undefined
   quiet?: boolean
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -71,7 +71,15 @@ import { getNextConfigRuntime, type NextConfigComplete } from '../config-shared'
 import {
   getRequestInsightsSnapshot,
   isRequestInsightsEnabled,
+  recordRequestInsightSource,
 } from './trace/request-insights'
+import {
+  NEXT_HTML_REQUEST_ID_HEADER,
+  NEXT_REQUEST_ID_HEADER,
+} from '../../client/components/app-router-headers'
+import { nanoid } from 'next/dist/compiled/nanoid'
+import { filterInvalidDevRequestIdHeaders } from './dev-request-id'
+import { resolveRequestInsightsIdentity } from './trace/request-insights-identity'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -252,9 +260,21 @@ export async function initialize(opts: {
       filterInternalHeaders(req.headers)
     }
 
+    if (opts.dev) {
+      filterInvalidDevRequestIdHeaders(req.headers)
+    }
+
     if (opts.dev && req.url) {
       if (config.experimental.requestInsights) {
         process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+        const identity = resolveRequestInsightsIdentity({
+          previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+          requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+          htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+          url: req.url,
+          createRequestId: nanoid,
+        })
+        addRequestMeta(req, 'requestInsightsIdentity', identity)
       }
 
       const urlParts = req.url.split('?', 1)
@@ -619,6 +639,15 @@ export async function initialize(opts: {
         }
 
         try {
+          if (config.experimental.requestInsights) {
+            const requestInsightsIdentity = getRequestMeta(
+              req,
+              'requestInsightsIdentity'
+            )
+            if (requestInsightsIdentity) {
+              recordRequestInsightSource(requestInsightsIdentity, 'asset')
+            }
+          }
           return await serveStatic(req, res, matchedOutput.itemPath, {
             root: matchedOutput.itemsRoot,
             // Ensures that etags are not generated for static files when disabled.

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -69,17 +69,45 @@ import {
 } from './chrome-devtools-workspace'
 import { getNextConfigRuntime, type NextConfigComplete } from '../config-shared'
 import {
-  getRequestInsightsSnapshot,
-  isRequestInsightsEnabled,
-  recordRequestInsightSource,
-} from './trace/request-insights'
-import {
   NEXT_HTML_REQUEST_ID_HEADER,
   NEXT_REQUEST_ID_HEADER,
 } from '../../client/components/app-router-headers'
 import { nanoid } from 'next/dist/compiled/nanoid'
 import { filterInvalidDevRequestIdHeaders } from './dev-request-id'
-import { resolveRequestInsightsIdentity } from './trace/request-insights-identity'
+
+type RouterServerRequestInsightsRuntime = {
+  RequestInsights: typeof import('./trace/request-insights').RequestInsights
+  resolveRequestInsightsIdentity: typeof import('./trace/request-insights-identity').resolveRequestInsightsIdentity
+  runWithRequestInsights: typeof import('./trace/request-insights-runtime').runWithRequestInsights
+  runWithRequestInsightsIdentity: typeof import('./trace/request-insights-identity').runWithRequestInsightsIdentity
+}
+
+let routerServerRequestInsightsRuntime:
+  | RouterServerRequestInsightsRuntime
+  | undefined
+
+function getRouterServerRequestInsightsRuntime():
+  | RouterServerRequestInsightsRuntime
+  | undefined {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!routerServerRequestInsightsRuntime) {
+      const { RequestInsights } =
+        require('./trace/request-insights') as typeof import('./trace/request-insights')
+      const { resolveRequestInsightsIdentity, runWithRequestInsightsIdentity } =
+        require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
+      const { runWithRequestInsights } =
+        require('./trace/request-insights-runtime') as typeof import('./trace/request-insights-runtime')
+      routerServerRequestInsightsRuntime = {
+        RequestInsights,
+        resolveRequestInsightsIdentity,
+        runWithRequestInsights,
+        runWithRequestInsightsIdentity,
+      }
+    }
+    return routerServerRequestInsightsRuntime
+  }
+  return undefined
+}
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -153,6 +181,11 @@ export async function initialize(opts: {
   })
 
   const renderServer: LazyRenderServerInstance = {}
+  const requestInsightsRuntime = getRouterServerRequestInsightsRuntime()
+  const requestInsights =
+    requestInsightsRuntime && opts.dev && config.experimental.requestInsights
+      ? new requestInsightsRuntime.RequestInsights()
+      : undefined
 
   let development:
     | {
@@ -227,6 +260,7 @@ export async function initialize(opts: {
         onDevServerCleanup: opts.onDevServerCleanup,
         resetFetch,
         serverFastRefresh: effectiveServerFastRefresh,
+        getRequestInsights: () => requestInsights,
       })
     )
 
@@ -237,7 +271,7 @@ export async function initialize(opts: {
       (req, res) => {
         return requestHandlers[opts.dir](req, res)
       },
-      Boolean(developmentConfig.experimental.requestInsights)
+      requestInsights
     )
 
     development = {
@@ -252,31 +286,8 @@ export async function initialize(opts: {
   renderServer.instance =
     require('./render-server') as typeof import('./render-server')
 
-  const requestHandlerImpl: WorkerRequestHandler = async (req, res) => {
-    addRequestMeta(req, 'relativeProjectDir', relativeProjectDir)
-
-    // internal headers should not be honored by the request handler
-    if (!process.env.NEXT_PRIVATE_TEST_HEADERS) {
-      filterInternalHeaders(req.headers)
-    }
-
-    if (opts.dev) {
-      filterInvalidDevRequestIdHeaders(req.headers)
-    }
-
+  const requestHandlerImplInner: WorkerRequestHandler = async (req, res) => {
     if (opts.dev && req.url) {
-      if (config.experimental.requestInsights) {
-        process.env.__NEXT_REQUEST_INSIGHTS = 'true'
-        const identity = resolveRequestInsightsIdentity({
-          previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
-          requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
-          htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
-          url: req.url,
-          createRequestId: nanoid,
-        })
-        addRequestMeta(req, 'requestInsightsIdentity', identity)
-      }
-
       const urlParts = req.url.split('?', 1)
       const pathname = removePathPrefix(urlParts[0] || '', config.basePath)
 
@@ -294,10 +305,7 @@ export async function initialize(opts: {
         }
 
         res.setHeader('Content-Type', 'application/json; charset=utf-8')
-        if (
-          !config.experimental.requestInsights &&
-          !isRequestInsightsEnabled()
-        ) {
+        if (!requestInsights) {
           res.statusCode = 404
           res.end(
             JSON.stringify({
@@ -309,7 +317,7 @@ export async function initialize(opts: {
         }
 
         res.statusCode = 200
-        res.end(JSON.stringify(getRequestInsightsSnapshot()))
+        res.end(JSON.stringify(requestInsights.getSnapshot()))
         return
       }
     }
@@ -639,13 +647,13 @@ export async function initialize(opts: {
         }
 
         try {
-          if (config.experimental.requestInsights) {
+          if (requestInsights) {
             const requestInsightsIdentity = getRequestMeta(
               req,
               'requestInsightsIdentity'
             )
             if (requestInsightsIdentity) {
-              recordRequestInsightSource(requestInsightsIdentity, 'asset')
+              requestInsights.recordSource(requestInsightsIdentity, 'asset')
             }
           }
           return await serveStatic(req, res, matchedOutput.itemPath, {
@@ -836,6 +844,47 @@ export async function initialize(opts: {
     }
   }
 
+  const requestHandlerImpl: WorkerRequestHandler = (req, res) => {
+    addRequestMeta(req, 'relativeProjectDir', relativeProjectDir)
+
+    // Internal and invalid debug headers must be removed before they can be
+    // considered while creating the server-owned request identity.
+    if (!process.env.NEXT_PRIVATE_TEST_HEADERS) {
+      filterInternalHeaders(req.headers)
+    }
+    if (opts.dev) {
+      filterInvalidDevRequestIdHeaders(req.headers)
+    }
+
+    const handleRequest = () => requestHandlerImplInner(req, res)
+    if (!requestInsights || !requestInsightsRuntime) {
+      return requestInsightsRuntime
+        ? requestInsightsRuntime.runWithRequestInsights(undefined, () =>
+            requestInsightsRuntime.runWithRequestInsightsIdentity(
+              undefined,
+              handleRequest
+            )
+          )
+        : handleRequest()
+    }
+
+    const identity = requestInsightsRuntime.resolveRequestInsightsIdentity({
+      previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
+      requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
+      htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+      url: req.url,
+      createRequestId: nanoid,
+    })
+    addRequestMeta(req, 'requestInsightsIdentity', identity)
+
+    return requestInsightsRuntime.runWithRequestInsights(requestInsights, () =>
+      requestInsightsRuntime.runWithRequestInsightsIdentity(
+        identity,
+        handleRequest
+      )
+    )
+  }
+
   let requestHandler: WorkerRequestHandler = requestHandlerImpl
   if (config.experimental.testProxy) {
     // Intercept fetch and other testmode apis.
@@ -865,6 +914,10 @@ export async function initialize(opts: {
     experimentalTestProxy: !!config.experimental.testProxy,
     experimentalHttpsServer: !!opts.experimentalHttpsServer,
     bundlerService: development?.service,
+    requestInsights,
+    // The render server has a non-optional close lifecycle, including for
+    // direct router initialization where no dev cleanup registrar is supplied.
+    requestInsightsOwner: requestInsights !== undefined,
     startServerSpan: opts.startServerSpan,
     quiet: opts.quiet,
     onDevServerCleanup: opts.onDevServerCleanup,

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -32,7 +32,7 @@ import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-p
 import { NextDataPathnameNormalizer } from '../../normalizers/request/next-data'
 import { BasePathPathnameNormalizer } from '../../normalizers/request/base-path'
 
-import { addRequestMeta } from '../../request-meta'
+import { addRequestMeta, getRequestMeta } from '../../request-meta'
 import { isRSCRequestHeader } from '../is-rsc-request'
 import {
   compileNonPath,
@@ -565,7 +565,7 @@ export function getResolveRoutes(
             /* non-fatal we can't decode so can't match it */
           }
 
-          if (
+          const matchesMiddleware =
             // @ts-expect-error BaseNextRequest stuff
             match?.(parsedUrl.pathname, req, parsedUrl.query) ||
             match?.(
@@ -574,7 +574,17 @@ export function getResolveRoutes(
               req,
               parsedUrl.query
             )
-          ) {
+          const requestInsightsIdentity = getRequestMeta(
+            req,
+            'requestInsightsIdentity'
+          )
+          if (requestInsightsIdentity && match) {
+            requestInsightsIdentity.proxyStatus = matchesMiddleware
+              ? 'matched'
+              : 'bypassed'
+          }
+
+          if (matchesMiddleware) {
             if (ensureMiddleware) {
               await ensureMiddleware(req.url)
             }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -102,6 +102,7 @@ import {
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
 import { Lockfile, type DevServerInfo } from '../../../build/lockfile'
 import { deobfuscateText } from '../../../shared/lib/magic-identifier'
+import type { RequestInsights } from '../trace/request-insights'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -119,6 +120,7 @@ export type SetupOpts = {
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
   resetFetch: () => void
   serverFastRefresh?: boolean
+  getRequestInsights: () => RequestInsights | undefined
 }
 
 export interface DevRoutesManifest {
@@ -272,6 +274,7 @@ async function startWatcher(
           resetFetch,
           lockfile,
           onDevServerCleanup: opts.onDevServerCleanup,
+          getRequestInsights: opts.getRequestInsights,
         })
       })()
 

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -6,12 +6,16 @@ import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
 import { createLocalSpan, traceLocalSpan } from './local-span-recorder'
-import { runWithRequestInsightsIdentity } from './request-insights-identity'
+import {
+  resolveRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './request-insights-identity'
 import { setSpanRecorderForTest, type SpanStoreRecord } from './span-store'
 import {
   workAsyncStorage,
   type WorkStore,
 } from '../../app-render/work-async-storage.external'
+import { filterInvalidDevRequestIdHeaders } from '../dev-request-id'
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const spanRecords: SpanStoreRecord[] = []
@@ -67,6 +71,98 @@ describe('local recording span', () => {
         },
       }),
     ])
+  })
+
+  it('keeps browser debug IDs separate from server-owned storage IDs', () => {
+    const identity = resolveRequestInsightsIdentity({
+      previousIdentity: undefined,
+      requestIdHeader: '1a2b3c4d',
+      htmlRequestIdHeader: 'html_request',
+      url: '/dashboard',
+      createRequestId: () => 'server_request',
+    })
+
+    expect(identity).toEqual({
+      requestId: 'server_request',
+      debugRequestId: '1a2b3c4d',
+      htmlRequestId: 'html_request',
+      url: '/dashboard',
+    })
+    expect(
+      resolveRequestInsightsIdentity({
+        previousIdentity: identity,
+        requestIdHeader: 'ffffffff',
+        htmlRequestIdHeader: 'other_html',
+        url: '/rewritten',
+        createRequestId: () => 'other_server_request',
+      })
+    ).toBe(identity)
+  })
+
+  it('records the framework-owned request source from the request identity', () => {
+    runWithRequestInsightsIdentity(
+      {
+        requestId: 'asset-request',
+        source: 'asset',
+        htmlRequestId: 'asset-request',
+        url: '/asset.svg',
+      },
+      () => {
+        const span = createLocalSpan({ name: 'serve static asset' })
+        span.end()
+      }
+    )
+
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        requestId: 'asset-request',
+        requestInsightSource: 'asset',
+        url: '/asset.svg',
+      }),
+    ])
+  })
+
+  it('rejects malformed browser IDs instead of using them as storage keys', () => {
+    expect(
+      resolveRequestInsightsIdentity({
+        previousIdentity: undefined,
+        requestIdHeader: 'not a request id',
+        htmlRequestIdHeader: '../not-safe',
+        url: '/',
+        createRequestId: () => 'server_request',
+      })
+    ).toEqual({
+      requestId: 'server_request',
+      debugRequestId: undefined,
+      htmlRequestId: 'server_request',
+      url: '/',
+    })
+  })
+
+  it('drops malformed development correlation headers at router ingress', () => {
+    const headers = {
+      'x-nextjs-request-id': 'not a request id',
+      'x-nextjs-html-request-id': '../not-safe',
+    }
+
+    filterInvalidDevRequestIdHeaders(headers)
+
+    expect(headers).toEqual({})
+  })
+
+  it('does not merge independent requests that reuse a valid browser ID', () => {
+    const createIdentity = (requestId: string) =>
+      resolveRequestInsightsIdentity({
+        previousIdentity: undefined,
+        requestIdHeader: '1a2b3c4d',
+        htmlRequestIdHeader: undefined,
+        url: '/',
+        createRequestId: () => requestId,
+      })
+
+    expect(createIdentity('server_request_1').requestId).not.toBe(
+      createIdentity('server_request_2').requestId
+    )
   })
 
   it('ignores undefined values when setting attributes', () => {

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -7,6 +7,7 @@ import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
 import { createLocalSpan, traceLocalSpan } from './local-span-recorder'
 import {
+  createRequestInsightsRetentionContext,
   resolveRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
 } from './request-insights-identity'
@@ -84,6 +85,8 @@ describe('local recording span', () => {
         runWithRequestInsightsIdentity(
           {
             requestId: 'late-request',
+            rootRequestId: 'late-request',
+            retention: createRequestInsightsRetentionContext(),
             htmlRequestId: 'late-request',
             url: '/late',
           },
@@ -115,6 +118,8 @@ describe('local recording span', () => {
         runWithRequestInsightsIdentity(
           {
             requestId: 'first-request',
+            rootRequestId: 'first-request',
+            retention: createRequestInsightsRetentionContext(),
             htmlRequestId: 'first-request',
             url: '/first',
           },
@@ -130,7 +135,7 @@ describe('local recording span', () => {
           spans: [expect.objectContaining({ name: 'first late span' })],
         }),
       ])
-      expect(second.getSnapshot()).toEqual({ requests: [] })
+      expect(second.getSnapshot().requests).toEqual([])
     } finally {
       first.dispose()
       second.dispose()
@@ -145,6 +150,8 @@ describe('local recording span', () => {
       const span = runWithRequestInsightsIdentity(
         {
           requestId: 'unowned-request',
+          rootRequestId: 'unowned-request',
+          retention: createRequestInsightsRetentionContext(),
           htmlRequestId: 'unowned-request',
           url: '/unowned',
         },
@@ -153,7 +160,7 @@ describe('local recording span', () => {
 
       runWithRequestInsights(requestInsights, () => span.end())
 
-      expect(requestInsights.getSnapshot()).toEqual({ requests: [] })
+      expect(requestInsights.getSnapshot().requests).toEqual([])
     } finally {
       requestInsights.dispose()
     }
@@ -168,12 +175,15 @@ describe('local recording span', () => {
       createRequestId: () => 'server_request',
     })
 
-    expect(identity).toEqual({
-      requestId: 'server_request',
-      debugRequestId: '1a2b3c4d',
-      htmlRequestId: 'html_request',
-      url: '/dashboard',
-    })
+    expect(identity).toEqual(
+      expect.objectContaining({
+        requestId: 'server_request',
+        rootRequestId: 'server_request',
+        debugRequestId: '1a2b3c4d',
+        htmlRequestId: 'html_request',
+        url: '/dashboard',
+      })
+    )
     expect(
       resolveRequestInsightsIdentity({
         previousIdentity: identity,
@@ -189,6 +199,8 @@ describe('local recording span', () => {
     runWithRequestInsightsIdentity(
       {
         requestId: 'asset-request',
+        rootRequestId: 'asset-request',
+        retention: createRequestInsightsRetentionContext(),
         source: 'asset',
         htmlRequestId: 'asset-request',
         url: '/asset.svg',
@@ -217,12 +229,15 @@ describe('local recording span', () => {
         url: '/',
         createRequestId: () => 'server_request',
       })
-    ).toEqual({
-      requestId: 'server_request',
-      debugRequestId: undefined,
-      htmlRequestId: 'server_request',
-      url: '/',
-    })
+    ).toEqual(
+      expect.objectContaining({
+        requestId: 'server_request',
+        rootRequestId: 'server_request',
+        debugRequestId: undefined,
+        htmlRequestId: 'server_request',
+        url: '/',
+      })
+    )
   })
 
   it('drops malformed development correlation headers at router ingress', () => {
@@ -363,6 +378,8 @@ describe('local recording span', () => {
     runWithRequestInsightsIdentity(
       {
         requestId: 'request-1',
+        rootRequestId: 'request-1',
+        retention: createRequestInsightsRetentionContext(),
         htmlRequestId: 'html-1',
         url: '/dashboard?tab=overview',
       },
@@ -393,6 +410,8 @@ describe('local recording span', () => {
       runWithRequestInsightsIdentity(
         {
           requestId: 'originating-request',
+          rootRequestId: 'originating-request',
+          retention: createRequestInsightsRetentionContext(),
           kind: 'instant-insights',
           htmlRequestId: 'originating-html',
           url: '/dashboard',

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -16,6 +16,8 @@ import {
   type WorkStore,
 } from '../../app-render/work-async-storage.external'
 import { filterInvalidDevRequestIdHeaders } from '../dev-request-id'
+import { RequestInsights } from './request-insights'
+import { runWithRequestInsights } from './request-insights-runtime'
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const spanRecords: SpanStoreRecord[] = []
@@ -71,6 +73,78 @@ describe('local recording span', () => {
         },
       }),
     ])
+  })
+
+  it('records on the controller captured when a span started after its scope exits', () => {
+    setSpanRecorderForTest(undefined)
+    const requestInsights = new RequestInsights()
+
+    try {
+      const span = runWithRequestInsights(requestInsights, () =>
+        runWithRequestInsightsIdentity(
+          { requestId: 'late-request', url: '/late' },
+          () => createLocalSpan({ name: 'late span' })
+        )
+      )
+
+      span.end()
+
+      expect(requestInsights.getSnapshot().requests).toEqual([
+        expect.objectContaining({
+          requestId: 'late-request',
+          url: '/late',
+          spans: [expect.objectContaining({ name: 'late span' })],
+        }),
+      ])
+    } finally {
+      requestInsights.dispose()
+    }
+  })
+
+  it('keeps a late span on its captured controller while another is active', () => {
+    setSpanRecorderForTest(undefined)
+    const first = new RequestInsights()
+    const second = new RequestInsights()
+
+    try {
+      const span = runWithRequestInsights(first, () =>
+        runWithRequestInsightsIdentity(
+          { requestId: 'first-request', url: '/first' },
+          () => createLocalSpan({ name: 'first late span' })
+        )
+      )
+
+      runWithRequestInsights(second, () => span.end())
+
+      expect(first.getSnapshot().requests).toEqual([
+        expect.objectContaining({
+          requestId: 'first-request',
+          spans: [expect.objectContaining({ name: 'first late span' })],
+        }),
+      ])
+      expect(second.getSnapshot()).toEqual({ requests: [] })
+    } finally {
+      first.dispose()
+      second.dispose()
+    }
+  })
+
+  it('does not fall back to the active controller when none was captured', () => {
+    setSpanRecorderForTest(undefined)
+    const requestInsights = new RequestInsights()
+
+    try {
+      const span = runWithRequestInsightsIdentity(
+        { requestId: 'unowned-request', url: '/unowned' },
+        () => createLocalSpan({ name: 'unowned late span' })
+      )
+
+      runWithRequestInsights(requestInsights, () => span.end())
+
+      expect(requestInsights.getSnapshot()).toEqual({ requests: [] })
+    } finally {
+      requestInsights.dispose()
+    }
   })
 
   it('keeps browser debug IDs separate from server-owned storage IDs', () => {

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -82,7 +82,11 @@ describe('local recording span', () => {
     try {
       const span = runWithRequestInsights(requestInsights, () =>
         runWithRequestInsightsIdentity(
-          { requestId: 'late-request', url: '/late' },
+          {
+            requestId: 'late-request',
+            htmlRequestId: 'late-request',
+            url: '/late',
+          },
           () => createLocalSpan({ name: 'late span' })
         )
       )
@@ -109,7 +113,11 @@ describe('local recording span', () => {
     try {
       const span = runWithRequestInsights(first, () =>
         runWithRequestInsightsIdentity(
-          { requestId: 'first-request', url: '/first' },
+          {
+            requestId: 'first-request',
+            htmlRequestId: 'first-request',
+            url: '/first',
+          },
           () => createLocalSpan({ name: 'first late span' })
         )
       )
@@ -135,7 +143,11 @@ describe('local recording span', () => {
 
     try {
       const span = runWithRequestInsightsIdentity(
-        { requestId: 'unowned-request', url: '/unowned' },
+        {
+          requestId: 'unowned-request',
+          htmlRequestId: 'unowned-request',
+          url: '/unowned',
+        },
         () => createLocalSpan({ name: 'unowned late span' })
       )
 

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -20,6 +20,7 @@ import type {
   RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { RequestInsights } from './request-insights'
+import type { RequestInsightsRetentionContext } from './request-insights-identity'
 
 export { isLocalSpanRecordingEnabled } from './span-store'
 
@@ -175,6 +176,8 @@ function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {
 type RequestIdentity = {
   requestInsights?: RequestInsights
   requestId?: string
+  rootRequestId?: string
+  requestInsightsRetention?: RequestInsightsRetentionContext
   requestInsightKind?: RequestInsightKind
   requestInsightSource?: RequestInsightSource
   requestInsightProxyStatus?: RequestInsightProxyStatus
@@ -382,6 +385,8 @@ class LocalRecordingSpan implements Span {
         spanId: this.spanContextValue.spanId,
         parentSpanId: this.parentSpanId,
         requestId: this.requestIdentity.requestId,
+        rootRequestId: this.requestIdentity.rootRequestId,
+        requestInsightsRetention: this.requestIdentity.requestInsightsRetention,
         requestInsightKind: this.requestIdentity.requestInsightKind,
         requestInsightSource: this.requestIdentity.requestInsightSource,
         requestInsightProxyStatus:
@@ -594,6 +599,9 @@ function getCurrentRequestIdentity(): RequestIdentity {
     return {
       requestInsights,
       requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
+      rootRequestId:
+        requestInsightsIdentity?.rootRequestId ?? workStore?.requestId,
+      requestInsightsRetention: requestInsightsIdentity?.retention,
       requestInsightKind: requestInsightsIdentity?.kind,
       requestInsightSource: requestInsightsIdentity?.source,
       requestInsightProxyStatus: requestInsightsIdentity?.proxyStatus,

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -14,6 +14,11 @@ import {
   type SpanStoreLink,
 } from './span-store'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 
 export { isLocalSpanRecordingEnabled } from './span-store'
 
@@ -169,6 +174,10 @@ function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {
 type RequestIdentity = {
   requestId?: string
   requestInsightKind?: RequestInsightKind
+  requestInsightSource?: RequestInsightSource
+  requestInsightProxyStatus?: RequestInsightProxyStatus
+  requestInsightRouterActivity?: RequestInsightRouterActivity
+  requestInsightServerAction?: true
   htmlRequestId?: string
   route?: string
   url?: string
@@ -371,6 +380,12 @@ class LocalRecordingSpan implements Span {
       parentSpanId: this.parentSpanId,
       requestId: this.requestIdentity.requestId,
       requestInsightKind: this.requestIdentity.requestInsightKind,
+      requestInsightSource: this.requestIdentity.requestInsightSource,
+      requestInsightProxyStatus: this.requestIdentity.requestInsightProxyStatus,
+      requestInsightRouterActivity:
+        this.requestIdentity.requestInsightRouterActivity,
+      requestInsightServerAction:
+        this.requestIdentity.requestInsightServerAction,
       htmlRequestId: this.requestIdentity.htmlRequestId,
       route:
         getStringAttribute(recordAttributes, 'next.route') ??
@@ -565,6 +580,10 @@ function getCurrentRequestIdentity(): RequestIdentity {
     return {
       requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
       requestInsightKind: requestInsightsIdentity?.kind,
+      requestInsightSource: requestInsightsIdentity?.source,
+      requestInsightProxyStatus: requestInsightsIdentity?.proxyStatus,
+      requestInsightRouterActivity: requestInsightsIdentity?.routerActivity,
+      requestInsightServerAction: requestInsightsIdentity?.serverAction,
       htmlRequestId:
         requestInsightsIdentity?.htmlRequestId ?? workStore?.htmlRequestId,
       route: workStore?.route,

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -19,6 +19,7 @@ import type {
   RequestInsightRouterActivity,
   RequestInsightSource,
 } from '../../../shared/lib/request-insights'
+import type { RequestInsights } from './request-insights'
 
 export { isLocalSpanRecordingEnabled } from './span-store'
 
@@ -172,6 +173,7 @@ function getLocalSpanAsyncStorage(): AsyncLocalStorage<Span> {
 }
 
 type RequestIdentity = {
+  requestInsights?: RequestInsights
   requestId?: string
   requestInsightKind?: RequestInsightKind
   requestInsightSource?: RequestInsightSource
@@ -370,35 +372,39 @@ class LocalRecordingSpan implements Span {
     const recordAttributes =
       Object.keys(this.attributes).length > 0 ? this.attributes : undefined
 
-    recordSpan({
-      name: this.name,
-      startTime: this.startTime,
-      durationMs: Math.max(0, getTimestamp(endTime) - this.startTime),
-      status: this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok',
-      traceId: this.spanContextValue.traceId,
-      spanId: this.spanContextValue.spanId,
-      parentSpanId: this.parentSpanId,
-      requestId: this.requestIdentity.requestId,
-      requestInsightKind: this.requestIdentity.requestInsightKind,
-      requestInsightSource: this.requestIdentity.requestInsightSource,
-      requestInsightProxyStatus: this.requestIdentity.requestInsightProxyStatus,
-      requestInsightRouterActivity:
-        this.requestIdentity.requestInsightRouterActivity,
-      requestInsightServerAction:
-        this.requestIdentity.requestInsightServerAction,
-      htmlRequestId: this.requestIdentity.htmlRequestId,
-      route:
-        getStringAttribute(recordAttributes, 'next.route') ??
-        getStringAttribute(recordAttributes, 'http.route') ??
-        this.requestIdentity.route,
-      url:
-        getStringAttribute(recordAttributes, 'http.url') ??
-        this.requestIdentity.url,
-      attributes: recordAttributes,
-      links: this.links,
-      events: this.events.length > 0 ? this.events : undefined,
-      error: this.getRecordError(),
-    })
+    recordSpan(
+      {
+        name: this.name,
+        startTime: this.startTime,
+        durationMs: Math.max(0, getTimestamp(endTime) - this.startTime),
+        status: this.statusCode === SpanStatusCode.ERROR ? 'error' : 'ok',
+        traceId: this.spanContextValue.traceId,
+        spanId: this.spanContextValue.spanId,
+        parentSpanId: this.parentSpanId,
+        requestId: this.requestIdentity.requestId,
+        requestInsightKind: this.requestIdentity.requestInsightKind,
+        requestInsightSource: this.requestIdentity.requestInsightSource,
+        requestInsightProxyStatus:
+          this.requestIdentity.requestInsightProxyStatus,
+        requestInsightRouterActivity:
+          this.requestIdentity.requestInsightRouterActivity,
+        requestInsightServerAction:
+          this.requestIdentity.requestInsightServerAction,
+        htmlRequestId: this.requestIdentity.htmlRequestId,
+        route:
+          getStringAttribute(recordAttributes, 'next.route') ??
+          getStringAttribute(recordAttributes, 'http.route') ??
+          this.requestIdentity.route,
+        url:
+          getStringAttribute(recordAttributes, 'http.url') ??
+          this.requestIdentity.url,
+        attributes: recordAttributes,
+        links: this.links,
+        events: this.events.length > 0 ? this.events : undefined,
+        error: this.getRecordError(),
+      },
+      this.requestIdentity.requestInsights
+    )
   }
 
   private releaseReferences(): void {
@@ -571,6 +577,14 @@ function getCurrentRequestIdentity(): RequestIdentity {
       require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
     const { workUnitAsyncStorage } =
       require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
+    let requestInsights: RequestInsights | undefined
+    if (process.env.__NEXT_DEV_SERVER) {
+      const { getActiveRequestInsights } =
+        require('./request-insights-runtime') as typeof import('./request-insights-runtime')
+      requestInsights = getActiveRequestInsights()
+    } else {
+      requestInsights = undefined
+    }
     const workStore = workAsyncStorage.getStore()
     const workUnitStore = workUnitAsyncStorage.getStore()
     const requestInsightsIdentity = getRequestInsightsIdentity()
@@ -578,6 +592,7 @@ function getCurrentRequestIdentity(): RequestIdentity {
       workUnitStore && 'url' in workUnitStore ? workUnitStore.url : undefined
 
     return {
+      requestInsights,
       requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
       requestInsightKind: requestInsightsIdentity?.kind,
       requestInsightSource: requestInsightsIdentity?.source,

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -15,6 +15,8 @@ export type RequestInsightsIdentity = {
   // This is a server-owned storage key. Browser-provided IDs are only used by
   // the development debug channel and must never become Request Insights keys.
   requestId: string
+  rootRequestId: string
+  retention: RequestInsightsRetentionContext
   debugRequestId?: string
   kind?: RequestInsightKind
   source?: RequestInsightSource
@@ -45,11 +47,104 @@ export function resolveRequestInsightsIdentity({
   const requestId = createRequestId()
   return {
     requestId,
+    rootRequestId: requestId,
+    retention: createRequestInsightsRetentionContext(),
     debugRequestId: getValidatedDevRequestId(requestIdHeader),
     htmlRequestId:
       getValidatedDevHtmlRequestId(htmlRequestIdHeader) ?? requestId,
     url,
   }
+}
+
+declare const requestInsightsRetentionContextBrand: unique symbol
+
+export type RequestInsightsRetentionContext = {
+  readonly [requestInsightsRetentionContextBrand]: true
+}
+
+type RequestInsightsRetentionGate = { closed: boolean }
+type RequestInsightsRetentionState = {
+  rootGate: RequestInsightsRetentionGate
+  recordGate: RequestInsightsRetentionGate
+}
+
+const REQUEST_INSIGHTS_RETENTION_STATES_KEY = Symbol.for(
+  '@next/request-insights-retention-states'
+)
+
+function getRequestInsightsRetentionStates(): WeakMap<
+  RequestInsightsRetentionContext,
+  RequestInsightsRetentionState
+> {
+  const globalStore = globalThis as typeof globalThis & {
+    [REQUEST_INSIGHTS_RETENTION_STATES_KEY]?: WeakMap<
+      RequestInsightsRetentionContext,
+      RequestInsightsRetentionState
+    >
+  }
+  return (globalStore[REQUEST_INSIGHTS_RETENTION_STATES_KEY] ??= new WeakMap())
+}
+
+export function createRequestInsightsRetentionContext(
+  parent?: RequestInsightsRetentionContext
+): RequestInsightsRetentionContext {
+  const parentState = parent
+    ? getRequestInsightsRetentionStates().get(parent)
+    : undefined
+  const context = Object.freeze({}) as RequestInsightsRetentionContext
+  getRequestInsightsRetentionStates().set(context, {
+    rootGate: parentState?.rootGate ?? { closed: false },
+    recordGate: { closed: false },
+  })
+  return context
+}
+
+export function isRequestInsightsRetentionContextOpen(
+  context: RequestInsightsRetentionContext
+): boolean {
+  const state = getRequestInsightsRetentionStates().get(context)
+  return Boolean(state && !state.rootGate.closed && !state.recordGate.closed)
+}
+
+export function hasSameRequestInsightsRetentionContext(
+  left: RequestInsightsRetentionContext,
+  right: RequestInsightsRetentionContext
+): boolean {
+  const states = getRequestInsightsRetentionStates()
+  const leftState = states.get(left)
+  const rightState = states.get(right)
+  return Boolean(
+    leftState &&
+      rightState &&
+      leftState.rootGate === rightState.rootGate &&
+      leftState.recordGate === rightState.recordGate
+  )
+}
+
+export function hasSameRequestInsightsRetentionRoot(
+  left: RequestInsightsRetentionContext,
+  right: RequestInsightsRetentionContext
+): boolean {
+  const states = getRequestInsightsRetentionStates()
+  const leftState = states.get(left)
+  const rightState = states.get(right)
+  return Boolean(
+    leftState && rightState && leftState.rootGate === rightState.rootGate
+  )
+}
+
+export function closeRequestInsightsRetentionRecord(
+  context: RequestInsightsRetentionContext
+): void {
+  const state = getRequestInsightsRetentionStates().get(context)
+  if (state) state.recordGate.closed = true
+}
+
+export function closeRequestInsightsRetentionRoot(
+  context: RequestInsightsRetentionContext
+): void {
+  const state = getRequestInsightsRetentionStates().get(context)
+  if (state) state.rootGate.closed = true
 }
 
 // This storage covers the part of BaseServer request handling that runs before

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -1,12 +1,55 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+import {
+  getValidatedDevHtmlRequestId,
+  getValidatedDevRequestId,
+} from '../dev-request-id'
 
 export type RequestInsightsIdentity = {
+  // This is a server-owned storage key. Browser-provided IDs are only used by
+  // the development debug channel and must never become Request Insights keys.
   requestId: string
+  debugRequestId?: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId: string
   url: string | undefined
+}
+
+export function resolveRequestInsightsIdentity({
+  previousIdentity,
+  requestIdHeader,
+  htmlRequestIdHeader,
+  url,
+  createRequestId,
+}: {
+  previousIdentity: RequestInsightsIdentity | undefined
+  requestIdHeader: string | string[] | undefined
+  htmlRequestIdHeader: string | string[] | undefined
+  url: string | undefined
+  createRequestId: () => string
+}): RequestInsightsIdentity {
+  if (previousIdentity) {
+    return previousIdentity
+  }
+
+  const requestId = createRequestId()
+  return {
+    requestId,
+    debugRequestId: getValidatedDevRequestId(requestIdHeader),
+    htmlRequestId:
+      getValidatedDevHtmlRequestId(htmlRequestIdHeader) ?? requestId,
+    url,
+  }
 }
 
 // This storage covers the part of BaseServer request handling that runs before

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -59,24 +59,55 @@ const REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY = Symbol.for(
   '@next/request-insights-identity-storage'
 )
 
-function getRequestInsightsIdentityStorage(): AsyncLocalStorage<RequestInsightsIdentity> {
-  const globalStore = globalThis as typeof globalThis & {
-    [REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY]?: AsyncLocalStorage<RequestInsightsIdentity>
-  }
+type RequestInsightsIdentityScope = {
+  identity: RequestInsightsIdentity | undefined
+}
+
+type GlobalWithRequestInsightsIdentityStorage = typeof globalThis & {
+  [REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY]?: AsyncLocalStorage<RequestInsightsIdentityScope>
+}
+
+function getExistingRequestInsightsIdentityStorage():
+  | AsyncLocalStorage<RequestInsightsIdentityScope>
+  | undefined {
+  return (globalThis as GlobalWithRequestInsightsIdentityStorage)[
+    REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY
+  ]
+}
+
+function getOrCreateRequestInsightsIdentityStorage(): AsyncLocalStorage<RequestInsightsIdentityScope> {
+  const globalStore = globalThis as GlobalWithRequestInsightsIdentityStorage
 
   return (globalStore[REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY] ??=
-    createAsyncLocalStorage())
+    createAsyncLocalStorage<RequestInsightsIdentityScope>())
 }
 
 export function runWithRequestInsightsIdentity<T>(
-  identity: RequestInsightsIdentity,
+  identity: RequestInsightsIdentity | undefined,
   fn: () => T
 ): T {
-  return getRequestInsightsIdentityStorage().run(identity, fn)
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return fn()
+  }
+
+  const storage = getExistingRequestInsightsIdentityStorage()
+  if (!storage) {
+    return identity === undefined
+      ? fn()
+      : getOrCreateRequestInsightsIdentityStorage().run({ identity }, fn)
+  }
+
+  return storage.getStore()?.identity === identity
+    ? fn()
+    : storage.run({ identity }, fn)
 }
 
 export function getRequestInsightsIdentity():
   | RequestInsightsIdentity
   | undefined {
-  return getRequestInsightsIdentityStorage().getStore()
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return undefined
+  }
+
+  return getExistingRequestInsightsIdentityStorage()?.getStore()?.identity
 }

--- a/packages/next/src/server/lib/trace/request-insights-router-activity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-router-activity.ts
@@ -1,0 +1,36 @@
+import {
+  NEXT_HMR_REFRESH_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  RSC_HEADER,
+} from '../../../client/components/app-router-headers'
+import type { RequestInsightRouterActivity } from '../../../shared/lib/request-insights'
+import { isRSCRequestHeader } from '../is-rsc-request'
+
+type RouterHeaders = Record<string, string | string[] | undefined>
+
+export function getRequestInsightRouterActivity(
+  headers: RouterHeaders
+): RequestInsightRouterActivity | undefined {
+  if (!isRSCRequestHeader(headers[RSC_HEADER])) {
+    return undefined
+  }
+
+  if (headers[NEXT_HMR_REFRESH_HEADER] === '1') {
+    return 'hmr-refresh'
+  }
+
+  const prefetch = headers[NEXT_ROUTER_PREFETCH_HEADER]
+  if (prefetch !== '1' && prefetch !== '2' && prefetch !== '3') {
+    return undefined
+  }
+
+  if (
+    prefetch === '1' &&
+    typeof headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === 'string'
+  ) {
+    return 'segment-prefetch'
+  }
+
+  return 'prefetch'
+}

--- a/packages/next/src/server/lib/trace/request-insights-runtime.ts
+++ b/packages/next/src/server/lib/trace/request-insights-runtime.ts
@@ -1,0 +1,66 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+import type { RequestInsights } from './request-insights'
+
+// The carrier is shared by CJS and ESM copies of the server runtime. It only
+// identifies the controller that owns the current async request scope; retained
+// insights and subscribers always live on that controller instance.
+const REQUEST_INSIGHTS_RUNTIME_STORAGE_KEY = Symbol.for(
+  '@next/request-insights-runtime-storage'
+)
+
+type RequestInsightsRuntimeScope = {
+  requestInsights: RequestInsights | undefined
+}
+
+type GlobalWithRequestInsightsRuntimeStorage = typeof globalThis & {
+  [REQUEST_INSIGHTS_RUNTIME_STORAGE_KEY]?: AsyncLocalStorage<RequestInsightsRuntimeScope>
+}
+
+function getExistingRequestInsightsRuntimeStorage():
+  | AsyncLocalStorage<RequestInsightsRuntimeScope>
+  | undefined {
+  return (globalThis as GlobalWithRequestInsightsRuntimeStorage)[
+    REQUEST_INSIGHTS_RUNTIME_STORAGE_KEY
+  ]
+}
+
+function getOrCreateRequestInsightsRuntimeStorage(): AsyncLocalStorage<RequestInsightsRuntimeScope> {
+  const globalWithStorage =
+    globalThis as GlobalWithRequestInsightsRuntimeStorage
+
+  return (globalWithStorage[REQUEST_INSIGHTS_RUNTIME_STORAGE_KEY] ??=
+    createAsyncLocalStorage<RequestInsightsRuntimeScope>())
+}
+
+export function runWithRequestInsights<T>(
+  requestInsights: RequestInsights | undefined,
+  fn: () => T
+): T {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return fn()
+  }
+
+  const storage = getExistingRequestInsightsRuntimeStorage()
+  if (!storage) {
+    return requestInsights === undefined
+      ? fn()
+      : getOrCreateRequestInsightsRuntimeStorage().run({ requestInsights }, fn)
+  }
+
+  return storage.getStore()?.requestInsights === requestInsights
+    ? fn()
+    : storage.run({ requestInsights }, fn)
+}
+
+export function getActiveRequestInsights(): RequestInsights | undefined {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return undefined
+  }
+
+  return getExistingRequestInsightsRuntimeStorage()?.getStore()?.requestInsights
+}
+
+export function isRequestInsightsRuntimeActive(): boolean {
+  return getActiveRequestInsights() !== undefined
+}

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -12,6 +12,21 @@ import {
 import { runWithRequestInsights } from './request-insights-runtime'
 import { recordSpan } from './span-store'
 import { getRequestInsightRouterActivity } from './request-insights-router-activity'
+import {
+  createRequestInsightsRetentionContext,
+  isRequestInsightsRetentionContextOpen,
+} from './request-insights-identity'
+import {
+  createBoundedRequestInsightsSnapshotProjection,
+  REQUEST_INSIGHTS_MAX_BYTES_PER_RETENTION_BUCKET,
+  REQUEST_INSIGHTS_MAX_BYTES_PER_RECORD,
+  REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN,
+  REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET,
+  REQUEST_INSIGHTS_MAX_RETAINED_BYTES,
+  REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES,
+  getRequestInsightsSerializedByteLength,
+  type RequestInsight,
+} from '../../../next-devtools/shared/request-insights'
 
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -136,56 +151,58 @@ describe('request insights', () => {
       },
     })
 
-    expect(getRequestInsightsSnapshot()).toEqual({
-      requests: [
-        expect.objectContaining({
-          requestId: 'req_1',
-          htmlRequestId: 'html_1',
-          route: '/products/[id]',
-          durationMs: 50,
-          status: 'ok',
-          spans: expect.arrayContaining([
-            expect.objectContaining({
-              name: 'fetch GET https://example.vercel.sh/',
-              attributes: expect.objectContaining({
-                'next.span_category': 'application',
+    expect(getRequestInsightsSnapshot()).toEqual(
+      expect.objectContaining({
+        requests: [
+          expect.objectContaining({
+            requestId: 'req_1',
+            htmlRequestId: 'html_1',
+            route: '/products/[id]',
+            durationMs: 50,
+            status: 'ok',
+            spans: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'fetch GET https://example.vercel.sh/',
+                attributes: expect.objectContaining({
+                  'next.span_category': 'application',
+                }),
               }),
-            }),
-            expect.objectContaining({
-              traceId: 'trace_1',
-              spanId: 'span_1',
-              attributes: expect.objectContaining({
-                'next.span_category': 'nextjs',
+              expect.objectContaining({
+                traceId: 'trace_1',
+                spanId: 'span_1',
+                attributes: expect.objectContaining({
+                  'next.span_category': 'nextjs',
+                }),
+                events: [
+                  {
+                    name: 'metadata ready',
+                    timestamp: 130,
+                  },
+                ],
+                links: [
+                  {
+                    traceId: 'linked_trace',
+                    spanId: 'linked_span',
+                  },
+                ],
               }),
-              events: [
-                {
-                  name: 'metadata ready',
-                  timestamp: 130,
-                },
-              ],
-              links: [
-                {
-                  traceId: 'linked_trace',
-                  spanId: 'linked_span',
-                },
-              ],
-            }),
-          ]),
-          fetches: [
-            {
-              url: 'https://example.vercel.sh/',
-              method: 'GET',
-              statusCode: 200,
-              startTime: 120,
-              durationMs: 25,
-              cacheStatus: 'skip',
-              cacheReason: 'cache: no-store',
-              index: 1,
-            },
-          ],
-        }),
-      ],
-    })
+            ]),
+            fetches: [
+              {
+                url: 'https://example.vercel.sh/',
+                method: 'GET',
+                statusCode: 200,
+                startTime: 120,
+                durationMs: 25,
+                cacheStatus: 'skip',
+                cacheReason: 'cache: no-store',
+                index: 1,
+              },
+            ],
+          }),
+        ],
+      })
+    )
   })
 
   test('notifies subscribers when a request insight changes', () => {
@@ -571,24 +588,26 @@ describe('request insights', () => {
       }
     )
 
-    expect(getRequestInsightsSnapshot()).toEqual({
-      requests: [
-        expect.objectContaining({
-          requestId: 'req_3',
-          htmlRequestId: 'html_3',
-          route: '/reports',
-          durationMs: 75,
-          fetches: [
-            expect.objectContaining({
-              url: 'https://example.vercel.sh/api',
-              startTime: 200,
-              durationMs: 75,
-              cacheStatus: 'miss',
-            }),
-          ],
-        }),
-      ],
-    })
+    expect(getRequestInsightsSnapshot()).toEqual(
+      expect.objectContaining({
+        requests: [
+          expect.objectContaining({
+            requestId: 'req_3',
+            htmlRequestId: 'html_3',
+            route: '/reports',
+            durationMs: 75,
+            fetches: [
+              expect.objectContaining({
+                url: 'https://example.vercel.sh/api',
+                startTime: 200,
+                durationMs: 75,
+                cacheStatus: 'miss',
+              }),
+            ],
+          }),
+        ],
+      })
+    )
   })
 
   test('redacts sensitive request insight payload fields', () => {
@@ -763,5 +782,816 @@ describe('request insights', () => {
         )
       )
     ).not.toContain('sk_live_SENTINEL')
+  })
+
+  it('retains independent newest suffixes for each fixed request bucket', () => {
+    const controller = new RequestInsights({ maxRequestGroupsPerBucket: 2 })
+    try {
+      for (const [source, prefix] of [
+        ['page', 'page'],
+        ['app-route', 'api'],
+        ['asset', 'asset'],
+        ['proxy', 'proxy'],
+        ['instant-insights', 'instant'],
+        ['unknown', 'unknown'],
+      ] as const) {
+        for (let index = 0; index < 3; index++) {
+          controller.recordFetch(
+            {
+              requestId: `${prefix}-${index}`,
+              rootRequestId: `${prefix}-${index}`,
+              source,
+              kind:
+                source === 'instant-insights' ? 'instant-insights' : 'request',
+            },
+            { url: `/${prefix}/${index}`, startTime: index, durationMs: 1 }
+          )
+        }
+      }
+
+      const capture = controller.getCaptureState()
+      expect(capture.usage.retainedRequestGroupCount).toBe(12)
+      for (const bucket of capture.usage.buckets) {
+        expect(bucket).toEqual(
+          expect.objectContaining({
+            retainedRequestGroupCount: 2,
+            evictedRequestGroupCount: 1,
+          })
+        )
+      }
+      expect(
+        controller.getSnapshot().requests.map((request) => request.requestId)
+      ).not.toContain('page-0')
+      expect(
+        controller.getSnapshot().requests.map((request) => request.requestId)
+      ).toContain('page-2')
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('enforces per-bucket and aggregate retained byte ceilings', () => {
+    const perBucket = new RequestInsights({
+      maxBytesPerRetentionBucket: 1_200,
+      maxRetainedBytes: 100_000,
+    })
+    const aggregate = new RequestInsights({
+      maxBytesPerRetentionBucket: 100_000,
+      maxRetainedBytes: 1_500,
+    })
+    try {
+      for (let index = 0; index < 10; index++) {
+        perBucket.recordSpan({
+          name: `page-${index}-${'x'.repeat(400)}`,
+          timestamp: index,
+          requestId: `page-${index}`,
+          rootRequestId: `page-${index}`,
+          requestInsightSource: 'page',
+        })
+      }
+      const pageUsage = perBucket
+        .getCaptureState()
+        .usage.buckets.find((bucket) => bucket.bucket === 'page')!
+      expect(pageUsage.retainedBytes).toBeLessThanOrEqual(1_200)
+      expect(pageUsage.evictedRequestGroupCount).toBeGreaterThan(0)
+
+      for (let index = 0; index < 10; index++) {
+        aggregate.recordSpan({
+          name: `${'x'.repeat(300)}-${index}`,
+          timestamp: index,
+          requestId: `global-${index}`,
+          rootRequestId: `global-${index}`,
+          requestInsightSource: index % 2 === 0 ? 'page' : 'app-route',
+        })
+      }
+      const aggregateCapture = aggregate.getCaptureState()
+      expect(aggregateCapture.usage.retainedBytes).toBeLessThanOrEqual(1_500)
+      expect(
+        aggregateCapture.usage.buckets.reduce(
+          (total, bucket) => total + bucket.evictedRequestGroupCount,
+          0
+        )
+      ).toBeGreaterThan(0)
+    } finally {
+      perBucket.dispose()
+      aggregate.dispose()
+    }
+  })
+
+  it('reports retained bytes from the serialized record payloads', () => {
+    const controller = new RequestInsights()
+    try {
+      controller.recordSpan({
+        name: 'page span',
+        timestamp: 1,
+        requestId: 'page-bytes',
+        rootRequestId: 'page-bytes',
+        requestInsightSource: 'page',
+      })
+      controller.recordSpan({
+        name: 'api span',
+        timestamp: 2,
+        requestId: 'api-bytes',
+        rootRequestId: 'api-bytes',
+        requestInsightSource: 'app-route',
+      })
+
+      const snapshot = controller.getSnapshot()
+      const expectedBytes = snapshot.requests.reduce(
+        (total, request) =>
+          total + Buffer.byteLength(JSON.stringify(request), 'utf8'),
+        0
+      )
+      expect(snapshot.capture?.usage.retainedBytes).toBe(expectedBytes)
+      expect(
+        snapshot.capture?.usage.buckets.reduce(
+          (total, bucket) => total + bucket.retainedBytes,
+          0
+        )
+      ).toBe(expectedBytes)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('bounds spans, fetches, record bytes, and reports irreversible loss', () => {
+    const controller = new RequestInsights()
+    try {
+      for (let index = 0; index < 205; index++) {
+        controller.recordSpan({
+          name: `operation-${index}-${'x'.repeat(400)}`,
+          timestamp: index,
+          requestId: 'bounded-record',
+          rootRequestId: 'bounded-record',
+        })
+        controller.recordFetch(
+          {
+            requestId: 'bounded-record',
+            rootRequestId: 'bounded-record',
+          },
+          {
+            url: `/fetch/${index}`,
+            startTime: index + 0.5,
+            durationMs: 1,
+            index,
+          }
+        )
+      }
+
+      const request = controller.getSnapshot().requests[0]
+      expect(request.spans.length).toBeLessThanOrEqual(200)
+      expect(request.fetches.length).toBeLessThanOrEqual(200)
+      expect(request.truncatedSpanCount).toBeGreaterThan(0)
+      expect(request.truncatedFetchCount).toBeGreaterThan(0)
+      expect(
+        Buffer.byteLength(JSON.stringify(request), 'utf8')
+      ).toBeLessThanOrEqual(REQUEST_INSIGHTS_MAX_BYTES_PER_RECORD)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('keeps exactly the newest 200 small spans and fetches per record', () => {
+    const controller = new RequestInsights()
+    try {
+      for (let index = 0; index < 205; index++) {
+        controller.recordSpan({
+          name: `s${index}`,
+          timestamp: index,
+          requestId: 'span-cap',
+          rootRequestId: 'span-cap',
+        })
+        controller.recordFetch(
+          { requestId: 'fetch-cap', rootRequestId: 'fetch-cap' },
+          { url: `/f/${index}`, startTime: index, index }
+        )
+      }
+
+      const requests = controller.getSnapshot().requests
+      const spanRequest = requests.find(
+        (request) => request.requestId === 'span-cap'
+      )!
+      const fetchRequest = requests.find(
+        (request) => request.requestId === 'fetch-cap'
+      )!
+      expect(spanRequest.spans).toHaveLength(200)
+      expect(spanRequest.spans[0].name).toBe('s5')
+      expect(spanRequest.truncatedSpanCount).toBe(5)
+      expect(fetchRequest.fetches).toHaveLength(200)
+      expect(fetchRequest.fetches[0].url).toBe('/f/5')
+      expect(fetchRequest.truncatedFetchCount).toBe(5)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('bounds individual spans and reports event, link, and metadata loss', () => {
+    const controller = new RequestInsights()
+    try {
+      controller.recordSpan({
+        name: 'x'.repeat(10_000),
+        timestamp: 1,
+        requestId: 'bounded-span',
+        rootRequestId: 'bounded-span',
+        attributes: {
+          'next.span_type': 'test.bounded',
+          'next.span_name': 'y'.repeat(10_000),
+          'next.segment': Array.from(
+            { length: 30 },
+            (_, index) => `segment-${index}-${'z'.repeat(100)}`
+          ),
+        },
+        events: Array.from({ length: 25 }, (_, index) => ({
+          name: `event-${index}-${'e'.repeat(500)}`,
+          timestamp: index,
+          attributes: { 'next.segment': 'a'.repeat(1_000) },
+        })),
+        links: Array.from({ length: 20 }, (_, index) => ({
+          traceId: `trace-${index}`,
+          spanId: `span-${index}`,
+          attributes: { 'next.segment': 'b'.repeat(1_000) },
+        })),
+      })
+
+      const span = controller.getSnapshot().requests[0].spans[0]
+      expect(span.name.length).toBeLessThanOrEqual(512)
+      expect(span.events?.length).toBeLessThanOrEqual(16)
+      expect(span.links?.length).toBeLessThanOrEqual(8)
+      expect(span.truncatedEventCount).toBeGreaterThanOrEqual(9)
+      expect(span.truncatedLinkCount).toBeGreaterThanOrEqual(12)
+      expect(span.truncatedMetadataValueCount).toBeGreaterThan(0)
+      expect(
+        Buffer.byteLength(JSON.stringify(span), 'utf8')
+      ).toBeLessThanOrEqual(REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('bounds each logical root atomically and keeps omission metadata on its root', () => {
+    const controller = new RequestInsights()
+    try {
+      controller.recordFetch(
+        { requestId: 'root', rootRequestId: 'root', source: 'page' },
+        { url: '/root', startTime: 0, durationMs: 1 }
+      )
+      for (let index = 0; index < 16; index++) {
+        controller.recordFetch(
+          {
+            requestId: `child-${index}`,
+            rootRequestId: 'root',
+            source: 'app-route',
+          },
+          { url: `/child/${index}`, startTime: index + 1, durationMs: 1 }
+        )
+      }
+
+      const requests = controller.getSnapshot().requests
+      expect(requests).toHaveLength(15)
+      expect(requests[0]).toEqual(
+        expect.objectContaining({
+          requestId: 'root',
+          omittedRequestCount: 2,
+        })
+      )
+      expect(
+        requests.every((request) => request.rootRequestId === 'root')
+      ).toBe(true)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('closes an evicted root so late spans and fetches cannot resurrect it', () => {
+    const controller = new RequestInsights({ maxRequestGroupsPerBucket: 1 })
+    const evictedRetention = createRequestInsightsRetentionContext()
+    const evictedChildRetention =
+      createRequestInsightsRetentionContext(evictedRetention)
+    try {
+      controller.recordFetch(
+        {
+          requestId: 'evicted',
+          rootRequestId: 'evicted',
+          retention: evictedRetention,
+          source: 'page',
+        },
+        { url: '/evicted', startTime: 1, durationMs: 1 }
+      )
+      controller.recordFetch(
+        {
+          requestId: 'evicted-child',
+          rootRequestId: 'evicted',
+          retention: evictedChildRetention,
+          source: 'app-route',
+        },
+        { url: '/evicted-child', startTime: 1.5, durationMs: 1 }
+      )
+      controller.recordFetch(
+        {
+          requestId: 'retained',
+          rootRequestId: 'retained',
+          retention: createRequestInsightsRetentionContext(),
+          source: 'page',
+        },
+        { url: '/retained', startTime: 2, durationMs: 1 }
+      )
+
+      expect(isRequestInsightsRetentionContextOpen(evictedRetention)).toBe(
+        false
+      )
+      expect(isRequestInsightsRetentionContextOpen(evictedChildRetention)).toBe(
+        false
+      )
+      controller.recordSpan({
+        name: 'late span',
+        timestamp: 3,
+        requestId: 'evicted-child',
+        rootRequestId: 'evicted',
+        requestInsightsRetention: evictedChildRetention,
+      })
+      controller.recordFetch(
+        {
+          requestId: 'evicted',
+          rootRequestId: 'evicted',
+          retention: evictedRetention,
+        },
+        { url: '/late', startTime: 3, durationMs: 1 }
+      )
+
+      expect(
+        controller.getSnapshot().requests.map((request) => request.requestId)
+      ).toEqual(['retained'])
+      expect(
+        controller
+          .getCaptureState()
+          .usage.buckets.find((bucket) => bucket.bucket === 'page')
+          ?.evictedRequestGroupCount
+      ).toBe(1)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('publishes isolated deep clones to snapshots and every subscriber', () => {
+    const controller = new RequestInsights()
+    const firstListener = jest.fn((insight) => {
+      insight.spans[0].name = 'mutated-listener'
+      const segment = insight.spans[0].attributes?.['next.segment']
+      if (Array.isArray(segment)) segment[0] = 'mutated-array'
+    })
+    const secondListener = jest.fn()
+    controller.subscribe(firstListener)
+    controller.subscribe(secondListener)
+    try {
+      controller.recordSpan({
+        name: 'original',
+        timestamp: 1,
+        requestId: 'isolated',
+        rootRequestId: 'isolated',
+        attributes: {
+          'next.segment': ['original-array'],
+        },
+      })
+
+      expect(secondListener.mock.calls[0][0].spans[0].name).toBe('original')
+      expect(
+        secondListener.mock.calls[0][0].spans[0].attributes?.['next.segment']
+      ).toEqual(['original-array'])
+
+      const firstSnapshot = controller.getSnapshot()
+      firstSnapshot.requests[0].spans[0].name = 'mutated-snapshot'
+      ;(
+        firstSnapshot.requests[0].spans[0].attributes?.[
+          'next.segment'
+        ] as string[]
+      )[0] = 'mutated-snapshot-array'
+      const secondSnapshot = controller.getSnapshot()
+      expect(secondSnapshot.requests[0].spans[0].name).toBe('original')
+      expect(
+        secondSnapshot.requests[0].spans[0].attributes?.['next.segment']
+      ).toEqual(['original-array'])
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('projects whole logical roots fairly under the snapshot byte cap', () => {
+    const maxSnapshotBytes = 3_500
+    const controller = new RequestInsights({ maxSnapshotBytes })
+    try {
+      for (let index = 0; index < 6; index++) {
+        for (const source of ['page', 'app-route'] as const) {
+          const prefix = source === 'page' ? 'page' : 'api'
+          controller.recordSpan({
+            name: `${prefix}-${index}-${'x'.repeat(400)}`,
+            timestamp: index,
+            requestId: `${prefix}-${index}`,
+            rootRequestId: `${prefix}-${index}`,
+            requestInsightSource: source,
+          })
+        }
+      }
+
+      const snapshot = controller.getSnapshot()
+      expect(
+        getRequestInsightsSerializedByteLength(snapshot)
+      ).toBeLessThanOrEqual(maxSnapshotBytes)
+      expect(snapshot.projection?.omittedRequestGroupCount).toBeGreaterThan(0)
+      expect(
+        snapshot.requests.some((request) => request.source === 'page')
+      ).toBe(true)
+      expect(
+        snapshot.requests.some((request) => request.source === 'app-route')
+      ).toBe(true)
+      expect(snapshot.projection?.buckets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ bucket: 'page' }),
+          expect.objectContaining({ bucket: 'api' }),
+        ])
+      )
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('queries and limits whole logical roots without conflating projection loss with capture eviction', () => {
+    const controller = new RequestInsights({ maxRequestGroupsPerBucket: 3 })
+    try {
+      controller.recordFetch(
+        { requestId: 'root', rootRequestId: 'root', source: 'page' },
+        { url: '/root', startTime: 1, durationMs: 1 }
+      )
+      controller.recordFetch(
+        { requestId: 'child', rootRequestId: 'root', source: 'app-route' },
+        { url: '/child', startTime: 2, durationMs: 1 }
+      )
+      controller.recordFetch(
+        { requestId: 'other', rootRequestId: 'other', source: 'page' },
+        { url: '/other', startTime: 3, durationMs: 1 }
+      )
+      controller.recordFetch(
+        { requestId: 'newest', rootRequestId: 'newest', source: 'page' },
+        { url: '/newest', startTime: 4, durationMs: 1 }
+      )
+
+      const childQuery = controller.getSnapshot({ requestId: 'child' })
+      expect(childQuery.requests.map((request) => request.requestId)).toEqual([
+        'root',
+        'child',
+      ])
+
+      const limited = controller.getSnapshot({ limit: 1 })
+      expect(
+        new Set(limited.requests.map((request) => request.rootRequestId))
+      ).toEqual(new Set(['newest']))
+      expect(limited.projection?.omittedRequestGroupCount).toBe(2)
+      expect(
+        limited.capture?.usage.buckets.find(
+          (bucket) => bucket.bucket === 'page'
+        )?.evictedRequestGroupCount
+      ).toBe(0)
+      expect(
+        getRequestInsightsSerializedByteLength(controller.getSnapshot())
+      ).toBeLessThanOrEqual(REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('counts serialized UTF-8 bytes exactly', () => {
+    for (const value of [
+      'ascii',
+      'é',
+      '😀',
+      '\ud800',
+      'line\nseparator\u2028',
+      { nested: ['😀', 'é', '\udfff'] },
+    ]) {
+      expect(getRequestInsightsSerializedByteLength(value)).toBe(
+        Buffer.byteLength(JSON.stringify(value), 'utf8')
+      )
+    }
+  })
+
+  it('enforces the exact snapshot boundary for UTF-8 logical roots', () => {
+    const createRequest = (
+      requestId: string,
+      source: RequestInsight['source'],
+      route: string
+    ): RequestInsight => ({
+      requestId,
+      rootRequestId: requestId,
+      source,
+      htmlRequestId: requestId,
+      route,
+      startTime: 1,
+      status: 'ok',
+      spans: [],
+      fetches: [],
+    })
+    const groups = Array.from({ length: 6 }, (_, index) => [
+      createRequest(`root-${index}`, 'page', `/é/😀/${index}`),
+    ])
+    const fullSnapshotByteLength = getRequestInsightsSerializedByteLength({
+      requests: groups.flat(),
+    })
+
+    const exact = createBoundedRequestInsightsSnapshotProjection(
+      groups,
+      fullSnapshotByteLength
+    )
+    expect(exact.snapshotByteLength).toBe(fullSnapshotByteLength)
+    expect(exact.snapshot.requests).toHaveLength(groups.length)
+
+    const below = createBoundedRequestInsightsSnapshotProjection(
+      groups,
+      fullSnapshotByteLength - 1
+    )
+    expect(below.snapshotByteLength).toBeLessThanOrEqual(
+      fullSnapshotByteLength - 1
+    )
+    expect(below.snapshot.requests.length).toBeLessThan(groups.length)
+
+    const largeGroups = Array.from({ length: 72 }, (_, index) => [
+      createRequest(`large-${index}`, 'page', `/${'é'.repeat(30_000)}`),
+    ])
+    const bounded = createBoundedRequestInsightsSnapshotProjection(
+      largeGroups,
+      REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES
+    )
+    expect(bounded.snapshotByteLength).toBeLessThanOrEqual(
+      REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES
+    )
+    expect(
+      bounded.snapshot.projection?.omittedRequestGroupCount
+    ).toBeGreaterThan(0)
+  })
+
+  it('uses the canonical root to bucket a child-first projection group', () => {
+    const createRequest = (
+      requestId: string,
+      rootRequestId: string,
+      source: RequestInsight['source']
+    ): RequestInsight => ({
+      requestId,
+      rootRequestId,
+      source,
+      htmlRequestId: rootRequestId,
+      startTime: 1,
+      status: 'ok',
+      spans: [],
+      fetches: [],
+    })
+    const childFirstPageGroup = [
+      createRequest('child', 'root', 'app-route'),
+      createRequest('root', 'root', 'page'),
+    ]
+    const newerApiGroup = [createRequest('api', 'api', 'app-route')]
+
+    const { snapshot } = createBoundedRequestInsightsSnapshotProjection(
+      [childFirstPageGroup, newerApiGroup],
+      REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES,
+      undefined,
+      1
+    )
+    expect(snapshot.requests.map((request) => request.requestId)).toEqual([
+      'api',
+    ])
+    expect(snapshot.projection?.buckets).toEqual([
+      { bucket: 'page', omittedRequestGroupCount: 1 },
+    ])
+  })
+
+  it('keeps creation order when a retained root changes buckets', () => {
+    const controller = new RequestInsights({ maxRequestGroupsPerBucket: 1 })
+    try {
+      controller.recordFetch(
+        { requestId: 'older', rootRequestId: 'older' },
+        { url: '/older', startTime: 1 }
+      )
+      controller.recordFetch(
+        { requestId: 'newer', rootRequestId: 'newer', source: 'page' },
+        { url: '/newer', startTime: 2 }
+      )
+
+      controller.recordSource(
+        { requestId: 'older', rootRequestId: 'older' },
+        'page'
+      )
+
+      expect(
+        controller.getSnapshot().requests.map((request) => request.requestId)
+      ).toEqual(['newer'])
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('closes a record omitted from a retained logical root', () => {
+    const controller = new RequestInsights()
+    const rootRetention = createRequestInsightsRetentionContext()
+    const omittedRetention =
+      createRequestInsightsRetentionContext(rootRetention)
+    try {
+      controller.recordFetch(
+        {
+          requestId: 'root',
+          rootRequestId: 'root',
+          retention: rootRetention,
+          source: 'page',
+        },
+        { url: '/root', startTime: 0 }
+      )
+      for (let index = 0; index < 15; index++) {
+        controller.recordFetch(
+          {
+            requestId: `child-${index}`,
+            rootRequestId: 'root',
+            retention:
+              index === 0
+                ? omittedRetention
+                : createRequestInsightsRetentionContext(rootRetention),
+          },
+          { url: `/child/${index}`, startTime: index + 1 }
+        )
+      }
+
+      expect(isRequestInsightsRetentionContextOpen(rootRetention)).toBe(true)
+      expect(isRequestInsightsRetentionContextOpen(omittedRetention)).toBe(
+        false
+      )
+      controller.recordFetch(
+        {
+          requestId: 'child-0',
+          rootRequestId: 'root',
+          retention: omittedRetention,
+        },
+        { url: '/late', startTime: 100 }
+      )
+      const snapshot = controller.getSnapshot()
+      expect(
+        snapshot.requests.some((request) => request.requestId === 'child-0')
+      ).toBe(false)
+      expect(
+        snapshot.requests.find((request) => request.requestId === 'root')
+          ?.omittedRequestCount
+      ).toBe(1)
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('rejects a related context created after its root was evicted', () => {
+    const controller = new RequestInsights({ maxRequestGroupsPerBucket: 1 })
+    const evictedRetention = createRequestInsightsRetentionContext()
+    try {
+      controller.recordFetch(
+        {
+          requestId: 'evicted',
+          rootRequestId: 'evicted',
+          retention: evictedRetention,
+          source: 'page',
+        },
+        { url: '/evicted', startTime: 1 }
+      )
+      controller.recordFetch(
+        {
+          requestId: 'retained',
+          rootRequestId: 'retained',
+          retention: createRequestInsightsRetentionContext(),
+          source: 'page',
+        },
+        { url: '/retained', startTime: 2 }
+      )
+
+      const lateChildRetention =
+        createRequestInsightsRetentionContext(evictedRetention)
+      expect(isRequestInsightsRetentionContextOpen(lateChildRetention)).toBe(
+        false
+      )
+      controller.recordFetch(
+        {
+          requestId: 'late-child',
+          rootRequestId: 'evicted',
+          retention: lateChildRetention,
+        },
+        { url: '/late-child', startTime: 3 }
+      )
+      expect(
+        controller.getSnapshot().requests.map((request) => request.requestId)
+      ).toEqual(['retained'])
+    } finally {
+      controller.dispose()
+    }
+  })
+
+  it('keeps late callbacks closed after clear and dispose', () => {
+    const cleared = new RequestInsights()
+    const clearedRetention = createRequestInsightsRetentionContext()
+    cleared.recordFetch(
+      {
+        requestId: 'cleared',
+        rootRequestId: 'cleared',
+        retention: clearedRetention,
+      },
+      { url: '/cleared', startTime: 1 }
+    )
+    cleared.clear()
+    cleared.recordFetch(
+      {
+        requestId: 'cleared',
+        rootRequestId: 'cleared',
+        retention: clearedRetention,
+      },
+      { url: '/late', startTime: 2 }
+    )
+    expect(cleared.getSnapshot().requests).toEqual([])
+    cleared.dispose()
+
+    const disposed = new RequestInsights()
+    const disposedRetention = createRequestInsightsRetentionContext()
+    disposed.recordFetch(
+      {
+        requestId: 'disposed',
+        rootRequestId: 'disposed',
+        retention: disposedRetention,
+      },
+      { url: '/disposed', startTime: 1 }
+    )
+    disposed.dispose()
+    disposed.recordFetch(
+      {
+        requestId: 'disposed',
+        rootRequestId: 'disposed',
+        retention: disposedRetention,
+      },
+      { url: '/late', startTime: 2 }
+    )
+    expect(disposed.getSnapshot()).toEqual({ requests: [] })
+  })
+
+  it('normalizes and copies configurable capture limits once', () => {
+    const mutableOptions = {
+      maxBytesPerRetentionBucket: 1_200.9,
+      maxRetainedBytes: 1_500.9,
+      maxRequestGroupsPerBucket: 2.9,
+      maxSnapshotBytes: 3_500.9,
+    }
+    const controller = new RequestInsights(mutableOptions)
+    mutableOptions.maxRequestGroupsPerBucket = 100
+    expect(controller.getCaptureState().limits).toEqual(
+      expect.objectContaining({
+        maxBytesPerBucket: 1_200,
+        maxRetainedBytes: 1_500,
+        maxRequestGroupsPerBucket: 2,
+        maxSnapshotBytes: 3_500,
+      })
+    )
+    controller.dispose()
+
+    const invalid = new RequestInsights({
+      maxBytesPerRetentionBucket: Number.NaN,
+      maxRetainedBytes: Number.POSITIVE_INFINITY,
+      maxRequestGroupsPerBucket: -1,
+      maxSnapshotBytes: -1,
+    })
+    expect(invalid.getCaptureState().limits).toEqual(
+      expect.objectContaining({
+        maxBytesPerBucket: REQUEST_INSIGHTS_MAX_BYTES_PER_RETENTION_BUCKET,
+        maxRetainedBytes: REQUEST_INSIGHTS_MAX_RETAINED_BYTES,
+        maxRequestGroupsPerBucket:
+          REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET,
+        maxSnapshotBytes: REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES,
+      })
+    )
+    invalid.dispose()
+
+    const zero = new RequestInsights({
+      maxBytesPerRetentionBucket: 0,
+      maxRetainedBytes: 0,
+      maxRequestGroupsPerBucket: 0,
+      maxSnapshotBytes: 0,
+    })
+    zero.recordFetch(
+      { requestId: 'not-retained', rootRequestId: 'not-retained' },
+      { url: '/not-retained', startTime: 1 }
+    )
+    const zeroSnapshot = zero.getSnapshot()
+    expect(zeroSnapshot.requests).toEqual([])
+    expect(zero.getCaptureState().limits).toEqual(
+      expect.objectContaining({
+        maxBytesPerBucket: 0,
+        maxRetainedBytes: 0,
+        maxRequestGroupsPerBucket: 0,
+      })
+    )
+    expect(zero.getCaptureState().limits.maxSnapshotBytes).toBeGreaterThan(0)
+    expect(zero.getCaptureState().limits.maxSnapshotBytes).toBeLessThan(
+      REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES
+    )
+    expect(
+      getRequestInsightsSerializedByteLength(zeroSnapshot)
+    ).toBeLessThanOrEqual(zero.getCaptureState().limits.maxSnapshotBytes)
+    zero.dispose()
   })
 })

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -39,13 +39,14 @@ describe('request insights', () => {
   })
 
   function withRequestInsights<TArgs extends unknown[]>(
-    fn: (...args: TArgs) => unknown
-  ): (...args: TArgs) => unknown {
-    return (...args) =>
+    fn: (...args: TArgs) => void
+  ): (...args: TArgs) => void {
+    return (...args) => {
       runWithRequestInsights(requestInsights, () => fn(...args))
+    }
   }
 
-  function test(name: string, fn: () => unknown): void {
+  function test(name: string, fn: () => void): void {
     it(name, withRequestInsights(fn))
   }
 

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -538,17 +538,18 @@ describe('request insights', () => {
   it('redacts sensitive request insight payload fields', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
+    const secret = 'Q2_SECRET_SENTINEL'
     recordSpan({
-      name: 'fetch GET https://example.vercel.sh/api',
+      name: `fetch GET https://example.vercel.sh/api?token=${secret}`,
       startTime: 100,
       durationMs: 10,
       requestId: 'req_4',
       route: '/account',
       attributes: {
         'next.span_type': 'AppRender.fetch',
-        'http.url':
-          'https://user:pass@example.vercel.sh/api?access_token=abc&delay=1&signature=sig',
+        'http.url': `https://user:pass@example.vercel.sh/api?access_token=${secret}&delay=1&signature=sig`,
         'http.method': 'GET',
+        'next.span_name': `fetch GET https://user:pass@example.vercel.sh/api?access_token=${secret}`,
         'custom.secret': 'should not be exposed',
       },
       events: [
@@ -588,11 +589,13 @@ describe('request insights', () => {
       expect.objectContaining({
         spans: [
           expect.objectContaining({
+            name: 'fetch GET https://example.vercel.sh/api?query=redacted',
             attributes: {
               'next.span_type': 'AppRender.fetch',
-              'http.url':
-                'https://example.vercel.sh/api?access_token=redacted&delay=1&signature=redacted',
+              'http.url': 'https://example.vercel.sh/api?query=redacted',
               'http.method': 'GET',
+              'next.span_name':
+                'fetch GET https://example.vercel.sh/api?query=redacted',
             },
             events: [
               {
@@ -614,13 +617,95 @@ describe('request insights', () => {
         ],
         fetches: [
           expect.objectContaining({
-            url: 'https://example.vercel.sh/api?access_token=redacted&delay=1&signature=redacted',
+            url: 'https://example.vercel.sh/api?query=redacted',
           }),
           expect.objectContaining({
-            url: 'https://example.vercel.sh/api?token=redacted&keep=1',
+            url: 'https://example.vercel.sh/api?query=redacted',
           }),
         ],
       })
     )
+    expect(JSON.stringify(getRequestInsightsSnapshot())).not.toContain(secret)
+  })
+
+  it('only exposes bounded URLs without query payloads', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const cases = [
+      {
+        requestId: 'relative',
+        input: '/products/blue?sort=price#details',
+        expected: '/products/blue?query=redacted',
+      },
+      {
+        requestId: 'protocol-relative',
+        input: '//example.com/items?cursor=secret',
+        expected: '//example.com/items?query=redacted',
+      },
+      {
+        requestId: 'absolute',
+        input: 'https://user:password@example.com/items?visible=value#details',
+        expected: 'https://example.com/items?query=redacted',
+      },
+      {
+        requestId: 'opaque',
+        input: 'data:text/plain,secret',
+        expected: 'data:redacted',
+      },
+      {
+        requestId: 'untrusted-relative',
+        input: 'items?token=secret',
+        expected: undefined,
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      recordRequestInsightFetch(
+        { requestId: testCase.requestId },
+        { url: testCase.input, startTime: 100, durationMs: 1 }
+      )
+    }
+
+    const requests = new Map(
+      getRequestInsightsSnapshot().requests.map((request) => [
+        request.requestId,
+        request,
+      ])
+    )
+    for (const testCase of cases) {
+      expect(requests.get(testCase.requestId)?.fetches[0]?.url).toBe(
+        testCase.expected
+      )
+    }
+
+    recordRequestInsightFetch(
+      { requestId: 'oversized' },
+      {
+        url: `https://example.com/${'x'.repeat(64 * 1024)}`,
+        startTime: 100,
+        durationMs: 1,
+      }
+    )
+    expect(
+      getRequestInsightsSnapshot().requests.find(
+        (request) => request.requestId === 'oversized'
+      )?.fetches[0]?.url
+    ).toBeUndefined()
+
+    recordRequestInsightFetch(
+      { requestId: 'query-name' },
+      {
+        url: 'https://example.com/items?sk_live_SENTINEL',
+        startTime: 100,
+        durationMs: 1,
+      }
+    )
+    expect(
+      JSON.stringify(
+        getRequestInsightsSnapshot().requests.find(
+          (request) => request.requestId === 'query-name'
+        )
+      )
+    ).not.toContain('sk_live_SENTINEL')
   })
 })

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -1,5 +1,7 @@
+/* eslint-disable jest/no-standalone-expect -- Assertions run inside the controller-scoped test wrapper. */
+
 import {
-  clearRequestInsightsForTest,
+  RequestInsights,
   getRequestInsightsSnapshot,
   recordRequestInsightFetch,
   recordRequestInsightRouterActivity,
@@ -7,6 +9,7 @@ import {
   recordRequestInsightSource,
   subscribeRequestInsights,
 } from './request-insights'
+import { runWithRequestInsights } from './request-insights-runtime'
 import { recordSpan } from './span-store'
 import { getRequestInsightRouterActivity } from './request-insights-router-activity'
 
@@ -22,17 +25,66 @@ function restoreEnv(name: string, value: string | undefined) {
 }
 
 describe('request insights', () => {
+  let requestInsights: RequestInsights
+
   beforeEach(() => {
     process.env.__NEXT_DEV_SERVER = '1'
+    requestInsights = new RequestInsights()
   })
 
   afterEach(() => {
     restoreEnv('__NEXT_REQUEST_INSIGHTS', originalRequestInsights)
     restoreEnv('__NEXT_DEV_SERVER', originalDevServer)
-    clearRequestInsightsForTest()
+    requestInsights.dispose()
   })
 
-  it('derives request history from local span records', () => {
+  function withRequestInsights<TArgs extends unknown[]>(
+    fn: (...args: TArgs) => unknown
+  ): (...args: TArgs) => unknown {
+    return (...args) =>
+      runWithRequestInsights(requestInsights, () => fn(...args))
+  }
+
+  function test(name: string, fn: () => unknown): void {
+    it(name, withRequestInsights(fn))
+  }
+
+  it('isolates retained data by active controller', () => {
+    const first = new RequestInsights()
+    const second = new RequestInsights()
+    try {
+      runWithRequestInsights(first, () => {
+        recordRequestInsightFetch(
+          { requestId: 'first' },
+          { url: '/first', startTime: 1, durationMs: 1 }
+        )
+        runWithRequestInsights(second, () => {
+          recordRequestInsightFetch(
+            { requestId: 'second' },
+            { url: '/second', startTime: 2, durationMs: 1 }
+          )
+        })
+        runWithRequestInsights(undefined, () => {
+          recordRequestInsightFetch(
+            { requestId: 'disabled' },
+            { url: '/disabled', startTime: 3, durationMs: 1 }
+          )
+        })
+      })
+
+      expect(
+        first.getSnapshot().requests.map(({ requestId }) => requestId)
+      ).toEqual(['first'])
+      expect(
+        second.getSnapshot().requests.map(({ requestId }) => requestId)
+      ).toEqual(['second'])
+    } finally {
+      first.dispose()
+      second.dispose()
+    }
+  })
+
+  test('derives request history from local span records', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     recordSpan({
@@ -135,7 +187,7 @@ describe('request insights', () => {
     })
   })
 
-  it('notifies subscribers when a request insight changes', () => {
+  test('notifies subscribers when a request insight changes', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const listener = jest.fn()
     const unsubscribe = subscribeRequestInsights(listener)
@@ -158,7 +210,7 @@ describe('request insights', () => {
     unsubscribe()
   })
 
-  it('uses the HTTP request span as the end-to-end request timing', () => {
+  test('uses the HTTP request span as the end-to-end request timing', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     recordSpan({
@@ -189,7 +241,7 @@ describe('request insights', () => {
     )
   })
 
-  it('classifies framework request sources without letting the root span erase a specific source', () => {
+  test('classifies framework request sources without letting the root span erase a specific source', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     recordSpan({
@@ -216,23 +268,26 @@ describe('request insights', () => {
     ['Node.runHandler', 'pages-api'],
     ['NextNodeServer.imageOptimizer', 'image'],
     ['Middleware.execute', 'proxy'],
-  ] as const)('classifies %s spans as %s requests', (spanType, source) => {
-    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+  ] as const)(
+    'classifies %s spans as %s requests',
+    withRequestInsights((spanType, source) => {
+      process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
-    recordSpan({
-      name: spanType,
-      requestId: `req_${source}`,
-      attributes: {
-        'next.span_type': spanType,
-      },
+      recordSpan({
+        name: spanType,
+        requestId: `req_${source}`,
+        attributes: {
+          'next.span_type': spanType,
+        },
+      })
+
+      expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+        expect.objectContaining({ source })
+      )
     })
+  )
 
-    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
-      expect.objectContaining({ source })
-    )
-  })
-
-  it('records an authoritative static asset source after tracing starts', () => {
+  test('records an authoritative static asset source after tracing starts', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const identity: Parameters<typeof recordRequestInsightSource>[0] = {
       requestId: 'req_asset',
@@ -253,7 +308,7 @@ describe('request insights', () => {
     )
   })
 
-  it('does not create a request only because a source was recorded', () => {
+  test('does not create a request only because a source was recorded', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     recordRequestInsightSource({ requestId: 'untraced-asset' }, 'asset')
@@ -261,7 +316,7 @@ describe('request insights', () => {
     expect(getRequestInsightsSnapshot().requests).toEqual([])
   })
 
-  it('does not classify the middleware pass as a page before an App Route runs', () => {
+  test('does not classify the middleware pass as a page before an App Route runs', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const identity = {
       requestId: 'middleware-app-route',
@@ -321,7 +376,7 @@ describe('request insights', () => {
     ])
   })
 
-  it('classifies the route pass as a page after middleware completes', () => {
+  test('classifies the route pass as a page after middleware completes', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const identity = {
       requestId: 'middleware-page',
@@ -365,7 +420,7 @@ describe('request insights', () => {
     ])
   })
 
-  it('records normalized router activity and confirmed Server Actions', () => {
+  test('records normalized router activity and confirmed Server Actions', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const identity = { requestId: 'req_activity' }
 
@@ -386,7 +441,7 @@ describe('request insights', () => {
     )
   })
 
-  it('derives router activity only from valid RSC protocol headers', () => {
+  test('derives router activity only from valid RSC protocol headers', () => {
     expect(
       getRequestInsightRouterActivity({
         rsc: '1',
@@ -407,7 +462,7 @@ describe('request insights', () => {
     ).toBe('hmr-refresh')
   })
 
-  it('keeps request and Instant Insights data separate for the same request ID', () => {
+  test('keeps request and Instant Insights data separate for the same request ID', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const listener = jest.fn()
     const unsubscribe = subscribeRequestInsights(listener)
@@ -481,7 +536,7 @@ describe('request insights', () => {
     unsubscribe()
   })
 
-  it('does not treat aggregate client component loading as a trace span', () => {
+  test('does not treat aggregate client component loading as a trace span', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     recordSpan({
@@ -497,7 +552,7 @@ describe('request insights', () => {
     expect(getRequestInsightsSnapshot().requests).toEqual([])
   })
 
-  it('records request fetch metrics when the OTel fetch span does not complete locally', () => {
+  test('records request fetch metrics when the OTel fetch span does not complete locally', () => {
     recordRequestInsightFetch(
       {
         requestId: 'req_3',
@@ -535,7 +590,7 @@ describe('request insights', () => {
     })
   })
 
-  it('redacts sensitive request insight payload fields', () => {
+  test('redacts sensitive request insight payload fields', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     const secret = 'Q2_SECRET_SENTINEL'
@@ -628,7 +683,7 @@ describe('request insights', () => {
     expect(JSON.stringify(getRequestInsightsSnapshot())).not.toContain(secret)
   })
 
-  it('only exposes bounded URLs without query payloads', () => {
+  test('only exposes bounded URLs without query payloads', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     const cases = [

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -2,9 +2,13 @@ import {
   clearRequestInsightsForTest,
   getRequestInsightsSnapshot,
   recordRequestInsightFetch,
+  recordRequestInsightRouterActivity,
+  recordRequestInsightServerAction,
+  recordRequestInsightSource,
   subscribeRequestInsights,
 } from './request-insights'
 import { recordSpan } from './span-store'
+import { getRequestInsightRouterActivity } from './request-insights-router-activity'
 
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -183,6 +187,224 @@ describe('request insights', () => {
         durationMs: 50,
       })
     )
+  })
+
+  it('classifies framework request sources without letting the root span erase a specific source', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: 'run app route',
+      requestId: 'req_source',
+      attributes: {
+        'next.span_type': 'AppRouteRouteHandlers.runHandler',
+      },
+    })
+    recordSpan({
+      name: 'GET /api/items',
+      requestId: 'req_source',
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source: 'app-route' })
+    )
+  })
+
+  it.each([
+    ['Node.runHandler', 'pages-api'],
+    ['NextNodeServer.imageOptimizer', 'image'],
+    ['Middleware.execute', 'proxy'],
+  ] as const)('classifies %s spans as %s requests', (spanType, source) => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordSpan({
+      name: spanType,
+      requestId: `req_${source}`,
+      attributes: {
+        'next.span_type': spanType,
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source })
+    )
+  })
+
+  it('records an authoritative static asset source after tracing starts', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity: Parameters<typeof recordRequestInsightSource>[0] = {
+      requestId: 'req_asset',
+    }
+
+    recordSpan({
+      name: 'GET /asset.svg',
+      requestId: identity.requestId,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    recordRequestInsightSource(identity, 'asset')
+
+    expect(identity.source).toBe('asset')
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({ source: 'asset' })
+    )
+  })
+
+  it('does not create a request only because a source was recorded', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    recordRequestInsightSource({ requestId: 'untraced-asset' }, 'asset')
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([])
+  })
+
+  it('does not classify the middleware pass as a page before an App Route runs', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = {
+      requestId: 'middleware-app-route',
+      source: 'proxy' as const,
+    }
+
+    recordSpan({
+      name: 'proxy POST /api/stream',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 1,
+      attributes: {
+        'next.span_type': 'Middleware.execute',
+      },
+    })
+    recordSpan({
+      name: 'POST /api/stream',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 2,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'proxy',
+      }),
+    ])
+
+    recordRequestInsightSource(identity, 'app-route')
+    recordSpan({
+      name: 'execute route handler',
+      requestId: identity.requestId,
+      startTime: 3,
+      attributes: {
+        'next.span_type': 'AppRouteRouteHandlers.runHandler',
+      },
+    })
+
+    const requests = getRequestInsightsSnapshot().requests
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toEqual(
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'app-route',
+      })
+    )
+    expect(
+      requests[0].spans.map((span) => span.attributes?.['next.span_type'])
+    ).toEqual([
+      'Middleware.execute',
+      'BaseServer.handleRequest',
+      'AppRouteRouteHandlers.runHandler',
+    ])
+  })
+
+  it('classifies the route pass as a page after middleware completes', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = {
+      requestId: 'middleware-page',
+      source: 'proxy' as 'proxy' | undefined,
+    }
+
+    recordSpan({
+      name: 'proxy GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 1,
+      attributes: {
+        'next.span_type': 'Middleware.execute',
+      },
+    })
+    recordSpan({
+      name: 'GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 2,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+    identity.source = undefined
+    recordSpan({
+      name: 'GET /products',
+      requestId: identity.requestId,
+      requestInsightSource: identity.source,
+      startTime: 3,
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(getRequestInsightsSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: identity.requestId,
+        source: 'page',
+      }),
+    ])
+  })
+
+  it('records normalized router activity and confirmed Server Actions', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const identity = { requestId: 'req_activity' }
+
+    recordSpan({
+      name: 'render route (app) /dashboard',
+      requestId: identity.requestId,
+    })
+
+    recordRequestInsightRouterActivity(identity, 'segment-prefetch')
+    recordRequestInsightServerAction(identity)
+
+    expect(getRequestInsightsSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        source: 'unknown',
+        routerActivity: 'segment-prefetch',
+        serverAction: true,
+      })
+    )
+  })
+
+  it('derives router activity only from valid RSC protocol headers', () => {
+    expect(
+      getRequestInsightRouterActivity({
+        rsc: '1',
+        'next-router-prefetch': '1',
+        'next-router-segment-prefetch': '/dashboard',
+      })
+    ).toBe('segment-prefetch')
+    expect(
+      getRequestInsightRouterActivity({
+        'next-router-prefetch': '1',
+      })
+    ).toBeUndefined()
+    expect(
+      getRequestInsightRouterActivity({
+        rsc: '1',
+        'next-hmr-refresh': '1',
+      })
+    ).toBe('hmr-refresh')
   })
 
   it('keeps request and Instant Insights data separate for the same request ID', () => {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -16,16 +16,16 @@ import {
   type RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { SpanStoreRecord } from './span-store'
+import { getActiveRequestInsights } from './request-insights-runtime'
 export { isRequestInsightsEnabled } from './span-store'
 
 const MAX_REQUEST_INSIGHTS = 100
 const MAX_REQUEST_INSIGHT_URL_LENGTH = 2048
 const MAX_REQUEST_INSIGHT_RAW_URL_LENGTH = 64 * 1024
-const REQUEST_INSIGHTS_STORE_KEY = Symbol.for('@next/request-insights-store')
 const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
   'NextNodeServer.clientComponentLoading'
 
-type RequestInsightsListener = (insight: RequestInsight) => void
+export type RequestInsightsListener = (insight: RequestInsight) => void
 type RequestInsightIdentity = {
   requestId?: string
   kind?: RequestInsightKind
@@ -57,7 +57,7 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.span_name',
   'next.span_type',
 ])
-class InMemoryRequestInsightsStore {
+export class RequestInsights {
   private readonly requests = new Map<string, RequestInsight>()
   private readonly requestTimings = new Map<
     string,
@@ -65,9 +65,14 @@ class InMemoryRequestInsightsStore {
   >()
   private readonly requestOrder: string[] = []
   private readonly listeners = new Set<RequestInsightsListener>()
+  private disposed = false
 
   recordSpan(span: SpanStoreRecord): void {
-    if (!span.requestId) {
+    if (
+      this.disposed ||
+      !span.requestId ||
+      span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
+    ) {
       return
     }
 
@@ -137,7 +142,7 @@ class InMemoryRequestInsightsStore {
   }
 
   recordFetch(identity: RequestInsightIdentity, fetch: RequestInsightFetch) {
-    if (!identity.requestId) {
+    if (this.disposed || !identity.requestId) {
       return
     }
 
@@ -149,7 +154,7 @@ class InMemoryRequestInsightsStore {
   }
 
   recordClassification(identity: RequestInsightIdentity): void {
-    if (!identity.requestId) {
+    if (this.disposed || !identity.requestId) {
       return
     }
 
@@ -168,6 +173,10 @@ class InMemoryRequestInsightsStore {
   }
 
   getSnapshot(): RequestInsightsSnapshot {
+    if (this.disposed) {
+      return { requests: [] }
+    }
+
     return {
       requests: this.requestOrder
         .map((insightKey) => this.requests.get(insightKey))
@@ -176,6 +185,10 @@ class InMemoryRequestInsightsStore {
   }
 
   subscribe(listener: RequestInsightsListener): () => void {
+    if (this.disposed) {
+      return () => {}
+    }
+
     this.listeners.add(listener)
     return () => {
       this.listeners.delete(listener)
@@ -183,9 +196,44 @@ class InMemoryRequestInsightsStore {
   }
 
   clear(): void {
+    if (this.disposed) {
+      return
+    }
+
     this.requests.clear()
     this.requestTimings.clear()
     this.requestOrder.length = 0
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return
+    }
+
+    this.clear()
+    this.disposed = true
+    this.listeners.clear()
+  }
+
+  recordRouterActivity(
+    identity: RequestInsightIdentity,
+    routerActivity: RequestInsightRouterActivity
+  ): void {
+    identity.routerActivity = routerActivity
+    this.recordClassification(identity)
+  }
+
+  recordServerAction(identity: RequestInsightIdentity): void {
+    identity.serverAction = true
+    this.recordClassification(identity)
+  }
+
+  recordSource(
+    identity: RequestInsightIdentity,
+    source: RequestInsightSource
+  ): void {
+    identity.source = source
+    this.recordClassification(identity)
   }
 
   private updateTiming(
@@ -334,60 +382,48 @@ export function recordRequestInsightSpan(span: SpanStoreRecord): void {
     return
   }
 
-  getRequestInsightsStore().recordSpan(span)
+  getActiveRequestInsights()?.recordSpan(span)
 }
 
 export function recordRequestInsightFetch(
   identity: RequestInsightIdentity,
   fetch: RequestInsightFetch
 ): void {
-  getRequestInsightsStore().recordFetch(identity, fetch)
+  getActiveRequestInsights()?.recordFetch(identity, fetch)
 }
 
 export function recordRequestInsightRouterActivity(
   identity: RequestInsightIdentity,
   routerActivity: RequestInsightRouterActivity
 ): void {
-  identity.routerActivity = routerActivity
-  getRequestInsightsStore().recordClassification(identity)
+  getActiveRequestInsights()?.recordRouterActivity(identity, routerActivity)
 }
 
 export function recordRequestInsightServerAction(
   identity: RequestInsightIdentity
 ): void {
-  identity.serverAction = true
-  getRequestInsightsStore().recordClassification(identity)
+  getActiveRequestInsights()?.recordServerAction(identity)
 }
 
 export function recordRequestInsightSource(
   identity: RequestInsightIdentity,
   source: RequestInsightSource
 ): void {
-  identity.source = source
-  getRequestInsightsStore().recordClassification(identity)
+  getActiveRequestInsights()?.recordSource(identity, source)
 }
 
 export function getRequestInsightsSnapshot(): RequestInsightsSnapshot {
-  return getRequestInsightsStore().getSnapshot()
+  return getActiveRequestInsights()?.getSnapshot() ?? { requests: [] }
 }
 
 export function subscribeRequestInsights(
   listener: RequestInsightsListener
 ): () => void {
-  return getRequestInsightsStore().subscribe(listener)
+  return getActiveRequestInsights()?.subscribe(listener) ?? (() => {})
 }
 
 export function clearRequestInsightsForTest(): void {
-  getRequestInsightsStore().clear()
-}
-
-function getRequestInsightsStore(): InMemoryRequestInsightsStore {
-  const globalStore = globalThis as typeof globalThis & {
-    [REQUEST_INSIGHTS_STORE_KEY]?: InMemoryRequestInsightsStore
-  }
-
-  return (globalStore[REQUEST_INSIGHTS_STORE_KEY] ??=
-    new InMemoryRequestInsightsStore())
+  getActiveRequestInsights()?.clear()
 }
 
 function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -8,6 +8,12 @@ import type { RequestInsightKind } from '../../../shared/lib/request-insights'
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightSource,
+  REQUEST_INSIGHT_PROXY_SPAN_TYPE,
+  REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  type RequestInsightProxyStatus,
+  type RequestInsightRouterActivity,
+  type RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { SpanStoreRecord } from './span-store'
 export { isRequestInsightsEnabled } from './span-store'
@@ -21,6 +27,10 @@ type RequestInsightsListener = (insight: RequestInsight) => void
 type RequestInsightIdentity = {
   requestId?: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
+  serverAction?: true
   htmlRequestId?: string
   route?: string
   url?: string
@@ -38,6 +48,7 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.fetch.cache_status',
   'next.fetch.idx',
   'next.route',
+  'next.request_source',
   'next.rsc',
   'next.segment',
   'next.span_category',
@@ -65,6 +76,10 @@ class InMemoryRequestInsightsStore {
       {
         requestId: span.requestId,
         kind: span.requestInsightKind,
+        source: span.requestInsightSource,
+        proxyStatus: span.requestInsightProxyStatus,
+        routerActivity: span.requestInsightRouterActivity,
+        serverAction: span.requestInsightServerAction,
         htmlRequestId: span.htmlRequestId,
         route: span.route,
         url: span.url,
@@ -74,6 +89,17 @@ class InMemoryRequestInsightsStore {
 
     const spanStartTime = span.startTime ?? span.timestamp
     insight.htmlRequestId = span.htmlRequestId ?? insight.htmlRequestId
+    this.updateClassification(
+      insight,
+      {
+        kind: span.requestInsightKind,
+        source: span.requestInsightSource,
+        proxyStatus: span.requestInsightProxyStatus,
+        routerActivity: span.requestInsightRouterActivity,
+        serverAction: span.requestInsightServerAction,
+      },
+      span
+    )
     insight.route = insight.route ?? span.route
     insight.url = insight.url ?? sanitizeUrl(span.url)
     this.updateTiming(
@@ -120,6 +146,25 @@ class InMemoryRequestInsightsStore {
     const insight = this.getOrCreateRequest(identity, fetchStartTime)
     this.updateTiming(insight, fetchStartTime, fetch.durationMs, false)
     this.recordFetchForInsight(insight, sanitizeFetchInsight(fetch))
+    this.notify(insight)
+  }
+
+  recordClassification(identity: RequestInsightIdentity): void {
+    if (!identity.requestId) {
+      return
+    }
+
+    const insight = this.requests.get(
+      getRequestInsightKey({
+        requestId: identity.requestId,
+        kind: identity.kind,
+      })
+    )
+    if (!insight) {
+      return
+    }
+
+    this.updateClassification(insight, identity)
     this.notify(insight)
   }
 
@@ -193,6 +238,10 @@ class InMemoryRequestInsightsStore {
       insight = {
         requestId,
         kind: getRequestInsightKind(identity),
+        source: getRequestInsightSource(identity),
+        proxyStatus: identity.proxyStatus,
+        routerActivity: identity.routerActivity,
+        serverAction: identity.serverAction,
         htmlRequestId: identity.htmlRequestId ?? requestId,
         route: identity.route,
         url: sanitizeUrl(identity.url),
@@ -207,11 +256,24 @@ class InMemoryRequestInsightsStore {
     }
 
     insight.htmlRequestId = identity.htmlRequestId ?? insight.htmlRequestId
+    this.updateClassification(insight, identity)
     insight.route = insight.route ?? identity.route
     insight.url = insight.url ?? sanitizeUrl(identity.url)
     insight.startTime = Math.min(insight.startTime, startTime)
 
     return insight
+  }
+
+  private updateClassification(
+    insight: RequestInsight,
+    identity: RequestInsightIdentity,
+    span?: SpanStoreRecord
+  ): void {
+    const source = identity.source ?? getSourceFromSpan(span)
+    insight.source = refineSource(insight.source, source)
+    insight.proxyStatus = identity.proxyStatus ?? insight.proxyStatus
+    insight.routerActivity = identity.routerActivity ?? insight.routerActivity
+    insight.serverAction = identity.serverAction ?? insight.serverAction
   }
 
   private recordFetchForInsight(
@@ -244,6 +306,28 @@ class InMemoryRequestInsightsStore {
   }
 }
 
+function refineSource(
+  current: RequestInsightSource,
+  candidate: RequestInsightSource | undefined
+): RequestInsightSource {
+  if (!candidate || candidate === 'unknown') {
+    return current
+  }
+  if (
+    candidate === 'app-route' ||
+    candidate === 'pages-api' ||
+    candidate === 'image' ||
+    candidate === 'asset' ||
+    candidate === 'instant-insights'
+  ) {
+    return candidate
+  }
+  if (current === 'unknown' || current === 'proxy') {
+    return candidate
+  }
+  return current
+}
+
 export function recordRequestInsightSpan(span: SpanStoreRecord): void {
   if (
     span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
@@ -259,6 +343,29 @@ export function recordRequestInsightFetch(
   fetch: RequestInsightFetch
 ): void {
   getRequestInsightsStore().recordFetch(identity, fetch)
+}
+
+export function recordRequestInsightRouterActivity(
+  identity: RequestInsightIdentity,
+  routerActivity: RequestInsightRouterActivity
+): void {
+  identity.routerActivity = routerActivity
+  getRequestInsightsStore().recordClassification(identity)
+}
+
+export function recordRequestInsightServerAction(
+  identity: RequestInsightIdentity
+): void {
+  identity.serverAction = true
+  getRequestInsightsStore().recordClassification(identity)
+}
+
+export function recordRequestInsightSource(
+  identity: RequestInsightIdentity,
+  source: RequestInsightSource
+): void {
+  identity.source = source
+  getRequestInsightsStore().recordClassification(identity)
 }
 
 export function getRequestInsightsSnapshot(): RequestInsightsSnapshot {
@@ -301,6 +408,39 @@ function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
     cacheReason: getStringAttribute(attributes['next.fetch.cache_reason']),
     index: getNumberAttribute(attributes['next.fetch.idx']),
   }
+}
+
+function getSourceFromSpan(
+  span: SpanStoreRecord | undefined
+): RequestInsightSource | undefined {
+  if (!span) {
+    return undefined
+  }
+
+  const spanType = getStringAttribute(span.attributes?.['next.span_type'])
+  const markedSource = getStringAttribute(
+    span.attributes?.['next.request_source']
+  )
+  if (markedSource === 'image' || markedSource === 'asset') {
+    return markedSource
+  }
+
+  if (spanType === 'AppRouteRouteHandlers.runHandler') {
+    return 'app-route'
+  }
+  if (spanType === 'Node.runHandler') {
+    return 'pages-api'
+  }
+  if (spanType === 'NextNodeServer.imageOptimizer') {
+    return 'image'
+  }
+  if (spanType === REQUEST_INSIGHT_REQUEST_SPAN_TYPE) {
+    return 'page'
+  }
+  if (spanType === REQUEST_INSIGHT_PROXY_SPAN_TYPE) {
+    return 'proxy'
+  }
+  return undefined
 }
 
 function sanitizeFetchInsight(fetch: RequestInsightFetch): RequestInsightFetch {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -19,6 +19,8 @@ import type { SpanStoreRecord } from './span-store'
 export { isRequestInsightsEnabled } from './span-store'
 
 const MAX_REQUEST_INSIGHTS = 100
+const MAX_REQUEST_INSIGHT_URL_LENGTH = 2048
+const MAX_REQUEST_INSIGHT_RAW_URL_LENGTH = 64 * 1024
 const REQUEST_INSIGHTS_STORE_KEY = Symbol.for('@next/request-insights-store')
 const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
   'NextNodeServer.clientComponentLoading'
@@ -55,9 +57,6 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.span_name',
   'next.span_type',
 ])
-const SENSITIVE_PARAM_NAME_RE =
-  /(?:^|[_-])(?:access[_-]?token|api[_-]?key|auth|authorization|code|cookie|credential|id[_-]?token|jwt|key|password|secret|session|signature|sig|token)(?:$|[_-])/i
-
 class InMemoryRequestInsightsStore {
   private readonly requests = new Map<string, RequestInsight>()
   private readonly requestTimings = new Map<
@@ -116,7 +115,7 @@ class InMemoryRequestInsightsStore {
           : insight.status
 
     insight.spans.push({
-      name: span.name,
+      name: sanitizeSpanName(span),
       startTime: spanStartTime,
       durationMs: span.durationMs,
       status: span.status,
@@ -462,15 +461,43 @@ function sanitizeSpanAttributes(
   }
 
   const sanitized: NonNullable<SpanStoreRecord['attributes']> = {}
+  const sanitizedFetchSpanName =
+    attributes['next.span_type'] === 'AppRender.fetch'
+      ? getSanitizedFetchSpanName(attributes)
+      : undefined
   for (const [key, value] of Object.entries(attributes)) {
     if (!SAFE_SPAN_ATTRIBUTE_KEYS.has(key)) {
       continue
     }
 
-    sanitized[key] = key === 'http.url' ? sanitizeUrlAttribute(value) : value
+    sanitized[key] =
+      key === 'http.url'
+        ? sanitizeUrlAttribute(value)
+        : key === 'next.span_name' && sanitizedFetchSpanName
+          ? sanitizedFetchSpanName
+          : value
   }
 
   return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+function sanitizeSpanName(span: SpanStoreRecord): string {
+  if (span.attributes?.['next.span_type'] !== 'AppRender.fetch') {
+    return span.name
+  }
+
+  return getSanitizedFetchSpanName(span.attributes, span.url)
+}
+
+function getSanitizedFetchSpanName(
+  attributes: NonNullable<SpanStoreRecord['attributes']>,
+  fallbackUrl?: string
+): string {
+  const method = getStringAttribute(attributes['http.method'])
+  const url = sanitizeUrl(
+    getStringAttribute(attributes['http.url']) ?? fallbackUrl
+  )
+  return ['fetch', method, url].filter(Boolean).join(' ')
 }
 
 function sanitizeSpanEvents(
@@ -500,24 +527,67 @@ function sanitizeUrl(value: string | undefined): string | undefined {
     return value
   }
 
-  const isRelativeUrl = value.startsWith('/')
+  if (value.length > MAX_REQUEST_INSIGHT_RAW_URL_LENGTH) {
+    return undefined
+  }
+
+  const isProtocolRelativeUrl = value.startsWith('//')
+  const isRootRelativeUrl = !isProtocolRelativeUrl && value.startsWith('/')
+  const hasProtocol = /^[a-z][a-z\d+.-]*:/i.test(value)
+
+  if (!isProtocolRelativeUrl && !isRootRelativeUrl && !hasProtocol) {
+    return undefined
+  }
 
   try {
-    const url = isRelativeUrl ? new URL(value, 'http://n') : new URL(value)
+    const url =
+      isProtocolRelativeUrl || isRootRelativeUrl
+        ? new URL(value, 'http://n')
+        : new URL(value)
+
+    if (
+      url.protocol !== 'http:' &&
+      url.protocol !== 'https:' &&
+      !isProtocolRelativeUrl &&
+      !isRootRelativeUrl
+    ) {
+      return `${url.protocol}${REDACTED_VALUE}`
+    }
 
     url.username = ''
     url.password = ''
+    url.hash = ''
 
-    for (const name of Array.from(url.searchParams.keys())) {
-      if (SENSITIVE_PARAM_NAME_RE.test(name)) {
-        url.searchParams.set(name, REDACTED_VALUE)
-      }
-    }
+    const hasApplicationQuery = Array.from(url.searchParams.keys()).some(
+      (name) => name !== '_rsc'
+    )
+    url.search = hasApplicationQuery ? `?query=${REDACTED_VALUE}` : ''
 
-    return isRelativeUrl ? `${url.pathname}${url.search}${url.hash}` : url.href
+    const sanitizedUrl = isProtocolRelativeUrl
+      ? `//${url.host}${url.pathname}${url.search}`
+      : isRootRelativeUrl
+        ? `${url.pathname}${url.search}`
+        : url.href
+
+    return truncateText(sanitizedUrl, MAX_REQUEST_INSIGHT_URL_LENGTH)
   } catch {
+    return undefined
+  }
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
     return value
   }
+
+  let end = Math.max(0, maxLength - 1)
+  if (end > 0) {
+    const lastCharCode = value.charCodeAt(end - 1)
+    if (lastCharCode >= 0xd800 && lastCharCode <= 0xdbff) {
+      end--
+    }
+  }
+  return `${value.slice(0, end)}…`
 }
 
 function getStringAttribute(value: AttributeValue | undefined) {

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -2,32 +2,72 @@ import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
 import type {
   RequestInsight,
   RequestInsightFetch,
+  RequestInsightSpan,
+  RequestInsightsCaptureState,
   RequestInsightsSnapshot,
 } from '../../../next-devtools/shared/request-insights'
-import type { RequestInsightKind } from '../../../shared/lib/request-insights'
+import {
+  createBoundedRequestInsightsSnapshotProjection,
+  REQUEST_INSIGHTS_MAX_BYTES_PER_RECORD,
+  REQUEST_INSIGHTS_MAX_BYTES_PER_RETENTION_BUCKET,
+  REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN,
+  REQUEST_INSIGHTS_MAX_EVENTS_PER_SPAN,
+  REQUEST_INSIGHTS_MAX_FETCHES_PER_RECORD,
+  REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET,
+  REQUEST_INSIGHTS_MAX_LINKS_PER_SPAN,
+  REQUEST_INSIGHTS_MAX_RECORDS_PER_GROUP,
+  REQUEST_INSIGHTS_MAX_RETAINED_BYTES,
+  REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES,
+  REQUEST_INSIGHTS_MAX_SPANS_PER_RECORD,
+} from '../../../next-devtools/shared/request-insights'
+import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
 import {
   getRequestInsightKey,
   getRequestInsightKind,
+  getRequestInsightRetentionBucket,
+  getRequestInsightRootId,
   getRequestInsightSource,
   REQUEST_INSIGHT_PROXY_SPAN_TYPE,
   REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
+  REQUEST_INSIGHT_RETENTION_BUCKETS,
   type RequestInsightProxyStatus,
+  type RequestInsightRetentionBucket,
   type RequestInsightRouterActivity,
   type RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { SpanStoreRecord } from './span-store'
 import { getActiveRequestInsights } from './request-insights-runtime'
+import {
+  closeRequestInsightsRetentionRecord,
+  closeRequestInsightsRetentionRoot,
+  hasSameRequestInsightsRetentionContext,
+  hasSameRequestInsightsRetentionRoot,
+  isRequestInsightsRetentionContextOpen,
+  type RequestInsightsRetentionContext,
+} from './request-insights-identity'
 export { isRequestInsightsEnabled } from './span-store'
 
-const MAX_REQUEST_INSIGHTS = 100
+const MAX_REQUEST_INSIGHT_STRING_LENGTH = 256
+const MAX_REQUEST_INSIGHT_SPAN_NAME_LENGTH = 512
+const MAX_REQUEST_INSIGHT_ROUTE_LENGTH = 1024
 const MAX_REQUEST_INSIGHT_URL_LENGTH = 2048
 const MAX_REQUEST_INSIGHT_RAW_URL_LENGTH = 64 * 1024
+const MAX_REQUEST_INSIGHT_ATTRIBUTE_ARRAY_LENGTH = 8
+const MAX_REQUEST_INSIGHT_ID_LENGTH = 128
 const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
   'NextNodeServer.clientComponentLoading'
 
 export type RequestInsightsListener = (insight: RequestInsight) => void
+export type RequestInsightsSnapshotQuery = {
+  requestId?: string
+  htmlRequestId?: string
+  limit?: number
+}
+
 type RequestInsightIdentity = {
   requestId?: string
+  rootRequestId?: string
+  retention?: RequestInsightsRetentionContext
   kind?: RequestInsightKind
   source?: RequestInsightSource
   proxyStatus?: RequestInsightProxyStatus
@@ -37,6 +77,23 @@ type RequestInsightIdentity = {
   route?: string
   url?: string
 }
+
+export type RequestInsightsOptions = {
+  maxBytesPerRetentionBucket?: number
+  maxRetainedBytes?: number
+  maxRequestGroupsPerBucket?: number
+  maxSnapshotBytes?: number
+}
+
+type RequestInsightsLimits = {
+  maxBytesPerRetentionBucket: number
+  maxRetainedBytes: number
+  maxRequestGroupsPerBucket: number
+  maxSnapshotBytes: number
+}
+
+// Leave room for the fixed capture and projection metadata envelope.
+const MIN_REQUEST_INSIGHTS_SNAPSHOT_BYTES = 2 * 1024
 
 const REDACTED_VALUE = 'redacted'
 const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
@@ -57,15 +114,65 @@ const SAFE_SPAN_ATTRIBUTE_KEYS = new Set([
   'next.span_name',
   'next.span_type',
 ])
+const KNOWN_ERROR_TYPES = new Set([
+  'AbortError',
+  'AggregateError',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+])
+
+type SanitizationState = {
+  truncatedMetadataValueCount: number
+}
+
 export class RequestInsights {
   private readonly requests = new Map<string, RequestInsight>()
   private readonly requestTimings = new Map<
     string,
     { startTime: number; durationMs: number }
   >()
-  private readonly requestOrder: string[] = []
+  private readonly rootRequestOrder = new Set<string>()
+  private readonly rootRequestSequence = new Map<string, number>()
+  private readonly requestKeysByRootRequestId = new Map<string, Set<string>>()
+  private readonly rootRetentionBuckets = new Map<
+    string,
+    RequestInsightRetentionBucket
+  >()
+  private readonly rootRequestOrderByRetentionBucket = new Map<
+    RequestInsightRetentionBucket,
+    Set<string>
+  >()
+  private readonly requestByteLengths = new Map<string, number>()
+  private readonly rootByteLengths = new Map<string, number>()
+  private readonly retainedBytesByBucket = new Map<
+    RequestInsightRetentionBucket,
+    number
+  >()
+  private readonly retentionContextsByRequestKey = new Map<
+    string,
+    RequestInsightsRetentionContext
+  >()
+  private readonly omittedRequestCountsByRootRequestId = new Map<
+    string,
+    number
+  >()
+  private readonly evictedRequestGroupCounts = new Map<
+    RequestInsightRetentionBucket,
+    number
+  >()
   private readonly listeners = new Set<RequestInsightsListener>()
+  private readonly limits: RequestInsightsLimits
+  private nextRootRequestSequence = 0
   private disposed = false
+
+  constructor(options: RequestInsightsOptions = {}) {
+    this.limits = normalizeRequestInsightsLimits(options)
+  }
 
   recordSpan(span: SpanStoreRecord): void {
     if (
@@ -76,9 +183,14 @@ export class RequestInsights {
       return
     }
 
+    const spanStartTime =
+      sanitizeFiniteNumber(span.startTime ?? span.timestamp) ??
+      getCurrentTimestamp()
     const insight = this.getOrCreateRequest(
       {
         requestId: span.requestId,
+        rootRequestId: span.rootRequestId,
+        retention: span.requestInsightsRetention,
         kind: span.requestInsightKind,
         source: span.requestInsightSource,
         proxyStatus: span.requestInsightProxyStatus,
@@ -88,11 +200,12 @@ export class RequestInsights {
         route: span.route,
         url: span.url,
       },
-      span.startTime ?? span.timestamp
+      spanStartTime
     )
+    if (!insight) return
 
-    const spanStartTime = span.startTime ?? span.timestamp
-    insight.htmlRequestId = span.htmlRequestId ?? insight.htmlRequestId
+    insight.htmlRequestId =
+      sanitizeRequestInsightId(span.htmlRequestId) ?? insight.htmlRequestId
     this.updateClassification(
       insight,
       {
@@ -104,13 +217,14 @@ export class RequestInsights {
       },
       span
     )
-    insight.route = insight.route ?? span.route
+    const route = sanitizeText(span.route, MAX_REQUEST_INSIGHT_ROUTE_LENGTH)
+    insight.route = insight.route ?? route
     insight.url = insight.url ?? sanitizeUrl(span.url)
     this.updateTiming(
       insight,
       spanStartTime,
       span.durationMs,
-      span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+      span.attributes?.['next.span_type'] === REQUEST_INSIGHT_REQUEST_SPAN_TYPE
     )
     insight.status =
       insight.status === 'error' || span.status === 'error'
@@ -119,44 +233,27 @@ export class RequestInsights {
           ? 'ok'
           : insight.status
 
-    insight.spans.push({
-      name: sanitizeSpanName(span),
-      startTime: spanStartTime,
-      durationMs: span.durationMs,
-      status: span.status,
-      traceId: span.traceId,
-      spanId: span.spanId,
-      parentSpanId: span.parentSpanId,
-      attributes: sanitizeSpanAttributes(span.attributes),
-      links: sanitizeSpanLinks(span.links),
-      events: sanitizeSpanEvents(span.events),
-      error: span.error,
-    })
-
+    this.recordSpanForInsight(insight, sanitizeSpan(span, spanStartTime))
     const fetch = getFetchInsight(span)
-    if (fetch) {
-      this.recordFetchForInsight(insight, fetch)
-    }
-
-    this.notify(insight)
+    if (fetch) this.recordFetchForInsight(insight, fetch)
+    this.finishMutation(insight)
   }
 
   recordFetch(identity: RequestInsightIdentity, fetch: RequestInsightFetch) {
-    if (this.disposed || !identity.requestId) {
-      return
-    }
+    if (this.disposed || !identity.requestId) return
 
-    const fetchStartTime = fetch.startTime ?? getCurrentTimestamp()
+    const fetchStartTime =
+      sanitizeFiniteNumber(fetch.startTime) ?? getCurrentTimestamp()
     const insight = this.getOrCreateRequest(identity, fetchStartTime)
+    if (!insight) return
+
     this.updateTiming(insight, fetchStartTime, fetch.durationMs, false)
-    this.recordFetchForInsight(insight, sanitizeFetchInsight(fetch))
-    this.notify(insight)
+    this.recordFetchForInsight(insight, fetch)
+    this.finishMutation(insight)
   }
 
   recordClassification(identity: RequestInsightIdentity): void {
-    if (this.disposed || !identity.requestId) {
-      return
-    }
+    if (this.disposed || !identity.requestId) return
 
     const insight = this.requests.get(
       getRequestInsightKey({
@@ -164,55 +261,10 @@ export class RequestInsights {
         kind: identity.kind,
       })
     )
-    if (!insight) {
-      return
-    }
+    if (!insight) return
 
     this.updateClassification(insight, identity)
-    this.notify(insight)
-  }
-
-  getSnapshot(): RequestInsightsSnapshot {
-    if (this.disposed) {
-      return { requests: [] }
-    }
-
-    return {
-      requests: this.requestOrder
-        .map((insightKey) => this.requests.get(insightKey))
-        .filter((request): request is RequestInsight => request !== undefined),
-    }
-  }
-
-  subscribe(listener: RequestInsightsListener): () => void {
-    if (this.disposed) {
-      return () => {}
-    }
-
-    this.listeners.add(listener)
-    return () => {
-      this.listeners.delete(listener)
-    }
-  }
-
-  clear(): void {
-    if (this.disposed) {
-      return
-    }
-
-    this.requests.clear()
-    this.requestTimings.clear()
-    this.requestOrder.length = 0
-  }
-
-  dispose(): void {
-    if (this.disposed) {
-      return
-    }
-
-    this.clear()
-    this.disposed = true
-    this.listeners.clear()
+    this.finishMutation(insight)
   }
 
   recordRouterActivity(
@@ -236,79 +288,295 @@ export class RequestInsights {
     this.recordClassification(identity)
   }
 
+  getSnapshot(
+    query: RequestInsightsSnapshotQuery = {}
+  ): RequestInsightsSnapshot {
+    if (this.disposed) return { requests: [] }
+
+    const requestId = sanitizeRequestInsightId(query.requestId)
+    const htmlRequestId = sanitizeRequestInsightId(query.htmlRequestId)
+    if (
+      (query.requestId !== undefined && requestId === undefined) ||
+      (query.htmlRequestId !== undefined && htmlRequestId === undefined)
+    ) {
+      return { requests: [], capture: this.getCaptureState() }
+    }
+
+    const matchingRootIds = new Set<string>()
+    for (const insight of this.requests.values()) {
+      if (
+        (requestId === undefined || insight.requestId === requestId) &&
+        (htmlRequestId === undefined || insight.htmlRequestId === htmlRequestId)
+      ) {
+        matchingRootIds.add(getRequestInsightRootId(insight))
+      }
+    }
+
+    const groups: RequestInsight[][] = []
+    for (const rootRequestId of this.rootRequestOrder) {
+      if (!matchingRootIds.has(rootRequestId)) continue
+      const group = Array.from(
+        this.requestKeysByRootRequestId.get(rootRequestId) ?? []
+      ).flatMap((requestKey) => {
+        const request = this.requests.get(requestKey)
+        return request ? [request] : []
+      })
+      if (group.length > 0) groups.push(group)
+    }
+
+    const { snapshot } = createBoundedRequestInsightsSnapshotProjection(
+      groups,
+      this.limits.maxSnapshotBytes,
+      this.getCaptureState(),
+      sanitizeSnapshotLimit(query.limit)
+    )
+    return {
+      ...snapshot,
+      requests: snapshot.requests.map(cloneRequestInsight),
+    }
+  }
+
+  getCaptureState(): RequestInsightsCaptureState {
+    const retainedRequestGroupCountByBucket = new Map<
+      RequestInsightRetentionBucket,
+      number
+    >()
+    const retainedRequestCountByBucket = new Map<
+      RequestInsightRetentionBucket,
+      number
+    >()
+    for (const rootRequestId of this.rootRequestOrder) {
+      const bucket = this.rootRetentionBuckets.get(rootRequestId) ?? 'unknown'
+      retainedRequestGroupCountByBucket.set(
+        bucket,
+        (retainedRequestGroupCountByBucket.get(bucket) ?? 0) + 1
+      )
+      retainedRequestCountByBucket.set(
+        bucket,
+        (retainedRequestCountByBucket.get(bucket) ?? 0) +
+          (this.requestKeysByRootRequestId.get(rootRequestId)?.size ?? 0)
+      )
+    }
+
+    const buckets = REQUEST_INSIGHT_RETENTION_BUCKETS.map((bucket) => ({
+      bucket,
+      retainedRequestGroupCount:
+        retainedRequestGroupCountByBucket.get(bucket) ?? 0,
+      retainedRequestCount: retainedRequestCountByBucket.get(bucket) ?? 0,
+      retainedBytes: this.retainedBytesByBucket.get(bucket) ?? 0,
+      evictedRequestGroupCount: this.evictedRequestGroupCounts.get(bucket) ?? 0,
+    }))
+
+    return {
+      limits: {
+        maxRequestGroupsPerBucket: this.limits.maxRequestGroupsPerBucket,
+        maxBytesPerBucket: this.limits.maxBytesPerRetentionBucket,
+        maxRetainedBytes: this.limits.maxRetainedBytes,
+        maxRecordsPerGroup: REQUEST_INSIGHTS_MAX_RECORDS_PER_GROUP,
+        maxSpansPerRecord: REQUEST_INSIGHTS_MAX_SPANS_PER_RECORD,
+        maxFetchesPerRecord: REQUEST_INSIGHTS_MAX_FETCHES_PER_RECORD,
+        maxBytesPerRecord: REQUEST_INSIGHTS_MAX_BYTES_PER_RECORD,
+        maxBytesPerSpan: REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN,
+        maxEventsPerSpan: REQUEST_INSIGHTS_MAX_EVENTS_PER_SPAN,
+        maxLinksPerSpan: REQUEST_INSIGHTS_MAX_LINKS_PER_SPAN,
+        maxSnapshotBytes: this.limits.maxSnapshotBytes,
+      },
+      usage: {
+        retainedRequestGroupCount: this.rootRequestOrder.size,
+        retainedRequestCount: this.requests.size,
+        retainedBytes: buckets.reduce(
+          (total, bucket) => total + bucket.retainedBytes,
+          0
+        ),
+        buckets,
+      },
+    }
+  }
+
+  subscribe(listener: RequestInsightsListener): () => void {
+    if (this.disposed) return () => {}
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  clear(): void {
+    if (this.disposed) return
+    this.clearRetainedState()
+    this.evictedRequestGroupCounts.clear()
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.clearRetainedState()
+    this.disposed = true
+    this.listeners.clear()
+  }
+
+  private clearRetainedState(): void {
+    for (const retention of this.retentionContextsByRequestKey.values()) {
+      closeRequestInsightsRetentionRoot(retention)
+      closeRequestInsightsRetentionRecord(retention)
+    }
+    this.requests.clear()
+    this.requestTimings.clear()
+    this.rootRequestOrder.clear()
+    this.rootRequestSequence.clear()
+    this.requestKeysByRootRequestId.clear()
+    this.rootRetentionBuckets.clear()
+    this.rootRequestOrderByRetentionBucket.clear()
+    this.requestByteLengths.clear()
+    this.rootByteLengths.clear()
+    this.retainedBytesByBucket.clear()
+    this.retentionContextsByRequestKey.clear()
+    this.omittedRequestCountsByRootRequestId.clear()
+    this.nextRootRequestSequence = 0
+  }
+
   private updateTiming(
     insight: RequestInsight,
     startTime: number,
     durationMs: number | undefined,
     isRequestSpan: boolean
   ): void {
-    const insightKey = getRequestInsightKey(insight)
+    const requestKey = getRequestInsightKey(insight)
+    const nextDurationMs = sanitizeFiniteNumber(durationMs) ?? 0
     if (isRequestSpan && durationMs !== undefined) {
-      const requestTiming = { startTime, durationMs }
-      this.requestTimings.set(insightKey, requestTiming)
-      insight.startTime = requestTiming.startTime
-      insight.durationMs = requestTiming.durationMs
+      const timing = { startTime, durationMs: nextDurationMs }
+      this.requestTimings.set(requestKey, timing)
+      insight.startTime = timing.startTime
+      insight.durationMs = timing.durationMs
       return
     }
 
-    const requestTiming = this.requestTimings.get(insightKey)
+    const requestTiming = this.requestTimings.get(requestKey)
     if (requestTiming) {
       insight.startTime = requestTiming.startTime
       insight.durationMs = requestTiming.durationMs
       return
     }
 
-    const endTime = startTime + (durationMs ?? 0)
-    const requestEndTime = insight.startTime + (insight.durationMs ?? 0)
-    insight.startTime = Math.min(insight.startTime, startTime)
-    insight.durationMs = Math.max(requestEndTime, endTime) - insight.startTime
+    const current = this.requestTimings.get(requestKey) ?? {
+      startTime: insight.startTime,
+      durationMs: insight.durationMs ?? 0,
+    }
+    const nextStartTime = Math.min(current.startTime, startTime)
+    const nextEndTime = Math.max(
+      current.startTime + current.durationMs,
+      startTime + nextDurationMs
+    )
+    const timing = {
+      startTime: nextStartTime,
+      durationMs: nextEndTime - nextStartTime,
+    }
+    insight.startTime = timing.startTime
+    insight.durationMs = timing.durationMs
   }
 
   private notify(insight: RequestInsight): void {
     for (const listener of this.listeners) {
-      listener(insight)
+      try {
+        listener(cloneRequestInsight(insight))
+      } catch (error) {
+        console.error('[request-insights] listener failed', error)
+      }
     }
   }
 
   private getOrCreateRequest(
     identity: RequestInsightIdentity,
     startTime: number
-  ): RequestInsight {
-    const requestId = identity.requestId!
-    const insightKey = getRequestInsightKey({
+  ): RequestInsight | undefined {
+    const requestId = sanitizeRequestInsightId(identity.requestId)
+    if (!requestId) return undefined
+
+    const rootRequestId =
+      sanitizeRequestInsightId(identity.rootRequestId) ?? requestId
+    const requestKey = getRequestInsightKey({
       requestId,
       kind: identity.kind,
     })
-    let insight = this.requests.get(insightKey)
+    const retention = identity.retention
+    if (retention && !isRequestInsightsRetentionContextOpen(retention)) {
+      return undefined
+    }
 
+    const retainedContext = this.retentionContextsByRequestKey.get(requestKey)
+    const retainedRootContext =
+      retainedContext ?? this.getRetentionContextForRoot(rootRequestId)
+    if (
+      retainedContext
+        ? !retention ||
+          !hasSameRequestInsightsRetentionContext(retainedContext, retention)
+        : retainedRootContext &&
+          (!retention ||
+            !hasSameRequestInsightsRetentionRoot(
+              retainedRootContext,
+              retention
+            ))
+    ) {
+      return undefined
+    }
+
+    let insight = this.requests.get(requestKey)
     if (!insight) {
       insight = {
         requestId,
+        rootRequestId,
         kind: getRequestInsightKind(identity),
         source: getRequestInsightSource(identity),
         proxyStatus: identity.proxyStatus,
         routerActivity: identity.routerActivity,
         serverAction: identity.serverAction,
-        htmlRequestId: identity.htmlRequestId ?? requestId,
-        route: identity.route,
+        htmlRequestId:
+          sanitizeRequestInsightId(identity.htmlRequestId) ?? requestId,
+        route: sanitizeText(identity.route, MAX_REQUEST_INSIGHT_ROUTE_LENGTH),
         url: sanitizeUrl(identity.url),
-        startTime,
+        startTime: sanitizeFiniteNumber(startTime) ?? getCurrentTimestamp(),
         status: 'pending',
         spans: [],
         fetches: [],
       }
-      this.requests.set(insightKey, insight)
-      this.requestOrder.push(insightKey)
-      this.trim()
+      this.requests.set(requestKey, insight)
+      let requestKeys = this.requestKeysByRootRequestId.get(rootRequestId)
+      if (!requestKeys) {
+        requestKeys = new Set()
+        this.requestKeysByRootRequestId.set(rootRequestId, requestKeys)
+        this.rootRequestOrder.add(rootRequestId)
+        this.rootRequestSequence.set(
+          rootRequestId,
+          this.nextRootRequestSequence++
+        )
+        const bucket = getRequestInsightRetentionBucket(insight)
+        this.rootRetentionBuckets.set(rootRequestId, bucket)
+        this.getRootRequestOrderForBucket(bucket).add(rootRequestId)
+      }
+      requestKeys.add(requestKey)
+      if (retention)
+        this.retentionContextsByRequestKey.set(requestKey, retention)
+    } else if (!retainedContext && retention) {
+      this.retentionContextsByRequestKey.set(requestKey, retention)
     }
 
-    insight.htmlRequestId = identity.htmlRequestId ?? insight.htmlRequestId
-    this.updateClassification(insight, identity)
-    insight.route = insight.route ?? identity.route
+    insight.htmlRequestId =
+      sanitizeRequestInsightId(identity.htmlRequestId) ?? insight.htmlRequestId
+    insight.route =
+      insight.route ??
+      sanitizeText(identity.route, MAX_REQUEST_INSIGHT_ROUTE_LENGTH)
     insight.url = insight.url ?? sanitizeUrl(identity.url)
-    insight.startTime = Math.min(insight.startTime, startTime)
-
+    this.updateClassification(insight, identity)
     return insight
+  }
+
+  private getRetentionContextForRoot(
+    rootRequestId: string
+  ): RequestInsightsRetentionContext | undefined {
+    for (const requestKey of this.requestKeysByRootRequestId.get(
+      rootRequestId
+    ) ?? []) {
+      const retention = this.retentionContextsByRequestKey.get(requestKey)
+      if (retention) return retention
+    }
+    return undefined
   }
 
   private updateClassification(
@@ -327,39 +595,378 @@ export class RequestInsights {
     insight: RequestInsight,
     fetch: RequestInsightFetch
   ): void {
+    const sanitizedFetch = sanitizeFetchInsight(fetch)
     if (
       insight.fetches.some(
         (existingFetch) =>
-          existingFetch.url === fetch.url &&
-          (existingFetch.index !== undefined && fetch.index !== undefined
-            ? existingFetch.index === fetch.index
-            : existingFetch.startTime === fetch.startTime)
+          existingFetch.url === sanitizedFetch.url &&
+          (existingFetch.index !== undefined &&
+          sanitizedFetch.index !== undefined
+            ? existingFetch.index === sanitizedFetch.index
+            : existingFetch.startTime === sanitizedFetch.startTime)
       )
     ) {
       return
     }
 
-    insight.fetches.push(sanitizeFetchInsight(fetch))
+    if (insight.fetches.length >= REQUEST_INSIGHTS_MAX_FETCHES_PER_RECORD) {
+      insight.fetches.shift()
+      insight.truncatedFetchCount = (insight.truncatedFetchCount ?? 0) + 1
+    }
+    insight.fetches.push(sanitizedFetch)
+    this.enforceInsightByteBudget(insight)
   }
 
-  private trim(): void {
-    while (this.requestOrder.length > MAX_REQUEST_INSIGHTS) {
-      const insightKey = this.requestOrder.shift()
-      if (insightKey) {
-        this.requests.delete(insightKey)
-        this.requestTimings.delete(insightKey)
+  private recordSpanForInsight(
+    insight: RequestInsight,
+    span: RequestInsightSpan
+  ): void {
+    if (insight.spans.length < REQUEST_INSIGHTS_MAX_SPANS_PER_RECORD) {
+      insight.spans.push(span)
+      this.enforceInsightByteBudget(insight)
+      return
+    }
+
+    const removableSpanIndex = insight.spans.findIndex(
+      (retainedSpan) => !isRootRequestInsightSpan(retainedSpan)
+    )
+    if (removableSpanIndex !== -1) {
+      insight.spans.splice(removableSpanIndex, 1)
+      insight.spans.push(span)
+    } else if (isRootRequestInsightSpan(span)) {
+      insight.spans.shift()
+      insight.spans.push(span)
+    }
+    insight.truncatedSpanCount = (insight.truncatedSpanCount ?? 0) + 1
+    this.enforceInsightByteBudget(insight)
+  }
+
+  private enforceInsightByteBudget(insight: RequestInsight): void {
+    while (
+      getSerializedByteLength(insight) >
+        REQUEST_INSIGHTS_MAX_BYTES_PER_RECORD &&
+      (insight.spans.length > 1 || insight.fetches.length > 0)
+    ) {
+      const nonRootSpanIndex = insight.spans.findIndex(
+        (span) => !isRootRequestInsightSpan(span)
+      )
+      const removableSpanIndex =
+        nonRootSpanIndex === -1 && insight.spans.length > 1
+          ? 0
+          : nonRootSpanIndex
+      const oldestSpan =
+        removableSpanIndex === -1
+          ? undefined
+          : insight.spans[removableSpanIndex]
+      const oldestFetch = insight.fetches[0]
+
+      if (
+        oldestSpan &&
+        (!oldestFetch ||
+          oldestSpan.startTime <=
+            (oldestFetch.startTime ?? Number.POSITIVE_INFINITY))
+      ) {
+        insight.spans.splice(removableSpanIndex, 1)
+        insight.truncatedSpanCount = (insight.truncatedSpanCount ?? 0) + 1
+      } else if (oldestFetch) {
+        insight.fetches.shift()
+        insight.truncatedFetchCount = (insight.truncatedFetchCount ?? 0) + 1
+      } else {
+        break
       }
     }
   }
+
+  private finishMutation(insight: RequestInsight): void {
+    const metadataUpdates = this.trimGroup(getRequestInsightRootId(insight))
+    if (this.requests.has(getRequestInsightKey(insight))) {
+      this.updateStoredInsightByteLength(insight)
+    }
+    for (const updated of metadataUpdates) {
+      if (this.requests.has(getRequestInsightKey(updated))) {
+        this.updateStoredInsightByteLength(updated)
+      }
+    }
+
+    const bucket = this.refreshRootRetentionBucket(
+      getRequestInsightRootId(insight)
+    )
+    this.trimRetentionBucket(bucket)
+    this.trimGlobalRetention()
+
+    if (this.requests.has(getRequestInsightKey(insight))) this.notify(insight)
+    for (const updated of metadataUpdates) {
+      if (
+        updated !== insight &&
+        this.requests.has(getRequestInsightKey(updated))
+      ) {
+        this.notify(updated)
+      }
+    }
+  }
+
+  private trimGroup(rootRequestId: string): RequestInsight[] {
+    const requestKeys = this.requestKeysByRootRequestId.get(rootRequestId)
+    if (!requestKeys) return []
+
+    const orderedKeys = Array.from(requestKeys)
+    const canonicalRootKey = orderedKeys.find((requestKey) => {
+      const request = this.requests.get(requestKey)
+      return (
+        request?.requestId === rootRequestId &&
+        getRequestInsightKind(request) === 'request'
+      )
+    })
+    let omittedRequestCount = 0
+    while (orderedKeys.length > REQUEST_INSIGHTS_MAX_RECORDS_PER_GROUP) {
+      const removableIndex = orderedKeys.findIndex(
+        (requestKey) => requestKey !== canonicalRootKey
+      )
+      if (removableIndex === -1) break
+      const [requestKey] = orderedKeys.splice(removableIndex, 1)
+      this.removeRequest(requestKey, false)
+      omittedRequestCount++
+    }
+
+    if (omittedRequestCount > 0) {
+      this.omittedRequestCountsByRootRequestId.set(
+        rootRequestId,
+        (this.omittedRequestCountsByRootRequestId.get(rootRequestId) ?? 0) +
+          omittedRequestCount
+      )
+    }
+
+    const retained = orderedKeys.flatMap((requestKey) => {
+      const request = this.requests.get(requestKey)
+      return request ? [request] : []
+    })
+    const metadataHolder =
+      (canonicalRootKey ? this.requests.get(canonicalRootKey) : undefined) ??
+      retained[0]
+    const totalOmitted =
+      this.omittedRequestCountsByRootRequestId.get(rootRequestId)
+    const updates: RequestInsight[] = []
+    for (const request of retained) {
+      const nextOmitted = request === metadataHolder ? totalOmitted : undefined
+      if (request.omittedRequestCount !== nextOmitted) {
+        request.omittedRequestCount = nextOmitted
+        this.enforceInsightByteBudget(request)
+        updates.push(request)
+      }
+    }
+    return updates
+  }
+
+  private updateStoredInsightByteLength(insight: RequestInsight): void {
+    const requestKey = getRequestInsightKey(insight)
+    if (!this.requests.has(requestKey)) return
+
+    const rootRequestId = getRequestInsightRootId(insight)
+    const previousByteLength = this.requestByteLengths.get(requestKey) ?? 0
+    const nextByteLength = getSerializedByteLength(insight)
+    const delta = nextByteLength - previousByteLength
+    if (delta === 0) return
+
+    this.requestByteLengths.set(requestKey, nextByteLength)
+    this.rootByteLengths.set(
+      rootRequestId,
+      (this.rootByteLengths.get(rootRequestId) ?? 0) + delta
+    )
+    const bucket =
+      this.rootRetentionBuckets.get(rootRequestId) ??
+      getRequestInsightRetentionBucket(insight)
+    this.retainedBytesByBucket.set(
+      bucket,
+      (this.retainedBytesByBucket.get(bucket) ?? 0) + delta
+    )
+  }
+
+  private refreshRootRetentionBucket(
+    rootRequestId: string
+  ): RequestInsightRetentionBucket {
+    const requests = Array.from(
+      this.requestKeysByRootRequestId.get(rootRequestId) ?? []
+    ).flatMap((requestKey) => {
+      const request = this.requests.get(requestKey)
+      return request ? [request] : []
+    })
+    const representative =
+      requests.find(
+        (request) =>
+          request.requestId === rootRequestId &&
+          getRequestInsightKind(request) === 'request'
+      ) ??
+      requests.find(
+        (request) => getRequestInsightKind(request) === 'request'
+      ) ??
+      requests[0]
+    const nextBucket = getRequestInsightRetentionBucket(representative ?? {})
+    const previousBucket = this.rootRetentionBuckets.get(rootRequestId)
+    if (previousBucket === nextBucket) return nextBucket
+
+    const rootByteLength = this.rootByteLengths.get(rootRequestId) ?? 0
+    if (previousBucket) {
+      this.rootRequestOrderByRetentionBucket
+        .get(previousBucket)
+        ?.delete(rootRequestId)
+      this.retainedBytesByBucket.set(
+        previousBucket,
+        Math.max(
+          0,
+          (this.retainedBytesByBucket.get(previousBucket) ?? 0) - rootByteLength
+        )
+      )
+    }
+    this.retainedBytesByBucket.set(
+      nextBucket,
+      (this.retainedBytesByBucket.get(nextBucket) ?? 0) + rootByteLength
+    )
+    this.rootRetentionBuckets.set(rootRequestId, nextBucket)
+    this.addRootRequestToBucketOrder(nextBucket, rootRequestId)
+    return nextBucket
+  }
+
+  private addRootRequestToBucketOrder(
+    bucket: RequestInsightRetentionBucket,
+    rootRequestId: string
+  ): void {
+    const order = this.getRootRequestOrderForBucket(bucket)
+    const sequence = this.rootRequestSequence.get(rootRequestId)
+    if (sequence === undefined || order.size === 0) {
+      order.add(rootRequestId)
+      return
+    }
+
+    const nextOrder = new Set<string>()
+    let inserted = false
+    for (const existingRootRequestId of order) {
+      if (
+        !inserted &&
+        (this.rootRequestSequence.get(existingRootRequestId) ?? -1) > sequence
+      ) {
+        nextOrder.add(rootRequestId)
+        inserted = true
+      }
+      nextOrder.add(existingRootRequestId)
+    }
+    if (!inserted) nextOrder.add(rootRequestId)
+    this.rootRequestOrderByRetentionBucket.set(bucket, nextOrder)
+  }
+
+  private getRootRequestOrderForBucket(
+    bucket: RequestInsightRetentionBucket
+  ): Set<string> {
+    let order = this.rootRequestOrderByRetentionBucket.get(bucket)
+    if (!order) {
+      order = new Set()
+      this.rootRequestOrderByRetentionBucket.set(bucket, order)
+    }
+    return order
+  }
+
+  private trimRetentionBucket(bucket: RequestInsightRetentionBucket): void {
+    const roots = this.getRootRequestOrderForBucket(bucket)
+    while (roots.size > this.limits.maxRequestGroupsPerBucket) {
+      const rootRequestId = roots.values().next().value
+      if (rootRequestId) this.evictRoot(rootRequestId)
+    }
+
+    while (
+      (this.retainedBytesByBucket.get(bucket) ?? 0) >
+      this.limits.maxBytesPerRetentionBucket
+    ) {
+      const rootRequestId = roots.values().next().value
+      if (!rootRequestId) break
+      this.evictRoot(rootRequestId)
+    }
+  }
+
+  private trimGlobalRetention(): void {
+    while (this.getRetainedByteLength() > this.limits.maxRetainedBytes) {
+      const rootRequestId = this.rootRequestOrder.values().next().value
+      if (!rootRequestId || !this.evictRoot(rootRequestId)) break
+    }
+  }
+
+  private getRetainedByteLength(): number {
+    let total = 0
+    for (const bucket of REQUEST_INSIGHT_RETENTION_BUCKETS) {
+      total += this.retainedBytesByBucket.get(bucket) ?? 0
+    }
+    return total
+  }
+
+  private evictRoot(rootRequestId: string): boolean {
+    const requestKeys = Array.from(
+      this.requestKeysByRootRequestId.get(rootRequestId) ?? []
+    )
+    if (requestKeys.length === 0) return false
+    const bucket = this.rootRetentionBuckets.get(rootRequestId) ?? 'unknown'
+    for (const requestKey of requestKeys) this.removeRequest(requestKey, true)
+    this.evictedRequestGroupCounts.set(
+      bucket,
+      (this.evictedRequestGroupCounts.get(bucket) ?? 0) + 1
+    )
+    return true
+  }
+
+  private removeRequest(requestKey: string, closeRoot: boolean): void {
+    const insight = this.requests.get(requestKey)
+    if (!insight) return
+
+    const rootRequestId = getRequestInsightRootId(insight)
+    const retention = this.retentionContextsByRequestKey.get(requestKey)
+    if (retention) {
+      if (closeRoot) closeRequestInsightsRetentionRoot(retention)
+      closeRequestInsightsRetentionRecord(retention)
+      this.retentionContextsByRequestKey.delete(requestKey)
+    }
+
+    const byteLength = this.requestByteLengths.get(requestKey) ?? 0
+    const bucket = this.rootRetentionBuckets.get(rootRequestId)
+    this.requestByteLengths.delete(requestKey)
+    this.rootByteLengths.set(
+      rootRequestId,
+      Math.max(0, (this.rootByteLengths.get(rootRequestId) ?? 0) - byteLength)
+    )
+    if (bucket) {
+      this.retainedBytesByBucket.set(
+        bucket,
+        Math.max(0, (this.retainedBytesByBucket.get(bucket) ?? 0) - byteLength)
+      )
+    }
+
+    this.requests.delete(requestKey)
+    this.requestTimings.delete(requestKey)
+    const requestKeys = this.requestKeysByRootRequestId.get(rootRequestId)
+    requestKeys?.delete(requestKey)
+    if (requestKeys?.size === 0) {
+      this.requestKeysByRootRequestId.delete(rootRequestId)
+      this.rootRequestOrder.delete(rootRequestId)
+      this.rootRequestSequence.delete(rootRequestId)
+      if (bucket) {
+        this.rootRequestOrderByRetentionBucket
+          .get(bucket)
+          ?.delete(rootRequestId)
+      }
+      this.rootRetentionBuckets.delete(rootRequestId)
+      this.rootByteLengths.delete(rootRequestId)
+      this.omittedRequestCountsByRootRequestId.delete(rootRequestId)
+    }
+  }
+}
+
+function isRootRequestInsightSpan(span: RequestInsightSpan): boolean {
+  return (
+    span.attributes?.['next.span_type'] === REQUEST_INSIGHT_REQUEST_SPAN_TYPE
+  )
 }
 
 function refineSource(
   current: RequestInsightSource,
   candidate: RequestInsightSource | undefined
 ): RequestInsightSource {
-  if (!candidate || candidate === 'unknown') {
-    return current
-  }
+  if (!candidate || candidate === 'unknown') return current
   if (
     candidate === 'app-route' ||
     candidate === 'pages-api' ||
@@ -369,20 +976,33 @@ function refineSource(
   ) {
     return candidate
   }
-  if (current === 'unknown' || current === 'proxy') {
-    return candidate
-  }
+  if (current === 'unknown' || current === 'proxy') return candidate
   return current
+}
+
+function getSourceFromSpan(
+  span: SpanStoreRecord | undefined
+): RequestInsightSource | undefined {
+  if (!span) return undefined
+  const spanType = getStringAttribute(span.attributes?.['next.span_type'])
+  const markedSource = getStringAttribute(
+    span.attributes?.['next.request_source']
+  )
+  if (markedSource === 'image' || markedSource === 'asset') return markedSource
+  if (spanType === 'AppRouteRouteHandlers.runHandler') return 'app-route'
+  if (spanType === 'Node.runHandler') return 'pages-api'
+  if (spanType === 'NextNodeServer.imageOptimizer') return 'image'
+  if (spanType === REQUEST_INSIGHT_REQUEST_SPAN_TYPE) return 'page'
+  if (spanType === REQUEST_INSIGHT_PROXY_SPAN_TYPE) return 'proxy'
+  return undefined
 }
 
 export function recordRequestInsightSpan(span: SpanStoreRecord): void {
   if (
-    span.attributes?.['next.span_type'] === CLIENT_COMPONENT_LOADING_SPAN_TYPE
+    span.attributes?.['next.span_type'] !== CLIENT_COMPONENT_LOADING_SPAN_TYPE
   ) {
-    return
+    getActiveRequestInsights()?.recordSpan(span)
   }
-
-  getActiveRequestInsights()?.recordSpan(span)
 }
 
 export function recordRequestInsightFetch(
@@ -428,13 +1048,11 @@ export function clearRequestInsightsForTest(): void {
 
 function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
   const attributes = span.attributes
-
   if (!attributes || attributes['next.span_type'] !== 'AppRender.fetch') {
     return null
   }
-
   return {
-    url: sanitizeUrl(getStringAttribute(attributes['http.url']) ?? span.url),
+    url: getStringAttribute(attributes['http.url']) ?? span.url,
     method: getStringAttribute(attributes['http.method']),
     statusCode: getNumberAttribute(attributes['http.status_code']),
     startTime: span.startTime ?? span.timestamp,
@@ -445,132 +1063,258 @@ function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
   }
 }
 
-function getSourceFromSpan(
-  span: SpanStoreRecord | undefined
-): RequestInsightSource | undefined {
-  if (!span) {
-    return undefined
-  }
-
-  const spanType = getStringAttribute(span.attributes?.['next.span_type'])
-  const markedSource = getStringAttribute(
-    span.attributes?.['next.request_source']
-  )
-  if (markedSource === 'image' || markedSource === 'asset') {
-    return markedSource
-  }
-
-  if (spanType === 'AppRouteRouteHandlers.runHandler') {
-    return 'app-route'
-  }
-  if (spanType === 'Node.runHandler') {
-    return 'pages-api'
-  }
-  if (spanType === 'NextNodeServer.imageOptimizer') {
-    return 'image'
-  }
-  if (spanType === REQUEST_INSIGHT_REQUEST_SPAN_TYPE) {
-    return 'page'
-  }
-  if (spanType === REQUEST_INSIGHT_PROXY_SPAN_TYPE) {
-    return 'proxy'
-  }
-  return undefined
-}
-
 function sanitizeFetchInsight(fetch: RequestInsightFetch): RequestInsightFetch {
   return {
-    ...fetch,
     url: sanitizeUrl(fetch.url),
+    method: sanitizeText(fetch.method, 32),
+    statusCode: sanitizeFiniteNumber(fetch.statusCode),
+    startTime: sanitizeFiniteNumber(fetch.startTime),
+    durationMs: sanitizeFiniteNumber(fetch.durationMs),
+    cacheStatus: sanitizeText(
+      fetch.cacheStatus,
+      MAX_REQUEST_INSIGHT_STRING_LENGTH
+    ),
+    cacheReason: sanitizeText(
+      fetch.cacheReason,
+      MAX_REQUEST_INSIGHT_STRING_LENGTH
+    ),
+    index: sanitizeFiniteNumber(fetch.index),
   }
 }
 
-function getCurrentTimestamp(): number {
-  return performance.timeOrigin + performance.now()
+function sanitizeSpan(
+  span: SpanStoreRecord,
+  startTime: number
+): RequestInsightSpan {
+  const state: SanitizationState = { truncatedMetadataValueCount: 0 }
+  const name = sanitizeSpanName(span, state)
+  const retainedEvents = span.events?.slice(
+    0,
+    REQUEST_INSIGHTS_MAX_EVENTS_PER_SPAN
+  )
+  const retainedLinks = span.links?.slice(
+    0,
+    REQUEST_INSIGHTS_MAX_LINKS_PER_SPAN
+  )
+  const events = retainedEvents?.map((event) => {
+    const eventName =
+      sanitizeText(event.name, MAX_REQUEST_INSIGHT_SPAN_NAME_LENGTH, state) ??
+      ''
+    return {
+      name: eventName,
+      timestamp: sanitizeFiniteNumber(event.timestamp) ?? 0,
+      attributes: sanitizeSpanAttributes(event.attributes, eventName, state),
+    }
+  })
+  const links = retainedLinks?.flatMap((link) => {
+    const traceId = sanitizeText(
+      link.traceId,
+      MAX_REQUEST_INSIGHT_ID_LENGTH,
+      state
+    )
+    const spanId = sanitizeText(
+      link.spanId,
+      MAX_REQUEST_INSIGHT_ID_LENGTH,
+      state
+    )
+    return traceId && spanId
+      ? [
+          {
+            traceId,
+            spanId,
+            attributes: sanitizeSpanAttributes(
+              link.attributes,
+              undefined,
+              state
+            ),
+          },
+        ]
+      : []
+  })
+  const sanitized: RequestInsightSpan = {
+    name,
+    startTime,
+    durationMs: sanitizeFiniteNumber(span.durationMs),
+    status: span.status,
+    traceId: sanitizeText(span.traceId, MAX_REQUEST_INSIGHT_ID_LENGTH, state),
+    spanId: sanitizeText(span.spanId, MAX_REQUEST_INSIGHT_ID_LENGTH, state),
+    parentSpanId: sanitizeText(
+      span.parentSpanId,
+      MAX_REQUEST_INSIGHT_ID_LENGTH,
+      state
+    ),
+    attributes: sanitizeSpanAttributes(span.attributes, name, state),
+    events,
+    links,
+    error: sanitizeSpanError(span.error, state),
+    truncatedMetadataValueCount: state.truncatedMetadataValueCount || undefined,
+    truncatedEventCount:
+      span.events && retainedEvents
+        ? span.events.length - retainedEvents.length || undefined
+        : undefined,
+    truncatedLinkCount:
+      span.links && retainedLinks
+        ? span.links.length - links!.length || undefined
+        : undefined,
+  }
+  return enforceSpanByteBudget(sanitized)
+}
+
+function sanitizeSpanName(
+  span: SpanStoreRecord,
+  state: SanitizationState
+): string {
+  if (span.attributes?.['next.span_type'] !== 'AppRender.fetch') {
+    return (
+      sanitizeText(span.name, MAX_REQUEST_INSIGHT_SPAN_NAME_LENGTH, state) ?? ''
+    )
+  }
+  const method = getStringAttribute(span.attributes['http.method'])
+  const url = sanitizeUrl(
+    getStringAttribute(span.attributes['http.url']) ?? span.url,
+    state
+  )
+  return (
+    sanitizeText(
+      ['fetch', method, url].filter(Boolean).join(' '),
+      MAX_REQUEST_INSIGHT_SPAN_NAME_LENGTH,
+      state
+    ) ?? ''
+  )
 }
 
 function sanitizeSpanAttributes(
-  attributes: SpanStoreRecord['attributes']
+  attributes: SpanStoreRecord['attributes'],
+  sanitizedSpanName: string | undefined,
+  state: SanitizationState
 ): SpanStoreRecord['attributes'] {
-  if (!attributes) {
-    return undefined
-  }
-
+  if (!attributes) return undefined
   const sanitized: NonNullable<SpanStoreRecord['attributes']> = {}
-  const sanitizedFetchSpanName =
-    attributes['next.span_type'] === 'AppRender.fetch'
-      ? getSanitizedFetchSpanName(attributes)
-      : undefined
   for (const [key, value] of Object.entries(attributes)) {
-    if (!SAFE_SPAN_ATTRIBUTE_KEYS.has(key)) {
-      continue
-    }
-
-    sanitized[key] =
+    if (!SAFE_SPAN_ATTRIBUTE_KEYS.has(key)) continue
+    const sanitizedValue =
       key === 'http.url'
-        ? sanitizeUrlAttribute(value)
-        : key === 'next.span_name' && sanitizedFetchSpanName
-          ? sanitizedFetchSpanName
-          : value
+        ? sanitizeUrlAttribute(value, state)
+        : key === 'next.span_name' && sanitizedSpanName
+          ? sanitizedSpanName
+          : sanitizeAttributeValue(value, state)
+    if (sanitizedValue !== undefined) sanitized[key] = sanitizedValue
   }
-
   return Object.keys(sanitized).length > 0 ? sanitized : undefined
 }
 
-function sanitizeSpanName(span: SpanStoreRecord): string {
-  if (span.attributes?.['next.span_type'] !== 'AppRender.fetch') {
-    return span.name
+function sanitizeUrlAttribute(
+  value: AttributeValue,
+  state: SanitizationState
+): AttributeValue | undefined {
+  if (typeof value === 'string') {
+    return sanitizeUrl(value, state) ?? REDACTED_VALUE
+  }
+  if (!Array.isArray(value)) return sanitizeAttributeValue(value, state)
+  const retained = value.slice(0, MAX_REQUEST_INSIGHT_ATTRIBUTE_ARRAY_LENGTH)
+  if (retained.length < value.length) state.truncatedMetadataValueCount++
+  return retained.map((item) =>
+    typeof item === 'string'
+      ? (sanitizeUrl(item, state) ?? REDACTED_VALUE)
+      : item
+  ) as AttributeValue
+}
+
+function sanitizeAttributeValue(
+  value: AttributeValue,
+  state: SanitizationState
+): AttributeValue | undefined {
+  if (typeof value === 'string') {
+    return sanitizeText(value, MAX_REQUEST_INSIGHT_STRING_LENGTH, state)
+  }
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? value : undefined
+  if (typeof value === 'boolean') return value
+  if (!Array.isArray(value)) return undefined
+  const retained = value.slice(0, MAX_REQUEST_INSIGHT_ATTRIBUTE_ARRAY_LENGTH)
+  if (retained.length < value.length) state.truncatedMetadataValueCount++
+  return retained.map((item) =>
+    typeof item === 'string'
+      ? sanitizeText(item, 64, state)
+      : typeof item === 'number' && !Number.isFinite(item)
+        ? undefined
+        : item
+  ) as AttributeValue
+}
+
+function sanitizeSpanError(
+  error: SpanStoreRecord['error'],
+  state: SanitizationState
+): RequestInsightSpan['error'] {
+  if (!error) return undefined
+  return {
+    type:
+      typeof error.type === 'string' && KNOWN_ERROR_TYPES.has(error.type)
+        ? error.type
+        : 'Error',
+    message: sanitizeText(
+      error.message,
+      MAX_REQUEST_INSIGHT_STRING_LENGTH,
+      state
+    ),
+  }
+}
+
+function enforceSpanByteBudget(span: RequestInsightSpan): RequestInsightSpan {
+  if (getSerializedByteLength(span) <= REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN) {
+    return span
   }
 
-  return getSanitizedFetchSpanName(span.attributes, span.url)
-}
+  let truncatedMetadataValueCount = span.truncatedMetadataValueCount ?? 0
+  span.events = span.events?.map((event) => {
+    truncatedMetadataValueCount += Object.keys(event.attributes ?? {}).length
+    return { name: event.name, timestamp: event.timestamp }
+  })
+  span.links = span.links?.map((link) => {
+    truncatedMetadataValueCount += Object.keys(link.attributes ?? {}).length
+    return { traceId: link.traceId, spanId: link.spanId }
+  })
 
-function getSanitizedFetchSpanName(
-  attributes: NonNullable<SpanStoreRecord['attributes']>,
-  fallbackUrl?: string
-): string {
-  const method = getStringAttribute(attributes['http.method'])
-  const url = sanitizeUrl(
-    getStringAttribute(attributes['http.url']) ?? fallbackUrl
-  )
-  return ['fetch', method, url].filter(Boolean).join(' ')
-}
-
-function sanitizeSpanEvents(
-  events: SpanStoreRecord['events']
-): SpanStoreRecord['events'] {
-  return events?.map((event) => ({
-    ...event,
-    attributes: sanitizeSpanAttributes(event.attributes),
-  }))
-}
-
-function sanitizeSpanLinks(
-  links: SpanStoreRecord['links']
-): SpanStoreRecord['links'] {
-  return links?.map((link) => ({
-    ...link,
-    attributes: sanitizeSpanAttributes(link.attributes),
-  }))
-}
-
-function sanitizeUrlAttribute(value: AttributeValue): AttributeValue {
-  return typeof value === 'string' ? (sanitizeUrl(value) ?? '') : value
-}
-
-function sanitizeUrl(value: string | undefined): string | undefined {
-  if (!value) {
-    return value
+  while (
+    getSerializedByteLength(span) > REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN &&
+    span.events?.length
+  ) {
+    span.events.shift()
+    span.truncatedEventCount = (span.truncatedEventCount ?? 0) + 1
   }
+  while (
+    getSerializedByteLength(span) > REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN &&
+    span.links?.length
+  ) {
+    span.links.shift()
+    span.truncatedLinkCount = (span.truncatedLinkCount ?? 0) + 1
+  }
+  if (getSerializedByteLength(span) > REQUEST_INSIGHTS_MAX_BYTES_PER_SPAN) {
+    const spanType = span.attributes?.['next.span_type']
+    truncatedMetadataValueCount += Math.max(
+      0,
+      Object.keys(span.attributes ?? {}).length -
+        (spanType === undefined ? 0 : 1)
+    )
+    span.attributes =
+      spanType === undefined ? undefined : { 'next.span_type': spanType }
+  }
+  span.truncatedMetadataValueCount = truncatedMetadataValueCount || undefined
+  return span
+}
 
+function sanitizeUrl(
+  value: string | undefined,
+  state?: SanitizationState
+): string | undefined {
+  if (!value) return value
   if (value.length > MAX_REQUEST_INSIGHT_RAW_URL_LENGTH) {
+    if (state) state.truncatedMetadataValueCount++
     return undefined
   }
-
   const isProtocolRelativeUrl = value.startsWith('//')
   const isRootRelativeUrl = !isProtocolRelativeUrl && value.startsWith('/')
   const hasProtocol = /^[a-z][a-z\d+.-]*:/i.test(value)
-
   if (!isProtocolRelativeUrl && !isRootRelativeUrl && !hasProtocol) {
     return undefined
   }
@@ -580,50 +1324,143 @@ function sanitizeUrl(value: string | undefined): string | undefined {
       isProtocolRelativeUrl || isRootRelativeUrl
         ? new URL(value, 'http://n')
         : new URL(value)
-
-    if (
-      url.protocol !== 'http:' &&
-      url.protocol !== 'https:' &&
-      !isProtocolRelativeUrl &&
-      !isRootRelativeUrl
-    ) {
+    if (url.protocol === 'data:' || url.protocol === 'blob:') {
       return `${url.protocol}${REDACTED_VALUE}`
     }
-
+    if (url.origin === 'null' && !url.hostname) {
+      return `${url.protocol}${REDACTED_VALUE}`
+    }
     url.username = ''
     url.password = ''
     url.hash = ''
-
     const hasApplicationQuery = Array.from(url.searchParams.keys()).some(
       (name) => name !== '_rsc'
     )
     url.search = hasApplicationQuery ? `?query=${REDACTED_VALUE}` : ''
-
     const sanitizedUrl = isProtocolRelativeUrl
       ? `//${url.host}${url.pathname}${url.search}`
       : isRootRelativeUrl
         ? `${url.pathname}${url.search}`
         : url.href
-
-    return truncateText(sanitizedUrl, MAX_REQUEST_INSIGHT_URL_LENGTH)
+    return sanitizeText(sanitizedUrl, MAX_REQUEST_INSIGHT_URL_LENGTH, state)
   } catch {
     return undefined
   }
 }
 
-function truncateText(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
-    return value
-  }
-
+function sanitizeText(
+  value: string | undefined,
+  maxLength: number,
+  state?: SanitizationState
+): string | undefined {
+  if (value === undefined || value.length <= maxLength) return value
+  if (state) state.truncatedMetadataValueCount++
   let end = Math.max(0, maxLength - 1)
   if (end > 0) {
-    const lastCharCode = value.charCodeAt(end - 1)
-    if (lastCharCode >= 0xd800 && lastCharCode <= 0xdbff) {
-      end--
-    }
+    const charCode = value.charCodeAt(end - 1)
+    if (charCode >= 0xd800 && charCode <= 0xdbff) end--
   }
   return `${value.slice(0, end)}…`
+}
+
+function sanitizeRequestInsightId(value: string | undefined) {
+  if (
+    !value ||
+    value.length > MAX_REQUEST_INSIGHT_ID_LENGTH ||
+    !/^[A-Za-z0-9._:-]+$/.test(value)
+  ) {
+    return undefined
+  }
+  return value
+}
+
+function sanitizeSnapshotLimit(value: number | undefined): number {
+  if (value === undefined) return Number.POSITIVE_INFINITY
+  if (!Number.isSafeInteger(value) || value <= 0) return 1
+  return Math.min(
+    value,
+    REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET *
+      REQUEST_INSIGHT_RETENTION_BUCKETS.length
+  )
+}
+
+function normalizeRequestInsightsLimits(
+  options: RequestInsightsOptions
+): RequestInsightsLimits {
+  return {
+    maxBytesPerRetentionBucket: normalizeNonNegativeInteger(
+      options.maxBytesPerRetentionBucket,
+      REQUEST_INSIGHTS_MAX_BYTES_PER_RETENTION_BUCKET
+    ),
+    maxRetainedBytes: normalizeNonNegativeInteger(
+      options.maxRetainedBytes,
+      REQUEST_INSIGHTS_MAX_RETAINED_BYTES
+    ),
+    maxRequestGroupsPerBucket: normalizeNonNegativeInteger(
+      options.maxRequestGroupsPerBucket,
+      REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET
+    ),
+    maxSnapshotBytes: Math.max(
+      MIN_REQUEST_INSIGHTS_SNAPSHOT_BYTES,
+      normalizeNonNegativeInteger(
+        options.maxSnapshotBytes,
+        REQUEST_INSIGHTS_MAX_SNAPSHOT_BYTES
+      )
+    ),
+  }
+}
+
+function normalizeNonNegativeInteger(
+  value: number | undefined,
+  fallback: number
+): number {
+  if (value === undefined) return fallback
+  if (!Number.isFinite(value) || value < 0) return fallback
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.floor(value))
+}
+
+function sanitizeFiniteNumber(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function getCurrentTimestamp(): number {
+  return performance.timeOrigin + performance.now()
+}
+
+function getSerializedByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8')
+}
+
+function cloneRequestInsight(insight: RequestInsight): RequestInsight {
+  return {
+    ...insight,
+    spans: insight.spans.map((span) => ({
+      ...span,
+      attributes: cloneAttributes(span.attributes),
+      links: span.links?.map((link) => ({
+        ...link,
+        attributes: cloneAttributes(link.attributes),
+      })),
+      events: span.events?.map((event) => ({
+        ...event,
+        attributes: cloneAttributes(event.attributes),
+      })),
+      error: span.error ? { ...span.error } : undefined,
+    })),
+    fetches: insight.fetches.map((fetch) => ({ ...fetch })),
+  }
+}
+
+function cloneAttributes(
+  attributes: RequestInsightSpan['attributes']
+): RequestInsightSpan['attributes'] {
+  if (!attributes) return undefined
+  return Object.fromEntries(
+    Object.entries(attributes).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? value.slice() : value,
+    ])
+  )
 }
 
 function getStringAttribute(value: AttributeValue | undefined) {

--- a/packages/next/src/server/lib/trace/span-store.test.ts
+++ b/packages/next/src/server/lib/trace/span-store.test.ts
@@ -1,7 +1,5 @@
-import {
-  clearRequestInsightsForTest,
-  getRequestInsightsSnapshot,
-} from './request-insights'
+import { RequestInsights, getRequestInsightsSnapshot } from './request-insights'
+import { runWithRequestInsights } from './request-insights-runtime'
 import {
   isLocalSpanRecordingEnabled,
   isRequestInsightsEnabled,
@@ -22,16 +20,19 @@ function restoreEnv(name: string, value: string | undefined) {
 }
 
 describe('span recording', () => {
+  let requestInsights: RequestInsights
+
   beforeEach(() => {
     process.env.__NEXT_DEV_SERVER = '1'
     delete process.env.__NEXT_REQUEST_INSIGHTS
+    requestInsights = new RequestInsights()
   })
 
   afterEach(() => {
     restoreEnv('__NEXT_REQUEST_INSIGHTS', originalRequestInsights)
     restoreEnv('__NEXT_DEV_SERVER', originalDevServer)
     setSpanRecorderForTest(undefined)
-    clearRequestInsightsForTest()
+    requestInsights.dispose()
   })
 
   it('records completed spans only when there is a consumer', () => {
@@ -62,51 +63,55 @@ describe('span recording', () => {
   })
 
   it('forwards request spans directly to request insights', () => {
-    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    runWithRequestInsights(requestInsights, () => {
+      process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
-    recordSpan({
-      name: 'render route (app) /dashboard',
-      startTime: 100,
-      durationMs: 25,
-      status: 'ok',
-      requestId: 'req_1',
-      route: '/dashboard',
-    })
+      recordSpan({
+        name: 'render route (app) /dashboard',
+        startTime: 100,
+        durationMs: 25,
+        status: 'ok',
+        requestId: 'req_1',
+        route: '/dashboard',
+      })
 
-    expect(getRequestInsightsSnapshot()).toEqual({
-      requests: [
-        expect.objectContaining({
-          requestId: 'req_1',
-          route: '/dashboard',
-          spans: [
-            expect.objectContaining({
-              name: 'render route (app) /dashboard',
-              startTime: 100,
-              durationMs: 25,
-            }),
-          ],
-        }),
-      ],
+      expect(getRequestInsightsSnapshot()).toEqual({
+        requests: [
+          expect.objectContaining({
+            requestId: 'req_1',
+            route: '/dashboard',
+            spans: [
+              expect.objectContaining({
+                name: 'render route (app) /dashboard',
+                startTime: 100,
+                durationMs: 25,
+              }),
+            ],
+          }),
+        ],
+      })
     })
   })
 
   it('does not record spans outside the dev server', () => {
     const recorder = jest.fn()
     delete process.env.__NEXT_DEV_SERVER
-    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
-    setSpanRecorderForTest(recorder)
+    runWithRequestInsights(requestInsights, () => {
+      process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+      setSpanRecorderForTest(recorder)
 
-    expect(isRequestInsightsEnabled()).toBe(false)
-    expect(isLocalSpanRecordingEnabled()).toBe(false)
+      expect(isRequestInsightsEnabled()).toBe(false)
+      expect(isLocalSpanRecordingEnabled()).toBe(false)
 
-    recordSpan({ name: 'test.production', requestId: 'req_2' })
-    expect(recorder).not.toHaveBeenCalled()
-    expect(getRequestInsightsSnapshot()).toEqual({ requests: [] })
+      recordSpan({ name: 'test.production', requestId: 'req_2' })
+      expect(recorder).not.toHaveBeenCalled()
+      expect(getRequestInsightsSnapshot()).toEqual({ requests: [] })
+    })
   })
 
-  it('treats boolean define-env request insights values as enabled', () => {
-    ;(process.env.__NEXT_REQUEST_INSIGHTS as unknown) = true
-
-    expect(isRequestInsightsEnabled()).toBe(true)
+  it('treats an active request controller as enabled', () => {
+    runWithRequestInsights(requestInsights, () => {
+      expect(isRequestInsightsEnabled()).toBe(true)
+    })
   })
 })

--- a/packages/next/src/server/lib/trace/span-store.test.ts
+++ b/packages/next/src/server/lib/trace/span-store.test.ts
@@ -75,21 +75,23 @@ describe('span recording', () => {
         route: '/dashboard',
       })
 
-      expect(getRequestInsightsSnapshot()).toEqual({
-        requests: [
-          expect.objectContaining({
-            requestId: 'req_1',
-            route: '/dashboard',
-            spans: [
-              expect.objectContaining({
-                name: 'render route (app) /dashboard',
-                startTime: 100,
-                durationMs: 25,
-              }),
-            ],
-          }),
-        ],
-      })
+      expect(getRequestInsightsSnapshot()).toEqual(
+        expect.objectContaining({
+          requests: [
+            expect.objectContaining({
+              requestId: 'req_1',
+              route: '/dashboard',
+              spans: [
+                expect.objectContaining({
+                  name: 'render route (app) /dashboard',
+                  startTime: 100,
+                  durationMs: 25,
+                }),
+              ],
+            }),
+          ],
+        })
+      )
     })
   })
 

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -8,6 +8,7 @@ import type {
   RequestInsightSource,
 } from '../../../shared/lib/request-insights'
 import type { RequestInsights } from './request-insights'
+import type { RequestInsightsRetentionContext } from './request-insights-identity'
 
 let spanStoreRequestInsightsRuntime:
   | typeof import('./request-insights-runtime')
@@ -47,6 +48,8 @@ export type SpanStoreRecord = {
   spanId?: string
   parentSpanId?: string
   requestId?: string
+  rootRequestId?: string
+  requestInsightsRetention?: RequestInsightsRetentionContext
   requestInsightKind?: RequestInsightKind
   requestInsightSource?: RequestInsightSource
   requestInsightProxyStatus?: RequestInsightProxyStatus

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -1,5 +1,10 @@
 import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightProxyStatus,
+  RequestInsightRouterActivity,
+  RequestInsightSource,
+} from '../../../shared/lib/request-insights'
 
 export type SpanStoreAttributes = Record<string, AttributeValue>
 
@@ -26,6 +31,10 @@ export type SpanStoreRecord = {
   parentSpanId?: string
   requestId?: string
   requestInsightKind?: RequestInsightKind
+  requestInsightSource?: RequestInsightSource
+  requestInsightProxyStatus?: RequestInsightProxyStatus
+  requestInsightRouterActivity?: RequestInsightRouterActivity
+  requestInsightServerAction?: true
   htmlRequestId?: string
   route?: string
   url?: string

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -1,5 +1,7 @@
-import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
-import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
+import type {
+  RequestInsightAttributeValue,
+  RequestInsightKind,
+} from '../../../next-devtools/shared/request-insights'
 import type {
   RequestInsightProxyStatus,
   RequestInsightRouterActivity,
@@ -21,7 +23,7 @@ function getSpanStoreRequestInsightsRuntime():
   return undefined
 }
 
-export type SpanStoreAttributes = Record<string, AttributeValue>
+export type SpanStoreAttributes = Record<string, RequestInsightAttributeValue>
 
 export type SpanStoreLink = {
   traceId: string

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -5,6 +5,21 @@ import type {
   RequestInsightRouterActivity,
   RequestInsightSource,
 } from '../../../shared/lib/request-insights'
+import type { RequestInsights } from './request-insights'
+
+let spanStoreRequestInsightsRuntime:
+  | typeof import('./request-insights-runtime')
+  | undefined
+
+function getSpanStoreRequestInsightsRuntime():
+  | typeof import('./request-insights-runtime')
+  | undefined {
+  if (process.env.__NEXT_DEV_SERVER) {
+    return (spanStoreRequestInsightsRuntime ??=
+      require('./request-insights-runtime') as typeof import('./request-insights-runtime'))
+  }
+  return undefined
+}
 
 export type SpanStoreAttributes = Record<string, AttributeValue>
 
@@ -51,8 +66,20 @@ type SpanRecorderForTest = (span: SpanStoreRecord) => void
 
 let spanRecorderForTest: SpanRecorderForTest | undefined
 
-export function recordSpan(record: Omit<SpanStoreRecord, 'timestamp'>): void {
-  if (!isLocalSpanRecordingEnabled()) {
+export function recordSpan(
+  record: Omit<SpanStoreRecord, 'timestamp'>,
+  ...requestInsightsOverride: [] | [RequestInsights | undefined]
+): void {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return
+  }
+
+  const requestInsights =
+    requestInsightsOverride.length === 0
+      ? getSpanStoreRequestInsightsRuntime()?.getActiveRequestInsights()
+      : requestInsightsOverride[0]
+
+  if (!spanRecorderForTest && !requestInsights) {
     return
   }
 
@@ -63,10 +90,8 @@ export function recordSpan(record: Omit<SpanStoreRecord, 'timestamp'>): void {
 
   spanRecorderForTest?.(spanRecord)
 
-  if (isRequestInsightsEnabled() && spanRecord.requestId) {
-    const { recordRequestInsightSpan } =
-      require('./request-insights') as typeof import('./request-insights')
-    recordRequestInsightSpan(spanRecord)
+  if (requestInsights && spanRecord.requestId) {
+    requestInsights.recordSpan(spanRecord)
   }
 }
 
@@ -85,16 +110,10 @@ export function isLocalSpanRecordingEnabled(): boolean {
 }
 
 export function isRequestInsightsEnabled(): boolean {
-  if (!process.env.__NEXT_DEV_SERVER) {
-    return false
-  }
-
-  const value = process.env.__NEXT_REQUEST_INSIGHTS
-  return isEnabledEnvValue(value)
-}
-
-function isEnabledEnvValue(value: string | undefined): boolean {
-  return value === '1' || value === 'true' || (value as unknown) === true
+  return (
+    getSpanStoreRequestInsightsRuntime()?.isRequestInsightsRuntimeActive() ??
+    false
+  )
 }
 
 function getCurrentTimestamp(): number {

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -2,6 +2,8 @@
  * @jest-environment node
  */
 
+/* eslint-disable jest/no-standalone-expect -- Assertions run inside the controller-scoped test wrapper. */
+
 import type {
   Context,
   ContextManager,
@@ -31,6 +33,8 @@ import {
   NodeSpan,
 } from './constants'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
+import { RequestInsights } from './request-insights'
+import { runWithRequestInsights } from './request-insights-runtime'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
@@ -162,12 +166,15 @@ describe('withPropagatedContext', () => {
 })
 
 describe('local span recording', () => {
+  let requestInsights: RequestInsights
+
   beforeEach(() => {
     process.env.__NEXT_DEV_SERVER = '1'
     delete process.env.__NEXT_REQUEST_INSIGHTS
     delete process.env.NEXT_OTEL_VERBOSE
     setSpanRecorderForTest((span) => spanRecords.push(span))
     registerLocalSpanRecorder()
+    requestInsights = new RequestInsights()
   })
 
   afterEach(() => {
@@ -190,7 +197,12 @@ describe('local span recording', () => {
     trace.disable()
     setSpanRecorderForTest(undefined)
     spanRecords.length = 0
+    requestInsights.dispose()
   })
+
+  function test(name: string, fn: () => unknown | Promise<unknown>): void {
+    it(name, () => runWithRequestInsights(requestInsights, fn))
+  }
 
   it('does not mirror spans by default', () => {
     setSpanRecorderForTest(undefined)
@@ -201,7 +213,7 @@ describe('local span recording', () => {
     expect(getSpanRecords()).toEqual([])
   })
 
-  it('records non-vanilla trace and wrapped spans for request insights', () => {
+  test('records non-vanilla trace and wrapped spans for request insights', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
 
     getTracer().trace(BaseServerSpan.render, () => undefined)
@@ -227,7 +239,7 @@ describe('local span recording', () => {
     ])
   })
 
-  it('only exports non-vanilla spans when verbose tracing is enabled', () => {
+  test('only exports non-vanilla spans when verbose tracing is enabled', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     const exportedSpans: string[] = []
     const delegateSpan = trace.wrapSpanContext({
@@ -264,7 +276,7 @@ describe('local span recording', () => {
     expect(exportedSpans).toEqual([NodeSpan.runHandler, BaseServerSpan.render])
   })
 
-  it('does not record or export hidden spans', () => {
+  test('does not record or export hidden spans', () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     let receivedSpan: unknown = 'not-called'
     const startSpan = jest.fn()
@@ -365,7 +377,7 @@ describe('local span recording', () => {
     ])
   })
 
-  it('keeps OTel-isolated spans out of the active OTel context', async () => {
+  test('keeps OTel-isolated spans out of the active OTel context', async () => {
     process.env.__NEXT_REQUEST_INSIGHTS = 'true'
     process.env.NEXT_OTEL_VERBOSE = '1'
     context.disable()

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -200,8 +200,10 @@ describe('local span recording', () => {
     requestInsights.dispose()
   })
 
-  function test(name: string, fn: () => unknown | Promise<unknown>): void {
-    it(name, () => runWithRequestInsights(requestInsights, fn))
+  function test(name: string, fn: () => void | Promise<void>): void {
+    it(name, async () => {
+      await runWithRequestInsights(requestInsights, fn)
+    })
   }
 
   it('does not mirror spans by default', () => {

--- a/packages/next/src/server/mcp/get-mcp-middleware.ts
+++ b/packages/next/src/server/mcp/get-mcp-middleware.ts
@@ -1,12 +1,15 @@
 import type { ServerResponse, IncomingMessage } from 'http'
 import {
-  getOrCreateMcpServer,
+  createMcpServer,
   type McpServerOptions,
 } from './get-or-create-mcp-server'
 import { parseBody } from '../api-utils/node/parse-body'
 import { StreamableHTTPServerTransport } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/streamableHttp'
 
 export function getMcpMiddleware(options: McpServerOptions) {
+  // Each middleware closure belongs to one dev server/project.
+  let mcpServer: ReturnType<typeof createMcpServer> | undefined
+
   return async function (
     req: IncomingMessage,
     res: ServerResponse,
@@ -16,7 +19,7 @@ export function getMcpMiddleware(options: McpServerOptions) {
     if (!pathname.startsWith('/_next/mcp')) {
       return next()
     }
-    const mcpServer = getOrCreateMcpServer(options)
+    mcpServer ??= createMcpServer(options)
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     })

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -12,6 +12,7 @@ import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
 import type { Project } from '../../build/swc/types'
 import type { FormattedIssue } from './tools/utils/format-compilation-issues'
+import type { RequestInsights } from '../lib/trace/request-insights'
 
 export interface McpServerOptions {
   projectPath: string
@@ -22,6 +23,7 @@ export interface McpServerOptions {
   sendHmrMessage: (message: HmrMessageSentToBrowser) => void
   getActiveConnectionCount: () => number
   getDevServerUrl: () => string | undefined
+  getRequestInsights: () => RequestInsights | undefined
   getTurbopackProject?: () => Project | undefined
   compileRoute?: (opts: {
     routeSpecifier?: string
@@ -29,14 +31,8 @@ export interface McpServerOptions {
   }) => Promise<{ routeSpecifier: string; issues: FormattedIssue[] }>
 }
 
-let mcpServer: McpServer | undefined
-
-export const getOrCreateMcpServer = (options: McpServerOptions) => {
-  if (mcpServer) {
-    return mcpServer
-  }
-
-  mcpServer = new McpServer({
+export const createMcpServer = (options: McpServerOptions) => {
+  const mcpServer = new McpServer({
     name: 'Next.js MCP Server',
     version: '0.2.0',
   })
@@ -64,7 +60,7 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
     pagesDir: options.pagesDir,
     appDir: options.appDir,
   })
-  registerGetRequestInsightsTool(mcpServer)
+  registerGetRequestInsightsTool(mcpServer, options.getRequestInsights)
 
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)

--- a/packages/next/src/server/mcp/tools/get-request-insights.ts
+++ b/packages/next/src/server/mcp/tools/get-request-insights.ts
@@ -1,12 +1,12 @@
 import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
 import z from 'next/dist/compiled/zod'
-import {
-  getRequestInsightsSnapshot,
-  isRequestInsightsEnabled,
-} from '../../lib/trace/request-insights'
+import type { RequestInsights } from '../../lib/trace/request-insights'
 import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
 
-export function registerGetRequestInsightsTool(server: McpServer) {
+export function registerGetRequestInsightsTool(
+  server: McpServer,
+  getRequestInsights: () => RequestInsights | undefined
+) {
   server.registerTool(
     'get_request_insights',
     {
@@ -20,7 +20,8 @@ export function registerGetRequestInsightsTool(server: McpServer) {
     async (request) => {
       mcpTelemetryTracker.recordToolCall('mcp/get_request_insights')
 
-      if (!isRequestInsightsEnabled()) {
+      const requestInsights = getRequestInsights()
+      if (!requestInsights) {
         return {
           content: [
             {
@@ -34,7 +35,7 @@ export function registerGetRequestInsightsTool(server: McpServer) {
         }
       }
 
-      const snapshot = getRequestInsightsSnapshot()
+      const snapshot = requestInsights.getSnapshot()
       const requests = snapshot.requests.filter((insight) => {
         return (
           (request.requestId === undefined ||

--- a/packages/next/src/server/mcp/tools/get-request-insights.ts
+++ b/packages/next/src/server/mcp/tools/get-request-insights.ts
@@ -35,21 +35,13 @@ export function registerGetRequestInsightsTool(
         }
       }
 
-      const snapshot = requestInsights.getSnapshot()
-      const requests = snapshot.requests.filter((insight) => {
-        return (
-          (request.requestId === undefined ||
-            insight.requestId === request.requestId) &&
-          (request.htmlRequestId === undefined ||
-            insight.htmlRequestId === request.htmlRequestId)
-        )
-      })
+      const snapshot = requestInsights.getSnapshot(request)
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify({ requests }, null, 2),
+            text: JSON.stringify(snapshot),
           },
         ],
       }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -226,15 +226,6 @@ export default class NextNodeServer extends BaseServer<
     if (this.renderOpts.nextScriptWorkers) {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
-    if (
-      (isDev || process.env.__NEXT_DEV_SERVER) &&
-      this.nextConfig.experimental.requestInsights
-    ) {
-      process.env.__NEXT_REQUEST_INSIGHTS = 'true'
-    } else {
-      delete process.env.__NEXT_REQUEST_INSIGHTS
-    }
-
     if (!this.minimalMode) {
       this.imageResponseCache = new ResponseCache(this.minimalMode)
     }
@@ -2181,6 +2172,9 @@ export default class NextNodeServer extends BaseServer<
   }
 
   async close(): Promise<void> {
+    if (this.ownsRequestInsights) {
+      this.requestInsights?.dispose()
+    }
     await this.cleanupListeners.runAll()
   }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -14,6 +14,7 @@ import type { OpaqueFallbackRouteParams } from './request/fallback-params'
 import type { IncrementalCache } from './lib/incremental-cache'
 import type { RevalidateFn } from './lib/router-utils/router-server-context'
 import type { NextRequest } from './web/exports'
+import type { RequestInsightsIdentity } from './lib/trace/request-insights-identity'
 
 // FIXME: (wyattjoh) this is a temporary solution to allow us to pass data between bundled modules
 export const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta')
@@ -49,6 +50,8 @@ export type OnCacheEntryHandler = (
 ) => Promise<boolean | void> | boolean | void
 
 export interface RequestMeta {
+  /** Server-owned identity for the development Request Insights timeline. */
+  requestInsightsIdentity?: RequestInsightsIdentity
   /**
    * The query that was used to make the request.
    */

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -92,8 +92,8 @@ import { LazyModule } from '../../lib/lazy-module'
 import { createPrerenderResumeDataCache } from '../../resume-data-cache/resume-data-cache'
 
 type AppRouteRequestInsightsRuntime = {
+  getActiveRequestInsights: typeof import('../../lib/trace/request-insights-runtime').getActiveRequestInsights
   getRequestInsightsIdentity: typeof import('../../lib/trace/request-insights-identity').getRequestInsightsIdentity
-  recordRequestInsightSource: typeof import('../../lib/trace/request-insights').recordRequestInsightSource
 }
 
 let appRouteRequestInsightsRuntime: AppRouteRequestInsightsRuntime | undefined
@@ -103,21 +103,20 @@ function markAppRouteRequestSource(): void {
     if (!appRouteRequestInsightsRuntime) {
       const { getRequestInsightsIdentity } =
         require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
-      const { recordRequestInsightSource } =
-        require('../../lib/trace/request-insights') as typeof import('../../lib/trace/request-insights')
+      const { getActiveRequestInsights } =
+        require('../../lib/trace/request-insights-runtime') as typeof import('../../lib/trace/request-insights-runtime')
 
       appRouteRequestInsightsRuntime = {
+        getActiveRequestInsights,
         getRequestInsightsIdentity,
-        recordRequestInsightSource,
       }
     }
 
     const identity = appRouteRequestInsightsRuntime.getRequestInsightsIdentity()
     if (identity) {
-      appRouteRequestInsightsRuntime.recordRequestInsightSource(
-        identity,
-        'app-route'
-      )
+      appRouteRequestInsightsRuntime
+        .getActiveRequestInsights()
+        ?.recordSource(identity, 'app-route')
     }
   }
 }

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -91,6 +91,37 @@ import { InvariantError } from '../../../shared/lib/invariant-error'
 import { LazyModule } from '../../lib/lazy-module'
 import { createPrerenderResumeDataCache } from '../../resume-data-cache/resume-data-cache'
 
+type AppRouteRequestInsightsRuntime = {
+  getRequestInsightsIdentity: typeof import('../../lib/trace/request-insights-identity').getRequestInsightsIdentity
+  recordRequestInsightSource: typeof import('../../lib/trace/request-insights').recordRequestInsightSource
+}
+
+let appRouteRequestInsightsRuntime: AppRouteRequestInsightsRuntime | undefined
+
+function markAppRouteRequestSource(): void {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!appRouteRequestInsightsRuntime) {
+      const { getRequestInsightsIdentity } =
+        require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
+      const { recordRequestInsightSource } =
+        require('../../lib/trace/request-insights') as typeof import('../../lib/trace/request-insights')
+
+      appRouteRequestInsightsRuntime = {
+        getRequestInsightsIdentity,
+        recordRequestInsightSource,
+      }
+    }
+
+    const identity = appRouteRequestInsightsRuntime.getRequestInsightsIdentity()
+    if (identity) {
+      appRouteRequestInsightsRuntime.recordRequestInsightSource(
+        identity,
+        'app-route'
+      )
+    }
+  }
+}
+
 export class WrappedNextRouterError {
   constructor(
     public readonly error: RedirectError,
@@ -838,6 +869,8 @@ export class AppRouteRouteModule extends RouteModule<
     req: NextRequest,
     context: AppRouteRouteHandlerContext
   ): Promise<PreparedAppRouteExecution> {
+    markAppRouteRequestSource()
+
     // Ensure userland is fully loaded (handles async modules with top-level
     // await, where require() returns a Promise instead of the module).
     await this.ensureUserland()

--- a/packages/next/src/shared/lib/request-insights.ts
+++ b/packages/next/src/shared/lib/request-insights.ts
@@ -1,14 +1,52 @@
 export type RequestInsightKind = 'request' | 'instant-insights'
 
+export const REQUEST_INSIGHT_REQUEST_SPAN_TYPE = 'BaseServer.handleRequest'
+export const REQUEST_INSIGHT_PROXY_SPAN_TYPE = 'Middleware.execute'
+
+export const REQUEST_INSIGHT_SOURCES = [
+  'page',
+  'app-route',
+  'pages-api',
+  'image',
+  'asset',
+  'proxy',
+  'instant-insights',
+  'unknown',
+] as const
+
+export type RequestInsightSource = (typeof REQUEST_INSIGHT_SOURCES)[number]
+export type RequestInsightProxyStatus = 'matched' | 'bypassed'
+
+export const REQUEST_INSIGHT_ROUTER_ACTIVITIES = [
+  'prefetch',
+  'segment-prefetch',
+  'hmr-refresh',
+] as const
+
+export type RequestInsightRouterActivity =
+  (typeof REQUEST_INSIGHT_ROUTER_ACTIVITIES)[number]
+
 export type RequestInsightIdentity = {
   requestId: string
   kind?: RequestInsightKind
+  source?: RequestInsightSource
+  proxyStatus?: RequestInsightProxyStatus
+  routerActivity?: RequestInsightRouterActivity
 }
 
 export function getRequestInsightKind(
   insight: Pick<RequestInsightIdentity, 'kind'>
 ): RequestInsightKind {
   return insight.kind ?? 'request'
+}
+
+export function getRequestInsightSource(
+  insight: Pick<RequestInsightIdentity, 'kind' | 'source'>
+): RequestInsightSource {
+  if (getRequestInsightKind(insight) === 'instant-insights') {
+    return 'instant-insights'
+  }
+  return insight.source ?? 'unknown'
 }
 
 export function getRequestInsightKey(insight: RequestInsightIdentity): string {

--- a/packages/next/src/shared/lib/request-insights.ts
+++ b/packages/next/src/shared/lib/request-insights.ts
@@ -26,8 +26,21 @@ export const REQUEST_INSIGHT_ROUTER_ACTIVITIES = [
 export type RequestInsightRouterActivity =
   (typeof REQUEST_INSIGHT_ROUTER_ACTIVITIES)[number]
 
+export const REQUEST_INSIGHT_RETENTION_BUCKETS = [
+  'page',
+  'api',
+  'asset',
+  'proxy',
+  'instant-insights',
+  'unknown',
+] as const
+
+export type RequestInsightRetentionBucket =
+  (typeof REQUEST_INSIGHT_RETENTION_BUCKETS)[number]
+
 export type RequestInsightIdentity = {
   requestId: string
+  rootRequestId?: string
   kind?: RequestInsightKind
   source?: RequestInsightSource
   proxyStatus?: RequestInsightProxyStatus
@@ -49,6 +62,25 @@ export function getRequestInsightSource(
   return insight.source ?? 'unknown'
 }
 
+export function getRequestInsightRetentionBucket(
+  insight: Pick<RequestInsightIdentity, 'kind' | 'source'>
+): RequestInsightRetentionBucket {
+  const source = getRequestInsightSource(insight)
+  if (source === 'app-route' || source === 'pages-api') {
+    return 'api'
+  }
+  if (source === 'image' || source === 'asset') {
+    return 'asset'
+  }
+  return source
+}
+
 export function getRequestInsightKey(insight: RequestInsightIdentity): string {
   return `${getRequestInsightKind(insight)}:${insight.requestId}`
+}
+
+export function getRequestInsightRootId(
+  insight: Pick<RequestInsightIdentity, 'requestId' | 'rootRequestId'>
+): string {
+  return insight.rootRequestId ?? insight.requestId
 }

--- a/packages/next/src/telemetry/post-telemetry-payload.test.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.test.ts
@@ -45,6 +45,92 @@ describe('postNextTelemetryPayload', () => {
     )
   })
 
+  it('bypasses only the Next.js patched fetch wrapper', async () => {
+    const originFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    const patchedFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      (input, init) => originFetch(input, init)
+    )
+    Object.assign(patchedFetch, {
+      __nextPatched: true,
+      _nextOriginalFetch: originFetch,
+    })
+    global.fetch = patchedFetch
+
+    const payload = {
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    }
+
+    await postNextTelemetryPayload(payload)
+
+    expect(patchedFetch).not.toHaveBeenCalled()
+    expect(originFetch).toHaveBeenCalledTimes(1)
+
+    await global.fetch('https://telemetry.nextjs.org/api/v1/record')
+
+    expect(patchedFetch).toHaveBeenCalledTimes(1)
+    expect(originFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not trust an unbranded _nextOriginalFetch property', async () => {
+    const unrelatedOriginalFetch = jest.fn(
+      async () => new Response(null, { status: 204 })
+    )
+    const customFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    Object.assign(customFetch, {
+      _nextOriginalFetch: unrelatedOriginalFetch,
+    })
+    global.fetch = customFetch
+
+    await postNextTelemetryPayload({
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    })
+
+    expect(customFetch).toHaveBeenCalledTimes(1)
+    expect(unrelatedOriginalFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not trust a non-callable _nextOriginalFetch property', async () => {
+    const customFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input: Parameters<typeof fetch>[0]) =>
+        new Response(null, { status: 204 })
+    )
+    Object.assign(customFetch, {
+      __nextPatched: true,
+      _nextOriginalFetch: 'not a function',
+    })
+    global.fetch = customFetch
+
+    await postNextTelemetryPayload({
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    })
+
+    expect(customFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('retries on failure', async () => {
     const mockFetch = jest
       .fn()

--- a/packages/next/src/telemetry/post-telemetry-payload.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.ts
@@ -15,6 +15,23 @@ interface Payload {
   }>
 }
 
+type MaybePatchedFetch = typeof fetch & {
+  readonly __nextPatched?: true
+  readonly _nextOriginalFetch?: typeof fetch
+}
+
+function getTelemetryFetch(): typeof fetch {
+  const currentFetch = globalThis.fetch as MaybePatchedFetch
+
+  // Framework telemetry is process activity, not application request work.
+  // Avoid inheriting an active render's patched-fetch context while preserving
+  // any user-provided fetch implementation when Next has not patched it.
+  return currentFetch.__nextPatched === true &&
+    typeof currentFetch._nextOriginalFetch === 'function'
+    ? currentFetch._nextOriginalFetch
+    : currentFetch
+}
+
 export function postNextTelemetryPayload(payload: Payload, signal?: any) {
   if (!signal && 'timeout' in AbortSignal) {
     signal = AbortSignal.timeout(5000)
@@ -22,7 +39,7 @@ export function postNextTelemetryPayload(payload: Payload, signal?: any) {
   return (
     retry(
       () =>
-        fetch('https://telemetry.nextjs.org/api/v1/record', {
+        getTelemetryFetch()('https://telemetry.nextjs.org/api/v1/record', {
           method: 'POST',
           body: JSON.stringify(payload),
           headers: { 'content-type': 'application/json' },

--- a/test/development/app-dir/request-insights/app/actions/cached-function-button.tsx
+++ b/test/development/app-dir/request-insights/app/actions/cached-function-button.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { runCachedFunction } from './cached'
+
+export function CachedFunctionButton() {
+  const [result, setResult] = useState('idle')
+  const [, startTransition] = useTransition()
+
+  return (
+    <>
+      <button
+        id="run-cached-function"
+        type="button"
+        onClick={() => {
+          startTransition(async () => {
+            setResult(await runCachedFunction())
+          })
+        }}
+      >
+        Run cached function
+      </button>
+      <p id="cached-function-result">{result}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/actions/cached.ts
+++ b/test/development/app-dir/request-insights/app/actions/cached.ts
@@ -1,0 +1,5 @@
+'use cache'
+
+export async function runCachedFunction() {
+  return 'cached-function-complete'
+}

--- a/test/development/app-dir/request-insights/app/actions/page.tsx
+++ b/test/development/app-dir/request-insights/app/actions/page.tsx
@@ -1,0 +1,18 @@
+import { CachedFunctionButton } from './cached-function-button'
+
+export default function ActionsPage() {
+  async function runAction() {
+    'use server'
+  }
+
+  return (
+    <>
+      <form action={runAction}>
+        <button id="run-server-action" type="submit">
+          Run action
+        </button>
+      </form>
+      <CachedFunctionButton />
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/api/app-stream-lifecycle/route.ts
+++ b/test/development/app-dir/request-insights/app/api/app-stream-lifecycle/route.ts
@@ -1,0 +1,46 @@
+const requestInsightsGlobal = globalThis as typeof globalThis & {
+  requestInsightsPendingAppRouteHandlers?: Map<string, () => void>
+}
+const pendingHandlers =
+  (requestInsightsGlobal.requestInsightsPendingAppRouteHandlers ??= new Map())
+
+export async function GET(request: Request) {
+  const waitKey = new URL(request.url).searchParams.get('wait')
+  if (waitKey) {
+    await new Promise<void>((resolve) => {
+      pendingHandlers.set(waitKey, resolve)
+    })
+  }
+
+  const encoder = new TextEncoder()
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('started\n'))
+        queueMicrotask(() => {
+          controller.enqueue(encoder.encode('finished\n'))
+          controller.close()
+        })
+      },
+    }),
+    {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      status: 202,
+    }
+  )
+}
+
+export function POST(request: Request) {
+  const waitKey = new URL(request.url).searchParams.get('release')
+  const release = waitKey ? pendingHandlers.get(waitKey) : undefined
+  if (!waitKey || !release) {
+    return new Response(null, { status: 404 })
+  }
+
+  pendingHandlers.delete(waitKey)
+  release()
+  return new Response(null, { status: 204 })
+}

--- a/test/development/app-dir/request-insights/app/api/proxied-page/page.tsx
+++ b/test/development/app-dir/request-insights/app/api/proxied-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>proxied page</p>
+}

--- a/test/development/app-dir/request-insights/app/api/source/route.ts
+++ b/test/development/app-dir/request-insights/app/api/source/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ source: 'app-route' })
+}

--- a/test/development/app-dir/request-insights/app/behind-proxy/page.tsx
+++ b/test/development/app-dir/request-insights/app/behind-proxy/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>behind proxy</p>
+}

--- a/test/development/app-dir/request-insights/app/products/[id]/page.tsx
+++ b/test/development/app-dir/request-insights/app/products/[id]/page.tsx
@@ -1,0 +1,23 @@
+import { headers } from 'next/headers'
+import { connection } from 'next/server'
+
+export const instant = false
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  await connection()
+  const { id } = await params
+  const host = (await headers()).get('host')
+  if (!host) {
+    throw new Error('Missing request host')
+  }
+
+  await fetch(`http://${host}/api/source?token=Q2_SECRET_SENTINEL`, {
+    cache: 'no-store',
+  })
+
+  return <p id="product-id">{id}</p>
+}

--- a/test/development/app-dir/request-insights/proxy.ts
+++ b/test/development/app-dir/request-insights/proxy.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  if (
+    request.nextUrl.pathname === '/request-insights-asset.svg' &&
+    request.nextUrl.searchParams.has('rewrite-to-page')
+  ) {
+    return NextResponse.rewrite(new URL('/behind-proxy', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/:path*', '/request-insights-asset.svg'],
+}

--- a/test/development/app-dir/request-insights/public/request-insights-asset.svg
+++ b/test/development/app-dir/request-insights/public/request-insights-asset.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path d="M0 0h1v1H0z" />
+</svg>

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -481,6 +481,7 @@ describe('request insights', () => {
     await browser.elementByCss('.request-insights-settings-trigger').click()
     await retry(async () => {
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: null },
         { label: 'Verbose traces', checked: null },
       ])
@@ -498,26 +499,26 @@ describe('request insights', () => {
       .click()
 
     await retry(async () => {
-      const nestedRows = await browser.eval(() => {
+      const internalRows = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
         return Array.from(
-          root?.querySelectorAll('.request-insights-row[data-nested="true"]') ??
-            []
+          root?.querySelectorAll(
+            '.request-insights-row[data-internal="true"]'
+          ) ?? []
         ).map((row) => ({
-          internal: row.getAttribute('data-internal'),
-          hasArrow: !!row.querySelector('.request-insights-nested-arrow'),
+          nested: row.hasAttribute('data-nested'),
           label: row.textContent ?? '',
         }))
       })
 
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
-      expect(nestedRows.length).toBeGreaterThan(0)
-      for (const row of nestedRows) {
-        expect(row.internal).toBe('true')
-        expect(row.hasArrow).toBe(true)
+      expect(internalRows.length).toBeGreaterThan(0)
+      for (const row of internalRows) {
+        expect(row.nested).toBe(false)
         expect(row.label).toContain('Instant Insights')
       }
     })
@@ -539,9 +540,76 @@ describe('request insights', () => {
 
     await retry(async () => {
       expect(await getSettingsMenuItems()).toEqual([
+        { label: 'Pause updates', checked: null },
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
+    })
+  })
+
+  it('filters typed request rows and pauses live updates', async () => {
+    const browser = await next.browser('/instant-insights')
+    expect((await next.fetch('/api/source?before=pause')).status).toBe(200)
+
+    await openRequestInsightsPanel(browser)
+    await browser.elementByCss('.request-insights-filter-trigger').click()
+    await browser
+      .elementByCss(
+        '.request-insights-filter-item[data-filter-value="source:api"]'
+      )
+      .click()
+
+    await retry(async () => {
+      const rowTypes = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-request-type') ?? []
+        ).map((type) => type.textContent?.trim())
+      })
+      expect(rowTypes.length).toBeGreaterThan(0)
+      expect(new Set(rowTypes)).toEqual(new Set(['API']))
+    })
+
+    await browser.elementByCss('.request-insights-details').click()
+    await browser.elementByCss('.request-insights-settings-trigger').click()
+    await browser
+      .elementByCss('.request-insights-settings-item:has-text("Pause updates")')
+      .click()
+
+    const pausedRowCount = await browser.eval(() => {
+      const root = document.querySelector('nextjs-portal')?.shadowRoot
+      return root?.querySelectorAll('.request-insights-row').length ?? 0
+    })
+    expect((await next.fetch('/api/source?while=paused')).status).toBe(200)
+
+    await retry(async () => {
+      const pausedState = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return {
+          paused: root?.querySelector('.request-insights-paused-state')
+            ?.textContent,
+          rowCount: root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(pausedState).toEqual({
+        paused: 'Paused',
+        rowCount: pausedRowCount,
+      })
+    })
+
+    await browser
+      .elementByCss('.request-insights-settings-item:has-text("Pause updates")')
+      .click()
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return {
+          paused: root?.querySelector('.request-insights-paused-state'),
+          rowCount: root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(state.paused).toBeNull()
+      expect(state.rowCount).toBeGreaterThan(pausedRowCount)
     })
   })
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -437,113 +437,118 @@ describe('request insights', () => {
     })
   })
 
-  it('hides internal activity behind the settings menu', async () => {
+  it('relates owned Instant Insights to the foreground request', async () => {
     const browser = await next.browser('/instant-insights')
     shouldResetRequestInsightsConfig = true
 
-    function getSettingsMenuItems(): Promise<
-      Array<{ label: string | undefined; checked: string | null }>
-    > {
-      return browser.eval(() => {
-        const root = document.querySelector('nextjs-portal')?.shadowRoot
-        return Array.from(
-          root?.querySelectorAll('.request-insights-settings-item') ?? []
-        ).map((item) => ({
-          label: item.textContent?.trim(),
-          checked:
-            item
-              .querySelector('.request-insights-settings-checkbox')
-              ?.getAttribute('data-checked') ?? null,
-        }))
-      })
-    }
-
     await openRequestInsightsPanel(browser)
 
+    let allRequestCount = 0
     await retry(async () => {
       const state = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
         const rows = Array.from(
           root?.querySelectorAll('.request-insights-row') ?? []
         )
+        const owner = rows.find(
+          (row) =>
+            row.querySelector('.request-insights-route-label')?.textContent ===
+            '/instant-insights'
+        )
         return {
           rowCount: rows.length,
-          hasInstantInsightsRow: rows.some((row) =>
-            row.textContent?.includes('Instant Insights')
-          ),
+          internalRowCount: rows.filter(
+            (row) => row.getAttribute('data-internal') === 'true'
+          ).length,
+          ownerInstantLabel: owner
+            ?.querySelector('[data-activity="instant-insights"]')
+            ?.textContent?.trim(),
         }
       })
 
+      allRequestCount = state.rowCount
       expect(state.rowCount).toBeGreaterThan(0)
-      expect(state.hasInstantInsightsRow).toBe(false)
+      expect(state.internalRowCount).toBe(0)
+      expect(state.ownerInstantLabel).toBe('Instant')
     })
 
-    await browser.elementByCss('.request-insights-settings-trigger').click()
     await retry(async () => {
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: null },
-        { label: 'Verbose traces', checked: null },
-      ])
-    })
-
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Internal activity")'
-      )
-      .click()
-    await browser
-      .elementByCss(
-        '.request-insights-settings-item:has-text("Verbose traces")'
-      )
-      .click()
-
-    await retry(async () => {
-      const internalRows = await browser.eval(() => {
+      const selected = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
-        return Array.from(
-          root?.querySelectorAll(
-            '.request-insights-row[data-internal="true"]'
-          ) ?? []
-        ).map((row) => ({
-          nested: row.hasAttribute('data-nested'),
-          label: row.textContent ?? '',
-        }))
+        const owner = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find(
+          (row) =>
+            row.querySelector('.request-insights-route-label')?.textContent ===
+            '/instant-insights'
+        )
+        owner?.click()
+        return owner !== undefined
       })
-
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: 'true' },
-        { label: 'Verbose traces', checked: 'true' },
-      ])
-      expect(internalRows.length).toBeGreaterThan(0)
-      for (const row of internalRows) {
-        expect(row.nested).toBe(false)
-        expect(row.label).toContain('Instant Insights')
-      }
+      expect(selected).toBe(true)
     })
 
     await retry(async () => {
-      const config = JSON.parse(
-        await next.readFile('build/dev/cache/next-devtools-config.json')
+      const instantSection = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const section = root?.querySelector<HTMLDetailsElement>(
+          '.request-insights-instant-section'
+        )
+        return {
+          exists: section !== null,
+          open: section?.open ?? null,
+          title: section
+            ?.querySelector('summary > span:first-child')
+            ?.textContent?.trim(),
+        }
+      })
+      expect(instantSection.exists).toBe(true)
+      expect(instantSection.open).toBe(false)
+      expect(instantSection.title).toBe('Instant Insights')
+    })
+
+    await browser
+      .elementByCss('.request-insights-instant-section > summary')
+      .click()
+    await retry(async () => {
+      const state = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const section = root?.querySelector<HTMLDetailsElement>(
+          '.request-insights-instant-section'
+        )
+        return {
+          open: section?.open ?? false,
+          traceRows:
+            section?.querySelectorAll('.request-insights-span-row').length ?? 0,
+        }
+      })
+      expect(state.open).toBe(true)
+      expect(state.traceRows).toBeGreaterThan(0)
+    })
+
+    await browser
+      .elementByCss(
+        '.request-insights-scope-switcher button:has-text("This page")'
       )
-      expect(config.requestInsights).toEqual({
-        showInternal: true,
-        verbose: true,
-      })
-    })
-
-    await browser.elementByCss('.request-insights-details').click()
-    await browser.refresh()
-    await openRequestInsightsPanel(browser)
-    await browser.elementByCss('.request-insights-settings-trigger').click()
-
+      .click()
     await retry(async () => {
-      expect(await getSettingsMenuItems()).toEqual([
-        { label: 'Pause updates', checked: null },
-        { label: 'Internal activity', checked: 'true' },
-        { label: 'Verbose traces', checked: 'true' },
-      ])
+      const pageScope = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const button = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>(
+            '.request-insights-scope-switcher button'
+          ) ?? []
+        ).find((item) => item.textContent?.trim() === 'This page')
+        return {
+          pressed: button?.getAttribute('aria-pressed'),
+          requestCount:
+            root?.querySelectorAll('.request-insights-row').length ?? 0,
+        }
+      })
+      expect(pageScope.pressed).toBe('true')
+      expect(pageScope.requestCount).toBeGreaterThan(0)
+      expect(pageScope.requestCount).toBeLessThan(allRequestCount)
     })
   })
 
@@ -671,6 +676,9 @@ describe('request insights', () => {
     const browser = await next.browser('/products/blue?tab=details')
     await openRequestInsightsPanel(browser)
 
+    const foregroundTraceSelector =
+      '.request-insights-details > .request-insights-section .request-insights-trace-rows'
+
     await retry(async () => {
       const selected = await browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
@@ -681,15 +689,17 @@ describe('request insights', () => {
           candidate.textContent?.includes('/products/blue?query=redacted')
         )
         row?.click()
-        return row !== undefined
+        return row?.dataset.selected === 'true'
       })
       expect(selected).toBe(true)
     })
 
     await browser
-      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .locator(
+        `nextjs-portal ${foregroundTraceSelector} .request-insights-span-row[data-active="true"]`
+      )
       .hover()
-    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+    await browser.locator(`nextjs-portal ${foregroundTraceSelector}`).focus()
 
     const readTraceState = () =>
       browser.eval(() => {
@@ -698,7 +708,7 @@ describe('request insights', () => {
           '.request-insights-panel-container'
         )
         const listbox = root?.querySelector<HTMLElement>(
-          '.request-insights-trace-rows'
+          '.request-insights-details > .request-insights-section .request-insights-trace-rows'
         )
         const activeDescendant = listbox?.getAttribute('aria-activedescendant')
         const activeRow = listbox?.querySelector<HTMLElement>(
@@ -715,11 +725,19 @@ describe('request insights', () => {
         const tooltipRect = tooltip?.getBoundingClientRect()
 
         return {
+          activeRowCount:
+            listbox?.querySelectorAll(
+              '.request-insights-span-row[data-active="true"]'
+            ).length ?? 0,
           activeDescendant,
           activeRowId: activeRow?.id ?? null,
           activeTraceItemId: activeRow?.dataset.traceItemId ?? null,
           firstRowId: firstRow?.id ?? null,
           activeLabel: activeRow?.getAttribute('aria-label') ?? null,
+          requestTitle:
+            root
+              ?.querySelector('.request-insights-title')
+              ?.textContent?.trim() ?? null,
           focused: root?.activeElement === listbox,
           horizontalOverlap:
             !!rowRect &&
@@ -747,6 +765,7 @@ describe('request insights', () => {
     const expectAnchoredTrace = async (expectedTraceItemId?: string | null) =>
       retry(async () => {
         const state = await readTraceState()
+        expect(state.activeRowCount).toBe(1)
         expect(state.activeDescendant).toEqual(expect.any(String))
         if (expectedTraceItemId !== undefined) {
           expect(state.activeTraceItemId).toBe(expectedTraceItemId)
@@ -765,7 +784,9 @@ describe('request insights', () => {
     await browser.eval(() => {
       const root = document.querySelector('nextjs-portal')?.shadowRoot
       root
-        ?.querySelector<HTMLElement>('.request-insights-trace-rows')
+        ?.querySelector<HTMLElement>(
+          '.request-insights-details > .request-insights-section .request-insights-trace-rows'
+        )
         ?.dispatchEvent(
           new KeyboardEvent('keydown', {
             altKey: true,
@@ -844,10 +865,19 @@ describe('request insights', () => {
       expect(selection.activeRowId).toBe(selection.firstRowId)
     })
 
+    await retry(async () => {
+      const state = await readTraceState()
+      expect(state.activeRowCount).toBe(1)
+      expect(state.requestTitle).toBe('/api/source?query=redacted')
+      expect(state.activeTraceItemId).not.toBe(nextState.activeTraceItemId)
+    })
+
     await browser
-      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .locator(
+        `nextjs-portal ${foregroundTraceSelector} .request-insights-span-row:first-child`
+      )
       .hover()
-    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+    await browser.locator(`nextjs-portal ${foregroundTraceSelector}`).focus()
 
     const switchedState = await expectAnchoredTrace()
     expect(switchedState.activeDescendant).toBe(switchedState.firstRowId)

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -10,8 +10,21 @@ import {
 type RequestInsight = {
   requestId: string
   kind?: 'request' | 'instant-insights'
+  source:
+    | 'page'
+    | 'app-route'
+    | 'pages-api'
+    | 'image'
+    | 'asset'
+    | 'proxy'
+    | 'instant-insights'
+    | 'unknown'
+  proxyStatus?: 'matched' | 'bypassed'
+  routerActivity?: 'prefetch' | 'segment-prefetch' | 'hmr-refresh'
+  serverAction?: true
   htmlRequestId: string
   route: string
+  url?: string
   startTime: number
   status: 'ok'
   spans: Array<{
@@ -37,6 +50,7 @@ describe('request insights', () => {
   function createRequest(index: number, fetchCount = 0): RequestInsight {
     return {
       requestId: `request-${index}`,
+      source: 'page',
       htmlRequestId: `page-${index}`,
       route: `/route-${index}`,
       startTime: index,
@@ -167,6 +181,61 @@ describe('request insights', () => {
           'AppRender.getBodyResult',
         ])
       )
+    })
+  })
+
+  it('classifies static files as assets in the serialized snapshot', async () => {
+    const response = await next.fetch('/request-insights-asset.svg')
+    expect(response.status).toBe(200)
+    await response.text()
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/request-insights-asset.svg' &&
+          candidate.kind !== 'instant-insights'
+      )
+
+      expect(request).toEqual(expect.objectContaining({ source: 'asset' }))
+    })
+  })
+
+  it('does not classify an asset URL rewritten by proxy as an asset', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((insightsResponse) => insightsResponse.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const response = await next.fetch(
+      '/request-insights-asset.svg?rewrite-to-page=1'
+    )
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('behind proxy')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.route === '/behind-proxy' &&
+          !existingRequestIds.has(candidate.requestId) &&
+          candidate.kind !== 'instant-insights'
+      )
+
+      expect(request).toEqual(expect.objectContaining({ source: 'page' }))
     })
   })
 
@@ -473,6 +542,269 @@ describe('request insights', () => {
         { label: 'Internal activity', checked: 'true' },
         { label: 'Verbose traces', checked: 'true' },
       ])
+    })
+  })
+
+  it('classifies framework-owned request activity without retaining action IDs', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const routeResponse = await next.fetch('/api/source')
+    expect(routeResponse.status).toBe(200)
+    const prefetchResponse = await next.fetch('/?activity=prefetch', {
+      headers: {
+        rsc: '1',
+        'next-router-prefetch': '2',
+      },
+    })
+    expect(prefetchResponse.status).toBe(200)
+    const actionIds: string[] = []
+    const browser = await next.browser('/actions', {
+      beforePageLoad(page) {
+        page.route('**/actions**', async (route) => {
+          const actionId = (await route.request().allHeaders())['next-action']
+          if (actionId) {
+            actionIds.push(actionId)
+          }
+          await route.continue()
+        })
+      },
+    })
+    await browser.eval(() => {
+      document.querySelector<HTMLButtonElement>('#run-server-action')?.click()
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const requests = snapshot.requests.filter(
+        (request) => !existingRequestIds.has(request.requestId)
+      )
+
+      expect(requests.find((request) => request.url === '/api/source')).toEqual(
+        expect.objectContaining({
+          source: 'app-route',
+          proxyStatus: 'matched',
+        })
+      )
+      expect(
+        requests.find((request) => request.routerActivity === 'prefetch')
+      ).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          proxyStatus: 'bypassed',
+          routerActivity: 'prefetch',
+        })
+      )
+      expect(
+        requests.find(
+          (request) =>
+            request.route === '/actions' && request.serverAction === true
+        )
+      ).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          serverAction: true,
+        })
+      )
+
+      const serialized = JSON.stringify(requests)
+      expect(actionIds).toHaveLength(1)
+      expect(actionIds[0]).toMatch(/^[0-9a-f]{42}$/)
+      for (const actionId of actionIds) {
+        expect(serialized).not.toContain(actionId)
+      }
+      expect(serialized).not.toContain('next-action')
+    })
+
+    const requestIdsAfterAction = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    await browser.elementById('run-cached-function').click()
+    await retry(async () => {
+      expect(await browser.elementById('cached-function-result').text()).toBe(
+        'cached-function-complete'
+      )
+    })
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const cacheRequests = snapshot.requests.filter(
+        (request) =>
+          !requestIdsAfterAction.has(request.requestId) &&
+          request.route === '/actions' &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'POST'
+          )
+      )
+
+      expect(cacheRequests).toHaveLength(1)
+      expect(cacheRequests[0].serverAction).toBeUndefined()
+      expect(actionIds).toHaveLength(2)
+      expect(JSON.stringify(cacheRequests[0])).not.toContain(actionIds[1])
+    })
+  })
+
+  it('classifies an App Route before its handler completes', async () => {
+    const waitKey = `active-${Date.now()}`
+    const requestPath = `/api/app-stream-lifecycle?wait=${waitKey}`
+    const responsePromise = next.fetch(requestPath)
+
+    try {
+      await retry(async () => {
+        const snapshot = (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+        const matchingRequests = snapshot.requests.filter(
+          (request) => request.url === requestPath
+        )
+
+        expect(matchingRequests).toHaveLength(1)
+        expect(matchingRequests[0]).toEqual(
+          expect.objectContaining({
+            source: 'app-route',
+            proxyStatus: 'matched',
+          })
+        )
+      })
+    } finally {
+      const release = await next.fetch(
+        `/api/app-stream-lifecycle?release=${waitKey}`,
+        { method: 'POST' }
+      )
+      expect(release.status).toBe(204)
+    }
+
+    const response = await responsePromise
+    expect(response.status).toBe(202)
+    expect(await response.text()).toContain('finished')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const matchingRequests = snapshot.requests.filter(
+        (request) =>
+          request.url === requestPath && request.kind !== 'instant-insights'
+      )
+
+      expect(matchingRequests).toHaveLength(1)
+      expect(
+        matchingRequests[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'Middleware.execute',
+          'BaseServer.handleRequest',
+          'AppRouteRouteHandlers.runHandler',
+        ])
+      )
+    })
+  })
+
+  it('classifies a Page after proxy completes', async () => {
+    const requestPath = `/api/proxied-page?run=${Date.now()}`
+    const response = await next.fetch(requestPath)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('proxied page')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const matchingRequests = snapshot.requests.filter(
+        (request) =>
+          request.url === requestPath && request.kind !== 'instant-insights'
+      )
+
+      expect(matchingRequests).toHaveLength(1)
+      expect(matchingRequests[0]).toEqual(
+        expect.objectContaining({
+          source: 'page',
+          proxyStatus: 'matched',
+        })
+      )
+      expect(
+        matchingRequests[0].spans.map(
+          (span) => span.attributes?.['next.span_type']
+        )
+      ).toEqual(
+        expect.arrayContaining([
+          'Middleware.execute',
+          'BaseServer.handleRequest',
+          'AppRender.getBodyResult',
+        ])
+      )
+    })
+  })
+
+  it('does not trust an unrecognized Server Action header', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const forgedActionId = '00'.repeat(21)
+
+    const response = await next.fetch('/actions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'text/plain',
+        'next-action': forgedActionId,
+      },
+      body: '[]',
+    })
+    expect(response.ok).toBe(false)
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const forgedRequest = snapshot.requests.find(
+        (request) =>
+          !existingRequestIds.has(request.requestId) &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'POST'
+          )
+      )
+
+      expect(forgedRequest).toBeDefined()
+      expect(forgedRequest?.serverAction).toBeUndefined()
+      expect(JSON.stringify(forgedRequest)).not.toContain(forgedActionId)
     })
   })
 

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -613,6 +613,246 @@ describe('request insights', () => {
     })
   })
 
+  it('shows concrete request URLs, route params, and fetch origins', async () => {
+    const browser = await next.browser('/products/blue?tab=details')
+
+    await retry(async () => {
+      expect(await browser.elementById('product-id').text()).toBe('blue')
+    })
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/products/blue?query=redacted')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+
+    await retry(async () => {
+      const details = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const panel = root?.querySelector('.request-insights-details')
+        return {
+          text: panel?.textContent ?? '',
+          paramsLabel:
+            panel?.querySelector('.request-insights-params-trigger')
+              ?.textContent ?? '',
+          fetchOrigins: Array.from(
+            panel?.querySelectorAll('.request-insights-fetch-origin') ?? []
+          ).map((element) => element.textContent ?? ''),
+          fetchTraceLabels: Array.from(
+            panel?.querySelectorAll(
+              '.request-insights-span-row[data-kind="fetch"] .request-insights-span-label'
+            ) ?? []
+          ).map((element) => element.textContent ?? ''),
+        }
+      })
+
+      expect(details.text).toContain('/products/blue?query=redacted')
+      expect(details.text).toContain('Route /products/[id]')
+      expect(details.paramsLabel).toBe('Params id')
+      expect(details.fetchOrigins).toContain('Same origin')
+      expect(
+        details.fetchTraceLabels.some((label) => label.includes('Same origin'))
+      ).toBe(true)
+      expect(details.text).not.toContain('Q2_SECRET_SENTINEL')
+    })
+  })
+
+  it('keeps trace inspection anchored while the panel is resized', async () => {
+    const browser = await next.browser('/products/blue?tab=details')
+    await openRequestInsightsPanel(browser)
+
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/products/blue?query=redacted')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+
+    await browser
+      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .hover()
+    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+
+    const readTraceState = () =>
+      browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const panel = root?.querySelector<HTMLElement>(
+          '.request-insights-panel-container'
+        )
+        const listbox = root?.querySelector<HTMLElement>(
+          '.request-insights-trace-rows'
+        )
+        const activeDescendant = listbox?.getAttribute('aria-activedescendant')
+        const activeRow = listbox?.querySelector<HTMLElement>(
+          '.request-insights-span-row[data-active="true"]'
+        )
+        const firstRow = listbox?.querySelector<HTMLElement>(
+          '.request-insights-span-row'
+        )
+        const tooltip = root?.querySelector<HTMLElement>(
+          '.request-insights-trace-tooltip'
+        )
+        const panelRect = panel?.getBoundingClientRect()
+        const rowRect = activeRow?.getBoundingClientRect()
+        const tooltipRect = tooltip?.getBoundingClientRect()
+
+        return {
+          activeDescendant,
+          activeRowId: activeRow?.id ?? null,
+          activeTraceItemId: activeRow?.dataset.traceItemId ?? null,
+          firstRowId: firstRow?.id ?? null,
+          activeLabel: activeRow?.getAttribute('aria-label') ?? null,
+          focused: root?.activeElement === listbox,
+          horizontalOverlap:
+            !!rowRect &&
+            !!tooltipRect &&
+            tooltipRect.right >= rowRect.left &&
+            tooltipRect.left <= rowRect.right,
+          tooltipLabel: tooltip?.textContent?.trim() ?? null,
+          tooltipNearPanel:
+            !!panelRect &&
+            !!tooltipRect &&
+            tooltipRect.right >= panelRect.left - 100 &&
+            tooltipRect.left <= panelRect.right + 100 &&
+            tooltipRect.bottom >= panelRect.top - 100 &&
+            tooltipRect.top <= panelRect.bottom + 100,
+          verticalGap:
+            rowRect && tooltipRect
+              ? Math.min(
+                  Math.abs(tooltipRect.bottom - rowRect.top),
+                  Math.abs(tooltipRect.top - rowRect.bottom)
+                )
+              : Number.POSITIVE_INFINITY,
+        }
+      })
+
+    const expectAnchoredTrace = async (expectedTraceItemId?: string | null) =>
+      retry(async () => {
+        const state = await readTraceState()
+        expect(state.activeDescendant).toEqual(expect.any(String))
+        if (expectedTraceItemId !== undefined) {
+          expect(state.activeTraceItemId).toBe(expectedTraceItemId)
+        }
+        expect(state.activeRowId).toBe(state.activeDescendant)
+        expect(state.activeLabel).toBe(state.tooltipLabel)
+        expect(state.focused).toBe(true)
+        expect(state.horizontalOverlap).toBe(true)
+        expect(state.tooltipNearPanel).toBe(true)
+        expect(state.verticalGap).toBeLessThan(160)
+        return state
+      })
+
+    const initialState = await expectAnchoredTrace()
+
+    await browser.eval(() => {
+      const root = document.querySelector('nextjs-portal')?.shadowRoot
+      root
+        ?.querySelector<HTMLElement>('.request-insights-trace-rows')
+        ?.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            altKey: true,
+            bubbles: true,
+            key: 'ArrowDown',
+          })
+        )
+    })
+    expect((await readTraceState()).activeTraceItemId).toBe(
+      initialState.activeTraceItemId
+    )
+
+    await browser.keydown('ArrowDown')
+    await browser.keyup('ArrowDown')
+
+    const nextState = await retry(async () => {
+      const state = await readTraceState()
+      expect(state.activeTraceItemId).not.toBe(initialState.activeTraceItemId)
+      return state
+    })
+    await expectAnchoredTrace(nextState.activeTraceItemId)
+
+    const columnCountAtPanelWidth = async (width: number): Promise<number> => {
+      return await browser.eval(`(() => {
+        const root = document.querySelector('nextjs-portal').shadowRoot
+        const panelContainer = root.querySelector('.dynamic-panel-container')
+        panelContainer.style.width = '${width}px'
+        const panel = root.querySelector('.request-insights-panel')
+        return getComputedStyle(panel).gridTemplateColumns.split(' ').length
+      })()`)
+    }
+
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(760)).toBe(2)
+    })
+    await expectAnchoredTrace()
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(560)).toBe(1)
+    })
+    await expectAnchoredTrace()
+    await retry(async () => {
+      expect(await columnCountAtPanelWidth(760)).toBe(2)
+    })
+    await expectAnchoredTrace()
+
+    await browser
+      .locator('nextjs-portal .request-insights-row[aria-label^="/api/source"]')
+      .first()
+      .click()
+
+    await retry(async () => {
+      const selection = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) => candidate.textContent?.includes('/api/source'))
+        return {
+          found: row !== undefined,
+          selected: row?.dataset.selected,
+          title: root
+            ?.querySelector<HTMLElement>('.request-insights-title')
+            ?.textContent?.trim(),
+          activeRowId: root?.querySelector<HTMLElement>(
+            '.request-insights-span-row[data-active="true"]'
+          )?.id,
+          firstRowId: root?.querySelector<HTMLElement>(
+            '.request-insights-span-row'
+          )?.id,
+        }
+      })
+      expect(selection.found).toBe(true)
+      expect(selection.selected).toBe('true')
+      expect(selection.title).toBe('/api/source?query=redacted')
+      expect(selection.firstRowId).toEqual(expect.any(String))
+      expect(selection.activeRowId).toBe(selection.firstRowId)
+    })
+
+    await browser
+      .locator('nextjs-portal .request-insights-span-row[data-active="true"]')
+      .hover()
+    await browser.locator('nextjs-portal .request-insights-trace-rows').focus()
+
+    const switchedState = await expectAnchoredTrace()
+    expect(switchedState.activeDescendant).toBe(switchedState.firstRowId)
+  })
+
   it('classifies framework-owned request activity without retaining action IDs', async () => {
     const existingRequestIds = new Set(
       (
@@ -734,8 +974,18 @@ describe('request insights', () => {
   })
 
   it('classifies an App Route before its handler completes', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
     const waitKey = `active-${Date.now()}`
     const requestPath = `/api/app-stream-lifecycle?wait=${waitKey}`
+    const recordedRequestPath = '/api/app-stream-lifecycle?query=redacted'
     const responsePromise = next.fetch(requestPath)
 
     try {
@@ -746,7 +996,10 @@ describe('request insights', () => {
           requests: RequestInsight[]
         }
         const matchingRequests = snapshot.requests.filter(
-          (request) => request.url === requestPath
+          (request) =>
+            !existingRequestIds.has(request.requestId) &&
+            request.url === recordedRequestPath &&
+            request.kind !== 'instant-insights'
         )
 
         expect(matchingRequests).toHaveLength(1)
@@ -777,7 +1030,12 @@ describe('request insights', () => {
       }
       const matchingRequests = snapshot.requests.filter(
         (request) =>
-          request.url === requestPath && request.kind !== 'instant-insights'
+          !existingRequestIds.has(request.requestId) &&
+          request.url === recordedRequestPath &&
+          request.kind !== 'instant-insights' &&
+          request.spans.some(
+            (span) => span.attributes?.['http.method'] === 'GET'
+          )
       )
 
       expect(matchingRequests).toHaveLength(1)
@@ -796,7 +1054,17 @@ describe('request insights', () => {
   })
 
   it('classifies a Page after proxy completes', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
     const requestPath = `/api/proxied-page?run=${Date.now()}`
+    const recordedRequestPath = '/api/proxied-page?query=redacted'
     const response = await next.fetch(requestPath)
     expect(response.status).toBe(200)
     expect(await response.text()).toContain('proxied page')
@@ -809,7 +1077,9 @@ describe('request insights', () => {
       }
       const matchingRequests = snapshot.requests.filter(
         (request) =>
-          request.url === requestPath && request.kind !== 'instant-insights'
+          !existingRequestIds.has(request.requestId) &&
+          request.url === recordedRequestPath &&
+          request.kind !== 'instant-insights'
       )
 
       expect(matchingRequests).toHaveLength(1)

--- a/test/unit/devtools-config-middleware/index.test.ts
+++ b/test/unit/devtools-config-middleware/index.test.ts
@@ -1,0 +1,364 @@
+import type { IncomingMessage, ServerResponse } from 'http'
+import * as fsPromises from 'fs/promises'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  devToolsConfigMiddleware,
+  getDevToolsConfig,
+} from 'next/dist/next-devtools/server/devtools-config-middleware'
+
+jest.mock('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises')
+  return {
+    ...actual,
+    rename: jest.fn(actual.rename),
+    writeFile: jest.fn(actual.writeFile),
+  }
+})
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function createRequest(
+  body: object,
+  {
+    bodyRequested,
+    bodyConsumed,
+    releaseBody,
+  }: {
+    bodyRequested?: ReturnType<typeof createDeferred>
+    bodyConsumed?: ReturnType<typeof createDeferred>
+    releaseBody?: Promise<void>
+  } = {}
+): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      bodyRequested?.resolve()
+      await releaseBody
+      yield Buffer.from(JSON.stringify(body))
+      bodyConsumed?.resolve()
+    },
+  } as IncomingMessage
+}
+
+function createResponse(): ServerResponse {
+  return {
+    end: jest.fn(),
+    setHeader: jest.fn(),
+  } as unknown as ServerResponse
+}
+
+function createChunkedRequest(chunks: Buffer[]): IncomingMessage {
+  return {
+    method: 'POST',
+    url: '/__nextjs_devtools_config',
+    async *[Symbol.asyncIterator]() {
+      yield* chunks
+    },
+  } as IncomingMessage
+}
+
+describe('DevTools config middleware', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    distDir = await mkdtemp(join(tmpdir(), 'next-devtools-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(distDir, { recursive: true, force: true })
+  })
+
+  it('commits concurrent patches in request arrival order', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const bodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstResponse = createResponse()
+    const secondResponse = createResponse()
+
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { showInternal: true, verbose: false } },
+        {
+          bodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      firstResponse,
+      jest.fn()
+    )
+
+    await bodyRequested.promise
+    const secondBodyConsumed = createDeferred()
+    const secondRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: secondBodyConsumed }
+      ),
+      secondResponse,
+      jest.fn()
+    )
+
+    await secondBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, secondRequest])
+
+    const config = JSON.parse(
+      await readFile(
+        join(distDir, 'cache', 'next-devtools-config.json'),
+        'utf8'
+      )
+    )
+    expect(config).toEqual({
+      requestInsights: {
+        showInternal: true,
+        verbose: true,
+      },
+    })
+    expect(firstResponse.statusCode).toBe(204)
+    expect(secondResponse.statusCode).toBe(204)
+    expect(sendUpdateSignal).toHaveBeenLastCalledWith(config)
+  })
+
+  it('keeps a queue reservation after an invalid request finishes early', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    const firstBodyRequested = createDeferred()
+    const releaseFirstBody = createDeferred()
+    const firstRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: false } },
+        {
+          bodyRequested: firstBodyRequested,
+          releaseBody: releaseFirstBody.promise,
+        }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await firstBodyRequested.promise
+    const invalidResponse = createResponse()
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      invalidResponse,
+      jest.fn()
+    )
+    expect(invalidResponse.statusCode).toBe(413)
+
+    const thirdBodyConsumed = createDeferred()
+    const thirdRequest = middleware(
+      createRequest(
+        { requestInsights: { verbose: true } },
+        { bodyConsumed: thirdBodyConsumed }
+      ),
+      createResponse(),
+      jest.fn()
+    )
+
+    await thirdBodyConsumed.promise
+    releaseFirstBody.resolve()
+    await Promise.all([firstRequest, thirdRequest])
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { verbose: true },
+    })
+  })
+
+  it('keeps the previous config readable until an update is complete', async () => {
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    const writeStarted = createDeferred()
+    const releaseWrite = createDeferred()
+    const { writeFile } =
+      jest.requireActual<typeof import('fs/promises')>('fs/promises')
+    const writeFileMock = jest.mocked(fsPromises.writeFile)
+    writeFileMock.mockImplementation(async (path, contents, options) => {
+      const serialized = String(contents)
+      if (serialized.includes('"verbose": true')) {
+        await writeFile(path, serialized.slice(0, serialized.length / 2))
+        writeStarted.resolve()
+        await releaseWrite.promise
+      }
+      return writeFile(path, contents, options)
+    })
+
+    try {
+      const update = middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+      await writeStarted.promise
+
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: { showInternal: true },
+      })
+
+      releaseWrite.resolve()
+      await update
+      await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+        requestInsights: {
+          showInternal: true,
+          verbose: true,
+        },
+      })
+    } finally {
+      releaseWrite.resolve()
+      writeFileMock.mockImplementation(writeFile)
+      writeFileMock.mockClear()
+    }
+  })
+
+  it('does not let a missing-file read overwrite the first update', async () => {
+    const writeFile = jest.mocked(fsPromises.writeFile)
+    writeFile.mockClear()
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+    expect(writeFile).not.toHaveBeenCalled()
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a corrupted config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, '{not valid JSON')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('recovers from a schema-invalid config file on the next update', async () => {
+    const configPath = join(distDir, 'cache', 'next-devtools-config.json')
+    await fsPromises.mkdir(join(distDir, 'cache'), { recursive: true })
+    await fsPromises.writeFile(configPath, JSON.stringify({ theme: 123 }))
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal: jest.fn(),
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+  })
+
+  it('keeps the previous config and releases the queue after a failed rename', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    await middleware(
+      createRequest({ requestInsights: { showInternal: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    sendUpdateSignal.mockClear()
+
+    jest
+      .mocked(fsPromises.rename)
+      .mockRejectedValueOnce(new Error('rename failed'))
+
+    await expect(
+      middleware(
+        createRequest({ requestInsights: { verbose: true } }),
+        createResponse(),
+        jest.fn()
+      )
+    ).rejects.toThrow('rename failed')
+
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true },
+    })
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(fsPromises.readdir(join(distDir, 'cache'))).resolves.toEqual([
+      'next-devtools-config.json',
+    ])
+
+    await middleware(
+      createRequest({ requestInsights: { verbose: true } }),
+      createResponse(),
+      jest.fn()
+    )
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({
+      requestInsights: { showInternal: true, verbose: true },
+    })
+  })
+
+  it('rejects config request bodies larger than 64 KiB', async () => {
+    const sendUpdateSignal = jest.fn()
+    const middleware = devToolsConfigMiddleware({
+      distDir,
+      sendUpdateSignal,
+    })
+    const response = createResponse()
+
+    await middleware(
+      createChunkedRequest([Buffer.alloc(64 * 1024, 'x'), Buffer.from('x')]),
+      response,
+      jest.fn()
+    )
+
+    expect(response.statusCode).toBe(413)
+    expect(response.end).toHaveBeenCalledWith('Payload Too Large')
+    expect(sendUpdateSignal).not.toHaveBeenCalled()
+    await expect(getDevToolsConfig(distDir)).resolves.toEqual({})
+  })
+})

--- a/test/unit/request-insights-controller-ownership/index.test.ts
+++ b/test/unit/request-insights-controller-ownership/index.test.ts
@@ -150,7 +150,12 @@ function probeDirectRouterLifecycle(): {
       path.join(os.tmpdir(), 'request-insights-router-lifecycle-')
     )
     process.on('exit', () =>
-      fs.rmSync(dir, { recursive: true, force: true })
+      fs.rmSync(dir, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 100,
+      })
     )
     fs.mkdirSync(path.join(dir, 'pages'), { recursive: true })
     fs.writeFileSync(path.join(dir, 'package.json'), '{"private":true}')

--- a/test/unit/request-insights-controller-ownership/index.test.ts
+++ b/test/unit/request-insights-controller-ownership/index.test.ts
@@ -1,0 +1,454 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const distDir = path.join(__dirname, '../../../packages/next/dist')
+const resultMarker = '__REQUEST_INSIGHTS_RESULT__'
+
+jest.setTimeout(120_000)
+
+function runProbe(script: string, env: Record<string, string> = {}): unknown {
+  const result = spawnSync(process.execPath, ['-e', script, distDir], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      __NEXT_DEV_SERVER: '1',
+      NEXT_TELEMETRY_DISABLED: '1',
+      ...env,
+    },
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 120_000,
+  })
+
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr || result.stdout || `probe exited ${result.status}`
+    )
+  }
+
+  const markerIndex = result.stdout.lastIndexOf(resultMarker)
+  if (markerIndex === -1) {
+    throw new Error(`probe did not report a result:\n${result.stdout}`)
+  }
+
+  return JSON.parse(result.stdout.slice(markerIndex + resultMarker.length))
+}
+
+function probeControllerAfterClose(inject: boolean): {
+  createdOwnController: boolean
+  retainedAfterClose: number
+} {
+  const script = String.raw`
+    const fs = require('node:fs')
+    const os = require('node:os')
+    const path = require('node:path')
+    const distDir = process.argv[1]
+    const inject = ${JSON.stringify(inject)}
+
+    function createFixture() {
+      const dir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'request-insights-ownership-')
+      )
+      fs.mkdirSync(path.join(dir, '.next/server'), { recursive: true })
+      fs.writeFileSync(path.join(dir, '.next/BUILD_ID'), 'test-build-id')
+      fs.writeFileSync(
+        path.join(dir, '.next/prerender-manifest.json'),
+        JSON.stringify({
+          version: 4,
+          routes: {},
+          dynamicRoutes: {},
+          notFoundRoutes: [],
+          preview: {
+            previewModeId: 'test',
+            previewModeSigningKey: 'test',
+            previewModeEncryptionKey: 'test',
+          },
+        })
+      )
+      fs.writeFileSync(path.join(dir, '.next/server/pages-manifest.json'), '{}')
+      fs.writeFileSync(
+        path.join(dir, '.next/server/next-font-manifest.json'),
+        JSON.stringify({
+          pages: {},
+          app: {},
+          appUsingSizeAdjust: false,
+          pagesUsingSizeAdjust: false,
+        })
+      )
+      return dir
+    }
+
+    const { defaultConfig } = require(path.join(
+      distDir,
+      'server/config-shared'
+    ))
+    const NextNodeServer = require(path.join(
+      distDir,
+      'server/next-server'
+    )).default
+    const { RequestInsights } = require(path.join(
+      distDir,
+      'server/lib/trace/request-insights'
+    ))
+
+    async function main() {
+      const injected = inject ? new RequestInsights() : undefined
+      const server = new NextNodeServer({
+        dir: createFixture(),
+        dev: true,
+        quiet: true,
+        minimalMode: false,
+        hostname: 'localhost',
+        port: 3000,
+        conf: {
+          ...defaultConfig,
+          configFileName: 'next.config.js',
+          experimental: {
+            ...defaultConfig.experimental,
+            requestInsights: true,
+            instantInsights: { validationLevel: 'warning' },
+          },
+        },
+        requestInsights: injected,
+      })
+
+      const controller = injected ?? server.requestInsights
+      await server.close()
+      controller.recordSpan({
+        requestId: 'after-close',
+        attributes: { 'next.span_type': 'BaseServer.handleRequest' },
+        startTime: 1,
+        durationMs: 1,
+      })
+      process.stdout.write(
+        '${resultMarker}' +
+          JSON.stringify({
+            createdOwnController: !inject && controller !== undefined,
+            retainedAfterClose: controller.getSnapshot().requests.length,
+          })
+      )
+    }
+
+    main().catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+  `
+
+  return runProbe(script) as ReturnType<typeof probeControllerAfterClose>
+}
+
+function probeDirectRouterLifecycle(): {
+  retainedBeforeClose: number
+  retainedAfterClose: number
+} {
+  const script = String.raw`
+    const fs = require('node:fs')
+    const os = require('node:os')
+    const path = require('node:path')
+    const distDir = process.argv[1]
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'request-insights-router-lifecycle-')
+    )
+    process.on('exit', () =>
+      fs.rmSync(dir, { recursive: true, force: true })
+    )
+    fs.mkdirSync(path.join(dir, 'pages'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"private":true}')
+    fs.writeFileSync(
+      path.join(dir, 'next.config.js'),
+      "module.exports = { experimental: { requestInsights: true, instantInsights: { validationLevel: 'warning' } } }"
+    )
+    fs.writeFileSync(
+      path.join(dir, 'pages/index.js'),
+      'export default function Page() { return null }\n'
+    )
+
+    async function main() {
+      let initialized
+      try {
+        const { initialize } = require(path.join(
+          distDir,
+          'server/lib/router-server'
+        ))
+        initialized = await initialize({
+          dir,
+          port: 3000,
+          dev: true,
+          hostname: 'localhost',
+          quiet: true,
+          onDevServerCleanup: undefined,
+        })
+        const controller = initialized.server.server.requestInsights
+        controller.recordSpan({
+          requestId: 'router-owned',
+          url: '/router-owned',
+          attributes: { 'next.span_type': 'BaseServer.handleRequest' },
+          startTime: 1,
+          durationMs: 1,
+        })
+        const retainedBeforeClose = controller.getSnapshot().requests.length
+
+        await initialized.closeUpgraded()
+        await initialized.server.close()
+        initialized = undefined
+
+        process.stdout.write(
+          '${resultMarker}' +
+            JSON.stringify({
+              retainedBeforeClose,
+              retainedAfterClose: controller.getSnapshot().requests.length,
+            }),
+          () => process.exit(0)
+        )
+      } finally {
+        if (initialized) {
+          await initialized.closeUpgraded()
+          await initialized.server.close().catch(() => {})
+        }
+      }
+    }
+
+    main().catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+  `
+
+  return runProbe(script, {
+    IS_TURBOPACK_TEST: '',
+    TURBOPACK: '',
+  }) as ReturnType<typeof probeDirectRouterLifecycle>
+}
+
+function probeConcurrentRealRequests(): {
+  firstUrls: string[]
+  secondUrls: string[]
+  firstRetainedAfterClose: number
+  secondUrlsAfterFirstClose: string[]
+} {
+  const script = String.raw`
+    const fs = require('node:fs')
+    const http = require('node:http')
+    const os = require('node:os')
+    const path = require('node:path')
+    const distDir = process.argv[1]
+
+    function createFixture(name) {
+      const dir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'request-insights-real-' + name + '-')
+      )
+      fs.mkdirSync(path.join(dir, '.next/server'), { recursive: true })
+      fs.writeFileSync(path.join(dir, '.next/BUILD_ID'), 'test-build-id')
+      fs.writeFileSync(
+        path.join(dir, '.next/prerender-manifest.json'),
+        JSON.stringify({
+          version: 4,
+          routes: {},
+          dynamicRoutes: {},
+          notFoundRoutes: [],
+          preview: {
+            previewModeId: 'test',
+            previewModeSigningKey: 'test',
+            previewModeEncryptionKey: 'test',
+          },
+        })
+      )
+      fs.writeFileSync(path.join(dir, '.next/server/pages-manifest.json'), '{}')
+      fs.writeFileSync(
+        path.join(dir, '.next/server/next-font-manifest.json'),
+        JSON.stringify({
+          pages: {},
+          app: {},
+          appUsingSizeAdjust: false,
+          pagesUsingSizeAdjust: false,
+        })
+      )
+      return dir
+    }
+
+    const { defaultConfig } = require(path.join(
+      distDir,
+      'server/config-shared'
+    ))
+    const NextNodeServer = require(path.join(
+      distDir,
+      'server/next-server'
+    )).default
+    const { traceLocalSpan } = require(path.join(
+      distDir,
+      'server/lib/trace/local-span-recorder'
+    ))
+
+    let concurrentArrivals = 0
+    let releaseConcurrentRequests
+    const concurrentRequestsReady = new Promise((resolve) => {
+      releaseConcurrentRequests = resolve
+    })
+
+    function createRunningServer(name, port) {
+      const server = new NextNodeServer({
+        dir: createFixture(name),
+        dev: true,
+        quiet: true,
+        minimalMode: false,
+        hostname: '127.0.0.1',
+        port,
+        conf: {
+          ...defaultConfig,
+          configFileName: 'next.config.js',
+          experimental: {
+            ...defaultConfig.experimental,
+            requestInsights: true,
+            instantInsights: { validationLevel: 'warning' },
+          },
+        },
+      })
+
+      server.handleRequestImpl = async (req, res) => {
+        await traceLocalSpan({ name: 'real request handler' }, async () => {
+          if (!req.url.includes('after-first-close')) {
+            concurrentArrivals += 1
+            if (concurrentArrivals === 2) releaseConcurrentRequests()
+            await concurrentRequestsReady
+          }
+          const response = res.originalResponse ?? res
+          response.statusCode = 200
+          response.end(req.url)
+        })
+      }
+
+      const httpServer = http.createServer((req, res) => {
+        server.getRequestHandler()(req, res).catch((error) => {
+          res.statusCode = 500
+          res.end(String(error.stack || error))
+        })
+      })
+      return { server, httpServer }
+    }
+
+    async function listen(running) {
+      await new Promise((resolve, reject) => {
+        running.httpServer.once('error', reject)
+        running.httpServer.listen(0, '127.0.0.1', resolve)
+      })
+      running.origin =
+        'http://127.0.0.1:' + running.httpServer.address().port
+    }
+
+    async function fetchOk(running, pathname) {
+      const response = await fetch(running.origin + pathname)
+      const body = await response.text()
+      if (!response.ok) {
+        throw new Error(pathname + ' returned ' + response.status + ': ' + body)
+      }
+    }
+
+    async function waitForUrl(controller, expectedUrl) {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const urls = controller.getSnapshot().requests.map(({ url }) => url)
+        if (urls.includes(expectedUrl)) return urls
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      throw new Error('Timed out waiting for ' + expectedUrl)
+    }
+
+    async function closeRunning(running) {
+      await new Promise((resolve, reject) => {
+        running.httpServer.close((error) =>
+          error ? reject(error) : resolve()
+        )
+        running.httpServer.closeAllConnections()
+      })
+      await running.server.close()
+    }
+
+    async function main() {
+      let first = createRunningServer('first', 3000)
+      let second = createRunningServer('second', 3001)
+      try {
+        await Promise.all([listen(first), listen(second)])
+        await Promise.all([
+          fetchOk(first, '/first'),
+          fetchOk(second, '/second'),
+        ])
+
+        const firstController = first.server.requestInsights
+        const secondController = second.server.requestInsights
+        const [firstUrls, secondUrls] = await Promise.all([
+          waitForUrl(firstController, '/first'),
+          waitForUrl(secondController, '/second'),
+        ])
+
+        await closeRunning(first)
+        first = undefined
+
+        await fetchOk(second, '/second-after-first-close')
+        const secondUrlsAfterFirstClose = await waitForUrl(
+          secondController,
+          '/second-after-first-close'
+        )
+
+        const result = {
+          firstUrls,
+          secondUrls,
+          firstRetainedAfterClose:
+            firstController.getSnapshot().requests.length,
+          secondUrlsAfterFirstClose,
+        }
+
+        await closeRunning(second)
+        second = undefined
+        process.stdout.write(
+          '${resultMarker}' + JSON.stringify(result),
+          () => process.exit(0)
+        )
+      } finally {
+        if (first) await closeRunning(first).catch(() => {})
+        if (second) await closeRunning(second).catch(() => {})
+      }
+    }
+
+    main().catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+  `
+
+  return runProbe(script) as ReturnType<typeof probeConcurrentRealRequests>
+}
+
+describe('Request Insights controller ownership', () => {
+  it('transfers router ownership to the render server close lifecycle', () => {
+    expect(probeDirectRouterLifecycle()).toEqual({
+      retainedBeforeClose: 1,
+      retainedAfterClose: 0,
+    })
+  })
+
+  it('isolates concurrent real requests across two servers', () => {
+    const result = probeConcurrentRealRequests()
+
+    expect(result.firstUrls).toContain('/first')
+    expect(result.firstUrls).not.toContain('/second')
+    expect(result.secondUrls).toContain('/second')
+    expect(result.secondUrls).not.toContain('/first')
+    expect(result.firstRetainedAfterClose).toBe(0)
+    expect(result.secondUrlsAfterFirstClose).toContain(
+      '/second-after-first-close'
+    )
+  })
+
+  it('preserves an injected controller across server close', () => {
+    expect(probeControllerAfterClose(true)).toEqual({
+      createdOwnController: false,
+      retainedAfterClose: 1,
+    })
+  })
+
+  it('disposes a self-created controller on server close', () => {
+    expect(probeControllerAfterClose(false)).toEqual({
+      createdOwnController: true,
+      retainedAfterClose: 0,
+    })
+  })
+})

--- a/test/unit/request-insights-production-dce/index.test.ts
+++ b/test/unit/request-insights-production-dce/index.test.ts
@@ -1,0 +1,134 @@
+import { spawnSync } from 'node:child_process'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const nextPackageDir = path.join(__dirname, '../../../packages/next')
+const distDir = path.join(nextPackageDir, 'dist')
+const productionRuntimeDir = path.join(distDir, 'compiled/next-server')
+const entrypoints = [
+  'server/base-server.js',
+  'server/lib/router-server.js',
+  'server/app-render/app-render.js',
+  'server/route-modules/app-route/module.js',
+  'server/lib/patch-fetch.js',
+  'server/next-server.js',
+]
+
+function probeLoadedRequestInsightsModules() {
+  const script = String.raw`
+    const path = require('node:path')
+    const distDir = process.argv[1]
+    const entrypoints = JSON.parse(process.argv[2])
+    const results = []
+
+    async function main() {
+      for (const entrypoint of entrypoints) {
+        for (const modulePath of Object.keys(require.cache)) {
+          delete require.cache[modulePath]
+        }
+
+        delete process.env.__NEXT_DEV_SERVER
+
+        const entrypointModule = require(path.join(distDir, entrypoint))
+        if (entrypoint === 'server/lib/patch-fetch.js') {
+          const originalFetch = globalThis.fetch
+          entrypointModule.patchFetch({
+            workAsyncStorage: { getStore: () => undefined },
+            workUnitAsyncStorage: { getStore: () => undefined },
+          })
+          const response = await globalThis.fetch(
+            'data:text/plain,request-insights-dce-probe'
+          )
+          await response.text()
+          globalThis.fetch = originalFetch
+          delete globalThis[Symbol.for('next-patch')]
+        }
+        results.push({
+          entrypoint,
+          modules: Object.keys(require.cache)
+            .map((modulePath) =>
+              path.relative(distDir, modulePath).split(path.sep).join('/')
+            )
+            .filter((modulePath) => modulePath.includes('request-insights')),
+        })
+      }
+
+      process.stdout.write(JSON.stringify(results))
+    }
+
+    main().catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+  `
+  const result = spawnSync(
+    process.execPath,
+    ['-e', script, distDir, JSON.stringify(entrypoints)],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        __NEXT_DEV_SERVER: '',
+      },
+    }
+  )
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `module probe exited ${result.status}`)
+  }
+
+  return JSON.parse(result.stdout) as Array<{
+    entrypoint: string
+    modules: string[]
+  }>
+}
+
+describe('Request Insights production module graph', () => {
+  it('does not load dev-only Request Insights modules in production', () => {
+    expect(probeLoadedRequestInsightsModules()).toEqual(
+      entrypoints.map((entrypoint) => ({
+        entrypoint,
+        modules: [],
+      }))
+    )
+  })
+
+  it('excludes the controller runtime from fresh app production bundles', () => {
+    const sourceMtime = Math.max(
+      statSync(
+        path.join(nextPackageDir, 'src/server/lib/trace/local-span-recorder.ts')
+      ).mtimeMs,
+      statSync(
+        path.join(
+          nextPackageDir,
+          'src/server/route-modules/app-route/module.ts'
+        )
+      ).mtimeMs
+    )
+    const runtimeArtifacts = readdirSync(productionRuntimeDir)
+      .filter((filename) =>
+        /^app-(?:page|route).*\.runtime\.prod\.js$/.test(filename)
+      )
+      .sort()
+
+    expect(runtimeArtifacts).toEqual([
+      'app-page-experimental.runtime.prod.js',
+      'app-page-turbo-experimental.runtime.prod.js',
+      'app-page-turbo.runtime.prod.js',
+      'app-page.runtime.prod.js',
+      'app-route-experimental.runtime.prod.js',
+      'app-route-turbo-experimental.runtime.prod.js',
+      'app-route-turbo.runtime.prod.js',
+      'app-route.runtime.prod.js',
+    ])
+
+    for (const filename of runtimeArtifacts) {
+      const artifactPath = path.join(productionRuntimeDir, filename)
+      expect(statSync(artifactPath).mtimeMs).toBeGreaterThanOrEqual(sourceMtime)
+
+      const contents = readFileSync(artifactPath, 'utf8')
+      expect(contents).not.toContain('request-insights-runtime')
+      expect(contents).not.toContain('@next/request-insights-runtime-storage')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- bound Request Insights retention independently across page, API, asset, proxy, Instant Insights, and unknown request groups, with aggregate and per-bucket serialized-byte budgets
- cap logical-root records, spans, fetches, events, links, identifiers, URLs, and metadata while reporting permanent capture loss separately from per-snapshot projection loss
- publish bucket-fair, newest-suffix snapshots under an exact 4 MiB UTF-8 limit and prevent late async completions from resurrecting evicted roots or records
- isolate subscriber, MCP, and snapshot consumers with deep-cloned bounded data and whole-root queries

## Verification

- focused capture, recorder, span-store, ownership, and production DCE tests (66 passed)
- Request Insights development tests with Turbopack (22 passed)
- Request Insights development tests with webpack (22 passed)
- `pnpm types`
- `pnpm types-and-precompiled`
- `pnpm --filter=next build`
- exact UTF-8, at-limit/over-limit, child-first classification, invalid-limit, late-write, eviction, clear, and disposal regressions
- changed-file Prettier, ESLint, lint-staged, and `git diff --check`
