### PR TITLE
fix(next/routing): correct placeholder substitution in rewrite destinations

### DIFF
--- a/packages/next-routing/src/__tests__/captures.test.ts
+++ b/packages/next-routing/src/__tests__/captures.test.ts
@@ -105,6 +105,79 @@ describe('Regex Captures in Destination', () => {
     expect(result.resolvedPathname).toBe('/u/alice/p/123')
   })
 
+  it('should not let a named capture consume a longer placeholder', async () => {
+    const params = createBaseParams({
+      url: new URL('https://example.com/users/7/admin'),
+      routes: {
+        beforeMiddleware: [],
+        beforeFiles: [
+          {
+            sourceRegex: '^/users/(?<id>[^/]+)/(?<idType>[^/]+)$',
+            destination: '/u/$id/$idType',
+          },
+        ],
+        afterFiles: [],
+        dynamicRoutes: [],
+        onMatch: [],
+        fallback: [],
+      },
+      pathnames: ['/u/7/admin'],
+    })
+
+    const result = await resolveRoutes(params)
+
+    expect(result.resolvedPathname).toBe('/u/7/admin')
+  })
+
+  it('should replace numbered captures above $9', async () => {
+    const segments = Array.from({ length: 10 }, (_, i) => `s${i}`)
+    const params = createBaseParams({
+      url: new URL(`https://example.com/${segments.join('/')}`),
+      routes: {
+        beforeMiddleware: [],
+        beforeFiles: [
+          {
+            sourceRegex: `^${segments.map(() => '/([^/]+)').join('')}$`,
+            destination: '/$10/$1',
+          },
+        ],
+        afterFiles: [],
+        dynamicRoutes: [],
+        onMatch: [],
+        fallback: [],
+      },
+      pathnames: ['/s9/s0'],
+    })
+
+    const result = await resolveRoutes(params)
+
+    expect(result.resolvedPathname).toBe('/s9/s0')
+  })
+
+  it('should not expand `$&` contained in a captured value', async () => {
+    const params = createBaseParams({
+      url: new URL('https://example.com/blog/a$&b'),
+      routes: {
+        beforeMiddleware: [],
+        beforeFiles: [
+          {
+            sourceRegex: '^/blog/([^/]+)$',
+            destination: '/posts/$1',
+          },
+        ],
+        afterFiles: [],
+        dynamicRoutes: [],
+        onMatch: [],
+        fallback: [],
+      },
+      pathnames: ['/posts/a$&b'],
+    })
+
+    const result = await resolveRoutes(params)
+
+    expect(result.resolvedPathname).toBe('/posts/a$&b')
+  })
+
   it('should mix numbered and named captures', async () => {
     const params = createBaseParams({
       url: new URL('https://example.com/api/v1/users/john'),

--- a/packages/next-routing/src/destination.ts
+++ b/packages/next-routing/src/destination.ts
@@ -1,3 +1,7 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /**
  * Replaces $1, $2, etc. and $name placeholders in the destination string
  * with matches from the regex and has conditions
@@ -7,30 +11,48 @@ export function replaceDestination(
   regexMatches: RegExpMatchArray | null,
   hasCaptures: Record<string, string>
 ): string {
-  let result = destination
+  const captures = new Map<string, string>()
 
-  // Replace numbered captures from regex ($1, $2, etc.)
+  // Numbered captures from regex ($1, $2, etc.), skipping index 0 which is the
+  // full match
   if (regexMatches) {
-    // Replace numbered groups (skip index 0 which is the full match)
     for (let i = 1; i < regexMatches.length; i++) {
-      const value = regexMatches[i] ?? ''
-      result = result.replace(new RegExp(`\\$${i}`, 'g'), value)
+      captures.set(String(i), regexMatches[i] ?? '')
     }
 
-    // Replace named groups ($name)
     if (regexMatches.groups) {
       for (const [name, value] of Object.entries(regexMatches.groups)) {
-        result = result.replace(new RegExp(`\\$${name}`, 'g'), value ?? '')
+        if (!captures.has(name)) {
+          captures.set(name, value ?? '')
+        }
       }
     }
   }
 
-  // Replace named captures from has conditions
   for (const [name, value] of Object.entries(hasCaptures)) {
-    result = result.replace(new RegExp(`\\$${name}`, 'g'), value)
+    if (!captures.has(name)) {
+      captures.set(name, value)
+    }
   }
 
-  return result
+  if (captures.size === 0) {
+    return destination
+  }
+
+  // Longest name first so `$id` doesn't consume the `$id` of `$idType`, and
+  // `$1` doesn't consume the `$1` of `$10`
+  const names = Array.from(captures.keys()).sort((a, b) => b.length - a.length)
+  const placeholder = new RegExp(
+    `\\$(${names.map(escapeRegExp).join('|')})`,
+    'g'
+  )
+
+  // A replacer function keeps `$&`, `` $` `` and `$'` inside captured values
+  // from being expanded again
+  return destination.replace(
+    placeholder,
+    (_, name: string) => captures.get(name)!
+  )
 }
 
 /**


### PR DESCRIPTION
`replaceDestination` substituted one placeholder at a time with `String.replace`, so the result depended on the order the captures happened to be iterated in. Three things go wrong because of that:

- A capture whose name is a prefix of another one rewrites the longer placeholder. With `^/users/(?<id>[^/]+)/(?<idType>[^/]+)$` and destination `/u/$id/$idType`, `/users/7/admin` resolves to `/u/7/7Type`.
- `$1` matches inside `$10`, so any source regex with ten or more groups resolves the wrong capture.
- A captured value containing `$&`, `` $` `` or `$'` is expanded a second time, because those are special in a string replacement. `/blog/a$&b` rewritten to `/posts/$1` resolves to `/posts/a$idb`.

The fix collects the captures into a map first and does a single pass, building the placeholder pattern with the longest name first and substituting through a replacer function so `$` in a value is taken literally.

Precedence between numbered captures, named groups and `has` captures is unchanged: the first one to define a name wins, which is what the sequential replacements did before.

### Tests

Three cases added to `packages/next-routing/src/__tests__/captures.test.ts`, one per defect. They fail on `canary` and pass with this change.
