### PR TITLE
fix(next/routing): parse Accept-Language parameters correctly

### DIFF
--- a/packages/next-routing/src/__tests__/i18n.test.ts
+++ b/packages/next-routing/src/__tests__/i18n.test.ts
@@ -120,6 +120,17 @@ describe('i18n utilities', () => {
       expect(getAcceptLanguageLocale('', locales)).toBeUndefined()
     })
 
+    it('should ignore whitespace around the language tag', () => {
+      expect(getAcceptLanguageLocale('de;q=0.2, fr ;q=0.9', locales)).toBe('fr')
+      expect(getAcceptLanguageLocale(' ja ', locales)).toBe('ja')
+    })
+
+    it('should read the quality value from any parameter', () => {
+      expect(
+        getAcceptLanguageLocale('fr;charset=utf-8;q=0.1,en;q=0.9', locales)
+      ).toBe('en')
+    })
+
     it('should handle malformed headers gracefully', () => {
       expect(getAcceptLanguageLocale('invalid;;;', locales)).toBeUndefined()
     })

--- a/packages/next-routing/src/i18n.ts
+++ b/packages/next-routing/src/i18n.ts
@@ -105,20 +105,20 @@ export function getAcceptLanguageLocale(
     const languages = acceptLanguageHeader
       .split(',')
       .map((lang) => {
-        const parts = lang.trim().split(';')
-        const locale = parts[0]
+        const [locale, ...params] = lang.split(';')
         let quality = 1
 
-        if (parts[1]) {
-          const qMatch = parts[1].match(/q=([0-9.]+)/)
-          if (qMatch && qMatch[1]) {
+        for (const param of params) {
+          const qMatch = param.match(/^\s*q\s*=\s*([0-9.]+)\s*$/)
+          if (qMatch) {
             quality = parseFloat(qMatch[1])
+            break
           }
         }
 
-        return { locale, quality }
+        return { locale: locale.trim(), quality }
       })
-      .filter((lang) => lang.quality > 0)
+      .filter((lang) => lang.locale !== '' && lang.quality > 0)
       .sort((a, b) => b.quality - a.quality)
 
     // Create lowercase lookup for locales


### PR DESCRIPTION
`getAcceptLanguageLocale` picks the wrong locale for two kinds of headers that are perfectly valid.

**Whitespace before `;`.** RFC 9110 allows optional whitespace around the parameter separator. The header is split on `,` and trimmed, but the language tag itself is taken from `parts[0]` after splitting on `;`, so any space before the `;` stays attached to the tag:

```js
getAcceptLanguageLocale('de;q=0.2, fr ;q=0.9', ['en', 'fr', 'de'])
// 'de' — the 'fr ' tag never matches, so the lower-quality 'de' wins
```

**Quality read from one parameter only.** `q` is only looked for in `parts[1]`, so a tag with another parameter in front of it silently keeps the default quality of 1:

```js
getAcceptLanguageLocale('fr;charset=utf-8;q=0.1,en;q=0.9', ['en', 'fr'])
// 'fr' — treated as q=1 and sorted ahead of en
```

This trims the language tag and scans every parameter for `q`. Tags that parse to an empty string are dropped, which keeps the existing "malformed headers" behaviour.

### Tests

Two cases added to `packages/next-routing/src/__tests__/i18n.test.ts`. Both fail on `canary`.
