### PR TITLE
fix(turbo-persistence): actually honor read_only when opening a database read-only

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -421,7 +421,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             parallel_scheduler,
             config,
         });
-        db.open_directory(false)?;
+        db.open_directory()?;
         Ok(db)
     }
 
@@ -438,16 +438,17 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             parallel_scheduler,
             config,
         });
-        db.open_directory(false)?;
+        db.open_directory()?;
         Ok(db)
     }
 
     /// Performs the initial check on the database directory.
-    fn open_directory(&mut self, read_only: bool) -> Result<()> {
+    fn open_directory(&mut self) -> Result<()> {
+        let read_only = self.read_only;
         match fs::read_dir(&self.path) {
             Ok(entries) => {
                 if !self
-                    .load_directory(entries, read_only)
+                    .load_directory(entries)
                     .context("Loading persistence directory failed")?
                 {
                     if read_only {
@@ -477,7 +478,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     }
 
     /// Loads an existing database directory and performs cleanup if necessary.
-    fn load_directory(&mut self, entries: ReadDir, read_only: bool) -> Result<bool> {
+    fn load_directory(&mut self, entries: ReadDir) -> Result<bool> {
+        let read_only = self.read_only;
         let mut meta_files = Vec::new();
         let mut current_file = match File::open(self.path.join("CURRENT")) {
             Ok(file) => file,

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -11,7 +11,7 @@ use crate::{
     write_batch::WriteBatch,
 };
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct RayonParallelScheduler;
 
 impl ParallelScheduler for RayonParallelScheduler {
@@ -2228,4 +2228,65 @@ fn stale_current_next_is_recovered() -> Result<()> {
     );
 
     Ok(())
+}
+
+/// A read-only open must not mutate the directory: no cleanup of
+/// CURRENT.next, no deletion of files with seq > CURRENT, and no processing
+/// of pending .del files.
+#[test]
+fn read_only_open_does_not_mutate_directory() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // A valid CURRENT file (sequence number 0).
+    fs::write(path.join("CURRENT"), 0u32.to_be_bytes())?;
+    // A leftover CURRENT.next from an interrupted commit.
+    fs::write(path.join("CURRENT.next"), 1u32.to_be_bytes())?;
+    // An in-flight SST file with a sequence number beyond CURRENT.
+    fs::write(path.join("00000005.sst"), b"in-flight")?;
+    // A pending deletion marker referencing another file.
+    fs::write(path.join("00000000.del"), 3u32.to_be_bytes())?;
+    fs::write(path.join("00000003.sst"), b"pending-deletion")?;
+
+    let snapshot = snapshot_dir(path)?;
+
+    let _db: TurboPersistence<RayonParallelScheduler, 1> =
+        TurboPersistence::open_read_only_with_config(path.to_path_buf(), DbConfig::default())?;
+
+    assert_eq!(
+        snapshot,
+        snapshot_dir(path)?,
+        "read-only open must not change the directory contents"
+    );
+    Ok(())
+}
+
+/// Opening a directory without a CURRENT file in read-only mode must fail
+/// instead of initializing a fresh database in it.
+#[test]
+fn read_only_open_without_current_fails() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let result: Result<TurboPersistence<RayonParallelScheduler, 1>> =
+        TurboPersistence::open_read_only_with_config(path.to_path_buf(), DbConfig::default());
+    assert!(result.is_err());
+    assert!(
+        fs::read_dir(path)?.next().is_none(),
+        "directory must stay empty"
+    );
+    Ok(())
+}
+
+fn snapshot_dir(path: &Path) -> Result<Vec<(String, Vec<u8>)>> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        entries.push((
+            entry.file_name().to_string_lossy().into_owned(),
+            fs::read(entry.path())?,
+        ));
+    }
+    entries.sort();
+    Ok(entries)
 }


### PR DESCRIPTION
## What

`open_read_only_with_parallel_scheduler` (turbopack/crates/turbo-persistence/src/db.rs) constructed the DB with `read_only: true` but then called `db.open_directory(false)` — the **writable** flag. Since `open_directory`/`load_directory` take that boolean as the sole authority, a "read-only" open performed the full crash-recovery/cleanup path:

- deletes leftover `CURRENT.next`,
- deletes every file with a sequence number greater than `CURRENT` — including **in-flight SST/blob files a live writer process is producing** (e.g. a running turbopack/Next.js dev server or build), which then commits a `CURRENT` pointing at unlinked files (corruption on next open),
- processes pending `.del` files (unlinking referenced sst/meta/blob files),
- and for a `CURRENT`-less directory, **initializes a fresh database** (the `read_only` bail branch was dead code).

The only consumer is `turbo-persistence-tools`, an inspection tool that must never mutate the directory it examines — including on read-only-mounted/permission-restricted directories, where the removal calls made the open fail outright.

## Fix

Drop the parameter entirely: `open_directory()`/`load_directory()` now read `self.read_only` (the struct field set at construction), so the two sources of truth can't diverge. All mutation sites were already gated on `!read_only`, so the writable open path is behavior-identical.

## Tests

Two new tests in tests.rs:

- `read_only_open_does_not_mutate_directory` — plants `CURRENT`, a `CURRENT.next` leftover, an in-flight `.sst` with seq > CURRENT, and a `.del` referencing another `.sst`; snapshots the directory (names + contents), opens read-only, asserts byte-identical. **Fails before the fix** (files deleted), passes after.
- `read_only_open_without_current_fails` — a `CURRENT`-less directory errors instead of being initialized. **Fails before the fix** (creates `CURRENT`), passes after.

Full crate suite: 60 pass + 3–5 pre-existing flaky compaction/merge failures that occur identically without this change (resource-sensitive on shared CI-class hardware); `clippy`/`fmt` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
