### PR TITLE
[15.x] Default deploy e2e tests to the repo next version

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -8,8 +8,11 @@ on:
   workflow_dispatch:
     inputs:
       nextVersion:
-        description: canary or custom tarball URL
-        default: canary
+        description: >-
+          Version of `next` to test against. Anything installable by npm:
+          a dist-tag (canary), an exact version (16.2.4), or a custom https
+          tarball URL. Leave empty to use the `next` version from
+          packages/next/package.json.
         type: string
       vercelCliVersion:
         description: Version of Vercel CLI to use
@@ -26,7 +29,9 @@ env:
   TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
   DD_ENV: 'ci'
 
-run-name: test-e2e-deploy ${{ inputs.nextVersion || 'canary' }}
+# run-name cannot read job outputs, so for release events it shows the tag name,
+# assuming the release tag matches the `next` version checked into packages/next/package.json
+run-name: test-e2e-deploy ${{ inputs.nextVersion || (github.event_name == 'release' && github.event.release.tag_name) || 'repo version' }}
 
 jobs:
   setup:
@@ -62,8 +67,22 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - id: version
-        name: Extract `next` version
-        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+        name: Resolve `next` version
+        env:
+          INPUT_NEXT_VERSION: ${{ inputs.nextVersion }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_NEXT_VERSION" ]; then
+            echo "value=$INPUT_NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log resolved `next` version
+        env:
+          RESOLVED_NEXT_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          echo "Resolved next version: $RESOLVED_NEXT_VERSION"
 
       - name: Setup test project
         run: |
@@ -81,7 +100,7 @@ jobs:
       matrix:
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
     with:
-      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" NEXT_TEST_PREVIEW_BUILDS_BASE_URL="${{ vars.PREVIEW_BUILDS_BASE_URL }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+      afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ needs.setup.outputs.next-version }}" VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" NEXT_TEST_PREVIEW_BUILDS_BASE_URL="${{ vars.PREVIEW_BUILDS_BASE_URL }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-${{ matrix.group }}'


### PR DESCRIPTION
Backports #96895 to `next-15-5`, adapted to this branch's layout (a single `test-deploy` job, no adapter jobs). This branch had a bug where `test-deploy` resolved `NEXT_TEST_VERSION` as `github.event.inputs.nextVersion || 'canary'`, so release runs always installed `canary` and ignored the released version.

