### PR TITLE
fix(turbo-tasks): keep the foreground-job counter balanced when a once-process panics

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/once_process_panic.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/once_process_panic.rs
@@ -1,0 +1,36 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::time::Duration;
+
+use turbo_tasks::TurboTasks;
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
+
+/// A once-process whose future panics must not corrupt the foreground-job
+/// counter: `start_once_process` finishes the job before awaiting the future
+/// and re-begins it after; without a drop-safe guard, a panic skips the
+/// re-begin and underflows the counter (wrapping to `usize::MAX`), so
+/// `stop_and_wait` would never return and the manager never reports idle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_once_process_panic_balances_foreground_jobs() {
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions::default(),
+        noop_backing_storage(),
+    ));
+
+    // A normal once-process completes fine...
+    tt.start_once_process(Box::pin(async {}));
+    // ...and one whose future panics.
+    tt.start_once_process(Box::pin(async {
+        panic!("intentional once-process panic");
+    }));
+
+    // Let the once processes run.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Pre-fix, the counter underflowed and this never returned.
+    tokio::time::timeout(Duration::from_secs(30), tt.stop_and_wait())
+        .await
+        .expect("stop_and_wait hung: foreground job counter underflowed");
+}

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -627,6 +627,18 @@ task_local! {
     pub(crate) static SUPPRESS_EVENTUAL_CONSISTENCY_TOP_LEVEL_TASK_CHECK: bool;
 }
 
+/// Re-begins a paused foreground job on drop, so
+/// `start_once_process`'s deliberate finish/begin imbalance stays balanced
+/// even if the process future panics (its unwinding drops this guard) or is
+/// cancelled.
+struct PausedForegroundJobGuard<B: Backend + 'static>(Arc<TurboTasks<B>>);
+
+impl<B: Backend + 'static> Drop for PausedForegroundJobGuard<B> {
+    fn drop(&mut self) {
+        self.0.begin_foreground_job();
+    }
+}
+
 impl<B: Backend + 'static> TurboTasks<B> {
     // TODO better lifetime management for turbo tasks
     // consider using unsafe for the task_local turbo tasks
@@ -768,8 +780,11 @@ impl<B: Backend + 'static> TurboTasks<B> {
             this.pin()
                 .run_once(async move {
                     this.finish_foreground_job();
+                    // Re-begins the job on drop — on normal completion, on
+                    // panic unwind, and on cancellation — so the counter
+                    // can't underflow.
+                    let _guard = PausedForegroundJobGuard(this.clone());
                     future.await;
-                    this.begin_foreground_job();
                     Ok(())
                 })
                 .await
@@ -928,11 +943,19 @@ impl<B: Backend + 'static> TurboTasks<B> {
     }
 
     fn finish_foreground_job(&self) {
-        if self
-            .currently_scheduled_foreground_jobs
-            .fetch_sub(1, Ordering::AcqRel)
-            == 1
-        {
+        // The counter must never underflow: if it does, something is badly
+        // wrong (an unbalanced begin/finish pair) — clamp at 0 instead of
+        // wrapping to usize::MAX, which would permanently break idle
+        // detection and hang stop_and_wait().
+        let prev = self.currently_scheduled_foreground_jobs.try_update(
+            Ordering::AcqRel,
+            Ordering::Acquire,
+            |v| {
+                debug_assert!(v > 0, "foreground job counter underflowed");
+                v.checked_sub(1)
+            },
+        );
+        if prev == Ok(1) {
             self.backend.idle_start(self);
             // That's not super race-condition-safe, but it's only for
             // statistical reasons


### PR DESCRIPTION
## What

`start_once_process` deliberately unbalances the foreground-job counter: it calls `finish_foreground_job()` **before** awaiting the process future and `begin_foreground_job()` **after**, so a long-running process doesn't keep turbo-tasks "busy".

That pairing isn't panic-safe. The body runs inside a `TransientTaskType::Once` task future, which the executor wraps in `CaptureFuture` (per-poll `catch_unwind`), so a panic inside the supplied future is caught and converted to a task error — and `begin_foreground_job()` never runs. The executor still runs its own `finish_foreground_job()` for the task, so one panicking once-process nets **-1** on `currently_scheduled_foreground_jobs`. Since the counter is frequently 0 at that moment, `fetch_sub` wraps the `AtomicUsize` to `usize::MAX`, permanently for the life of the process:

- `is_idle()` never reports idle again → the backend stops firing idle transitions used for cache snapshotting/GC,
- `stop_and_wait()` sees a non-zero count and awaits an event that only fires when a decrement returns exactly 1 — i.e. **never**: shutdown hangs forever.

Reachable in production: `turbopack-dev-server`'s HMR websocket loop is a once-process whose message handling has client-controlled `unwrap()`s (`HeaderName::from_bytes(...)` on JSON-subscribe input) — one malformed header name panics it, leaving the dev server permanently "busy" and un-stoppable.

## Fix

- **RAII guard** (`PausedForegroundJobGuard`) whose `Drop` re-begins the job — balanced on normal completion, panic unwind, and cancellation.
- **Checked decrement** in `finish_foreground_job` (`try_update` + `checked_sub` + `debug_assert!`), so a future imbalance clamps at 0 loudly in debug instead of wrapping to `usize::MAX`.

(The client-controlled `unwrap()`s in `turbopack-dev-server`'s `resource_to_request` are a separate, recommended hardening — not included here.)

## Tests

New `turbo-tasks-backend/tests/once_process_panic.rs` drives a real `TurboTasks` (noop backing storage): one normal + one panicking once-process, then asserts `stop_and_wait()` completes within 30s. **Verified: pre-fix the test fails after 30.5s** ("stop_and_wait hung: foreground job counter underflowed"); post-fix passes in 0.52s.

Regression suites: `turbo-tasks` lib (83) and backend `basic`/`bug`/`call_types` green; `clippy`/`fmt` clean.

---

Note: commits on this branch are currently unsigned; happy to re-sign and force-push if needed before review.
