### PR TITLE
fix(server): emit basePath-free x-nextjs-rewritten-path for config rewrites

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -884,7 +884,15 @@ export function getResolveRoutes(
             if (parsedUrl.pathname !== parsedDestination.pathname) {
               res.setHeader(
                 NEXT_REWRITTEN_PATH_HEADER,
-                parsedDestination.pathname
+                // Emit the basePath-free route pathname: clients parse route
+                // params from this value, and route paths never include the
+                // basePath (middleware rewrites via web/adapter.ts already
+                // emit the basePath-free form). Only strip for internal
+                // rewrites — external destinations never had this app's
+                // basePath prepended.
+                parsedDestination.origin
+                  ? parsedDestination.pathname
+                  : removePathPrefix(parsedDestination.pathname, config.basePath)
               )
             }
             if (parsedUrl.search !== parsedDestination.search) {

--- a/test/e2e/app-dir/rewrite-headers-basepath/app/layout.jsx
+++ b/test/e2e/app-dir/rewrite-headers-basepath/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/rewrite-headers-basepath/app/page.jsx
+++ b/test/e2e/app-dir/rewrite-headers-basepath/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>home</div>
+}

--- a/test/e2e/app-dir/rewrite-headers-basepath/app/team/[slug]/page.jsx
+++ b/test/e2e/app-dir/rewrite-headers-basepath/app/team/[slug]/page.jsx
@@ -1,0 +1,3 @@
+export default function TeamPage() {
+  return <div>team</div>
+}

--- a/test/e2e/app-dir/rewrite-headers-basepath/next.config.js
+++ b/test/e2e/app-dir/rewrite-headers-basepath/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import("next").NextConfig} */
+module.exports = {
+  basePath: "/docs",
+  rewrites: async () => [
+    {
+      source: "/r/:path*",
+      destination: "/team/:path*",
+    },
+  ],
+}

--- a/test/e2e/app-dir/rewrite-headers-basepath/rewrite-headers-basepath.test.ts
+++ b/test/e2e/app-dir/rewrite-headers-basepath/rewrite-headers-basepath.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('rewrite-headers with basePath', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('emits a basePath-free x-nextjs-rewritten-path for config rewrites (RSC)', async () => {
+    const res = await next.fetch('/docs/r/alpha', {
+      headers: { rsc: '1' },
+      redirect: 'manual',
+    })
+    // The client parses route params from this header, and route paths never
+    // include the basePath. Previously this was '/docs/team/alpha', shifting
+    // every dynamic param by one segment.
+    expect(res.headers.get('x-nextjs-rewritten-path')).toBe('/team/alpha')
+  })
+
+  it('emits no rewrite headers for a direct hit', async () => {
+    const res = await next.fetch('/docs/team/alpha', {
+      headers: { rsc: '1' },
+      redirect: 'manual',
+    })
+    expect(res.headers.get('x-nextjs-rewritten-path')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

`getRenderedPathname` (client/route-params.ts) returns the `x-nextjs-rewritten-path` header verbatim, while the no-rewrite fallback explicitly strips the basePath. The server emitter (`resolve-routes.ts`) set the header from `parsedDestination.pathname`, which **carries the configured basePath for config rewrites** (`load-custom-routes.ts` prepends `destBasePath` to internal destinations).

Clients split that pathname into parts to index dynamic params (`fillInFallbackFlightRouterState`, `convertRootTreePrefetchToRouteTree`), so with e.g. `basePath: '/docs'` + a config rewrite on a dynamic route, every dynamic/catch-all param shifted by one segment (`useParams().slug === 'docs'`) and segment-cache/vary-path entries were keyed under the wrong values.

## Fix

Strip the basePath at the emitter so the header carries the canonical route pathname — the same shape middleware rewrites already emit via `web/adapter.ts`:

```ts
res.setHeader(
  NEXT_REWRITTEN_PATH_HEADER,
  parsedDestination.origin
    ? parsedDestination.pathname
    : removePathPrefix(parsedDestination.pathname, config.basePath)
)
```

- `removePathPrefix` is segment-boundary aware (`/documents/x` with basePath `/docs` is untouched).
- **External rewrites** to allowed origins are unaffected: they never had this app's basePath prepended, so nothing is stripped.
- The emitter-side fix (rather than client-side normalization) avoids the ambiguity where a middleware rewrite to a literal route `/docs/team` under basePath `/docs` is indistinguishable from a basePath-carrying config rewrite — the client cannot tell the two shapes apart, but the emitter knows.

Verified end-to-end with a real app (`basePath: '/docs'`, rewrite `/r/:path*` → `/team/:path*`, built and started with the patched dist): pre-fix header `/docs/team/alpha`, post-fix `/team/alpha`; direct hits and the middleware emitter unchanged.

## Tests

New e2e `test/e2e/app-dir/rewrite-headers-basepath`: asserts the basePath-free header for config rewrites (RSC) and a null header for direct hits — fails before this fix, passes after. The existing `rewrite-headers` suite (35 tests) passes; `tsc`/`eslint` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
