### PR TITLE
fix(server): keep ReplayableNodeStream chunk order when reads lag behind

### DIFF
--- a/packages/next/src/server/app-render/app-render-prerender-utils.test.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.test.ts
@@ -16,6 +16,19 @@ function tick(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve))
 }
 
+async function waitForChunks(
+  replayable: ReplayableNodeStream,
+  count: number
+): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if ((replayable as any)._chunks.length >= count) {
+      return
+    }
+    await tick()
+  }
+  throw new Error('timed out waiting for chunks to buffer')
+}
+
 describe('ReplayableNodeStream', () => {
   describe('construction and buffering', () => {
     it('buffers Uint8Array chunks from the source', async () => {
@@ -387,6 +400,52 @@ describe('ReplayableNodeStream', () => {
         [1, 2],
         [3, 4],
       ])
+    })
+  })
+
+  describe('ordering', () => {
+    it('delivers buffered and live chunks in order when a chunk arrives between createReplayStream() and the first read', async () => {
+      const source = new PassThrough()
+      const replayable = new ReplayableNodeStream(source)
+
+      source.write(new Uint8Array([1]))
+      // The first chunk is buffered before the replay stream is created.
+      await waitForChunks(replayable, 1)
+
+      const replay = replayable.createReplayStream()
+
+      // A new chunk arrives after createReplayStream() but before the
+      // consumer reads. It must not overtake the buffered chunk.
+      source.write(new Uint8Array([2]))
+      await waitForChunks(replayable, 2)
+      source.end()
+
+      const collected = await collectBytes(replay)
+      expect(collected).toEqual([[1], [2]])
+    })
+
+    it('delivers buffered chunks when the source ends before the first read', async () => {
+      const source = new PassThrough()
+      const replayable = new ReplayableNodeStream(source)
+
+      source.write(new Uint8Array([1]))
+      await waitForChunks(replayable, 1)
+
+      const replay = replayable.createReplayStream()
+
+      // The source ends before the consumer reads anything; the buffered
+      // chunk must still be delivered (not truncated by an early end).
+      source.end()
+      await waitForChunks(replayable, 1)
+      await new Promise<void>((resolve) => {
+        if ((replayable as any)._done) {
+          return resolve()
+        }
+        source.on('end', () => resolve())
+      })
+
+      const collected = await collectBytes(replay)
+      expect(collected).toEqual([[1]])
     })
   })
 })

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -176,6 +176,12 @@ export class ReplayableNodeStream {
     const bufferedChunks = this._chunks.slice()
     let bufferIndex = 0
     let bufferDrained = false
+    // Chunks that arrive after this replay stream was created but before its
+    // buffer was drained. They must not be pushed eagerly: the buffered chunks
+    // are delivered from _read() (see the comment above), so an eager push
+    // would deliver a newer chunk before the buffered ones — out of order.
+    const pendingChunks: Uint8Array[] = []
+    let sourceEnded = false
     const isDone = this._done
     const sourceError = this._error
 
@@ -187,7 +193,11 @@ export class ReplayableNodeStream {
             this.push(bufferedChunks[i])
           }
           bufferIndex = bufferedChunks.length
-          if (isDone) {
+          for (const chunk of pendingChunks) {
+            this.push(chunk)
+          }
+          pendingChunks.length = 0
+          if (isDone || sourceEnded) {
             this.push(null)
           }
         }
@@ -205,10 +215,19 @@ export class ReplayableNodeStream {
 
     const subscriber: ReplayableStreamSubscriber = {
       onChunk: (chunk) => {
-        stream.push(chunk)
+        if (bufferDrained) {
+          stream.push(chunk)
+        } else {
+          pendingChunks.push(chunk)
+        }
       },
       onEnd: () => {
-        stream.push(null)
+        if (bufferDrained) {
+          stream.push(null)
+        } else {
+          // The end is delivered once the buffer is drained in _read().
+          sourceEnded = true
+        }
       },
       onError: (err) => {
         stream.destroy(err)


### PR DESCRIPTION
## What

`ReplayableNodeStream` (server/app-render/app-render-prerender-utils.ts — used to tee the RSC Flight payload for SSR and inlined hydration data on Node builds) attaches a `data` listener at construction, buffering source chunks into `_chunks`. `createReplayStream()` snapshots the buffered chunks and delivers them lazily from `_read()` — deliberately pull-based so delivery happens in the consumer's AsyncLocalStorage scope — while a subscriber pushes **newly arriving** chunks eagerly via `stream.push()`.

Those two delivery paths aren't ordered with respect to each other:

1. **Reordering:** a chunk arriving after `createReplayStream()` but before the consumer's first read is pushed into the fresh Readable first; `_read()` then pushes the snapshot after it. The replay yields `N+1, 0..N` — out-of-order Flight rows (corrupted deserialization, broken hydration, truncated responses).

2. **Truncation (found while testing):** if the source **ends** before the first read, the subscriber's `onEnd` pushes `null` immediately and the buffered snapshot is never delivered at all — the replay silently loses all buffered content.

## Fix

Queue chunks that arrive before the snapshot is drained in a per-replay `pendingChunks` array (and defer the end marker via a `sourceEnded` flag); `_read()` flushes the snapshot then the pending queue in order, and live pushes resume once the stream is caught up. Delivery stays pull-based through `_read()` for both the snapshot and the pending queue, which is also *more* aligned with the AsyncLocalStorage requirement than the previous eager push. Disposal semantics are unchanged (the snapshot copy is retained per replay stream).

## Tests

Two new tests in the existing test file:

- a chunk arriving between `createReplayStream()` and the first read must not overtake the buffered chunks — **fails before the fix** (receives `ba` instead of `ab`);
- a source ending before the first read still delivers buffered chunks — **fails before the fix** (delivers nothing).

All 23 tests in the file pass after the fix (21 existing unaffected). `tsc`/`eslint` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
