### PR TITLE
turbo-tasks: explicit GC root anchoring + cross-session orphan reclamation

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
+    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbo_tasks, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -174,7 +174,25 @@ impl VersionedContentMap {
             client_output_path,
         );
         this.map_op_to_compute_entry.update_conditionally(|map| {
-            map.insert(assets_operation, compute_entry) != Some(compute_entry)
+            let previous = map.insert(assets_operation, compute_entry);
+            if previous == Some(compute_entry) {
+                // No-op update.
+                return false;
+            }
+            // Pin the operations so GC keeps their tasks alive while this map holds them — nothing
+            // in the persistent graph parents them.
+            let tt = turbo_tasks();
+            match previous {
+                None => {
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+                Some(old_compute_entry) => {
+                    tt.unpin_task_for_gc(old_compute_entry.task_id());
+                    tt.pin_task_for_gc(compute_entry.task_id());
+                }
+            }
+            true
         });
         Ok(())
     }
@@ -198,30 +216,38 @@ impl VersionedContentMap {
         self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
+            let tt = turbo_tasks();
+
             // get current map's keys, subtract keys that don't exist in operation
             let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                let res = map
+                let inserted = map
                     .0
                     .entry(k.clone())
                     .or_default()
                     .0
                     .insert(assets_operation);
+                if inserted {
+                    tt.pin_task_for_gc(assets_operation.task_id());
+                }
                 stale_assets.remove(k);
-                changed = changed || res;
+                changed = changed || inserted;
             }
 
             // Make more efficient with reverse map
             for k in &stale_assets {
-                let res = map
+                let removed = map
                     .0
                     .get_mut(k)
                     // guaranteed
                     .unwrap()
                     .0
                     .swap_remove(&assets_operation);
-                changed = changed || res
+                if removed {
+                    tt.unpin_task_for_gc(assets_operation.task_id());
+                }
+                changed = changed || removed
             }
             changed
         });

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -4,8 +4,9 @@ use next_core::emit_assets;
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbo_tasks, turbobail,
+    FxIndexSet, GcRoot, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State,
+    TryFlatJoinIterExt, TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    turbo_tasks, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -44,15 +45,33 @@ pub struct PathToOutputOperation(
     FxHashMap<FileSystemPath, ExpandedOutputAssetsOperationSet>,
 );
 
+/// The operations that produce the assets at one path.
+///
+/// A set of [`GcRoot`]s rather than of bare operations, so an operation is pinned against GC
+/// exactly as long as it is mentioned here: inserting takes a pin and removing drops it, with no
+/// separate bookkeeping to keep in sync. The same operation appears under many paths, and each
+/// occurrence carries its own pin, which is why [`GcRoot`] is reference counted via [`Clone`].
+///
+/// A guard hashes and compares as the operation it pins, and borrows to it, so the set behaves like
+/// the set of operations it replaced — including lookup and removal by a bare [`OperationVc`].
 #[derive(Clone, Default, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Debug, NonLocalValue)]
-struct ExpandedOutputAssetsOperationSet(FxIndexSet<OperationVc<ExpandedOutputAssets>>);
+struct ExpandedOutputAssetsOperationSet(FxIndexSet<GcRoot<ExpandedOutputAssets>>);
 
 // HACK: This is technically incorrect because the map's key contains a `ResolvedVc`...
 unsafe impl OperationValue for PathToOutputOperation {}
 
+/// The pinned assets operation and the compute entry derived from it. Both are held by
+/// [`GcRoot`]s, so both stay alive exactly as long as this map entry does.
+#[derive(
+    Clone, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Debug, NonLocalValue, OperationValue,
+)]
+struct ComputeEntry {
+    assets_operation: GcRoot<ExpandedOutputAssets>,
+    compute_entry: GcRoot<OptionMapEntry>,
+}
+
 // A precomputed map for quick access to output asset by filepath
-type OutputOperationToComputeEntry =
-    FxHashMap<OperationVc<ExpandedOutputAssets>, OperationVc<OptionMapEntry>>;
+type OutputOperationToComputeEntry = FxHashMap<OperationVc<ExpandedOutputAssets>, ComputeEntry>;
 
 /// Tracks all the output assets produced in a session. This allows us to compute fine grained
 /// change information which drives HMR sessions.
