### PR TITLE
fix(shared): UTF-8 encode before btoa in segment value encoding

### DIFF
--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.test.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.test.ts
@@ -1,0 +1,50 @@
+import {
+  createSegmentRequestKeyPart,
+  appendSegmentRequestKeyPart,
+  ROOT_SEGMENT_REQUEST_KEY,
+} from './segment-value-encoding'
+
+describe('segment-value-encoding', () => {
+  it('passes ASCII names through unchanged', () => {
+    expect(createSegmentRequestKeyPart('about')).toBe('about')
+    expect(createSegmentRequestKeyPart(['slug', 'id', 'd'] as any)).toBe(
+      '$d$slug'
+    )
+  })
+
+  it('encodes non-Latin-1 static segment names without throwing', () => {
+    // btoa() throws InvalidCharacterError for code points above U+00FF.
+    expect(() => createSegmentRequestKeyPart('日本語')).not.toThrow()
+    const part = createSegmentRequestKeyPart('日本語')
+    expect(part).toMatch(/^!/)
+    // Deterministic
+    expect(createSegmentRequestKeyPart('日本語')).toBe(part)
+    // And distinct per input
+    expect(createSegmentRequestKeyPart('日本語')).not.toBe(
+      createSegmentRequestKeyPart('日本語x')
+    )
+  })
+
+  it('encodes non-Latin-1 dynamic param names without throwing', () => {
+    expect(() =>
+      createSegmentRequestKeyPart(['名前', 'user', 'd'] as any)
+    ).not.toThrow()
+    expect(createSegmentRequestKeyPart(['名前', 'user', 'd'] as any)).toMatch(
+      /^\$d\$!/
+    )
+  })
+
+  it('encodes non-Latin-1 parallel route keys without throwing', () => {
+    expect(() =>
+      appendSegmentRequestKeyPart(
+        ROOT_SEGMENT_REQUEST_KEY,
+        'サイドバー',
+        createSegmentRequestKeyPart('page' as any)
+      )
+    ).not.toThrow()
+  })
+
+  it('encodes Latin-1 names without throwing', () => {
+    expect(() => createSegmentRequestKeyPart('café')).not.toThrow()
+  })
+})

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -74,13 +74,23 @@ export function appendSegmentRequestKeyPart(
 // by default for compactness, and for easier debugging.
 const simpleParamValueRegex = /^[a-zA-Z0-9\-_@]+$/
 
+const textEncoder = new TextEncoder()
+
 function encodeToFilesystemAndURLSafeString(value: string) {
   if (simpleParamValueRegex.test(value)) {
     return value
   }
   // If there are any unsafe characters, base64url-encode the entire value.
   // We also add a ! prefix so it doesn't collide with the simple case.
-  const base64url = btoa(value)
+  // Encode as UTF-8 bytes first: btoa() only accepts Latin-1 code points and
+  // throws InvalidCharacterError for anything above U+00FF (e.g. non-ASCII
+  // route folder or dynamic param names like `app/日本語` or `[名前]`).
+  const bytes = textEncoder.encode(value)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  const base64url = btoa(binary)
     .replace(/\+/g, '-') // Replace '+' with '-'
     .replace(/\//g, '_') // Replace '/' with '_'
     .replace(/=+$/, '') // Remove trailing '='


### PR DESCRIPTION
## What

`encodeToFilesystemAndURLSafeString` (shared/lib/segment-cache/segment-value-encoding.ts) falls back to `btoa(value)` for any segment name outside `/^[a-zA-Z0-9\-_@]+$/`. `btoa` only accepts Latin-1 code points and **throws `InvalidCharacterError`** for anything above U+00FF.

The values that reach it are raw app-directory names — static route folder names (`app/日本語/page.tsx`), dynamic param names (`app/[名前]/page.tsx`), and parallel-route keys — so such apps crash:

- **server/build:** `collect-segment-data.tsx` calls `createSegmentRequestKeyPart` while collecting per-segment prefetch data during prerender,
- **client:** segment-cache route-tree construction (`cache.ts`) — taking down navigation/prefetching for that route.

(Not security-relevant: URL-supplied param *values* don't reach this function; only param *names* and folder names do.)

## Fix

Encode as UTF-8 bytes before base64, reusing the byte-safe pattern from `shared/lib/router/utils/cache-busting-search-param.ts`:

```ts
const bytes = new TextEncoder().encode(value)
let binary = ''
for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
const base64url = btoa(binary)...
```

- ASCII and ASCII-with-special-chars output is **byte-identical** (UTF-8 == Latin-1 there).
- Latin-1 names (`é`) change encoding vs. before, but the function is one-way and both server and client run the identical code within a build; static-export filenames for non-ASCII routes regenerate on rebuild.

## Tests

New `segment-value-encoding.test.ts`: ASCII passthrough unchanged; non-Latin-1 static segment / dynamic param name / parallel-route key encode without throwing, deterministically, and distinctly; Latin-1 encodes without throwing. The three non-Latin-1 tests throw `InvalidCharacterError` before this fix; all pass after. segment-cache + client unit suites green; `tsc`/`eslint` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
