### PR TITLE
fix(server): propagate errors/cancellation through the Node HTML transform pipeline

### DIFF
--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -14,7 +14,7 @@ import {
   resumeToPipeableStream,
 } from 'react-dom/server'
 import { prerender } from 'react-dom/static'
-import { PassThrough, Readable, Transform } from 'node:stream'
+import { PassThrough, Readable, Transform, pipeline } from 'node:stream'
 import { isUtf8 } from 'node:buffer'
 
 import {
@@ -74,6 +74,34 @@ export type {
 // ---------------------------------------------------------------------------
 
 export type AnyStream = AnyStreamType
+
+/**
+ * Pipes a render stream through the given transforms using Node's pipeline()
+ * instead of chained pipe() calls. Unlike pipe(), pipeline() propagates errors
+ * downstream (each stage is destroyed with the error, so the consumer sees an
+ * 'error' event instead of hanging) and destroys upstream stages when a
+ * downstream stage is torn down (e.g. on client disconnect), cancelling the
+ * chain back to the render — matching pipeThrough() semantics of the web
+ * implementation.
+ *
+ * The completion callback intentionally ignores errors: they are surfaced to
+ * consumers via the returned stream's 'error'/'close' events, and a client
+ * disconnect manifests as ERR_STREAM_PREMATURE_CLOSE, which is an expected
+ * teardown path (handled by pipe-readable.ts).
+ */
+function pipelineTransforms(
+  first: Readable,
+  transforms: Array<Transform>
+): Readable {
+  if (transforms.length === 0) {
+    return first
+  }
+  // pipeline() returns the last stream, but its types don't reflect that.
+  const last = transforms[transforms.length - 1]
+  pipeline([first, ...transforms], () => {})
+  return last
+}
+
 
 export type FlightComponentMod = {
   renderToReadableStream: (
@@ -191,6 +219,13 @@ function createFlightDataInjectionTransform(
         () => callback(),
         (err) => callback(err as Error)
       )
+    },
+    destroy(err, callback) {
+      // When the transform is torn down (e.g. client disconnect), stop
+      // pulling from the data stream as well instead of leaking the read
+      // loop — the iterator would otherwise keep waiting on new chunks.
+      dataStream.destroy()
+      callback(err)
     },
   })
 
@@ -720,56 +755,41 @@ export async function continueFizzStream(
   // 1. Buffer – coalesces chunks written in the same microtask into one Uint8Array
   // 2. Flight data injection – interleaves RSC data chunks with the HTML stream
   // 3. Head insertion – inserts server-generated HTML before </head>
-  const buffered = createNodeBufferedTransformStream()
-  webToReadable(renderStream).pipe(buffered)
-
-  let source: Readable = buffered
+  const transforms: Array<Transform> = [createNodeBufferedTransformStream()]
 
   if (deploymentId) {
-    const dplId = createHtmlDataDplIdTransform(deploymentId)
-    source.pipe(dplId)
-    source = dplId
+    transforms.push(createHtmlDataDplIdTransform(deploymentId))
   }
 
   // Metadata (icon mark replacement)
-  const metadata = createMetadataTransform(getServerInsertedMetadata)
-  source.pipe(metadata)
-  source = metadata
+  transforms.push(createMetadataTransform(getServerInsertedMetadata))
 
   // Insert suffix content
   if (suffixUnclosed != null && suffixUnclosed.length > 0) {
-    const deferredSuffix = createDeferredSuffixTransform(suffixUnclosed)
-    source.pipe(deferredSuffix)
-    source = deferredSuffix
+    transforms.push(createDeferredSuffixTransform(suffixUnclosed))
   }
 
   // Flight data injection – interleaves RSC data chunks with the HTML stream
   if (inlinedDataStream) {
-    const flightInjection = createFlightDataInjectionTransform(
-      webToReadable(inlinedDataStream),
-      true
+    transforms.push(
+      createFlightDataInjectionTransform(
+        webToReadable(inlinedDataStream),
+        true
+      )
     )
-    source.pipe(flightInjection)
-    source = flightInjection
   }
 
   if (validateRootLayout) {
-    const rootLayoutValidator = createRootLayoutValidatorTransform()
-    source.pipe(rootLayoutValidator)
-    source = rootLayoutValidator
+    transforms.push(createRootLayoutValidatorTransform())
   }
 
   // Close tags should always be deferred to the end
-  const moveSuffix = createMoveSuffixTransform()
-  source.pipe(moveSuffix)
-  source = moveSuffix
+  transforms.push(createMoveSuffixTransform())
 
   // Head insertion – inserts server-generated HTML before </head>
-  const headInsertion = createHeadInsertionTransform(getServerInsertedHTML)
-  source.pipe(headInsertion)
-  source = headInsertion
+  transforms.push(createHeadInsertionTransform(getServerInsertedHTML))
 
-  return source
+  return pipelineTransforms(webToReadable(renderStream), transforms)
 }
 
 export async function continueStaticPrerender(
@@ -831,37 +851,26 @@ export async function continueDynamicHTMLResumeNode(
 ): Promise<AnyStream> {
   await waitAtLeastOneReactRenderTask()
 
-  const buffered = createNodeBufferedTransformStream()
-  webToReadable(renderStream).pipe(buffered)
-
-  let source: Readable = buffered
+  const transforms: Array<Transform> = [createNodeBufferedTransformStream()]
 
   if (deploymentId) {
-    const dplId = createHtmlDataDplIdTransform(deploymentId)
-    source.pipe(dplId)
-    source = dplId
+    transforms.push(createHtmlDataDplIdTransform(deploymentId))
   }
 
-  const headInsertion = createHeadInsertionTransform(getServerInsertedHTML)
-  source.pipe(headInsertion)
-  source = headInsertion
+  transforms.push(createHeadInsertionTransform(getServerInsertedHTML))
 
-  const metadata = createMetadataTransform(getServerInsertedMetadata)
-  source.pipe(metadata)
-  source = metadata
+  transforms.push(createMetadataTransform(getServerInsertedMetadata))
 
-  const flightInjection = createFlightDataInjectionTransform(
-    webToReadable(inlinedDataStream),
-    delayDataUntilFirstHtmlChunk
+  transforms.push(
+    createFlightDataInjectionTransform(
+      webToReadable(inlinedDataStream),
+      delayDataUntilFirstHtmlChunk
+    )
   )
-  source.pipe(flightInjection)
-  source = flightInjection
 
-  const moveSuffix = createMoveSuffixTransform()
-  source.pipe(moveSuffix)
-  source = moveSuffix
+  transforms.push(createMoveSuffixTransform())
 
-  return source
+  return pipelineTransforms(webToReadable(renderStream), transforms)
 }
 
 export async function continueDynamicHTMLResumeWeb(

--- a/packages/next/src/server/pipe-readable.test.ts
+++ b/packages/next/src/server/pipe-readable.test.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'events'
+import { Readable } from 'stream'
+
+// Mock the tracer/logger so the module loads without telemetry setup.
+jest.mock('./lib/trace/tracer', () => ({
+  getTracer: () => ({
+    trace: (_name: any, _opts: any, fn: any) => fn(),
+    startSpan: () => ({ end: () => {} }),
+  }),
+}))
+jest.mock('./client-component-renderer-logger', () => ({
+  getClientComponentLoaderMetrics: () => null,
+}))
+
+import { pipeNodeReadableToNodeResponse } from './pipe-readable'
+
+function createMockResponse() {
+  const res = new EventEmitter() as any
+  res.errored = null
+  res.destroyed = false
+  res.writableFinished = false
+  res.destroy = (err: any) => {
+    res.destroyed = true
+    res.destroyError = err
+    res.emit('close')
+  }
+  res.write = () => true
+  res.end = () => {
+    res.writableFinished = true
+    res.emit('close')
+  }
+  res.flushHeaders = () => {}
+  return res
+}
+
+describe('pipeNodeReadableToNodeResponse', () => {
+  it('destroys the response instead of hanging when the stream already errored', async () => {
+    const readable = new Readable({ read() {} })
+    const failure = new Error('failed before piping')
+    // The stream errored while a previous consumer (e.g. a pipeline) still
+    // had an error listener attached — its terminal state is retained in
+    // `readable.errored`.
+    readable.on('error', () => {})
+    readable.destroy(failure)
+    // Let the 'error' event actually fire before piping — this is the real
+    // race: the consumer attaches after the stream already errored.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    const res = createMockResponse()
+    // Must resolve (not hang) and destroy the response with the stream error.
+    await pipeNodeReadableToNodeResponse(readable, res)
+    expect(res.destroyed).toBe(true)
+    expect(res.destroyError).toBe(failure)
+  })
+
+  it('still pipes a healthy stream to the response', async () => {
+    const readable = new Readable({
+      read() {
+        this.push(Buffer.from('hello'))
+        this.push(null)
+      },
+    })
+    const res = createMockResponse()
+    const written: Buffer[] = []
+    res.write = (chunk: Buffer) => {
+      written.push(chunk)
+      return true
+    }
+    await pipeNodeReadableToNodeResponse(readable, res)
+    expect(Buffer.concat(written).toString()).toBe('hello')
+    expect(res.writableFinished).toBe(true)
+  })
+})

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -155,6 +155,18 @@ export async function pipeNodeReadableToNodeResponse(
     const { errored, destroyed } = res
     if (errored || destroyed) return
 
+    // If the stream already errored before we started piping (e.g. a render
+    // transform failed while the response was being set up), its 'error'
+    // event already fired and won't fire again — waiting for it would hang
+    // forever. Destroy the response with that error instead.
+    const streamError = readable.errored
+    if (streamError) {
+      if (!isAbortError(streamError)) {
+        res.destroy(streamError)
+      }
+      return
+    }
+
     let started = false
 
     const finished = new DetachedPromise<void>()


### PR DESCRIPTION
## What

`continueFizzStream` and `continueDynamicHTMLResumeNode` (server/app-render/stream-ops.node.ts — the Node HTML pipeline for all non-edge builds) built their transform chains with `readable.pipe()`. Per Node's own docs, `pipe()` does **not** forward errors and does **not** destroy upstream stages on downstream teardown:

1. **Upstream error ⇒ hung response.** An erroring stage (flight-data injection when the inlined RSC stream fails, head/metadata insertion when `getServerInsertedHTML()`/`getServerInsertedMetadata()` rejects, a Fizz PassThrough error, …) destroyed only itself. The stream returned to `pipeNodeReadableToNodeResponse` then emitted neither `end` nor `error`, so the request promise and the socket were held open indefinitely — a socket/memory exhaustion vector on repeated render-time errors.

2. **Downstream destroy ⇒ upstream leak.** On client disconnect, `res.on('close')` destroyed only the last transform; the entire upstream chain (buffered transform, Fizz PassThrough, React render, RSC stream) kept running and buffering instead of being cancelled — unlike the web implementation's `pipeThrough` chain, which cancels back to the Fizz stream.

## Fix

- **Build the chains with `stream.pipeline()`** (stage order preserved exactly). `pipeline()` propagates errors downstream — each stage is destroyed with the error and the returned last stream emits `'error'`, which the existing `pipe-readable` handler turns into `res.destroy(err)` — and destroying any stage (e.g. the last one, on client disconnect) tears down the whole chain back to the render. Verified with direct Node experiments.
- **`pipeNodeReadableToNodeResponse`: handle streams that errored before piping.** `pipeline()` starts draining as soon as the chain is built, and Node does not replay an already-emitted `'error'` event (verified empirically). If that race window hits, the pipe would wait forever — now it checks `readable.errored` on entry and destroys the response with that error instead. This is a general fix for piping any pre-errored stream.
- **`createFlightDataInjectionTransform`: cancel the side stream on teardown.** The transform's async iterator over the inlined RSC stream kept pulling after the transform was destroyed (leaking the read loop); a `destroy(err, cb)` hook now destroys the data stream first.

## Tests

- New `pipe-readable.test.ts`: piping an already-errored stream **hangs forever before this fix** (jest timeout) and resolves with `res.destroy(error)` after; a healthy stream pipes normally.
- Live e2e with a real app: normal Suspense streaming and the React-recovered error path unchanged.
- 618 server unit tests pass (3 pre-existing environment failures in unrelated suites, identical without the change); `tsc`/`eslint` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