@@ -174,24 +193,23 @@ impl VersionedContentMap {
             client_output_path,
         );
         this.map_op_to_compute_entry.update_conditionally(|map| {
-            let previous = map.insert(assets_operation, compute_entry);
-            if previous == Some(compute_entry) {
+            if let Some(existing) = map.get(&assets_operation)
+                && *existing.compute_entry == compute_entry
+            {
                 // No-op update.
                 return false;
             }
             // Pin the operations so GC keeps their tasks alive while this map holds them — nothing
-            // in the persistent graph parents them.
+            // in the persistent graph parents them. The replaced entry's guards are dropped by the
+            // `insert`, which releases its pins.
             let tt = turbo_tasks();
-            match previous {
-                None => {
-                    tt.pin_task_for_gc(assets_operation.task_id());
-                    tt.pin_task_for_gc(compute_entry.task_id());
-                }
-                Some(old_compute_entry) => {
-                    tt.unpin_task_for_gc(old_compute_entry.task_id());
-                    tt.pin_task_for_gc(compute_entry.task_id());
-                }
-            }
+            map.insert(
+                assets_operation,
+                ComputeEntry {
+                    assets_operation: GcRoot::pin(tt.clone(), assets_operation),
+                    compute_entry: GcRoot::pin(tt, compute_entry),
+                },
+            );
             true
         });
         Ok(())
@@ -222,20 +240,21 @@ impl VersionedContentMap {
             let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                let inserted = map
-                    .0
-                    .entry(k.clone())
-                    .or_default()
-                    .0
-                    .insert(assets_operation);
+                // Each occurrence takes its own pin, so dropping one path's entry can't release
+                // another path's pin on the same operation. Check membership before pinning: a
+                // guard for an operation the path already lists would be discarded by `insert`
+                // (the set keeps the original), so pinning first would take a pin only to release
+                // it again on drop.
+                let set = &mut map.0.entry(k.clone()).or_default().0;
+                let inserted = !set.contains(&assets_operation);
                 if inserted {
-                    tt.pin_task_for_gc(assets_operation.task_id());
+                    set.insert(GcRoot::pin(tt.clone(), assets_operation));
                 }
                 stale_assets.remove(k);
                 changed = changed || inserted;
             }
 
-            // Make more efficient with reverse map
+            // Make more efficient with reverse map. Removing the entry drops its pin.
             for k in &stale_assets {
                 let removed = map
                     .0
@@ -244,9 +263,6 @@ impl VersionedContentMap {
                     .unwrap()
                     .0
                     .swap_remove(&assets_operation);
-                if removed {
-                    tt.unpin_task_for_gc(assets_operation.task_id());
-                }
                 changed = changed || removed
             }
             changed
@@ -331,7 +347,7 @@ impl VersionedContentMap {
     fn raw_get(&self, path: FileSystemPath) -> Vc<OptionMapEntry> {
         let assets = {
             let map = &self.map_path_to_op.get().0;
-            map.get(&path).and_then(|m| m.0.iter().next().copied())
+            map.get(&path).and_then(|m| m.0.first().map(|pin| **pin))
         };
         let Some(assets) = assets else {
             return Vc::cell(None);
@@ -341,7 +357,7 @@ impl VersionedContentMap {
 
         let compute_entry = {
             let map = self.map_op_to_compute_entry.get();
-            map.get(&assets).copied()
+            map.get(&assets).map(|entry| *entry.compute_entry)
         };
         let Some(compute_entry) = compute_entry else {
             return Vc::cell(None);

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -46,22 +46,13 @@ pub struct PathToOutputOperation(
 );
 
 /// The operations that produce the assets at one path.
-///
-/// A set of [`GcRoot`]s rather than of bare operations, so an operation is pinned against GC
-/// exactly as long as it is mentioned here: inserting takes a pin and removing drops it, with no
-/// separate bookkeeping to keep in sync. The same operation appears under many paths, and each
-/// occurrence carries its own pin, which is why [`GcRoot`] is reference counted via [`Clone`].
-///
-/// A guard hashes and compares as the operation it pins, and borrows to it, so the set behaves like
-/// the set of operations it replaced — including lookup and removal by a bare [`OperationVc`].
 #[derive(Clone, Default, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Debug, NonLocalValue)]
 struct ExpandedOutputAssetsOperationSet(FxIndexSet<GcRoot<ExpandedOutputAssets>>);
 
 // HACK: This is technically incorrect because the map's key contains a `ResolvedVc`...
 unsafe impl OperationValue for PathToOutputOperation {}
 
-/// The pinned assets operation and the compute entry derived from it. Both are held by
-/// [`GcRoot`]s, so both stay alive exactly as long as this map entry does.
+/// The pinned assets operation and the compute entry derived from it.
 #[derive(
     Clone, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, Debug, NonLocalValue, OperationValue,
 )]
@@ -199,9 +190,7 @@ impl VersionedContentMap {
                 // No-op update.
                 return false;
             }
-            // Pin the operations so GC keeps their tasks alive while this map holds them — nothing
-            // in the persistent graph parents them. The replaced entry's guards are dropped by the
-            // `insert`, which releases its pins.
+
             let tt = turbo_tasks();
             map.insert(
                 assets_operation,
@@ -240,11 +229,6 @@ impl VersionedContentMap {
             let mut stale_assets = map.0.keys().cloned().collect::<FxHashSet<_>>();
 
             for (k, _) in entries.iter().flatten() {
-                // Each occurrence takes its own pin, so dropping one path's entry can't release
-                // another path's pin on the same operation. Check membership before pinning: a
-                // guard for an operation the path already lists would be discarded by `insert`
-                // (the set keeps the original), so pinning first would take a pin only to release
-                // it again on drop.
                 let set = &mut map.0.entry(k.clone()).or_default().0;
                 let inserted = !set.contains(&assets_operation);
                 if inserted {

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -23,8 +23,8 @@ use turbo_tasks::{
 use turbopack_core::issue::{IssueFilter, PlainIssue};
 
 use crate::next_api::utils::{
-    DetachedVc, NapiIssue, RootTask, TurbopackResult, strongly_consistent_catch_collectables,
-    subscribe,
+    DetachedVc, NapiIssue, SubscriptionTask, TurbopackResult,
+    strongly_consistent_catch_collectables, subscribe,
 };
 
 #[napi(object)]
@@ -195,7 +195,7 @@ pub fn endpoint_server_changed_subscribe(
         TurbopackResult<()>,
         (),
     >,
-) -> napi::Result<External<RootTask>> {
+) -> napi::Result<External<SubscriptionTask>> {
     let turbopack_ctx = endpoint.turbopack_ctx().clone();
     let endpoint = ****endpoint;
     subscribe(
@@ -282,7 +282,7 @@ pub fn endpoint_client_changed_subscribe(
         TurbopackResult<()>,
         (),
     >,
-) -> napi::Result<External<RootTask>> {
+) -> napi::Result<External<SubscriptionTask>> {
     let turbopack_ctx = endpoint.turbopack_ctx().clone();
     let endpoint_op = ****endpoint;
     subscribe(

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -52,9 +52,9 @@ use tracing::Instrument;
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Effects, FxIndexSet, OperationValue, OperationVc, PrettyPrintError, ReadRef, ResolvedVc,
-    TransientInstance, TryJoinIterExt, TurboTasksApi, TurboTasksCallApi, UpdateInfo, Vc,
-    mark_top_level_task,
+    Effects, FxIndexSet, GcRoot, OperationValue, OperationVc, PrettyPrintError, ReadRef,
+    ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasksApi, TurboTasksCallApi, UpdateInfo,
+    Vc, mark_top_level_task,
     message_queue::{CompilationEvent, Severity},
     read_strongly_consistent_and_apply_effects, take_effects,
     trace::TraceRawVcs,
@@ -419,6 +419,8 @@ pub struct ProjectInstance {
     container: ResolvedVc<ProjectContainer>,
     // Never locked across an await point.
     exit_receiver: Mutex<Option<ExitReceiver>>,
+    // Pin the ProjectContainer for as long as this struct survives.
+    _container_gc_root: GcRoot,
 }
 
 #[napi(ts_return_type = "Promise<{ __napiType: \"Project\" }>")]
@@ -613,14 +615,17 @@ pub fn project_new<'env>(
             let options = ProjectOptions::from(options);
             let is_dev = options.dev;
             let root_path = options.root_path.clone();
-            let container = turbo_tasks
+            let (container, container_root_task) = turbo_tasks
                 .run(async move {
                     let container_op = ProjectContainer::new_operation(rcstr!("next.js"), is_dev);
                     ProjectContainer::initialize(container_op, options).await?;
-                    container_op.resolve().strongly_consistent().await
+                    let container = container_op.resolve().strongly_consistent().await?;
+                    // Capture the container task id so we can pin it below
+                    Ok((container, container_op.task_id()))
                 })
                 .or_else(|e| turbopack_ctx.throw_turbopack_internal_result(&e.into()))
                 .await?;
+            let container_gc_root = GcRoot::pin(turbo_tasks.clone(), container_root_task);
 
             if is_dev {
                 Handle::current().spawn({
@@ -661,6 +666,7 @@ pub fn project_new<'env>(
                 turbopack_ctx,
                 container,
                 exit_receiver: Mutex::new(Some(exit_receiver)),
+                _container_gc_root: container_gc_root,
             }))
         }
         .instrument(tracing::info_span!("create project")),

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -420,7 +420,7 @@ pub struct ProjectInstance {
     // Never locked across an await point.
     exit_receiver: Mutex<Option<ExitReceiver>>,
     // Pin the ProjectContainer for as long as this struct survives.
-    _container_gc_root: GcRoot,
+    _container_gc_root: GcRoot<ProjectContainer>,
 }
 
 #[napi(ts_return_type = "Promise<{ __napiType: \"Project\" }>")]
@@ -615,17 +615,17 @@ pub fn project_new<'env>(
             let options = ProjectOptions::from(options);
             let is_dev = options.dev;
             let root_path = options.root_path.clone();
-            let (container, container_root_task) = turbo_tasks
+            let (container, container_op) = turbo_tasks
                 .run(async move {
                     let container_op = ProjectContainer::new_operation(rcstr!("next.js"), is_dev);
                     ProjectContainer::initialize(container_op, options).await?;
                     let container = container_op.resolve().strongly_consistent().await?;
-                    // Capture the container task id so we can pin it below
-                    Ok((container, container_op.task_id()))
+                    // Return the operation itself so we can pin it below
+                    Ok((container, container_op))
                 })
                 .or_else(|e| turbopack_ctx.throw_turbopack_internal_result(&e.into()))
                 .await?;
-            let container_gc_root = GcRoot::pin(turbo_tasks.clone(), container_root_task);
+            let container_gc_root = GcRoot::pin(turbo_tasks.clone(), container_op);
 
             if is_dev {
                 Handle::current().spawn({

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -93,7 +93,7 @@ use crate::{
             NextTurboTasks, NextTurbopackContext, create_turbo_tasks,
         },
         utils::{
-            DetachedVc, NapiIssue, NapiUsedFeature, RootTask, TurbopackResult, get_issues,
+            DetachedVc, NapiIssue, NapiUsedFeature, SubscriptionTask, TurbopackResult, get_issues,
             strongly_consistent_catch_collectables, subscribe,
         },
     },
@@ -1772,7 +1772,7 @@ pub fn project_entrypoints_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<Partial<NapiEntrypoints>>) => void")]
     func: FunctionRef<TurbopackResult<Option<NapiEntrypoints>>, ()>,
-) -> napi::Result<External<RootTask>> {
+) -> napi::Result<External<SubscriptionTask>> {
     let turbopack_ctx = project.turbopack_ctx.clone();
     let container = project.container;
     subscribe(
@@ -2016,7 +2016,7 @@ pub fn project_client_hmr_events(
         TurbopackResult<Unknown<'static>>,
         (),
     >,
-) -> napi::Result<External<RootTask>> {
+) -> napi::Result<External<SubscriptionTask>> {
     let container = project.container;
     let session = TransientInstance::new(());
     subscribe(
@@ -2150,7 +2150,7 @@ pub fn project_client_hmr_chunk_names_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<HmrChunkNames>) => void")]
     func: FunctionRef<TurbopackResult<HmrChunkNames>, ()>,
-) -> napi::Result<External<RootTask>> {
+) -> napi::Result<External<SubscriptionTask>> {
     let container = project.container;
     subscribe(
         project.turbopack_ctx.clone(),

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -47,20 +47,18 @@ use crate::next_api::turbopack_ctx::NextTurbopackContext;
 /// handle exists.
 pub struct DetachedVc<T> {
     turbopack_ctx: NextTurbopackContext,
-    /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
-    vc: OperationVc<T>,
-    /// Holds a pin on this operation to prevent GC
-    _gc_root: GcRoot,
+    /// Pins the operation to prevent GC, and holds the `Vc` itself. Must be unresolved, otherwise
+    /// you are referencing an inactive operation.
+    gc_root: GcRoot<T>,
 }
 
 impl<T> DetachedVc<T> {
     pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
         // Pin the operation's task so GC treats this out-of-graph handle as a root.
-
+        let gc_root = GcRoot::pin(turbopack_ctx.turbo_tasks().clone(), vc);
         Self {
             turbopack_ctx,
-            vc,
-            _gc_root: GcRoot::pin(turbopack_ctx.turbo_tasks().clone(), vc.task_id()),
+            gc_root,
         }
     }
 
@@ -73,7 +71,7 @@ impl<T> Deref for DetachedVc<T> {
     type Target = OperationVc<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.vc
+        &self.gc_root
     }
 }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -56,12 +56,11 @@ pub struct DetachedVc<T> {
 impl<T> DetachedVc<T> {
     pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
         // Pin the operation's task so GC treats this out-of-graph handle as a root.
-        let gc_root = GcRoot::pin(turbopack_ctx.turbo_tasks().clone(), vc.task_id());
 
         Self {
             turbopack_ctx,
             vc,
-            _gc_root: gc_root,
+            _gc_root: GcRoot::pin(turbopack_ctx.turbo_tasks().clone(), vc.task_id()),
         }
     }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -85,30 +85,32 @@ impl<T> Deref for DetachedVc<T> {
 /// task promptly. If it doesn't, [`Drop`] disposes it as a backstop.
 ///
 /// This is used by [`subscribe`] to create a computation that re-executes when dependencies change.
-pub struct RootTask {
+pub struct SubscriptionTask {
     turbopack_ctx: NextTurbopackContext,
     task_id: Option<TaskId>,
 }
 
-impl Drop for RootTask {
-    fn drop(&mut self) {
-        // Tear it down now if `root_task_dispose` wasn't called.
+impl SubscriptionTask {
+    fn dispose(&mut self) {
         if let Some(task) = self.task_id.take() {
             self.turbopack_ctx.turbo_tasks().dispose_root_task(task);
         }
     }
 }
 
+impl Drop for SubscriptionTask {
+    fn drop(&mut self) {
+        self.dispose();
+    }
+}
+
 #[napi]
 pub fn root_task_dispose(
-    #[napi(ts_arg_type = "{ __napiType: \"RootTask\" }")] mut root_task: ExternalRef<RootTask>,
+    #[napi(ts_arg_type = "{ __napiType: \"RootTask\" }")] mut root_task: ExternalRef<
+        SubscriptionTask,
+    >,
 ) -> napi::Result<()> {
-    if let Some(task) = root_task.task_id.take() {
-        root_task
-            .turbopack_ctx
-            .turbo_tasks()
-            .dispose_root_task(task);
-    }
+    root_task.dispose();
     Ok(())
 }
 
@@ -444,7 +446,7 @@ pub fn subscribe<
     func: &FunctionRef<V, ()>,
     handler: impl 'static + Sync + Send + Clone + Fn() -> F,
     mapper: impl 'static + Sync + Send + FnMut(ThreadsafeCallContext<T>) -> napi::Result<V>,
-) -> napi::Result<External<RootTask>> {
+) -> napi::Result<External<SubscriptionTask>> {
     let js_func = func.borrow_back(env)?;
     let func: ThreadsafeFunction<T, (), V, Status, true> = js_func
         .build_threadsafe_function::<T>()
@@ -472,7 +474,7 @@ pub fn subscribe<
             }
         }
     });
-    Ok(External::new(RootTask {
+    Ok(External::new(SubscriptionTask {
         turbopack_ctx: ctx,
         task_id: Some(task_id),
     }))

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -21,7 +21,7 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Effects, OperationVc, ReadRef, TaskId, Vc, VcValueType, take_effects};
+use turbo_tasks::{Effects, GcRoot, OperationVc, ReadRef, TaskId, Vc, VcValueType, take_effects};
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
     issue::{
@@ -43,17 +43,26 @@ use crate::next_api::turbopack_ctx::NextTurbopackContext;
 /// [`turbo_tasks::OperationValue`] and should be dereferenced to an [`OperationVc`] before being
 /// passed to a [`turbo_tasks::function`].
 //
-// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
-#[derive(Clone)]
+/// A `DetachedVc` holds its operation's task alive against garbage collection for as long as the
+/// handle exists.
 pub struct DetachedVc<T> {
     turbopack_ctx: NextTurbopackContext,
     /// The Vc. Must be unresolved, otherwise you are referencing an inactive operation.
     vc: OperationVc<T>,
+    /// Holds a pin on this operation to prevent GC
+    _gc_root: GcRoot,
 }
 
 impl<T> DetachedVc<T> {
     pub fn new(turbopack_ctx: NextTurbopackContext, vc: OperationVc<T>) -> Self {
-        Self { turbopack_ctx, vc }
+        // Pin the operation's task so GC treats this out-of-graph handle as a root.
+        let gc_root = GcRoot::pin(turbopack_ctx.turbo_tasks().clone(), vc.task_id());
+
+        Self {
+            turbopack_ctx,
+            vc,
+            _gc_root: gc_root,
+        }
     }
 
     pub fn turbopack_ctx(&self) -> &NextTurbopackContext {
@@ -73,12 +82,10 @@ impl<T> Deref for DetachedVc<T> {
 /// [`turbo_tasks::TurboTasks::spawn_root_task`] that can be passed back and forth to JS across the
 /// [`napi`][mod@napi] boundary via [`External`].
 ///
-/// JavaScript code receiving this value **must** call [`root_task_dispose`] in a `try...finally`
-/// block to avoid leaking root tasks.
+/// JavaScript code should call [`root_task_dispose`] in a `try...finally` block to dispose the root
+/// task promptly. If it doesn't, [`Drop`] disposes it as a backstop.
 ///
 /// This is used by [`subscribe`] to create a computation that re-executes when dependencies change.
-//
-// TODO: If we add a tracing garbage collector to turbo-tasks, this should be tracked as a GC root.
 pub struct RootTask {
     turbopack_ctx: NextTurbopackContext,
     task_id: Option<TaskId>,
@@ -86,7 +93,10 @@ pub struct RootTask {
 
 impl Drop for RootTask {
     fn drop(&mut self) {
-        // TODO stop the root task
+        // Tear it down now if `root_task_dispose` wasn't called.
+        if let Some(task) = self.task_id.take() {
+            self.turbopack_ctx.turbo_tasks().dispose_root_task(task);
+        }
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -19,7 +19,6 @@
 use std::{
     fmt::Display,
     ops::ControlFlow,
-    sync::atomic::Ordering,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -295,12 +294,12 @@ impl TurboTasksBackend {
         op: &'static str,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
     ) {
-        // Once stopping, GC bookkeeping is irrelevant. This also keeps handles finalized during
-        // shutdown (after the map is dropped) from underflowing the count.
-        if self.stopping.load(Ordering::Acquire) {
+        // We expect this call to come from outside a turbo-task context, at least sometimes
+        // So be defensive about conostructing a context.  If we get none then we are shutting down
+        // and it is too late for ref-counting.
+        let Some(mut ctx) = self.try_execute_context(turbo_tasks) else {
             return;
-        }
-        let mut ctx = self.execute_context(turbo_tasks);
+        };
         // Technically we only need to manipulate transient data so meta is overkill. But the task
         // must be resident if we are adding a pin so this isn't wasteful
         let mut task = ctx.task(task, TaskDataCategory::Meta);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -58,7 +58,7 @@ pub(crate) const DEFAULT_GC_ROOT_TTL: Duration = Duration::from_secs(3 * 24 * 60
 pub enum TtlCounter {
     /// Observed live (a durable, anchored root) in the most recent session.
     MostRecent,
-    /// Wall-clock millis at which a session's **first** GC pass first found this root not live.
+    /// System time millis at which a session's **first** GC pass first found this root not live.
     FirstStale(u64),
 }
 
@@ -130,15 +130,16 @@ impl TurboTasksBackend {
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
         phase: &SnapshotPhase<'_, AnyOperation>,
     ) -> (GcStats, Option<Vec<(TaskId, TtlCounter)>>) {
-        let now = Self::now_ms();
+        // Record the time at the beginning of the loop to have a consistent timestamp for the roots
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
 
         let mut roots = self
             .backing_storage
             .roots()
-            .unwrap_or_else(|err| {
-                eprintln!("failed to read GC roots, treating as empty: {err:?}");
-                Vec::new()
-            })
+            .expect("reading gc roots should not fail")
             .into_iter()
             .collect::<FxHashMap<TaskId, TtlCounter>>();
         let roots_before = roots.clone();
@@ -230,14 +231,6 @@ impl TurboTasksBackend {
         let roots_to_persist: Option<Vec<_>> =
             (roots != roots_before).then(|| roots.into_iter().collect());
         (stats, roots_to_persist)
-    }
-
-    /// Wall-clock now as millis since the Unix epoch.
-    fn now_ms() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0)
     }
 
     /// Compute which persisted roots have expired their TTL
@@ -337,12 +330,8 @@ impl TurboTasksBackend {
         let phase = self.snapshot_coord.begin_snapshot();
         let (stats, roots) = self.gc_collect(turbo_tasks, &phase);
 
-        // Persist the roots map this pass produced. Production does this by holding the same
-        // exclusion across the GC pass and the snapshot that follows it; this hook has no
-        // snapshot. Dropping the result would not merely lose an optimization: the pass also
-        // consumed the session's one demotion opportunity (`first_gc_pass_of_session`), so a root
-        // that went stale this session would stay `MostRecent` with no later pass able to demote
-        // it.
+        // Persist the roots map this pass produced. Some tests query the roots set and GC itself
+        // does as well, this ensures it is available to the next cycle.
         if let Some(roots) = roots
             && let Err(err) = self.backing_storage.save_snapshot(
                 Vec::new(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -144,8 +144,7 @@ impl TurboTasksBackend {
             .collect::<FxHashMap<TaskId, TtlCounter>>();
         let roots_before = roots.clone();
 
-        let first_pass_of_session = self.first_gc_pass_of_session.swap(false, Ordering::Relaxed);
-        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now, first_pass_of_session);
+        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now);
 
         let aged_out_count = aged_out.len();
         // TODO(perf): recycle the task ids of collected tasks.
@@ -195,7 +194,7 @@ impl TurboTasksBackend {
                 drop(task); // drop the lock so CleanupOldEdgesOperation can run
                 stats.collected += 1;
                 stats.edges_deleted += old_edges.len();
-                // If we happeend to delete a known root at this point record it so we can reconcile
+                // If we happened to delete a known root at this point record it so we can reconcile
                 // later.
                 if roots.contains_key(&task_id) {
                     stats.deleted_roots.push(task_id);
@@ -235,13 +234,12 @@ impl TurboTasksBackend {
 
     /// Compute which persisted roots have expired their TTL
     /// Also
-    /// - update timestamps if this is the first pass
+    /// - start the staleness clock for roots that are no longer resident
     /// - drop roots that are resident (the GC pass will pass judgement)
     fn gc_roots_refresh_and_age_out(
         &self,
         map: &mut FxHashMap<TaskId, TtlCounter>,
         now: u64,
-        first_pass_of_session: bool,
     ) -> Vec<TaskId> {
         let ttl_ms = self.gc_root_ttl.as_millis() as u64;
 
@@ -253,12 +251,19 @@ impl TurboTasksBackend {
             }
             match *counter {
                 TtlCounter::MostRecent => {
-                    // First session in which it is missing from the heap: start the clock. Only
-                    // the first pass of a session may do this, so the TTL counts sessions rather
-                    // than passes.
-                    if first_pass_of_session {
-                        *counter = TtlCounter::FirstStale(now);
-                    }
+                    // First pass in which it is missing from the heap: start the clock.
+                    //
+                    // A root cannot return to `MostRecent` later in this session: the only writer
+                    // of `MostRecent` is the `gc_scan_roots` upgrade below, which requires the
+                    // task to be resident, and a resident root cannot go non-resident while
+                    // remaining a root (every pin that makes `gc_is_root` true either blocks
+                    // eviction outright -- `transient_ref_count` is transient-category so
+                    // eviction never drops it, and `in_progress`/`activeness` are
+                    // `UnevictableReason::InProgress` -- or is itself the residue that keeps the
+                    // map entry alive, and once it drains the task is collectible rather than a
+                    // root). So the clock is started at most once per root per session and the
+                    // TTL is never refreshed by pass churn.
+                    *counter = TtlCounter::FirstStale(now);
                     true
                 }
                 TtlCounter::FirstStale(since) => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -12,23 +12,55 @@
 //! that could resurrect a task mid-collect, and hand its decisions straight to persistence: the
 //! same guard stays held across the snapshot that writes the tombstones.
 //!
-//! TODO: find a way to collect GC roots that go away between sessions.  Right now they are
-//! persisted forever and if a later session doesn't read them it is never deleted.
+//! A pass has two phases: a fully parallel, unbounded job pool that tears down garbage, followed by
+//! a single scan that classifies GC roots once the graph is quiescent (see
+//! [`TurboTasksBackend::gc_collect`]).
 
-use std::{fmt::Display, ops::ControlFlow, sync::atomic::Ordering};
+use std::{
+    fmt::Display,
+    ops::ControlFlow,
+    sync::atomic::Ordering,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
+use bincode::{Decode, Encode};
+use rustc_hash::FxHashMap;
 use turbo_tasks::{TaskId, TurboTasks, scope_unbounded::scope_unbounded_with};
 
-use crate::backend::{
-    AnyOperation, TurboTasksBackend,
-    operation::{
-        AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
-        TaskGuard, capture_all_outgoing_edges,
+use crate::{
+    backend::{
+        AnyOperation, TurboTasksBackend,
+        operation::{
+            AggregationUpdateQueue, CleanupOldEdgesOperation, ExecuteContext, ExecuteContextImpl,
+            TaskGuard, capture_all_outgoing_edges,
+        },
+        snapshot_coordinator::SnapshotPhase,
+        storage::{SpecificTaskDataCategory, TaskDataCategory},
+        storage_schema::TaskStorageAccessors,
     },
-    snapshot_coordinator::SnapshotPhase,
-    storage::{SpecificTaskDataCategory, TaskDataCategory},
-    storage_schema::TaskStorageAccessors,
+    backing_storage::SnapshotItem,
 };
+
+/// How long a GC root may go un-anchored before it is collected.
+/// Default to 3 days so that a root that is at least occasionally used can survive a weekend.
+///
+/// Aging out roots solves the problem of missing `gc_unpin` calls.  We can miss them for structural
+/// reasons, bugs or just shutdown races (drops from native threads race with turbopack shutdown).
+/// So using a TTL to track roots that haven't shown up in new sessions we can solve this leak.
+///
+/// The TTL counter is serving as a check for both new sessions and time.  To be aged out you get
+/// one session to start the clock and then eventually the timer expires.  This is intentionally
+/// course.
+pub(crate) const DEFAULT_GC_ROOT_TTL: Duration = Duration::from_secs(3 * 24 * 60 * 60);
+
+/// How long a GC root has gone without being observed live, as stored in the persisted roots map.
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TtlCounter {
+    /// Observed live (a durable, anchored root) in the most recent session.
+    MostRecent,
+    /// Wall-clock millis at which a session's **first** GC pass first found this root not live.
+    FirstStale(u64),
+}
 
 /// One unit of GC work.
 enum GcJob {
@@ -40,29 +72,48 @@ enum GcJob {
 }
 
 /// Observability counters for one [`TurboTasksBackend::gc_collect`] pass.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct GcStats {
+    /// Number of roots detected by the pass
+    pub gc_roots: usize,
     /// Tasks collected (marked soft-deleted).
     pub collected: usize,
     /// Edges torn down across all collected tasks (children + forward-dependency reverse edges).
     pub edges_deleted: usize,
+    /// Cross-session roots that aged out past the TTL.
+    pub aged_out_roots: usize,
+    /// Persisted roots that this pass collected, to be dropped from the roots map.
+    pub deleted_roots: Vec<TaskId>,
 }
 
 impl Display for GcStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "collected: {collected}, edges_deleted: {edges_deleted}",
+            "gc_roots = {gc_roots}, collected: {collected}, edges_deleted: {edges_deleted}, \
+             aged_out_roots = {aged_out_roots}",
+            gc_roots = self.gc_roots,
             collected = self.collected,
-            edges_deleted = self.edges_deleted
+            edges_deleted = self.edges_deleted,
+            aged_out_roots = self.aged_out_roots
         )
     }
 }
 
 impl GcStats {
-    fn merge(mut self, other: Self) -> Self {
+    fn merge(mut self, mut other: Self) -> Self {
         self.collected += other.collected;
         self.edges_deleted += other.edges_deleted;
+        self.gc_roots += other.gc_roots;
+        self.aged_out_roots += other.aged_out_roots;
+        // Order doesn't matter, so keep the larger allocation and append the smaller one into it.
+        // One or both sides are usually empty.
+        if other.deleted_roots.len() > self.deleted_roots.len() {
+            other.deleted_roots.append(&mut self.deleted_roots);
+            self.deleted_roots = other.deleted_roots;
+        } else {
+            self.deleted_roots.append(&mut other.deleted_roots);
+        }
         self
     }
 }
@@ -78,10 +129,30 @@ impl TurboTasksBackend {
         &self,
         turbo_tasks: &TurboTasks<TurboTasksBackend>,
         phase: &SnapshotPhase<'_, AnyOperation>,
-    ) -> GcStats {
+    ) -> (GcStats, Option<Vec<(TaskId, TtlCounter)>>) {
+        let now = Self::now_ms();
+
+        let mut roots = self
+            .backing_storage
+            .roots()
+            .unwrap_or_else(|err| {
+                eprintln!("failed to read GC roots, treating as empty: {err:?}");
+                Vec::new()
+            })
+            .into_iter()
+            .collect::<FxHashMap<TaskId, TtlCounter>>();
+        let roots_before = roots.clone();
+
+        let first_pass_of_session = self.first_gc_pass_of_session.swap(false, Ordering::Relaxed);
+        let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now, first_pass_of_session);
+
+        let aged_out_count = aged_out.len();
         // TODO(perf): recycle the task ids of collected tasks.
-        scope_unbounded_with(
-            (0..self.storage.shard_count()).map(GcJob::ScanShard),
+        let mut stats: GcStats = scope_unbounded_with(
+            // Start by scanning all shards and collecting the aged out roots from prior sessions
+            (0..self.storage.shard_count())
+                .map(GcJob::ScanShard)
+                .chain(aged_out.into_iter().map(GcJob::Collect)),
             GcStats::default,
             |spawner, job, stats| {
                 let collector = |task_id| spawner.spawn(GcJob::Collect(task_id));
@@ -123,6 +194,11 @@ impl TurboTasksBackend {
                 drop(task); // drop the lock so CleanupOldEdgesOperation can run
                 stats.collected += 1;
                 stats.edges_deleted += old_edges.len();
+                // If we happeend to delete a known root at this point record it so we can reconcile
+                // later.
+                if roots.contains_key(&task_id) {
+                    stats.deleted_roots.push(task_id);
+                }
                 CleanupOldEdgesOperation::run(
                     task_id,
                     old_edges,
@@ -132,7 +208,80 @@ impl TurboTasksBackend {
                 ControlFlow::Continue(())
             },
             GcStats::merge,
-        )
+        );
+
+        // Drop the entries for the roots this pass collected, recorded as they were deleted.
+        for id in &stats.deleted_roots {
+            roots.remove(id);
+        }
+
+        // Collect all active roots
+        // We don't do this in the GC pass because a task detected as a root 'early' might become a
+        // non-root later due to other operations (e.g. it might get promoted to a live aggregation
+        // root).
+        for id in self.storage.gc_scan_roots() {
+            roots.insert(id, TtlCounter::MostRecent);
+        }
+
+        stats.gc_roots = roots.len();
+        stats.aged_out_roots = aged_out_count;
+
+        // Only persist the roots map if it actually changed
+        let roots_to_persist: Option<Vec<_>> =
+            (roots != roots_before).then(|| roots.into_iter().collect());
+        (stats, roots_to_persist)
+    }
+
+    /// Wall-clock now as millis since the Unix epoch.
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    }
+
+    /// Compute which persisted roots have expired their TTL
+    /// Also
+    /// - update timestamps if this is the first pass
+    /// - drop roots that are resident (the GC pass will pass judgement)
+    fn gc_roots_refresh_and_age_out(
+        &self,
+        map: &mut FxHashMap<TaskId, TtlCounter>,
+        now: u64,
+        first_pass_of_session: bool,
+    ) -> Vec<TaskId> {
+        let ttl_ms = self.gc_root_ttl.as_millis() as u64;
+
+        let mut aged_out = Vec::new();
+        map.retain(|id, counter| {
+            if self.storage.with_task(*id, |_| ()).is_some() {
+                // Resident: `gc_scan_roots` decides. Drop it either way.
+                return false;
+            }
+            match *counter {
+                TtlCounter::MostRecent => {
+                    // First session in which it is missing from the heap: start the clock. Only
+                    // the first pass of a session may do this, so the TTL counts sessions rather
+                    // than passes.
+                    if first_pass_of_session {
+                        *counter = TtlCounter::FirstStale(now);
+                    }
+                    true
+                }
+                TtlCounter::FirstStale(since) => {
+                    if now.saturating_sub(since) > ttl_ms {
+                        // Enqueue for collection, which restores it from disk and attempts the
+                        // delete. Dropped from the map: see the note above.
+                        aged_out.push(*id);
+                        false
+                    } else {
+                        true
+                    }
+                }
+            }
+        });
+
+        aged_out
     }
 
     pub(super) fn pin_task_for_gc(
@@ -186,6 +335,23 @@ impl TurboTasksBackend {
         );
         let _serialize = self.snapshot_in_progress.lock();
         let phase = self.snapshot_coord.begin_snapshot();
-        self.gc_collect(turbo_tasks, &phase).collected
+        let (stats, roots) = self.gc_collect(turbo_tasks, &phase);
+
+        // Persist the roots map this pass produced. Production does this by holding the same
+        // exclusion across the GC pass and the snapshot that follows it; this hook has no
+        // snapshot. Dropping the result would not merely lose an optimization: the pass also
+        // consumed the session's one demotion opportunity (`first_gc_pass_of_session`), so a root
+        // that went stale this session would stay `MostRecent` with no later pass able to demote
+        // it.
+        if let Some(roots) = roots
+            && let Err(err) = self.backing_storage.save_snapshot(
+                Vec::new(),
+                Some(roots),
+                Vec::<Vec<SnapshotItem>>::new(),
+            )
+        {
+            panic!("gc_for_testing: failed to persist GC roots: {err:?}");
+        }
+        stats.collected
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -251,18 +251,7 @@ impl TurboTasksBackend {
             }
             match *counter {
                 TtlCounter::MostRecent => {
-                    // First pass in which it is missing from the heap: start the clock.
-                    //
-                    // A root cannot return to `MostRecent` later in this session: the only writer
-                    // of `MostRecent` is the `gc_scan_roots` upgrade below, which requires the
-                    // task to be resident, and a resident root cannot go non-resident while
-                    // remaining a root (every pin that makes `gc_is_root` true either blocks
-                    // eviction outright -- `transient_ref_count` is transient-category so
-                    // eviction never drops it, and `in_progress`/`activeness` are
-                    // `UnevictableReason::InProgress` -- or is itself the residue that keeps the
-                    // map entry alive, and once it drains the task is collectible rather than a
-                    // root). So the clock is started at most once per root per session and the
-                    // TTL is never refreshed by pass churn.
+                    // It was recent in the last pass but not this one. Start the clock
                     *counter = TtlCounter::FirstStale(now);
                     true
                 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -433,10 +433,7 @@ impl TurboTasksBackend {
             .unwrap_or(0)
     }
 
-    /// The GC roots set as currently persisted on disk (task id -> [`TtlCounter`]). Reads the
-    /// `GcRoots` infra key directly, so it reflects the last committed snapshot — not any in-flight
-    /// pass. Test-only hook for asserting that a root seeded for collection but *not* collected
-    /// stays tracked (see `gc_roots_refresh_and_age_out`'s monotonicity note).
+    /// The GC roots set as currently persisted on disk (task id -> [`TtlCounter`]).
     #[doc(hidden)]
     pub fn persisted_gc_roots_for_testing(&self) -> Vec<(TaskId, TtlCounter)> {
         self.backing_storage.roots().unwrap_or_default()
@@ -1625,24 +1622,13 @@ impl TurboTasksBackend {
     }
 
     fn stopping(&self) {
-        // Scoped: the write lock is only needed to flip the flag. Any context that acquired a read
-        // guard before this point keeps running; `stop()` re-takes the write lock and waits for
-        // them. After this returns, `try_execute_context` refuses to hand out new ones.
+        // modify via a write guard so we synchronize with top level calls into try_execute_context
         *self.stopping.write() = true;
         self.stopping_event.notify(usize::MAX);
     }
 
     #[allow(unused_variables)]
     fn stop(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
-        // Wait out any context handed out by `try_execute_context` before `stopping()` flipped the
-        // flag, and keep new ones from starting for the duration of the teardown below.
-        //
-        // This cannot deadlock against our own body: nothing reachable from here takes a read
-        // guard. `snapshot_and_persist` -> `gc_collect` builds contexts through
-        // `ExecuteContextImpl::new_for_gc`, which deliberately takes no shutdown guard (see its
-        // doc comment). Routing GC's context construction through `try_execute_context` would
-        // deadlock `stop()` against itself.
-        let _teardown = self.stopping.write();
         #[cfg(feature = "verify_aggregation_graph")]
         {
             self.is_idle.store(false, Ordering::Release);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -244,10 +244,6 @@ pub struct TurboTasksBackend {
     /// How long a GC root may go un-anchored before it ages out.
     gc_root_ttl: Duration,
 
-    /// `true` until the first GC pass of this session runs. Used to detect 'session boundaries'
-    /// which allows us to detect which roots have become stale from prior sessions.
-    first_gc_pass_of_session: AtomicBool,
-
     #[cfg(feature = "verify_aggregation_graph")]
     root_tasks: Mutex<FxHashSet<TaskId>>,
 }
@@ -328,7 +324,6 @@ impl TurboTasksBackend {
             task_statistics: TaskStatisticsApi::default(),
             backing_storage,
             gc_root_ttl,
-            first_gc_pass_of_session: AtomicBool::new(true),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -241,16 +241,11 @@ pub struct TurboTasksBackend {
     task_statistics: TaskStatisticsApi,
 
     backing_storage: TurboBackingStorage,
-    /// How long a GC root may go un-anchored before it ages out, resolved once at construction
-    /// from [`BackendOptions::gc_root_ttl`] / the `TURBO_ENGINE_GC_ROOT_TTL_MS` env /
-    /// [`DEFAULT_GC_ROOT_TTL`].
+    /// How long a GC root may go un-anchored before it ages out.
     gc_root_ttl: Duration,
 
-    /// `true` until the first GC pass of this session runs. Only that pass may demote a live root
-    /// to `TtlCounter::FirstStale` — GC runs many times per session (on the snapshot cadence), and
-    /// a single pass can easily miss a root that is still live (evicted, or not yet re-requested).
-    /// Demoting on every pass would make the TTL measure idleness within a session rather than
-    /// "was not live in a whole session". See `gc_roots_refresh_and_age_out`.
+    /// `true` until the first GC pass of this session runs. Used to detect 'session boundaries'
+    /// which allows us to detect which roots have become stale from prior sessions.
     first_gc_pass_of_session: AtomicBool,
 
     #[cfg(feature = "verify_aggregation_graph")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -7,6 +7,10 @@ mod snapshot_coordinator;
 mod storage;
 pub mod storage_schema;
 
+// Only the `verify_aggregation_graph` feature still uses atomics here; `stopping` is an
+// `RwLock<bool>` so that checking it and acting on it cannot be split (see the field's docs).
+#[cfg(feature = "verify_aggregation_graph")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     borrow::Cow,
     fmt::{self, Write},
@@ -14,10 +18,7 @@ use std::{
     hash::BuildHasherDefault,
     mem::take,
     pin::Pin,
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, LazyLock},
     time::SystemTime,
 };
 
@@ -27,7 +28,7 @@ use gc::DEFAULT_GC_ROOT_TTL;
 pub use gc::TtlCounter;
 use hashbrown::hash_table::Entry;
 use indexmap::IndexSet;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use smallvec::{SmallVec, smallvec};
 use tokio::time::{Duration, Instant};
@@ -231,7 +232,7 @@ pub struct TurboTasksBackend {
     /// Experimental feature to enable dead tasks to be deleted from storage and ram.
     gc_enabled: bool,
 
-    stopping: AtomicBool,
+    stopping: RwLock<bool>,
     stopping_event: Event,
     idle_start_event: Event,
     idle_end_event: Event,
@@ -315,7 +316,7 @@ impl TurboTasksBackend {
             storage: Storage::new(shard_amount, small_preallocation),
             snapshot_coord: SnapshotCoordinator::new(),
             snapshot_in_progress: Mutex::new(()),
-            stopping: AtomicBool::new(false),
+            stopping: RwLock::new(false),
             stopping_event: Event::new(|| || "TurboTasksBackend::stopping_event".to_string()),
             idle_start_event: Event::new(|| || "TurboTasksBackend::idle_start_event".to_string()),
             idle_end_event: Event::new(|| || "TurboTasksBackend::idle_end_event".to_string()),
@@ -334,6 +335,28 @@ impl TurboTasksBackend {
         turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
     ) -> impl ExecuteContext<'a> {
         ExecuteContextImpl::new(self, turbo_tasks)
+    }
+
+    /// Like [`TurboTasksBackend::execute_context`], but refuses to hand out a context once
+    /// shutdown has begun, and blocks shutdown for as long as the returned context is alive.
+    ///
+    /// Use this for entry points reachable from threads that `stop_and_wait` does **not** drain.
+    ///
+    /// Returns `None` once [`TurboTasksBackend::stopping`] has run, in which case the caller must
+    /// do nothing: storage teardown is imminent or already underway.
+    fn try_execute_context<'a>(
+        &'a self,
+        turbo_tasks: &'a TurboTasks<TurboTasksBackend>,
+    ) -> Option<impl ExecuteContext<'a>> {
+        let stopping = self.stopping.read();
+        if *stopping {
+            return None;
+        }
+        Some(ExecuteContextImpl::new_with_shutdown_guard(
+            self,
+            turbo_tasks,
+            stopping,
+        ))
     }
 
     fn operation_suspend_point(&self, suspend: impl FnOnce() -> AnyOperation) {
@@ -418,7 +441,6 @@ impl TurboTasksBackend {
     pub fn persisted_gc_roots_for_testing(&self) -> Vec<(TaskId, TtlCounter)> {
         self.backing_storage.roots().unwrap_or_default()
     }
-
     /// Opens `task` with the must-exist [`ExecuteContext::task`] and drops the guard. Test-only
     /// hook to exercise the non-fabricating existence guarantee: this panics if `task` exists in
     /// neither memory nor persistent storage (rather than fabricating a blank).
@@ -1603,12 +1625,24 @@ impl TurboTasksBackend {
     }
 
     fn stopping(&self) {
-        self.stopping.store(true, Ordering::Release);
+        // Scoped: the write lock is only needed to flip the flag. Any context that acquired a read
+        // guard before this point keeps running; `stop()` re-takes the write lock and waits for
+        // them. After this returns, `try_execute_context` refuses to hand out new ones.
+        *self.stopping.write() = true;
         self.stopping_event.notify(usize::MAX);
     }
 
     #[allow(unused_variables)]
     fn stop(&self, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
+        // Wait out any context handed out by `try_execute_context` before `stopping()` flipped the
+        // flag, and keep new ones from starting for the duration of the teardown below.
+        //
+        // This cannot deadlock against our own body: nothing reachable from here takes a read
+        // guard. `snapshot_and_persist` -> `gc_collect` builds contexts through
+        // `ExecuteContextImpl::new_for_gc`, which deliberately takes no shutdown guard (see its
+        // doc comment). Routing GC's context construction through `try_execute_context` would
+        // deadlock `stop()` against itself.
+        let _teardown = self.stopping.write();
         #[cfg(feature = "verify_aggregation_graph")]
         {
             self.is_idle.store(false, Ordering::Release);
@@ -3066,7 +3100,7 @@ impl TurboTasksBackend {
                         let until = last_snapshot + time;
                         if until > Instant::now() {
                             let mut stop_listener = self.stopping_event.listen();
-                            if self.stopping.load(Ordering::Acquire) {
+                            if *self.stopping.read() {
                                 return;
                             }
                             let mut idle_time = if turbo_tasks.is_idle() && fresh_idle {
@@ -3444,15 +3478,17 @@ impl TurboTasksBackend {
     }
 
     fn dispose_root_task(&self, task_id: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
-        // Once stopping, it is too late to tear down tasks safely
-        if self.stopping.load(Ordering::Acquire) {
+        // Once stopping, it is too late to tear down tasks safely. Holding the context returned
+        // here also blocks `stop()` from tearing storage down while this runs -- this is called
+        // from JS (`root_task_dispose`, or `SubscriptionTask::drop`) on a thread that
+        // `stop_and_wait` does not drain.
+        let Some(mut ctx) = self.try_execute_context(turbo_tasks) else {
             return;
-        }
+        };
 
         #[cfg(feature = "verify_aggregation_graph")]
         self.root_tasks.lock().remove(&task_id);
 
-        let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         let is_dirty = task.is_dirty();
         let has_dirty_containers = task.has_dirty_containers();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -23,6 +23,8 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
+use gc::DEFAULT_GC_ROOT_TTL;
+pub use gc::TtlCounter;
 use hashbrown::hash_table::Entry;
 use indexmap::IndexSet;
 use parking_lot::Mutex;
@@ -67,8 +69,8 @@ use crate::{
             AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext,
             CleanupOldEdgesOperation, ConnectChildOperation, ExecuteContext, ExecuteContextImpl,
             LeafDistanceUpdateQueue, Operation, OutdatedEdge, TaskGuard, TaskType, TaskTypeRef,
-            connect_children, get_aggregation_number, get_uppers, make_task_dirty_internal,
-            prepare_new_children,
+            capture_all_outgoing_edges, connect_children, get_aggregation_number, get_uppers,
+            make_task_dirty_internal, prepare_new_children,
         },
         snapshot_coordinator::{OperationGuard, SnapshotCoordinator},
         storage::Storage,
@@ -147,12 +149,16 @@ pub struct BackendOptions {
 
     /// Strategy for evicting evictable tasks from in-memory storage after a snapshot.
     /// This reclaims memory by clearing persisted data that can be re-loaded from disk on demand.
-    /// This is an EXPERIMENTAL FEATURE under development
     pub eviction_mode: EvictionMode,
 
     /// Overrides whether the reference-counting GC runs for this backend. `None` (default) derives
     /// it from the `TURBO_ENGINE_GC` env var;
     pub gc: Option<bool>,
+
+    /// Overrides how long a GC root may go un-anchored before it ages out. `None` (default)
+    /// derives it from the `TURBO_ENGINE_GC_ROOT_TTL_MS` env var, falling back to
+    /// [`DEFAULT_GC_ROOT_TTL`].
+    pub gc_root_ttl: Option<Duration>,
 }
 
 impl Default for BackendOptions {
@@ -165,6 +171,7 @@ impl Default for BackendOptions {
             small_preallocation: false,
             eviction_mode: EvictionMode::Off,
             gc: None,
+            gc_root_ttl: None,
         }
     }
 }
@@ -234,6 +241,17 @@ pub struct TurboTasksBackend {
     task_statistics: TaskStatisticsApi,
 
     backing_storage: TurboBackingStorage,
+    /// How long a GC root may go un-anchored before it ages out, resolved once at construction
+    /// from [`BackendOptions::gc_root_ttl`] / the `TURBO_ENGINE_GC_ROOT_TTL_MS` env /
+    /// [`DEFAULT_GC_ROOT_TTL`].
+    gc_root_ttl: Duration,
+
+    /// `true` until the first GC pass of this session runs. Only that pass may demote a live root
+    /// to `TtlCounter::FirstStale` — GC runs many times per session (on the snapshot cadence), and
+    /// a single pass can easily miss a root that is still live (evicted, or not yet re-requested).
+    /// Demoting on every pass would make the TTL measure idleness within a session rather than
+    /// "was not live in a whole session". See `gc_roots_refresh_and_age_out`.
+    first_gc_pass_of_session: AtomicBool,
 
     #[cfg(feature = "verify_aggregation_graph")]
     root_tasks: Mutex<FxHashSet<TaskId>>,
@@ -275,6 +293,22 @@ impl TurboTasksBackend {
             gc_enabled = false;
         }
 
+        let gc_root_ttl = options.gc_root_ttl.unwrap_or_else(|| {
+            match std::env::var("TURBO_ENGINE_GC_ROOT_TTL_MS") {
+                Ok(v) => match v.parse::<u64>() {
+                    Ok(ms) => Duration::from_millis(ms),
+                    Err(e) => {
+                        eprintln!(
+                            "warning: TURBO_ENGINE_GC_ROOT_TTL_MS set but is not parsable: {e}. \
+                             Using the default instead."
+                        );
+                        DEFAULT_GC_ROOT_TTL
+                    }
+                },
+                Err(_) => DEFAULT_GC_ROOT_TTL,
+            }
+        });
+
         Self {
             options,
             gc_enabled,
@@ -298,6 +332,8 @@ impl TurboTasksBackend {
             is_idle: AtomicBool::new(false),
             task_statistics: TaskStatisticsApi::default(),
             backing_storage,
+            gc_root_ttl,
+            first_gc_pass_of_session: AtomicBool::new(true),
             #[cfg(feature = "verify_aggregation_graph")]
             root_tasks: Default::default(),
         }
@@ -382,6 +418,15 @@ impl TurboTasksBackend {
         self.storage
             .with_task(task, |t| t.gc_transient_ref_count())
             .unwrap_or(0)
+    }
+
+    /// The GC roots set as currently persisted on disk (task id -> [`TtlCounter`]). Reads the
+    /// `GcRoots` infra key directly, so it reflects the last committed snapshot — not any in-flight
+    /// pass. Test-only hook for asserting that a root seeded for collection but *not* collected
+    /// stays tracked (see `gc_roots_refresh_and_age_out`'s monotonicity note).
+    #[doc(hidden)]
+    pub fn persisted_gc_roots_for_testing(&self) -> Vec<(TaskId, TtlCounter)> {
+        self.backing_storage.roots().unwrap_or_default()
     }
 
     /// Opens `task` with the must-exist [`ExecuteContext::task`] and drops the guard. Test-only
@@ -1070,19 +1115,18 @@ impl TurboTasksBackend {
         // can't be used for cross-process trace correlation.
         let wall_start = SystemTime::now();
         let mut snapshot_phase = self.snapshot_coord.begin_snapshot();
-        let gc_elapsed = if self.gc_enabled {
+        let (gc_elapsed, gc_roots_to_persist) = if self.gc_enabled {
             let gc_span = tracing::info_span!(
                 parent: parent_span.clone(),
                 "gc",
                 stats = tracing::field::Empty,
-                edges_deleted = tracing::field::Empty,
             )
             .entered();
-            let stats = self.gc_collect(turbo_tasks, &snapshot_phase);
+            let (stats, roots) = self.gc_collect(turbo_tasks, &snapshot_phase);
             gc_span.record("stats", display(stats));
-            Some(start.elapsed())
+            (Some(start.elapsed()), roots)
         } else {
-            None
+            (None, None)
         };
 
         debug_assert!(self.should_persist());
@@ -1095,7 +1139,7 @@ impl TurboTasksBackend {
         let snapshot_time = Instant::now();
         drop(snapshot_phase);
 
-        if !has_modifications {
+        if !has_modifications && gc_roots_to_persist.is_none() {
             // No tasks modified since the last snapshot — drop the guard (which
             // calls end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
@@ -1389,9 +1433,10 @@ impl TurboTasksBackend {
         let snapshot_duration = start.elapsed();
         let task_count = task_snapshots.len();
 
-        if task_snapshots.is_empty() {
-            // This should be impossible — if we got here, modified_count was nonzero, and every
-            // modification that increments the count also failed during encoding.
+        if task_snapshots.is_empty() && gc_roots_to_persist.is_none() {
+            // This should be impossible — if we got here, modified_count was nonzero or gc_roots
+            // was present, and every modification that increments the count also failed
+            // during encoding.
             std::hint::cold_path();
             return Ok((snapshot_time, false));
         }
@@ -1407,9 +1452,11 @@ impl TurboTasksBackend {
         // Tasks were already consumed by take_snapshot, so a future snapshot
         // would not re-persist them — returning an error signals to the caller
         // that further persist attempts would corrupt the task graph in storage.
-        let snapshot_meta = self
-            .backing_storage
-            .save_snapshot(suspended_operations, task_snapshots)?;
+        let snapshot_meta = self.backing_storage.save_snapshot(
+            suspended_operations,
+            gc_roots_to_persist,
+            task_snapshots,
+        )?;
         span.record("snapshot_meta", display(snapshot_meta));
 
         #[cfg(feature = "print_cache_item_size")]
@@ -3407,6 +3454,11 @@ impl TurboTasksBackend {
     }
 
     fn dispose_root_task(&self, task_id: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
+        // Once stopping, it is too late to tear down tasks safely
+        if self.stopping.load(Ordering::Acquire) {
+            return;
+        }
+
         #[cfg(feature = "verify_aggregation_graph")]
         self.root_tasks.lock().remove(&task_id);
 
@@ -3420,10 +3472,24 @@ impl TurboTasksBackend {
                 activeness_state.unset_root_type();
                 activeness_state.set_active_until_clean();
             };
-        } else if let Some(activeness_state) = task.take_activeness() {
-            // Technically nobody should be listening to this event, but just in case
-            // we notify it anyway
-            activeness_state.all_clean_event.notify(usize::MAX);
+        } else {
+            if let Some(activeness_state) = task.take_activeness() {
+                // Technically nobody should be listening to this event, but just in case
+                // we notify it anyway
+                activeness_state.all_clean_event.notify(usize::MAX);
+            }
+            // Remove all the outgoing edges of this task.
+            let old_edges = capture_all_outgoing_edges(&task);
+            drop(task);
+
+            if !old_edges.is_empty() {
+                CleanupOldEdgesOperation::run(
+                    task_id,
+                    old_edges,
+                    AggregationUpdateQueue::new(),
+                    &mut ctx,
+                );
+            }
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,6 +14,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
+use parking_lot::RwLockReadGuard;
 use tracing::info_span;
 #[cfg(feature = "trace_prepare_tasks")]
 use tracing::trace_span;
@@ -231,6 +232,9 @@ pub struct ExecuteContextImpl<'e> {
     backend: &'e TurboTasksBackend,
     turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
     phase: ExecutePhase<'e>,
+    /// Held by contexts built through `TurboTasksBackend::try_execute_context`, so that storage
+    /// teardown in `stop()` waits for this context to be dropped.
+    _shutdown_guard: Option<RwLockReadGuard<'e, bool>>,
     task_lock_counter: TaskLockCounter,
 }
 
@@ -245,6 +249,26 @@ impl<'e> ExecuteContextImpl<'e> {
             phase: ExecutePhase::Normal {
                 _guard: backend.start_operation(),
             },
+            _shutdown_guard: None,
+            task_lock_counter: TaskLockCounter::new(),
+        }
+    }
+
+    /// Like [`ExecuteContextImpl::new`], but owns the shutdown read guard that
+    /// [`TurboTasksBackend::try_execute_context`] acquired, keeping `stop()` out until this
+    /// context is dropped.
+    pub(super) fn new_with_shutdown_guard(
+        backend: &'e TurboTasksBackend,
+        turbo_tasks: &'e TurboTasks<TurboTasksBackend>,
+        shutdown_guard: RwLockReadGuard<'e, bool>,
+    ) -> Self {
+        Self {
+            backend,
+            turbo_tasks,
+            phase: ExecutePhase::Normal {
+                _guard: backend.start_operation(),
+            },
+            _shutdown_guard: Some(shutdown_guard),
             task_lock_counter: TaskLockCounter::new(),
         }
     }
@@ -265,6 +289,7 @@ impl<'e> ExecuteContextImpl<'e> {
             backend,
             turbo_tasks,
             phase: ExecutePhase::Gc(gc_collectible),
+            _shutdown_guard: None,
             task_lock_counter: TaskLockCounter::new(),
         }
     }
@@ -1243,6 +1268,9 @@ impl<'e> ChildExecuteContext<'e> for ChildExecuteContextImpl<'e> {
             backend: self.backend,
             turbo_tasks: self.turbo_tasks,
             phase: ExecutePhase::Child,
+            // A child context runs inside its parent's execution, which the foreground drain
+            // already waits for, so it needs no shutdown guard of its own.
+            _shutdown_guard: None,
             task_lock_counter: TaskLockCounter::new(),
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -551,15 +551,45 @@ impl Storage {
         self.map.shards().len()
     }
 
+    /// Iterates the non-transient tasks of a **single** shard of the resident map by index, under
+    /// that shard's read lock.
+    fn for_each_resident_persistent_in_shard(
+        &self,
+        index: usize,
+        mut f: impl FnMut(TaskId, &TaskStorage),
+    ) {
+        let shard = self.map.shards()[index].read();
+        for (task_id, task) in shard.iter() {
+            if task_id.is_transient() {
+                continue;
+            }
+            f(*task_id, task);
+        }
+    }
+
     /// Scans a **single** shard by index, invoking `on_candidate` for each resident, non-transient
     /// task whose storage passes the cheap [`TaskStorage::gc_maybe_collectible`] pre-filter.
     pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) {
-        let shard = self.map.shards()[index].read();
-        for (task_id, task) in shard.iter() {
-            if !task_id.is_transient() && task.gc_maybe_collectible() {
-                on_candidate(*task_id);
+        self.for_each_resident_persistent_in_shard(index, |task_id, storage| {
+            if storage.gc_maybe_collectible() {
+                on_candidate(task_id);
             }
-        }
+        });
+    }
+
+    /// Return the set of all known live roots.
+    pub fn gc_scan_roots(&self) -> impl Iterator<Item = TaskId> {
+        let per_shard: Vec<Vec<TaskId>> =
+            parallel::map_collect(&(0..self.shard_count()).collect::<Vec<_>>(), |&index| {
+                let mut roots = Vec::new();
+                self.for_each_resident_persistent_in_shard(index, |task_id, storage| {
+                    if storage.gc_is_root() {
+                        roots.push(task_id);
+                    }
+                });
+                roots
+            });
+        per_shard.into_iter().flatten()
     }
 
     pub fn access_pair_mut(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -584,6 +584,8 @@ impl Storage {
                 let mut roots = Vec::new();
                 self.for_each_resident_persistent_in_shard(index, |task_id, storage| {
                     if storage.gc_is_root() {
+                        // The `is_root` criteria is conservative, in debug assert that we aren't m
+                        storage.gc_debug_assert_root_held_by_transient_pin();
                         roots.push(task_id);
                     }
                 });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -867,10 +867,6 @@ impl TaskStorage {
     /// conservatism lets the cheap Meta-only shard scan and the authoritative under-guard recheck
     /// (which opens `TaskDataCategory::All`, and is what actually gates collection) share this
     /// single predicate.
-    ///
-    /// Refusing to collect a task with dependents is what makes task-id reuse safe: a hard-deleted
-    /// id can be handed out again, so a surviving dependent edge would silently resolve to an
-    /// unrelated live task instead of tripping `MustExist`.
     pub fn gc_maybe_collectible(&self) -> bool {
         // None of the predicates below are correct without this.
         self.flags.is_restored(TaskDataCategory::Meta)
@@ -897,6 +893,14 @@ impl TaskStorage {
                     && self
                         .cell_dependents_hashed()
                         .is_none_or(|d| d.is_empty())))
+    }
+
+    /// Whether this task is a GC **root**: parent-less, but pinned for some reason
+    pub fn gc_is_root(&self) -> bool {
+        self.flags.is_restored(TaskDataCategory::Meta)
+            && !self.flags.deleted()
+            && self.gc_parent_count() == 0
+            && !self.gc_maybe_collectible()
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -896,11 +896,28 @@ impl TaskStorage {
     }
 
     /// Whether this task is a GC **root**: parent-less, but pinned for some reason
+    ///
+    /// NOTE: this is a conservative classification.  The typical reason is that there is a
+    /// [`TaskStorage::transient_ref`] live, but this will return true if there is merely an
+    /// `upper/follower`.
     pub fn gc_is_root(&self) -> bool {
         self.flags.is_restored(TaskDataCategory::Meta)
             && !self.flags.deleted()
             && self.gc_parent_count() == 0
             && !self.gc_maybe_collectible()
+    }
+
+    /// Assert that a task classified by [`TaskStorage::gc_is_root`] is held by a pin that eviction
+    /// cannot drop.
+    pub fn gc_debug_assert_root_held_by_transient_pin(&self) {
+        debug_assert!(self.gc_is_root()); // sanity for our caller
+        debug_assert!(
+            self.gc_transient_ref_count() > 0
+                || self.get_in_progress().is_some()
+                || self.get_activeness().is_some(),
+            "GC root is held by a non-transient pin: {self:?}.\nBeing held by another kind of \
+             reference implies a bug in GC or the aggregation graph."
+        );
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -18,7 +18,7 @@ use turbo_tasks::{
 
 use crate::{
     GitVersionInfo,
-    backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
+    backend::{AnyOperation, SpecificTaskDataCategory, TtlCounter, storage_schema::TaskStorage},
     backing_storage::{SnapshotItem, SnapshotMeta, compute_task_type_hash_from_components},
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
@@ -30,8 +30,34 @@ use crate::{
     db_invalidation::invalidation_reasons,
 };
 
-const META_KEY_OPERATIONS: u32 = 0;
-const META_KEY_NEXT_FREE_TASK_ID: u32 = 1;
+/// The fixed keys in the [`KeySpace::Infra`] keyspace.
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum InfraKey {
+    Operations = 0,
+    NextFreeTaskId = 1,
+    GcRoots = 2,
+}
+
+impl InfraKey {
+    fn key(self) -> ByteKey {
+        ByteKey::new(self as u8)
+    }
+}
+
+struct ByteKey([u8; 1]);
+
+impl ByteKey {
+    fn new(value: u8) -> Self {
+        Self([value])
+    }
+}
+
+impl AsRef<[u8]> for ByteKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
 
 struct IntKey([u8; 4]);
 
@@ -183,9 +209,9 @@ impl TurboBackingStorageInner {
     }
 
     /// Used to read the next free task ID from the database.
-    fn get_infra_u32(&self, key: u32) -> Result<Option<u32>> {
+    fn get_infra_u32(&self, key: InfraKey) -> Result<Option<u32>> {
         self.database
-            .get(KeySpace::Infra, IntKey::new(key).as_ref())?
+            .get(KeySpace::Infra, key.key().as_ref())?
             .map(as_u32)
             .transpose()
     }
@@ -206,7 +232,7 @@ impl TurboBackingStorage {
     pub(crate) fn next_free_task_id(&self) -> Result<TaskId> {
         Ok(self
             .inner
-            .get_infra_u32(META_KEY_NEXT_FREE_TASK_ID)
+            .get_infra_u32(InfraKey::NextFreeTaskId)
             .context("Unable to read next free task id from database")?
             .map_or(Ok(TaskId::MIN), TaskId::try_from)?)
     }
@@ -214,7 +240,7 @@ impl TurboBackingStorage {
     pub(crate) fn uncompleted_operations(&self) -> Result<Vec<AnyOperation>> {
         fn get(database: &TurboKeyValueDatabase) -> Result<Vec<AnyOperation>> {
             let Some(operations) =
-                database.get(KeySpace::Infra, IntKey::new(META_KEY_OPERATIONS).as_ref())?
+                database.get(KeySpace::Infra, InfraKey::Operations.key().as_ref())?
             else {
                 return Ok(Vec::new());
             };
@@ -224,9 +250,23 @@ impl TurboBackingStorage {
         get(&self.inner.database).context("Unable to read uncompleted operations from database")
     }
 
+    /// Reads the persisted GC roots set (see [`InfraKey::GcRoots`]). Empty on a fresh database.
+    pub(crate) fn roots(&self) -> Result<Vec<(TaskId, TtlCounter)>> {
+        fn get(database: &TurboKeyValueDatabase) -> Result<Vec<(TaskId, TtlCounter)>> {
+            let Some(roots) = database.get(KeySpace::Infra, InfraKey::GcRoots.key().as_ref())?
+            else {
+                return Ok(Vec::new());
+            };
+            let roots = turbo_bincode_decode(roots.borrow())?;
+            Ok(roots)
+        }
+        get(&self.inner.database).context("Unable to read GC roots from database")
+    }
+
     pub(crate) fn save_snapshot<I>(
         &self,
         operations: Vec<Arc<AnyOperation>>,
+        roots: Option<Vec<(TaskId, TtlCounter)>>,
         snapshots: Vec<I>,
     ) -> Result<SnapshotMeta>
     where
@@ -327,7 +367,7 @@ impl TurboBackingStorage {
             let mut next_task_id = get_next_free_task_id(&batch)?;
             next_task_id = next_task_id.max(snapshot_meta.max_next_task_id + 1);
 
-            save_infra(&batch, next_task_id, operations)?;
+            save_infra(&batch, next_task_id, operations, roots)?;
             {
                 let _span = tracing::trace_span!("commit").entered();
                 // Byte totals are the physical on-disk bytes (post-compression, including .sst /
@@ -444,10 +484,7 @@ impl TurboBackingStorage {
 
 fn get_next_free_task_id(batch: &TurboWriteBatch<'_>) -> Result<u32, anyhow::Error> {
     Ok(
-        match batch.get(
-            KeySpace::Infra,
-            IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref(),
-        )? {
+        match batch.get(KeySpace::Infra, InfraKey::NextFreeTaskId.key().as_ref())? {
             Some(bytes) => u32::from_le_bytes(Borrow::<[u8]>::borrow(&bytes).try_into()?),
             None => 1,
         },
@@ -458,11 +495,12 @@ fn save_infra(
     batch: &TurboWriteBatch<'_>,
     next_task_id: u32,
     operations: Vec<Arc<AnyOperation>>,
+    roots: Option<Vec<(TaskId, TtlCounter)>>,
 ) -> Result<(), anyhow::Error> {
     batch
         .put(
             KeySpace::Infra,
-            WriteBuffer::Borrowed(IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref()),
+            WriteBuffer::Borrowed(InfraKey::NextFreeTaskId.key().as_ref()),
             WriteBuffer::Borrowed(&next_task_id.to_le_bytes()),
         )
         .context("Unable to write next free task id")?;
@@ -474,10 +512,21 @@ fn save_infra(
         batch
             .put(
                 KeySpace::Infra,
-                WriteBuffer::Borrowed(IntKey::new(META_KEY_OPERATIONS).as_ref()),
+                WriteBuffer::Borrowed(InfraKey::Operations.key().as_ref()),
                 WriteBuffer::SmallVec(operations),
             )
             .context("Unable to write operations")?;
+    }
+    if let Some(roots) = roots {
+        let _span = tracing::trace_span!("update roots", roots = roots.len()).entered();
+        let roots = turbo_bincode_encode(&roots).context("Unable to serialize GC roots")?;
+        batch
+            .put(
+                KeySpace::Infra,
+                WriteBuffer::Borrowed(InfraKey::GcRoots.key().as_ref()),
+                WriteBuffer::SmallVec(roots),
+            )
+            .context("Unable to write GC roots")?;
     }
     // Safety: save_infra is called after all concurrent writes to Infra are done.
     unsafe { batch.flush(KeySpace::Infra)? };
@@ -680,6 +729,7 @@ mod tests {
         // Snapshot with no task data, just the one deletion.
         storage.save_snapshot(
             Vec::new(),
+            None,
             vec![vec![SnapshotItem::Delete {
                 task_id: deleted_id,
                 task_type_hash: collision_hash.to_le_bytes(),

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -16,7 +16,7 @@ use turbo_persistence::{CompactConfig, TurboPersistence};
 
 use crate::database::turbo::{self, TurboKeyValueDatabase};
 pub use crate::{
-    backend::{BackendOptions, EvictionMode, StorageMode, TurboTasksBackend},
+    backend::{BackendOptions, EvictionMode, StorageMode, TtlCounter, TurboTasksBackend},
     database::{
         db_invalidation,
         db_invalidation::StartupCacheState,

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
@@ -2,12 +2,20 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
+mod gc_fixture;
 mod util;
 
-use anyhow::Result;
-use turbo_tasks::{ResolvedVc, State, TaskId, Vc, prevent_gc};
+use std::sync::Arc;
 
-use crate::util::create_tt;
+use anyhow::Result;
+use turbo_tasks::{
+    ResolvedVc, TaskId, Vc, prevent_gc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+
+use crate::{
+    gc_fixture::{Selector, create_selector},
+    util::create_tt,
+};
 
 /// The `TaskId` backing a resolved `Vc` (its `TaskOutput` node).
 fn task_id_of<T>(vc: Vc<T>) -> TaskId {
@@ -16,24 +24,13 @@ fn task_id_of<T>(vc: Vc<T>) -> TaskId {
         .expect("a resolved Vc should be backed by a task")
 }
 
-#[turbo_tasks::value(transparent)]
-struct Selector(State<bool>);
-
-#[turbo_tasks::function(operation, root)]
-fn create_selector(initial: bool) -> Vc<Selector> {
-    Selector(State::new(initial)).cell()
-}
-
 #[turbo_tasks::function]
 fn leaf(n: u32) -> Vc<u32> {
     Vc::cell(n)
 }
 
-/// Resolves `leaf(n)` and returns the raw `TaskId` backing it, as a `u32`.
-///
-/// This runs inside a tracked task rather than at the top level of `run_once`, so the plain
-/// (eventually consistent) `.resolve()` read below is legal and deterministic — the read is
-/// ordered by the task graph instead of racing whatever the session happens to be doing.
+/// Resolves `leaf(n)` and returns the raw `TaskId` backing it, as a `u32`. Runs inside a tracked
+/// task so the eventually-consistent `.resolve()` read is ordered by the task graph.
 #[turbo_tasks::function(operation, root)]
 async fn leaf_task_id(n: u32) -> Result<Vc<u32>> {
     Ok(Vc::cell(*task_id_of(leaf(n).resolve().await?)))
@@ -49,16 +46,14 @@ async fn branch_b() -> Result<Vc<u32>> {
     Ok(Vc::cell(2 + *leaf(20).await?))
 }
 
-/// A task that pins itself against GC while executing. Once pinned it must survive collection even
-/// after it is disconnected.
+/// Pins itself against GC while executing.
 #[turbo_tasks::function]
 async fn pinned_branch() -> Result<Vc<u32>> {
     prevent_gc();
     Ok(Vc::cell(99))
 }
 
-/// Reads exactly one branch depending on the selector; flipping it re-executes and disconnects the
-/// previously-read branch (and its subtree), which should drop that branch's `parent_count` to 0.
+/// Reads one branch depending on the selector; flipping it disconnects the other branch's subtree.
 #[turbo_tasks::function(operation, root)]
 async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     let use_b = *selector.await?.get();
@@ -70,7 +65,7 @@ async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
-/// Like `select`, but reads `pinned_branch` instead of `branch_a` when the selector is false.
+/// [`select`] with `pinned_branch` in place of `branch_a`.
 #[turbo_tasks::function(operation, root)]
 async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     let use_b = *selector.await?.get();
@@ -95,7 +90,6 @@ async fn gc_collects_disconnected_subtree() {
         let output = select(selector_vc);
         assert_eq!(*output.read_strongly_consistent().await?, 11);
 
-        // Flip: select drops branch_a; branch_a (parent_count 0) becomes a candidate.
         selector.set(true);
         assert_eq!(*output.read_strongly_consistent().await?, 22);
 
@@ -104,16 +98,9 @@ async fn gc_collects_disconnected_subtree() {
     .await;
     result.unwrap();
 
-    let collected = tt2.backend().gc_for_testing(&tt2);
-    assert_eq!(
-        collected, 2,
-        "branch_a and its cascaded child leaf(10) should both be collected"
-    );
-    assert_eq!(
-        tt2.backend().gc_for_testing(&tt2),
-        0,
-        "a second GC pass must collect nothing"
-    );
+    // branch_a and its cascaded child leaf(10).
+    assert_eq!(tt2.backend().gc_for_testing(&tt2), 2);
+    assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
 
     // Flipping back must recompute branch_a fresh, since it was collected.
     let tt3 = tt.clone();
@@ -134,8 +121,7 @@ async fn gc_collects_disconnected_subtree() {
     tt.stop_and_wait().await;
 }
 
-/// A task that pins itself via `prevent_gc()` must survive collection even after it is disconnected
-/// from the live graph, because the pin makes it a GC root.
+/// A task pinned via `prevent_gc()` must survive collection after it is disconnected.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gc_does_not_collect_pinned_task() {
     let (tt, _persistence_dir) = create_tt("gc_does_not_collect_pinned_task");
@@ -149,7 +135,6 @@ async fn gc_does_not_collect_pinned_task() {
         let output = select_pinned(selector_vc);
         assert_eq!(*output.read_strongly_consistent().await?, 99);
 
-        // Flip: select_pinned re-executes, reads branch_b, and disconnects pinned_branch.
         selector.set(true);
         assert_eq!(*output.read_strongly_consistent().await?, 22);
 
@@ -158,33 +143,76 @@ async fn gc_does_not_collect_pinned_task() {
     .await;
     result.unwrap();
 
-    // GC runs after the run has released activeness, so pinned_branch is disconnected
-    // (parent_count 0) and otherwise collectible.
-    let collected = tt2.backend().gc_for_testing(&tt2);
-    assert_eq!(
-        collected, 0,
-        "a pinned task must not be collected even when disconnected"
-    );
+    // The run has released activeness, so pinned_branch is disconnected and otherwise collectible.
+    assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
 
-    // A snapshot + evict must not lose the (transient) pin. A pinned task is not forced fully
-    // resident — its Meta/Data may be partially evicted — but the session-only
-    // `transient_ref_count` is retained as residue (the map entry is kept), so the task stays
-    // uncollectible and a subsequent GC still collects nothing.
+    // Eviction may drop a pinned task's Meta/Data, but the session-only `transient_ref_count` is
+    // retained as residue, so the task stays uncollectible.
     tt2.backend().snapshot_and_evict_for_testing(&tt2);
-    assert_eq!(
-        tt2.backend().gc_for_testing(&tt2),
-        0,
-        "pinned task must survive eviction and not be collected"
-    );
+    assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
 
     tt.stop_and_wait().await;
+}
+
+/// Disposing a root task (as `RootTask::Drop` does when JS stops listening to a subscription) must
+/// release the anchor its child edges placed on the tasks it read. Disposal is also idempotent and
+/// safe after the backend has stopped, which `RootTask::Drop` relies on.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispose_root_task_releases_anchored_subgraph() {
+    let (tt, _persistence_dir) = create_tt("dispose_root_task_releases_anchored_subgraph");
+
+    // The root sends the leaf's id out via a oneshot rather than a `run_once` probe: a probe is its
+    // own transient `Once` task that would also connect the leaf, and `Once` tasks are never
+    // disposed, so the leaf's count would never drop to 0.
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+    let root_id = tt.spawn_root_task(move || {
+        let tx = tx.lock().unwrap().take();
+        Box::pin(async move {
+            // The root body runs as a top-level task, as `subscribe`'s HMR handler does.
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let leaf_vc = leaf(88);
+            let value = *leaf_vc.await?;
+            if let Some(tx) = tx {
+                let _ = tx.send(task_id_of(leaf_vc.resolve().await?));
+            }
+            anyhow::Ok(Vc::<u32>::cell(value))
+        })
+    });
+
+    let leaf_id = rx.await.unwrap();
+    for _ in 0..100 {
+        if tt.backend().transient_ref_count_for_testing(leaf_id) > 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(tt.backend().parent_count_for_testing(leaf_id), 0);
+    assert_eq!(tt.backend().transient_ref_count_for_testing(leaf_id), 1);
+    assert_eq!(tt.backend().gc_for_testing(&tt), 0);
+
+    // Disposing twice must not panic or underflow the child's count: JS may dispose explicitly and
+    // then drop.
+    tt.dispose_root_task(root_id);
+    tt.dispose_root_task(root_id);
+    assert_eq!(tt.backend().transient_ref_count_for_testing(leaf_id), 0);
+
+    // A `run_once` keeps touched tasks active until it returns, so GC has to run after it.
+    turbo_tasks::run_once(tt.clone(), async move { anyhow::Ok(()) })
+        .await
+        .unwrap();
+    assert_eq!(tt.backend().gc_for_testing(&tt), 1);
+
+    // Disposal after the backend has stopped (the whole task map is dropped by `stop`), as a
+    // `RootTask` finalized during Node worker teardown would be.
+    tt.stop_and_wait().await;
+    tt.dispose_root_task(root_id);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unpin_after_stop_does_not_panic() {
     let (tt, _persistence_dir) = create_tt("unpin_after_stop_does_not_panic");
 
-    // Pin a real task inside a session (as `prevent_gc` / `DetachedVc::new` would).
     let tt2 = tt.clone();
     let leaf_id = turbo_tasks::run_once(tt.clone(), async move {
         let id = TaskId::try_from(*leaf_task_id(7).read_strongly_consistent().await?)?;
@@ -194,8 +222,8 @@ async fn unpin_after_stop_does_not_panic() {
     .await
     .unwrap();
 
-    // Stop the backend — this drops the in-memory task map, so the pinned task is no longer
-    // resident (exactly as at `next build` shutdown).
+    // Stopping drops the in-memory task map, so the pinned task is no longer resident, exactly as
+    // at `next build` shutdown.
     tt.stop_and_wait().await;
 
     tt.unpin_task_for_gc(leaf_id);

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
@@ -29,8 +29,11 @@ fn leaf(n: u32) -> Vc<u32> {
     Vc::cell(n)
 }
 
-/// Resolves `leaf(n)` and returns the raw `TaskId` backing it, as a `u32`. Runs inside a tracked
-/// task so the eventually-consistent `.resolve()` read is ordered by the task graph.
+/// Resolves `leaf(n)` and returns the raw `TaskId` backing it, as a `u32`.
+///
+/// This runs inside a tracked task rather than at the top level of `run_once`, so the plain
+/// (eventually consistent) `.resolve()` read below is legal and deterministic — the read is
+/// ordered by the task graph instead of racing whatever the session happens to be doing.
 #[turbo_tasks::function(operation, root)]
 async fn leaf_task_id(n: u32) -> Result<Vc<u32>> {
     Ok(Vc::cell(*task_id_of(leaf(n).resolve().await?)))
@@ -46,14 +49,16 @@ async fn branch_b() -> Result<Vc<u32>> {
     Ok(Vc::cell(2 + *leaf(20).await?))
 }
 
-/// Pins itself against GC while executing.
+/// A task that pins itself against GC while executing. Once pinned it must survive collection even
+/// after it is disconnected.
 #[turbo_tasks::function]
 async fn pinned_branch() -> Result<Vc<u32>> {
     prevent_gc();
     Ok(Vc::cell(99))
 }
 
-/// Reads one branch depending on the selector; flipping it disconnects the other branch's subtree.
+/// Reads exactly one branch depending on the selector; flipping it re-executes and disconnects the
+/// previously-read branch (and its subtree), which should drop that branch's `parent_count` to 0.
 #[turbo_tasks::function(operation, root)]
 async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     let use_b = *selector.await?.get();
@@ -65,7 +70,7 @@ async fn select(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     Ok(Vc::cell(value))
 }
 
-/// [`select`] with `pinned_branch` in place of `branch_a`.
+/// Like `select`, but reads `pinned_branch` instead of `branch_a` when the selector is false.
 #[turbo_tasks::function(operation, root)]
 async fn select_pinned(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
     let use_b = *selector.await?.get();
@@ -90,6 +95,7 @@ async fn gc_collects_disconnected_subtree() {
         let output = select(selector_vc);
         assert_eq!(*output.read_strongly_consistent().await?, 11);
 
+        // Flip: select drops branch_a; branch_a (parent_count 0) becomes a candidate.
         selector.set(true);
         assert_eq!(*output.read_strongly_consistent().await?, 22);
 
@@ -98,9 +104,16 @@ async fn gc_collects_disconnected_subtree() {
     .await;
     result.unwrap();
 
-    // branch_a and its cascaded child leaf(10).
-    assert_eq!(tt2.backend().gc_for_testing(&tt2), 2);
-    assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 2,
+        "branch_a and its cascaded child leaf(10) should both be collected"
+    );
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "a second GC pass must collect nothing"
+    );
 
     // Flipping back must recompute branch_a fresh, since it was collected.
     let tt3 = tt.clone();
@@ -121,7 +134,8 @@ async fn gc_collects_disconnected_subtree() {
     tt.stop_and_wait().await;
 }
 
-/// A task pinned via `prevent_gc()` must survive collection after it is disconnected.
+/// A task that pins itself via `prevent_gc()` must survive collection even after it is disconnected
+/// from the live graph, because the pin makes it a GC root.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gc_does_not_collect_pinned_task() {
     let (tt, _persistence_dir) = create_tt("gc_does_not_collect_pinned_task");
@@ -135,6 +149,7 @@ async fn gc_does_not_collect_pinned_task() {
         let output = select_pinned(selector_vc);
         assert_eq!(*output.read_strongly_consistent().await?, 99);
 
+        // Flip: select_pinned re-executes, reads branch_b, and disconnects pinned_branch.
         selector.set(true);
         assert_eq!(*output.read_strongly_consistent().await?, 22);
 
@@ -143,13 +158,24 @@ async fn gc_does_not_collect_pinned_task() {
     .await;
     result.unwrap();
 
-    // The run has released activeness, so pinned_branch is disconnected and otherwise collectible.
-    assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
+    // GC runs after the run has released activeness, so pinned_branch is disconnected
+    // (parent_count 0) and otherwise collectible.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert_eq!(
+        collected, 0,
+        "a pinned task must not be collected even when disconnected"
+    );
 
-    // Eviction may drop a pinned task's Meta/Data, but the session-only `transient_ref_count` is
-    // retained as residue, so the task stays uncollectible.
+    // A snapshot + evict must not lose the (transient) pin. A pinned task is not forced fully
+    // resident — its Meta/Data may be partially evicted — but the session-only
+    // `transient_ref_count` is retained as residue (the map entry is kept), so the task stays
+    // uncollectible and a subsequent GC still collects nothing.
     tt2.backend().snapshot_and_evict_for_testing(&tt2);
-    assert_eq!(tt2.backend().gc_for_testing(&tt2), 0);
+    assert_eq!(
+        tt2.backend().gc_for_testing(&tt2),
+        0,
+        "pinned task must survive eviction and not be collected"
+    );
 
     tt.stop_and_wait().await;
 }
@@ -213,6 +239,7 @@ async fn dispose_root_task_releases_anchored_subgraph() {
 async fn unpin_after_stop_does_not_panic() {
     let (tt, _persistence_dir) = create_tt("unpin_after_stop_does_not_panic");
 
+    // Pin a real task inside a session (as `prevent_gc` / `DetachedVc::new` would).
     let tt2 = tt.clone();
     let leaf_id = turbo_tasks::run_once(tt.clone(), async move {
         let id = TaskId::try_from(*leaf_task_id(7).read_strongly_consistent().await?)?;
@@ -222,8 +249,8 @@ async fn unpin_after_stop_does_not_panic() {
     .await
     .unwrap();
 
-    // Stopping drops the in-memory task map, so the pinned task is no longer resident, exactly as
-    // at `next build` shutdown.
+    // Stop the backend — this drops the in-memory task map, so the pinned task is no longer
+    // resident (exactly as at `next build` shutdown).
     tt.stop_and_wait().await;
 
     tt.unpin_task_for_gc(leaf_id);

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
@@ -217,8 +217,8 @@ async fn dispose_root_task_releases_anchored_subgraph() {
     assert_eq!(tt.backend().transient_ref_count_for_testing(leaf_id), 1);
     assert_eq!(tt.backend().gc_for_testing(&tt), 0);
 
-    // Disposing twice must not panic or underflow the child's count: JS may dispose explicitly and
-    // then drop.
+    // Disposing twice must not panic or underflow the child's count: JS could dispose explicitly
+    // multiple times
     tt.dispose_root_task(root_id);
     tt.dispose_root_task(root_id);
     assert_eq!(tt.backend().transient_ref_count_for_testing(leaf_id), 0);

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_cross_session.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_cross_session.rs
@@ -1,0 +1,230 @@
+#![feature(arbitrary_self_types)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+//! Cross-session collection of GC roots.
+
+mod gc_fixture;
+mod util;
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use turbo_tasks::{
+    GcRoot, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
+};
+use turbo_tasks_backend::TurboTasksBackend;
+
+use crate::{
+    gc_fixture::{create_constant, diamond_root_op},
+    util::{create_persistence_dir, reopen_tt_with_gc, reopen_tt_with_gc_ttl},
+};
+
+/// Counts executions of [`orphan_leaf`], keyed by its argument. A collected task re-executes when
+/// next requested; a merely evicted one restores from disk without executing.
+static LEAF_EXECUTIONS: [AtomicU32; 3] = [AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0)];
+
+fn leaf_executions(n: u32) -> u32 {
+    LEAF_EXECUTIONS[n as usize].load(Ordering::Relaxed)
+}
+
+/// A leaf keyed by `n`, so each root gets a distinct child.
+#[turbo_tasks::function]
+fn orphan_leaf(n: u32) -> Vc<u32> {
+    LEAF_EXECUTIONS[n as usize].fetch_add(1, Ordering::Relaxed);
+    Vc::cell(n)
+}
+
+/// A two-task "root -> subtree": read at the top level of a session this op has no persistent
+/// parent, so it is a durable GC root and its leaf gets `parent_count 1`.
+#[turbo_tasks::function(operation, root)]
+async fn root_with_child(n: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(*orphan_leaf(n).await? + 1))
+}
+
+/// Runs GC until at least `want` tasks have been collected, or gives up after 20 passes.
+///
+/// A loop rather than a fixed pass count because age-out needs `elapsed > TTL` strictly, so a pass
+/// sharing a millisecond with the demotion collects nothing.
+async fn gc_until_collected(tt: &Arc<TurboTasks<TurboTasksBackend>>, want: usize) -> usize {
+    let mut collected = 0usize;
+    for _ in 0..20 {
+        collected += tt.backend().gc_for_testing(tt);
+        if collected >= want {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    collected
+}
+
+/// Width of the diamond: the fanout gives many chances for the interleaving where an `A` scrubs a
+/// not-yet-restored `B`.
+const DIAMOND_FANOUT: u32 = 64;
+
+/// A root is kept alive by being used and reclaimed by not being used, across process restarts.
+///
+/// Both roots have `parent_count == 0` forever, so only the cross-session roots map distinguishes
+/// the one that keeps being requested from the one that is abandoned. The TTL is forced to 0 so the
+/// age-out lands inside the test rather than days later.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reused_root_survives_sessions_that_abandon_its_sibling() {
+    let dir = create_persistence_dir("reused_root_survives_sessions_that_abandon_its_sibling");
+
+    // Session 1: build both subtrees and pin each root, the way an embedder holds a live handle to
+    // a route. The pin makes it a durable root, recorded in the persisted roots map on shutdown.
+    let kept_root = {
+        let tt = reopen_tt_with_gc(&dir);
+        let ids = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let kept = root_with_child(1);
+            let dropped = root_with_child(2);
+            assert_eq!(*kept.read_strongly_consistent().await?, 2);
+            assert_eq!(*dropped.read_strongly_consistent().await?, 3);
+            anyhow::Ok((kept.task_id(), dropped.task_id()))
+        })
+        .await
+        .unwrap();
+
+        let kept_pin = GcRoot::pin(tt.clone(), ids.0);
+        let dropped_pin = GcRoot::pin(tt.clone(), ids.1);
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+        drop(kept_pin);
+        drop(dropped_pin);
+
+        tt.stop_and_wait().await;
+        ids.0
+    };
+
+    // Sessions 2 and 3: only root 1 is ever requested again. Session 2's first pass demotes root 2
+    // and a later pass ages it out; session 3 proves the collection stuck.
+    let mut total_collected = 0usize;
+    for session in 2..=3 {
+        let tt = reopen_tt_with_gc_ttl(&dir, Duration::ZERO);
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // Re-request root 1 only, so it has a resident entry to pin.
+            assert_eq!(
+                *root_with_child(1).read_strongly_consistent().await?,
+                2,
+                "the reused root must still compute in session {session}"
+            );
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+
+        let kept_pin = GcRoot::pin(tt.clone(), kept_root);
+        total_collected += gc_until_collected(&tt, 2).await;
+        drop(kept_pin);
+
+        tt.stop_and_wait().await;
+    }
+
+    // Exactly the abandoned root and its leaf: root 1 is re-pinned every session and its leaf has
+    // a parent, so nothing else here is collectible.
+    assert_eq!(total_collected, 2);
+
+    // Session 4: the survivor must still be cached, the collected one must rebuild.
+    {
+        let tt = reopen_tt_with_gc(&dir);
+        let kept_before = leaf_executions(1);
+        let dropped_before = leaf_executions(2);
+        let result = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+
+            // A dangling edge left by the collection, or a resurrected half-deleted task, would
+            // surface as a wrong value or a panic here.
+            assert_eq!(*root_with_child(1).read_strongly_consistent().await?, 2);
+            assert_eq!(*root_with_child(2).read_strongly_consistent().await?, 3);
+
+            // The survivor's leaf comes from the persisted cache; the collected one re-executes.
+            assert_eq!(leaf_executions(1), kept_before);
+            assert_eq!(leaf_executions(2), dropped_before + 1);
+            anyhow::Ok(())
+        })
+        .await;
+        tt.stop_and_wait().await;
+        result.unwrap();
+    }
+}
+
+/// Collecting an orphaned root whose subtree holds a forward cell-dependency on a **disk-only**
+/// target (never restored this session) must scrub that stale reverse edge by restoring the live
+/// target.
+///
+/// Session 2 ages the root out and cascades its `A`/`B` children concurrently, so an `A`'s
+/// `CleanupOldEdges` can open its target `B` before `B` has been restored from disk. Unlike
+/// `gc_resurrection::gc_diamond_forward_dep_no_resurrection`, where every target is resident, only
+/// a restart can reach the disk-only case.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn gc_collect_scrubs_disk_only_forward_dep_target() {
+    let dir = create_persistence_dir("gc_collect_scrubs_disk_only_forward_dep_target");
+
+    // Session 1: build the diamond and persist it. Without the pin the root is never a tracked
+    // root, so nothing is collected and the cascade under test never runs.
+    {
+        let tt = reopen_tt_with_gc(&dir);
+        let root_id = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let constant_op = create_constant();
+            let constant_vc = constant_op.resolve().strongly_consistent().await?;
+            let root_op = diamond_root_op(constant_vc, DIAMOND_FANOUT);
+            root_op.read_strongly_consistent().await?;
+            anyhow::Ok(root_op.task_id())
+        })
+        .await
+        .unwrap();
+
+        let root_pin = GcRoot::pin(tt.clone(), root_id);
+        // A GC pass is what admits a live root to the persisted map; the snapshot alone leaves
+        // nothing for session 2 to age out.
+        tt.backend().gc_for_testing(&tt);
+        tt.backend().snapshot_and_evict_for_testing(&tt);
+        drop(root_pin);
+
+        tt.stop_and_wait().await;
+    }
+
+    // Session 2: the root is never re-requested, so it ages out and cascades to every A/B pair.
+    {
+        let tt = reopen_tt_with_gc_ttl(&dir, Duration::ZERO);
+        let tt2 = tt.clone();
+        turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            // No panic in these passes is the real assertion. The diamond is a root plus
+            // DIAMOND_FANOUT A/B pairs; the cascade may also reach the constant op above it.
+            let collected = gc_until_collected(&tt2, 2 * DIAMOND_FANOUT as usize + 1).await;
+            assert!(
+                collected > 2 * DIAMOND_FANOUT as usize,
+                "the orphaned diamond subtree should be collected (got {collected})"
+            );
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+        tt.stop_and_wait().await;
+    }
+
+    // Session 3: a clean recompute, proving no dangling reverse edge survived.
+    {
+        let tt = reopen_tt_with_gc(&dir);
+        let result = turbo_tasks::run_once(tt.clone(), async move {
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let constant_op = create_constant();
+            let constant_vc = constant_op.resolve().strongly_consistent().await?;
+            diamond_root_op(constant_vc, DIAMOND_FANOUT)
+                .read_strongly_consistent()
+                .await?;
+            anyhow::Ok(())
+        })
+        .await;
+        tt.stop_and_wait().await;
+        result.unwrap();
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_cross_session.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_cross_session.rs
@@ -76,46 +76,46 @@ async fn reused_root_survives_sessions_that_abandon_its_sibling() {
 
     // Session 1: build both subtrees and pin each root, the way an embedder holds a live handle to
     // a route. The pin makes it a durable root, recorded in the persisted roots map on shutdown.
-    let kept_root = {
+    {
         let tt = reopen_tt_with_gc(&dir);
-        let ids = turbo_tasks::run_once(tt.clone(), async move {
+        let ops = turbo_tasks::run_once(tt.clone(), async move {
             let kept = root_with_child(1);
             let dropped = root_with_child(2);
             assert_eq!(*kept.read_strongly_consistent().await?, 2);
             assert_eq!(*dropped.read_strongly_consistent().await?, 3);
-            anyhow::Ok((kept.task_id(), dropped.task_id()))
+            anyhow::Ok((kept, dropped))
         })
         .await
         .unwrap();
 
-        let kept_pin = GcRoot::pin(tt.clone(), ids.0);
-        let dropped_pin = GcRoot::pin(tt.clone(), ids.1);
+        let kept_pin = GcRoot::pin(tt.clone(), ops.0);
+        let dropped_pin = GcRoot::pin(tt.clone(), ops.1);
         tt.backend().snapshot_and_evict_for_testing(&tt);
         drop(kept_pin);
         drop(dropped_pin);
 
         tt.stop_and_wait().await;
-        ids.0
-    };
+    }
 
     // Sessions 2 and 3: only root 1 is ever requested again. Session 2's first pass demotes root 2
     // and a later pass ages it out; session 3 proves the collection stuck.
     let mut total_collected = 0usize;
     for session in 2..=3 {
         let tt = reopen_tt_with_gc_ttl(&dir, Duration::ZERO);
-        turbo_tasks::run_once(tt.clone(), async move {
+        let kept_op = turbo_tasks::run_once(tt.clone(), async move {
             // Re-request root 1 only, so it has a resident entry to pin.
+            let kept = root_with_child(1);
             assert_eq!(
-                *root_with_child(1).read_strongly_consistent().await?,
+                *kept.read_strongly_consistent().await?,
                 2,
                 "the reused root must still compute in session {session}"
             );
-            anyhow::Ok(())
+            anyhow::Ok(kept)
         })
         .await
         .unwrap();
 
-        let kept_pin = GcRoot::pin(tt.clone(), kept_root);
+        let kept_pin = GcRoot::pin(tt.clone(), kept_op);
         total_collected += gc_until_collected(&tt, 2).await;
         drop(kept_pin);
 
@@ -164,17 +164,17 @@ async fn gc_collect_scrubs_disk_only_forward_dep_target() {
     // root, so nothing is collected and the cascade under test never runs.
     {
         let tt = reopen_tt_with_gc(&dir);
-        let root_id = turbo_tasks::run_once(tt.clone(), async move {
+        let root_op = turbo_tasks::run_once(tt.clone(), async move {
             let constant_op = create_constant();
             let constant_vc = constant_op.resolve().strongly_consistent().await?;
             let root_op = diamond_root_op(constant_vc, DIAMOND_FANOUT);
             root_op.read_strongly_consistent().await?;
-            anyhow::Ok(root_op.task_id())
+            anyhow::Ok(root_op)
         })
         .await
         .unwrap();
 
-        let root_pin = GcRoot::pin(tt.clone(), root_id);
+        let root_pin = GcRoot::pin(tt.clone(), root_op);
         // A GC pass is what admits a live root to the persisted map; the snapshot alone leaves
         // nothing for session 2 to age out.
         tt.backend().gc_for_testing(&tt);

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_cross_session.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_cross_session.rs
@@ -15,9 +15,7 @@ use std::{
 };
 
 use anyhow::Result;
-use turbo_tasks::{
-    GcRoot, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{GcRoot, TurboTasks, Vc};
 use turbo_tasks_backend::TurboTasksBackend;
 
 use crate::{
@@ -81,7 +79,6 @@ async fn reused_root_survives_sessions_that_abandon_its_sibling() {
     let kept_root = {
         let tt = reopen_tt_with_gc(&dir);
         let ids = turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             let kept = root_with_child(1);
             let dropped = root_with_child(2);
             assert_eq!(*kept.read_strongly_consistent().await?, 2);
@@ -107,7 +104,6 @@ async fn reused_root_survives_sessions_that_abandon_its_sibling() {
     for session in 2..=3 {
         let tt = reopen_tt_with_gc_ttl(&dir, Duration::ZERO);
         turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             // Re-request root 1 only, so it has a resident entry to pin.
             assert_eq!(
                 *root_with_child(1).read_strongly_consistent().await?,
@@ -136,8 +132,6 @@ async fn reused_root_survives_sessions_that_abandon_its_sibling() {
         let kept_before = leaf_executions(1);
         let dropped_before = leaf_executions(2);
         let result = turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
-
             // A dangling edge left by the collection, or a resurrected half-deleted task, would
             // surface as a wrong value or a panic here.
             assert_eq!(*root_with_child(1).read_strongly_consistent().await?, 2);
@@ -171,7 +165,6 @@ async fn gc_collect_scrubs_disk_only_forward_dep_target() {
     {
         let tt = reopen_tt_with_gc(&dir);
         let root_id = turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             let constant_op = create_constant();
             let constant_vc = constant_op.resolve().strongly_consistent().await?;
             let root_op = diamond_root_op(constant_vc, DIAMOND_FANOUT);
@@ -196,7 +189,6 @@ async fn gc_collect_scrubs_disk_only_forward_dep_target() {
         let tt = reopen_tt_with_gc_ttl(&dir, Duration::ZERO);
         let tt2 = tt.clone();
         turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             // No panic in these passes is the real assertion. The diamond is a root plus
             // DIAMOND_FANOUT A/B pairs; the cascade may also reach the constant op above it.
             let collected = gc_until_collected(&tt2, 2 * DIAMOND_FANOUT as usize + 1).await;
@@ -215,7 +207,6 @@ async fn gc_collect_scrubs_disk_only_forward_dep_target() {
     {
         let tt = reopen_tt_with_gc(&dir);
         let result = turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             let constant_op = create_constant();
             let constant_vc = constant_op.resolve().strongly_consistent().await?;
             diamond_root_op(constant_vc, DIAMOND_FANOUT)

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_fixture.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_fixture.rs
@@ -1,0 +1,62 @@
+//! Shared graph shapes for the GC tests.
+
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, State, Vc};
+
+/// A flag a test flips to disconnect a subtree.
+#[turbo_tasks::value(transparent)]
+pub struct Selector(State<bool>);
+
+#[turbo_tasks::function(operation, root)]
+pub fn create_selector(initial: bool) -> Vc<Selector> {
+    Selector(State::new(initial)).cell()
+}
+
+/// A never-changing State read by leaf tasks purely to make them mutable, so a reader records a
+/// real dependency edge (an immutable constant records none — see `add_cell_dependency`).
+#[turbo_tasks::value(transparent)]
+pub struct Constant(State<u32>);
+
+#[turbo_tasks::function(operation, root)]
+pub fn create_constant() -> Vc<Constant> {
+    Constant(State::new(0)).cell()
+}
+
+// --- Diamond fixture ---
+//
+// Reader `A` forward-cell-depends on target `B` without `B` being its child; both are children of
+// the root. So collecting the root drives `A` and `B` to `parent_count 0` at once and they cascade
+// concurrently, while `A` still has a forward-dep on `B` to scrub.
+
+/// The forward-dependency target `B`.
+#[turbo_tasks::function]
+pub async fn diamond_target(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
+    let base = *constant.await?.get();
+    Ok(Vc::cell(base.wrapping_add(index).wrapping_mul(7)))
+}
+
+/// The diamond reader `A`: `B` arrives already resolved, so reading it records a forward dependency
+/// without making `B` a child (only calling a task creates a child edge).
+#[turbo_tasks::function]
+pub async fn diamond_reader(target: ResolvedVc<u32>) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *target.await?))
+}
+
+/// Parents each `A`/`B` pair as siblings. `fanout` is part of the cache key, so each caller gets
+/// distinct task instances.
+#[turbo_tasks::function]
+pub async fn diamond_root(constant: ResolvedVc<Constant>, fanout: u32) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for index in 0..fanout {
+        let target = diamond_target(*constant, index).to_resolved().await?;
+        sum = sum.wrapping_add(*target.await?);
+        sum = sum.wrapping_add(*diamond_reader(*target).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+/// [`diamond_root`] as an op, for tests that need a `task_id()` to pin as a durable root.
+#[turbo_tasks::function(operation, root)]
+pub async fn diamond_root_op(constant: ResolvedVc<Constant>, fanout: u32) -> Result<Vc<u32>> {
+    Ok(diamond_root(*constant, fanout))
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_resurrection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_resurrection.rs
@@ -14,34 +14,18 @@
 //! subtree must also be disconnected *cleanly* — drop the parent's reference, don't invalidate,
 //! since invalidation runs `cleanup_old_edges` and strips the outgoing deps first.
 
+mod gc_fixture;
 mod util;
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, State, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 
-use crate::util::create_tt;
-
-#[turbo_tasks::value(transparent)]
-struct Selector(State<bool>);
-
-#[turbo_tasks::function(operation, root)]
-fn create_selector(initial: bool) -> Vc<Selector> {
-    Selector(State::new(initial)).cell()
-}
-
-/// A long-lived State whose *value never changes*, read by the leaves purely to make each leaf
-/// **mutable**, so a reader records a real dependency edge on it. The state task is a root and
-/// stays alive; the leaves reach it via a dependency edge, not a child edge, so disconnecting the
-/// leaves as children still lets them lose activeness.
-#[turbo_tasks::value(transparent)]
-struct Constant(State<u32>);
-
-#[turbo_tasks::function(operation, root)]
-fn create_constant() -> Vc<Constant> {
-    Constant(State::new(0)).cell()
-}
+use crate::{
+    gc_fixture::{Constant, Selector, create_constant, create_selector, diamond_root},
+    util::create_tt,
+};
 
 /// The forward-dependency *target*: mutable because it reads `constant`'s State. `FANOUT` distinct
 /// leaves per reader give many chances for the racing interleaving.
@@ -62,38 +46,6 @@ async fn reader(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
     let mut sum = 0u32;
     for index in 0..FANOUT {
         sum = sum.wrapping_add(*sd_leaf(*constant, index).await?);
-    }
-    Ok(Vc::cell(sum))
-}
-
-/// A *sibling* forward-dependency target for the diamond fixture (`B`).
-#[turbo_tasks::function]
-async fn diamond_target(constant: ResolvedVc<Constant>, index: u32) -> Result<Vc<u32>> {
-    let base = *constant.await?.get();
-    Ok(Vc::cell(base.wrapping_add(index).wrapping_mul(7)))
-}
-
-/// A diamond *reader* (`A`): reads the cell of a `diamond_target` (`B`) that is **passed in as an
-/// already-resolved `Vc`** — so `A` records a forward (cell) dependency on `B` WITHOUT connecting
-/// `B` as `A`'s child (a child edge is only created by *calling* a task; here `B` was called by
-/// `diamond_root`). This decoupling is the crux: `B`'s only parent is `diamond_root`, so when the
-/// root is collected BOTH `A` and `B` reach `parent_count 0` at the same time and cascade-collect
-/// concurrently — while `A` still holds a forward-dep on `B` to scrub.
-#[turbo_tasks::function]
-async fn diamond_reader(target: ResolvedVc<u32>) -> Result<Vc<u32>> {
-    Ok(Vc::cell(1 + *target.await?))
-}
-
-/// The diamond root: parents both `A` and `B` as siblings, so collecting the root cascades a
-/// `Collect` for every `A` and `B` at once — a `B` can therefore be collected before the
-/// `Collect(A)` whose `CleanupOldEdges` opens it.
-#[turbo_tasks::function]
-async fn diamond_root(constant: ResolvedVc<Constant>) -> Result<Vc<u32>> {
-    let mut sum = 0u32;
-    for index in 0..FANOUT {
-        let target = diamond_target(*constant, index).to_resolved().await?;
-        sum = sum.wrapping_add(*target.await?);
-        sum = sum.wrapping_add(*diamond_reader(*target).await?);
     }
     Ok(Vc::cell(sum))
 }
@@ -125,7 +77,7 @@ async fn select_diamond(
 ) -> Result<Vc<u32>> {
     let use_diamond = !*selector.await?.get();
     let value = if use_diamond {
-        *diamond_root(*constant).await?
+        *diamond_root(*constant, FANOUT).await?
     } else {
         0u32
     };
@@ -179,6 +131,13 @@ async fn gc_rebalances_aggregation_and_cascades_in_one_pass() {
         baseline - (FANOUT as usize + 1),
         "resident count must drop by exactly the collected subtree"
     );
+
+    // Only the three top-level `(operation, root)` tasks may be tracked as roots. A leaf that
+    // reached the post-drain scan still holding a dangling `upper` edge to the deleted `reader`
+    // would land in the map as `MostRecent`, which never ages out. If this fires it is a finding
+    // about the aggregation graph, not a reason to narrow `gc_is_root`.
+    let roots = tt2.backend().persisted_gc_roots_for_testing();
+    assert_eq!(roots.len(), 3, "unexpected roots tracked: {roots:?}");
 
     tt.stop_and_wait().await;
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -6,8 +6,12 @@
 //! `Arc<dyn TurboTasksApi>`, which erases the concrete backend type and makes `tt.backend()`
 //! unreachable. It also owns the session loop (re-running the body and comparing results), whereas
 //! these tests need to drive snapshots — and sometimes a DB reopen — on their own schedule.
+//!
+//! This module is compiled into each test binary separately, so any helper a given binary doesn't
+//! call reads as dead code there.
+#![allow(dead_code)]
 
-use std::{path::Path, sync::Arc};
+use std::{path::Path, sync::Arc, time::Duration};
 
 use turbo_tasks::TurboTasks;
 use turbo_tasks_backend::{
@@ -19,6 +23,21 @@ use turbo_tasks_backend::{
 /// Reusing the same `path` (after the previous backend has been stopped) reopens the persisted
 /// database, which is how a test can assert that state survives a restart.
 fn open_tt_at(path: &Path, num_workers: usize) -> Arc<TurboTasks<TurboTasksBackend>> {
+    open_tt_at_with_gc(path, num_workers, Some(true), None)
+}
+
+/// Like [`open_tt_at`], but forces the GC on or off for this backend instead of deriving it from
+/// the `TURBO_ENGINE_GC` env var, which every test in the binary would share.
+///
+/// A test that depends on the persisted GC roots map must force it on: the map is only written by
+/// the GC branch of `snapshot_and_persist`, so with GC off a session persists an empty root set and
+/// the cross-session behaviour under test silently never engages.
+fn open_tt_at_with_gc(
+    path: &Path,
+    num_workers: usize,
+    gc: Option<bool>,
+    gc_root_ttl: Option<Duration>,
+) -> Arc<TurboTasks<TurboTasksBackend>> {
     TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {
             num_workers: Some(num_workers),
@@ -27,9 +46,8 @@ fn open_tt_at(path: &Path, num_workers: usize) -> Arc<TurboTasks<TurboTasksBacke
             // snapshot_and_evict_for_testing manually.
             storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
             eviction_mode: EvictionMode::Full,
-            // `gc_for_testing` requires a GC-enabled backend. Set per-backend rather than via
-            // `TURBO_ENGINE_GC` so parallel tests in the same binary don't share the setting.
-            gc: Some(true),
+            gc,
+            gc_root_ttl,
             ..Default::default()
         },
         turbo_tasks_backend::turbo_backing_storage(
@@ -49,15 +67,37 @@ fn open_tt_at(path: &Path, num_workers: usize) -> Arc<TurboTasks<TurboTasksBacke
     ))
 }
 
+/// A persistence directory that outlives the backends opened on it, so a test can stop one backend
+/// and open another on the same path to simulate a restart.
+pub fn create_persistence_dir(name: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("{name}-"))
+        .tempdir()
+        .unwrap()
+}
+
+/// Opens a new session over an existing persistence directory, with the GC forced on (see
+/// [`open_tt_at_with_gc`]). The previous backend must already be stopped so its shutdown snapshot
+/// has been flushed.
+pub fn reopen_tt_with_gc(dir: &tempfile::TempDir) -> Arc<TurboTasks<TurboTasksBackend>> {
+    open_tt_at_with_gc(dir.path(), 2, Some(true), None)
+}
+
+/// [`reopen_tt_with_gc`] with the GC root TTL pinned, so a test can age a root out inside the test
+/// rather than days later. Set at construction, where the TTL is resolved.
+pub fn reopen_tt_with_gc_ttl(
+    dir: &tempfile::TempDir,
+    gc_root_ttl: Duration,
+) -> Arc<TurboTasks<TurboTasksBackend>> {
+    open_tt_at_with_gc(dir.path(), 2, Some(true), Some(gc_root_ttl))
+}
+
 /// A fresh persistent backend in its own temp directory, with `num_workers` workers.
 pub fn create_tt_with_workers(
     name: &str,
     num_workers: usize,
 ) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
-    let dir = tempfile::Builder::new()
-        .prefix(&format!("{name}-"))
-        .tempdir()
-        .unwrap();
+    let dir = create_persistence_dir(name);
     let tt = open_tt_at(dir.path(), num_workers);
     (tt, dir)
 }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -102,7 +102,7 @@ pub use crate::{
     },
     join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt},
     manager::{
-        CurrentCellRef, InputResolution, ReadCellTracking, ReadConsistency, ReadTracking,
+        CurrentCellRef, GcRoot, InputResolution, ReadCellTracking, ReadConsistency, ReadTracking,
         ScheduleKey, TaskPersistence, TaskPriority, TurboTasks, TurboTasksApi, TurboTasksCallApi,
         Unused, UpdateInfo, dynamic_call, emit, get_serialization_invalidator, mark_finished,
         mark_stateful, mark_top_level_task, prevent_gc, run, run_once, run_once_with_reason,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -2262,6 +2262,33 @@ pub fn prevent_gc() {
     }
 }
 
+/// An RAII guard that pins a task against garbage collection.
+/// Not `Clone`: each guard owns exactly one pin. To share one pin across several owners, wrap the
+/// guard in an [`Arc`].
+pub struct GcRoot {
+    tt: Arc<dyn TurboTasksApi>,
+    task: TaskId,
+}
+
+impl GcRoot {
+    /// Pins `task`, returning a guard that unpins it on drop.
+    pub fn pin(tt: Arc<dyn TurboTasksApi>, task: TaskId) -> Self {
+        tt.pin_task_for_gc(task);
+        Self { tt, task }
+    }
+
+    /// The task this guard is pinning.
+    pub fn task_id(&self) -> TaskId {
+        self.task
+    }
+}
+
+impl Drop for GcRoot {
+    fn drop(&mut self) {
+        self.tt.unpin_task_for_gc(self.task);
+    }
+}
+
 pub fn emit<T: VcValueTrait + ?Sized>(collectible: ResolvedVc<T>) {
     with_turbo_tasks(|tt| {
         let raw_vc = collectible.node.node;

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1,9 +1,10 @@
 use std::{
+    borrow::Borrow,
     cell::Cell,
     cmp::Reverse,
     fmt::{Debug, Display},
     future::Future,
-    hash::{BuildHasher, BuildHasherDefault},
+    hash::{BuildHasher, BuildHasherDefault, Hash},
     mem::take,
     ops::Deref,
     panic::AssertUnwindSafe,
@@ -30,9 +31,9 @@ use tracing::{Instrument, Span, instrument};
 use turbo_tasks_hash::{DeterministicHash, hash_xxh3_hash128};
 
 use crate::{
-    CellId, Completion, InvalidationReason, InvalidationReasonSet, OutputContent, RawVc,
-    ReadCellOptions, ReadOutcome, ReadOutputOptions, ResolvedVc, SharedReference, TaskId,
-    TraitMethod, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
+    CellId, Completion, InvalidationReason, InvalidationReasonSet, NonLocalValue, OperationValue,
+    OperationVc, OutputContent, RawVc, ReadCellOptions, ReadOutcome, ReadOutputOptions, ResolvedVc,
+    SharedReference, TaskId, TraitMethod, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
     backend::{
         Backend, CellContent, CellHash, TaskCollectiblesMap, TaskExecutionSpec, TransientTaskType,
         TurboTasksExecutionError, TypedCellContent, VerificationMode,
@@ -2262,32 +2263,88 @@ pub fn prevent_gc() {
     }
 }
 
-/// An RAII guard that pins a task against garbage collection.
-/// Not `Clone`: each guard owns exactly one pin. To share one pin across several owners, wrap the
-/// guard in an [`Arc`].
-pub struct GcRoot {
+/// An RAII guard that pins an [`OperationVc`]'s task against garbage collection.
+pub struct GcRoot<T: ?Sized> {
     tt: Arc<dyn TurboTasksApi>,
-    task: TaskId,
+    vc: OperationVc<T>,
 }
 
-impl GcRoot {
-    /// Pins `task`, returning a guard that unpins it on drop.
-    pub fn pin(tt: Arc<dyn TurboTasksApi>, task: TaskId) -> Self {
-        tt.pin_task_for_gc(task);
-        Self { tt, task }
-    }
-
-    /// The task this guard is pinning.
-    pub fn task_id(&self) -> TaskId {
-        self.task
+impl<T: ?Sized> GcRoot<T> {
+    /// Pins `vc`'s task, returning a guard that unpins it on drop.
+    pub fn pin(tt: Arc<dyn TurboTasksApi>, vc: OperationVc<T>) -> Self {
+        tt.pin_task_for_gc(vc.task_id());
+        Self { tt, vc }
     }
 }
 
-impl Drop for GcRoot {
+/// A guard derefs to the operation it pins, so [`OperationVc`]'s own methods can be called on it
+/// directly and `*guard` recovers the operation itself.
+impl<T: ?Sized> Deref for GcRoot<T> {
+    type Target = OperationVc<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.vc
+    }
+}
+
+impl<T: ?Sized> Clone for GcRoot<T> {
+    fn clone(&self) -> Self {
+        Self::pin(self.tt.clone(), self.vc)
+    }
+}
+
+impl<T: ?Sized> Drop for GcRoot<T> {
     fn drop(&mut self) {
-        self.tt.unpin_task_for_gc(self.task);
+        self.tt.unpin_task_for_gc(self.vc.task_id());
     }
 }
+
+impl<T: ?Sized> Debug for GcRoot<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcRoot").field("vc", &self.vc).finish()
+    }
+}
+
+impl<T: ?Sized> PartialEq for GcRoot<T> {
+    /// Compares the pinned operation only. Two guards for the same operation are interchangeable
+    /// as far as reachability is concerned, even though each holds its own pin.
+    fn eq(&self, other: &Self) -> bool {
+        self.vc == other.vc
+    }
+}
+
+impl<T: ?Sized> Eq for GcRoot<T> {}
+
+impl<T: ?Sized> Hash for GcRoot<T> {
+    /// Hashes the pinned operation, consistently with [`PartialEq`], so a guard can be looked up
+    /// in a set by the [`OperationVc`] it pins (see the [`Borrow`] impl).
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.vc.hash(state);
+    }
+}
+
+/// Lets a collection keyed on guards be queried with the bare operation: `Borrow` plus the
+/// matching [`Hash`]/[`Eq`] impls give `OperationVc<T>: Equivalent<GcRoot<T>>`, so e.g.
+/// `IndexSet<GcRoot<T>>::swap_remove` accepts an `&OperationVc<T>`.
+impl<T: ?Sized> Borrow<OperationVc<T>> for GcRoot<T> {
+    fn borrow(&self) -> &OperationVc<T> {
+        &self.vc
+    }
+}
+
+impl<T: ?Sized> TraceRawVcs for GcRoot<T> {
+    fn trace_raw_vcs(&self, trace_context: &mut crate::trace::TraceRawVcsContext) {
+        self.vc.trace_raw_vcs(trace_context);
+    }
+}
+
+/// Safety: a `GcRoot` contains exactly one [`OperationVc`] and no [`Vc`] or [`ResolvedVc`], which
+/// is what [`OperationValue`] asserts.
+unsafe impl<T: ?Sized + Send> OperationValue for GcRoot<T> {}
+
+/// Safety: mirrors the [`OperationVc`] impl — a `GcRoot` holds no task-local data beyond the
+/// operation it pins.
+unsafe impl<T: NonLocalValue + ?Sized> NonLocalValue for GcRoot<T> {}
 
 pub fn emit<T: VcValueTrait + ?Sized>(collectible: ResolvedVc<T>) {
     with_turbo_tasks(|tt| {


### PR DESCRIPTION
### What?

Reworks how the reference-counting GC decides what is a **root** (a task that must not be collected), and adds a durable path to reclaim cross-session orphaned roots

Currently GC roots are persisted and the only way to get collected is for another session to revive them, and then for their ref-counts to drop.  This provides a new mechanism.

1. **In-session** — Top level operations get reference counted so they can be dropped in session.
2. **Cross-session** — live roots are recorded along with a simple aging mechanism so they can still be collected even if a later session never restores it.

### Why?
This closes the final GC gap.  Top level operations are ambiguous currently and need tracking.  With cross session aging we close a basic gap where if you delete a route between sessions we never clean up the tasks.  Now it will eventually age out.

### How?

**Roots are anchored explicitly**.  Via pins and RAII guards like `GcRoot`

**Persisted roots set + TTL age-out** A new Infra-keyspace `GcRoots` entry persists `Vec<(TaskId, ttl)>`.  That allows us to detect when roots are stale and can be dropped.

**Dispose transient root tasks on drop.** `RootTask::Drop` now disposes tasks and cleans up references allowing the GC to work
