### PR TITLE
fix(next/routing): require has/missing values to match the whole value

### DIFF
--- a/packages/next-routing/src/__tests__/conditions.test.ts
+++ b/packages/next-routing/src/__tests__/conditions.test.ts
@@ -238,6 +238,78 @@ describe('Has conditions', () => {
     expect(result.resolvedPathname).toBe('/mobile')
   })
 
+  it('should NOT match when the value only appears as a substring', async () => {
+    const headers = new Headers({
+      'x-env': 'preproduction',
+    })
+
+    const params = createBaseParams({
+      url: new URL('https://example.com/'),
+      headers,
+      routes: {
+        beforeMiddleware: [],
+        beforeFiles: [
+          {
+            sourceRegex: '^/$',
+            destination: '/production',
+            has: [
+              {
+                type: 'header',
+                key: 'x-env',
+                value: 'production',
+              },
+            ],
+          },
+        ],
+        afterFiles: [],
+        dynamicRoutes: [],
+        onMatch: [],
+        fallback: [],
+      },
+      pathnames: ['/', '/production'],
+    })
+
+    const result = await resolveRoutes(params)
+
+    expect(result.resolvedPathname).toBe('/')
+  })
+
+  it('should match a missing condition when the value is only a substring', async () => {
+    const headers = new Headers({
+      'x-env': 'preproduction',
+    })
+
+    const params = createBaseParams({
+      url: new URL('https://example.com/'),
+      headers,
+      routes: {
+        beforeMiddleware: [],
+        beforeFiles: [
+          {
+            sourceRegex: '^/$',
+            destination: '/not-production',
+            missing: [
+              {
+                type: 'header',
+                key: 'x-env',
+                value: 'production',
+              },
+            ],
+          },
+        ],
+        afterFiles: [],
+        dynamicRoutes: [],
+        onMatch: [],
+        fallback: [],
+      },
+      pathnames: ['/not-production'],
+    })
+
+    const result = await resolveRoutes(params)
+
+    expect(result.resolvedPathname).toBe('/not-production')
+  })
+
   it('should require ALL has conditions to match', async () => {
     const headers = new Headers({
       'x-user-role': 'admin',

--- a/packages/next-routing/src/matchers.ts
+++ b/packages/next-routing/src/matchers.ts
@@ -22,12 +22,10 @@ function matchesCondition(
     return { matched: true, capturedValue: actualValue }
   }
 
-  // Try to match as regex first
+  // Try to match as regex first. The pattern has to cover the whole value, the
+  // same way `matchHas` anchors it in the core router.
   try {
-    const exactRegex = new RegExp(`^(?:${conditionValue})$`)
-    const fallbackRegex = new RegExp(conditionValue)
-    const match =
-      actualValue.match(exactRegex) ?? actualValue.match(fallbackRegex)
+    const match = actualValue.match(new RegExp(`^(?:${conditionValue})$`))
     if (match) {
       const namedCaptures: Record<string, string> = {}
       if (match.groups) {


### PR DESCRIPTION
`matchesCondition` builds an anchored regex from the condition's `value`, and when that does not match it retries with an unanchored one:

```ts
const exactRegex = new RegExp(`^(?:${conditionValue})$`)
const fallbackRegex = new RegExp(conditionValue)
const match = actualValue.match(exactRegex) ?? actualValue.match(fallbackRegex)
```

The retry means a substring is enough to satisfy the condition. A route guarded with

```js
has: [{ type: 'header', key: 'x-env', value: 'production' }]
```

also matches a request carrying `x-env: preproduction`. The same slip runs the other way for `missing`, where the route is skipped for a value that was never supposed to match.

`matchHas` in the core router anchors the pattern and has no fallback, so this drops the unanchored retry. An invalid regex still falls through to the direct string comparison below it, which is what the `try/catch` is there for.

### Tests

Two cases added to `packages/next-routing/src/__tests__/conditions.test.ts`, one for `has` and one for `missing`. Both fail on `canary`. The existing 255 tests pass unchanged, so nothing was relying on the substring behaviour.
