### PR TITLE
fix(turbo-persistence): return errors instead of panicking on corrupt .meta files

### DIFF
--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -281,6 +281,12 @@ impl MetaFile {
         }
         let family = reader.read_u32::<BE>()?;
         let obsolete_count = reader.read_u32::<BE>()?;
+        // The count is file-derived: validate it against the remaining mapped
+        // length (each entry is a u32) before allocating, so a corrupt value
+        // can't trigger a huge allocation.
+        if (obsolete_count as u64) * 4 > reader.len() as u64 {
+            bail!("Obsolete SST count {obsolete_count} out of bounds in {sequence_number:08}.meta");
+        }
         let mut obsolete_sst_files = Vec::with_capacity(obsolete_count as usize);
         for _ in 0..obsolete_count {
             obsolete_sst_files.push(reader.read_u32::<BE>()?);
@@ -291,9 +297,22 @@ impl MetaFile {
         // Compute where the AMQF data region starts so we can deserialize filters inline.
         // Remaining header: count * ENTRY_HEADER_SIZE + used_keys_end_offset.
         let header_so_far = (mmap.len() - reader.len()) as u32;
-        let amqf_data_start =
-            header_so_far + count * (size_of::<EntryHeader>() as u32) + size_of::<u32>() as u32;
-        let amqf_data = &mmap[amqf_data_start as usize..];
+        // All of count and the offsets come from the file — validate the
+        // arithmetic and the slice bounds instead of panicking on a corrupt
+        // or truncated file.
+        let amqf_data_start = count
+            .checked_mul(size_of::<EntryHeader>() as u32)
+            .and_then(|v| v.checked_add(header_so_far))
+            .and_then(|v| v.checked_add(size_of::<u32>() as u32))
+            .context("AMQF data offset overflow")?;
+        let amqf_data = mmap
+            .get(amqf_data_start as usize..)
+            .context("AMQF data region out of bounds")?;
+
+        // Same for the entry count: every entry header must fit in the file.
+        if (count as u64) * (size_of::<EntryHeader>() as u64) > reader.len() as u64 {
+            bail!("Entry count {count} out of bounds in {sequence_number:08}.meta");
+        }
 
         // Parse entries and eagerly deserialize AMQF filters as zero-copy FilterRefs.
         let mut entries = Vec::with_capacity(count as usize);
@@ -303,9 +322,19 @@ impl MetaFile {
                 .ok()
                 .context("Entry header out of bounds")?;
             reader = rest;
+            let block_count = header.block_count.get();
+            // A present SST always has at least one block; a zero here is
+            // file corruption that would underflow block_count - 1 in the
+            // SST lookup path later.
+            if block_count == 0 {
+                bail!(
+                    "Invalid block count 0 in {sequence_number:08}.meta entry {}",
+                    header.sequence_number.get()
+                );
+            }
             let sst_data = StaticSortedFileMetaData {
                 sequence_number: header.sequence_number.get(),
-                block_count: header.block_count.get(),
+                block_count,
             };
             let min_hash = header.min_hash.get();
             let max_hash = header.max_hash.get();
@@ -313,9 +342,20 @@ impl MetaFile {
             let flags = MetaEntryFlags(header.flags.get());
             let end_of_amqf_data_offset = header.amqf_end_offset.get();
 
+            // Validate the file-derived offsets before use: they must be
+            // monotonic and within the AMQF data region.
+            if start_of_amqf_data_offset > end_of_amqf_data_offset
+                || end_of_amqf_data_offset as usize > amqf_data.len()
+            {
+                bail!(
+                    "Invalid AMQF offsets {start_of_amqf_data_offset}..{end_of_amqf_data_offset} \
+                     (region size {}) in {sequence_number:08}.meta",
+                    amqf_data.len()
+                );
+            }
             let amqf_bytes = amqf_data
                 .get(start_of_amqf_data_offset as usize..end_of_amqf_data_offset as usize)
-                .expect("AMQF data out of bounds");
+                .context("AMQF data out of bounds")?;
             // Deserialize the filter borrowing from the mmap, then erase the lifetime.
             let amqf: qfilter::FilterRef<'_> =
                 postcard::from_bytes(amqf_bytes).with_context(|| {
@@ -344,6 +384,20 @@ impl MetaFile {
 
         let start_of_used_keys_amqf_data_offset = start_of_amqf_data_offset;
         let end_of_used_keys_amqf_data_offset = reader.read_u32::<BE>()?;
+
+        // Validate the used-keys offsets as well — they are dereferenced much
+        // later (during compaction, on a rayon worker thread), where a panic
+        // would crash mid-commit instead of failing the open cleanly.
+        if end_of_used_keys_amqf_data_offset < start_of_used_keys_amqf_data_offset
+            || end_of_used_keys_amqf_data_offset as usize > amqf_data.len()
+        {
+            bail!(
+                "Invalid used-keys AMQF offsets \
+                 {start_of_used_keys_amqf_data_offset}..{end_of_used_keys_amqf_data_offset} \
+                 (region size {}) in {sequence_number:08}.meta",
+                amqf_data.len()
+            );
+        }
 
         Ok(Self {
             db_path,

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -191,6 +191,26 @@ pub struct StaticSortedFileMetaData {
     pub block_count: u16,
 }
 
+/// Validates that the block offset table of `block_count` u32 offsets fits in
+/// an SST file of `sst_len` bytes. The block count comes from the (potentially
+/// corrupt) meta file — without this check `block_offsets_start` would
+/// underflow and panic.
+fn ensure_block_offsets_fit(
+    path: &Path,
+    meta: &StaticSortedFileMetaData,
+    sst_len: usize,
+) -> Result<()> {
+    if (meta.block_count as usize) * size_of::<u32>() > sst_len {
+        bail!(
+            "SST file {} ({} bytes) is too small for its meta file's block count {}",
+            path.display(),
+            sst_len,
+            meta.block_count
+        );
+    }
+    Ok(())
+}
+
 impl StaticSortedFileMetaData {
     pub fn block_offsets_start(&self, sst_len: usize) -> usize {
         let bc: usize = self.block_count.into();
@@ -227,6 +247,7 @@ impl StaticSortedFile {
                 file.metadata().map(|m| m.len()).unwrap_or(0)
             )
         })?;
+        ensure_block_offsets_fit(&path, &meta, mmap.len())?;
         #[cfg(unix)]
         {
             mmap.advise(memmap2::Advice::Random)?;
@@ -541,7 +562,8 @@ fn get_raw_block_slice<'a>(
     meta: &StaticSortedFileMetaData,
     block_index: u16,
 ) -> Result<(u32, u32, &'a [u8])> {
-    #[cfg(feature = "strict_checks")]
+    // Unconditional (not strict_checks-gated): the block count and offset
+    // table come from the meta file, which may be corrupt.
     if block_index >= meta.block_count {
         bail!(
             "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x})",
@@ -552,7 +574,6 @@ fn get_raw_block_slice<'a>(
         );
     }
     let offset = meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
-    #[cfg(feature = "strict_checks")]
     if offset + 4 > mmap.len() {
         bail!(
             "Corrupted file seq:{} block:{} block offset locations {} + 4 bytes > file end {} \
@@ -570,7 +591,6 @@ fn get_raw_block_slice<'a>(
         be::read_u32(&mmap[offset - 4..]) as usize
     };
     let block_end = be::read_u32(&mmap[offset..]) as usize;
-    #[cfg(feature = "strict_checks")]
     if block_end > mmap.len() || block_start > mmap.len() {
         bail!(
             "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x})",
@@ -788,6 +808,7 @@ impl StaticSortedFileIter {
                 file.metadata().map(|m| m.len()).unwrap_or(0)
             )
         })?;
+        ensure_block_offsets_fit(&path, &meta, mmap.len())?;
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Sequential)?;
         advise_mmap_for_persistence(&mmap)?;

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2229,3 +2229,147 @@ fn stale_current_next_is_recovered() -> Result<()> {
 
     Ok(())
 }
+
+/// A corrupt or truncated .meta file must produce an open error, never a
+/// panic (the AMQF offsets are file-derived and were previously used as raw
+/// slice indices / range bounds).
+#[test]
+fn corrupt_meta_file_returns_error_instead_of_panicking() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    {
+        let db = TurboPersistence::<RayonParallelScheduler, 16>::open_with_parallel_scheduler(
+            path.to_path_buf(),
+            RayonParallelScheduler,
+        )?;
+        let mut batch = db.write_batch()?;
+        for i in 10..20u8 {
+            batch.put(0, vec![1, i], vec![i].into())?;
+        }
+        db.commit_write_batch(batch)?;
+        drop(db);
+    }
+
+    let meta_path = fs::read_dir(path)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| p.extension().is_some_and(|e| e == "meta"))
+        .expect("no .meta file produced");
+    let original = fs::read(&meta_path)?;
+
+    // Sanity: the file parses fine as-is.
+    {
+        let db = TurboPersistence::<RayonParallelScheduler, 16>::open_with_parallel_scheduler(
+            path.to_path_buf(),
+            RayonParallelScheduler,
+        )?;
+        drop(db);
+    }
+
+    let meta_prefix_len = 16; // magic + family + obsolete_count + count
+    let entry_header_size = 38; // EntryHeader: u32 + u16 + u64*3 + u32*2
+    let first_amqf_end_offset_pos = meta_prefix_len + entry_header_size - 4;
+
+    let cases: [(&str, Box<dyn Fn(&mut Vec<u8>)>); 7] = [
+        // The first entry's amqf_end_offset points way past the file.
+        (
+            "offset out of bounds",
+            Box::new(move |data: &mut Vec<u8>| {
+                data[first_amqf_end_offset_pos..first_amqf_end_offset_pos + 4]
+                    .copy_from_slice(&u32::MAX.to_be_bytes());
+            }),
+        ),
+        // The entry count is huge, overflowing/misplacing the AMQF region.
+        (
+            "huge entry count",
+            Box::new(move |data: &mut Vec<u8>| {
+                data[12..16].copy_from_slice(&u32::MAX.to_be_bytes());
+            }),
+        ),
+        // The obsolete-SST count is huge, which would otherwise drive a huge
+        // speculative allocation before any bounds check.
+        (
+            "huge obsolete count",
+            Box::new(move |data: &mut Vec<u8>| {
+                data[8..12].copy_from_slice(&u32::MAX.to_be_bytes());
+            }),
+        ),
+        // The first entry's block_count is zero, which would underflow
+        // `block_count - 1` in the SST lookup path later.
+        (
+            "zero block count",
+            Box::new(move |data: &mut Vec<u8>| {
+                data[16 + 4..16 + 6].copy_from_slice(&0u16.to_be_bytes());
+            }),
+        ),
+        // The first entry's block_count exceeds what the SST file can hold,
+        // which would underflow block_offsets_start when the SST is opened.
+        (
+            "oversized block count",
+            Box::new(move |data: &mut Vec<u8>| {
+                data[16 + 4..16 + 6].copy_from_slice(&u16::MAX.to_be_bytes());
+            }),
+        ),
+        // The used-keys AMQF end offset (stored after the last entry header)
+        // points past the AMQF region — previously dereferenced much later
+        // during compaction.
+        (
+            "used-keys offset out of bounds",
+            Box::new(move |data: &mut Vec<u8>| {
+                // Layout: magic(4) + family(4) + obsolete_count(4) + count(4)
+                // + count * EntryHeader(38) + used_keys_end_offset(4).
+                let count = u32::from_be_bytes(data[12..16].try_into().unwrap()) as usize;
+                let pos = 16 + count * 38;
+                data[pos..pos + 4].copy_from_slice(&u32::MAX.to_be_bytes());
+            }),
+        ),
+        // The block count is incremented by one: in-bounds for the offset
+        // table size check, but the table now points into payload bytes.
+        (
+            "off-by-one block count",
+            Box::new(move |data: &mut Vec<u8>| {
+                let pos = 16 + 4;
+                let bc = u16::from_be_bytes(data[pos..pos + 2].try_into().unwrap());
+                data[pos..pos + 2].copy_from_slice(&(bc + 1).to_be_bytes());
+            }),
+        ),
+    ];
+    for (name, corrupt) in cases {
+        let mut corrupted = original.clone();
+        corrupt(&mut corrupted);
+        fs::write(&meta_path, &corrupted)?;
+        let result = TurboPersistence::<RayonParallelScheduler, 16>::open_with_parallel_scheduler(
+            path.to_path_buf(),
+            RayonParallelScheduler,
+        );
+        // Open must not panic; if it succeeds (the SST itself is opened
+        // lazily), reading must return an error rather than panic.
+        match result {
+            Ok(db) => {
+                let read = db.get(0, &[1, 12u8]);
+                assert!(
+                    read.is_err(),
+                    "corrupt meta ({name}) must return an error on read, not panic"
+                );
+                drop(db);
+            }
+            Err(_) => {}
+        }
+        // Restore for the next case.
+        fs::write(&meta_path, &original)?;
+    }
+
+    // Truncated right after the magic number.
+    fs::write(&meta_path, &original[..8])?;
+    let result = TurboPersistence::<RayonParallelScheduler, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    );
+    assert!(
+        result.is_err(),
+        "truncated meta must return an error, not panic"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## What

`turbo-persistence`'s `.meta` parsing used file-derived offsets without validation and **panicked** on corrupt/truncated files — while every other failure mode in the module is a recoverable `anyhow::Error` (so callers can invalidate and rebuild the cache):

- per-entry `amqf_end_offset` used as a range bound with `.expect("AMQF data out of bounds")` (panics on out-of-bounds or non-monotonic offsets),
- `amqf_size()` underflows (`end - start`),
- `end_of_used_keys_amqf_data_offset` stored **unvalidated at open** and first dereferenced during **compaction on a rayon worker** (db.rs) — a crash mid-commit instead of a clean open failure,
- the `amqf_data` region slice itself (`&mmap[amqf_data_start..]`) panics when the file's entry count is corrupt,
- `block_offsets_start` underflows when `block_count` is zero or oversized — also on the **compaction iterator** path (`StaticSortedFileIter::open`),
- the block-read bounds checks in `get_raw_block_slice` were gated behind `strict_checks`, so an in-bounds overcount (e.g. real+1) made the offset table point into payload bytes whose contents were then used as block offsets → slice panics.

Triggers: a `.meta` truncated by a full disk, an interrupted cache upload/download in CI, or bit-rot. Result before this PR: hard crash / crash-loop of the build or dev server.

## Fix

Validate at parse/open time (returning contextual `Err`):

- checked `u32` arithmetic + bounds-checked slice for the AMQF region,
- per-entry offsets must be monotonic and in-bounds; the `.expect` becomes `?`,
- used-keys offsets validated at open,
- `obsolete_count`/`count` bounded by the remaining mapped length **before** `Vec::with_capacity` (no corrupt-value OOM/abort),
- `block_count == 0` rejected; `ensure_block_offsets_fit` (block offset table must fit the SST) shared by **both** `StaticSortedFile::open` and `StaticSortedFileIter::open`,
- the three `get_raw_block_slice` bounds checks are now unconditional (cheap integer comparisons per block read).

`MetaEntry`'s sole constructor is the validated parse loop, so the later accessors can't see invalid ranges.

## Tests

`corrupt_meta_file_returns_error_instead_of_panicking` builds a real committed DB, then per-case corrupts its `.meta` (7 cases: `amqf_end_offset=MAX` — **verified to panic before this fix at meta_file.rs:318** — entry count=`MAX`, obsolete count=`MAX`, `block_count=0`, `block_count=u16::MAX`, `block_count=real+1`, truncate-to-8-bytes), asserting open or read returns `Err` and never panics; the uncorrupted round-trip opens fine.

Full crate suite: green except the pre-existing resource-flaky compaction/merge tests (identical failures without this change; they pass in isolation). `clippy`/`fmt` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
