### PR TITLE
fix(server): read the checked manifest in getMaybePagePath's locale fallback

### DIFF
--- a/packages/next/src/server/require.test.ts
+++ b/packages/next/src/server/require.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { getMaybePagePath } from './require'
+
+function makeDistDir(pagesManifest: Record<string, string>, appPathsManifest?: Record<string, string>) {
+  const distDir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-require-'))
+  fs.mkdirSync(path.join(distDir, 'server'), { recursive: true })
+  fs.writeFileSync(
+    path.join(distDir, 'server', 'pages-manifest.json'),
+    JSON.stringify(pagesManifest)
+  )
+  if (appPathsManifest) {
+    fs.writeFileSync(
+      path.join(distDir, 'server', 'app-paths-manifest.json'),
+      JSON.stringify(appPathsManifest)
+    )
+  }
+  return distDir
+}
+
+describe('getMaybePagePath', () => {
+  it('resolves locale-prefixed app paths from the app paths manifest', () => {
+    const distDir = makeDistDir(
+      {},
+      { '/en/blog/page': 'app/blog/page.js' }
+    )
+    try {
+      // The app manifest key is locale-prefixed; '/blog/page' must resolve
+      // via the locale-stripped lookup, reading values from the APP manifest
+      // (the pages manifest is empty here).
+      const result = getMaybePagePath('/blog/page', distDir, ['en', 'fr'], true)
+      expect(result).toBe(path.join(distDir, 'server', 'app/blog/page.js'))
+    } finally {
+      fs.rmSync(distDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not clobber a direct pages-manifest hit when locales are configured', () => {
+    const distDir = makeDistDir({ '/en/about': 'pages/about.js' })
+    try {
+      // Direct hit on '/en/about' — the locale fallback must not run and
+      // overwrite it with a miss.
+      const result = getMaybePagePath('/en/about', distDir, ['en'], false)
+      expect(result).toBe(path.join(distDir, 'server', 'pages/about.js'))
+    } finally {
+      fs.rmSync(distDir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns null for unknown pages', () => {
+    const distDir = makeDistDir({ '/index': 'pages/index.js' })
+    try {
+      expect(
+        getMaybePagePath('/definitely-not-here', distDir, ['en'], false)
+      ).toBeNull()
+    } finally {
+      fs.rmSync(distDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/next/src/server/require.ts
+++ b/packages/next/src/server/require.ts
@@ -59,12 +59,15 @@ export function getMaybePagePath(
   const checkManifest = (manifest: PagesManifest) => {
     let curPath = manifest[page]
 
-    if (!manifest[curPath] && locales) {
+    // Only build the locale-stripped lookup when the direct lookup missed —
+    // and read values from the manifest being checked, not the pages
+    // manifest (which would mismatch when checking the app paths manifest).
+    if (!curPath && locales) {
       const manifestNoLocales: typeof pagesManifest = {}
 
       for (const key of Object.keys(manifest)) {
         manifestNoLocales[normalizeLocalePath(key, locales).pathname] =
-          pagesManifest[key]
+          manifest[key]
       }
       curPath = manifestNoLocales[page]
     }


### PR DESCRIPTION
## What

`getMaybePagePath` (server/require.ts, used by `NextNodeServer.hasPage`) builds a locale-stripped lookup table inside the `checkManifest(manifest)` closure — but populated the values from the outer **`pagesManifest`** instead of the `manifest` argument:

```ts
manifestNoLocales[normalizeLocalePath(key, locales).pathname] = pagesManifest[key]
```

and gated the fallback on `!manifest[curPath]` — which is always true after a successful direct lookup, because `curPath` is a bundle **path value** (e.g. `app/blog/page.js`), never a manifest key.

For a deployment with an `i18n` config (deprecated but still allowed — `server/config.ts` only warns) plus an `app` directory, checking the **app paths manifest** paired app-manifest keys with pages-manifest values (usually `undefined`), so App Router pages failed to resolve — with the negative result cached in the `pagePathCache` LRU in production. And where an app-manifest key collides with a pages-manifest key, the Pages Router bundle path could be returned for an App Router route.

## Fix

Read `manifest[key]` (the manifest being checked), and only run the locale fallback when the direct lookup missed (`!curPath`).

## Tests

New `require.test.ts` with synthetic manifests in temp distDirs:

- locale-prefixed app-manifest entry (`/en/blog/page`) resolving `/blog/page` → the app bundle — previously returned `null`;
- a direct locale-prefixed pages hit (`/en/about`) not clobbered by the fallback — previously returned `null`;
- unknown page → `null`.

The first two fail before this fix; all pass after. Full server unit suite green; `tsc`/`eslint` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
