### PR TITLE
Unify how server responses are written into the client cache

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -7,13 +7,10 @@ import type { AppRouterState } from './router-reducer-types'
 import { transportNodeToFlightRouterState } from '../../../shared/lib/rsc-transport'
 import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import {
-  resolveStaleAt,
-  processRuntimePrefetchStream,
-  writeDynamicRenderResponseIntoCache,
-  writePrerenderResponseIntoCache,
+  writeRuntimePrefetchStreamIntoCache,
+  spawnStaticStageCacheWrite,
 } from '../segment-cache/cache'
 import { decodeTransportTreeIntoRouteTree } from '../segment-cache/decode-server-response'
-import { FetchStrategy } from '../segment-cache/types'
 import {
   UnknownDynamicStaleTime,
   computeDynamicStaleAt,
@@ -125,10 +122,6 @@ export function createInitialRouterState({
       false // hasDynamicRewrite
     )
 
-    // TODO: Implement Shell extraction as part of Cached Navigations.
-    // Intentionally holding off on doing this until we decide how the Cached
-    // Navigations behavior should work in combination with App Shells.
-
     // Write the initial seed data into the segment cache so subsequent
     // navigations to the initial page can serve cached segments instantly.
     if (initialStaleTime !== undefined) {
@@ -148,19 +141,13 @@ export function createInitialRouterState({
                 byteLength,
                 undefined
               )
-            const now = Date.now()
-            const staleAt = await resolveStaleAt(now, staticStageResponse.s)
-
-            writePrerenderResponseIntoCache(
-              now,
-              FetchStrategy.PPR,
-              staticStageResponse.t,
-              undefined, // no build ID mismatch check for initial HTML
-              staticStageResponse.r ?? null,
-              staleAt,
+            spawnStaticStageCacheWrite(
+              Date.now(),
+              staticStageResponse,
+              true, // isResponsePartial
+              null, // responseHeaders — no build-id check for initial HTML
               initialTree,
-              initialRenderedSearch,
-              true // isResponsePartial
+              initialRenderedSearch
             )
           })
           .catch(() => {
@@ -173,26 +160,22 @@ export function createInitialRouterState({
         // the two branches) to avoid unnecessary decoding of the Flight data,
         // since we can just take the seed data that we already decoded during
         // hydration and write it into the cache directly.
-        const now = Date.now()
-
-        resolveStaleAt(now, initialStaleTime)
-          .then((staleAt) => {
-            writePrerenderResponseIntoCache(
-              now,
-              FetchStrategy.PPR,
-              initialTransportData,
-              undefined, // buildId — not applicable for initial HTML
-              initialRootVaryParams ?? null,
-              staleAt,
-              initialTree,
-              initialRenderedSearch,
-              false // isResponsePartial
-            )
-          })
-          .catch(() => {
-            // The static stage processing failed. Not fatal — the page
-            // rendered normally, we just won't write into the cache.
-          })
+        spawnStaticStageCacheWrite(
+          Date.now(),
+          // The transport subset of the initial payload, already decoded
+          // during hydration. Synthesized so the helper can resolve the
+          // stale time from the response's own `s` field, the same as the
+          // truncated branch above.
+          {
+            t: initialTransportData,
+            r: initialRootVaryParams,
+            s: initialStaleTime,
+          },
+          false, // isResponsePartial
+          null, // responseHeaders — no build-id check for initial HTML
+          initialTree,
+          initialRenderedSearch
+        )
 
         // Cancel the stream clone — fully static path doesn't need it.
         initialFlightStreamForCache?.cancel()
@@ -207,31 +190,15 @@ export function createInitialRouterState({
     // subsequent navigations to serve runtime-prefetchable content from cache
     // without a separate prefetch request.
     if (initialRuntimePrefetchStream != null) {
-      processRuntimePrefetchStream(
+      writeRuntimePrefetchStreamIntoCache(
         Date.now(),
         initialRuntimePrefetchStream,
         initialTree,
         initialRenderedSearch
-      )
-        .then((processed) => {
-          if (processed !== null) {
-            writeDynamicRenderResponseIntoCache(
-              Date.now(),
-              FetchStrategy.PPRRuntime,
-              processed.buildId,
-              processed.isResponsePartial,
-              processed.headVaryParams,
-              processed.rootVaryParamsIterable,
-              processed.staleAt,
-              processed.navigationSeed,
-              null
-            )
-          }
-        })
-        .catch(() => {
-          // Runtime prefetch cache write failed. Not fatal — the page rendered
-          // normally, we just won't cache runtime data.
-        })
+      ).catch(() => {
+        // Runtime prefetch cache write failed. Not fatal — the page rendered
+        // normally, we just won't cache runtime data.
+      })
     }
   }
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -7,14 +7,11 @@ import type { AppRouterState } from './router-reducer-types'
 import { transportNodeToFlightRouterState } from '../../../shared/lib/rsc-transport'
 import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import {
-  resolveStaleAt,
-  processRuntimePrefetchStream,
+  writeRuntimePrefetchStreamIntoCache,
+  spawnStaticStageCacheWrite,
   segmentCacheMap,
-  writeDynamicRenderResponseIntoCache,
-  writePrerenderResponseIntoCache,
 } from '../segment-cache/cache'
 import { decodeTransportTreeIntoRouteTree } from '../segment-cache/decode-server-response'
-import { FetchStrategy } from '../segment-cache/types'
 import {
   UnknownDynamicStaleTime,
   computeDynamicStaleAt,
@@ -149,19 +146,13 @@ export function createInitialRouterState({
                 byteLength,
                 undefined
               )
-            const now = Date.now()
-            const staleAt = await resolveStaleAt(now, staticStageResponse.s)
-
-            writePrerenderResponseIntoCache(
-              now,
-              FetchStrategy.PPR,
-              staticStageResponse.t,
-              undefined, // no build ID mismatch check for initial HTML
-              staticStageResponse.r ?? null,
-              staleAt,
+            spawnStaticStageCacheWrite(
+              Date.now(),
+              staticStageResponse,
+              true, // isResponsePartial
+              null, // responseHeaders — no build-id check for initial HTML
               initialTree,
               initialRenderedSearch,
-              true, // isResponsePartial
               segmentCacheMap // hydration writes are bound to the shared map
             )
           })
@@ -175,27 +166,23 @@ export function createInitialRouterState({
         // the two branches) to avoid unnecessary decoding of the Flight data,
         // since we can just take the seed data that we already decoded during
         // hydration and write it into the cache directly.
-        const now = Date.now()
-
-        resolveStaleAt(now, initialStaleTime)
-          .then((staleAt) => {
-            writePrerenderResponseIntoCache(
-              now,
-              FetchStrategy.PPR,
-              initialTransportData,
-              undefined, // buildId — not applicable for initial HTML
-              initialRootVaryParams ?? null,
-              staleAt,
-              initialTree,
-              initialRenderedSearch,
-              false, // isResponsePartial
-              segmentCacheMap // hydration writes are bound to the shared map
-            )
-          })
-          .catch(() => {
-            // The static stage processing failed. Not fatal — the page
-            // rendered normally, we just won't write into the cache.
-          })
+        spawnStaticStageCacheWrite(
+          Date.now(),
+          // The transport subset of the initial payload, already decoded
+          // during hydration. Synthesized so the helper can resolve the
+          // stale time from the response's own `s` field, the same as the
+          // truncated branch above.
+          {
+            t: initialTransportData,
+            r: initialRootVaryParams,
+            s: initialStaleTime,
+          },
+          false, // isResponsePartial
+          null, // responseHeaders — no build-id check for initial HTML
+          initialTree,
+          initialRenderedSearch,
+          segmentCacheMap // hydration writes are bound to the shared map
+        )
 
         // Cancel the stream clone — fully static path doesn't need it.
         initialFlightStreamForCache?.cancel()
@@ -210,32 +197,16 @@ export function createInitialRouterState({
     // subsequent navigations to serve runtime-prefetchable content from cache
     // without a separate prefetch request.
     if (initialRuntimePrefetchStream != null) {
-      processRuntimePrefetchStream(
+      writeRuntimePrefetchStreamIntoCache(
         Date.now(),
         initialRuntimePrefetchStream,
         initialTree,
-        initialRenderedSearch
-      )
-        .then((processed) => {
-          if (processed !== null) {
-            writeDynamicRenderResponseIntoCache(
-              Date.now(),
-              FetchStrategy.PPRRuntime,
-              processed.buildId,
-              processed.isResponsePartial,
-              processed.headVaryParams,
-              processed.rootVaryParamsIterable,
-              processed.staleAt,
-              processed.navigationSeed,
-              null,
-              segmentCacheMap // hydration writes are bound to the shared map
-            )
-          }
-        })
-        .catch(() => {
-          // Runtime prefetch cache write failed. Not fatal — the page rendered
-          // normally, we just won't cache runtime data.
-        })
+        initialRenderedSearch,
+        segmentCacheMap // hydration writes are bound to the shared map
+      ).catch(() => {
+        // Runtime prefetch cache write failed. Not fatal — the page rendered
+        // normally, we just won't cache runtime data.
+      })
     }
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -40,7 +40,7 @@ import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   stripIsPartialByte,
-  createNonTaskyPrefetchResponseStream,
+  bufferPrefetchResponseBody,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
 
@@ -66,15 +66,6 @@ export interface FetchServerResponseOptions {
   readonly signal?: AbortSignal
 }
 
-export type StaticStageData<
-  T extends
-    | NavigationFlightResponse
-    | InitialRSCPayload = NavigationFlightResponse,
-> = {
-  readonly response: T
-  readonly isResponsePartial: boolean
-}
-
 type SpaFetchServerResponseResult = {
   transportData: PartialTransportData | null
   canonicalUrl: URL
@@ -83,7 +74,15 @@ type SpaFetchServerResponseResult = {
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
   dynamicStaleTime: number
-  staticStageData: StaticStageData | null
+  /**
+   * Whether the response body was marked partial (contains unresolved
+   * dynamic holes), read from the leading isPartial byte. Always false when
+   * Cache Components is disabled. When `staticStageResponse` is non-null,
+   * this is also its partiality: a complete response is cached whole, a
+   * partial response is cached as its truncated static-stage prefix.
+   */
+  isResponsePartial: boolean
+  staticStageResponse: NavigationFlightResponse | null
   runtimePrefetchStream: ReadableStream<Uint8Array> | null
   responseHeaders: Headers
   debugInfo: Array<any> | null
@@ -282,9 +281,9 @@ export async function fetchServerResponse(
       return doMpaNavigation(flightResponse.n)
     }
 
-    const staticStageData =
+    const staticStageResponse =
       cacheData !== null
-        ? await resolveStaticStageData(cacheData, flightResponse, headers)
+        ? await resolveStaticStageResponse(cacheData, flightResponse, headers)
         : null
 
     return {
@@ -310,7 +309,9 @@ export async function fetchServerResponse(
       // When absent (UnknownDynamicStaleTime), the client falls back to the
       // global DYNAMIC_STALETIME_MS. The value is in seconds.
       dynamicStaleTime: flightResponse.d ?? UnknownDynamicStaleTime,
-      staticStageData,
+      isResponsePartial:
+        cacheData !== null ? cacheData.isResponsePartial : false,
+      staticStageResponse,
       runtimePrefetchStream: flightResponse.p ?? null,
       responseHeaders: res.headers,
       debugInfo: flightResponsePromise._debugInfo ?? null,
@@ -452,20 +453,23 @@ export async function processFetch(response: Response): Promise<{
 
 /**
  * Resolves the static stage response from the raw `processFetch` outputs and
- * the decoded flight response, for writing into the segment cache.
+ * the decoded flight response, for writing into the segment cache. The
+ * resolved response's partiality is the whole response's partiality
+ * (`cacheData.isResponsePartial`): a complete response is resolved whole, a
+ * partial one as its truncated static-stage prefix.
  *
  * - Fully static: use the decoded flight response as-is, no truncation needed.
  * - Not fully static + `l` field: truncate the body clone at the static stage
  *   byte boundary and decode.
  * - Otherwise: no cache-worthy data.
  */
-export async function resolveStaticStageData<
+async function resolveStaticStageResponse<
   T extends NavigationFlightResponse | InitialRSCPayload,
 >(
   cacheData: FetchResponseCacheData,
   flightResponse: T,
   headers: RequestHeaders | undefined
-): Promise<StaticStageData<T> | null> {
+): Promise<T | null> {
   const { isResponsePartial, staticBodyClone } = cacheData
 
   if (staticBodyClone) {
@@ -473,20 +477,18 @@ export async function resolveStaticStageData<
       // Fully static — cache the entire decoded response as-is.
       staticBodyClone.cancel()
 
-      return { response: flightResponse, isResponsePartial: false }
+      return flightResponse
     }
 
     if (flightResponse.l !== undefined) {
       // Partially static — truncate the body clone at the byte boundary and
       // decode it.
       const staticStageByteLength = await flightResponse.l
-      const response = await decodeStageUntilBoundary<T>(
+      return decodeStageUntilBoundary<T>(
         staticBodyClone,
         staticStageByteLength,
         headers
       )
-
-      return { response, isResponsePartial: true }
     }
 
     // No caching — cancel the unused clone.
@@ -497,19 +499,16 @@ export async function resolveStaticStageData<
 }
 
 /**
- * Resolves the shell stage of a prerender response, performing a separate
- * Flight decode of the byte prefix when the shell differs from the main
- * response. Returns null when no separate decode is needed:
+ * Resolves the shell stage of a prerender response:
  *
- * - `a === undefined`: server didn't emit shell stage info.
- * - `a` resolves to `null`: the shell IS the main response — the caller can
- *   reuse the existing decoded `flightResponse` if it needs a shell payload.
- *
- * Returns the decoded shell payload when `a` resolves to a number, i.e.
- * the shell is a strict prefix of the response and requires a separate
- * decode at that byte boundary.
+ * - `a === undefined` (server didn't emit shell stage info) or no shell body
+ *   clone: no shell exists — returns null.
+ * - `a` resolves to `null`: the shell IS the main response — returns
+ *   `flightResponse` itself (callers compare by reference).
+ * - `a` resolves to a number: the shell is a strict prefix of the response —
+ *   returns a separate Flight decode of the byte prefix.
  */
-export async function resolveShellStageData<
+export async function resolveShellStageResponse<
   T extends NavigationFlightResponse | InitialRSCPayload,
 >(
   cacheData: FetchResponseCacheData,
@@ -523,15 +522,20 @@ export async function resolveShellStageData<
   }
 
   if (flightResponse.a === undefined) {
+    // The render wasn't staged — no shell exists.
     shellBodyClone.cancel()
     return null
   }
 
   const shellByteLength = await flightResponse.a
   if (shellByteLength === null) {
-    // Shell == main response — caller reuses the existing flightResponse.
+    // The shell IS the full response (no shell/full split). Return the full
+    // response itself — callers detect this case by reference equality —
+    // rather than collapsing it into null, which would lose the distinction
+    // from "no shell exists". This mirrors the convention of the per-segment
+    // prefetch fetch (see fetchAndWritePerSegmentPrefetchResponse in cache.ts).
     shellBodyClone.cancel()
-    return null
+    return flightResponse
   }
 
   return decodeStageUntilBoundary<T>(shellBodyClone, shellByteLength, headers)
@@ -547,15 +551,14 @@ export async function decodeStageUntilBoundary<T>(
   byteLength: number,
   headers: RequestHeaders | undefined
 ): Promise<T> {
-  const { buffer } = await createNonTaskyPrefetchResponseStream(
-    responseBodyClone,
-    byteLength
-  )
+  const buffer = await bufferPrefetchResponseBody(responseBodyClone, byteLength)
   return decodeBufferedStage<T>(buffer, headers)
 }
 
 /**
- * Decodes already-buffered Flight response bytes as a stage payload. The
+ * Decodes already-buffered Flight response bytes as a stage payload. A
+ * "stage" is a prefix of the staged server render — see `RenderStage` in
+ * packages/next/src/server/app-render/staged-rendering.ts. The
  * bytes are delivered to Flight as a single chunk so all rows are processed
  * synchronously in one call — required for the thenable-status reads that
  * scope a response's late-resolving metadata (vary params, isPartial, ...)

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,7 +41,7 @@ import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   stripIsPartialByte,
-  createNonTaskyPrefetchResponseStream,
+  bufferPrefetchResponseBody,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
 
@@ -67,15 +67,6 @@ export interface FetchServerResponseOptions {
   readonly signal?: AbortSignal
 }
 
-export type StaticStageData<
-  T extends
-    | NavigationFlightResponse
-    | InitialRSCPayload = NavigationFlightResponse,
-> = {
-  readonly response: T
-  readonly isResponsePartial: boolean
-}
-
 type SpaFetchServerResponseResult = {
   transportData: PartialTransportData | null
   canonicalUrl: URL
@@ -84,7 +75,15 @@ type SpaFetchServerResponseResult = {
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
   dynamicStaleTime: number
-  staticStageData: StaticStageData | null
+  /**
+   * Whether the response body was marked partial (contains unresolved
+   * dynamic holes), read from the leading isPartial byte. Always false when
+   * Cache Components is disabled. When `staticStageResponse` is non-null,
+   * this is also its partiality: a complete response is cached whole, a
+   * partial response is cached as its truncated static-stage prefix.
+   */
+  isResponsePartial: boolean
+  staticStageResponse: NavigationFlightResponse | null
   runtimePrefetchStream: ReadableStream<Uint8Array> | null
   responseHeaders: Headers
   debugInfo: Array<any> | null
@@ -271,9 +270,9 @@ export async function fetchServerResponse(
       return doMpaNavigation(flightResponse.n)
     }
 
-    const staticStageData =
+    const staticStageResponse =
       cacheData !== null
-        ? await resolveStaticStageData(cacheData, flightResponse, headers)
+        ? await resolveStaticStageResponse(cacheData, flightResponse, headers)
         : null
 
     return {
@@ -295,7 +294,9 @@ export async function fetchServerResponse(
       // When absent (UnknownDynamicStaleTime), the client falls back to the
       // global DYNAMIC_STALETIME_MS. The value is in seconds.
       dynamicStaleTime: flightResponse.d ?? UnknownDynamicStaleTime,
-      staticStageData,
+      isResponsePartial:
+        cacheData !== null ? cacheData.isResponsePartial : false,
+      staticStageResponse,
       runtimePrefetchStream: flightResponse.p ?? null,
       responseHeaders: res.headers,
       debugInfo: flightResponsePromise._debugInfo ?? null,
@@ -437,20 +438,23 @@ export async function processFetch(response: Response): Promise<{
 
 /**
  * Resolves the static stage response from the raw `processFetch` outputs and
- * the decoded flight response, for writing into the segment cache.
+ * the decoded flight response, for writing into the segment cache. The
+ * resolved response's partiality is the whole response's partiality
+ * (`cacheData.isResponsePartial`): a complete response is resolved whole, a
+ * partial one as its truncated static-stage prefix.
  *
  * - Fully static: use the decoded flight response as-is, no truncation needed.
  * - Not fully static + `l` field: truncate the body clone at the static stage
  *   byte boundary and decode.
  * - Otherwise: no cache-worthy data.
  */
-export async function resolveStaticStageData<
+async function resolveStaticStageResponse<
   T extends NavigationFlightResponse | InitialRSCPayload,
 >(
   cacheData: FetchResponseCacheData,
   flightResponse: T,
   headers: RequestHeaders | undefined
-): Promise<StaticStageData<T> | null> {
+): Promise<T | null> {
   const { isResponsePartial, staticBodyClone } = cacheData
 
   if (staticBodyClone) {
@@ -458,20 +462,18 @@ export async function resolveStaticStageData<
       // Fully static — cache the entire decoded response as-is.
       staticBodyClone.cancel()
 
-      return { response: flightResponse, isResponsePartial: false }
+      return flightResponse
     }
 
     if (flightResponse.l !== undefined) {
       // Partially static — truncate the body clone at the byte boundary and
       // decode it.
       const staticStageByteLength = await flightResponse.l
-      const response = await decodeStageUntilBoundary<T>(
+      return decodeStageUntilBoundary<T>(
         staticBodyClone,
         staticStageByteLength,
         headers
       )
-
-      return { response, isResponsePartial: true }
     }
 
     // No caching — cancel the unused clone.
@@ -482,19 +484,16 @@ export async function resolveStaticStageData<
 }
 
 /**
- * Resolves the shell stage of a prerender response, performing a separate
- * Flight decode of the byte prefix when the shell differs from the main
- * response. Returns null when no separate decode is needed:
+ * Resolves the shell stage of a prerender response:
  *
- * - `a === undefined`: server didn't emit shell stage info.
- * - `a` resolves to `null`: the shell IS the main response — the caller can
- *   reuse the existing decoded `flightResponse` if it needs a shell payload.
- *
- * Returns the decoded shell payload when `a` resolves to a number, i.e.
- * the shell is a strict prefix of the response and requires a separate
- * decode at that byte boundary.
+ * - `a === undefined` (server didn't emit shell stage info) or no shell body
+ *   clone: no shell exists — returns null.
+ * - `a` resolves to `null`: the shell IS the main response — returns
+ *   `flightResponse` itself (callers compare by reference).
+ * - `a` resolves to a number: the shell is a strict prefix of the response —
+ *   returns a separate Flight decode of the byte prefix.
  */
-export async function resolveShellStageData<
+export async function resolveShellStageResponse<
   T extends NavigationFlightResponse | InitialRSCPayload,
 >(
   cacheData: FetchResponseCacheData,
@@ -508,15 +507,20 @@ export async function resolveShellStageData<
   }
 
   if (flightResponse.a === undefined) {
+    // The render wasn't staged — no shell exists.
     shellBodyClone.cancel()
     return null
   }
 
   const shellByteLength = await flightResponse.a
   if (shellByteLength === null) {
-    // Shell == main response — caller reuses the existing flightResponse.
+    // The shell IS the full response (no shell/full split). Return the full
+    // response itself — callers detect this case by reference equality —
+    // rather than collapsing it into null, which would lose the distinction
+    // from "no shell exists". This mirrors the convention of the per-segment
+    // prefetch fetch (see fetchAndWritePerSegmentPrefetchResponse in cache.ts).
     shellBodyClone.cancel()
-    return null
+    return flightResponse
   }
 
   return decodeStageUntilBoundary<T>(shellBodyClone, shellByteLength, headers)
@@ -532,15 +536,14 @@ export async function decodeStageUntilBoundary<T>(
   byteLength: number,
   headers: RequestHeaders | undefined
 ): Promise<T> {
-  const { buffer } = await createNonTaskyPrefetchResponseStream(
-    responseBodyClone,
-    byteLength
-  )
+  const buffer = await bufferPrefetchResponseBody(responseBodyClone, byteLength)
   return decodeBufferedStage<T>(buffer, headers)
 }
 
 /**
- * Decodes already-buffered Flight response bytes as a stage payload. The
+ * Decodes already-buffered Flight response bytes as a stage payload. A
+ * "stage" is a prefix of the staged server render — see `RenderStage` in
+ * packages/next/src/server/app-render/staged-rendering.ts. The
  * bytes are delivered to Flight as a single chunk so all rows are processed
  * synchronously in one call — required for the thenable-status reads that
  * scope a response's late-resolving metadata (vary params, isPartial, ...)

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -36,15 +36,11 @@ import {
   waitForSegmentCacheEntry,
   markRouteEntryAsDynamicRewrite,
   invalidateRouteCacheEntries,
-  resolveStaleAt,
-  writePrerenderResponseIntoCache,
-  processRuntimePrefetchStream,
-  writeDynamicRenderResponseIntoCache,
+  spawnStaticStageCacheWrite,
+  writeRuntimePrefetchStreamIntoCache,
   EntryStatus,
 } from '../segment-cache/cache'
-import { FetchStrategy } from '../segment-cache/types'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
-import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import { urlSearchParamsToParsedUrlQuery } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
 import type { CacheMap } from '../segment-cache/cache-map'
@@ -1840,65 +1836,29 @@ async function fetchMissingDynamicData(
       await navigationLock
     }
 
-    // TODO: Implement Shell extraction as part of Cached Navigations.
-    // Intentionally holding off on doing this until we decide how the Cached
-    // Navigations behavior should work in combination with App Shells.
-    if (routeCacheEntry !== null && result.staticStageData !== null) {
-      const { response: staticStageResponse, isResponsePartial } =
-        result.staticStageData
-
-      resolveStaleAt(now, staticStageResponse.s)
-        .then((staleAt) => {
-          const buildId =
-            result.responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-            staticStageResponse.b
-
-          writePrerenderResponseIntoCache(
-            now,
-            FetchStrategy.PPR,
-            staticStageResponse.t ?? null,
-            buildId,
-            staticStageResponse.r ?? null,
-            staleAt,
-            dynamicRequestTree,
-            result.renderedSearch,
-            isResponsePartial,
-            map
-          )
-        })
-        .catch(() => {
-          // The static stage processing failed. Not fatal — the navigation
-          // completed normally, we just won't write into the cache.
-        })
+    if (routeCacheEntry !== null && result.staticStageResponse !== null) {
+      spawnStaticStageCacheWrite(
+        now,
+        result.staticStageResponse,
+        result.isResponsePartial,
+        result.responseHeaders,
+        dynamicRequestTree,
+        result.renderedSearch,
+        map
+      )
     }
 
     if (routeCacheEntry !== null && result.runtimePrefetchStream !== null) {
-      processRuntimePrefetchStream(
+      writeRuntimePrefetchStreamIntoCache(
         now,
         result.runtimePrefetchStream,
         dynamicRequestTree,
-        result.renderedSearch
-      )
-        .then((processed) => {
-          if (processed !== null) {
-            writeDynamicRenderResponseIntoCache(
-              now,
-              FetchStrategy.PPRRuntime,
-              processed.buildId,
-              processed.isResponsePartial,
-              processed.headVaryParams,
-              processed.rootVaryParamsIterable,
-              processed.staleAt,
-              processed.navigationSeed,
-              null,
-              map
-            )
-          }
-        })
-        .catch(() => {
-          // The runtime prefetch cache write failed. Not fatal — the
-          // navigation completed normally, we just won't cache runtime data.
-        })
+        result.renderedSearch,
+        map
+      ).catch(() => {
+        // The runtime prefetch cache write failed. Not fatal — the
+        // navigation completed normally, we just won't cache runtime data.
+      })
     }
 
     // result.dynamicStaleTime is in seconds (from the server's `d` field).

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -34,15 +34,11 @@ import {
   waitForSegmentCacheEntry,
   markRouteEntryAsDynamicRewrite,
   invalidateRouteCacheEntries,
-  resolveStaleAt,
-  writePrerenderResponseIntoCache,
-  processRuntimePrefetchStream,
-  writeDynamicRenderResponseIntoCache,
+  spawnStaticStageCacheWrite,
+  writeRuntimePrefetchStreamIntoCache,
   EntryStatus,
 } from '../segment-cache/cache'
-import { FetchStrategy } from '../segment-cache/types'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
-import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import { urlSearchParamsToParsedUrlQuery } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
 import {
@@ -1815,63 +1811,27 @@ async function fetchMissingDynamicData(
       await navigationLock
     }
 
-    // TODO: Implement Shell extraction as part of Cached Navigations.
-    // Intentionally holding off on doing this until we decide how the Cached
-    // Navigations behavior should work in combination with App Shells.
-    if (routeCacheEntry !== null && result.staticStageData !== null) {
-      const { response: staticStageResponse, isResponsePartial } =
-        result.staticStageData
-
-      resolveStaleAt(now, staticStageResponse.s)
-        .then((staleAt) => {
-          const buildId =
-            result.responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-            staticStageResponse.b
-
-          writePrerenderResponseIntoCache(
-            now,
-            FetchStrategy.PPR,
-            staticStageResponse.t ?? null,
-            buildId,
-            staticStageResponse.r ?? null,
-            staleAt,
-            dynamicRequestTree,
-            result.renderedSearch,
-            isResponsePartial
-          )
-        })
-        .catch(() => {
-          // The static stage processing failed. Not fatal — the navigation
-          // completed normally, we just won't write into the cache.
-        })
+    if (routeCacheEntry !== null && result.staticStageResponse !== null) {
+      spawnStaticStageCacheWrite(
+        now,
+        result.staticStageResponse,
+        result.isResponsePartial,
+        result.responseHeaders,
+        dynamicRequestTree,
+        result.renderedSearch
+      )
     }
 
     if (routeCacheEntry !== null && result.runtimePrefetchStream !== null) {
-      processRuntimePrefetchStream(
+      writeRuntimePrefetchStreamIntoCache(
         now,
         result.runtimePrefetchStream,
         dynamicRequestTree,
         result.renderedSearch
-      )
-        .then((processed) => {
-          if (processed !== null) {
-            writeDynamicRenderResponseIntoCache(
-              now,
-              FetchStrategy.PPRRuntime,
-              processed.buildId,
-              processed.isResponsePartial,
-              processed.headVaryParams,
-              processed.rootVaryParamsIterable,
-              processed.staleAt,
-              processed.navigationSeed,
-              null
-            )
-          }
-        })
-        .catch(() => {
-          // The runtime prefetch cache write failed. Not fatal — the
-          // navigation completed normally, we just won't cache runtime data.
-        })
+      ).catch(() => {
+        // The runtime prefetch cache write failed. Not fatal — the
+        // navigation completed normally, we just won't cache runtime data.
+      })
     }
 
     // result.dynamicStaleTime is in seconds (from the server's `d` field).

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2,10 +2,8 @@ import type React from 'react'
 import type { SegmentPrefetchResponse } from '../../../server/app-render/collect-segment-data'
 import type { Segment as FlightRouterStateSegment } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
-import type { PartialTransportData } from '../../../shared/lib/rsc-transport'
 import {
   readVaryParams,
-  type VaryParams,
   type VaryParamsIterable,
 } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import {
@@ -22,7 +20,7 @@ import {
   createFetch,
   createFromNextReadableStream,
   decodeBufferedStage,
-  resolveShellStageData,
+  resolveShellStageResponse,
   type RSCResponse,
   type RequestHeaders,
 } from '../router-reducer/fetch-server-response'
@@ -94,7 +92,6 @@ import {
   convertServerPatchToFullTree,
   decodeTransportTreeIntoRouteTree,
   createRouteTreeNode,
-  type NavigationSeed,
 } from './decode-server-response'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
@@ -105,6 +102,28 @@ import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
  */
 export function getStaleTimeMs(staleTimeSeconds: number): number {
   return Math.max(staleTimeSeconds, 30) * 1000
+}
+
+// How long a rejected cache entry blocks re-fetching before it may be
+// retried (its staleAt is set this far in the future).
+const REJECTION_BACKOFF_MS = 10 * 1000
+
+/**
+ * The staleAt to reject entries with when a prefetch fails: if we're
+ * offline, expire immediately (-1) so the entry is re-fetched once the
+ * scheduler is re-pinged after connectivity is restored; otherwise apply a
+ * short backoff. (Unlike navigations and server actions, prefetches don't
+ * await `waitForConnection`.)
+ */
+function getPrefetchErrorStaleAt(error: unknown): number {
+  if (process.env.__NEXT_USE_OFFLINE) {
+    const { checkOfflineError } =
+      require('../offline') as typeof import('../offline')
+    if (checkOfflineError(error)) {
+      return -1
+    }
+  }
+  return Date.now() + REJECTION_BACKOFF_MS
 }
 
 // A note on async/await when working in the prefetch cache:
@@ -1897,7 +1916,7 @@ export async function fetchRouteOnCacheMiss(
         //
         // Note that we can't use headResponse.ok here, because
         // Response#ok returns `false` with 3xx responses.
-        rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+        rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
         return null
       }
 
@@ -1922,7 +1941,7 @@ export async function fetchRouteOnCacheMiss(
     if (!response || !response.ok || !response.body) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -1964,16 +1983,13 @@ export async function fetchRouteOnCacheMiss(
     // NavigationFlightResponses carrying a buildId and a structure-only
     // transport tree — which is all this flow reads — so one decode path
     // serves both.
-    const { stream: prefetchStream, size: responseSize } =
-      await createNonTaskyPrefetchResponseStream(response.body)
+    const buffer = await bufferPrefetchResponseBody(response.body)
     closed.resolve()
-    setSizeInCacheMap(entry, responseSize)
-    const serverData =
-      await createFromNextReadableStream<NavigationFlightResponse>(
-        prefetchStream,
-        headers,
-        { allowPartialStream: true }
-      )
+    setSizeInCacheMap(entry, buffer.byteLength)
+    const serverData = await decodeBufferedStage<NavigationFlightResponse>(
+      buffer,
+      headers
+    )
 
     if (
       (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b) !==
@@ -1982,7 +1998,7 @@ export async function fetchRouteOnCacheMiss(
       // The server build does not match the client. Treat as a 404. During
       // an actual navigation, the router will trigger an MPA navigation.
       // TODO: We should cache the fact that this is an MPA navigation.
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -1990,7 +2006,7 @@ export async function fetchRouteOnCacheMiss(
     if (transportData === undefined || serverData.n !== undefined) {
       // The response carries no route tree (e.g. it's an MPA navigation), so
       // there's nothing to cache.
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -2017,7 +2033,7 @@ export async function fetchRouteOnCacheMiss(
     )
     const metadataVaryPath = acc.metadataVaryPath
     if (metadataVaryPath === null) {
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -2076,7 +2092,7 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
     }
-    rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+    rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
     return null
   }
 }
@@ -2128,20 +2144,9 @@ export async function fetchSegmentsOnCacheMiss(
     result = await fetchSegmentsOnCacheMissImpl(route, routeKey, tree)
   } catch (error) {
     // The connection failed, or the response couldn't be decoded. Reject the
-    // pending entries so they don't stay Pending forever, and get retried once
-    // the entry expires. If we're offline, expire immediately (-1) so the entry
-    // is re-fetched once the scheduler is re-pinged on reconnect; otherwise
-    // apply a 10s backoff. (Unlike navigations and server actions, prefetches
-    // don't await `waitForConnection`.)
-    let staleAt = Date.now() + 10 * 1000
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        staleAt = -1
-      }
-    }
-    rejectRemainingSegmentsInBundle(segments, staleAt)
+    // pending entries so they don't stay Pending forever, and get retried
+    // once the entry expires.
+    rejectRemainingSegmentsInBundle(segments, getPrefetchErrorStaleAt(error))
     return null
   }
 
@@ -2149,7 +2154,7 @@ export async function fetchSegmentsOnCacheMiss(
     // The response was fetched but isn't usable yet (server error/miss, empty
     // data, or a build-id mismatch — the server may be transiently unready).
     // Reject with a short backoff so the entries are retried soon.
-    rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)
+    rejectRemainingSegmentsInBundle(segments, Date.now() + REJECTION_BACKOFF_MS)
     return null
   }
 
@@ -2284,22 +2289,17 @@ async function fetchSegmentsOnCacheMissImpl(
   // buffered prefetch paths.
   const closed = createPromiseWithResolvers<void>()
 
-  const {
-    stream: prefetchStream,
-    size: responseSize,
-    buffer,
-  } = await createNonTaskyPrefetchResponseStream(response.body)
+  const buffer = await bufferPrefetchResponseBody(response.body)
   closed.resolve()
+  const responseSize = buffer.byteLength
 
   // Parse the response. Always a SegmentPrefetchResponse with a build ID and a
   // data array. A connection drop or malformed stream throws here, which
   // propagates to the caller as a non-retryable failure.
-  const serverResponse =
-    await createFromNextReadableStream<SegmentPrefetchResponse>(
-      prefetchStream,
-      headers,
-      { allowPartialStream: true }
-    )
+  const serverResponse = await decodeBufferedStage<SegmentPrefetchResponse>(
+    buffer,
+    headers
+  )
 
   if (serverResponse.data.length === 0) {
     return null
@@ -2403,7 +2403,7 @@ function writeSegmentBundleResponseVariants(
       // the Rejected case in pingSegmentBundle in scheduler.ts), so these
       // segments get no shell prefetch and no runtime substitute until the
       // rejection's backoff expires.
-      rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+      rejectRemainingSegmentsInBundle(segments, now + REJECTION_BACKOFF_MS)
     } else {
       writeSegmentBundleResponse(
         shellResponse,
@@ -2537,7 +2537,7 @@ function writeSegmentBundleResponse(
       if (node.entry !== null && node.entry.status === EntryStatus.Pending) {
         rejectSegmentCacheEntry(
           node.entry as PendingSegmentCacheEntry,
-          now + 10 * 1000
+          now + REJECTION_BACKOFF_MS
         )
       }
       node = node.parent
@@ -2654,7 +2654,7 @@ function writeSegmentBundleResponse(
   // If the server returned fewer segments than expected, reject any
   // remaining pending entries so they don't stay Pending forever.
   if (node !== null) {
-    rejectRemainingSegmentsInBundle(node, now + 10 * 1000)
+    rejectRemainingSegmentsInBundle(node, now + REJECTION_BACKOFF_MS)
   }
 }
 
@@ -2735,7 +2735,7 @@ function readFulfilledValue<T>(
 /**
  * Reads a stale-at time from the staleTime async iterable of a fully-buffered
  * response — segment bundles and stage decodes, which go through
- * `createNonTaskyPrefetchResponseStream`. Because the bytes are all present,
+ * `bufferPrefetchResponseBody`. Because the bytes are all present,
  * each yielded value is already visible on its chunk's thenable status (the
  * same trick `readVaryParams` uses), so this drains synchronously and takes
  * the last value (the final staleTime, as `resolveStaleAt` does for the
@@ -2870,7 +2870,7 @@ async function retryUpgradeableFallbackPrefetch(
 // boolean flag. At that point, the per-segment and inlined fetch paths will
 // merge, and these separate functions will be removed.
 //
-export async function fetchSegmentPrefetchesUsingDynamicRequest(
+export async function fetchSegmentPrefetchesUsingRuntimeRequest(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   fetchStrategy:
@@ -2934,7 +2934,10 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     if (!response || !response.ok || !response.body) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        Date.now() + REJECTION_BACKOFF_MS
+      )
       return null
     }
 
@@ -2947,7 +2950,10 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // TODO: For now, since this is an edge case, we reject the prefetch, but
       // the proper way to handle this is to evict the stale route tree entry
       // then fill the cache with the new response.
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        Date.now() + REJECTION_BACKOFF_MS
+      )
       return null
     }
 
@@ -2957,14 +2963,14 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const closed = createPromiseWithResolvers<void>()
 
     let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null = null
-    let prefetchStream: ReadableStream<Uint8Array>
     let bufferedResponseSize: number | null = null
+    let serverDataPromise: Promise<NavigationFlightResponse>
     if (fetchStrategy === FetchStrategy.Full) {
       // Full prefetches are dynamic responses stored in the prefetch cache.
       // They don't carry vary params or other cache metadata, so there's no
       // need to buffer them. Use the incremental version to allow data to be
       // processed as it arrives.
-      prefetchStream = createIncrementalPrefetchResponseStream(
+      const prefetchStream = createIncrementalPrefetchResponseStream(
         response.body,
         closed.resolve,
         function onResponseSizeUpdate(totalBytesReceivedSoFar) {
@@ -2982,21 +2988,24 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           }
         }
       )
+      serverDataPromise =
+        createFromNextReadableStream<NavigationFlightResponse>(
+          prefetchStream,
+          headers,
+          { allowPartialStream: true }
+        )
     } else {
-      const { stream, size } = await createNonTaskyPrefetchResponseStream(
-        response.body
-      )
+      const buffer = await bufferPrefetchResponseBody(response.body)
       closed.resolve()
-      prefetchStream = stream
-      bufferedResponseSize = size
+      bufferedResponseSize = buffer.byteLength
+      serverDataPromise = decodeBufferedStage<NavigationFlightResponse>(
+        buffer,
+        headers
+      )
     }
 
     const [serverData, cacheData] = await Promise.all([
-      createFromNextReadableStream<NavigationFlightResponse>(
-        prefetchStream,
-        headers,
-        { allowPartialStream: true }
-      ),
+      serverDataPromise,
       response.cacheData,
     ])
 
@@ -3014,21 +3023,25 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     if (cacheData === null) {
       // No shell can be extracted without cache metadata (only present when
       // Cached Navigations is enabled). For routes without a distinct App Shell
-      // the extraction below is a no-op anyway (`resolveShellStageData` returns
-      // null), so this just short-circuits that case.
+      // the extraction below is a no-op anyway (`resolveShellStageResponse`
+      // returns null), so this just short-circuits that case.
       serverDataThatSatisfiesSpawnedEntries = serverData
     } else {
-      const shellStageData = await resolveShellStageData(
+      const shellStageResponse = await resolveShellStageResponse(
         cacheData,
         serverData,
         headers
       )
-      if (shellStageData === null) {
-        // No App Shell can be extracted. This usually means the entire response
-        // _is_ the App Shell. The other possibility (for now, until the feature
-        // is fully stabilized) is that App Shells are not yet enabled. Either
-        // way, there's nothing extra for us to do: fulfill the pending entries
-        // using the response from the server.
+      if (shellStageResponse === null || shellStageResponse === serverData) {
+        // Either no App Shell exists (App Shells are not yet enabled, or the
+        // render wasn't staged), or the shell IS the entire response
+        // (reference-equal). Either way, there's nothing extra for us to do:
+        // fulfill the pending entries using the response from the server.
+        // TODO: When the shell coincides with the full response, the entries
+        // could be recorded at the tier that describes the full payload's
+        // content, the way the per-segment flow promotes a coincident shell
+        // (see writeSegmentBundleResponseVariants). For now the coincident
+        // case is treated the same as no shell.
         serverDataThatSatisfiesSpawnedEntries = serverData
       } else {
         // Successfully extracted an App Shell that is a subset of the main
@@ -3047,27 +3060,28 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
         // the result of a pending entry, do one additional cache look-up right
         // after the promise resolves, to ensure we never get a mismatching
         // entry. Leaving this for a follow up.
-        // shellStageData is a fully-buffered stage decode, so read staleTime
-        // synchronously off the thenable status.
-        const shellStaleAt = readFulfilledStaleAt(now, shellStageData.s)
+        // shellStageResponse is a fully-buffered stage decode, so read
+        // staleTime synchronously off the thenable status.
+        const shellStaleAt = readFulfilledStaleAt(now, shellStageResponse.s)
         if (fetchStrategy === FetchStrategy.RuntimeShell) {
           // This is a Shell prefetch, so the pending entries must be fulfilled
           // with the shell.
-          serverDataThatSatisfiesSpawnedEntries = shellStageData
+          serverDataThatSatisfiesSpawnedEntries = shellStageResponse
           staleAtForSpawnedEntries = shellStaleAt
 
           // Separately, we'll also cache the entire response, by upserting it
           // into the cache.
-          writePrerenderResponseIntoCache(
+          writeServerResponseIntoCache(
             now,
             FetchStrategy.PPR,
-            serverData.t ?? null,
-            buildId,
-            serverData.r ?? null,
-            staleAt,
+            serverData,
             dynamicRequestTree,
             renderedSearch,
-            cacheData.isResponsePartial
+            buildId,
+            staleAt,
+            cacheData.isResponsePartial,
+            // No owned entries; every write is a detached upsert.
+            null
           )
         } else {
           // This is _not_ a Shell prefetch, so the pending entries should be
@@ -3077,31 +3091,27 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           // Additionally, we might as well upsert the extracted Shell into the
           // cache, too.
 
-          // `shellStageData` is only provided in cases where the shell is
-          // different from the main response. If they are equivalent, this
-          // branch is skipped. So it follows that any shell data reaches
-          // this path must be partial -- it does not represent the entire
-          // UI of the target page.
+          // `shellStageResponse` only reaches this path when the shell is
+          // distinct from the main response (a strict prefix of it). So it
+          // follows that any shell data that reaches this path must be
+          // partial -- it does not represent the entire UI of the
+          // target page.
           const isShellStagePartial = true
-          writePrerenderResponseIntoCache(
+          writeServerResponseIntoCache(
             now,
             FetchStrategy.RuntimeShell,
-            shellStageData.t ?? null,
-            buildId,
-            shellStageData.r ?? null,
-            shellStaleAt,
+            shellStageResponse,
             dynamicRequestTree,
             renderedSearch,
-            isShellStagePartial
+            buildId,
+            shellStaleAt,
+            isShellStagePartial,
+            // No owned entries; every write is a detached upsert.
+            null
           )
         }
       }
     }
-
-    // Root params are emitted once at the response level; the iterable is
-    // threaded down so each segment unions it too.
-    const rootVaryParamsIterable =
-      serverDataThatSatisfiesSpawnedEntries.r ?? null
 
     // PPRRuntime and RuntimeShell prefetches are partial when the server
     // marks the response as '~' (Partial). RuntimeShell additionally omits
@@ -3113,40 +3123,18 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       (fetchStrategy === FetchStrategy.PPRRuntime &&
         (cacheData?.isResponsePartial ?? false))
 
-    const transportData = serverDataThatSatisfiesSpawnedEntries.t
-    if (transportData === undefined) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-      return null
-    }
-    const navigationSeed = convertServerPatchToFullTree(
-      now,
-      dynamicRequestTree,
-      transportData,
-      // The response always includes the param values in the tree, so
-      // there's no pathname to parse them from.
-      null,
-      renderedSearch,
-      // Not needed for prefetch responses; pass unknown to use the default.
-      UnknownDynamicStaleTime
-    )
-    // Read head vary params synchronously, unioning in the response-level
-    // root params.
-    const headVaryParams = readVaryParams(
-      navigationSeed.headVaryParams,
-      rootVaryParamsIterable
-    )
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
     // in the LRU as more data comes in.
-    fulfilledEntries = writeDynamicRenderResponseIntoCache(
+    fulfilledEntries = writeServerResponseIntoCache(
       now,
       fetchStrategy,
+      serverDataThatSatisfiesSpawnedEntries,
+      dynamicRequestTree,
+      renderedSearch,
       buildId,
-      isResponsePartial,
-      headVaryParams,
-      rootVaryParamsIterable,
       staleAtForSpawnedEntries,
-      navigationSeed,
+      isResponsePartial,
       spawnedEntries
     )
 
@@ -3167,19 +3155,10 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // the scheduler can track the number of concurrent network connections.
     return { value: null, closed: closed.promise }
   } catch (error) {
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        // Unlike navigations and server actions, prefetches don't await
-        // waitForConnection — they just reject the cache entry with an
-        // immediate expiration so it gets retried once the scheduler is
-        // re-pinged after connectivity is restored.
-        rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
-        return null
-      }
-    }
-    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+    rejectSegmentEntriesIfStillPending(
+      spawnedEntries,
+      getPrefetchErrorStaleAt(error)
+    )
     return null
   }
 }
@@ -3199,7 +3178,15 @@ function rejectSegmentEntriesIfStillPending(
   return fulfilledEntries
 }
 
-export function writeDynamicRenderResponseIntoCache(
+/**
+ * Writes a decoded server response into the segment cache: decodes the
+ * response's transport tree into a RouteTree overlaid on `baseTree`, then
+ * writes every rendered segment, plus the head, into the cache. Fulfills the
+ * entries in `spawnedEntries` that the response covers; rejects the rest, so
+ * a task blocked on them isn't stranded. Returns the fulfilled entries (for
+ * LRU size accounting), or null if the response was unusable.
+ */
+export function writeServerResponseIntoCache(
   now: number,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
@@ -3207,22 +3194,67 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.PPRRuntime
     | FetchStrategy.RuntimeShell
     | FetchStrategy.Full,
+  // The decoded response payload to write: the full response, or a
+  // truncated stage decode of the same bytes (the static stage of a
+  // navigation response, or the shell stage of a runtime prefetch response).
+  response: NavigationFlightResponse,
+  // The base router state the response overlays.
+  baseTree: FlightRouterState,
+  renderedSearch: string,
   buildId: string | undefined,
-  isResponsePartial: boolean,
-  headVaryParams: VaryParams | null,
-  rootVaryParamsIterable: VaryParamsIterable | null,
+  // Response-level staleness, applied to every segment and the head.
   staleAt: number,
-  navigationSeed: NavigationSeed,
+  // Whether anything in the response is not fully resolved: dynamic holes,
+  // runtime holes, anything suspended.
+  isResponsePartial: boolean,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
   if (buildId && buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
     // an actual navigation, the router will trigger an MPA navigation.
     if (spawnedEntries !== null) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, now + 10 * 1000)
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        now + REJECTION_BACKOFF_MS
+      )
     }
     return null
   }
+
+  const transportData = response.t
+  if (transportData === undefined) {
+    // The response carries no tree. Settle anything we own so a task blocked
+    // on it isn't stranded.
+    if (spawnedEntries !== null) {
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        now + REJECTION_BACKOFF_MS
+      )
+    }
+    return null
+  }
+
+  const navigationSeed = convertServerPatchToFullTree(
+    now,
+    baseTree,
+    transportData,
+    // The response always includes the param values in the tree, so
+    // there's no pathname to parse them from.
+    null,
+    renderedSearch,
+    // Only navigations consume the seed's dynamicStaleAt; cache writes pass
+    // unknown to use the default.
+    UnknownDynamicStaleTime
+  )
+
+  // Root params are emitted once at the top level of the response; the
+  // iterable is threaded down so each segment unions it into its own set,
+  // and readVaryParams unions it into the head's below.
+  const rootVaryParamsIterable = response.r ?? null
+  const headVaryParams = readVaryParams(
+    navigationSeed.headVaryParams,
+    rootVaryParamsIterable
+  )
 
   const routeTree = navigationSeed.routeTree
   const metadataTree =
@@ -3267,8 +3299,7 @@ export function writeDynamicRenderResponseIntoCache(
       head,
       isHeadPartial,
       staleAt,
-      // For head entries, use the head-specific vary params passed as
-      // parameter.
+      // For head entries, use the head-specific vary params read above.
       headVaryParams,
       metadataTree,
       spawnedEntries
@@ -3285,7 +3316,7 @@ export function writeDynamicRenderResponseIntoCache(
   if (spawnedEntries !== null) {
     const fulfilledEntries = rejectSegmentEntriesIfStillPending(
       spawnedEntries,
-      now + 10 * 1000
+      now + REJECTION_BACKOFF_MS
     )
     return fulfilledEntries
   }
@@ -3533,7 +3564,7 @@ async function fetchPrefetchResponse<T>(
   // When issuing a prefetch request, don't immediately decode the response; we
   // use the lower level `createFromResponse` API instead because we need to do
   // some extra processing of the response stream. See
-  // `createNonTaskyPrefetchResponseStream` for more details.
+  // `bufferPrefetchResponseBody` for more details.
   const shouldImmediatelyDecode = false
   const response = await createFetch<T>(
     url,
@@ -3577,29 +3608,26 @@ function wasServedFromPerSegmentCache(response: RSCResponse<unknown>): boolean {
   )
 }
 
-export async function createNonTaskyPrefetchResponseStream(
+/**
+ * Reads a prefetch response body to completion — optionally truncating at
+ * `byteLimit` — and returns the bytes as a single contiguous buffer.
+ *
+ * Buffering the entire response before passing it to the Flight client
+ * ensures that when Flight processes the stream, all model data is available
+ * synchronously. This is what makes the thenable-status reads (vary params,
+ * isPartial, staleTime) sound: if data arrived in multiple network chunks,
+ * the thenables might not yet be fulfilled. (`decodeBufferedStage` performs
+ * the matching single-chunk decode.)
+ *
+ * TODO: There are too many intermediate stream transformations in the
+ * prefetch response pipeline (e.g. stripIsPartialByte, this function).
+ * These could all be consolidated into a single transformation. Refactor
+ * once the cached navigations experiment lands.
+ */
+export async function bufferPrefetchResponseBody(
   body: ReadableStream<Uint8Array>,
   byteLimit?: number
-): Promise<{
-  stream: ReadableStream<Uint8Array>
-  size: number
-  // The materialized response bytes backing `stream`. Exposed so callers that
-  // need to decode the same response a second time (e.g. the static App Shell
-  // extraction, which re-decodes a truncated prefix of the buffer) don't have
-  // to buffer the body twice. Most callers only use `stream` and `size`.
-  buffer: Uint8Array
-}> {
-  // Buffer the entire response before passing it to the Flight client. This
-  // ensures that when Flight processes the stream, all model data is available
-  // synchronously. This is important for readVaryParams, which synchronously
-  // checks the thenable status — if data arrived in multiple network chunks,
-  // the thenables might not yet be fulfilled.
-  //
-  // TODO: There are too many intermediate stream transformations in the
-  // prefetch response pipeline (e.g. stripIsPartialByte, this function).
-  // These could all be consolidated into a single transformation. Refactor
-  // once the cached navigations experiment lands.
-  //
+): Promise<Uint8Array> {
   // Read the response from the network, optionally truncating at byteLimit.
   const reader = body.getReader()
   const chunks: Uint8Array[] = []
@@ -3630,26 +3658,19 @@ export async function createNonTaskyPrefetchResponseStream(
   // PromiseResolveThenableJob from `await` can cause the root to initialize
   // eagerly, scheduling the continuation before remaining chunks (including
   // promise value rows) are processed. A single chunk avoids this.
-  let buffer: Uint8Array
   if (chunks.length === 1) {
-    buffer = chunks[0]
+    return chunks[0]
   } else if (chunks.length > 1) {
-    buffer = new Uint8Array(size)
+    const buffer = new Uint8Array(size)
     let offset = 0
     for (const chunk of chunks) {
       buffer.set(chunk, offset)
       offset += chunk.byteLength
     }
+    return buffer
   } else {
-    buffer = new Uint8Array(0)
+    return new Uint8Array(0)
   }
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(buffer)
-      controller.close()
-    },
-  })
-  return { stream, size, buffer }
 }
 
 /**
@@ -3806,73 +3827,71 @@ export async function resolveStaleAt(
 }
 
 /**
- * Writes a prerender response into the segment cache at the vary path
- * determined by `fetchStrategy`. Default segments are skipped (by
- * `writeSeedDataIntoCache`) to avoid caching fallback content that would
- * block refreshes from overwriting with dynamic data.
+ * Fire-and-forget ("spawn"), unlike the synchronous cache-write family it
+ * wraps (writeServerResponseIntoCache and below): the stage's staleTime must
+ * be resolved asynchronously from the response's own `s` field before the
+ * write can happen, and failures are swallowed — a failed cache write is not
+ * fatal to the render that produced the response.
+ *
+ * Writes the static stage of a navigation response — or of the initial RSC
+ * payload — into the segment cache, so subsequent navigations can serve
+ * cached static segments instantly.
  */
-export function writePrerenderResponseIntoCache(
+export function spawnStaticStageCacheWrite(
   now: number,
-  fetchStrategy: FetchStrategy.PPR | FetchStrategy.RuntimeShell,
-  transportData: PartialTransportData | null,
-  buildId: string | undefined,
-  rootVaryParamsIterable: VaryParamsIterable | null,
-  staleAt: number,
+  response: NavigationFlightResponse,
+  isResponsePartial: boolean,
+  // The navigation response's headers, used to derive the buildId for the
+  // write-layer build check (the deployment header, falling back to the
+  // response's `b` field). Null for the initial payload, which arrived in
+  // the HTML document and has no build-id check.
+  responseHeaders: Headers | null,
   baseTree: FlightRouterState,
-  renderedSearch: string,
-  isResponsePartial: boolean
+  renderedSearch: string
 ): void {
-  if (transportData === null) {
-    return
-  }
-  const navigationSeed = convertServerPatchToFullTree(
-    now,
-    baseTree,
-    transportData,
-    // The response always includes the param values in the tree, so there's
-    // no pathname to parse them from.
-    null,
-    renderedSearch,
-    UnknownDynamicStaleTime
-  )
-  // Root params are emitted once at the top level; readVaryParams unions them
-  // into the head, and they're threaded down to each segment below.
-  const headVaryParams = readVaryParams(
-    navigationSeed.headVaryParams,
-    rootVaryParamsIterable
-  )
-  writeDynamicRenderResponseIntoCache(
-    now,
-    fetchStrategy,
-    buildId,
-    isResponsePartial,
-    headVaryParams,
-    rootVaryParamsIterable,
-    staleAt,
-    navigationSeed,
-    null // spawnedEntries — no pre-created entries; will create or upsert
-  )
+  const buildId =
+    responseHeaders !== null
+      ? (responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? response.b)
+      : undefined
+  resolveStaleAt(now, response.s)
+    .then((staleAt) => {
+      // TODO: This entire write is legacy and will be deleted in a future
+      // PR: caching is organized around the conceptual shell vs not-shell
+      // distinction, not around the static vs runtime render stages, so a
+      // static-stage write has no place in the model. It's kept only until
+      // its removal PR lands — do not extend it (e.g. with shell
+      // extraction).
+      writeServerResponseIntoCache(
+        now,
+        FetchStrategy.PPR,
+        response,
+        baseTree,
+        renderedSearch,
+        buildId,
+        staleAt,
+        isResponsePartial,
+        // No owned entries; every write is a detached upsert.
+        null
+      )
+    })
+    .catch(() => {
+      // The static stage processing failed. Not fatal — the render
+      // completed normally, we just won't write into the cache.
+    })
 }
 
 /**
- * Decodes an embedded runtime prefetch Flight stream, normalizes the flight
- * data, and derives a `NavigationSeed` from the base tree.
- *
- * Returns `null` if the response triggers an MPA navigation.
+ * Decodes an embedded runtime prefetch Flight stream and writes it into the
+ * segment cache, so subsequent navigations can serve runtime-prefetchable
+ * content from cache without a separate prefetch request. This flow owns no
+ * pending entries, so every write is a detached upsert.
  */
-export async function processRuntimePrefetchStream(
+export async function writeRuntimePrefetchStreamIntoCache(
   now: number,
   runtimePrefetchStream: ReadableStream<Uint8Array>,
   baseTree: FlightRouterState,
   renderedSearch: string
-): Promise<{
-  navigationSeed: NavigationSeed
-  buildId: string | undefined
-  isResponsePartial: boolean
-  headVaryParams: VaryParams | null
-  rootVaryParamsIterable: VaryParamsIterable | null
-  staleAt: number
-} | null> {
+): Promise<void> {
   const { stream, isPartial } = await stripIsPartialByte(runtimePrefetchStream)
 
   const serverData =
@@ -3882,41 +3901,21 @@ export async function processRuntimePrefetchStream(
       { allowPartialStream: true }
     )
 
-  const rootVaryParamsIterable = serverData.r ?? null
-
   const staleAt = await resolveStaleAt(now, serverData.s)
 
-  const transportData = serverData.t
-  if (transportData === undefined) {
-    return null
-  }
-  const navigationSeed = convertServerPatchToFullTree(
+  writeServerResponseIntoCache(
     now,
+    // A runtime prefetch stream is by definition a runtime prefetch.
+    FetchStrategy.PPRRuntime,
+    serverData,
     baseTree,
-    transportData,
-    // The response always includes the param values in the tree, so there's
-    // no pathname to parse them from.
-    null,
     renderedSearch,
-    UnknownDynamicStaleTime
-  )
-
-  // Root params are emitted once at the top level; readVaryParams unions them
-  // into the head, and we return the iterable so the caller can union it into
-  // each segment too.
-  const headVaryParams = readVaryParams(
-    navigationSeed.headVaryParams,
-    rootVaryParamsIterable
-  )
-
-  return {
-    navigationSeed,
-    buildId: serverData.b,
-    isResponsePartial: isPartial,
-    headVaryParams,
-    rootVaryParamsIterable,
+    serverData.b,
     staleAt,
-  }
+    isPartial,
+    // This flow owns no pending entries; every write is a detached upsert.
+    null
+  )
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2,10 +2,8 @@ import type React from 'react'
 import type { SegmentPrefetchResponse } from '../../../server/app-render/collect-segment-data'
 import type { Segment as FlightRouterStateSegment } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
-import type { PartialTransportData } from '../../../shared/lib/rsc-transport'
 import {
   readVaryParams,
-  type VaryParams,
   type VaryParamsIterable,
 } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import {
@@ -22,7 +20,7 @@ import {
   createFetch,
   createFromNextReadableStream,
   decodeBufferedStage,
-  resolveShellStageData,
+  resolveShellStageResponse,
   type RSCResponse,
   type RequestHeaders,
 } from '../router-reducer/fetch-server-response'
@@ -94,7 +92,6 @@ import {
   convertServerPatchToFullTree,
   decodeTransportTreeIntoRouteTree,
   createRouteTreeNode,
-  type NavigationSeed,
 } from './decode-server-response'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
@@ -105,6 +102,28 @@ import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
  */
 export function getStaleTimeMs(staleTimeSeconds: number): number {
   return Math.max(staleTimeSeconds, 30) * 1000
+}
+
+// How long a rejected cache entry blocks re-fetching before it may be
+// retried (its staleAt is set this far in the future).
+const REJECTION_BACKOFF_MS = 10 * 1000
+
+/**
+ * The staleAt to reject entries with when a prefetch fails: if we're
+ * offline, expire immediately (-1) so the entry is re-fetched once the
+ * scheduler is re-pinged after connectivity is restored; otherwise apply a
+ * short backoff. (Unlike navigations and server actions, prefetches don't
+ * await `waitForConnection`.)
+ */
+function getPrefetchErrorStaleAt(error: unknown): number {
+  if (process.env.__NEXT_USE_OFFLINE) {
+    const { checkOfflineError } =
+      require('../offline') as typeof import('../offline')
+    if (checkOfflineError(error)) {
+      return -1
+    }
+  }
+  return Date.now() + REJECTION_BACKOFF_MS
 }
 
 // A note on async/await when working in the prefetch cache:
@@ -1834,7 +1853,7 @@ export async function fetchRouteOnCacheMiss(
         //
         // Note that we can't use headResponse.ok here, because
         // Response#ok returns `false` with 3xx responses.
-        rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+        rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
         return null
       }
 
@@ -1859,7 +1878,7 @@ export async function fetchRouteOnCacheMiss(
     if (!response || !response.ok || !response.body) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -1905,16 +1924,13 @@ export async function fetchRouteOnCacheMiss(
     // NavigationFlightResponses carrying a buildId and a structure-only
     // transport tree — which is all this flow reads — so one decode path
     // serves both.
-    const { stream: prefetchStream, size: responseSize } =
-      await createNonTaskyPrefetchResponseStream(response.body)
+    const buffer = await bufferPrefetchResponseBody(response.body)
     closed.resolve()
-    setSizeInCacheMap(entry, responseSize)
-    const serverData =
-      await createFromNextReadableStream<NavigationFlightResponse>(
-        prefetchStream,
-        headers,
-        { allowPartialStream: true }
-      )
+    setSizeInCacheMap(entry, buffer.byteLength)
+    const serverData = await decodeBufferedStage<NavigationFlightResponse>(
+      buffer,
+      headers
+    )
 
     if (
       (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b) !==
@@ -1923,7 +1939,7 @@ export async function fetchRouteOnCacheMiss(
       // The server build does not match the client. Treat as a 404. During
       // an actual navigation, the router will trigger an MPA navigation.
       // TODO: We should cache the fact that this is an MPA navigation.
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -1931,7 +1947,7 @@ export async function fetchRouteOnCacheMiss(
     if (transportData === undefined || serverData.n !== undefined) {
       // The response carries no route tree (e.g. it's an MPA navigation), so
       // there's nothing to cache.
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -1961,7 +1977,7 @@ export async function fetchRouteOnCacheMiss(
     )
     const metadataVaryPath = acc.metadataVaryPath
     if (metadataVaryPath === null) {
-      rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+      rejectRouteCacheEntry(entry, Date.now() + REJECTION_BACKOFF_MS)
       return null
     }
 
@@ -2005,22 +2021,8 @@ export async function fetchRouteOnCacheMiss(
     return { value: null, closed: closed.promise }
   } catch (error) {
     // Either the connection itself failed, or something bad happened while
-    // decoding the response. If we're offline, reject with staleAt=-1 so the
-    // entry immediately expires and gets retried once the scheduler is
-    // re-pinged after connectivity is restored.
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        // Unlike navigations and server actions, prefetches don't await
-        // waitForConnection — they just reject the cache entry with an
-        // immediate expiration so it gets retried once the scheduler is
-        // re-pinged after connectivity is restored.
-        rejectRouteCacheEntry(entry, -1)
-        return null
-      }
-    }
-    rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+    // decoding the response.
+    rejectRouteCacheEntry(entry, getPrefetchErrorStaleAt(error))
     return null
   }
 }
@@ -2072,20 +2074,9 @@ export async function fetchSegmentsOnCacheMiss(
     result = await fetchSegmentsOnCacheMissImpl(route, routeKey, tree)
   } catch (error) {
     // The connection failed, or the response couldn't be decoded. Reject the
-    // pending entries so they don't stay Pending forever, and get retried once
-    // the entry expires. If we're offline, expire immediately (-1) so the entry
-    // is re-fetched once the scheduler is re-pinged on reconnect; otherwise
-    // apply a 10s backoff. (Unlike navigations and server actions, prefetches
-    // don't await `waitForConnection`.)
-    let staleAt = Date.now() + 10 * 1000
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        staleAt = -1
-      }
-    }
-    rejectRemainingSegmentsInBundle(segments, staleAt)
+    // pending entries so they don't stay Pending forever, and get retried
+    // once the entry expires.
+    rejectRemainingSegmentsInBundle(segments, getPrefetchErrorStaleAt(error))
     return null
   }
 
@@ -2093,7 +2084,7 @@ export async function fetchSegmentsOnCacheMiss(
     // The response was fetched but isn't usable yet (server error/miss, empty
     // data, or a build-id mismatch — the server may be transiently unready).
     // Reject with a short backoff so the entries are retried soon.
-    rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)
+    rejectRemainingSegmentsInBundle(segments, Date.now() + REJECTION_BACKOFF_MS)
     return null
   }
 
@@ -2229,22 +2220,17 @@ async function fetchSegmentsOnCacheMissImpl(
   // buffered prefetch paths.
   const closed = createPromiseWithResolvers<void>()
 
-  const {
-    stream: prefetchStream,
-    size: responseSize,
-    buffer,
-  } = await createNonTaskyPrefetchResponseStream(response.body)
+  const buffer = await bufferPrefetchResponseBody(response.body)
   closed.resolve()
+  const responseSize = buffer.byteLength
 
   // Parse the response. Always a SegmentPrefetchResponse with a build ID and a
   // data array. A connection drop or malformed stream throws here, which
   // propagates to the caller as a non-retryable failure.
-  const serverResponse =
-    await createFromNextReadableStream<SegmentPrefetchResponse>(
-      prefetchStream,
-      headers,
-      { allowPartialStream: true }
-    )
+  const serverResponse = await decodeBufferedStage<SegmentPrefetchResponse>(
+    buffer,
+    headers
+  )
 
   if (serverResponse.data.length === 0) {
     return null
@@ -2352,7 +2338,7 @@ function writeSegmentBundleResponseVariants(
       // the Rejected case in pingSegmentBundle in scheduler.ts), so these
       // segments get no shell prefetch and no runtime substitute until the
       // rejection's backoff expires.
-      rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+      rejectRemainingSegmentsInBundle(segments, now + REJECTION_BACKOFF_MS)
     } else {
       writeSegmentBundleResponse(
         map,
@@ -2490,7 +2476,7 @@ function writeSegmentBundleResponse(
       if (node.entry !== null && node.entry.status === EntryStatus.Pending) {
         rejectSegmentCacheEntry(
           node.entry as PendingSegmentCacheEntry,
-          now + 10 * 1000
+          now + REJECTION_BACKOFF_MS
         )
       }
       node = node.parent
@@ -2604,7 +2590,7 @@ function writeSegmentBundleResponse(
   // If the server returned fewer segments than expected, reject any
   // remaining pending entries so they don't stay Pending forever.
   if (node !== null) {
-    rejectRemainingSegmentsInBundle(node, now + 10 * 1000)
+    rejectRemainingSegmentsInBundle(node, now + REJECTION_BACKOFF_MS)
   }
 }
 
@@ -2685,7 +2671,7 @@ function readFulfilledValue<T>(
 /**
  * Reads a stale-at time from the staleTime async iterable of a fully-buffered
  * response — segment bundles and stage decodes, which go through
- * `createNonTaskyPrefetchResponseStream`. Because the bytes are all present,
+ * `bufferPrefetchResponseBody`. Because the bytes are all present,
  * each yielded value is already visible on its chunk's thenable status (the
  * same trick `readVaryParams` uses), so this drains synchronously and takes
  * the last value (the final staleTime, as `resolveStaleAt` does for the
@@ -2821,7 +2807,7 @@ async function retryUpgradeableFallbackPrefetch(
 // boolean flag. At that point, the per-segment and inlined fetch paths will
 // merge, and these separate functions will be removed.
 //
-export async function fetchSegmentPrefetchesUsingDynamicRequest(
+export async function fetchSegmentPrefetchesUsingRuntimeRequest(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   fetchStrategy:
@@ -2885,7 +2871,10 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     if (!response || !response.ok || !response.body) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        Date.now() + REJECTION_BACKOFF_MS
+      )
       return null
     }
 
@@ -2898,7 +2887,10 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // TODO: For now, since this is an edge case, we reject the prefetch, but
       // the proper way to handle this is to evict the stale route tree entry
       // then fill the cache with the new response.
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        Date.now() + REJECTION_BACKOFF_MS
+      )
       return null
     }
 
@@ -2908,14 +2900,14 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const closed = createPromiseWithResolvers<void>()
 
     let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null = null
-    let prefetchStream: ReadableStream<Uint8Array>
     let bufferedResponseSize: number | null = null
+    let serverDataPromise: Promise<DynamicNavigationFlightResponse>
     if (fetchStrategy === FetchStrategy.Full) {
       // Full prefetches are dynamic responses stored in the prefetch cache.
       // They don't carry vary params or other cache metadata, so there's no
       // need to buffer them. Use the incremental version to allow data to be
       // processed as it arrives.
-      prefetchStream = createIncrementalPrefetchResponseStream(
+      const prefetchStream = createIncrementalPrefetchResponseStream(
         response.body,
         closed.resolve,
         function onResponseSizeUpdate(totalBytesReceivedSoFar) {
@@ -2933,21 +2925,24 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           }
         }
       )
+      serverDataPromise =
+        createFromNextReadableStream<DynamicNavigationFlightResponse>(
+          prefetchStream,
+          headers,
+          { allowPartialStream: true }
+        )
     } else {
-      const { stream, size } = await createNonTaskyPrefetchResponseStream(
-        response.body
-      )
+      const buffer = await bufferPrefetchResponseBody(response.body)
       closed.resolve()
-      prefetchStream = stream
-      bufferedResponseSize = size
+      bufferedResponseSize = buffer.byteLength
+      serverDataPromise = decodeBufferedStage<DynamicNavigationFlightResponse>(
+        buffer,
+        headers
+      )
     }
 
     const [serverData, cacheData] = await Promise.all([
-      createFromNextReadableStream<DynamicNavigationFlightResponse>(
-        prefetchStream,
-        headers,
-        { allowPartialStream: true }
-      ),
+      serverDataPromise,
       response.cacheData,
     ])
 
@@ -2955,6 +2950,17 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const staleAt = await resolveStaleAt(now, serverData.s, response)
     const buildId =
       response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+
+    // When the request tree was derived from the route entry's stored
+    // prediction, pass the entry to the write path so it can be marked if the
+    // server's rendered tree diverges from the prediction. A head-only
+    // request uses the MetadataOnlyRequestTree stub rather than a tree
+    // derived from the route entry, so divergence from it carries no signal.
+    // TODO: This special case goes away once the response is diffed against
+    // the base RouteTree (route.tree) instead of the request tree.
+    const predictedFromRoute =
+      dynamicRequestTree !== MetadataOnlyRequestTree ? route : null
+    const routeHadDynamicRewrite = route.hasDynamicRewrite
 
     // Check if a reusable App Shell can be extracted from the main response.
     let serverDataThatSatisfiesSpawnedEntries: NavigationFlightResponse
@@ -2965,21 +2971,25 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     if (cacheData === null) {
       // No shell can be extracted without cache metadata (only present when
       // Cached Navigations is enabled). For routes without a distinct App Shell
-      // the extraction below is a no-op anyway (`resolveShellStageData` returns
-      // null), so this just short-circuits that case.
+      // the extraction below is a no-op anyway (`resolveShellStageResponse`
+      // returns null), so this just short-circuits that case.
       serverDataThatSatisfiesSpawnedEntries = serverData
     } else {
-      const shellStageData = await resolveShellStageData(
+      const shellStageResponse = await resolveShellStageResponse(
         cacheData,
         serverData,
         headers
       )
-      if (shellStageData === null) {
-        // No App Shell can be extracted. This usually means the entire response
-        // _is_ the App Shell. The other possibility (for now, until the feature
-        // is fully stabilized) is that App Shells are not yet enabled. Either
-        // way, there's nothing extra for us to do: fulfill the pending entries
-        // using the response from the server.
+      if (shellStageResponse === null || shellStageResponse === serverData) {
+        // Either no App Shell exists (App Shells are not yet enabled, or the
+        // render wasn't staged), or the shell IS the entire response
+        // (reference-equal). Either way, there's nothing extra for us to do:
+        // fulfill the pending entries using the response from the server.
+        // TODO: When the shell coincides with the full response, the entries
+        // could be recorded at the tier that describes the full payload's
+        // content, the way the per-segment flow promotes a coincident shell
+        // (see writeSegmentBundleResponseVariants). For now the coincident
+        // case is treated the same as no shell.
         serverDataThatSatisfiesSpawnedEntries = serverData
       } else {
         // Successfully extracted an App Shell that is a subset of the main
@@ -2998,27 +3008,29 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
         // the result of a pending entry, do one additional cache look-up right
         // after the promise resolves, to ensure we never get a mismatching
         // entry. Leaving this for a follow up.
-        // shellStageData is a fully-buffered stage decode, so read staleTime
-        // synchronously off the thenable status.
-        const shellStaleAt = readFulfilledStaleAt(now, shellStageData.s)
+        // shellStageResponse is a fully-buffered stage decode, so read
+        // staleTime synchronously off the thenable status.
+        const shellStaleAt = readFulfilledStaleAt(now, shellStageResponse.s)
         if (fetchStrategy === FetchStrategy.RuntimeShell) {
           // This is a Shell prefetch, so the pending entries must be fulfilled
           // with the shell.
-          serverDataThatSatisfiesSpawnedEntries = shellStageData
+          serverDataThatSatisfiesSpawnedEntries = shellStageResponse
           staleAtForSpawnedEntries = shellStaleAt
 
           // Separately, we'll also cache the entire response, by upserting it
           // into the cache.
-          writePrerenderResponseIntoCache(
+          writeServerResponseIntoCache(
             now,
             FetchStrategy.PPR,
-            serverData.t ?? null,
-            buildId,
-            serverData.r ?? null,
-            staleAt,
+            serverData,
             dynamicRequestTree,
+            predictedFromRoute,
             renderedSearch,
+            buildId,
+            staleAt,
             cacheData.isResponsePartial,
+            // No owned entries; every write is a detached upsert.
+            null,
             task.segmentCacheMap
           )
         } else {
@@ -3029,32 +3041,29 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           // Additionally, we might as well upsert the extracted Shell into the
           // cache, too.
 
-          // `shellStageData` is only provided in cases where the shell is
-          // different from the main response. If they are equivalent, this
-          // branch is skipped. So it follows that any shell data reaches
-          // this path must be partial -- it does not represent the entire
-          // UI of the target page.
+          // `shellStageResponse` only reaches this path when the shell is
+          // distinct from the main response (a strict prefix of it). So it
+          // follows that any shell data that reaches this path must be
+          // partial -- it does not represent the entire UI of the
+          // target page.
           const isShellStagePartial = true
-          writePrerenderResponseIntoCache(
+          writeServerResponseIntoCache(
             now,
             FetchStrategy.RuntimeShell,
-            shellStageData.t ?? null,
-            buildId,
-            shellStageData.r ?? null,
-            shellStaleAt,
+            shellStageResponse,
             dynamicRequestTree,
+            predictedFromRoute,
             renderedSearch,
+            buildId,
+            shellStaleAt,
             isShellStagePartial,
+            // No owned entries; every write is a detached upsert.
+            null,
             task.segmentCacheMap
           )
         }
       }
     }
-
-    // Root params are emitted once at the response level; the iterable is
-    // threaded down so each segment unions it too.
-    const rootVaryParamsIterable =
-      serverDataThatSatisfiesSpawnedEntries.r ?? null
 
     // PPRRuntime and RuntimeShell prefetches are partial when the server
     // marks the response as '~' (Partial). RuntimeShell additionally omits
@@ -3066,73 +3075,19 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       (fetchStrategy === FetchStrategy.PPRRuntime &&
         (cacheData?.isResponsePartial ?? false))
 
-    const transportData = serverDataThatSatisfiesSpawnedEntries.t
-    if (transportData === undefined) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-      return null
-    }
-    const navigationSeed = convertServerPatchToFullTree(
-      now,
-      dynamicRequestTree,
-      transportData,
-      // The response always includes the param values in the tree, so
-      // there's no pathname to parse them from.
-      null,
-      renderedSearch,
-      // Not needed for prefetch responses; pass unknown to use the default.
-      UnknownDynamicStaleTime
-    )
-
-    if (
-      navigationSeed.treeDivergedFromBase &&
-      // A head-only request uses the MetadataOnlyRequestTree stub rather than
-      // a tree derived from the route entry, so divergence from it carries
-      // no signal.
-      // TODO: This special case goes away once convertServerPatchToFullTree
-      // diffs against the base RouteTree (route.tree) instead of the
-      // request tree.
-      dynamicRequestTree !== MetadataOnlyRequestTree
-    ) {
-      // The server rendered a different route tree than the one we requested:
-      // the URL has a rewrite that behaves dynamically, so the params baked
-      // into the request are wrong and the server can never fulfill it. Mark
-      // the route entry — which doubles as the stored prediction pattern, so
-      // this also disables a bad prediction (see matchKnownRoute) that would
-      // otherwise be re-derived on every retry — and invalidate entries that
-      // were derived from it. This mirrors dispatchRetryDueToTreeMismatch on
-      // the navigation path. It can't loop: the refetched route entry is
-      // built from the server's response, so it only mismatches again if the
-      // rewrite's behavior changes again.
-      markRouteEntryAsDynamicRewrite(route)
-      invalidateRouteCacheEntries(key.nextUrl, task.treeAtTimeOfPrefetch)
-      // Reject with an immediate expiration instead of the usual backoff: the
-      // invalidation above triggers a re-prefetch, which per the above does
-      // not loop.
-      // TODO: Consider also bounding retries with a counter on the task
-      // object, so a prefetch that repeatedly fails to settle backs off
-      // regardless of the reason.
-      rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
-      return null
-    }
-
-    // Read head vary params synchronously, unioning in the response-level
-    // root params.
-    const headVaryParams = readVaryParams(
-      navigationSeed.headVaryParams,
-      rootVaryParamsIterable
-    )
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
     // in the LRU as more data comes in.
-    fulfilledEntries = writeDynamicRenderResponseIntoCache(
+    fulfilledEntries = writeServerResponseIntoCache(
       now,
       fetchStrategy,
+      serverDataThatSatisfiesSpawnedEntries,
+      dynamicRequestTree,
+      predictedFromRoute,
+      renderedSearch,
       buildId,
-      isResponsePartial,
-      headVaryParams,
-      rootVaryParamsIterable,
       staleAtForSpawnedEntries,
-      navigationSeed,
+      isResponsePartial,
       spawnedEntries,
       task.segmentCacheMap
     )
@@ -3150,23 +3105,29 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       }
     }
 
+    if (!routeHadDynamicRewrite && route.hasDynamicRewrite) {
+      // The write path discovered that the server rendered a different route
+      // tree than the prediction this request was derived from, and marked
+      // the route entry (see writeServerResponseIntoCache). Invalidate
+      // entries that were derived from the prediction so they're
+      // re-prefetched against the server's actual tree. This mirrors
+      // dispatchRetryDueToTreeMismatch on the navigation path. It can't loop:
+      // the refetched route entry is built from the server's response, so it
+      // only mismatches again if the rewrite's behavior changes again.
+      // TODO: Consider also bounding retries with a counter on the task
+      // object, so a prefetch that repeatedly fails to settle backs off
+      // regardless of the reason.
+      invalidateRouteCacheEntries(key.nextUrl, task.treeAtTimeOfPrefetch)
+    }
+
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
     return { value: null, closed: closed.promise }
   } catch (error) {
-    if (process.env.__NEXT_USE_OFFLINE) {
-      const { checkOfflineError } =
-        require('../offline') as typeof import('../offline')
-      if (checkOfflineError(error)) {
-        // Unlike navigations and server actions, prefetches don't await
-        // waitForConnection — they just reject the cache entry with an
-        // immediate expiration so it gets retried once the scheduler is
-        // re-pinged after connectivity is restored.
-        rejectSegmentEntriesIfStillPending(spawnedEntries, -1)
-        return null
-      }
-    }
-    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+    rejectSegmentEntriesIfStillPending(
+      spawnedEntries,
+      getPrefetchErrorStaleAt(error)
+    )
     return null
   }
 }
@@ -3186,7 +3147,15 @@ function rejectSegmentEntriesIfStillPending(
   return fulfilledEntries
 }
 
-export function writeDynamicRenderResponseIntoCache(
+/**
+ * Writes a decoded server response into the segment cache: decodes the
+ * response's transport tree into a RouteTree overlaid on `baseTree`, then
+ * writes every rendered segment, plus the head, into the cache. Fulfills the
+ * entries in `spawnedEntries` that the response covers; rejects the rest, so
+ * a task blocked on them isn't stranded. Returns the fulfilled entries (for
+ * LRU size accounting), or null if the response was unusable.
+ */
+export function writeServerResponseIntoCache(
   now: number,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
@@ -3194,12 +3163,31 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.PPRRuntime
     | FetchStrategy.RuntimeShell
     | FetchStrategy.Full,
+  // The decoded response payload to write: the full response, or a
+  // truncated stage decode of the same bytes (the static stage of a
+  // navigation response, or the shell stage of a runtime prefetch response).
+  response: NavigationFlightResponse,
+  // The base router state the response overlays.
+  baseTree: FlightRouterState,
+  // Non-null when `baseTree` was derived from this route entry's stored
+  // prediction (see matchKnownRoute). If the server's rendered tree diverges
+  // from the base, the URL has a rewrite that behaves dynamically, so the
+  // params baked into the prediction are wrong: the entry is marked as
+  // having a dynamic rewrite — which doubles as the stored prediction
+  // pattern, so this also disables a bad prediction that would otherwise be
+  // re-derived on every retry. The response data is still written into the
+  // cache: it's real data keyed by what the server actually rendered,
+  // useful regardless of whether the prediction matched. The caller is
+  // responsible for invalidating entries derived from the prediction (see
+  // markRouteEntryAsDynamicRewrite).
+  predictedFromRoute: FulfilledRouteCacheEntry | null,
+  renderedSearch: string,
   buildId: string | undefined,
-  isResponsePartial: boolean,
-  headVaryParams: VaryParams | null,
-  rootVaryParamsIterable: VaryParamsIterable | null,
+  // Response-level staleness, applied to every segment and the head.
   staleAt: number,
-  navigationSeed: NavigationSeed,
+  // Whether anything in the response is not fully resolved: dynamic holes,
+  // runtime holes, anything suspended.
+  isResponsePartial: boolean,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
   // The map the work that spawned this response's request is bound to: the
   // spawning task's `PrefetchTask.segmentCacheMap` for prefetches, the
@@ -3212,10 +3200,54 @@ export function writeDynamicRenderResponseIntoCache(
     // The server build does not match the client. Treat as a 404. During
     // an actual navigation, the router will trigger an MPA navigation.
     if (spawnedEntries !== null) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, now + 10 * 1000)
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        now + REJECTION_BACKOFF_MS
+      )
     }
     return null
   }
+
+  const transportData = response.t
+  if (transportData === undefined) {
+    // The response carries no tree. Settle anything we own so a task blocked
+    // on it isn't stranded.
+    if (spawnedEntries !== null) {
+      rejectSegmentEntriesIfStillPending(
+        spawnedEntries,
+        now + REJECTION_BACKOFF_MS
+      )
+    }
+    return null
+  }
+
+  const navigationSeed = convertServerPatchToFullTree(
+    now,
+    baseTree,
+    transportData,
+    // The response always includes the param values in the tree, so
+    // there's no pathname to parse them from.
+    null,
+    renderedSearch,
+    // Only navigations consume the seed's dynamicStaleAt; cache writes pass
+    // unknown to use the default.
+    UnknownDynamicStaleTime
+  )
+
+  const treeDivergedFromPrediction =
+    predictedFromRoute !== null && navigationSeed.treeDivergedFromBase
+  if (treeDivergedFromPrediction) {
+    markRouteEntryAsDynamicRewrite(predictedFromRoute)
+  }
+
+  // Root params are emitted once at the top level of the response; the
+  // iterable is threaded down so each segment unions it into its own set,
+  // and readVaryParams unions it into the head's below.
+  const rootVaryParamsIterable = response.r ?? null
+  const headVaryParams = readVaryParams(
+    navigationSeed.headVaryParams,
+    rootVaryParamsIterable
+  )
 
   const routeTree = navigationSeed.routeTree
   const metadataTree =
@@ -3262,8 +3294,7 @@ export function writeDynamicRenderResponseIntoCache(
       head,
       isHeadPartial,
       staleAt,
-      // For head entries, use the head-specific vary params passed as
-      // parameter.
+      // For head entries, use the head-specific vary params read above.
       headVaryParams,
       metadataTree,
       spawnedEntries
@@ -3280,7 +3311,12 @@ export function writeDynamicRenderResponseIntoCache(
   if (spawnedEntries !== null) {
     const fulfilledEntries = rejectSegmentEntriesIfStillPending(
       spawnedEntries,
-      now + 10 * 1000
+      // When the response diverged from the prediction, the leftover entries
+      // can never be fulfilled — their keys were derived from the wrong
+      // tree. Reject with an immediate expiration instead of the usual
+      // backoff: the caller invalidates the route, which triggers a
+      // re-prefetch against the server's actual tree.
+      treeDivergedFromPrediction ? -1 : now + REJECTION_BACKOFF_MS
     )
     return fulfilledEntries
   }
@@ -3528,7 +3564,7 @@ async function fetchPrefetchResponse<T>(
   // When issuing a prefetch request, don't immediately decode the response; we
   // use the lower level `createFromResponse` API instead because we need to do
   // some extra processing of the response stream. See
-  // `createNonTaskyPrefetchResponseStream` for more details.
+  // `bufferPrefetchResponseBody` for more details.
   const shouldImmediatelyDecode = false
   const response = await createFetch<T>(
     url,
@@ -3572,29 +3608,26 @@ function wasServedFromPerSegmentCache(response: RSCResponse<unknown>): boolean {
   )
 }
 
-export async function createNonTaskyPrefetchResponseStream(
+/**
+ * Reads a prefetch response body to completion — optionally truncating at
+ * `byteLimit` — and returns the bytes as a single contiguous buffer.
+ *
+ * Buffering the entire response before passing it to the Flight client
+ * ensures that when Flight processes the stream, all model data is available
+ * synchronously. This is what makes the thenable-status reads (vary params,
+ * isPartial, staleTime) sound: if data arrived in multiple network chunks,
+ * the thenables might not yet be fulfilled. (`decodeBufferedStage` performs
+ * the matching single-chunk decode.)
+ *
+ * TODO: There are too many intermediate stream transformations in the
+ * prefetch response pipeline (e.g. stripIsPartialByte, this function).
+ * These could all be consolidated into a single transformation. Refactor
+ * once the cached navigations experiment lands.
+ */
+export async function bufferPrefetchResponseBody(
   body: ReadableStream<Uint8Array>,
   byteLimit?: number
-): Promise<{
-  stream: ReadableStream<Uint8Array>
-  size: number
-  // The materialized response bytes backing `stream`. Exposed so callers that
-  // need to decode the same response a second time (e.g. the static App Shell
-  // extraction, which re-decodes a truncated prefix of the buffer) don't have
-  // to buffer the body twice. Most callers only use `stream` and `size`.
-  buffer: Uint8Array
-}> {
-  // Buffer the entire response before passing it to the Flight client. This
-  // ensures that when Flight processes the stream, all model data is available
-  // synchronously. This is important for readVaryParams, which synchronously
-  // checks the thenable status — if data arrived in multiple network chunks,
-  // the thenables might not yet be fulfilled.
-  //
-  // TODO: There are too many intermediate stream transformations in the
-  // prefetch response pipeline (e.g. stripIsPartialByte, this function).
-  // These could all be consolidated into a single transformation. Refactor
-  // once the cached navigations experiment lands.
-  //
+): Promise<Uint8Array> {
   // Read the response from the network, optionally truncating at byteLimit.
   const reader = body.getReader()
   const chunks: Uint8Array[] = []
@@ -3625,26 +3658,19 @@ export async function createNonTaskyPrefetchResponseStream(
   // PromiseResolveThenableJob from `await` can cause the root to initialize
   // eagerly, scheduling the continuation before remaining chunks (including
   // promise value rows) are processed. A single chunk avoids this.
-  let buffer: Uint8Array
   if (chunks.length === 1) {
-    buffer = chunks[0]
+    return chunks[0]
   } else if (chunks.length > 1) {
-    buffer = new Uint8Array(size)
+    const buffer = new Uint8Array(size)
     let offset = 0
     for (const chunk of chunks) {
       buffer.set(chunk, offset)
       offset += chunk.byteLength
     }
+    return buffer
   } else {
-    buffer = new Uint8Array(0)
+    return new Uint8Array(0)
   }
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(buffer)
-      controller.close()
-    },
-  })
-  return { stream, size, buffer }
 }
 
 /**
@@ -3801,77 +3827,81 @@ export async function resolveStaleAt(
 }
 
 /**
- * Writes a prerender response into the segment cache at the vary path
- * determined by `fetchStrategy`. Default segments are skipped (by
- * `writeSeedDataIntoCache`) to avoid caching fallback content that would
- * block refreshes from overwriting with dynamic data.
+ * Fire-and-forget ("spawn"), unlike the synchronous cache-write family it
+ * wraps (writeServerResponseIntoCache and below): the stage's staleTime must
+ * be resolved asynchronously from the response's own `s` field before the
+ * write can happen, and failures are swallowed — a failed cache write is not
+ * fatal to the render that produced the response.
+ *
+ * Writes the static stage of a navigation response — or of the initial RSC
+ * payload — into the segment cache, so subsequent navigations can serve
+ * cached static segments instantly.
  */
-export function writePrerenderResponseIntoCache(
+export function spawnStaticStageCacheWrite(
   now: number,
-  fetchStrategy: FetchStrategy.PPR | FetchStrategy.RuntimeShell,
-  transportData: PartialTransportData | null,
-  buildId: string | undefined,
-  rootVaryParamsIterable: VaryParamsIterable | null,
-  staleAt: number,
+  response: NavigationFlightResponse,
+  isResponsePartial: boolean,
+  // The navigation response's headers, used to derive the buildId for the
+  // write-layer build check (the deployment header, falling back to the
+  // response's `b` field). Null for the initial payload, which arrived in
+  // the HTML document and has no build-id check.
+  responseHeaders: Headers | null,
   baseTree: FlightRouterState,
   renderedSearch: string,
-  isResponsePartial: boolean,
   // The map the work that spawned this response's request is bound to. See
-  // writeDynamicRenderResponseIntoCache.
+  // writeServerResponseIntoCache.
   map: CacheMap<SegmentCacheEntry>
 ): void {
-  if (transportData === null) {
-    return
-  }
-  const navigationSeed = convertServerPatchToFullTree(
-    now,
-    baseTree,
-    transportData,
-    // The response always includes the param values in the tree, so there's
-    // no pathname to parse them from.
-    null,
-    renderedSearch,
-    UnknownDynamicStaleTime
-  )
-  // Root params are emitted once at the top level; readVaryParams unions them
-  // into the head, and they're threaded down to each segment below.
-  const headVaryParams = readVaryParams(
-    navigationSeed.headVaryParams,
-    rootVaryParamsIterable
-  )
-  writeDynamicRenderResponseIntoCache(
-    now,
-    fetchStrategy,
-    buildId,
-    isResponsePartial,
-    headVaryParams,
-    rootVaryParamsIterable,
-    staleAt,
-    navigationSeed,
-    null, // spawnedEntries — no pre-created entries; will create or upsert
-    map
-  )
+  const buildId =
+    responseHeaders !== null
+      ? (responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? response.b)
+      : undefined
+  resolveStaleAt(now, response.s)
+    .then((staleAt) => {
+      // TODO: This entire write is legacy and will be deleted in a future
+      // PR: caching is organized around the conceptual shell vs not-shell
+      // distinction, not around the static vs runtime render stages, so a
+      // static-stage write has no place in the model. It's kept only until
+      // its removal PR lands — do not extend it (e.g. with shell
+      // extraction).
+      writeServerResponseIntoCache(
+        now,
+        FetchStrategy.PPR,
+        response,
+        baseTree,
+        // The base tree is the navigation's current tree, not a prediction;
+        // divergence from it carries no signal.
+        null,
+        renderedSearch,
+        buildId,
+        staleAt,
+        isResponsePartial,
+        // No owned entries; every write is a detached upsert.
+        null,
+        map
+      )
+    })
+    .catch(() => {
+      // The static stage processing failed. Not fatal — the render
+      // completed normally, we just won't write into the cache.
+    })
 }
 
 /**
- * Decodes an embedded runtime prefetch Flight stream, normalizes the flight
- * data, and derives a `NavigationSeed` from the base tree.
- *
- * Returns `null` if the response triggers an MPA navigation.
+ * Decodes an embedded runtime prefetch Flight stream and writes it into the
+ * segment cache, so subsequent navigations can serve runtime-prefetchable
+ * content from cache without a separate prefetch request. This flow owns no
+ * pending entries, so every write is a detached upsert.
  */
-export async function processRuntimePrefetchStream(
+export async function writeRuntimePrefetchStreamIntoCache(
   now: number,
   runtimePrefetchStream: ReadableStream<Uint8Array>,
   baseTree: FlightRouterState,
-  renderedSearch: string
-): Promise<{
-  navigationSeed: NavigationSeed
-  buildId: string | undefined
-  isResponsePartial: boolean
-  headVaryParams: VaryParams | null
-  rootVaryParamsIterable: VaryParamsIterable | null
-  staleAt: number
-} | null> {
+  renderedSearch: string,
+  // The map the work that spawned this response's request is bound to. See
+  // writeServerResponseIntoCache.
+  map: CacheMap<SegmentCacheEntry>
+): Promise<void> {
   const { stream, isPartial } = await stripIsPartialByte(runtimePrefetchStream)
 
   const serverData =
@@ -3881,41 +3911,25 @@ export async function processRuntimePrefetchStream(
       { allowPartialStream: true }
     )
 
-  const rootVaryParamsIterable = serverData.r ?? null
-
   const staleAt = await resolveStaleAt(now, serverData.s)
 
-  const transportData = serverData.t
-  if (transportData === undefined) {
-    return null
-  }
-  const navigationSeed = convertServerPatchToFullTree(
+  writeServerResponseIntoCache(
     now,
+    // A runtime prefetch stream is by definition a runtime prefetch.
+    FetchStrategy.PPRRuntime,
+    serverData,
     baseTree,
-    transportData,
-    // The response always includes the param values in the tree, so there's
-    // no pathname to parse them from.
+    // The base tree is the navigation's current tree, not a prediction;
+    // divergence from it carries no signal.
     null,
     renderedSearch,
-    UnknownDynamicStaleTime
-  )
-
-  // Root params are emitted once at the top level; readVaryParams unions them
-  // into the head, and we return the iterable so the caller can union it into
-  // each segment too.
-  const headVaryParams = readVaryParams(
-    navigationSeed.headVaryParams,
-    rootVaryParamsIterable
-  )
-
-  return {
-    navigationSeed,
-    buildId: serverData.b,
-    isResponsePartial: isPartial,
-    headVaryParams,
-    rootVaryParamsIterable,
+    serverData.b,
     staleAt,
-  }
+    isPartial,
+    // This flow owns no pending entries; every write is a detached upsert.
+    null,
+    map
+  )
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/decode-server-response.ts
+++ b/packages/next/src/client/components/segment-cache/decode-server-response.ts
@@ -78,7 +78,7 @@ export type NavigationSeed = {
   // request tree derived from a cached route entry, as during a prefetch:
   // divergence then means the entry doesn't describe what the server renders
   // — the URL has a rewrite that behaves dynamically (see
-  // fetchSegmentPrefetchesUsingDynamicRequest). During a navigation the base
+  // fetchSegmentPrefetchesUsingRuntimeRequest). During a navigation the base
   // is the current page's tree, so divergence carries no signal. False when
   // there was no base to compare against.
   treeDivergedFromBase: boolean

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -14,17 +14,14 @@ import {
   type NavigationRequestAccumulation,
 } from '../router-reducer/ppr-navigations'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
-import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   EntryStatus,
   segmentCacheMap,
   type SegmentCacheEntry,
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
-  resolveStaleAt,
-  writePrerenderResponseIntoCache,
-  processRuntimePrefetchStream,
-  writeDynamicRenderResponseIntoCache,
+  spawnStaticStageCacheWrite,
+  writeRuntimePrefetchStreamIntoCache,
   type FulfilledRouteCacheEntry,
 } from './cache'
 import { discoverKnownRoute } from './optimistic-routes'
@@ -515,7 +512,8 @@ async function navigateToUnknownRoute(
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
     dynamicStaleTime,
-    staticStageData,
+    isResponsePartial,
+    staticStageResponse,
     runtimePrefetchStream,
     responseHeaders,
     debugInfo,
@@ -558,68 +556,29 @@ async function navigateToUnknownRoute(
       false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
     )
 
-    if (staticStageData !== null) {
-      const { response: staticStageResponse, isResponsePartial } =
-        staticStageData
-
-      // Write the static stage of the response into the segment cache so that
-      // subsequent navigations can serve cached static segments instantly.
-      resolveStaleAt(now, staticStageResponse.s)
-        .then((staleAt) => {
-          const buildId =
-            responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-            staticStageResponse.b
-
-          // TODO: Implement Shell extraction as part of Cached Navigations.
-          // Intentionally holding off on doing this until we decide how the
-          // Cached Navigations behavior should work in combination with App
-          // Shells.
-          writePrerenderResponseIntoCache(
-            now,
-            FetchStrategy.PPR,
-            staticStageResponse.t ?? null,
-            buildId,
-            staticStageResponse.r ?? null,
-            staleAt,
-            currentFlightRouterState,
-            renderedSearch,
-            isResponsePartial,
-            map
-          )
-        })
-        .catch(() => {
-          // The static stage processing failed. Not fatal — the navigation
-          // completed normally, we just won't write into the cache.
-        })
+    if (staticStageResponse !== null) {
+      spawnStaticStageCacheWrite(
+        now,
+        staticStageResponse,
+        isResponsePartial,
+        responseHeaders,
+        currentFlightRouterState,
+        renderedSearch,
+        map
+      )
     }
 
     if (runtimePrefetchStream !== null) {
-      processRuntimePrefetchStream(
+      writeRuntimePrefetchStreamIntoCache(
         now,
         runtimePrefetchStream,
         currentFlightRouterState,
-        renderedSearch
-      )
-        .then((processed) => {
-          if (processed !== null) {
-            writeDynamicRenderResponseIntoCache(
-              now,
-              FetchStrategy.PPRRuntime,
-              processed.buildId,
-              processed.isResponsePartial,
-              processed.headVaryParams,
-              processed.rootVaryParamsIterable,
-              processed.staleAt,
-              processed.navigationSeed,
-              null,
-              map
-            )
-          }
-        })
-        .catch(() => {
-          // The runtime prefetch cache write failed. Not fatal — the
-          // navigation completed normally, we just won't cache runtime data.
-        })
+        renderedSearch,
+        map
+      ).catch(() => {
+        // The runtime prefetch cache write failed. Not fatal — the
+        // navigation completed normally, we just won't cache runtime data.
+      })
     }
   }
 

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -14,15 +14,12 @@ import {
   type NavigationRequestAccumulation,
 } from '../router-reducer/ppr-navigations'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
-import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   EntryStatus,
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
-  resolveStaleAt,
-  writePrerenderResponseIntoCache,
-  processRuntimePrefetchStream,
-  writeDynamicRenderResponseIntoCache,
+  spawnStaticStageCacheWrite,
+  writeRuntimePrefetchStreamIntoCache,
   type FulfilledRouteCacheEntry,
 } from './cache'
 import { discoverKnownRoute } from './optimistic-routes'
@@ -494,7 +491,8 @@ async function navigateToUnknownRoute(
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
     dynamicStaleTime,
-    staticStageData,
+    isResponsePartial,
+    staticStageResponse,
     runtimePrefetchStream,
     responseHeaders,
     debugInfo,
@@ -537,66 +535,27 @@ async function navigateToUnknownRoute(
       false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
     )
 
-    if (staticStageData !== null) {
-      const { response: staticStageResponse, isResponsePartial } =
-        staticStageData
-
-      // Write the static stage of the response into the segment cache so that
-      // subsequent navigations can serve cached static segments instantly.
-      resolveStaleAt(now, staticStageResponse.s)
-        .then((staleAt) => {
-          const buildId =
-            responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-            staticStageResponse.b
-
-          // TODO: Implement Shell extraction as part of Cached Navigations.
-          // Intentionally holding off on doing this until we decide how the
-          // Cached Navigations behavior should work in combination with App
-          // Shells.
-          writePrerenderResponseIntoCache(
-            now,
-            FetchStrategy.PPR,
-            staticStageResponse.t ?? null,
-            buildId,
-            staticStageResponse.r ?? null,
-            staleAt,
-            currentFlightRouterState,
-            renderedSearch,
-            isResponsePartial
-          )
-        })
-        .catch(() => {
-          // The static stage processing failed. Not fatal — the navigation
-          // completed normally, we just won't write into the cache.
-        })
+    if (staticStageResponse !== null) {
+      spawnStaticStageCacheWrite(
+        now,
+        staticStageResponse,
+        isResponsePartial,
+        responseHeaders,
+        currentFlightRouterState,
+        renderedSearch
+      )
     }
 
     if (runtimePrefetchStream !== null) {
-      processRuntimePrefetchStream(
+      writeRuntimePrefetchStreamIntoCache(
         now,
         runtimePrefetchStream,
         currentFlightRouterState,
         renderedSearch
-      )
-        .then((processed) => {
-          if (processed !== null) {
-            writeDynamicRenderResponseIntoCache(
-              now,
-              FetchStrategy.PPRRuntime,
-              processed.buildId,
-              processed.isResponsePartial,
-              processed.headVaryParams,
-              processed.rootVaryParamsIterable,
-              processed.staleAt,
-              processed.navigationSeed,
-              null
-            )
-          }
-        })
-        .catch(() => {
-          // The runtime prefetch cache write failed. Not fatal — the
-          // navigation completed normally, we just won't cache runtime data.
-        })
+      ).catch(() => {
+        // The runtime prefetch cache write failed. Not fatal — the
+        // navigation completed normally, we just won't cache runtime data.
+      })
     }
   }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -18,7 +18,7 @@ import {
   type FulfilledRouteCacheEntry,
   type RouteCacheEntry,
   type RouteTree,
-  fetchSegmentPrefetchesUsingDynamicRequest,
+  fetchSegmentPrefetchesUsingRuntimeRequest,
   type PendingSegmentCacheEntry,
   type SegmentCacheEntry,
   type SegmentBundle,
@@ -977,7 +977,7 @@ function pingRootRouteTree(
               )
               if (spawnedEntries.size > 0) {
                 spawnPrefetchSubtask(
-                  fetchSegmentPrefetchesUsingDynamicRequest(
+                  fetchSegmentPrefetchesUsingRuntimeRequest(
                     task,
                     route,
                     runtimeStrategy,
@@ -1024,7 +1024,7 @@ function pingRootRouteTree(
           let needsDynamicRequest = spawnedEntries.size > 0
           if (needsDynamicRequest) {
             spawnPrefetchSubtask(
-              fetchSegmentPrefetchesUsingDynamicRequest(
+              fetchSegmentPrefetchesUsingRuntimeRequest(
                 task,
                 route,
                 fetchStrategy,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -18,7 +18,7 @@ import {
   type FulfilledRouteCacheEntry,
   type RouteCacheEntry,
   type RouteTree,
-  fetchSegmentPrefetchesUsingDynamicRequest,
+  fetchSegmentPrefetchesUsingRuntimeRequest,
   type PendingSegmentCacheEntry,
   type SegmentCacheEntry,
   type SegmentBundle,
@@ -954,7 +954,7 @@ function pingRootRouteTree(
               )
               if (spawnedEntries.size > 0) {
                 spawnPrefetchSubtask(
-                  fetchSegmentPrefetchesUsingDynamicRequest(
+                  fetchSegmentPrefetchesUsingRuntimeRequest(
                     task,
                     route,
                     runtimeStrategy,
@@ -1001,7 +1001,7 @@ function pingRootRouteTree(
           let needsDynamicRequest = spawnedEntries.size > 0
           if (needsDynamicRequest) {
             spawnPrefetchSubtask(
-              fetchSegmentPrefetchesUsingDynamicRequest(
+              fetchSegmentPrefetchesUsingRuntimeRequest(
                 task,
                 route,
                 fetchStrategy,

--- a/packages/next/src/client/components/segment-cache/types.ts
+++ b/packages/next/src/client/components/segment-cache/types.ts
@@ -40,7 +40,7 @@ export const enum FetchStrategy {
   //
   // These numeric values are client-internal and never cross the wire — the
   // `next-router-prefetch` request header values are mapped explicitly in
-  // fetchSegmentPrefetchesUsingDynamicRequest (cache.ts) — so the members can
+  // fetchSegmentPrefetchesUsingRuntimeRequest (cache.ts) — so the members can
   // be renumbered freely as long as the relative order is preserved.
   LoadingBoundary = 0,
   // The App Shell variant extracted from a static per-segment prefetch

--- a/test/lib/router-act.ts
+++ b/test/lib/router-act.ts
@@ -26,7 +26,7 @@ const APP_SHELL_PREFETCH_VALUE = '3'
 //   (`fetchSegmentsOnCacheMissImpl`) and the route tree fetch
 //   (`fetchRouteOnCacheMiss`).
 // - 'runtime': dynamic prefetch requests, issued by
-//   `fetchSegmentPrefetchesUsingDynamicRequest` in the client. These carry a
+//   `fetchSegmentPrefetchesUsingRuntimeRequest` in the client. These carry a
 //   FlightRouterState request tree and a `next-router-prefetch` header value
 //   of '2' (FetchStrategy.PPRRuntime) or '3' (FetchStrategy.RuntimeShell).
 //   The other strategies used by that path — LoadingBoundary ('1') and Full


### PR DESCRIPTION
Every flow that writes a server response into the client cache now goes through a single function, writeServerResponseIntoCache.

This is preparation for subsequent steps in this stack that migrate even more callers to this unified path.

While we're modifying it, fetchSegmentPrefetchesUsingDynamicRequest is renamed to fetchSegmentPrefetchesUsingRuntimeRequest: these responses are produced by a runtime request, and "dynamic" refers to non-cached data, which prefetch responses never contain.

One subtle fix that fell out of the unification: a runtime prefetch response that carries no transport data used to make the flow bail before writing anything; now the shared function rejects the pending entries it was given, the same as a build id mismatch.
