### PR TITLE
ci: stop publishing @vercel/devlow-bench

### DIFF
--- a/packages/devlow-bench/package.json
+++ b/packages/devlow-bench/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@vercel/devlow-bench",
+  "private": true,
   "version": "16.3.1-canary.6",
   "description": "Benchmarking tool for the developer workflow",
   "repository": {


### PR DESCRIPTION
`@vercel/devlow-bench` was supposed to start being published again in #96860, but something's going wrong there and it broke the publishing workflow

I think our npm token currently doesn't allow publishing that package