### PR TITLE
Unify how a response's shell and full payloads are written

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -197,9 +197,10 @@ type RouteTreeShared<TData> = {
   // TODO: Remove the `segment` field, now that it can be reconstructed
   // from `param`.
   segment: FlightRouterStateSegment
-  // The vary path used to key this segment's App Shell entry: the segment's
-  // vary path with every non-root param replaced with Fallback (see
-  // getShellSegmentVaryPath). Precomputed once during tree construction so we
+  // The vary path used for shell-scoped keying of this segment: the
+  // segment's vary path with every non-root param replaced with Fallback
+  // (see getShellSegmentVaryPath), so one shell-tier entry serves all param
+  // values below the root. Precomputed once during tree construction so we
   // don't have to recompute it on every shell request.
   shellVaryPath: SegmentVaryPath
   refreshState: RefreshState | null
@@ -2146,10 +2147,9 @@ export async function fetchSegmentPrefetchesUsingStaticRequest(
  * response, and writes every payload of it into the cache — the full
  * payload, and, when the response carries a shell byte boundary, a second
  * decode of the same bytes truncated at that boundary, the segments'
- * shell-stage variant — through writeServerResponseIntoCache, the same
- * write path live-render responses use. The response-shape switch below
- * owns which payload fulfills the spawned entries and the tier each payload
- * is written at.
+ * shell-stage variant — through the shared payload-write orchestration
+ * (writeResponsePayloadsIntoCache), which owns which payload fulfills the
+ * spawned entries and the tier each payload is written at.
  *
  * Returns whether the response was an upgradeable ISR fallback shell (the
  * page hadn't been prerendered with concrete params yet), or `null` if the
@@ -2308,10 +2308,11 @@ async function fetchAndWritePerSegmentPrefetchResponse(
   // unfulfilled `a`, which would be a Next.js bug since the full buffer is
   // present. Both read the same here: no shell, and the scheduler skips the
   // affected segments rather than falling back to a runtime request — see
-  // the no-shell handling below. Failing in that direction costs a shell
-  // prefetch but never leaks post-shell content into shell positions. 0 can
-  // double as "none" on the wire precisely because it's never a valid
-  // offset — see the `a` field doc on NavigationFlightResponse.)
+  // the no-shell handling in writeResponsePayloadsIntoCache. Failing in that
+  // direction costs a shell prefetch but never leaks post-shell content into
+  // shell positions. 0 can double as "none" on the wire precisely because
+  // it's never a valid offset — see the `a` field doc on
+  // NavigationFlightResponse.)
   const shellOffset =
     serverResponse.a !== undefined ? readFulfilledValue(serverResponse.a, 0) : 0
   let shellResponse: PrefetchFlightResponse | null
@@ -2330,7 +2331,7 @@ async function fetchAndWritePerSegmentPrefetchResponse(
       // exists; the full payload is still usable. (For a StaticShell-spawned
       // bundle this means the spawned entries are rejected — the scheduler
       // then skips them rather than issuing a runtime substitute; see the
-      // no-shell handling below.)
+      // no-shell handling in writeResponsePayloadsIntoCache.)
       shellResponse = null
     }
   }
@@ -2371,119 +2372,25 @@ async function fetchAndWritePerSegmentPrefetchResponse(
   //   cast is sound.)
   const now = Date.now()
   const metadataVaryPath = route.metadata.varyPath as PageVaryPath
-
-  let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null
-  if (shellResponse === serverResponse) {
-    // The shell IS the full response (reference-equal — a page with nothing
-    // below its shell). One payload fulfills the spawned entries, keyed by
-    // the walk that spawned them, and records the strategy that describes
-    // the CONTENT — the full payload's tier (PPR). See the recorded-tier
-    // derivation in writeSegmentDataIntoCache.
-    fulfilledEntries = writeServerResponseIntoCache(
-      now,
-      fetchStrategy,
-      serverResponse,
-      null,
-      // The payload is root-anchored (no base tree), so there's no
-      // prediction to diverge from.
-      null,
-      renderedPathname,
-      route.renderedSearch,
-      undefined,
-      now + STATIC_STALETIME_MS,
-      true,
-      metadataVaryPath,
-      spawnedEntries,
-      FetchStrategy.PPR,
-      task.segmentCacheMap
-    )
-  } else {
-    // The full payload is written first, so the shell write's precedence
-    // checks and shadow eviction compare against the fresh concrete entry
-    // rather than whatever stale entry preceded it. It fulfills the spawned
-    // entries when the concrete tier is what the walk requested; for a
-    // StaticShell walk it's written detached (no owned entries — every
-    // write is an upsert), because fulfilling a spawned StaticShell entry
-    // with the concrete payload would leak param-dependent content into
-    // shell positions: during a navigation, a pending entry can be rendered
-    // as a promise that resolves to its eventual value.
-    const fullFulfilledEntries = writeServerResponseIntoCache(
-      now,
-      FetchStrategy.PPR,
-      serverResponse,
-      null,
-      // The payload is root-anchored (no base tree), so there's no
-      // prediction to diverge from.
-      null,
-      renderedPathname,
-      route.renderedSearch,
-      undefined,
-      now + STATIC_STALETIME_MS,
-      true,
-      metadataVaryPath,
-      fetchStrategy === FetchStrategy.StaticShell ? null : spawnedEntries,
-      FetchStrategy.PPR,
-      task.segmentCacheMap
-    )
-    if (shellResponse === null) {
-      if (fetchStrategy === FetchStrategy.StaticShell) {
-        // A static shell was requested but the response carries no shell
-        // (its shell byte offset read as 0 — a bug in Next.js itself — or
-        // the shell prefix couldn't be decoded). The full payload was still
-        // usable, so it was written detached at the concrete tier above;
-        // the spawned entries are rejected so the task isn't stranded
-        // blocking on them. Note the scheduler does NOT fall back to a
-        // runtime request for rejected segments — it skips them outright
-        // (see the Rejected case in pingSegmentBundle in scheduler.ts), so
-        // these segments get no shell prefetch and no runtime substitute
-        // until the rejection's backoff expires.
-        rejectSegmentEntriesIfStillPending(
-          spawnedEntries,
-          now + REJECTION_BACKOFF_MS
-        )
-        fulfilledEntries = null
-      } else {
-        fulfilledEntries = fullFulfilledEntries
-      }
-    } else {
-      // The shell is a strict prefix of the response. Write it at the shell
-      // tier, fulfilling the spawned entries when a shell is what the
-      // walk requested.
-      const shellFulfilledEntries = writeServerResponseIntoCache(
-        now,
-        FetchStrategy.StaticShell,
-        shellResponse,
-        null,
-        // The payload is root-anchored (no base tree), so there's no
-        // prediction to diverge from.
-        null,
-        renderedPathname,
-        route.renderedSearch,
-        undefined,
-        now + STATIC_STALETIME_MS,
-        true,
-        metadataVaryPath,
-        fetchStrategy === FetchStrategy.StaticShell ? spawnedEntries : null,
-        FetchStrategy.StaticShell,
-        task.segmentCacheMap
-      )
-      fulfilledEntries =
-        fetchStrategy === FetchStrategy.StaticShell
-          ? shellFulfilledEntries
-          : fullFulfilledEntries
-    }
-  }
-
-  // Distribute the response size evenly across the entries this response
-  // fulfilled. Entries created by a detached write aren't sized: one wire
-  // response is only charged to the LRU once, to the entries it fulfilled.
-  if (fulfilledEntries !== null && fulfilledEntries.length > 0) {
-    const averageSize = buffer.byteLength / fulfilledEntries.length
-    for (const entry of fulfilledEntries) {
-      setSizeInCacheMap(entry, averageSize)
-    }
-  }
-
+  writeResponsePayloadsIntoCache(
+    now,
+    fetchStrategy,
+    serverResponse,
+    shellResponse,
+    null,
+    // The payloads are root-anchored (no base tree), so there's no
+    // prediction to diverge from.
+    null,
+    renderedPathname,
+    route.renderedSearch,
+    undefined,
+    now + STATIC_STALETIME_MS,
+    true,
+    metadataVaryPath,
+    spawnedEntries,
+    buffer.byteLength,
+    task.segmentCacheMap
+  )
   return isUpgradeableISRFallback
 }
 
@@ -2596,11 +2503,12 @@ async function retryUpgradeableFallbackPrefetch(
   task.fallbackRetryStatus = EntryStatus.Rejected
 }
 
-// TODO: The inlined prefetch flow below is temporary. Eventually, inlining
-// will be the default behavior controlled by a size heuristic rather than a
-// boolean flag. At that point, the per-segment and inlined fetch paths will
-// merge, and these separate functions will be removed.
-//
+// The runtime counterpart of the per-segment static prefetch flow
+// (fetchSegmentPrefetchesUsingStaticRequest). The two flows differ in how
+// they obtain their payloads — one runtime request here (streamed for Full
+// prefetches), versus a buffered per-segment response with a shell
+// double-decode there — but share the payload write orchestration
+// (writeResponsePayloadsIntoCache).
 export async function fetchSegmentPrefetchesUsingRuntimeRequest(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
@@ -2754,140 +2662,44 @@ export async function fetchSegmentPrefetchesUsingRuntimeRequest(
     // the base RouteTree (route.tree) instead of the request tree.
     const predictedFromRoute =
       dynamicRequestTree !== MetadataOnlyRequestTree ? route : null
+
+    // Extract the response's shell-stage payload, when it carries one. No
+    // shell can be extracted without cache metadata (only present when
+    // Cached Navigations is enabled); for responses without a distinct
+    // shell stage the extraction is a no-op anyway
+    // (`resolveShellStageResponse` returns null), so the null check just
+    // short-circuits that case.
+    const shellResponse =
+      cacheData !== null
+        ? await resolveShellStageResponse(cacheData, serverData, headers)
+        : null
+
+    // Runtime prefetch responses (PPRRuntime and RuntimeShell requests) are
+    // partial when the server marks the response as '~' (Partial).
+    // Full/LoadingBoundary prefetch responses are always complete. This only
+    // describes the FULL payload: shell-tier writes don't consume it — a
+    // shell is partial by construction (RuntimeShell responses omit every
+    // dynamic suspense boundary below the shell stage, regardless of what
+    // the server marker says); see writeResponsePayloadsIntoCache.
+    const isFullResponsePartial =
+      (fetchStrategy === FetchStrategy.PPRRuntime ||
+        fetchStrategy === FetchStrategy.RuntimeShell) &&
+      (cacheData?.isResponsePartial ?? false)
+
+    // Captured immediately before the write — in the same synchronous
+    // block, so the false→true transition observed below can only have been
+    // caused by this write, not by a concurrent response for the same route
+    // marking the entry during one of the awaits above.
     const routeHadDynamicRewrite = route.hasDynamicRewrite
 
-    // Check if a reusable App Shell can be extracted from the main response.
-    let serverDataThatSatisfiesSpawnedEntries: NavigationFlightResponse
-    // The shell and full response have independent stale times. Track the
-    // staleAt that corresponds to whatever payload the spawned entries get
-    // filled with below.
-    let staleAtForSpawnedEntries = staleAt
-    if (cacheData === null) {
-      // No shell can be extracted without cache metadata (only present when
-      // Cached Navigations is enabled). For routes without a distinct App Shell
-      // the extraction below is a no-op anyway (`resolveShellStageResponse`
-      // returns null), so this just short-circuits that case.
-      serverDataThatSatisfiesSpawnedEntries = serverData
-    } else {
-      const shellStageResponse = await resolveShellStageResponse(
-        cacheData,
-        serverData,
-        headers
-      )
-      if (shellStageResponse === null || shellStageResponse === serverData) {
-        // Either no App Shell exists (App Shells are not yet enabled, or the
-        // render wasn't staged), or the shell IS the entire response
-        // (reference-equal). Either way, there's nothing extra for us to do:
-        // fulfill the pending entries using the response from the server.
-        // TODO: When the shell coincides with the full response, the entries
-        // could be recorded at the tier that describes the full payload's
-        // content, the way the per-segment flow promotes a coincident shell
-        // (see fetchAndWritePerSegmentPrefetchResponse). For now the
-        // coincident case is treated the same as no shell.
-        serverDataThatSatisfiesSpawnedEntries = serverData
-      } else {
-        // Successfully extracted an App Shell that is a subset of the main
-        // response. Depending on the type of prefetch this is, we need to
-        // decide whether to fulfill the pending entries with the shell or with
-        // the entire response. In either scenario, we'll be inserting _both_
-        // versions of the response into the cache; the extra logic is only
-        // here so that we don't fulfill pending shell entries with something
-        // that's more concrete than what they expect.
-        // TODO: The only reason this matters is because during a navigation,
-        // if a segment is still pending, we render a promise that resolves to
-        // the eventual value of that segment. But that means we cannot
-        // eventually resolve that segment to something more concrete than what
-        // was already requested. Hence the extra logic here. A cleaner way to
-        // model this, though, is whenever we render a promise that resolves to
-        // the result of a pending entry, do one additional cache look-up right
-        // after the promise resolves, to ensure we never get a mismatching
-        // entry. Leaving this for a follow up.
-        // shellStageResponse is a fully-buffered stage decode, so read
-        // staleTime synchronously off the thenable status.
-        const shellStaleAt = readFulfilledStaleAt(now, shellStageResponse.s)
-        if (fetchStrategy === FetchStrategy.RuntimeShell) {
-          // This is a Shell prefetch, so the pending entries must be fulfilled
-          // with the shell.
-          serverDataThatSatisfiesSpawnedEntries = shellStageResponse
-          staleAtForSpawnedEntries = shellStaleAt
-
-          // Separately, we'll also cache the entire response, by upserting it
-          // into the cache.
-          writeServerResponseIntoCache(
-            now,
-            FetchStrategy.PPR,
-            serverData,
-            dynamicRequestTree,
-            predictedFromRoute,
-            // Navigation responses always include the param values in the
-            // tree, so there's no pathname to parse them from (nor a
-            // need to).
-            null,
-            renderedSearch,
-            buildId,
-            staleAt,
-            cacheData.isResponsePartial,
-            null,
-            // No owned entries; every write is a detached upsert.
-            null,
-            null,
-            task.segmentCacheMap
-          )
-        } else {
-          // This is _not_ a Shell prefetch, so the pending entries should be
-          // fulfilled with the entire response.
-          serverDataThatSatisfiesSpawnedEntries = serverData
-
-          // Additionally, we might as well upsert the extracted Shell into the
-          // cache, too.
-
-          // `shellStageResponse` only reaches this path when the shell is
-          // distinct from the main response (a strict prefix of it). So it
-          // follows that any shell data that reaches this path must be
-          // partial -- it does not represent the entire UI of the
-          // target page.
-          const isShellStagePartial = true
-          writeServerResponseIntoCache(
-            now,
-            FetchStrategy.RuntimeShell,
-            shellStageResponse,
-            dynamicRequestTree,
-            predictedFromRoute,
-            // Navigation responses always include the param values in the
-            // tree, so there's no pathname to parse them from (nor a
-            // need to).
-            null,
-            renderedSearch,
-            buildId,
-            shellStaleAt,
-            isShellStagePartial,
-            null,
-            // No owned entries; every write is a detached upsert.
-            null,
-            null,
-            task.segmentCacheMap
-          )
-        }
-      }
-    }
-
-    // PPRRuntime and RuntimeShell prefetches are partial when the server
-    // marks the response as '~' (Partial). RuntimeShell additionally omits
-    // every dynamic suspense boundary below the App Shell, so its segments
-    // are always partial regardless of what the server marker says.
-    // Full/LoadingBoundary prefetches are always complete.
-    const isResponsePartial =
-      fetchStrategy === FetchStrategy.RuntimeShell ||
-      (fetchStrategy === FetchStrategy.PPRRuntime &&
-        (cacheData?.isResponsePartial ?? false))
-
-    // Aside from writing the data into the cache, this function also returns
-    // the entries that were fulfilled, so we can streamingly update their sizes
-    // in the LRU as more data comes in.
-    fulfilledEntries = writeServerResponseIntoCache(
+    // Aside from writing the data into the cache, this also returns the
+    // entries that were fulfilled, so we can streamingly update their sizes
+    // in the LRU as more data comes in (Full responses, which stream).
+    fulfilledEntries = writeResponsePayloadsIntoCache(
       now,
       fetchStrategy,
-      serverDataThatSatisfiesSpawnedEntries,
+      serverData,
+      shellResponse,
       dynamicRequestTree,
       predictedFromRoute,
       // Navigation responses always include the param values in the tree, so
@@ -2895,26 +2707,13 @@ export async function fetchSegmentPrefetchesUsingRuntimeRequest(
       null,
       renderedSearch,
       buildId,
-      staleAtForSpawnedEntries,
-      isResponsePartial,
+      staleAt,
+      isFullResponsePartial,
       null,
       spawnedEntries,
-      null,
+      bufferedResponseSize,
       task.segmentCacheMap
     )
-
-    // For buffered responses, update LRU sizes now that we know which
-    // entries were fulfilled.
-    if (
-      bufferedResponseSize !== null &&
-      fulfilledEntries !== null &&
-      fulfilledEntries.length > 0
-    ) {
-      const averageSize = bufferedResponseSize / fulfilledEntries.length
-      for (const entry of fulfilledEntries) {
-        setSizeInCacheMap(entry, averageSize)
-      }
-    }
 
     if (!routeHadDynamicRewrite && route.hasDynamicRewrite) {
       // The write path discovered that the server rendered a different route
@@ -2946,13 +2745,258 @@ export async function fetchSegmentPrefetchesUsingRuntimeRequest(
 function rejectSegmentEntriesIfStillPending(
   entries: Map<SegmentRequestKey, SegmentCacheEntry>,
   staleAt: number
-): Array<FulfilledSegmentCacheEntry> {
-  const fulfilledEntries = []
+): void {
   for (const entry of entries.values()) {
     if (entry.status === EntryStatus.Pending) {
       rejectSegmentCacheEntry(entry, staleAt)
-    } else if (entry.status === EntryStatus.Fulfilled) {
-      fulfilledEntries.push(entry)
+    }
+  }
+}
+
+/**
+ * Writes a prefetch response's payloads into the cache: the full payload,
+ * plus its shell payload when the response carries one. This is the write
+ * orchestration shared by the prefetch response kinds — per-segment
+ * static responses (fetchAndWritePerSegmentPrefetchResponse) and
+ * live-render responses (fetchSegmentPrefetchesUsingRuntimeRequest, and the
+ * embedded runtime prefetch stream via writeRuntimePrefetchStreamIntoCache)
+ * — which differ in how they obtain their payloads but not in what must
+ * happen to them.
+ *
+ * Returns the entries the fulfilling payload's write produced content into
+ * (so the streaming caller can keep updating their LRU sizes as bytes
+ * arrive), or null if nothing entered the cache.
+ */
+function writeResponsePayloadsIntoCache(
+  now: number,
+  // The strategy of the request that produced the response. Decides which
+  // payload fulfills the spawned entries and their keying, and identifies
+  // the response family: PPR/StaticShell are per-segment static responses,
+  // everything else a live-render response.
+  fetchStrategy: FetchStrategy,
+  fullPayload: NavigationFlightResponse,
+  // The response's shell payload: null (the response carries no shell),
+  // `fullPayload` itself (the shell IS the full response), or a distinct
+  // stage decode truncated at the shell byte boundary.
+  shellPayload: NavigationFlightResponse | null,
+  // The next five are threaded through to every write; see
+  // writeServerResponseIntoCache for their meaning.
+  baseTree: FlightRouterState | null,
+  predictedFromRoute: FulfilledRouteCacheEntry | null,
+  renderedPathname: string | null,
+  renderedSearch: string,
+  buildId: string | undefined,
+  // Response-level staleness of the full payload. The shell payload's own
+  // staleness is read off the shell decode below (a shell payload is always
+  // fully buffered).
+  staleAt: number,
+  // Whether anything in the full payload is not fully resolved (dynamic or runtime holes, anything suspended). Shell-tier
+  // writes don't consume it: a shell payload is partial by construction.
+  // (Per-segment payloads encode partiality per node and ignore the
+  // response-level value entirely.)
+  isFullResponsePartial: boolean,
+  metadataVaryPath: PageVaryPath | null,
+  // The pending entries this response fulfills. Null when the caller owns
+  // none (the embedded runtime prefetch stream), in which case every write
+  // is a detached upsert.
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
+  // The response's size in bytes, distributed across the entries the
+  // fulfilling payload's write produced; null when unknown (streamed Full
+  // responses — the caller sizes those incrementally as bytes
+  // arrive instead).
+  responseByteLength: number | null,
+  // The map the work that spawned this response's request is bound to. See
+  // writeServerResponseIntoCache.
+  map: CacheMap<SegmentCacheEntry>
+): Array<FulfilledSegmentCacheEntry> | null {
+  const isStaticResponse =
+    fetchStrategy === FetchStrategy.PPR ||
+    fetchStrategy === FetchStrategy.StaticShell
+  const shellWasRequested =
+    fetchStrategy === FetchStrategy.StaticShell ||
+    fetchStrategy === FetchStrategy.RuntimeShell
+
+  let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null
+  if (shellPayload === null) {
+    if (fetchStrategy === FetchStrategy.StaticShell) {
+      // A static shell was requested but the response carries no shell (its
+      // shell byte offset read as 0 — a bug in Next.js itself — or the
+      // shell prefix couldn't be decoded). The full payload is still
+      // usable, so it's written detached at the concrete tier; the spawned
+      // entries are rejected so the task isn't stranded blocking on them.
+      // Note the scheduler does NOT fall back to a runtime request for
+      // rejected segments — it skips them outright (see the Rejected case
+      // in pingSegmentBundle in scheduler.ts), so these segments get no
+      // shell prefetch and no runtime substitute until the rejection's
+      // backoff expires.
+      writeServerResponseIntoCache(
+        now,
+        FetchStrategy.PPR,
+        fullPayload,
+        baseTree,
+        predictedFromRoute,
+        renderedPathname,
+        renderedSearch,
+        buildId,
+        staleAt,
+        isFullResponsePartial,
+        metadataVaryPath,
+        null,
+        null,
+        map
+      )
+      if (spawnedEntries !== null) {
+        rejectSegmentEntriesIfStillPending(
+          spawnedEntries,
+          now + REJECTION_BACKOFF_MS
+        )
+      }
+      return null
+    }
+    // No shell exists, and the request wasn't a static shell walk. The full
+    // payload fulfills the spawned entries at the request's own keying —
+    // including for a RuntimeShell request (shell staging not enabled, or
+    // the render wasn't staged), whose response is then conservatively treated
+    // as the shell it asked for: keyed at the shell tier and partial
+    // by construction.
+    fulfilledEntries = writeServerResponseIntoCache(
+      now,
+      fetchStrategy,
+      fullPayload,
+      baseTree,
+      predictedFromRoute,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      staleAt,
+      fetchStrategy === FetchStrategy.RuntimeShell
+        ? true
+        : isFullResponsePartial,
+      metadataVaryPath,
+      spawnedEntries,
+      null,
+      map
+    )
+  } else if (shellPayload === fullPayload) {
+    // The shell IS the full response (reference-equal — a page with nothing
+    // below its shell). One payload fulfills the spawned entries, recording
+    // the strategy that describes the CONTENT — the full payload's tier.
+    // The content tier also drives the entries' keying: content that isn't
+    // shell-grade is param-independent only on the server's vary-params
+    // evidence, so it must not be parked in the shell slot on the strength
+    // of the missing split alone (see the keying derivation in
+    // writeSegmentDataIntoCache).
+    fulfilledEntries = writeServerResponseIntoCache(
+      now,
+      fetchStrategy,
+      fullPayload,
+      baseTree,
+      predictedFromRoute,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      staleAt,
+      shellWasRequested ? true : isFullResponsePartial,
+      metadataVaryPath,
+      spawnedEntries,
+      // The full payload's tier: PPR for a static response, PPRRuntime for
+      // a runtime response (whose full payload is everything a runtime
+      // prefetch can produce when nothing lies below the shell). For a
+      // full-tier request it agrees with the request's own strategy, so
+      // only shell-tier requests pass it.
+      shellWasRequested
+        ? isStaticResponse
+          ? FetchStrategy.PPR
+          : FetchStrategy.PPRRuntime
+        : null,
+      map
+    )
+  } else {
+    // The shell is a strict prefix of the response. Write both payloads.
+    // The payload matching the tier the spawned entries were requested at
+    // fulfills them; the other is written detached (no owned entries —
+    // every write is an upsert). Fulfilling a spawned shell entry with the
+    // concrete payload would store content that doesn't match the entry's
+    // shell vary path — wrong for every later read at that key, and
+    // immediately observable during a navigation, where a pending entry can
+    // be rendered as a promise that resolves to its eventual value.
+    //
+    // The full payload is written first. The order is not observable: the
+    // two writes key at different tiers, upsert precedence between a full
+    // payload and its own shell payload is order-independent (the full
+    // payload always wins the comparison — a shell segment is never
+    // complete where its full counterpart is partial, see
+    // readFulfilledIsPartial), and fulfillment pings only enqueue scheduler
+    // work that runs after this synchronous block. Full-first is preferred
+    // so the shell write's precedence checks and shadow eviction compare
+    // against the fresh concrete entry rather than whatever stale entry
+    // preceded it.
+    const fullFulfilledEntries = writeServerResponseIntoCache(
+      now,
+      // The full payload is written at the request's own tier, except for
+      // shell-tier requests: when a shell request returns more than the
+      // shell, the extra content is at least as complete as what the
+      // corresponding non-shell request would have returned — PPR for a
+      // StaticShell request, PPRRuntime for a RuntimeShell request. Record
+      // that tier so the scheduler doesn't re-request content this payload
+      // already provides. (Same rule as the coincident-shell case below.)
+      shellWasRequested
+        ? isStaticResponse
+          ? FetchStrategy.PPR
+          : FetchStrategy.PPRRuntime
+        : fetchStrategy,
+      fullPayload,
+      baseTree,
+      predictedFromRoute,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      staleAt,
+      isFullResponsePartial,
+      metadataVaryPath,
+      shellWasRequested ? null : spawnedEntries,
+      null,
+      map
+    )
+    const shellFulfilledEntries = writeServerResponseIntoCache(
+      now,
+      isStaticResponse ? FetchStrategy.StaticShell : FetchStrategy.RuntimeShell,
+      shellPayload,
+      baseTree,
+      predictedFromRoute,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      // The shell payload carries its own staleness, independent of the
+      // full payload's. Shell decodes are fully buffered, so it's read
+      // synchronously; when absent (per-segment responses carry staleTime
+      // per node instead) this falls back to the same static stale time the
+      // per-segment writes use as their response-level fallback.
+      readFulfilledStaleAt(now, shellPayload.s),
+      // A shell payload is a strict subset of the full response, so it does
+      // not represent the entire UI of the target page — it's partial
+      // by construction.
+      true,
+      metadataVaryPath,
+      shellWasRequested ? spawnedEntries : null,
+      null,
+      map
+    )
+    fulfilledEntries = shellWasRequested
+      ? shellFulfilledEntries
+      : fullFulfilledEntries
+  }
+
+  // Entries created by a detached write aren't sized: one wire response is
+  // only charged to the LRU once, to the entries it fulfilled.
+  if (
+    responseByteLength !== null &&
+    fulfilledEntries !== null &&
+    fulfilledEntries.length > 0
+  ) {
+    const averageSize = responseByteLength / fulfilledEntries.length
+    for (const entry of fulfilledEntries) {
+      setSizeInCacheMap(entry, averageSize)
     }
   }
   return fulfilledEntries
@@ -2965,8 +3009,9 @@ function rejectSegmentEntriesIfStillPending(
  * it covers its own spine (per-segment prefetch payloads) — then writes
  * every rendered segment, plus the head, into the cache. Fulfills the
  * entries in `spawnedEntries` that the response covers; rejects the rest, so
- * a task blocked on them isn't stranded. Returns the fulfilled entries (for
- * LRU size accounting), or null if the response was unusable.
+ * a task blocked on them isn't stranded. Returns the entries the write
+ * produced content into — fulfilled spawned entries plus installed detached
+ * upserts — for LRU size accounting, or null if nothing entered the cache.
  *
  * Serves every response kind: live-render prefetch responses (runtime
  * prefetches, and Full/LoadingBoundary prefetches in the
@@ -2974,7 +3019,7 @@ function rejectSegmentEntriesIfStillPending(
  * extraction, cached navigations, the initial payload), embedded runtime
  * prefetch streams, and the payloads of per-segment prefetch responses.
  */
-export function writeServerResponseIntoCache(
+function writeServerResponseIntoCache(
   now: number,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
@@ -2990,17 +3035,18 @@ export function writeServerResponseIntoCache(
   // The base router state the response overlays. Null when the response's
   // tree is root-anchored (per-segment prefetch payloads).
   baseTree: FlightRouterState | null,
-  // Non-null when `baseTree` was derived from this route entry's stored
-  // prediction (see matchKnownRoute). If the server's rendered tree diverges
-  // from the base, the URL has a rewrite that behaves dynamically, so the
-  // params baked into the prediction are wrong: the entry is marked as
-  // having a dynamic rewrite — which doubles as the stored prediction
-  // pattern, so this also disables a bad prediction that would otherwise be
-  // re-derived on every retry. The response data is still written into the
-  // cache: it's real data keyed by what the server actually rendered,
-  // useful regardless of whether the prediction matched. The caller is
-  // responsible for invalidating entries derived from the prediction (see
-  // markRouteEntryAsDynamicRewrite).
+  // Non-null when `baseTree` was derived from this route entry. Any
+  // route-derived request tree is a prediction that the URL's rewrite (if
+  // any) behaves statically; if the server's rendered tree diverges from the
+  // base, that prediction failed — the rewrite behaves dynamically, so the
+  // params baked into the request are wrong. The entry is marked as having a
+  // dynamic rewrite — the entry doubles as the stored prediction pattern
+  // (see matchKnownRoute), so this also disables a bad prediction that would
+  // otherwise be re-derived on every retry. The response data is still
+  // written into the cache: it's real data keyed by what the server actually
+  // rendered, useful regardless of whether the prediction matched. The
+  // caller is responsible for invalidating entries derived from the
+  // prediction (see markRouteEntryAsDynamicRewrite).
   predictedFromRoute: FulfilledRouteCacheEntry | null,
   // The pathname the response was rendered for, used to resolve dynamic
   // segments the server sent without a param value (`k: null`). Null for
@@ -3023,15 +3069,11 @@ export function writeServerResponseIntoCache(
   // instead, since a standalone head response's tree has no page node.
   metadataVaryPath: PageVaryPath | null,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  // Present (non-null) for the payloads of per-segment prefetch responses,
-  // null for everything written through the live-render path (live renders
-  // and prerendered page payloads). Carries the strategy tier that
-  // describes the payload's CONTENT, recorded on the entries it fulfills.
-  // Differs from `fetchStrategy` (which drives matching and keying) in one
-  // case: a StaticShell write whose payload IS the full response (no
-  // shell/full split) records PPR — see the coincident-shell write in
-  // fetchAndWritePerSegmentPrefetchResponse.
-  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell | null,
+  // The strategy tier describing the CONTENT of the payload being written,
+  // when it differs from `fetchStrategy` (which drives matching and
+  // keying); null when they agree. See the param docs on
+  // writeSegmentDataIntoCache.
+  contentFetchStrategy: FetchStrategy.PPR | FetchStrategy.PPRRuntime | null,
   // The map the work that spawned this response's request is bound to: the
   // spawning task's `PrefetchTask.segmentCacheMap` for prefetches, the
   // navigation's map for navigation-side writes. Binding the write to the
@@ -3113,10 +3155,15 @@ export function writeServerResponseIntoCache(
   // itself doesn't need that data. The read is load-bearing in one direction
   // only: a false `true` costs a wasted runtime request; a false `false`
   // would record too high a tier and skip a runtime request that had more
-  // content.
+  // content. A rejected row (an aborted prerender errors rows that were
+  // still pending at the abort) must therefore read as `true`, matching the
+  // server's own read of the page payload's flag (see the `u` read in
+  // collect-segment-data.tsx).
   const isUpgradeableISRFallback = response.f === true
   const responseNeedsRuntimeRequest =
-    response.u !== undefined ? readFulfilledValue(response.u, false) : null
+    response.u !== undefined
+      ? readFulfilledValue(response.u, false, /* rejectedValue */ true)
+      : null
 
   const routeTree = navigationSeed.routeTree
   if (metadataVaryPath === null) {
@@ -3128,6 +3175,7 @@ export function writeServerResponseIntoCache(
   // The route tree carries the render output of every segment the response
   // included, so a single traversal from the root writes all of it into
   // the cache.
+  const writtenEntries: Array<FulfilledSegmentCacheEntry> = []
   writeTreeDataIntoCache(
     now,
     map,
@@ -3135,9 +3183,10 @@ export function writeServerResponseIntoCache(
     routeTree,
     staleAt,
     spawnedEntries,
-    payloadFetchStrategy,
+    contentFetchStrategy,
     isUpgradeableISRFallback,
-    responseNeedsRuntimeRequest
+    responseNeedsRuntimeRequest,
+    writtenEntries
   )
 
   const head = navigationSeed.head
@@ -3149,7 +3198,7 @@ export function writeServerResponseIntoCache(
         ? now + getStaleTimeMs(navigationSeed.headStaleTimeSeconds)
         : staleAt
 
-    writeSegmentDataIntoCache(
+    const writtenHeadEntry = writeSegmentDataIntoCache(
       now,
       map,
       fetchStrategy,
@@ -3162,10 +3211,13 @@ export function writeServerResponseIntoCache(
       navigationSeed.headVaryParams,
       metadataTree,
       spawnedEntries,
-      payloadFetchStrategy,
+      contentFetchStrategy,
       isUpgradeableISRFallback,
       responseNeedsRuntimeRequest
     )
+    if (writtenHeadEntry !== null) {
+      writtenEntries.push(writtenHeadEntry)
+    }
   }
   // Any entry that's still pending was intentionally not rendered by the
   // server, because it was inside the loading boundary. Mark them as rejected
@@ -3176,7 +3228,7 @@ export function writeServerResponseIntoCache(
   // somehow that the reason for the rejection is because of a non-PPR prefetch.
   // That way a per-segment prefetch knows to disregard the rejection.
   if (spawnedEntries !== null) {
-    const fulfilledEntries = rejectSegmentEntriesIfStillPending(
+    rejectSegmentEntriesIfStillPending(
       spawnedEntries,
       // When the response diverged from the prediction, the leftover entries
       // can never be fulfilled — their keys were derived from the wrong
@@ -3185,9 +3237,8 @@ export function writeServerResponseIntoCache(
       // re-prefetch against the server's actual tree.
       treeDivergedFromPrediction ? -1 : now + REJECTION_BACKOFF_MS
     )
-    return fulfilledEntries
   }
-  return null
+  return writtenEntries.length > 0 ? writtenEntries : null
 }
 
 function writeTreeDataIntoCache(
@@ -3203,9 +3254,12 @@ function writeTreeDataIntoCache(
   tree: RouteTree<RSCSegmentData | null>,
   staleAt: number,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell | null,
+  contentFetchStrategy: FetchStrategy.PPR | FetchStrategy.PPRRuntime | null,
   isUpgradeableISRFallback: boolean,
-  responseNeedsRuntimeRequest: boolean | null
+  responseNeedsRuntimeRequest: boolean | null,
+  // Accumulates the entries the walk wrote content into (fulfilled spawned
+  // entries and installed detached upserts), for LRU size accounting.
+  writtenEntries: Array<FulfilledSegmentCacheEntry>
 ) {
   // Writes the render output embedded in the route tree into the
   // prefetch cache.
@@ -3217,7 +3271,7 @@ function writeTreeDataIntoCache(
       data.staleTimeSeconds !== null
         ? now + getStaleTimeMs(data.staleTimeSeconds)
         : staleAt
-    writeSegmentDataIntoCache(
+    const writtenEntry = writeSegmentDataIntoCache(
       now,
       map,
       fetchStrategy,
@@ -3227,10 +3281,13 @@ function writeTreeDataIntoCache(
       data.varyParams,
       tree,
       spawnedEntries,
-      payloadFetchStrategy,
+      contentFetchStrategy,
       isUpgradeableISRFallback,
       responseNeedsRuntimeRequest
     )
+    if (writtenEntry !== null) {
+      writtenEntries.push(writtenEntry)
+    }
   } else {
     // Either the response carried no information for this segment (no data
     // object — e.g. the identity spine of a per-segment prefetch response,
@@ -3251,9 +3308,10 @@ function writeTreeDataIntoCache(
         childTree,
         staleAt,
         spawnedEntries,
-        payloadFetchStrategy,
+        contentFetchStrategy,
         isUpgradeableISRFallback,
-        responseNeedsRuntimeRequest
+        responseNeedsRuntimeRequest,
+        writtenEntries
       )
     }
   }
@@ -3266,6 +3324,11 @@ function writeTreeDataIntoCache(
  * carry a runtime-data verdict (per-segment prefetch responses and
  * prerendered page payloads) additionally refine the tier the entry
  * records — see `recordedFetchStrategy` below.
+ *
+ * Returns the entry this write produced content into — the fulfilled spawned
+ * entry, or the detached entry the upsert installed — so the caller can
+ * charge the response's size to it. Null when nothing entered the cache (the
+ * upsert declined a detached candidate).
  */
 function writeSegmentDataIntoCache(
   now: number,
@@ -3283,12 +3346,14 @@ function writeSegmentDataIntoCache(
   segmentVaryParams: Set<string> | null,
   tree: RouteTree<RSCSegmentData | null>,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  // Non-null for the payloads of per-segment prefetch responses: the
-  // strategy tier describing the CONTENT of the payload this write came
-  // from, which drives the keying fallback and recorded tier below. Null
-  // for everything else (live renders and prerendered page payloads). See
-  // writeServerResponseIntoCache.
-  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell | null,
+  // The strategy tier describing the CONTENT of the payload this write came
+  // from, when it differs from the write's own `fetchStrategy` (which
+  // drives matching and keying); null when they agree. It differs only for
+  // the coincident-shell case: a write that fulfills shell-keyed entries
+  // with a payload that IS the full response passes the full payload's tier
+  // (PPR for a per-segment static response, PPRRuntime for a RuntimeShell
+  // response) — see writeResponsePayloadsIntoCache.
+  contentFetchStrategy: FetchStrategy.PPR | FetchStrategy.PPRRuntime | null,
   // Whether the response is an upgradeable fallback shell. Always false for
   // live-render responses — they are never ISR fallbacks.
   isUpgradeableISRFallback: boolean,
@@ -3296,53 +3361,67 @@ function writeSegmentDataIntoCache(
   // this payload accessed runtime data (page-global; combined with the
   // segment's own `isPartial` to decide the tier the entry records below).
   // Null when the response carries no verdict (`u`) — live renders emit
-  // none; per-segment prefetch responses and prerendered page payloads do —
-  // in which case the entry records the request's own strategy unrefined.
+  // none; per-segment prefetch responses and prerendered page payloads
+  // (including the truncated initial payload) do — in which case the entry
+  // records the payload's tier unrefined.
   responseNeedsRuntimeRequest: boolean | null
-) {
+): FulfilledSegmentCacheEntry | null {
+  // The strategy tier recorded on the entry — the tier of the content that
+  // actually satisfied it, which spans both axes: shell-vs-concrete AND
+  // static-vs-runtime. The payload's content tier (`fetchStrategy`, unless
+  // the caller passed a distinct `contentFetchStrategy`), refined by the
+  // response's runtime-data verdict when it carries one:
+  //
   // A runtime prefetch can only provide more content than this entry if the
   // render accessed runtime data AND this particular segment has holes — a
   // fully static segment gains nothing from a runtime request no matter
-  // what the page accessed.
-  const needsRuntimeRequest = responseNeedsRuntimeRequest === true && isPartial
-
-  // An entry records the tier of the content that actually satisfied it,
-  // which spans both axes: shell-vs-concrete AND static-vs-runtime.
-  //
-  // When this payload fully satisfied the segment — no runtime request
-  // needed — the content is as complete as a RUNTIME response of the same
-  // variant would have been, so it records that runtime tier. That's what
-  // lets the scheduler decide "would a runtime request return more?" by
-  // comparing tiers alone, with no separate signal to consult.
-  //
-  // Otherwise the content is only as complete as the static tier it was
-  // requested at, so a follow-up runtime request can still supersede it.
-  //
-  // A response that carries no verdict (a live render's, or the
-  // synthesized initial-payload subset's — see create-initial-router-state)
-  // records the request's own strategy unrefined. A verdict is honored
-  // wherever it appears: prerendered page payloads carry one too (the
-  // prerender's runtime-data probe), and refining on it is correct — a
-  // prerendered response whose verdict is `false` is genuinely
-  // runtime-complete content.
-  // The refinement maps a static tier UP to the runtime tier of the same
-  // variant. Only the static tiers have a runtime counterpart to refine to;
-  // any other payload tier records itself — never below the payload's own
-  // tier. (This also makes the verdict inert for Full payloads, which
-  // matters because the Full flow decodes incrementally and `response.u` is
-  // read off the thenable's status — only sound on fully-buffered decodes. A
-  // prerendered page payload served to a Full prefetch carries a verdict; a
-  // not-yet-arrived row misreads as `false`, and without this clamp that
-  // would downgrade a Full-tier write to PPRRuntime.)
-  const payloadTier = payloadFetchStrategy ?? fetchStrategy
-  const recordedFetchStrategy =
-    responseNeedsRuntimeRequest !== null && !needsRuntimeRequest
-      ? payloadTier === FetchStrategy.StaticShell
+  // what the page accessed. When this payload fully satisfied the segment —
+  // no runtime request needed — the content is as complete as a RUNTIME
+  // response of the same variant would have been, so it records that
+  // runtime tier. That's what lets the scheduler decide "would a runtime
+  // request return more?" by comparing tiers alone, with no separate signal
+  // to consult. Otherwise the content is only as complete as the static
+  // tier it was requested at, so a follow-up runtime request can still
+  // supersede it.
+  let recordedFetchStrategy: FetchStrategy
+  if (responseNeedsRuntimeRequest === null) {
+    // The response carries no verdict — a live render's, or the synthesized
+    // initial-payload subset's (see create-initial-router-state): record
+    // the payload's tier as-is. A verdict is honored wherever it appears:
+    // prerendered page payloads carry one too (the prerender's runtime-data
+    // probe), and refining on it is correct — a prerendered response whose
+    // verdict is `false` is genuinely runtime-complete content.
+    recordedFetchStrategy = contentFetchStrategy ?? fetchStrategy
+  } else if (responseNeedsRuntimeRequest && isPartial) {
+    // A runtime request would provide more than this payload, so no runtime
+    // tier is recorded — but the entry must still honor the payload's
+    // CONTENT grade. In the coincident-shell case the payload that satisfied
+    // a shell-keyed entry IS the full response, whose content grades at the
+    // concrete static tier (`contentFetchStrategy`, PPR — the verdict only
+    // rides static-family responses, so no higher grade can appear here).
+    // The verdict is consistent with that grade: it says the runtime tiers
+    // would provide more, which they would over PPR just as over the shell
+    // tier.
+    recordedFetchStrategy = contentFetchStrategy ?? fetchStrategy
+  } else {
+    // The verdict says this payload is runtime-complete: refine the recorded
+    // tier UP to the runtime tier of the same variant. Only the static
+    // tiers have a runtime counterpart to refine to; any other payload tier
+    // records itself — never below the payload's own tier. (This also makes
+    // the verdict inert for Full payloads, which matters because the Full
+    // flow decodes incrementally and `response.u` is read off the thenable's
+    // status — only sound on fully-buffered decodes. A prerendered page
+    // payload served to a Full prefetch carries a verdict; a not-yet-arrived
+    // row misreads as `false`, and without this clamp that would downgrade a
+    // Full-tier write to PPRRuntime.)
+    const payloadFetchStrategy = contentFetchStrategy ?? fetchStrategy
+    recordedFetchStrategy =
+      payloadFetchStrategy === FetchStrategy.StaticShell
         ? FetchStrategy.RuntimeShell
-        : payloadTier === FetchStrategy.PPR
+        : payloadFetchStrategy === FetchStrategy.PPR
           ? FetchStrategy.PPRRuntime
-          : payloadTier
-      : fetchStrategy
+          : payloadFetchStrategy
+  }
 
   // Decide whether to re-key the entry under a more generic vary path based on
   // which params the segment actually depends on.
@@ -3356,7 +3435,7 @@ function writeSegmentDataIntoCache(
   // unrelated URLs read each other's content from the cache.
   //
   // Key the entry by which params the server said this segment depends on
-  // (judged by the payload's CONTENT: payloadFetchStrategy differs from
+  // (judged by the payload's CONTENT: contentFetchStrategy differs from
   // fetchStrategy exactly when a shell request's response turned out to
   // carry more — the coincident case). Reusing one copy across param values
   // is the point of the shell, but it requires knowing the content doesn't
@@ -3370,7 +3449,7 @@ function writeSegmentDataIntoCache(
   // which reduces param-dependent content to param fallbacks, so it really
   // is good for any value of them (its request path below IS the shell
   // vary path).
-  const payloadStrategy = payloadFetchStrategy ?? fetchStrategy
+  const payloadStrategy = contentFetchStrategy ?? fetchStrategy
   let fulfilledVaryPath: SegmentVaryPath | null = null
   if (
     process.env.__NEXT_VARY_PARAMS &&
@@ -3435,9 +3514,11 @@ function writeSegmentDataIntoCache(
   // must fall through to the detached path below.
   const ownedEntry =
     spawnedEntries !== null ? spawnedEntries.get(tree.requestKey) : undefined
+  const isOwned =
+    ownedEntry !== undefined && ownedEntry.status === EntryStatus.Pending
   let fulfilledEntry: FulfilledSegmentCacheEntry
   let insertVaryPath: SegmentVaryPath | null
-  if (ownedEntry !== undefined && ownedEntry.status === EntryStatus.Pending) {
+  if (isOwned) {
     // We own this entry — fulfill it directly.
     fulfilledEntry = fulfillSegmentCacheEntry(
       ownedEntry,
@@ -3490,8 +3571,24 @@ function writeSegmentDataIntoCache(
     // unreachable at the concrete read path: the scheduler would keep
     // re-reading the stale entry and, for a revalidation, respawn it
     // forever. See evictShadowingSegmentEntries.
-    upsertSegmentEntry(now, map, insertVaryPath, fulfilledEntry, tree.varyPath)
+    const installedEntry = upsertSegmentEntry(
+      now,
+      map,
+      insertVaryPath,
+      fulfilledEntry,
+      tree.varyPath
+    )
+    if (installedEntry === null && !isOwned) {
+      // The upsert declined the detached candidate (an existing entry took
+      // precedence, or the candidate was already expired), so no cache slot
+      // holds this write's content — nothing for the caller to charge to
+      // the LRU. (An owned entry is returned regardless: it was fulfilled
+      // above and stays live for waiters that hold it, whether or not the
+      // re-key installed it.)
+      return null
+    }
   }
+  return fulfilledEntry
 }
 
 async function fetchPrefetchResponse<T>(
@@ -3674,11 +3771,11 @@ function addSegmentPathToUrlInOutputExportMode(
  *
  * Generally, when an app uses dynamic data, a "more specific" fetch strategy is expected to provide more content:
  * - `LoadingBoundary` only provides static layouts
- * - `StaticShell` provides the App Shell variant extracted from a static response —
+ * - `StaticShell` provides the shell-stage variant extracted from a static response —
  *   param-dependent content reduced to pending fallbacks, and never any content that
  *   depends on session data (cookies, headers)
- * - `RuntimeShell` provides the App Shell rendered by a runtime request, which can
- *   additionally include shell content that depends on session data
+ * - `RuntimeShell` provides the shell stage rendered by a runtime request, which can
+ *   additionally include shell-stage content that depends on session data
  * - `PPR` can provide shells for each segment (even for segments that use dynamic data),
  *   including prerendered param-dependent content at concrete paths
  * - `PPRRuntime` can additionally include content that uses searchParams, params, or cookies
@@ -3834,8 +3931,17 @@ export function spawnStaticStageCacheWrite(
 /**
  * Decodes an embedded runtime prefetch Flight stream and writes it into the
  * segment cache, so subsequent navigations can serve runtime-prefetchable
- * content from cache without a separate prefetch request. This flow owns no
- * pending entries, so every write is a detached upsert.
+ * content from cache without a separate prefetch request.
+ *
+ * The stream is buffered before it's decoded, like every prefetch response
+ * that carries cache metadata: the shell byte offset (`a`) and staleTime are
+ * read synchronously off their thenable status, and extracting a distinct
+ * shell stage requires re-decoding a truncated copy of the same bytes. The
+ * writes go through the shared payload-pair orchestration
+ * (writeResponsePayloadsIntoCache): the full payload is written at
+ * PPRRuntime and a distinct shell stage at the shell tier (RuntimeShell),
+ * like any other runtime prefetch response. This flow owns no pending
+ * entries, so every write is a detached upsert.
  */
 export async function writeRuntimePrefetchStreamIntoCache(
   now: number,
@@ -3848,20 +3954,46 @@ export async function writeRuntimePrefetchStreamIntoCache(
 ): Promise<void> {
   const { stream, isPartial } = await stripIsPartialByte(runtimePrefetchStream)
 
-  const serverData =
-    await createFromNextReadableStream<NavigationFlightResponse>(
-      stream,
-      undefined,
-      { allowPartialStream: true }
-    )
+  const buffer = await bufferPrefetchResponseBody(stream)
+  const serverData = await decodeBufferedStage<NavigationFlightResponse>(
+    buffer,
+    undefined
+  )
 
-  const staleAt = await resolveStaleAt(now, serverData.s)
+  // Extract the shell payload, when the response carries one. Same wire
+  // convention as the other live-render responses (see
+  // resolveShellStageResponse): `a` absent means the render wasn't staged —
+  // no shell exists; `null` means the shell IS the full response; a number
+  // is the byte boundary of a distinct shell prefix, which is re-decoded
+  // from a truncated copy of the buffer. An unreadable `a` — pending or
+  // rejected, which only an aborted render produces — conservatively reads
+  // as no shell: the full payload is still written, there's just no shell
+  // stage to extract from it.
+  let shellResponse: NavigationFlightResponse | null = null
+  if (serverData.a !== undefined) {
+    const shellByteLength = readFulfilledValue(serverData.a, undefined)
+    if (shellByteLength === null) {
+      shellResponse = serverData
+    } else if (shellByteLength !== undefined) {
+      try {
+        shellResponse = await decodeBufferedStage<NavigationFlightResponse>(
+          buffer.subarray(0, shellByteLength),
+          undefined
+        )
+      } catch {
+        // The truncated prefix couldn't be decoded. Treat it as if no shell
+        // exists; the full payload is still usable.
+        shellResponse = null
+      }
+    }
+  }
 
-  writeServerResponseIntoCache(
+  writeResponsePayloadsIntoCache(
     now,
     // A runtime prefetch stream is by definition a runtime prefetch.
     FetchStrategy.PPRRuntime,
     serverData,
+    shellResponse,
     baseTree,
     // The base tree is the navigation's current tree, not a prediction;
     // divergence from it carries no signal.
@@ -3871,11 +4003,13 @@ export async function writeRuntimePrefetchStreamIntoCache(
     null,
     renderedSearch,
     serverData.b,
-    staleAt,
+    // The response is fully buffered, so staleTime is read synchronously.
+    readFulfilledStaleAt(now, serverData.s),
     isPartial,
     null,
     // This flow owns no pending entries; every write is a detached upsert.
     null,
+    // Detached writes aren't sized; see writeResponsePayloadsIntoCache.
     null,
     map
   )

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1421,7 +1421,11 @@ function pingBlockedTasks(entry: {
 }
 
 export function createMetadataRouteTree(
-  metadataVaryPath: PageVaryPath
+  metadataVaryPath: PageVaryPath,
+  // The route root's prefetch hints. The head has no node of its own on the
+  // wire, so route-level hints are read from the root on its behalf — the
+  // same convention as pingStaticHead in scheduler.ts.
+  rootPrefetchHints: number
 ): RouteTree<null> {
   // The Head is not actually part of the route tree, but other than that, it's
   // fetched and cached like a segment. Some functions expect a RouteTree
@@ -1439,7 +1443,13 @@ export function createMetadataRouteTree(
     // one. If this logic ever gets more complex we can change this to an enum.
     isPage: true,
     slots: null,
-    prefetchHints: 0,
+    // Only the static-attempt bit applies to the head: it's a route-level
+    // fact ("static per-segment responses may exist for this route"), and
+    // it's what lets a shell-tier cached head attempt a static head fetch
+    // before deopting to a runtime request (see the shell-tier eligibility
+    // check in pingSegmentBundle). The other bits describe tree structure
+    // the head doesn't participate in.
+    prefetchHints: rootPrefetchHints & PrefetchHint.ShouldAttemptStaticPrefetch,
   }
   return metadata
 }
@@ -1523,7 +1533,10 @@ export function fulfillRouteCacheEntry(
   const fulfilledEntry: FulfilledRouteCacheEntry = entry as any
   fulfilledEntry.status = EntryStatus.Fulfilled
   fulfilledEntry.tree = stripDataFromRouteTree(tree)
-  fulfilledEntry.metadata = createMetadataRouteTree(metadataVaryPath)
+  fulfilledEntry.metadata = createMetadataRouteTree(
+    metadataVaryPath,
+    tree.prefetchHints
+  )
   // Route structure is essentially static — it only changes on deploy.
   // Always use the static stale time.
   // NOTE: An exception is rewrites/redirects in middleware or proxy, which can
@@ -3170,7 +3183,12 @@ function writeServerResponseIntoCache(
     metadataVaryPath = navigationSeed.metadataVaryPath
   }
   const metadataTree =
-    metadataVaryPath !== null ? createMetadataRouteTree(metadataVaryPath) : null
+    metadataVaryPath !== null
+      ? createMetadataRouteTree(
+          metadataVaryPath,
+          navigationSeed.routeTree.prefetchHints
+        )
+      : null
 
   // The route tree carries the render output of every segment the response
   // included, so a single traversal from the root writes all of it into

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -196,9 +196,10 @@ type RouteTreeShared<TData> = {
   // TODO: Remove the `segment` field, now that it can be reconstructed
   // from `param`.
   segment: FlightRouterStateSegment
-  // The vary path used to key this segment's App Shell entry: the segment's
-  // vary path with every non-root param replaced with Fallback (see
-  // getShellSegmentVaryPath). Precomputed once during tree construction so we
+  // The vary path used for shell-scoped keying of this segment: the
+  // segment's vary path with every non-root param replaced with Fallback
+  // (see getShellSegmentVaryPath), so one shell-tier entry serves all param
+  // values below the root. Precomputed once during tree construction so we
   // don't have to recompute it on every shell request.
   shellVaryPath: SegmentVaryPath
   refreshState: RefreshState | null
@@ -2213,10 +2214,9 @@ export async function fetchSegmentPrefetchesUsingStaticRequest(
  * response, and writes every payload of it into the cache — the full
  * payload, and, when the response carries a shell byte boundary, a second
  * decode of the same bytes truncated at that boundary, the segments'
- * shell-stage variant — through writeServerResponseIntoCache, the same
- * write path live-render responses use. The response-shape switch below
- * owns which payload fulfills the spawned entries and the tier each payload
- * is written at.
+ * shell-stage variant — through the shared payload-write orchestration
+ * (writeResponsePayloadsIntoCache), which owns which payload fulfills the
+ * spawned entries and the tier each payload is written at.
  *
  * Returns whether the response was an upgradeable ISR fallback shell (the
  * page hadn't been prerendered with concrete params yet), or `null` if the
@@ -2375,10 +2375,11 @@ async function fetchAndWritePerSegmentPrefetchResponse(
   // unfulfilled `a`, which would be a Next.js bug since the full buffer is
   // present. Both read the same here: no shell, and the scheduler skips the
   // affected segments rather than falling back to a runtime request — see
-  // the no-shell handling below. Failing in that direction costs a shell
-  // prefetch but never leaks post-shell content into shell positions. 0 can
-  // double as "none" on the wire precisely because it's never a valid
-  // offset — see the `a` field doc on NavigationFlightResponse.)
+  // the no-shell handling in writeResponsePayloadsIntoCache. Failing in that
+  // direction costs a shell prefetch but never leaks post-shell content into
+  // shell positions. 0 can double as "none" on the wire precisely because
+  // it's never a valid offset — see the `a` field doc on
+  // NavigationFlightResponse.)
   const shellOffset =
     serverResponse.a !== undefined ? readFulfilledValue(serverResponse.a, 0) : 0
   let shellResponse: NavigationFlightResponse | null
@@ -2397,7 +2398,7 @@ async function fetchAndWritePerSegmentPrefetchResponse(
       // exists; the full payload is still usable. (For a StaticShell-spawned
       // bundle this means the spawned entries are rejected — the scheduler
       // then skips them rather than issuing a runtime substitute; see the
-      // no-shell handling below.)
+      // no-shell handling in writeResponsePayloadsIntoCache.)
       shellResponse = null
     }
   }
@@ -2438,107 +2439,21 @@ async function fetchAndWritePerSegmentPrefetchResponse(
   //   cast is sound.)
   const now = Date.now()
   const metadataVaryPath = route.metadata.varyPath as PageVaryPath
-
-  let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null
-  if (shellResponse === serverResponse) {
-    // The shell IS the full response (reference-equal — a page with nothing
-    // below its shell). One payload fulfills the spawned entries, keyed by
-    // the walk that spawned them, and records the strategy that describes
-    // the CONTENT — the full payload's tier (PPR). See the recorded-tier
-    // derivation in writeSegmentDataIntoCache.
-    fulfilledEntries = writeServerResponseIntoCache(
-      now,
-      fetchStrategy,
-      serverResponse,
-      null,
-      renderedPathname,
-      route.renderedSearch,
-      undefined,
-      now + STATIC_STALETIME_MS,
-      true,
-      metadataVaryPath,
-      spawnedEntries,
-      FetchStrategy.PPR
-    )
-  } else {
-    // The full payload is written first, so the shell write's precedence
-    // checks and shadow eviction compare against the fresh concrete entry
-    // rather than whatever stale entry preceded it. It fulfills the spawned
-    // entries when the concrete tier is what the walk requested; for a
-    // StaticShell walk it's written detached (no owned entries — every
-    // write is an upsert), because fulfilling a spawned StaticShell entry
-    // with the concrete payload would leak param-dependent content into
-    // shell positions: during a navigation, a pending entry can be rendered
-    // as a promise that resolves to its eventual value.
-    const fullFulfilledEntries = writeServerResponseIntoCache(
-      now,
-      FetchStrategy.PPR,
-      serverResponse,
-      null,
-      renderedPathname,
-      route.renderedSearch,
-      undefined,
-      now + STATIC_STALETIME_MS,
-      true,
-      metadataVaryPath,
-      fetchStrategy === FetchStrategy.StaticShell ? null : spawnedEntries,
-      FetchStrategy.PPR
-    )
-    if (shellResponse === null) {
-      if (fetchStrategy === FetchStrategy.StaticShell) {
-        // A static shell was requested but the response carries no shell
-        // (its shell byte offset read as 0 — a bug in Next.js itself — or
-        // the shell prefix couldn't be decoded). The full payload was still
-        // usable, so it was written detached at the concrete tier above;
-        // the spawned entries are rejected so the task isn't stranded
-        // blocking on them. Note the scheduler does NOT fall back to a
-        // runtime request for rejected segments — it skips them outright
-        // (see the Rejected case in pingSegmentBundle in scheduler.ts), so
-        // these segments get no shell prefetch and no runtime substitute
-        // until the rejection's backoff expires.
-        rejectSegmentEntriesIfStillPending(
-          spawnedEntries,
-          now + REJECTION_BACKOFF_MS
-        )
-        fulfilledEntries = null
-      } else {
-        fulfilledEntries = fullFulfilledEntries
-      }
-    } else {
-      // The shell is a strict prefix of the response. Write it at the shell
-      // tier, fulfilling the spawned entries when a shell is what the
-      // walk requested.
-      const shellFulfilledEntries = writeServerResponseIntoCache(
-        now,
-        FetchStrategy.StaticShell,
-        shellResponse,
-        null,
-        renderedPathname,
-        route.renderedSearch,
-        undefined,
-        now + STATIC_STALETIME_MS,
-        true,
-        metadataVaryPath,
-        fetchStrategy === FetchStrategy.StaticShell ? spawnedEntries : null,
-        FetchStrategy.StaticShell
-      )
-      fulfilledEntries =
-        fetchStrategy === FetchStrategy.StaticShell
-          ? shellFulfilledEntries
-          : fullFulfilledEntries
-    }
-  }
-
-  // Distribute the response size evenly across the entries this response
-  // fulfilled. Entries created by a detached write aren't sized: one wire
-  // response is only charged to the LRU once, to the entries it fulfilled.
-  if (fulfilledEntries !== null && fulfilledEntries.length > 0) {
-    const averageSize = buffer.byteLength / fulfilledEntries.length
-    for (const entry of fulfilledEntries) {
-      setSizeInCacheMap(entry, averageSize)
-    }
-  }
-
+  writeResponsePayloadsIntoCache(
+    now,
+    fetchStrategy,
+    serverResponse,
+    shellResponse,
+    null,
+    renderedPathname,
+    route.renderedSearch,
+    undefined,
+    now + STATIC_STALETIME_MS,
+    true,
+    metadataVaryPath,
+    spawnedEntries,
+    buffer.byteLength
+  )
   return isUpgradeableISRFallback
 }
 
@@ -2651,11 +2566,12 @@ async function retryUpgradeableFallbackPrefetch(
   task.fallbackRetryStatus = EntryStatus.Rejected
 }
 
-// TODO: The inlined prefetch flow below is temporary. Eventually, inlining
-// will be the default behavior controlled by a size heuristic rather than a
-// boolean flag. At that point, the per-segment and inlined fetch paths will
-// merge, and these separate functions will be removed.
-//
+// The runtime counterpart of the per-segment static prefetch flow
+// (fetchSegmentPrefetchesUsingStaticRequest). The two flows differ in how
+// they obtain their payloads — one runtime request here (streamed for Full
+// prefetches), versus a buffered per-segment response with a shell
+// double-decode there — but share the payload write orchestration
+// (writeResponsePayloadsIntoCache).
 export async function fetchSegmentPrefetchesUsingRuntimeRequest(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
@@ -2800,159 +2716,49 @@ export async function fetchSegmentPrefetchesUsingRuntimeRequest(
     const buildId =
       response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
 
-    // Check if a reusable App Shell can be extracted from the main response.
-    let serverDataThatSatisfiesSpawnedEntries: NavigationFlightResponse
-    // The shell and full response have independent stale times. Track the
-    // staleAt that corresponds to whatever payload the spawned entries get
-    // filled with below.
-    let staleAtForSpawnedEntries = staleAt
-    if (cacheData === null) {
-      // No shell can be extracted without cache metadata (only present when
-      // Cached Navigations is enabled). For routes without a distinct App Shell
-      // the extraction below is a no-op anyway (`resolveShellStageResponse`
-      // returns null), so this just short-circuits that case.
-      serverDataThatSatisfiesSpawnedEntries = serverData
-    } else {
-      const shellStageResponse = await resolveShellStageResponse(
-        cacheData,
-        serverData,
-        headers
-      )
-      if (shellStageResponse === null || shellStageResponse === serverData) {
-        // Either no App Shell exists (App Shells are not yet enabled, or the
-        // render wasn't staged), or the shell IS the entire response
-        // (reference-equal). Either way, there's nothing extra for us to do:
-        // fulfill the pending entries using the response from the server.
-        // TODO: When the shell coincides with the full response, the entries
-        // could be recorded at the tier that describes the full payload's
-        // content, the way the per-segment flow promotes a coincident shell
-        // (see fetchAndWritePerSegmentPrefetchResponse). For now the
-        // coincident case is treated the same as no shell.
-        serverDataThatSatisfiesSpawnedEntries = serverData
-      } else {
-        // Successfully extracted an App Shell that is a subset of the main
-        // response. Depending on the type of prefetch this is, we need to
-        // decide whether to fulfill the pending entries with the shell or with
-        // the entire response. In either scenario, we'll be inserting _both_
-        // versions of the response into the cache; the extra logic is only
-        // here so that we don't fulfill pending shell entries with something
-        // that's more concrete than what they expect.
-        // TODO: The only reason this matters is because during a navigation,
-        // if a segment is still pending, we render a promise that resolves to
-        // the eventual value of that segment. But that means we cannot
-        // eventually resolve that segment to something more concrete than what
-        // was already requested. Hence the extra logic here. A cleaner way to
-        // model this, though, is whenever we render a promise that resolves to
-        // the result of a pending entry, do one additional cache look-up right
-        // after the promise resolves, to ensure we never get a mismatching
-        // entry. Leaving this for a follow up.
-        // shellStageResponse is a fully-buffered stage decode, so read
-        // staleTime synchronously off the thenable status.
-        const shellStaleAt = readFulfilledStaleAt(now, shellStageResponse.s)
-        if (fetchStrategy === FetchStrategy.RuntimeShell) {
-          // This is a Shell prefetch, so the pending entries must be fulfilled
-          // with the shell.
-          serverDataThatSatisfiesSpawnedEntries = shellStageResponse
-          staleAtForSpawnedEntries = shellStaleAt
+    // Extract the response's shell-stage payload, when it carries one. No
+    // shell can be extracted without cache metadata (only present when
+    // Cached Navigations is enabled); for responses without a distinct
+    // shell stage the extraction is a no-op anyway
+    // (`resolveShellStageResponse` returns null), so the null check just
+    // short-circuits that case.
+    const shellResponse =
+      cacheData !== null
+        ? await resolveShellStageResponse(cacheData, serverData, headers)
+        : null
 
-          // Separately, we'll also cache the entire response, by upserting it
-          // into the cache.
-          writeServerResponseIntoCache(
-            now,
-            FetchStrategy.PPR,
-            serverData,
-            dynamicRequestTree,
-            // Navigation responses always include the param values in the
-            // tree, so there's no pathname to parse them from (nor a
-            // need to).
-            null,
-            renderedSearch,
-            buildId,
-            staleAt,
-            cacheData.isResponsePartial,
-            null,
-            // No owned entries; every write is a detached upsert.
-            null,
-            null
-          )
-        } else {
-          // This is _not_ a Shell prefetch, so the pending entries should be
-          // fulfilled with the entire response.
-          serverDataThatSatisfiesSpawnedEntries = serverData
+    // Runtime prefetch responses (PPRRuntime and RuntimeShell requests) are
+    // partial when the server marks the response as '~' (Partial).
+    // Full/LoadingBoundary prefetch responses are always complete. This only
+    // describes the FULL payload: shell-tier writes don't consume it — a
+    // shell is partial by construction (RuntimeShell responses omit every
+    // dynamic suspense boundary below the shell stage, regardless of what
+    // the server marker says); see writeResponsePayloadsIntoCache.
+    const isFullResponsePartial =
+      (fetchStrategy === FetchStrategy.PPRRuntime ||
+        fetchStrategy === FetchStrategy.RuntimeShell) &&
+      (cacheData?.isResponsePartial ?? false)
 
-          // Additionally, we might as well upsert the extracted Shell into the
-          // cache, too.
-
-          // `shellStageResponse` only reaches this path when the shell is
-          // distinct from the main response (a strict prefix of it). So it
-          // follows that any shell data that reaches this path must be
-          // partial -- it does not represent the entire UI of the
-          // target page.
-          const isShellStagePartial = true
-          writeServerResponseIntoCache(
-            now,
-            FetchStrategy.RuntimeShell,
-            shellStageResponse,
-            dynamicRequestTree,
-            // Navigation responses always include the param values in the
-            // tree, so there's no pathname to parse them from (nor a
-            // need to).
-            null,
-            renderedSearch,
-            buildId,
-            shellStaleAt,
-            isShellStagePartial,
-            null,
-            // No owned entries; every write is a detached upsert.
-            null,
-            null
-          )
-        }
-      }
-    }
-
-    // PPRRuntime and RuntimeShell prefetches are partial when the server
-    // marks the response as '~' (Partial). RuntimeShell additionally omits
-    // every dynamic suspense boundary below the App Shell, so its segments
-    // are always partial regardless of what the server marker says.
-    // Full/LoadingBoundary prefetches are always complete.
-    const isResponsePartial =
-      fetchStrategy === FetchStrategy.RuntimeShell ||
-      (fetchStrategy === FetchStrategy.PPRRuntime &&
-        (cacheData?.isResponsePartial ?? false))
-
-    // Aside from writing the data into the cache, this function also returns
-    // the entries that were fulfilled, so we can streamingly update their sizes
-    // in the LRU as more data comes in.
-    fulfilledEntries = writeServerResponseIntoCache(
+    // Aside from writing the data into the cache, this also returns the
+    // entries that were fulfilled, so we can streamingly update their sizes
+    // in the LRU as more data comes in (Full responses, which stream).
+    fulfilledEntries = writeResponsePayloadsIntoCache(
       now,
       fetchStrategy,
-      serverDataThatSatisfiesSpawnedEntries,
+      serverData,
+      shellResponse,
       dynamicRequestTree,
       // Navigation responses always include the param values in the tree, so
       // there's no pathname to parse them from (nor a need to).
       null,
       renderedSearch,
       buildId,
-      staleAtForSpawnedEntries,
-      isResponsePartial,
+      staleAt,
+      isFullResponsePartial,
       null,
       spawnedEntries,
-      null
+      bufferedResponseSize
     )
-
-    // For buffered responses, update LRU sizes now that we know which
-    // entries were fulfilled.
-    if (
-      bufferedResponseSize !== null &&
-      fulfilledEntries !== null &&
-      fulfilledEntries.length > 0
-    ) {
-      const averageSize = bufferedResponseSize / fulfilledEntries.length
-      for (const entry of fulfilledEntries) {
-        setSizeInCacheMap(entry, averageSize)
-      }
-    }
 
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
@@ -2976,6 +2782,240 @@ function rejectSegmentEntriesIfStillPending(
       rejectSegmentCacheEntry(entry, staleAt)
     } else if (entry.status === EntryStatus.Fulfilled) {
       fulfilledEntries.push(entry)
+    }
+  }
+  return fulfilledEntries
+}
+
+/**
+ * Writes a prefetch response's payloads into the cache: the full payload,
+ * plus its shell payload when the response carries one. This is the write
+ * orchestration shared by the prefetch response kinds — per-segment
+ * static responses (fetchAndWritePerSegmentPrefetchResponse) and
+ * live-render responses (fetchSegmentPrefetchesUsingRuntimeRequest, and the
+ * embedded runtime prefetch stream via writeRuntimePrefetchStreamIntoCache)
+ * — which differ in how they obtain their payloads but not in what must
+ * happen to them.
+ *
+ * Returns the entries fulfilled from `spawnedEntries` (so the streaming
+ * caller can keep updating their LRU sizes as bytes arrive), or null if no
+ * payload fulfilled them.
+ */
+function writeResponsePayloadsIntoCache(
+  now: number,
+  // The strategy of the request that produced the response. Decides which
+  // payload fulfills the spawned entries and their keying, and identifies
+  // the response family: PPR/StaticShell are per-segment static responses,
+  // everything else a live-render response.
+  fetchStrategy: FetchStrategy,
+  fullResponse: NavigationFlightResponse,
+  // The response's shell payload: null (the response carries no shell),
+  // `fullResponse` itself (the shell IS the full response), or a distinct
+  // stage decode truncated at the shell byte boundary.
+  shellResponse: NavigationFlightResponse | null,
+  // The next four are threaded through to every write; see
+  // writeServerResponseIntoCache for their meaning.
+  baseTree: FlightRouterState | null,
+  renderedPathname: string | null,
+  renderedSearch: string,
+  buildId: string | undefined,
+  // Response-level staleness of the full payload. The shell payload's own
+  // staleness is read off the shell decode below (a shell payload is always
+  // fully buffered).
+  staleAt: number,
+  // Whether anything in the full payload is not fully resolved (dynamic or runtime holes, anything suspended). Shell-tier
+  // writes don't consume it: a shell payload is partial by construction.
+  // (Per-segment payloads encode partiality per node and ignore the
+  // response-level value entirely.)
+  isFullResponsePartial: boolean,
+  metadataVaryPath: PageVaryPath | null,
+  // The pending entries this response fulfills. Null when the caller owns
+  // none (the embedded runtime prefetch stream), in which case every write
+  // is a detached upsert.
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
+  // The response's size in bytes, distributed across the fulfilled entries;
+  // null when unknown (streamed Full responses — the caller sizes those
+  // incrementally as bytes arrive instead).
+  responseByteLength: number | null
+): Array<FulfilledSegmentCacheEntry> | null {
+  const isStaticResponse =
+    fetchStrategy === FetchStrategy.PPR ||
+    fetchStrategy === FetchStrategy.StaticShell
+  const shellWasRequested =
+    fetchStrategy === FetchStrategy.StaticShell ||
+    fetchStrategy === FetchStrategy.RuntimeShell
+
+  let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null
+  if (shellResponse === null) {
+    if (fetchStrategy === FetchStrategy.StaticShell) {
+      // A static shell was requested but the response carries no shell (its
+      // shell byte offset read as 0 — a bug in Next.js itself — or the
+      // shell prefix couldn't be decoded). The full payload is still
+      // usable, so it's written detached at the concrete tier; the spawned
+      // entries are rejected so the task isn't stranded blocking on them.
+      // Note the scheduler does NOT fall back to a runtime request for
+      // rejected segments — it skips them outright (see the Rejected case
+      // in pingSegmentBundle in scheduler.ts), so these segments get no
+      // shell prefetch and no runtime substitute until the rejection's
+      // backoff expires.
+      writeServerResponseIntoCache(
+        now,
+        FetchStrategy.PPR,
+        fullResponse,
+        baseTree,
+        renderedPathname,
+        renderedSearch,
+        buildId,
+        staleAt,
+        isFullResponsePartial,
+        metadataVaryPath,
+        null,
+        null
+      )
+      if (spawnedEntries !== null) {
+        rejectSegmentEntriesIfStillPending(
+          spawnedEntries,
+          now + REJECTION_BACKOFF_MS
+        )
+      }
+      return null
+    }
+    // No shell exists, and the request wasn't a static shell walk. The full
+    // payload fulfills the spawned entries at the request's own keying —
+    // including for a RuntimeShell request (shell staging not enabled, or
+    // the render wasn't staged), whose response is then conservatively treated
+    // as the shell it asked for: keyed at the shell tier and partial
+    // by construction.
+    fulfilledEntries = writeServerResponseIntoCache(
+      now,
+      fetchStrategy,
+      fullResponse,
+      baseTree,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      staleAt,
+      fetchStrategy === FetchStrategy.RuntimeShell
+        ? true
+        : isFullResponsePartial,
+      metadataVaryPath,
+      spawnedEntries,
+      null
+    )
+  } else if (shellResponse === fullResponse) {
+    // The shell IS the full response (reference-equal — a page with nothing
+    // below its shell). One payload fulfills the spawned entries, recording
+    // the strategy that describes the CONTENT — the full payload's tier.
+    // The content tier also drives the entries' keying: content that isn't
+    // shell-grade is param-independent only on the server's vary-params
+    // evidence, so it must not be parked in the shell slot on the strength
+    // of the missing split alone (see the keying derivation in
+    // writeSegmentDataIntoCache).
+    fulfilledEntries = writeServerResponseIntoCache(
+      now,
+      fetchStrategy,
+      fullResponse,
+      baseTree,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      staleAt,
+      shellWasRequested ? true : isFullResponsePartial,
+      metadataVaryPath,
+      spawnedEntries,
+      // The full payload's tier: PPR for a static response, PPRRuntime for
+      // a runtime response (whose full payload is everything a runtime
+      // prefetch can produce when nothing lies below the shell). For a
+      // full-tier request it agrees with the request's own strategy, so
+      // only shell-tier requests pass it.
+      shellWasRequested
+        ? isStaticResponse
+          ? FetchStrategy.PPR
+          : FetchStrategy.PPRRuntime
+        : null
+    )
+  } else {
+    // The shell is a strict prefix of the response. Write both payloads.
+    // The payload matching the tier the spawned entries were requested at
+    // fulfills them; the other is written detached (no owned entries —
+    // every write is an upsert). Fulfilling a spawned shell entry with the
+    // concrete payload would store content that doesn't match the entry's
+    // shell vary path — wrong for every later read at that key, and
+    // immediately observable during a navigation, where a pending entry can
+    // be rendered as a promise that resolves to its eventual value.
+    //
+    // The full payload is written first. The order is not observable: the
+    // two writes key at different tiers, upsert precedence between a full
+    // payload and its own shell payload is order-independent (the full
+    // payload always wins the comparison — a shell segment is never
+    // complete where its full counterpart is partial, see
+    // readFulfilledIsPartial), and fulfillment pings only enqueue scheduler
+    // work that runs after this synchronous block. Full-first is preferred
+    // so the shell write's precedence checks and shadow eviction compare
+    // against the fresh concrete entry rather than whatever stale entry
+    // preceded it.
+    const fullFulfilledEntries = writeServerResponseIntoCache(
+      now,
+      // The full payload is written at the request's own tier, except for
+      // shell-tier requests: when a shell request returns more than the
+      // shell, the extra content is at least as complete as what the
+      // corresponding non-shell request would have returned — PPR for a
+      // StaticShell request, PPRRuntime for a RuntimeShell request. Record
+      // that tier so the scheduler doesn't re-request content this payload
+      // already provides. (Same rule as the coincident-shell case below.)
+      shellWasRequested
+        ? isStaticResponse
+          ? FetchStrategy.PPR
+          : FetchStrategy.PPRRuntime
+        : fetchStrategy,
+      fullResponse,
+      baseTree,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      staleAt,
+      isFullResponsePartial,
+      metadataVaryPath,
+      shellWasRequested ? null : spawnedEntries,
+      null
+    )
+    const shellFulfilledEntries = writeServerResponseIntoCache(
+      now,
+      isStaticResponse ? FetchStrategy.StaticShell : FetchStrategy.RuntimeShell,
+      shellResponse,
+      baseTree,
+      renderedPathname,
+      renderedSearch,
+      buildId,
+      // The shell payload carries its own staleness, independent of the
+      // full payload's. Shell decodes are fully buffered, so it's read
+      // synchronously; when absent (per-segment responses carry staleTime
+      // per node instead) this falls back to the same static stale time the
+      // per-segment writes use as their response-level fallback.
+      readFulfilledStaleAt(now, shellResponse.s),
+      // A shell payload is a strict subset of the full response, so it does
+      // not represent the entire UI of the target page — it's partial
+      // by construction.
+      true,
+      metadataVaryPath,
+      shellWasRequested ? spawnedEntries : null,
+      null
+    )
+    fulfilledEntries = shellWasRequested
+      ? shellFulfilledEntries
+      : fullFulfilledEntries
+  }
+
+  // Entries created by a detached write aren't sized: one wire response is
+  // only charged to the LRU once, to the entries it fulfilled.
+  if (
+    responseByteLength !== null &&
+    fulfilledEntries !== null &&
+    fulfilledEntries.length > 0
+  ) {
+    const averageSize = responseByteLength / fulfilledEntries.length
+    for (const entry of fulfilledEntries) {
+      setSizeInCacheMap(entry, averageSize)
     }
   }
   return fulfilledEntries
@@ -3034,14 +3074,11 @@ export function writeServerResponseIntoCache(
   // instead, since a standalone head response's tree has no page node.
   metadataVaryPath: PageVaryPath | null,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  // Present (non-null) for the payloads of per-segment prefetch responses,
-  // null for live-render responses. Carries the strategy tier that
-  // describes the payload's CONTENT, recorded on the entries it fulfills.
-  // Differs from `fetchStrategy` (which drives matching and keying) in one
-  // case: a StaticShell write whose payload IS the full response (no
-  // shell/full split) records PPR — see the coincident-shell write in
-  // fetchAndWritePerSegmentPrefetchResponse.
-  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell | null
+  // The strategy tier describing the CONTENT of the payload being written,
+  // when it differs from `fetchStrategy` (which drives matching and
+  // keying); null when they agree. See the param docs on
+  // writeSegmentDataIntoCache.
+  contentFetchStrategy: FetchStrategy.PPR | FetchStrategy.PPRRuntime | null
 ): Array<FulfilledSegmentCacheEntry> | null {
   // Which layer owns the buildId check differs by flow. The route and
   // segment fetch layers check it themselves (see fetchRouteOnCacheMiss and
@@ -3099,9 +3136,10 @@ export function writeServerResponseIntoCache(
 
   // Only static (per-segment) responses can be ISR fallbacks (`f`). A
   // present `u` means the response carries a stage-scoped runtime-data
-  // verdict (per-segment prefetch responses always emit one). A response
-  // without one decodes to a null verdict, and its entries record their
-  // request's own strategy unrefined (see writeSegmentDataIntoCache).
+  // verdict — per-segment prefetch responses always do, and so does the
+  // truncated initial payload, which forwards the page payload's. A
+  // response without one decodes to a null verdict, and its entries record
+  // their request's own strategy unrefined (see writeSegmentDataIntoCache).
   // `u` is deliberately read here, off THIS decode's thenable status, rather
   // than normalized where the response is fetched: the read scopes it to the
   // payload being written — a truncated shell decode reads a post-shell
@@ -3109,10 +3147,15 @@ export function writeServerResponseIntoCache(
   // itself doesn't need that data. The read is load-bearing in one direction
   // only: a false `true` costs a wasted runtime request; a false `false`
   // would record too high a tier and skip a runtime request that had more
-  // content.
+  // content. A rejected row (an aborted prerender errors rows that were
+  // still pending at the abort) must therefore read as `true`, matching the
+  // server's own read of the page payload's flag (see the `u` read in
+  // collect-segment-data.tsx).
   const isUpgradeableISRFallback = response.f === true
   const responseNeedsRuntimeRequest =
-    response.u !== undefined ? readFulfilledValue(response.u, false) : null
+    response.u !== undefined
+      ? readFulfilledValue(response.u, false, /* rejectedValue */ true)
+      : null
 
   const routeTree = navigationSeed.routeTree
   if (metadataVaryPath === null) {
@@ -3130,17 +3173,19 @@ export function writeServerResponseIntoCache(
     routeTree,
     staleAt,
     spawnedEntries,
-    payloadFetchStrategy,
+    contentFetchStrategy,
     isUpgradeableISRFallback,
     responseNeedsRuntimeRequest
   )
 
   const head = navigationSeed.head
   if (head !== null && metadataTree !== null) {
-    // Responses that carry a runtime-data verdict (the `u` read above —
-    // per-segment prefetch responses) use the decoded head partiality as
-    // authoritative: they promise-encode the head's partiality exactly, per
-    // node, via the staged encoding (see TransportSegmentData).
+    // Responses that carry a runtime-data verdict (the `u` read above) use
+    // the decoded head partiality as authoritative. Only per-segment
+    // prefetch responses additionally promise-encode the head's partiality —
+    // exactly, per node, via the staged encoding; the truncated initial
+    // payload, the other verdict-carrying response, sends the boolean form,
+    // which decodes to the response-level partiality it was written with.
     //
     // For live-render responses: when Cache Components is enabled, the
     // server's `isHeadPartial` flag (isPossiblyPartialHead in app-render.tsx)
@@ -3177,7 +3222,7 @@ export function writeServerResponseIntoCache(
       navigationSeed.headVaryParams,
       metadataTree,
       spawnedEntries,
-      payloadFetchStrategy,
+      contentFetchStrategy,
       isUpgradeableISRFallback,
       responseNeedsRuntimeRequest
     )
@@ -3212,7 +3257,7 @@ function writeTreeDataIntoCache(
   tree: RouteTree<RSCSegmentData | null>,
   staleAt: number,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell | null,
+  contentFetchStrategy: FetchStrategy.PPR | FetchStrategy.PPRRuntime | null,
   isUpgradeableISRFallback: boolean,
   responseNeedsRuntimeRequest: boolean | null
 ) {
@@ -3235,7 +3280,7 @@ function writeTreeDataIntoCache(
       data.varyParams,
       tree,
       spawnedEntries,
-      payloadFetchStrategy,
+      contentFetchStrategy,
       isUpgradeableISRFallback,
       responseNeedsRuntimeRequest
     )
@@ -3258,7 +3303,7 @@ function writeTreeDataIntoCache(
         childTree,
         staleAt,
         spawnedEntries,
-        payloadFetchStrategy,
+        contentFetchStrategy,
         isUpgradeableISRFallback,
         responseNeedsRuntimeRequest
       )
@@ -3288,47 +3333,64 @@ function writeSegmentDataIntoCache(
   segmentVaryParams: Set<string> | null,
   tree: RouteTree<RSCSegmentData | null>,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  // Non-null for the payloads of per-segment prefetch responses: the
-  // strategy tier describing the CONTENT of the payload this write came
-  // from, which drives the keying fallback and recorded tier below. Null
-  // for live-render responses. See writeServerResponseIntoCache.
-  payloadFetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell | null,
+  // The strategy tier describing the CONTENT of the payload this write came
+  // from, when it differs from the write's own `fetchStrategy` (which
+  // drives matching and keying); null when they agree. It differs only for
+  // the coincident-shell case: a write that fulfills shell-keyed entries
+  // with a payload that IS the full response passes the full payload's tier
+  // (PPR for a per-segment static response, PPRRuntime for a RuntimeShell
+  // response) — see writeResponsePayloadsIntoCache.
+  contentFetchStrategy: FetchStrategy.PPR | FetchStrategy.PPRRuntime | null,
   // Whether the response is an upgradeable fallback shell. Always false for
   // live-render responses — they are never ISR fallbacks.
   isUpgradeableISRFallback: boolean,
   // The response's runtime-data verdict: whether the render that produced
   // this payload accessed runtime data (page-global; combined with the
   // segment's own `isPartial` to decide the tier the entry records below).
-  // Null when the response carries no verdict (`u`), in which case the
-  // entry records the request's own strategy unrefined.
+  // Null when the response carries no verdict (`u`) — per-segment prefetch
+  // responses and the truncated initial payload emit one — in which case
+  // the entry records the payload's tier unrefined.
   responseNeedsRuntimeRequest: boolean | null
 ) {
+  // The strategy tier recorded on the entry — the tier of the content that
+  // actually satisfied it, which spans both axes: shell-vs-concrete AND
+  // static-vs-runtime. The payload's content tier (`fetchStrategy`, unless
+  // the caller passed a distinct `contentFetchStrategy`), refined by the
+  // response's runtime-data verdict when it carries one:
+  //
   // A runtime prefetch can only provide more content than this entry if the
   // render accessed runtime data AND this particular segment has holes — a
   // fully static segment gains nothing from a runtime request no matter
-  // what the page accessed.
-  const needsRuntimeRequest = responseNeedsRuntimeRequest === true && isPartial
-
-  // An entry records the tier of the content that actually satisfied it,
-  // which spans both axes: shell-vs-concrete AND static-vs-runtime.
-  //
-  // When this payload fully satisfied the segment — no runtime request
-  // needed — the content is as complete as a RUNTIME response of the same
-  // variant would have been, so it records that runtime tier. That's what
-  // lets the scheduler decide "would a runtime request return more?" by
-  // comparing tiers alone, with no separate signal to consult.
-  //
-  // Otherwise the content is only as complete as the static tier it was
-  // requested at, so a follow-up runtime request can still supersede it.
-  //
-  // A response that carries no verdict (live-render responses) records the
-  // request's own strategy unrefined.
-  const recordedFetchStrategy =
-    responseNeedsRuntimeRequest !== null && !needsRuntimeRequest
-      ? payloadFetchStrategy === FetchStrategy.StaticShell
+  // what the page accessed. When this payload fully satisfied the segment —
+  // no runtime request needed — the content is as complete as a RUNTIME
+  // response of the same variant would have been, so it records that
+  // runtime tier. That's what lets the scheduler decide "would a runtime
+  // request return more?" by comparing tiers alone, with no separate signal
+  // to consult. Otherwise the content is only as complete as the static
+  // tier it was requested at, so a follow-up runtime request can still
+  // supersede it.
+  let recordedFetchStrategy: FetchStrategy
+  if (responseNeedsRuntimeRequest === null) {
+    // The response carries no verdict (live-render responses): record
+    // the payload's tier as-is.
+    recordedFetchStrategy = contentFetchStrategy ?? fetchStrategy
+  } else if (responseNeedsRuntimeRequest && isPartial) {
+    // A runtime request would provide more than this payload, so no runtime
+    // tier is recorded — but the entry must still honor the payload's
+    // CONTENT grade. In the coincident-shell case the payload that satisfied
+    // a shell-keyed entry IS the full response, whose content grades at the
+    // concrete static tier (`contentFetchStrategy`, PPR — the verdict only
+    // rides static-family responses, so no higher grade can appear here).
+    // The verdict is consistent with that grade: it says the runtime tiers
+    // would provide more, which they would over PPR just as over the shell
+    // tier.
+    recordedFetchStrategy = contentFetchStrategy ?? fetchStrategy
+  } else {
+    recordedFetchStrategy =
+      (contentFetchStrategy ?? fetchStrategy) === FetchStrategy.StaticShell
         ? FetchStrategy.RuntimeShell
         : FetchStrategy.PPRRuntime
-      : fetchStrategy
+  }
 
   // Decide whether to re-key the entry under a more generic vary path based on
   // which params the segment actually depends on.
@@ -3342,7 +3404,7 @@ function writeSegmentDataIntoCache(
   // unrelated URLs read each other's content from the cache.
   //
   // Key the entry by which params the server said this segment depends on
-  // (judged by the payload's CONTENT: payloadFetchStrategy differs from
+  // (judged by the payload's CONTENT: contentFetchStrategy differs from
   // fetchStrategy exactly when a shell request's response turned out to
   // carry more — the coincident case). Reusing one copy across param values
   // is the point of the shell, but it requires knowing the content doesn't
@@ -3356,7 +3418,7 @@ function writeSegmentDataIntoCache(
   // which reduces param-dependent content to param fallbacks, so it really
   // is good for any value of them (its request path below IS the shell
   // vary path).
-  const payloadStrategy = payloadFetchStrategy ?? fetchStrategy
+  const payloadStrategy = contentFetchStrategy ?? fetchStrategy
   let fulfilledVaryPath: SegmentVaryPath | null = null
   if (
     process.env.__NEXT_VARY_PARAMS &&
@@ -3635,11 +3697,11 @@ function addSegmentPathToUrlInOutputExportMode(
  *
  * Generally, when an app uses dynamic data, a "more specific" fetch strategy is expected to provide more content:
  * - `LoadingBoundary` only provides static layouts
- * - `StaticShell` provides the App Shell variant extracted from a static response —
+ * - `StaticShell` provides the shell-stage variant extracted from a static response —
  *   param-dependent content reduced to pending fallbacks, and never any content that
  *   depends on session data (cookies, headers)
- * - `RuntimeShell` provides the App Shell rendered by a runtime request, which can
- *   additionally include shell content that depends on session data
+ * - `RuntimeShell` provides the shell stage rendered by a runtime request, which can
+ *   additionally include shell-stage content that depends on session data
  * - `PPR` can provide shells for each segment (even for segments that use dynamic data),
  *   including prerendered param-dependent content at concrete paths
  * - `PPRRuntime` can additionally include content that uses searchParams, params, or cookies
@@ -3787,8 +3849,17 @@ export function spawnStaticStageCacheWrite(
 /**
  * Decodes an embedded runtime prefetch Flight stream and writes it into the
  * segment cache, so subsequent navigations can serve runtime-prefetchable
- * content from cache without a separate prefetch request. This flow owns no
- * pending entries, so every write is a detached upsert.
+ * content from cache without a separate prefetch request.
+ *
+ * The stream is buffered before it's decoded, like every prefetch response
+ * that carries cache metadata: the shell byte offset (`a`) and staleTime are
+ * read synchronously off their thenable status, and extracting a distinct
+ * shell stage requires re-decoding a truncated copy of the same bytes. The
+ * writes go through the shared payload-pair orchestration
+ * (writeResponsePayloadsIntoCache): the full payload is written at
+ * PPRRuntime and a distinct shell stage at the shell tier (RuntimeShell),
+ * like any other runtime prefetch response. This flow owns no pending
+ * entries, so every write is a detached upsert.
  */
 export async function writeRuntimePrefetchStreamIntoCache(
   now: number,
@@ -3798,31 +3869,59 @@ export async function writeRuntimePrefetchStreamIntoCache(
 ): Promise<void> {
   const { stream, isPartial } = await stripIsPartialByte(runtimePrefetchStream)
 
-  const serverData =
-    await createFromNextReadableStream<NavigationFlightResponse>(
-      stream,
-      undefined,
-      { allowPartialStream: true }
-    )
+  const buffer = await bufferPrefetchResponseBody(stream)
+  const serverData = await decodeBufferedStage<NavigationFlightResponse>(
+    buffer,
+    undefined
+  )
 
-  const staleAt = await resolveStaleAt(now, serverData.s)
+  // Extract the shell payload, when the response carries one. Same wire
+  // convention as the other live-render responses (see
+  // resolveShellStageResponse): `a` absent means the render wasn't staged —
+  // no shell exists; `null` means the shell IS the full response; a number
+  // is the byte boundary of a distinct shell prefix, which is re-decoded
+  // from a truncated copy of the buffer. An unreadable `a` — pending or
+  // rejected, which only an aborted render produces — conservatively reads
+  // as no shell: the full payload is still written, there's just no shell
+  // stage to extract from it.
+  let shellResponse: NavigationFlightResponse | null = null
+  if (serverData.a !== undefined) {
+    const shellByteLength = readFulfilledValue(serverData.a, undefined)
+    if (shellByteLength === null) {
+      shellResponse = serverData
+    } else if (shellByteLength !== undefined) {
+      try {
+        shellResponse = await decodeBufferedStage<NavigationFlightResponse>(
+          buffer.subarray(0, shellByteLength),
+          undefined
+        )
+      } catch {
+        // The truncated prefix couldn't be decoded. Treat it as if no shell
+        // exists; the full payload is still usable.
+        shellResponse = null
+      }
+    }
+  }
 
-  writeServerResponseIntoCache(
+  writeResponsePayloadsIntoCache(
     now,
     // A runtime prefetch stream is by definition a runtime prefetch.
     FetchStrategy.PPRRuntime,
     serverData,
+    shellResponse,
     baseTree,
     // Navigation responses always include the param values in the tree, so
     // there's no pathname to parse them from (nor a need to).
     null,
     renderedSearch,
     serverData.b,
-    staleAt,
+    // The response is fully buffered, so staleTime is read synchronously.
+    readFulfilledStaleAt(now, serverData.s),
     isPartial,
     null,
     // This flow owns no pending entries; every write is a detached upsert.
     null,
+    // Detached writes aren't sized; see writeResponsePayloadsIntoCache.
     null
   )
 }

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -785,7 +785,10 @@ export function matchKnownRoute(
     // This shouldn't be reachable for a valid route tree.
     return null
   }
-  const reifiedMetadata = createMetadataRouteTree(metadataVaryPath)
+  const reifiedMetadata = createMetadataRouteTree(
+    metadataVaryPath,
+    reifiedTree.prefetchHints
+  )
 
   // Create a synthetic (predicted) entry and store it as the new pattern.
   //

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -221,8 +221,10 @@ const enum PrefetchTaskExitStatus {
  * before per-link work:
  *
  * - RouteTree: fetch the route's tree structure.
- * - Shell: fetch the route's reusable App Shell (param-free loading state),
- *   if the route can produce one and the feature is enabled. Bounded by
+ * - Shell: fetch each segment's shell-stage variant, keyed to be reusable
+ *   across all params below the root (root params are kept) — the phase's
+ *   target is the conceptual App Shell. Runs if the route can produce a
+ *   shell and the feature is enabled. Bounded by
  *   filesystem-route count, not link count — so all Shell prefetches across
  *   queued tasks complete before any Speculative prefetch runs, because
  *   shell responses are shared across every navigation to the same route.
@@ -872,10 +874,11 @@ function pingRootRouteTree(
 
           // Derive the static walk's parameters once per pass; the walk
           // functions below receive them as arguments and are phase-agnostic.
-          // During the Shell phase the walk targets the App Shell variant of
-          // each segment (keyed at the shell vary paths); otherwise it's the
-          // ordinary per-segment static strategy. This is the only place the
-          // phase is consulted — everything below keys off the strategy.
+          // During the Shell phase the walk requests each segment's
+          // shell-stage variant (keyed at the shell vary paths); otherwise
+          // it's the ordinary per-segment static strategy. This is the only
+          // place the phase is consulted — everything below keys off
+          // the strategy.
           const staticWalkStrategy =
             task.phase === PrefetchPhase.Shell
               ? FetchStrategy.StaticShell
@@ -976,7 +979,7 @@ function pingRootRouteTree(
             // and fall through to Speculative.
             return PrefetchTaskExitStatus.Done
           }
-          // Prefetch multiple segments using a single dynamic request.
+          // Prefetch multiple segments using a single runtime request.
           // TODO: We can consolidate this branch with previous one by modeling
           // it as if the first segment in the new tree has runtime prefetching
           // enabled. Will do this as a follow-up refactor. Might want to remove
@@ -1067,7 +1070,7 @@ function pingStaticHead(
   fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): void {
   // The head is subject to the same per-pass runtime-completeness contract
-  // as the route's segments: during an App Shell walk, and during any walk
+  // as the route's segments: during a StaticShell walk, and during any walk
   // of a Partial Prefetching route, the head needs a response at least as
   // complete as a runtime one.
   const headRequiresRuntimeCompleteness = walkRequiresRuntimeCompleteness(
@@ -1137,10 +1140,10 @@ function pingStaticHead(
  *   with a partial-prefetching config, or the global `partialPrefetching`
  *   flag — both surfaced as SubtreeHasPartialPrefetching on the route
  *   root), in both the Shell and Speculative phases.
- * - Every App Shell (StaticShell) walk, because the App Shell must be
- *   reusable across all params by definition. (In practice this is implied
- *   by the first case — the Shell phase only runs for Partial Prefetching
- *   routes.)
+ * - Every StaticShell walk — the Shell phase's walk, whose target (the
+ *   conceptual App Shell) must be reusable across all params by definition.
+ *   (In practice this is implied by the first case — the Shell phase only
+ *   runs for Partial Prefetching routes.)
  *
  * Routes without Partial Prefetching keep the static-only contract: their
  * walks prefetch static data and partial entries are acceptable — the
@@ -1176,8 +1179,9 @@ function walkRequiresRuntimeCompleteness(
 /**
  * The runtime counterpart of a pass's static walk strategy: the strategy the
  * batched runtime request uses if this walk deopts. Each phase has exactly one
- * — the Shell phase escalates to a runtime App Shell, the Speculative phase to
- * a per-link concrete runtime prefetch.
+ * — the Shell phase escalates to a shell-scoped runtime request
+ * (RuntimeShell), the Speculative phase to a per-link concrete
+ * runtime prefetch.
  */
 function getRuntimeStrategyForWalk(
   staticWalkStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
@@ -1575,7 +1579,7 @@ function diffRouteTreeAgainstCurrent(
         switch (fetchStrategy) {
           case FetchStrategy.LoadingBoundary: {
             // When PPR is disabled, we can't prefetch per segment. We must
-            // fallback to the old prefetch behavior and send a dynamic request.
+            // fallback to the old prefetch behavior and send a runtime request.
             // Only routes that include a loading boundary can be prefetched in
             // this way.
             //

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -2068,7 +2068,9 @@ function pingRuntimePrefetches(
  * produced the entry). The callers surface this signal to the per-segment
  * decision point in pingNewPartOfCacheComponentsTree (and its analog for
  * the head in pingStaticHead), which uses it during a static attempt to
- * decide whether to fall back to a runtime prefetch.
+ * decide whether to fall back to a runtime prefetch. One exception withholds
+ * the signal: a shell-tier entry whose segment carries the static-attempt
+ * hint spawns a concrete static attempt first — see the Fulfilled case.
  */
 function pingSegmentBundle(
   now: number,
@@ -2086,8 +2088,8 @@ function pingSegmentBundle(
   // already settled or in flight: the chain's terminal segments are inside
   // the deopted subtree, and re-fetching their static bundle would at best
   // duplicate the runtime request and at worst replace a runtime-complete
-  // entry (e.g. a runtime App Shell) with a less complete static fallback
-  // response.
+  // entry (e.g. a RuntimeShell-tier entry) with a less complete static
+  // fallback response.
   spawnRevalidations: boolean
 ): boolean {
   let needsRuntimeRequest = false
@@ -2208,10 +2210,40 @@ function pingSegmentBundle(
           nodeEntry,
           fetchStrategy
         )
-        if (runtimeWouldProvideMore) {
+
+        // A shell-tier cached entry (StaticShell or RuntimeShell recorded
+        // tier) is not evidence that a static attempt at this walk's tier
+        // would be pointless — unlike a concrete static (PPR) entry, where a
+        // static re-fetch would return the same bytes. So when the segment's
+        // hint says a static attempt is worthwhile (the build-time prerender
+        // accessed no runtime data), treat the entry like a less complete
+        // one: take the static attempt path below (the revalidation) instead
+        // of deopting straight to a runtime request, and let the response's
+        // own verdict decide — as for any static attempt — whether to
+        // escalate afterward. The attempt can't recur: its response records
+        // at least the concrete static tier, which fails the shell-tier
+        // check here on the re-run pass.
+        const shellEntryEligibleForStaticAttempt =
+          (nodeEntry.fetchStrategy === FetchStrategy.StaticShell ||
+            nodeEntry.fetchStrategy === FetchStrategy.RuntimeShell) &&
+          (nodeTree.prefetchHints &
+            PrefetchHint.ShouldAttemptStaticPrefetch) !==
+            0 &&
+          // A StaticShell walk's static attempt is the shell tier itself, so
+          // it only applies when the walk's static strategy outranks
+          // the entry.
+          canNewFetchStrategyProvideMoreContent(
+            nodeEntry.fetchStrategy,
+            fetchStrategy
+          )
+
+        if (runtimeWouldProvideMore && !shellEntryEligibleForStaticAttempt) {
           // A runtime request would return more content for this segment
           // than the entry contains. Surface it via the return value, so the
-          // caller can deopt this subtree to a runtime prefetch.
+          // caller can deopt this subtree to a runtime prefetch. (An
+          // eligible shell-tier entry withholds the signal for this pass:
+          // the static attempt spawned below blocks the task, and the re-run
+          // pass reads the attempt's result instead.)
           needsRuntimeRequest = true
         }
 
@@ -2222,11 +2254,12 @@ function pingSegmentBundle(
         // re-fetched.
         //
         // Exception: when a runtime request would return more AND this walk
-        // permits one, skip the static path entirely. The runtime request
-        // covers this segment and supersedes anything a static fetch could
-        // add, so a static upgrade would at best duplicate it — delivering
-        // the same content twice — and at worst replace runtime content with
-        // static content.
+        // permits one, skip the static path entirely — unless the entry is
+        // an eligible shell-tier entry (see above), whose static attempt IS
+        // this upgrade. Otherwise the runtime request covers this segment
+        // and supersedes anything a static fetch could add, so a static
+        // upgrade would at best duplicate it — delivering the same content
+        // twice — and at worst replace runtime content with static content.
         //
         // When no runtime request is permitted, the signal is irrelevant:
         // nothing can act on it, so it must not suppress the static upgrade.
@@ -2234,6 +2267,7 @@ function pingSegmentBundle(
         // cached shell.
         const willBeSupersededByRuntimeRequest =
           runtimeWouldProvideMore &&
+          !shellEntryEligibleForStaticAttempt &&
           walkRequiresRuntimeCompleteness(fetchStrategy, route)
 
         // Check if we should attempt to upgrade a fallback ISR response to

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -1236,6 +1236,54 @@ function wouldRuntimeRequestProvideMore(
 }
 
 /**
+ * Whether a fulfilled shell-tier entry should take a static attempt (a
+ * spawned revalidation at the walk's static tier) before its position deopts
+ * to a runtime request. A shell-tier recorded entry (StaticShell or
+ * RuntimeShell) is not evidence that a static attempt would be pointless —
+ * unlike a concrete static (PPR) entry, where a static re-fetch would return
+ * the same bytes — so when the segment's hint says a static attempt is
+ * worthwhile (the build-time prerender accessed no runtime data), the
+ * attempt is taken and its response's own verdict decides whether to
+ * escalate afterward.
+ *
+ * Consults the revalidation slot so an attempt that already ran and settled
+ * without healing the entry (a rejected attempt: server miss or network
+ * error; a successful one upserts over the shell-tier entry, so the caller
+ * reads the healed entry instead) doesn't suppress the runtime deopt
+ * forever. The slot read creates an Empty placeholder on first evaluation —
+ * there is no read-only variant — which is harmless: when the entry is
+ * eligible, the spawn that follows claims the same slot.
+ */
+function isShellEntryEligibleForStaticAttempt(
+  now: number,
+  map: CacheMap<SegmentCacheEntry>,
+  entry: SegmentCacheEntry,
+  tree: RouteTree<null>,
+  fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
+): boolean {
+  if (
+    (entry.fetchStrategy !== FetchStrategy.StaticShell &&
+      entry.fetchStrategy !== FetchStrategy.RuntimeShell) ||
+    (tree.prefetchHints & PrefetchHint.ShouldAttemptStaticPrefetch) === 0 ||
+    // A StaticShell walk's static attempt is the shell tier itself, so it
+    // only applies when the walk's static strategy outranks the entry.
+    !canNewFetchStrategyProvideMoreContent(entry.fetchStrategy, fetchStrategy)
+  ) {
+    return false
+  }
+  const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
+    now,
+    map,
+    fetchStrategy,
+    tree
+  )
+  return (
+    revalidatingEntry.status === EntryStatus.Empty ||
+    revalidatingEntry.status === EntryStatus.Pending
+  )
+}
+
+/**
  * Register a subtree root (or the head's metadata key) for the batched
  * runtime request issued by the gate at the end of pingRootRouteTree.
  */
@@ -2090,7 +2138,9 @@ function pingRuntimePrefetches(
  * produced the entry). The callers surface this signal to the per-segment
  * decision point in pingNewPartOfCacheComponentsTree (and its analog for
  * the head in pingStaticHead), which uses it during a static attempt to
- * decide whether to fall back to a runtime prefetch.
+ * decide whether to fall back to a runtime prefetch. One exception withholds
+ * the signal: a shell-tier entry whose segment carries the static-attempt
+ * hint spawns a concrete static attempt first — see the Fulfilled case.
  */
 function pingSegmentBundle(
   now: number,
@@ -2108,8 +2158,8 @@ function pingSegmentBundle(
   // already settled or in flight: the chain's terminal segments are inside
   // the deopted subtree, and re-fetching their static bundle would at best
   // duplicate the runtime request and at worst replace a runtime-complete
-  // entry (e.g. a runtime App Shell) with a less complete static fallback
-  // response.
+  // entry (e.g. a RuntimeShell-tier entry) with a less complete static
+  // fallback response.
   spawnRevalidations: boolean
 ): boolean {
   let needsRuntimeRequest = false
@@ -2226,10 +2276,30 @@ function pingSegmentBundle(
           nodeEntry,
           fetchStrategy
         )
-        if (runtimeWouldProvideMore) {
+
+        // An eligible shell-tier entry takes the static attempt path below
+        // (the revalidation) instead of deopting straight to a runtime
+        // request; see isShellEntryEligibleForStaticAttempt. The attempt
+        // can't recur: its response records at least the concrete static
+        // tier, which fails the shell-tier check on the re-run pass — and an
+        // attempt that already settled without healing the entry reads as
+        // ineligible, so the deopt proceeds after all.
+        const shellEntryEligibleForStaticAttempt =
+          isShellEntryEligibleForStaticAttempt(
+            now,
+            task.segmentCacheMap,
+            nodeEntry,
+            nodeTree,
+            fetchStrategy
+          )
+
+        if (runtimeWouldProvideMore && !shellEntryEligibleForStaticAttempt) {
           // A runtime request would return more content for this segment
           // than the entry contains. Surface it via the return value, so the
-          // caller can deopt this subtree to a runtime prefetch.
+          // caller can deopt this subtree to a runtime prefetch. (An
+          // eligible shell-tier entry withholds the signal for this pass:
+          // the static attempt spawned below blocks the task, and the re-run
+          // pass reads the attempt's result instead.)
           needsRuntimeRequest = true
         }
 
@@ -2240,11 +2310,12 @@ function pingSegmentBundle(
         // re-fetched.
         //
         // Exception: when a runtime request would return more AND this walk
-        // permits one, skip the static path entirely. The runtime request
-        // covers this segment and supersedes anything a static fetch could
-        // add, so a static upgrade would at best duplicate it — delivering
-        // the same content twice — and at worst replace runtime content with
-        // static content.
+        // permits one, skip the static path entirely — unless the entry is
+        // an eligible shell-tier entry (see above), whose static attempt IS
+        // this upgrade. Otherwise the runtime request covers this segment
+        // and supersedes anything a static fetch could add, so a static
+        // upgrade would at best duplicate it — delivering the same content
+        // twice — and at worst replace runtime content with static content.
         //
         // When no runtime request is permitted, the signal is irrelevant:
         // nothing can act on it, so it must not suppress the static upgrade.
@@ -2252,6 +2323,7 @@ function pingSegmentBundle(
         // cached shell.
         const willBeSupersededByRuntimeRequest =
           runtimeWouldProvideMore &&
+          !shellEntryEligibleForStaticAttempt &&
           walkRequiresRuntimeCompleteness(fetchStrategy, route)
 
         // Check if we should attempt to upgrade a fallback ISR response to
@@ -2306,7 +2378,11 @@ function pingSegmentBundle(
               // pass depends on its response. Wait for it before the phase
               // can complete. (A settled revalidation we chose not to use
               // needs no waiting and is not a prefetch failure — the base
-              // entry here is already Fulfilled.)
+              // entry here is already Fulfilled. A settled revalidation
+              // can't strand an eligible shell-tier entry either:
+              // isShellEntryEligibleForStaticAttempt reads the slot, so a
+              // settled attempt makes the entry ineligible and the runtime
+              // deopt proceeds above.)
               blockTaskOnPendingResponse(task, revalidatingEntry)
             }
           }
@@ -2398,10 +2474,21 @@ function accumulateSegmentBundle(
       // ping only reaches the terminal descendant, and if that descendant is
       // itself a decision point it consumes the signal for its own subtree,
       // leaving this ancestor's insufficiency invisible to the decision
-      // point above it.
+      // point above it. An eligible shell-tier entry withholds the signal,
+      // the same exception the bundle ping applies: deopting here would
+      // pre-empt the static attempt the chain ping spawns for this node when
+      // it reaches the terminal descendant (its Fulfilled case runs for
+      // every node in the chain).
       needsRuntimeRequest:
         segment.status === EntryStatus.Fulfilled &&
-        wouldRuntimeRequestProvideMore(segment, fetchStrategy),
+        wouldRuntimeRequestProvideMore(segment, fetchStrategy) &&
+        !isShellEntryEligibleForStaticAttempt(
+          now,
+          task.segmentCacheMap,
+          segment,
+          tree,
+          fetchStrategy
+        ),
     }
   }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -234,8 +234,10 @@ const enum PrefetchTaskExitStatus {
  * before per-link work:
  *
  * - RouteTree: fetch the route's tree structure.
- * - Shell: fetch the route's reusable App Shell (param-free loading state),
- *   if the route can produce one and the feature is enabled. Bounded by
+ * - Shell: fetch each segment's shell-stage variant, keyed to be reusable
+ *   across all params below the root (root params are kept) — the phase's
+ *   target is the conceptual App Shell. Runs if the route can produce a
+ *   shell and the feature is enabled. Bounded by
  *   filesystem-route count, not link count — so all Shell prefetches across
  *   queued tasks complete before any Speculative prefetch runs, because
  *   shell responses are shared across every navigation to the same route.
@@ -895,10 +897,11 @@ function pingRootRouteTree(
 
           // Derive the static walk's parameters once per pass; the walk
           // functions below receive them as arguments and are phase-agnostic.
-          // During the Shell phase the walk targets the App Shell variant of
-          // each segment (keyed at the shell vary paths); otherwise it's the
-          // ordinary per-segment static strategy. This is the only place the
-          // phase is consulted — everything below keys off the strategy.
+          // During the Shell phase the walk requests each segment's
+          // shell-stage variant (keyed at the shell vary paths); otherwise
+          // it's the ordinary per-segment static strategy. This is the only
+          // place the phase is consulted — everything below keys off
+          // the strategy.
           const staticWalkStrategy =
             task.phase === PrefetchPhase.Shell
               ? FetchStrategy.StaticShell
@@ -999,7 +1002,7 @@ function pingRootRouteTree(
             // and fall through to Speculative.
             return PrefetchTaskExitStatus.Done
           }
-          // Prefetch multiple segments using a single dynamic request.
+          // Prefetch multiple segments using a single runtime request.
           // TODO: We can consolidate this branch with previous one by modeling
           // it as if the first segment in the new tree has runtime prefetching
           // enabled. Will do this as a follow-up refactor. Might want to remove
@@ -1090,7 +1093,7 @@ function pingStaticHead(
   fetchStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
 ): void {
   // The head is subject to the same per-pass runtime-completeness contract
-  // as the route's segments: during an App Shell walk, and during any walk
+  // as the route's segments: during a StaticShell walk, and during any walk
   // of a Partial Prefetching route, the head needs a response at least as
   // complete as a runtime one.
   const headRequiresRuntimeCompleteness = walkRequiresRuntimeCompleteness(
@@ -1160,10 +1163,10 @@ function pingStaticHead(
  *   with a partial-prefetching config, or the global `partialPrefetching`
  *   flag — both surfaced as SubtreeHasPartialPrefetching on the route
  *   root), in both the Shell and Speculative phases.
- * - Every App Shell (StaticShell) walk, because the App Shell must be
- *   reusable across all params by definition. (In practice this is implied
- *   by the first case — the Shell phase only runs for Partial Prefetching
- *   routes.)
+ * - Every StaticShell walk — the Shell phase's walk, whose target (the
+ *   conceptual App Shell) must be reusable across all params by definition.
+ *   (In practice this is implied by the first case — the Shell phase only
+ *   runs for Partial Prefetching routes.)
  *
  * Routes without Partial Prefetching keep the static-only contract: their
  * walks prefetch static data and partial entries are acceptable — the
@@ -1199,8 +1202,9 @@ function walkRequiresRuntimeCompleteness(
 /**
  * The runtime counterpart of a pass's static walk strategy: the strategy the
  * batched runtime request uses if this walk deopts. Each phase has exactly one
- * — the Shell phase escalates to a runtime App Shell, the Speculative phase to
- * a per-link concrete runtime prefetch.
+ * — the Shell phase escalates to a shell-scoped runtime request
+ * (RuntimeShell), the Speculative phase to a per-link concrete
+ * runtime prefetch.
  */
 function getRuntimeStrategyForWalk(
   staticWalkStrategy: FetchStrategy.PPR | FetchStrategy.StaticShell
@@ -1598,7 +1602,7 @@ function diffRouteTreeAgainstCurrent(
         switch (fetchStrategy) {
           case FetchStrategy.LoadingBoundary: {
             // When PPR is disabled, we can't prefetch per segment. We must
-            // fallback to the old prefetch behavior and send a dynamic request.
+            // fallback to the old prefetch behavior and send a runtime request.
             // Only routes that include a loading boundary can be prefetched in
             // this way.
             //

--- a/packages/next/src/client/components/segment-cache/types.ts
+++ b/packages/next/src/client/components/segment-cache/types.ts
@@ -38,14 +38,23 @@ export const enum FetchStrategy {
   // canNewFetchStrategyProvideMoreContent in cache.ts for what each tier can
   // contain relative to the others.
   //
+  // Full and LoadingBoundary belong to the non-Partial-Prefetching regime:
+  // they're only relevant in modes where the staging concepts (shell tiers,
+  // runtime prefetches) don't apply. They sit on this single ordered ladder
+  // as an accepted convenience, because cross-regime comparisons exist
+  // (e.g. canNewFetchStrategyProvideMoreContent).
+  //
   // These numeric values are client-internal and never cross the wire — the
   // `next-router-prefetch` request header values are mapped explicitly in
   // fetchSegmentPrefetchesUsingRuntimeRequest (cache.ts) — so the members can
   // be renumbered freely as long as the relative order is preserved.
   LoadingBoundary = 0,
-  // The App Shell variant extracted from a static per-segment prefetch
+  // The shell-stage variant extracted from a static per-segment prefetch
   // response: every segment's param-dependent content is reduced to pending
-  // references that render as the param fallback. Less complete than
+  // references that render as the param fallback, keyed at the shell vary
+  // paths (only root params kept concrete). The Shell PHASE that issues
+  // these requests targets the conceptual App Shell; the strategy itself is
+  // just this mechanical truncation and keying. Less complete than
   // RuntimeShell — a static response can't include content that depends on
   // session data (cookies, headers) — and less complete than PPR at concrete
   // paths, which includes prerendered param-dependent content.

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -207,8 +207,10 @@ export async function collectSegmentData(
       // row reads as `false`: a successful render always settles the flag
       // (prerender completion resolves `false`), so a pending row can only
       // appear in an aborted render's buffer, where it means no access was
-      // recorded before the abort.
-      runtimeDataAccessed = readFulfilledValue(pagePayload.u, false)
+      // recorded before the abort. A rejected row reads as `true`,
+      // conservatively — an abort errors rows that were still pending when
+      // it happened.
+      runtimeDataAccessed = readFulfilledValue(pagePayload.u, false, true)
     }
   } catch {}
 


### PR DESCRIPTION
A response may contain two payloads: the full response, plus a shell stage that the client obtains by decoding the same bytes again, truncated at the shell byte offset. Each flow had its own copy of the logic that decides which payload fulfills the pending entries and what fetch strategy each write records. Those copies are replaced by a single function, writeResponsePayloadsIntoCache. The embedded runtime prefetch stream, which previously ignored the byte offset entirely, now goes through it too.

When a shell request receives more than it asked for, the extra content is at least as complete as what the corresponding non-shell request would have returned, so that's the strategy the write records: PPR for a StaticShell request, PPRRuntime for a RuntimeShell request. Previously some of these writes under-recorded, causing the scheduler to issue runtime requests for content it already had. A rejected needsRuntimeRequest row now also reads conservatively (as true) on the client, matching how the server reads the same flag.

The second commit fixes an oversight where a static prefetch attempt was mistakenly skipped: when the scheduler found a cached entry that was only a shell, it deopted straight to a runtime request even though the full static response contains more and the segment's hint says a static attempt is worthwhile. A shell entry with the hint now takes the normal static revalidation path first, and the response's own signals decide whether to escalate afterward.
