### PR TITLE
fix(build): rename source maps alongside their chunk in inline-static-env

### DIFF
--- a/packages/next/src/lib/inline-static-env.test.ts
+++ b/packages/next/src/lib/inline-static-env.test.ts
@@ -1,0 +1,76 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { inlineStaticEnv } from './inline-static-env'
+
+describe('inlineStaticEnv', () => {
+  const ENV_KEY = 'NEXT_PUBLIC_DEEPSEC_TEST'
+
+  beforeEach(() => {
+    process.env[ENV_KEY] = 'inlined-value'
+  })
+  afterEach(() => {
+    delete process.env[ENV_KEY]
+  })
+
+  it('renames a chunk and its source map to one consistent new hash', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'inline-static-env-'))
+    try {
+      const distDir = path.join(tmp, '.next')
+      const hash = 'aaaaaaaaaaaaaaaa'
+      fs.mkdirSync(path.join(distDir, 'static', 'chunks'), {
+        recursive: true,
+      })
+      fs.mkdirSync(path.join(distDir, 'server'), { recursive: true })
+      fs.writeFileSync(
+        path.join(distDir, 'static', 'chunks', `main-${hash}.js`),
+        `console.log(process.env.${ENV_KEY})\n//# sourceMappingURL=main-${hash}.js.map\n`
+      )
+      fs.writeFileSync(
+        path.join(distDir, 'static', 'chunks', `main-${hash}.js.map`),
+        JSON.stringify({
+          version: 3,
+          file: `main-${hash}.js`,
+          sources: ['input.js'],
+          // The map embeds the original source, so it contains the same
+          // env reference and is also rewritten.
+          sourcesContent: [`console.log(process.env.${ENV_KEY})`],
+        })
+      )
+      fs.writeFileSync(
+        path.join(distDir, 'build-manifest.json'),
+        JSON.stringify({ pages: { '/': [`static/chunks/main-${hash}.js`] } })
+      )
+
+      await inlineStaticEnv({ distDir, config: { env: {} } as any })
+
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(distDir, 'build-manifest.json'), 'utf8')
+      )
+      const chunkRef: string = manifest.pages['/'][0]
+      const newHash = chunkRef.match(/main-([a-z0-9]{16})\.js/)![1]
+      expect(newHash).not.toBe(hash)
+
+      // The manifest references a chunk that actually exists...
+      expect(fs.existsSync(path.join(distDir, chunkRef))).toBe(true)
+      // ...and its sourcemap link resolves to an existing map with the same hash.
+      const chunkContent = fs.readFileSync(path.join(distDir, chunkRef), 'utf8')
+      expect(chunkContent).toContain('sourceMappingURL=main-' + newHash + '.js.map')
+      expect(
+        fs.existsSync(
+          path.join(distDir, 'static', 'chunks', `main-${newHash}.js.map`)
+        )
+      ).toBe(true)
+
+      // The env value was inlined into both files.
+      expect(chunkContent).toContain('"inlined-value"')
+      const mapContent = fs.readFileSync(
+        path.join(distDir, 'static', 'chunks', `main-${newHash}.js.map`),
+        'utf8'
+      )
+      expect(mapContent).toContain('inlined-value')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/next/src/lib/inline-static-env.ts
+++ b/packages/next/src/lib/inline-static-env.ts
@@ -80,6 +80,17 @@ export async function inlineStaticEnv({
 
   // hashes need updating for any changed client files
   for (const { file, content } of changedClientFiles) {
+    // Source maps are renamed alongside their chunk below: they share the
+    // chunk's original hash, so computing a separate content hash for the
+    // map would produce two hashChanges entries with the same originalHash
+    // and different newHashes. The reference fixup would then rewrite
+    // manifests/runtime to whichever entry landed first (nondeterministic,
+    // under concurrent I/O), potentially pointing at a .js name that was
+    // never created.
+    if (file.endsWith('.js.map')) {
+      continue
+    }
+
     // hash is 16 chars currently for all client chunks
     const originalHash = file.match(/([a-z0-9]{16})\./)?.[1] || ''
 
@@ -98,6 +109,28 @@ export async function inlineStaticEnv({
 
     const filepath = path.join(clientDir, file)
     const newFilepath = filepath.replace(originalHash, newHash)
+
+    filesToCheck.delete(filepath)
+    filesToCheck.add(newFilepath)
+
+    await fs.promises.rename(filepath, newFilepath)
+  }
+
+  // Rename source maps to their chunk's new hash so every name derived from
+  // one original hash stays consistent (and so `sourceMappingURL` references
+  // rewritten by the fixup below resolve to an existing file).
+  for (const { file } of changedClientFiles) {
+    if (!file.endsWith('.js.map')) {
+      continue
+    }
+    const originalHash = file.match(/([a-z0-9]{16})\./)?.[1] || ''
+    const change = hashChanges.find((c) => c.originalHash === originalHash)
+    if (!change) {
+      // The chunk itself wasn't renamed — leave the map as is.
+      continue
+    }
+    const filepath = path.join(clientDir, file)
+    const newFilepath = filepath.replace(originalHash, change.newHash)
 
     filesToCheck.delete(filepath)
     filesToCheck.add(newFilepath)


### PR DESCRIPTION
## What

In the deploy-time env-inlining flow (`next build --experimental-build-mode generate`/`generate-env`), `inline-static-env.ts` processes the client glob `**/*.{js,json,js.map}` under `distDir/static`. With `productionBrowserSourceMaps` enabled, both `chunks/main-<hash>.js` and `chunks/main-<hash>.js.map` contain the inlined `NEXT_PUBLIC_*` text (sourcemaps embed it in `sourcesContent`), so both land in `changedClientFiles`.

For each entry the code extracts `originalHash` from the **filename** (identical for the two files) but computes `newHash` from the **content** (different). Two `hashChanges` entries then share one `originalHash` with different `newHash`es. Both files are renamed to different names, and the reference fixup's `replaceAll(originalHash, newHash)` effectively applies only the first entry — whose identity depends on concurrent I/O completion order (`new Sema(8)`), i.e. **nondeterministic**:

- If the `.js.map` entry wins, `build-manifest.json`/`webpack-runtime.js` are rewritten to `main-<mapHash>.js` — a file that does not exist — so the app's main chunk 404s and the deployed site is broken.
- In the "lucky" ordering, the JS chunk's `//# sourceMappingURL=main-<hash>.js.map` is rewritten to a name that doesn't exist (the map was renamed to its own hash).

## Fix

Compute content hashes from the JS chunk only, then rename each `.js.map` to its chunk's new hash in a second loop. Every name derived from one original hash stays consistent; the global `replaceAll` fixup then rewrites all references (including `sourceMappingURL` and the map's `file` field) coherently. A changed map whose chunk was *not* renamed is left mutated in place (name unchanged, references stay consistent).

## Tests

New `inline-static-env.test.ts` builds a temp `.next` (chunk with env ref + `sourceMappingURL`, its `.js.map` with `sourcesContent`, and a `build-manifest.json` referencing the chunk), runs `inlineStaticEnv`, and asserts:

- the manifest references an **existing** chunk with a new hash,
- the chunk's `sourceMappingURL` points at an **existing** same-hash map,
- both files got the inlined value.

Verified failing before the fix (broken reference), passing after. `jest`/`tsc`/`eslint` green.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
