### PR TITLE
fix(client): bound the offline retry loops in fetchServerResponse and fetchServerAction

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response-offline.test.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response-offline.test.ts
@@ -1,0 +1,72 @@
+import { fetchServerResponse } from './fetch-server-response'
+import { fetch as segmentCacheFetch } from '../segment-cache/fetch'
+
+jest.mock('../segment-cache/fetch', () => ({
+  fetch: jest.fn(),
+}))
+
+// Mock the offline module so the test controls connectivity state without
+// touching the network or timers.
+jest.mock('../offline', () => ({
+  checkOfflineError: jest.fn(() => true),
+  getOffline: jest.fn(() => ({})),
+  waitForConnection: jest.fn(() => Promise.resolve()),
+}))
+
+// The real react-server-dom-webpack client needs Next's bundler-config aliasing
+// that only exists in built apps. The Flight client reports fetch rejections
+// through the response (not as unhandled rejections); emulate that here.
+jest.mock('react-server-dom-webpack/client', () => ({
+  createFromFetch: (promise: Promise<any>) => {
+    promise.catch(() => {})
+    return promise
+  },
+  createFromReadableStream: jest.fn(),
+}))
+
+const fetchMock = segmentCacheFetch as jest.Mock
+
+describe('fetchServerResponse offline retry', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    process.env.__NEXT_USE_OFFLINE = '1'
+  })
+
+  afterEach(() => {
+    delete process.env.__NEXT_USE_OFFLINE
+  })
+
+  const options = {
+    flightRouterState: ['', {}] as any,
+    nextUrl: null,
+  }
+
+  it('falls back to an MPA navigation after the retry budget is exhausted', async () => {
+    // A deterministic failure that checkOfflineError misclassifies as
+    // offline (e.g. a Flight decode error) must not retry forever.
+    fetchMock.mockRejectedValue(new Error('deterministic failure'))
+
+    const result = await fetchServerResponse(
+      new URL('https://example.com/foo'),
+      options
+    )
+
+    // 1 initial attempt + MAX_OFFLINE_RETRIES (2) retries, then the MPA
+    // fallback. Before the fix, this looped forever.
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result).toBe('https://example.com/foo')
+  })
+
+  it('does not retry when the offline handling is disabled', async () => {
+    delete process.env.__NEXT_USE_OFFLINE
+    fetchMock.mockRejectedValue(new Error('deterministic failure'))
+
+    const result = await fetchServerResponse(
+      new URL('https://example.com/foo'),
+      options
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result).toBe('https://example.com/foo')
+  })
+})

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -146,9 +146,22 @@ if (typeof window !== 'undefined') {
  * Fetch the flight data for the provided url. Takes in the current router state
  * to decide what to render server-side.
  */
+// How many times a failed navigation fetch is retried after connectivity
+// is restored when experimental.useOffline is enabled. The retry is only
+// reached when checkOfflineError classified the failure as a network error,
+// but that classification is by exclusion — a deterministic failure (e.g. a
+// Flight decode error) would otherwise loop forever: retry -> same error ->
+// connectivity check succeeds -> retry. After the budget is exhausted we fall
+// through to the console.error + MPA-navigation fallback below.
+const MAX_OFFLINE_RETRIES = 2
+
 export async function fetchServerResponse(
   url: URL,
-  options: FetchServerResponseOptions
+  options: FetchServerResponseOptions,
+  // Number of times this request has already been retried after connectivity
+  // was restored. Bounds the offline retry loop so a deterministic failure
+  // can never loop forever.
+  offlineRetryCount = 0
 ): Promise<FetchServerResponseResult> {
   const { flightRouterState, nextUrl } = options
 
@@ -332,7 +345,11 @@ export async function fetchServerResponse(
     // all pending retries resume simultaneously. This is mitigated in PR 3
     // by reusing back-forward cache entries during offline navigation, which
     // avoids issuing new fetches in the first place.
-    if (process.env.__NEXT_USE_OFFLINE && !isPageUnloading) {
+    if (
+      process.env.__NEXT_USE_OFFLINE &&
+      !isPageUnloading &&
+      offlineRetryCount < MAX_OFFLINE_RETRIES
+    ) {
       const { checkOfflineError, getOffline, waitForConnection } =
         require('../offline') as typeof import('../offline')
       if (checkOfflineError(err)) {
@@ -340,7 +357,10 @@ export async function fetchServerResponse(
         if (offline !== null) {
           await waitForConnection(offline)
         }
-        return fetchServerResponse(url, options)
+        // Retry from the original URL: in output-export mode `url` was
+        // rewritten to the .txt asset above, and re-deriving it from the
+        // rewritten URL would append .txt again on each retry.
+        return fetchServerResponse(originalUrl, options, offlineRetryCount + 1)
       }
     }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -101,10 +101,19 @@ type FetchServerActionResult = {
   couldBeIntercepted: boolean
 }
 
+// How many times a failed server-action fetch is replayed after connectivity
+// is restored when experimental.useOffline is enabled. Bounds the offline
+// retry loop so a deterministic failure can never loop forever.
+const MAX_OFFLINE_RETRIES = 2
+
 async function fetchServerAction(
   state: ReadonlyReducerState,
   nextUrl: ReadonlyReducerState['nextUrl'],
-  action: ServerActionAction
+  action: ServerActionAction,
+  // Number of times this action has already been replayed after connectivity
+  // was restored. Bounds the offline retry loop so a deterministic failure
+  // can never loop forever.
+  offlineRetryCount = 0
 ): Promise<FetchServerActionResult> {
   const { actionId, actionArgs } = action
   const temporaryReferences = createTemporaryReferenceSet()
@@ -153,7 +162,10 @@ async function fetchServerAction(
       notifyOnline()
     }
   } catch (err) {
-    if (process.env.__NEXT_USE_OFFLINE) {
+    if (
+      process.env.__NEXT_USE_OFFLINE &&
+      offlineRetryCount < MAX_OFFLINE_RETRIES
+    ) {
       const { checkOfflineError, getOffline, waitForConnection } =
         require('../../offline') as typeof import('../../offline')
       if (checkOfflineError(err)) {
@@ -164,7 +176,7 @@ async function fetchServerAction(
         if (offline !== null) {
           await waitForConnection(offline)
         }
-        return fetchServerAction(state, nextUrl, action)
+        return fetchServerAction(state, nextUrl, action, offlineRetryCount + 1)
       }
     }
     throw err


### PR DESCRIPTION
## What

`checkOfflineError()` (client/components/offline.ts, behind `experimental.useOffline`) classifies by exclusion: every thrown value except `AbortError`/`TimeoutError` is treated as a network failure. But in `fetch-server-response.ts` the `try` block spans the **whole response pipeline** — `createFetch`, `new URL(res.url)`, Flight decoding, `resolveStaticStageData` — so any deterministic, non-network failure (a Flight decode error, a truncated RSC stream, a framework `TypeError`) is misclassified as offline, and the handler then:

```
checkOfflineError(err) → notifyOffline() → checkConnectivity() → HEAD succeeds
(the server was always reachable) → waitForConnection() resolves immediately
→ return fetchServerResponse(url, options)   // same error → repeat
```

— an **uncapped, no-backoff retry loop** of full RSC requests from every affected client (and of POST requests via `server-action-reducer.ts`): self-DoS in the browser, request amplification against the origin/CDN, the navigation never completes, and the existing `console.error` + MPA-navigation fallback is never reached.

Verified empirically: with fetch rejecting deterministically and the offline module mocked to report offline-then-online, the navigation retry **loops forever** (jest 60s timeout) before this fix.

## Fix

Both `fetchServerResponse` and `fetchServerAction` get a retry budget (`MAX_OFFLINE_RETRIES = 2`, threaded as an internal trailing parameter, default 0). Once exhausted:

- navigation fetches fall through to the pre-existing `console.error` + MPA-navigation fallback,
- action fetches rethrow.

Genuine offline recovery is unaffected: the retry only runs after `waitForConnection()` resolves, and a healthy retry succeeds on the first replay.

Also fixed along the way: the retry now starts from `originalUrl` — in `output: 'export'` mode the request URL was rewritten to the `.txt` asset before the fetch, and retrying from the rewritten URL would append `.txt` again on every attempt (`/foo.txt.txt`).

## Scope note

The segment-cache prefetch path (`cache.ts`, `rejectRouteCacheEntry(entry, -1)`) has an analogous ping-driven re-fetch loop, and the deeper fix — scoping offline classification to the network call itself rather than the whole pipeline — is left as follow-up. This PR is the bounded safety net that makes a deterministic failure terminate.

## Tests

New `fetch-server-response-offline.test.ts` (mocks `../segment-cache/fetch` with a deterministic rejection, `../offline` to report offline-then-online, and `react-server-dom-webpack/client` to emulate the Flight client's rejection handling):

- budget exhaustion → exactly 3 fetch calls (1 + 2 retries), then the MPA fallback — loops forever before the fix;
- control: with the flag disabled, exactly 1 call.

All 43 client unit tests pass; `tsc`/`eslint` green.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
