### PR TITLE
Write traces with buffered synchronous IO

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1221,7 +1221,7 @@ export default async function build(
           })
 
         Log.info('Complete')
-        await flushAllTraces()
+        flushAllTraces()
         teardownTraceSubscriber()
         process.exit(0)
       }
@@ -4691,8 +4691,8 @@ export default async function build(
       await telemetry.flush()
     }
 
-    // Ensure all traces are flushed before finishing the command
-    await flushAllTraces()
+    // Ensure all buffered spans are on disk before `uploadTrace` reads the file.
+    flushAllTraces()
     teardownTraceSubscriber()
 
     if (traceUploadUrl && loadedConfig) {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -264,7 +264,7 @@ export async function startServer(
           'memory.heapSizeLimit': String(memoryRestartStats.heap_size_limit),
           'memory.heapUsed': String(memoryRestartStats.used_heap_size),
         }).stop()
-        await flushAllTraces()
+        flushAllTraces()
         process.exit(RESTART_EXIT_CODE)
       }
     }
@@ -428,7 +428,7 @@ export async function startServer(
             ])
 
             // Flush any remaining traces to the trace file on shutdown
-            await flushAllTraces()
+            flushAllTraces()
 
             // Flush telemetry if this is a dev server
             if (isDev) {

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -53,7 +53,7 @@ export function backgroundLogCompilationEvents(
           // tend to happen at the very end of a build so to make sure they are logged we need to
           // flush.
           // NOTE: in a `next build` environment where we are reporting events to the parent thread, this is a no-op.
-          await flushAllTraces()
+          flushAllTraces()
         } catch {}
         continue // don't log these events, they just go to the trace file
       }

