### PR TITLE
fix(client): don't replay server actions while the page is unloading

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -127,6 +127,16 @@ function doMpaNavigation(url: string): FetchServerResponseResult {
 
 let isPageUnloading = false
 
+/**
+ * Whether the page is currently unloading (reloading or hard-navigating).
+ * When true, in-flight request failures are expected — the browser cancels
+ * pending requests during unload — so callers should suppress offline
+ * handling, retries, and error logging.
+ */
+export function getIsPageUnloading(): boolean {
+  return isPageUnloading
+}
+
 if (typeof window !== 'undefined') {
   // Track when the page is unloading, e.g. due to reloading the page or
   // performing hard navigations. This allows us to suppress error logging when

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -16,6 +16,7 @@ import {
 } from '../../app-router-headers'
 import { UnrecognizedActionError } from '../../unrecognized-action-error'
 import { fetch } from '../../segment-cache/fetch'
+import { getIsPageUnloading } from '../fetch-server-response'
 
 // TODO: Explicitly import from client.browser
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -153,13 +154,16 @@ async function fetchServerAction(
       notifyOnline()
     }
   } catch (err) {
-    if (process.env.__NEXT_USE_OFFLINE) {
+    if (process.env.__NEXT_USE_OFFLINE && !getIsPageUnloading()) {
       const { checkOfflineError, getOffline, waitForConnection } =
         require('../../offline') as typeof import('../../offline')
       if (checkOfflineError(err)) {
-        // It's safe to replay the action because the fetch rejection
-        // means the request never reached the server — there are no
-        // side effects to duplicate.
+        // Best-effort replay: a fetch rejection usually means the request
+        // never reached the server, but it cannot be distinguished from
+        // "sent, response lost" — so the action may run twice server-side.
+        // Skipped entirely while the page is unloading, when the browser
+        // cancels in-flight requests (a plain TypeError, not an AbortError)
+        // and any replay would race page teardown.
         const offline = getOffline()
         if (offline !== null) {
           await waitForConnection(offline)


### PR DESCRIPTION
## What

The navigation path's offline retry (`fetch-server-response.ts`, behind `experimental.useOffline`) is deliberately gated on `!isPageUnloading`: during page unload (reload, external link, MPA navigation) the browser cancels in-flight requests with a plain `TypeError` — **not** a `DOMException` — which `checkOfflineError` misclassifies as a network failure.

The server-action path — the only **non-idempotent** one — omits that guard. On unload:

1. the in-flight action POST is aborted and misclassified as offline,
2. the action is **replayed** after the connectivity probe, racing page teardown — even though the original request may already have committed server-side (duplicate mutation),
3. `notifyOffline()` falsely flips the whole app into the offline state (pausing the prefetch scheduler) while the page is dying.

The existing comment justifying the replay ("the fetch rejection means the request never reached the server — there are no side effects to duplicate") is also inaccurate: a `fetch` rejection covers the window where the request was fully transmitted and the response was lost (LB idle timeout, server restart post-commit, network handover), which cannot be distinguished client-side.

## Fix

- Export `getIsPageUnloading()` from `fetch-server-response.ts` and gate the action replay on it, mirroring the navigation path.
- Correct the comment to document the "sent, response lost" window.

Intentionally out of scope: the broader replay-by-default design (idempotency keys echoed to the server, per-action opt-in) is a protocol decision for the maintainers. This PR just mirrors the unload guard the navigation path already has.

## Tests

`tsc`/`eslint` clean; module-load probe confirms no circular import; all 43 client unit tests pass. (Interacts with #96850's retry budget at the same condition — either merge order works with a trivial rebase.)

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