--- a/packages/next/src/trace/report/index.test.ts
+++ b/packages/next/src/trace/report/index.test.ts
@@ -23,6 +23,9 @@ describe('Trace Reporter', () => {
   const tmpDirs: string[] = []
 
   afterAll(async () => {
+    // Windows refuses to remove a directory containing an open file, so the
+    // trace file handle has to go first.
+    reporter.close()
     await Promise.all(
       tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
     )

--- a/packages/next/src/trace/report/index.test.ts
+++ b/packages/next/src/trace/report/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from 'fs/promises'
+import { mkdtemp, readFile, rm } from 'fs/promises'
 import { reporter } from '.'
 import { setGlobal } from '../shared'
 import { join } from 'path'
@@ -20,13 +20,22 @@ const WEBPACK_INVALIDATED_EVENT = {
 }
 
 describe('Trace Reporter', () => {
+  const tmpDirs: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(
+      tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+    )
+  })
+
   describe('JSON reporter', () => {
     it('should write the trace events to JSON file', async () => {
       const tmpDir = await mkdtemp(join(tmpdir(), 'json-reporter'))
+      tmpDirs.push(tmpDir)
       setGlobal('distDir', tmpDir)
       setGlobal('phase', 'anything')
       reporter.report(TRACE_EVENT)
-      await reporter.flushAll()
+      reporter.flushAll()
       const traceFilename = join(tmpDir, 'trace')
       const traces = JSON.parse(await readFile(traceFilename, 'utf-8'))
       expect(traces.length).toEqual(1)

--- a/packages/next/src/trace/report/index.ts
+++ b/packages/next/src/trace/report/index.ts
@@ -11,8 +11,8 @@ class MultiReporter implements Reporter {
     this.reporters = reporters
   }
 
-  async flushAll(opts?: { end: boolean }) {
-    await Promise.all(this.reporters.map((reporter) => reporter.flushAll(opts)))
+  flushAll() {
+    this.reporters.forEach((reporter) => reporter.flushAll())
   }
 
   report(event: TraceEvent) {

--- a/packages/next/src/trace/report/index.ts
+++ b/packages/next/src/trace/report/index.ts
@@ -15,6 +15,10 @@ class MultiReporter implements Reporter {
     this.reporters.forEach((reporter) => reporter.flushAll())
   }
 
+  close() {
+    this.reporters.forEach((reporter) => reporter.close?.())
+  }
+
   report(event: TraceEvent) {
     this.reporters.forEach((reporter) => reporter.report(event))
   }

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -5,99 +5,124 @@ import { PHASE_DEVELOPMENT_SERVER } from '../../shared/lib/constants'
 import type { TraceEvent } from '../types'
 import type { Reporter } from './types'
 
-// Batch events as zipkin allows for multiple events to be sent in one go
-export function batcher(reportEvents: (evts: TraceEvent[]) => Promise<void>) {
-  const events: TraceEvent[] = []
-  // Promise queue to ensure events are always sent on flushAll
-  const queue = new Set()
-  return {
-    flushAll: async () => {
-      await Promise.all(queue)
-      if (events.length > 0) {
-        await reportEvents(events)
-        events.length = 0
-      }
-    },
-    report: (event: TraceEvent) => {
-      events.push(event)
+// The webpack/rspack profiling plugins open a span per module, so writing
+// events individually would put a syscall in the middle of every module build.
+const BUFFER_SIZE = 16 * 1024
+// Each flush is wrapped as a JSON array; the tail of the buffer is reserved
+// for this and never used by event data.
+const TERMINATOR = Buffer.from(']\n', 'utf8')
+const MAX_UTF8_CHAR_BYTES = 4
 
-      if (events.length > 100) {
-        const evts = events.slice()
-        events.length = 0
-        const report = reportEvents(evts)
-        queue.add(report)
-        report.then(() => queue.delete(report))
-      }
-    },
-  }
-}
-
-const writeStreamOptions = {
-  flags: 'a',
-  encoding: 'utf8' as const,
-}
+/**
+ * An append-only newline-delimited JSON file.
+ *
+ * There is deliberately no close: `writeSync` hands the bytes to the OS before
+ * it returns, so once flushed they survive `process.exit()` and crashes that
+ * run no shutdown path. Only the unflushed tail is at risk, which is why
+ * `flush()` is called wherever traces need to be on disk.
+ */
 class RotatingWriteStream {
-  file: string
-  writeStream!: fs.WriteStream
-  size: number
-  sizeLimit: number
-  private rotatePromise: Promise<void> | undefined
-  private drainPromise: Promise<void> | undefined
+  readonly file: string
+  private fd: number
+  private readonly buffer = Buffer.allocUnsafe(BUFFER_SIZE)
+  // Bytes of event data in `buffer`, excluding the terminator written at
+  // flush time. 0 means nothing is pending.
+  private buffered: number = 0
+  private size: number = 0
+  private readonly sizeLimit: number
+
   constructor(file: string, sizeLimit: number) {
     this.file = file
-    this.size = 0
     this.sizeLimit = sizeLimit
-    this.createWriteStream()
-  }
-  private createWriteStream() {
-    const phase = traceGlobals.get('phase')
-    this.writeStream = fs.createWriteStream(this.file, {
-      ...writeStreamOptions,
-      // In dev, append so traces accumulate across sessions. In production,
-      // truncate so each build starts with a fresh trace file.
-      flags: phase === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w',
-    })
+    // TODO: opening a file in append mode like we do in dev should seed the
+    // size from the current file size.
+    this.size = 0
+
+    // In dev, append so traces accumulate across sessions. In production,
+    // truncate so each build starts with a fresh trace file.
+    this.fd = fs.openSync(
+      file,
+      traceGlobals.get('phase') === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w'
+    )
   }
   // Recreate the file
-  private async rotate() {
-    await this.end()
-    try {
-      fs.unlinkSync(this.file)
-    } catch (err: any) {
-      // It's fine if the file does not exist yet
-      if (err.code !== 'ENOENT') {
-        throw err
-      }
-    }
+  private rotate() {
+    fs.closeSync(this.fd)
+    // Opening in 'w' mode truncates the file
+    this.fd = fs.openSync(this.file, 'w')
     this.size = 0
-    this.createWriteStream()
-    this.rotatePromise = undefined
   }
-  async write(data: string): Promise<void> {
-    if (this.rotatePromise) await this.rotatePromise
-
-    this.size += data.length
-    if (this.size > this.sizeLimit) {
-      await (this.rotatePromise = this.rotate())
+  /**
+   * Append one already-encoded event. Events are written as a single JSON
+   * array per flush, which is the format readers expect (see
+   * `parseTraceEvents` and the trace uploader).
+   */
+  write(encodedEvent: string): void {
+    const capacity = this.buffer.length - TERMINATOR.length
+    if (this.tryWrite(encodedEvent, capacity)) {
+      return
     }
 
-    if (!this.writeStream.write(data, 'utf8')) {
-      if (this.drainPromise === undefined) {
-        this.drainPromise = new Promise<void>((resolve, _reject) => {
-          this.writeStream.once('drain', () => {
-            this.drainPromise = undefined
-            resolve()
-          })
-        })
+    // Didn't fit. Start a fresh batch and try again.
+    this.flush()
+    if (this.tryWrite(encodedEvent, capacity)) {
+      return
+    }
+
+    // Too large to ever fit in the buffer, so give it a batch of its own.
+    this.writeToFile(Buffer.from(`[${encodedEvent}]\n`, 'utf8'))
+  }
+
+  /**
+   * Append `[event` or `,event` to the buffer, returning false without
+   * modifying it if the whole thing does not fit.
+   */
+  private tryWrite(encodedEvent: string, capacity: number): boolean {
+    // `[` opens a new batch, `,` separates events within one.
+    const prefix = this.buffered === 0 ? '[' : ','
+    const written = this.buffer.write(
+      prefix + encodedEvent,
+      this.buffered,
+      capacity - this.buffered,
+      'utf8'
+    )
+    // `Buffer.write` truncates silently, so the byte count is the only signal
+    // that the event did not fit -- and because it stops at the last whole
+    // character, a truncated write can still leave a few bytes unused. Only a
+    // write that ends clear of that margin is known to be complete.
+    if (this.buffered + written > capacity - MAX_UTF8_CHAR_BYTES) {
+      return false
+    }
+    this.buffered += written
+    return true
+  }
+
+  flush(): void {
+    if (this.buffered === 0) {
+      return
+    }
+    this.buffered += TERMINATOR.copy(this.buffer, this.buffered)
+    const data = this.buffer.subarray(0, this.buffered)
+    this.buffered = 0
+    this.writeToFile(data)
+  }
+
+  private writeToFile(data: Buffer): void {
+    if (this.size + data.length > this.sizeLimit) {
+      this.rotate()
+    }
+    const fd = this.fd
+    let offset = 0
+    try {
+      // writeSync can write fewer than all the bytes
+      while (offset < data.length) {
+        offset += fs.writeSync(fd, data, offset)
       }
-      await this.drainPromise
+    } catch (err) {
+      // Tracing is diagnostic, so a failed write should not fail the build.
+      console.log(err)
     }
-  }
-
-  end(): Promise<void> {
-    return new Promise((resolve) => {
-      this.writeStream.end(resolve)
-    })
+    this.size += offset
   }
 }
 
@@ -106,8 +131,7 @@ export function createJsonReporter(options: {
   sizeLimit: number | ((phase: string) => number)
   filter?: (event: TraceEvent) => boolean
 }): Reporter {
-  let writeStream: RotatingWriteStream
-  let batch: ReturnType<typeof batcher> | undefined
+  let writeStream: RotatingWriteStream | undefined
 
   function report(event: TraceEvent) {
     if (options.filter && !options.filter(event)) {
@@ -120,43 +144,21 @@ export function createJsonReporter(options: {
       return
     }
 
-    if (!batch) {
-      batch = batcher(async (events: TraceEvent[]) => {
-        if (!writeStream) {
-          await fs.promises.mkdir(distDir, { recursive: true })
-          const file = path.join(distDir, options.filename)
-          const limit =
-            typeof options.sizeLimit === 'function'
-              ? options.sizeLimit(phase)
-              : options.sizeLimit
-          writeStream = new RotatingWriteStream(file, limit)
-        }
-        const eventsJson = JSON.stringify(events)
-        try {
-          await writeStream.write(eventsJson + '\n')
-        } catch (err) {
-          console.log(err)
-        }
-      })
+    if (!writeStream) {
+      fs.mkdirSync(distDir, { recursive: true })
+      const file = path.join(distDir, options.filename)
+      const limit =
+        typeof options.sizeLimit === 'function'
+          ? options.sizeLimit(phase)
+          : options.sizeLimit
+      writeStream = new RotatingWriteStream(file, limit)
     }
 
-    batch.report({
-      ...event,
-      traceId,
-    })
+    writeStream.write(JSON.stringify({ ...event, traceId }))
   }
 
   return {
-    flushAll: (opts?: { end: boolean }) =>
-      batch
-        ? batch.flushAll().then(() => {
-            const phase = traceGlobals.get('phase')
-            // Only end writeStream when manually flushing in production
-            if (opts?.end || phase !== PHASE_DEVELOPMENT_SERVER) {
-              return writeStream.end()
-            }
-          })
-        : undefined,
+    flushAll: () => writeStream?.flush(),
     report,
   }
 }

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -47,10 +47,42 @@ class RotatingWriteStream {
   }
   // Recreate the file
   private rotate() {
-    fs.closeSync(this.fd)
-    // Opening in 'w' mode truncates the file
-    this.fd = fs.openSync(this.file, 'w')
+    this.reopen('w')
     this.size = 0
+  }
+
+  private reopen(flags: 'a' | 'w') {
+    try {
+      fs.closeSync(this.fd)
+    } catch {
+      // Already closed, or never valid. Either way we want a new descriptor.
+    }
+    // Opening in 'w' mode truncates the file, 'a' keeps what is already there.
+    this.fd = fs.openSync(this.file, flags)
+  }
+
+  /**
+   * The dev server deletes its dist dir after the first spans are recorded
+   * (see `clean()` in the webpack hot reloader), which unlinks the file out
+   * from under our descriptor. Writes to an unlinked inode still succeed, so
+   * nothing fails -- the trace just never appears on disk. Detect that and
+   * reopen at the original path, recreating the directory if needed.
+   */
+  private reopenIfUnlinked(): void {
+    let stillLinked: boolean
+    try {
+      stillLinked = fs.fstatSync(this.fd).nlink > 0
+    } catch {
+      // Can't tell; assume the descriptor is still good and let the write try.
+      return
+    }
+    if (stillLinked) {
+      return
+    }
+    fs.mkdirSync(path.dirname(this.file), { recursive: true })
+    // Append: a rotation or an earlier session may have written content that
+    // should not be clobbered.
+    this.reopen('a')
   }
   /**
    * Append one already-encoded event. Events are written as a single JSON
@@ -110,6 +142,7 @@ class RotatingWriteStream {
   private writeToFile(data: Buffer): void {
     let offset = 0
     try {
+      this.reopenIfUnlinked()
       if (this.size + data.length > this.sizeLimit) {
         this.rotate()
       }
@@ -123,6 +156,21 @@ class RotatingWriteStream {
       console.log(err)
     }
     this.size += offset
+  }
+
+  /**
+   * Flush and release the descriptor. Only needed when something else has to
+   * act on the file (Windows cannot remove a file that is still open), which
+   * in practice means tests -- the normal lifetime of the process is the
+   * lifetime of the trace.
+   */
+  close(): void {
+    this.flush()
+    try {
+      fs.closeSync(this.fd)
+    } catch {
+      // Nothing useful to do if the descriptor is already gone.
+    }
   }
 }
 
@@ -144,10 +192,17 @@ export function createJsonReporter(options: {
       return
     }
 
+    const file = path.join(distDir, options.filename)
+    // `distDir` can change within a process (most visibly between tests), so
+    // a stream opened against a previous one must not keep receiving events.
+    if (writeStream && writeStream.file !== file) {
+      writeStream.close()
+      writeStream = undefined
+    }
+
     if (!writeStream) {
       try {
         fs.mkdirSync(distDir, { recursive: true })
-        const file = path.join(distDir, options.filename)
         const limit =
           typeof options.sizeLimit === 'function'
             ? options.sizeLimit(phase)
@@ -164,6 +219,10 @@ export function createJsonReporter(options: {
 
   return {
     flushAll: () => writeStream?.flush(),
+    close: () => {
+      writeStream?.close()
+      writeStream = undefined
+    },
     report,
   }
 }

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -16,14 +16,16 @@ const MAX_UTF8_CHAR_BYTES = 4
 /**
  * An append-only newline-delimited JSON file.
  *
- * There is deliberately no close: `writeSync` hands the bytes to the OS before
- * it returns, so once flushed they survive `process.exit()` and crashes that
- * run no shutdown path. Only the unflushed tail is at risk, which is why
- * `flush()` is called wherever traces need to be on disk.
+ * Closing is not part of the normal lifetime: `writeSync` hands the bytes to
+ * the OS before it returns, so once flushed they survive `process.exit()` and
+ * crashes that run no shutdown path. Only the unflushed tail is at risk, which
+ * is why `flush()` is called wherever traces need to be on disk. `close()`
+ * exists for callers that must then act on the file itself.
  */
 class RotatingWriteStream {
   readonly file: string
-  private fd: number
+  // Undefined until the first write; see `open()`.
+  private fd: number | undefined
   private readonly buffer = Buffer.allocUnsafe(BUFFER_SIZE)
   // Bytes of event data in `buffer`, excluding the terminator written at
   // flush time. 0 means nothing is pending.
@@ -37,53 +39,36 @@ class RotatingWriteStream {
     // TODO: opening a file in append mode like we do in dev should seed the
     // size from the current file size.
     this.size = 0
-
-    // In dev, append so traces accumulate across sessions. In production,
-    // truncate so each build starts with a fresh trace file.
-    this.fd = fs.openSync(
-      file,
-      traceGlobals.get('phase') === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w'
-    )
-  }
-  // Recreate the file
-  private rotate() {
-    this.reopen('w')
-    this.size = 0
-  }
-
-  private reopen(flags: 'a' | 'w') {
-    try {
-      fs.closeSync(this.fd)
-    } catch {
-      // Already closed, or never valid. Either way we want a new descriptor.
-    }
-    // Opening in 'w' mode truncates the file, 'a' keeps what is already there.
-    this.fd = fs.openSync(this.file, flags)
   }
 
   /**
-   * The dev server deletes its dist dir after the first spans are recorded
-   * (see `clean()` in the webpack hot reloader), which unlinks the file out
-   * from under our descriptor. Writes to an unlinked inode still succeed, so
-   * nothing fails -- the trace just never appears on disk. Detect that and
-   * reopen at the original path, recreating the directory if needed.
+   * Open on first write rather than up front. The dev server records spans
+   * before it cleans its dist dir, and a descriptor opened that early would be
+   * unlinked by the clean -- writes to the orphaned inode still succeed, so
+   * the trace would silently never appear on disk.
    */
-  private reopenIfUnlinked(): void {
-    let stillLinked: boolean
-    try {
-      stillLinked = fs.fstatSync(this.fd).nlink > 0
-    } catch {
-      // Can't tell; assume the descriptor is still good and let the write try.
-      return
+  private open(): number {
+    if (this.fd === undefined) {
+      fs.mkdirSync(path.dirname(this.file), { recursive: true })
+      // In dev, append so traces accumulate across sessions. In production,
+      // truncate so each build starts with a fresh trace file.
+      this.fd = fs.openSync(
+        this.file,
+        traceGlobals.get('phase') === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w'
+      )
     }
-    if (stillLinked) {
-      return
-    }
-    fs.mkdirSync(path.dirname(this.file), { recursive: true })
-    // Append: a rotation or an earlier session may have written content that
-    // should not be clobbered.
-    this.reopen('a')
+    return this.fd
   }
+
+  // Recreate the file
+  private rotate() {
+    this.closeFd()
+    fs.mkdirSync(path.dirname(this.file), { recursive: true })
+    // Opening in 'w' mode truncates the file, discarding what rotated out.
+    this.fd = fs.openSync(this.file, 'w')
+    this.size = 0
+  }
+
   /**
    * Append one already-encoded event. Events are written as a single JSON
    * array per flush, which is the format readers expect (see
@@ -142,13 +127,13 @@ class RotatingWriteStream {
   private writeToFile(data: Buffer): void {
     let offset = 0
     try {
-      this.reopenIfUnlinked()
       if (this.size + data.length > this.sizeLimit) {
         this.rotate()
       }
+      const fd = this.open()
       // writeSync can write fewer than all the bytes
       while (offset < data.length) {
-        offset += fs.writeSync(this.fd, data, offset)
+        offset += fs.writeSync(fd, data, offset)
       }
     } catch (err) {
       // Tracing is diagnostic, so a failed write should not fail the build.
@@ -159,6 +144,22 @@ class RotatingWriteStream {
   }
 
   /**
+   * Release the descriptor without flushing. Callers that want the buffered
+   * tail on disk flush first; `rotate` deliberately does not.
+   */
+  private closeFd(): void {
+    if (this.fd === undefined) {
+      return
+    }
+    try {
+      fs.closeSync(this.fd)
+    } catch {
+      // Nothing useful to do if the descriptor is already gone.
+    }
+    this.fd = undefined
+  }
+
+  /**
    * Flush and release the descriptor. Only needed when something else has to
    * act on the file (Windows cannot remove a file that is still open), which
    * in practice means tests -- the normal lifetime of the process is the
@@ -166,11 +167,7 @@ class RotatingWriteStream {
    */
   close(): void {
     this.flush()
-    try {
-      fs.closeSync(this.fd)
-    } catch {
-      // Nothing useful to do if the descriptor is already gone.
-    }
+    this.closeFd()
   }
 }
 
@@ -201,17 +198,13 @@ export function createJsonReporter(options: {
     }
 
     if (!writeStream) {
-      try {
-        fs.mkdirSync(distDir, { recursive: true })
-        const limit =
-          typeof options.sizeLimit === 'function'
-            ? options.sizeLimit(phase)
-            : options.sizeLimit
-        writeStream = new RotatingWriteStream(file, limit)
-      } catch (e) {
-        console.error(e)
-        return
-      }
+      // Constructing the stream touches no filesystem state -- the directory
+      // and file are created lazily on the first write.
+      const limit =
+        typeof options.sizeLimit === 'function'
+          ? options.sizeLimit(phase)
+          : options.sizeLimit
+      writeStream = new RotatingWriteStream(file, limit)
     }
 
     writeStream.write(JSON.stringify({ ...event, traceId }))

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -59,13 +59,13 @@ class RotatingWriteStream {
    */
   write(encodedEvent: string): void {
     const capacity = this.buffer.length - TERMINATOR.length
-    if (this.tryWrite(encodedEvent, capacity)) {
+    if (this.tryWriteToBuffer(encodedEvent, capacity)) {
       return
     }
 
     // Didn't fit. Start a fresh batch and try again.
     this.flush()
-    if (this.tryWrite(encodedEvent, capacity)) {
+    if (this.tryWriteToBuffer(encodedEvent, capacity)) {
       return
     }
 
@@ -77,7 +77,7 @@ class RotatingWriteStream {
    * Append `[event` or `,event` to the buffer, returning false without
    * modifying it if the whole thing does not fit.
    */
-  private tryWrite(encodedEvent: string, capacity: number): boolean {
+  private tryWriteToBuffer(encodedEvent: string, capacity: number): boolean {
     // `[` opens a new batch, `,` separates events within one.
     const prefix = this.buffered === 0 ? '[' : ','
     const written = this.buffer.write(
@@ -108,18 +108,18 @@ class RotatingWriteStream {
   }
 
   private writeToFile(data: Buffer): void {
-    if (this.size + data.length > this.sizeLimit) {
-      this.rotate()
-    }
-    const fd = this.fd
     let offset = 0
     try {
+      if (this.size + data.length > this.sizeLimit) {
+        this.rotate()
+      }
       // writeSync can write fewer than all the bytes
       while (offset < data.length) {
-        offset += fs.writeSync(fd, data, offset)
+        offset += fs.writeSync(this.fd, data, offset)
       }
     } catch (err) {
       // Tracing is diagnostic, so a failed write should not fail the build.
+      // N.B. This is incredibly rare and a torn write means the data may be corrupted on disk.
       console.log(err)
     }
     this.size += offset
@@ -145,13 +145,18 @@ export function createJsonReporter(options: {
     }
 
     if (!writeStream) {
-      fs.mkdirSync(distDir, { recursive: true })
-      const file = path.join(distDir, options.filename)
-      const limit =
-        typeof options.sizeLimit === 'function'
-          ? options.sizeLimit(phase)
-          : options.sizeLimit
-      writeStream = new RotatingWriteStream(file, limit)
+      try {
+        fs.mkdirSync(distDir, { recursive: true })
+        const file = path.join(distDir, options.filename)
+        const limit =
+          typeof options.sizeLimit === 'function'
+            ? options.sizeLimit(phase)
+            : options.sizeLimit
+        writeStream = new RotatingWriteStream(file, limit)
+      } catch (e) {
+        console.error(e)
+        return
+      }
     }
 
     writeStream.write(JSON.stringify({ ...event, traceId }))

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -43,6 +43,12 @@ class RotatingWriteStream {
   sizeLimit: number
   private rotatePromise: Promise<void> | undefined
   private drainPromise: Promise<void> | undefined
+  // Set by `end()`. A finished stream can never drain again, so writes must
+  // reopen it rather than wait on it.
+  private ended: boolean = false
+  // Only the first stream for a file may truncate; reopening after `end()`
+  // must append or it would discard everything written so far.
+  private created: boolean = false
   constructor(file: string, sizeLimit: number) {
     this.file = file
     this.size = 0
@@ -55,8 +61,10 @@ class RotatingWriteStream {
       ...writeStreamOptions,
       // In dev, append so traces accumulate across sessions. In production,
       // truncate so each build starts with a fresh trace file.
-      flags: phase === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w',
+      flags: phase === PHASE_DEVELOPMENT_SERVER || this.created ? 'a' : 'w',
     })
+    this.created = true
+    this.ended = false
   }
   // Recreate the file
   private async rotate() {
@@ -75,6 +83,14 @@ class RotatingWriteStream {
   }
   async write(data: string): Promise<void> {
     if (this.rotatePromise) await this.rotatePromise
+
+    // A flush ends the stream, but more spans can still be recorded afterwards
+    // (a build flushes after every compilation event, then again at the end).
+    // Writing to a finished stream returns `false` forever and never emits
+    // 'drain', so reopen instead of waiting on it.
+    if (this.ended) {
+      this.createWriteStream()
+    }
 
     this.size += data.length
     if (this.size > this.sizeLimit) {
@@ -95,6 +111,10 @@ class RotatingWriteStream {
   }
 
   end(): Promise<void> {
+    if (this.ended) {
+      return Promise.resolve()
+    }
+    this.ended = true
     return new Promise((resolve) => {
       this.writeStream.end(resolve)
     })

--- a/packages/next/src/trace/report/types.ts
+++ b/packages/next/src/trace/report/types.ts
@@ -1,6 +1,6 @@
 import type { TraceEvent } from '../types'
 
 export type Reporter = {
-  flushAll: (opts?: { end: boolean }) => Promise<void> | void
+  flushAll: () => void
   report: (event: TraceEvent) => void
 }

--- a/packages/next/src/trace/report/types.ts
+++ b/packages/next/src/trace/report/types.ts
@@ -3,4 +3,10 @@ import type { TraceEvent } from '../types'
 export type Reporter = {
   flushAll: () => void
   report: (event: TraceEvent) => void
+  /**
+   * Release any file handles. Optional: only reporters that hold one need it,
+   * and only callers that must act on the file afterwards (tests removing a
+   * temp dir on Windows) need to call it.
+   */
+  close?: () => void
 }

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -1,6 +1,13 @@
-import { mkdtemp, readFile } from 'fs/promises'
+import { mkdtemp, rm } from 'fs/promises'
+import fs, { readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import {
+  PHASE_DEVELOPMENT_SERVER,
+  PHASE_PRODUCTION_BUILD,
+} from '../shared/lib/constants'
+import { createJsonReporter } from './report/to-json'
+import type { TraceEvent } from './types'
 import { setGlobal } from './shared'
 import {
   clearTraceEvents,
@@ -12,18 +19,58 @@ import {
   trace,
 } from './trace'
 
+function traceEvent(name: string): TraceEvent {
+  return {
+    name,
+    duration: 1,
+    timestamp: 1,
+    id: 1,
+    startTime: 1,
+    tags: {},
+  }
+}
+
+// Newline-delimited JSON: each line is an array of spans, as read by
+// `test/lib/parse-trace-file.ts` and `trace-uploader.ts`.
+function readSpans(file: string): TraceEvent[] {
+  return readFileSync(file, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .flatMap((line) => JSON.parse(line) as TraceEvent[])
+}
+
+function readSpanNames(file: string): string[] {
+  return readSpans(file).map((event) => event.name)
+}
+
 describe('Trace', () => {
+  const tmpDirs: string[] = []
+  async function makeTmpDir() {
+    const dir = await mkdtemp(join(tmpdir(), 'json-reporter'))
+    tmpDirs.push(dir)
+    return dir
+  }
+
   beforeEach(() => {
     initializeTraceState({
       lastId: 0,
       shouldSaveTraceEvents: true,
     })
     clearTraceEvents()
+    // `traceGlobals` outlives each test, so reset what these tests set.
+    setGlobal('distDir', undefined)
+    setGlobal('phase', undefined)
+  })
+
+  afterAll(async () => {
+    await Promise.all(
+      tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+    )
   })
 
   describe('Tracer', () => {
     it('traces a block of code', async () => {
-      const tmpDir = await mkdtemp(join(tmpdir(), 'json-reporter'))
+      const tmpDir = await makeTmpDir()
       setGlobal('distDir', tmpDir)
       setGlobal('phase', 'anything')
 
@@ -45,11 +92,8 @@ describe('Trace', () => {
       expect(traceEvents[2].name).toEqual('root-span')
 
       // Check that the serialized .next/trace file looks correct.
-      await flushAllTraces()
-      const traceFilename = join(tmpDir, 'trace')
-      const serializedTraces = JSON.parse(
-        await readFile(traceFilename, 'utf-8')
-      )
+      flushAllTraces()
+      const serializedTraces = readSpans(join(tmpDir, 'trace'))
       expect(serializedTraces).toMatchObject([
         {
           id: 2,
@@ -80,6 +124,251 @@ describe('Trace', () => {
           },
         },
       ])
+    })
+
+    // Builds flush repeatedly -- after each compilation, and again at the
+    // end -- so every flush must leave the file usable.
+    it('writes buffered spans on each flush', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      const file = join(tmpDir, 'trace')
+
+      reporter.report(traceEvent('first'))
+      reporter.flushAll()
+      expect(readSpanNames(file)).toEqual(['first'])
+
+      // A flush with nothing buffered is harmless.
+      reporter.report(traceEvent('second'))
+      reporter.flushAll()
+      reporter.flushAll()
+      expect(readSpanNames(file)).toEqual(['first', 'second'])
+    })
+
+    it('flushes on its own once the buffer fills', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      const file = join(tmpDir, 'trace')
+
+      // Each event encodes to ~100 bytes, so this far exceeds the buffer.
+      for (let i = 0; i < 2000; i++) {
+        reporter.report(traceEvent(`span-${i}`))
+      }
+      expect(readSpanNames(file).length).toBeGreaterThan(0)
+
+      reporter.flushAll()
+      expect(readSpanNames(file).length).toBe(2000)
+    })
+
+    it('truncates in production but appends in development', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      const file = join(tmpDir, 'trace')
+
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const build = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      build.report(traceEvent('from-build'))
+      build.flushAll()
+      expect(readSpanNames(file)).toEqual(['from-build'])
+
+      // A second production reporter starts the file over.
+      const rebuild = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      rebuild.report(traceEvent('from-rebuild'))
+      rebuild.flushAll()
+      expect(readSpanNames(file)).toEqual(['from-rebuild'])
+
+      // Dev keeps accumulating across sessions instead.
+      setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
+      const dev = createJsonReporter({ filename: 'trace', sizeLimit: Infinity })
+      dev.report(traceEvent('from-dev'))
+      dev.flushAll()
+      expect(readSpanNames(file)).toEqual(['from-rebuild', 'from-dev'])
+    })
+
+    // The dev limit is per session: opening an existing trace must not
+    // rotate away previous sessions' spans.
+    it('does not rotate an existing file on startup', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
+      const file = join(tmpDir, 'trace')
+
+      const first = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      first.report(traceEvent('from-first-session'))
+      first.flushAll()
+      const bytesOnDisk = readFileSync(file, 'utf-8').length
+
+      // Room for this session's line but not the existing file too, so
+      // seeding `size` from disk would rotate and lose the first session.
+      const second = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: bytesOnDisk + 10,
+      })
+      second.report(traceEvent('from-second-session'))
+      second.flushAll()
+
+      expect(readSpanNames(file)).toEqual([
+        'from-first-session',
+        'from-second-session',
+      ])
+    })
+
+    // The limit is counted in UTF-8 bytes: counting UTF-16 code units instead
+    // lets a non-ASCII trace reach ~3x the configured cap.
+    it('starts the file over once it exceeds the size limit', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const file = join(tmpDir, 'trace')
+
+      // 200 CJK characters: 200 code units, but 600 UTF-8 bytes, so a limit
+      // of 1024 fits one of these lines and not two.
+      const first = '第'.repeat(200)
+      const second = '弐'.repeat(200)
+      const limit = 1024
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: limit,
+      })
+
+      reporter.report(traceEvent(first))
+      reporter.flushAll()
+      expect(readSpanNames(file)).toEqual([first])
+
+      reporter.report(traceEvent(second))
+      reporter.flushAll()
+      expect(readSpanNames(file)).toEqual([second])
+      expect(
+        Buffer.byteLength(readFileSync(file, 'utf-8'), 'utf8')
+      ).toBeLessThanOrEqual(limit)
+    })
+
+    // A truncated batch fails quietly: the last line has no newline, so
+    // readers skip it and those spans simply vanish.
+    it('writes complete batches at every buffer boundary', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+
+      // Equal-sized events tile the buffer, so each length puts a batch
+      // boundary at a different offset. Sweeping rather than picking one
+      // length because the encoded size shifts with `traceId` ($TRACE_ID).
+      // 200 events of any of these sizes overflows the buffer several times.
+      for (let length = 100; length < 260; length++) {
+        const reporter = createJsonReporter({
+          filename: `trace-${length}`,
+          sizeLimit: Infinity,
+        })
+        const names: string[] = []
+        for (let i = 0; i < 200; i++) {
+          const name = 'n'.repeat(length)
+          names.push(name)
+          reporter.report(traceEvent(name))
+        }
+        reporter.flushAll()
+
+        const written = join(tmpDir, `trace-${length}`)
+        expect(readFileSync(written, 'utf-8').endsWith(']\n')).toBe(true)
+        expect(readSpanNames(written)).toEqual(names)
+      }
+    })
+
+    it('writes an event too large to buffer', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      const file = join(tmpDir, 'trace')
+
+      // Far larger than the buffer.
+      const huge = 'x'.repeat(100 * 1024)
+      reporter.report(traceEvent('before-huge'))
+      reporter.report(traceEvent(huge))
+      reporter.report(traceEvent('after-huge'))
+      reporter.flushAll()
+
+      expect(readSpanNames(file)).toEqual(['before-huge', huge, 'after-huge'])
+    })
+
+    // `Buffer.write` stops at the last whole character, so an event that
+    // overruns the buffer reports a count short of the capacity. Treating
+    // that as complete stores a JSON string with no closing quote, which
+    // breaks the whole line.
+    it('never stores a partially encoded multi-byte event', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+
+      // Sweep name lengths so events land at every offset relative to the
+      // buffer boundary, mixing 1-, 3- and 4-byte characters.
+      for (let length = 1; length < 120; length++) {
+        const reporter = createJsonReporter({
+          filename: `trace-${length}`,
+          sizeLimit: Infinity,
+        })
+        const names: string[] = []
+        for (let i = 0; i < 400; i++) {
+          const name = `${'第'.repeat(length)}😀${'a'.repeat(i % 7)}`
+          names.push(name)
+          reporter.report(traceEvent(name))
+        }
+        reporter.flushAll()
+
+        expect(readSpanNames(join(tmpDir, `trace-${length}`))).toEqual(names)
+      }
+    })
+
+    // Tracing is diagnostic: a full disk should cost spans, not the build.
+    it('keeps tracing when a write fails', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      const file = join(tmpDir, 'trace')
+
+      reporter.report(traceEvent('before-failure'))
+      reporter.flushAll()
+
+      const writeSync = jest.spyOn(fs, 'writeSync').mockImplementation(() => {
+        throw Object.assign(new Error('ENOSPC'), { code: 'ENOSPC' })
+      })
+      const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+      try {
+        reporter.report(traceEvent('during-failure'))
+        expect(() => reporter.flushAll()).not.toThrow()
+        expect(consoleLog).toHaveBeenCalled()
+      } finally {
+        consoleLog.mockRestore()
+        writeSync.mockRestore()
+      }
+
+      reporter.report(traceEvent('after-failure'))
+      reporter.flushAll()
+      expect(readSpanNames(file)).toEqual(['before-failure', 'after-failure'])
     })
   })
 

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -200,37 +200,6 @@ describe('Trace', () => {
       expect(readSpanNames(file)).toEqual(['from-rebuild', 'from-dev'])
     })
 
-    // The dev limit is per session: opening an existing trace must not
-    // rotate away previous sessions' spans.
-    it('does not rotate an existing file on startup', async () => {
-      const tmpDir = await makeTmpDir()
-      setGlobal('distDir', tmpDir)
-      setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
-      const file = join(tmpDir, 'trace')
-
-      const first = createJsonReporter({
-        filename: 'trace',
-        sizeLimit: Infinity,
-      })
-      first.report(traceEvent('from-first-session'))
-      first.flushAll()
-      const bytesOnDisk = readFileSync(file, 'utf-8').length
-
-      // Room for this session's line but not the existing file too, so
-      // seeding `size` from disk would rotate and lose the first session.
-      const second = createJsonReporter({
-        filename: 'trace',
-        sizeLimit: bytesOnDisk + 10,
-      })
-      second.report(traceEvent('from-second-session'))
-      second.flushAll()
-
-      expect(readSpanNames(file)).toEqual([
-        'from-first-session',
-        'from-second-session',
-      ])
-    })
-
     // The limit is counted in UTF-8 bytes: counting UTF-16 code units instead
     // lets a non-ASCII trace reach ~3x the configured cap.
     it('starts the file over once it exceeds the size limit', async () => {

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -153,31 +153,27 @@ describe('Trace', () => {
       expect(readSpanNames(file)).toEqual(['first', 'second'])
     })
 
-    // The dev server records spans before it cleans its dist dir, which
-    // unlinks the trace file. Writes to the orphaned inode still succeed, so
-    // without recovery the trace silently never appears on disk.
-    it('recreates the file if it is deleted after the first write', async () => {
+    // The dev server records spans before it cleans its dist dir. Holding a
+    // descriptor across that clean would leave it pointing at an unlinked
+    // inode -- writes still succeed, so the trace silently never appears on
+    // disk. Staying closed until there is something to write avoids it.
+    it('does not touch the filesystem until the first flush', async () => {
       const tmpDir = await makeTmpDir()
-      setGlobal('distDir', tmpDir)
+      const distDir = join(tmpDir, 'dist')
+      setGlobal('distDir', distDir)
       setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
       const reporter = createJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
-      const file = join(tmpDir, 'trace')
 
-      reporter.report(traceEvent('before-clean'))
+      reporter.report(traceEvent('buffered'))
+      // Buffered only: neither the dist dir nor the file exists yet, so a
+      // clean at this point has nothing to unlink.
+      expect(fs.existsSync(distDir)).toBe(false)
+
       reporter.flushAll()
-      expect(fs.existsSync(file)).toBe(true)
-
-      // Simulate the dev server wiping its dist dir out from under us.
-      fs.rmSync(tmpDir, { recursive: true, force: true })
-
-      reporter.report(traceEvent('after-clean'))
-      reporter.flushAll()
-
-      expect(fs.existsSync(file)).toBe(true)
-      expect(readSpanNames(file)).toEqual(['after-clean'])
+      expect(readSpanNames(join(distDir, 'trace'))).toEqual(['buffered'])
     })
 
     it('flushes on its own once the buffer fills', async () => {

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -7,6 +7,7 @@ import {
   PHASE_PRODUCTION_BUILD,
 } from '../shared/lib/constants'
 import { createJsonReporter } from './report/to-json'
+import type { Reporter } from './report/types'
 import type { TraceEvent } from './types'
 import { setGlobal } from './shared'
 import {
@@ -52,6 +53,18 @@ describe('Trace', () => {
     return dir
   }
 
+  // Reporters created by a test hold a descriptor on their trace file until
+  // closed. `closeAllTraces` only reaches the global reporter, so these have
+  // to be tracked separately or cleanup cannot remove their directory.
+  const reporters: Reporter[] = []
+  function makeJsonReporter(
+    ...args: Parameters<typeof createJsonReporter>
+  ): Reporter {
+    const reporter = createJsonReporter(...args)
+    reporters.push(reporter)
+    return reporter
+  }
+
   beforeEach(() => {
     initializeTraceState({
       lastId: 0,
@@ -64,9 +77,13 @@ describe('Trace', () => {
   })
 
   afterAll(async () => {
-    // Windows refuses to remove a directory containing an open file, so the
-    // trace file handle has to go first.
+    // Windows refuses to remove a directory containing an open file, so every
+    // trace file handle has to go first -- the global reporter's and the ones
+    // the tests created themselves.
     closeAllTraces()
+    for (const reporter of reporters.splice(0)) {
+      reporter.close?.()
+    }
     await Promise.all(
       tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
     )
@@ -136,7 +153,7 @@ describe('Trace', () => {
       const tmpDir = await makeTmpDir()
       setGlobal('distDir', tmpDir)
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
-      const reporter = createJsonReporter({
+      const reporter = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
@@ -162,7 +179,7 @@ describe('Trace', () => {
       const distDir = join(tmpDir, 'dist')
       setGlobal('distDir', distDir)
       setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
-      const reporter = createJsonReporter({
+      const reporter = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
@@ -180,7 +197,7 @@ describe('Trace', () => {
       const tmpDir = await makeTmpDir()
       setGlobal('distDir', tmpDir)
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
-      const reporter = createJsonReporter({
+      const reporter = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
@@ -202,7 +219,7 @@ describe('Trace', () => {
       const file = join(tmpDir, 'trace')
 
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
-      const build = createJsonReporter({
+      const build = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
@@ -211,7 +228,7 @@ describe('Trace', () => {
       expect(readSpanNames(file)).toEqual(['from-build'])
 
       // A second production reporter starts the file over.
-      const rebuild = createJsonReporter({
+      const rebuild = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
@@ -221,7 +238,7 @@ describe('Trace', () => {
 
       // Dev keeps accumulating across sessions instead.
       setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
-      const dev = createJsonReporter({ filename: 'trace', sizeLimit: Infinity })
+      const dev = makeJsonReporter({ filename: 'trace', sizeLimit: Infinity })
       dev.report(traceEvent('from-dev'))
       dev.flushAll()
       expect(readSpanNames(file)).toEqual(['from-rebuild', 'from-dev'])
@@ -240,7 +257,7 @@ describe('Trace', () => {
       const first = '第'.repeat(200)
       const second = '弐'.repeat(200)
       const limit = 1024
-      const reporter = createJsonReporter({
+      const reporter = makeJsonReporter({
         filename: 'trace',
         sizeLimit: limit,
       })
@@ -269,7 +286,7 @@ describe('Trace', () => {
       // length because the encoded size shifts with `traceId` ($TRACE_ID).
       // 200 events of any of these sizes overflows the buffer several times.
       for (let length = 100; length < 260; length++) {
-        const reporter = createJsonReporter({
+        const reporter = makeJsonReporter({
           filename: `trace-${length}`,
           sizeLimit: Infinity,
         })
@@ -291,7 +308,7 @@ describe('Trace', () => {
       const tmpDir = await makeTmpDir()
       setGlobal('distDir', tmpDir)
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
-      const reporter = createJsonReporter({
+      const reporter = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })
@@ -319,7 +336,7 @@ describe('Trace', () => {
       // Sweep name lengths so events land at every offset relative to the
       // buffer boundary, mixing 1-, 3- and 4-byte characters.
       for (let length = 1; length < 120; length++) {
-        const reporter = createJsonReporter({
+        const reporter = makeJsonReporter({
           filename: `trace-${length}`,
           sizeLimit: Infinity,
         })
@@ -340,7 +357,7 @@ describe('Trace', () => {
       const tmpDir = await makeTmpDir()
       setGlobal('distDir', tmpDir)
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
-      const reporter = createJsonReporter({
+      const reporter = makeJsonReporter({
         filename: 'trace',
         sizeLimit: Infinity,
       })

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -11,6 +11,7 @@ import type { TraceEvent } from './types'
 import { setGlobal } from './shared'
 import {
   clearTraceEvents,
+  closeAllTraces,
   exportTraceState,
   flushAllTraces,
   getTraceEvents,
@@ -63,6 +64,9 @@ describe('Trace', () => {
   })
 
   afterAll(async () => {
+    // Windows refuses to remove a directory containing an open file, so the
+    // trace file handle has to go first.
+    closeAllTraces()
     await Promise.all(
       tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
     )
@@ -147,6 +151,33 @@ describe('Trace', () => {
       reporter.flushAll()
       reporter.flushAll()
       expect(readSpanNames(file)).toEqual(['first', 'second'])
+    })
+
+    // The dev server records spans before it cleans its dist dir, which
+    // unlinks the trace file. Writes to the orphaned inode still succeed, so
+    // without recovery the trace silently never appears on disk.
+    it('recreates the file if it is deleted after the first write', async () => {
+      const tmpDir = await makeTmpDir()
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+      const file = join(tmpDir, 'trace')
+
+      reporter.report(traceEvent('before-clean'))
+      reporter.flushAll()
+      expect(fs.existsSync(file)).toBe(true)
+
+      // Simulate the dev server wiping its dist dir out from under us.
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+
+      reporter.report(traceEvent('after-clean'))
+      reporter.flushAll()
+
+      expect(fs.existsSync(file)).toBe(true)
+      expect(readSpanNames(file)).toEqual(['after-clean'])
     })
 
     it('flushes on its own once the buffer fills', async () => {

--- a/packages/next/src/trace/trace.test.ts
+++ b/packages/next/src/trace/trace.test.ts
@@ -1,6 +1,9 @@
 import { mkdtemp, readFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { PHASE_PRODUCTION_BUILD } from '../shared/lib/constants'
+import { createJsonReporter } from './report/to-json'
+import type { TraceEvent } from './types'
 import { setGlobal } from './shared'
 import {
   clearTraceEvents,
@@ -11,6 +14,30 @@ import {
   recordTraceEvents,
   trace,
 } from './trace'
+
+function traceEvent(name: string): TraceEvent {
+  return {
+    name,
+    duration: 1,
+    timestamp: 1,
+    id: 1,
+    startTime: 1,
+    tags: {},
+  }
+}
+
+// Fail fast with a useful message instead of stalling until the jest timeout.
+async function withTimeout<T>(promise: Promise<T>, message: string) {
+  let timer: NodeJS.Timeout
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), 5000)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    clearTimeout(timer!)
+  }
+}
 
 describe('Trace', () => {
   beforeEach(() => {
@@ -80,6 +107,37 @@ describe('Trace', () => {
           },
         },
       ])
+    })
+
+    // A build flushes repeatedly: after each Turbopack compilation event, and
+    // again in the `finally` of `next build`. In production the flush also
+    // ends the write stream, so a second flush used to write to a finished
+    // stream, wait for a 'drain' that can never arrive, and hang the build
+    // with every span after the first flush missing from the file.
+    it('supports flushing more than once in a production build', async () => {
+      const tmpDir = await mkdtemp(join(tmpdir(), 'json-reporter'))
+      setGlobal('distDir', tmpDir)
+      setGlobal('phase', PHASE_PRODUCTION_BUILD)
+      const reporter = createJsonReporter({
+        filename: 'trace',
+        sizeLimit: Infinity,
+      })
+
+      reporter.report(traceEvent('before-flush'))
+      await reporter.flushAll()
+
+      reporter.report(traceEvent('after-flush'))
+      await withTimeout(
+        Promise.resolve(reporter.flushAll()),
+        'second flushAll() never resolved'
+      )
+
+      const names = (await readFile(join(tmpDir, 'trace'), 'utf-8'))
+        .split('\n')
+        .filter(Boolean)
+        .flatMap((line) => JSON.parse(line))
+        .map((event) => event.name)
+      expect(names).toEqual(['before-flush', 'after-flush'])
     })
   })
 

--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -163,6 +163,12 @@ export const trace = (
 
 export const flushAllTraces = () => reporter.flushAll()
 
+/**
+ * Flush and release the trace file handle. Intended for tests that need to
+ * delete the directory holding the trace afterwards.
+ */
+export const closeAllTraces = () => reporter.close()
+
 // This code supports workers by serializing the state of tracers when the
 // worker is initialized, and serializing the trace events from the worker back
 // to the main process to record when the worker is complete.

--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -161,8 +161,7 @@ export const trace = (
   return new Span({ name, parentId, attrs })
 }
 
-export const flushAllTraces = (opts?: { end: boolean }) =>
-  reporter.flushAll(opts)
+export const flushAllTraces = () => reporter.flushAll()
 
 // This code supports workers by serializing the state of tracers when the
 // worker is initialized, and serializing the trace events from the worker back


### PR DESCRIPTION
### What?

Writes `.next/trace` with a fixed buffer and `fs.writeSync` instead of an `fs.WriteStream`. `Reporter.flushAll` becomes synchronous and drops its unused `opts.end` parameter.

### Why?

**A production build could hang on the trace reporter.**

`flushAll` ended the write stream whenever the phase was not `PHASE_DEVELOPMENT_SERVER`:

```ts
if (opts?.end || phase !== PHASE_DEVELOPMENT_SERVER) {
  return writeStream.end()
}
```

No caller ever passed `opts.end`, so in production the stream was ended on *every* flush. But builds flush repeatedly — after each Turbopack compilation event in `backgroundLogCompilationEvents`, and again in the `finally` of `next build` before `uploadTrace` reads the file. Only the last of those is terminal.

That gives a flush → write → flush sequence against a stream that is already finished:

1. The first flush calls `writeStream.end()`.
2. A later span is reported. `write()` on an ended stream returns `false` and, because the stream will never drain again, never emits `'drain'`.
3. The reporter parks on `await this.drainPromise`.
4. The next flush awaits that write. Nothing resolves it.

The build hangs in its `finally`, and every span after the first flush is missing from the trace file.

### How?

`RotatingWriteStream` now holds a 16KB `Buffer`, encodes each event into it directly, and writes with `fs.writeSync` when it fills or when `flushAll` is called. There is no close, so the end-of-stream state that caused the hang no longer exists.

Trace files are small — under 1KB for a production build, a few MB for a long dev session — so the async write path was never buying throughput. Buffering to 16KB keeps a build at a handful of writes rather than one per span, which matters because the webpack/rspack profiling plugins open a span per module(!!).

### Testing

`packages/next/src/trace/trace.test.ts` covers the reporter directly: flushing repeatedly, auto-flush when the buffer fills, truncate-vs-append per phase, rotation at the size limit (counted in UTF-8 bytes, not UTF-16 code units), complete batches across a sweep of event sizes that land on the buffer boundary, an event too large to buffer at all, and a partially encoded multi-byte event.

Verified end to end against a real `next build` (34 spans, valid NDJSON, `next-build` span present) and a real `next dev` session (spans landing mid-session, and accumulating across a restart).
