### PR TITLE
Complete App Router render observability

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1467,5 +1467,7 @@
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1468": "Missing workUnitStore in createComponentTree",
-  "1469": "%s stream closed before completion"
+  "1469": "%s stream closed before completion",
+  "1470": "Response closed before its first chunk",
+  "1471": "Response stream failed before its first chunk"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1466,5 +1466,6 @@
   "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1468": "Missing workUnitStore in createComponentTree"
+  "1468": "Missing workUnitStore in createComponentTree",
+  "1469": "%s stream closed before completion"
 }

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -22,7 +22,10 @@ import {
   getRequestMeta,
   setRequestMeta,
 } from '../../server/request-meta' with { 'turbopack-transition': 'next-server-utility' }
-import { BaseServerSpan } from '../../server/lib/trace/constants' with { 'turbopack-transition': 'next-server-utility' }
+import {
+  AppRenderSpan,
+  BaseServerSpan,
+} from '../../server/lib/trace/constants' with { 'turbopack-transition': 'next-server-utility' }
 import { stripFlightHeaders } from '../../server/app-render/strip-flight-headers' with { 'turbopack-transition': 'next-server-utility' }
 import {
   NodeNextRequest,
@@ -226,10 +229,15 @@ export function createAppPageEntrypoint({
     const multiZoneDraftMode = process.env
       .__NEXT_MULTI_ZONE_DRAFT_MODE as any as boolean
 
-    const prepareResult = await routeModule.prepare(req, res, {
-      srcPage,
-      multiZoneDraftMode,
-    })
+    const prepareResult = await getTracer().trace(
+      AppRenderSpan.prepareAppPageResponse,
+      { spanName: 'prepare app page response' },
+      () =>
+        routeModule.prepare(req, res, {
+          srcPage,
+          multiZoneDraftMode,
+        })
+    )
 
     if (!prepareResult) {
       res.statusCode = 400

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -330,9 +330,19 @@ describe('request insights trace viewer', () => {
           },
         },
         {
+          name: 'BaseServer.renderToResponseWithComponents',
+          spanId: 'render-with-components',
+          parentSpanId: 'base-render',
+          startTime: 110.5,
+          durationMs: 84.5,
+          attributes: {
+            'next.span_type': 'BaseServer.renderToResponseWithComponents',
+          },
+        },
+        {
           name: 'prepare app page response',
           spanId: 'prepare-app-page',
-          parentSpanId: 'base-render',
+          parentSpanId: 'render-with-components',
           startTime: 111,
           durationMs: 1,
           attributes: {
@@ -342,7 +352,7 @@ describe('request insights trace viewer', () => {
         {
           name: 'initialize app render',
           spanId: 'initialize-app-render',
-          parentSpanId: 'base-render',
+          parentSpanId: 'render-with-components',
           startTime: 112,
           durationMs: 1,
           attributes: { 'next.span_type': 'AppRender.initializeRender' },
@@ -350,7 +360,7 @@ describe('request insights trace viewer', () => {
         {
           name: 'render route (app) /',
           spanId: 'render',
-          parentSpanId: 'base-render',
+          parentSpanId: 'render-with-components',
           startTime: 113,
           durationMs: 80,
           attributes: { 'next.span_type': 'AppRender.getBodyResult' },
@@ -425,6 +435,7 @@ describe('request insights trace viewer', () => {
       'render',
       'resolve page components',
       'load components',
+      'render to response with components',
       'prepare app page response',
       'initialize app render',
       'render route (app) /',

--- a/packages/next/src/server/app-render/app-render-prerender-utils.test.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.test.ts
@@ -1,5 +1,9 @@
 import { PassThrough } from 'node:stream'
-import { ReplayableNodeStream } from './app-render-prerender-utils'
+import {
+  createTrackedStream,
+  ReplayableNodeStream,
+  trackWebStreamCompletion,
+} from './app-render-prerender-utils'
 
 function collectBytes(
   stream: import('node:stream').Readable
@@ -17,6 +21,117 @@ function tick(): Promise<void> {
 }
 
 describe('ReplayableNodeStream', () => {
+  describe('tracked source completion', () => {
+    it('reports a clean end once', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      await createTrackedStream(() => source, onComplete)
+
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.resume()
+      source.end()
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith()
+    })
+
+    it('attaches completion listeners before a direct stream ends on the next tick', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      const trackedSource = createTrackedStream(() => {
+        process.nextTick(() => source.end())
+        return source
+      }, onComplete)
+
+      expect(trackedSource).toBe(source)
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.resume()
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith()
+    })
+
+    it('reports source errors once', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      await createTrackedStream(() => source, onComplete)
+
+      const error = new Error('RSC render failed')
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.destroy(error)
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+
+    it('attaches error listeners before a direct stream errors on the next tick', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      const error = new Error('RSC render failed')
+      const trackedSource = createTrackedStream(() => {
+        process.nextTick(() => source.destroy(error))
+        return source
+      }, onComplete)
+
+      expect(trackedSource).toBe(source)
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      await closed
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+
+    it('rejects replay consumers when the source closes prematurely', async () => {
+      const source = new PassThrough()
+      const onComplete = jest.fn()
+      const trackedSource = await createTrackedStream(() => source, onComplete)
+      const replayable = new ReplayableNodeStream(trackedSource)
+      const replayResult = collectBytes(replayable.createReplayStream())
+
+      const closed = new Promise<void>((resolve) => source.on('close', resolve))
+      source.destroy()
+      await closed
+
+      await expect(replayResult).rejects.toEqual(
+        expect.objectContaining({ name: 'AbortError' })
+      )
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({
+        error: expect.objectContaining({ name: 'AbortError' }),
+      })
+      expect((replayable as any)._subscribers.size).toBe(0)
+    })
+
+    it('reports synchronous stream creation failures', () => {
+      const onComplete = jest.fn()
+      const error = new Error('RSC render failed')
+
+      expect(() =>
+        createTrackedStream(() => {
+          throw error
+        }, onComplete)
+      ).toThrow(error)
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+
+    it('reports asynchronous stream creation failures', async () => {
+      const onComplete = jest.fn()
+      const error = new Error('RSC render failed')
+
+      await expect(
+        createTrackedStream(() => Promise.reject(error), onComplete)
+      ).rejects.toBe(error)
+
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledWith({ error })
+    })
+  })
+
   describe('construction and buffering', () => {
     it('buffers Uint8Array chunks from the source', async () => {
       const source = new PassThrough()
@@ -387,6 +502,62 @@ describe('ReplayableNodeStream', () => {
         [1, 2],
         [3, 4],
       ])
+    })
+  })
+})
+
+describe('trackWebStreamCompletion', () => {
+  it('forwards chunks and reports a clean end', async () => {
+    const onComplete = jest.fn()
+    const stream = trackWebStreamCompletion(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          controller.close()
+        },
+      }),
+      onComplete
+    )
+
+    const reader = stream.getReader()
+    expect(await reader.read()).toEqual({
+      done: false,
+      value: new Uint8Array([1, 2, 3]),
+    })
+    expect(await reader.read()).toEqual({ done: true, value: undefined })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(onComplete).toHaveBeenCalledWith()
+  })
+
+  it('reports source errors', async () => {
+    const onComplete = jest.fn()
+    const error = new Error('RSC render failed')
+    const stream = trackWebStreamCompletion(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          throw error
+        },
+      }),
+      onComplete
+    )
+
+    await expect(stream.getReader().read()).rejects.toBe(error)
+    expect(onComplete).toHaveBeenCalledWith({ error })
+  })
+
+  it('reports cancellation as an abort', async () => {
+    const onComplete = jest.fn()
+    const cancel = jest.fn()
+    const stream = trackWebStreamCompletion(
+      new ReadableStream<Uint8Array>({ cancel }, { highWaterMark: 0 }),
+      onComplete
+    )
+
+    await stream.cancel('not needed')
+
+    expect(cancel).toHaveBeenCalledWith('not needed')
+    expect(onComplete).toHaveBeenCalledWith({
+      error: expect.objectContaining({ name: 'AbortError' }),
     })
   })
 })

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -2,6 +2,8 @@ import type { Readable } from 'node:stream'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 export type AnyStream = ReadableStream<Uint8Array> | Readable
+export type StreamCompletion = { error: unknown }
+type OnStreamComplete = (completion?: StreamCompletion) => void
 
 function isWebStream(stream: AnyStream): stream is ReadableStream<Uint8Array> {
   return typeof (stream as ReadableStream).tee === 'function'
@@ -133,6 +135,17 @@ export class ReplayableNodeStream {
       }
       this._subscribers.clear()
     })
+
+    stream.on('close', () => {
+      if (!this._done && !this._error) {
+        const error = createPrematureStreamCloseError('RSC')
+        this._error = error
+        for (const sub of this._subscribers) {
+          sub.onError(error)
+        }
+        this._subscribers.clear()
+      }
+    })
   }
 
   /**
@@ -230,6 +243,136 @@ export class ReplayableNodeStream {
   dispose(): void {
     this._chunks = null
   }
+}
+
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => T,
+  onComplete: OnStreamComplete
+): T
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => Promise<T>,
+  onComplete: OnStreamComplete
+): Promise<T>
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => T | Promise<T>,
+  onComplete: OnStreamComplete
+): T | Promise<T>
+export function createTrackedStream<T extends AnyStream>(
+  createStream: () => T | Promise<T>,
+  onComplete: OnStreamComplete
+): T | Promise<T> {
+  let stream: T | Promise<T>
+  try {
+    stream = createStream()
+  } catch (error) {
+    onComplete({ error })
+    throw error
+  }
+
+  if (isThenable(stream)) {
+    return stream.then(
+      (resolvedStream) => trackStreamCompletion(resolvedStream, onComplete),
+      (error) => {
+        onComplete({ error })
+        throw error
+      }
+    )
+  }
+
+  return trackStreamCompletion(stream, onComplete)
+}
+
+function isThenable<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>).then === 'function'
+}
+
+function trackStreamCompletion<T extends AnyStream>(
+  stream: T,
+  onComplete: OnStreamComplete
+): T {
+  if (isWebStream(stream)) {
+    return trackWebStreamCompletion(stream, onComplete) as T
+  }
+
+  trackNodeStreamCompletion(stream, onComplete)
+  return stream
+}
+
+function trackNodeStreamCompletion(
+  stream: Readable,
+  onComplete: OnStreamComplete
+): void {
+  const complete = createOneShotCompletion(onComplete)
+
+  stream.on('end', () => complete())
+  stream.on('error', (error) => complete({ error }))
+  stream.on('close', () => {
+    if (!stream.readableEnded && !stream.errored) {
+      complete({ error: createPrematureStreamCloseError('RSC') })
+    }
+  })
+}
+
+/**
+ * Ends the render phase when the RSC source stream finishes producing without
+ * eagerly reading from the stream or adding another buffer.
+ */
+export function trackWebStreamCompletion(
+  stream: ReadableStream<Uint8Array>,
+  onComplete: OnStreamComplete
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader()
+  const complete = createOneShotCompletion(onComplete)
+
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        let result: ReadableStreamReadResult<Uint8Array>
+        try {
+          result = await reader.read()
+        } catch (error) {
+          complete({ error })
+          controller.error(error)
+          return
+        }
+
+        if (result.done) {
+          complete()
+          controller.close()
+        } else {
+          controller.enqueue(result.value)
+        }
+      },
+      cancel(reason) {
+        complete({ error: createPrematureStreamCloseError('RSC') })
+        return reader.cancel(reason)
+      },
+    },
+    { highWaterMark: 0 }
+  )
+}
+
+function createOneShotCompletion(
+  onComplete: OnStreamComplete
+): OnStreamComplete {
+  let isComplete = false
+  return (completion) => {
+    if (isComplete) {
+      return
+    }
+    isComplete = true
+    if (completion) {
+      onComplete(completion)
+    } else {
+      onComplete()
+    }
+  }
+}
+
+function createPrematureStreamCloseError(streamName: string): Error {
+  const error = new Error(`${streamName} stream closed before completion`)
+  error.name = 'AbortError'
+  return error
 }
 
 export type ReactServerPrerenderResolveToType = {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -116,6 +116,7 @@ import {
   runWithRequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
 import { getTracer, SpanStatusCode } from '../lib/trace/tracer'
+import { createOneShotTracePhase } from '../lib/trace/phase'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
@@ -234,6 +235,7 @@ import {
   createReactServerPrerenderResult,
   ReactServerResult,
   ReplayableNodeStream,
+  createTrackedStream,
   createReactServerPrerenderResultFromRender,
 } from './app-render-prerender-utils'
 import {
@@ -966,19 +968,21 @@ async function generateDynamicFlightRenderResult(
       options
     )
 
-    const flightStream = workUnitAsyncStorage.run(
-      requestStore,
-      renderToNodeFlightStream,
-      ctx.componentMod,
-      rscPayload,
-      clientModules,
-      {
-        onError,
-        temporaryReferences: options?.temporaryReferences,
-        filterStackFrame,
-        debugChannel: debugChannel?.serverSide,
-        signal: requestAbortSignal,
-      }
+    const flightStream = createTrackedRSCStream(() =>
+      workUnitAsyncStorage.run(
+        requestStore,
+        renderToNodeFlightStream,
+        ctx.componentMod,
+        rscPayload,
+        clientModules,
+        {
+          onError,
+          temporaryReferences: options?.temporaryReferences,
+          filterStackFrame,
+          debugChannel: debugChannel?.serverSide,
+          signal: requestAbortSignal,
+        }
+      )
     )
 
     return new FlightRenderResult(
@@ -1002,19 +1006,21 @@ async function generateDynamicFlightRenderResult(
       options
     )
 
-    const flightStream = workUnitAsyncStorage.run(
-      requestStore,
-      renderToWebFlightStream,
-      ctx.componentMod,
-      rscPayload,
-      clientModules,
-      {
-        onError,
-        temporaryReferences: options?.temporaryReferences,
-        filterStackFrame,
-        debugChannel: debugChannel?.serverSide,
-        signal: requestAbortSignal,
-      }
+    const flightStream = createTrackedRSCStream(() =>
+      workUnitAsyncStorage.run(
+        requestStore,
+        renderToWebFlightStream,
+        ctx.componentMod,
+        rscPayload,
+        clientModules,
+        {
+          onError,
+          temporaryReferences: options?.temporaryReferences,
+          filterStackFrame,
+          debugChannel: debugChannel?.serverSide,
+          signal: requestAbortSignal,
+        }
+      )
     )
 
     return new FlightRenderResult(
@@ -1150,14 +1156,17 @@ async function generateStagedDynamicFlightRenderResultNode(
     () => {
       stageController.advanceStage(RenderStage.ShellStatic)
 
-      const sourceStream = workUnitAsyncStorage.run(
-        requestStore,
-        renderToNodeFlightStream,
-        ctx.componentMod,
-        rscPayload,
-        clientModules,
-        { onError, filterStackFrame }
-      ) as Readable
+      const sourceStream = createTrackedRSCStream(
+        () =>
+          workUnitAsyncStorage.run(
+            requestStore,
+            renderToNodeFlightStream,
+            ctx.componentMod,
+            rscPayload,
+            clientModules,
+            { onError, filterStackFrame }
+          ) as Readable
+      )
 
       const replayable = new ReplayableNodeStream(sourceStream)
       const dynamicStream = replayable.createReplayStream()
@@ -1303,16 +1312,18 @@ async function stagedRenderWithoutCachesInDevNode(
     () => {
       stageController.advanceStage(RenderStage.ShellStatic)
 
-      return workUnitAsyncStorage.run(
-        requestStore,
-        renderToNodeFlightStream,
-        ctx.componentMod,
-        rscPayload,
-        clientModules,
-        {
-          ...options,
-          environmentName,
-        }
+      return createTrackedRSCStream(() =>
+        workUnitAsyncStorage.run(
+          requestStore,
+          renderToNodeFlightStream,
+          ctx.componentMod,
+          rscPayload,
+          clientModules,
+          {
+            ...options,
+            environmentName,
+          }
+        )
       )
     },
     () => {
@@ -1947,17 +1958,19 @@ async function finalRuntimeServerPrerender(
     async () => {
       finalStageController.advanceStage(RenderStage.ShellStatic)
 
-      let stream = workUnitAsyncStorage.run(
-        finalServerPrerenderStore,
-        ComponentMod.renderToReadableStream,
-        finalRSCPayload,
-        clientModules,
-        {
-          filterStackFrame,
-          onError,
-          signal: finalServerController.signal,
-          debugChannel,
-        }
+      const stream = createTrackedRSCStream(() =>
+        workUnitAsyncStorage.run(
+          finalServerPrerenderStore,
+          ComponentMod.renderToReadableStream,
+          finalRSCPayload,
+          clientModules,
+          {
+            filterStackFrame,
+            onError,
+            signal: finalServerController.signal,
+            debugChannel,
+          }
+        )
       )
 
       // Note: this await will only resolve after the last task (unless sync IO aborts the render earlier)
@@ -3498,6 +3511,30 @@ type RSCInitialPayloadPartialDev = {
   c?: InitialRSCPayload['c']
 }
 
+/**
+ * Traces React's RSC stream production only. Payload preparation happens
+ * before this boundary, and response delivery happens after it.
+ */
+function createTrackedRSCStream<T extends AnyStream>(createStream: () => T): T
+function createTrackedRSCStream<T extends AnyStream>(
+  createStream: () => Promise<T>
+): Promise<T>
+function createTrackedRSCStream<T extends AnyStream>(
+  createStream: () => T | Promise<T>
+): T | Promise<T> {
+  if (!isRequestInsightsEnabled() && process.env.NEXT_OTEL_VERBOSE !== '1') {
+    return createStream()
+  }
+
+  return createTrackedStream(
+    createStream,
+    createOneShotTracePhase(
+      AppRenderSpan.renderRSCResponse,
+      'render RSC response'
+    )
+  )
+}
+
 async function renderToStream(
   requestStore: RequestStore,
   req: BaseNextRequest,
@@ -3781,17 +3818,18 @@ async function renderToStream(
 
           const debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
-          const serverStream = await stagedRenderWithoutCachesInDevNode(
-            ctx,
-            requestStore,
-            getPayload,
-            {
-              onError: serverComponentsErrorHandler,
-              filterStackFrame,
-              debugChannel: debugChannel?.serverSide,
-            }
+          reactServerResult = new ReactServerResult(
+            await stagedRenderWithoutCachesInDevNode(
+              ctx,
+              requestStore,
+              getPayload,
+              {
+                onError: serverComponentsErrorHandler,
+                filterStackFrame,
+                debugChannel: debugChannel?.serverSide,
+              }
+            )
           )
-          reactServerResult = new ReactServerResult(serverStream)
 
           if (debugChannel) {
             debugChannelClientStream = new ReplayableNodeStream(
@@ -3906,17 +3944,20 @@ async function renderToStream(
           () => {
             stageController.advanceStage(RenderStage.ShellStatic)
 
-            const stream = workUnitAsyncStorage.run(
-              requestStore,
-              renderToNodeFlightStream,
-              ctx.componentMod,
-              RSCPayload,
-              clientModules,
-              {
-                onError: serverComponentsErrorHandler,
-                filterStackFrame,
-              }
-            ) as Readable
+            const stream = createTrackedRSCStream(
+              () =>
+                workUnitAsyncStorage.run(
+                  requestStore,
+                  renderToNodeFlightStream,
+                  ctx.componentMod,
+                  RSCPayload,
+                  clientModules,
+                  {
+                    onError: serverComponentsErrorHandler,
+                    filterStackFrame,
+                  }
+                ) as Readable
+            )
 
             const replayable = new ReplayableNodeStream(stream)
             const dynamicStream = replayable.createReplayStream()
@@ -3984,17 +4025,19 @@ async function renderToStream(
           }
 
           reactServerResult = new ReactServerResult(
-            workUnitAsyncStorage.run(
-              requestStore,
-              renderToNodeFlightStream,
-              ctx.componentMod,
-              RSCPayload,
-              clientModules,
-              {
-                filterStackFrame,
-                onError: serverComponentsErrorHandler,
-                debugChannel: debugChannel?.serverSide,
-              }
+            createTrackedRSCStream(() =>
+              workUnitAsyncStorage.run(
+                requestStore,
+                renderToNodeFlightStream,
+                ctx.componentMod,
+                RSCPayload,
+                clientModules,
+                {
+                  filterStackFrame,
+                  onError: serverComponentsErrorHandler,
+                  debugChannel: debugChannel?.serverSide,
+                }
+              )
             )
           )
         } else {
@@ -4026,17 +4069,19 @@ async function renderToStream(
           }
 
           reactServerResult = new ReactServerResult(
-            workUnitAsyncStorage.run(
-              requestStore,
-              renderToWebFlightStream,
-              ctx.componentMod,
-              RSCPayload,
-              clientModules,
-              {
-                filterStackFrame,
-                onError: serverComponentsErrorHandler,
-                debugChannel: debugChannel?.serverSide,
-              }
+            createTrackedRSCStream(() =>
+              workUnitAsyncStorage.run(
+                requestStore,
+                renderToWebFlightStream,
+                ctx.componentMod,
+                RSCPayload,
+                clientModules,
+                {
+                  filterStackFrame,
+                  onError: serverComponentsErrorHandler,
+                  debugChannel: debugChannel?.serverSide,
+                }
+              )
             )
           )
         }
@@ -4045,7 +4090,11 @@ async function renderToStream(
       // React doesn't start rendering synchronously but we want the RSC render to have a chance to start
       // before we begin SSR rendering because we want to capture any available preload headers so we tick
       // one task before continuing
-      await waitAtLeastOneReactRenderTask()
+      await getTracer().trace(
+        AppRenderSpan.waitForRSC,
+        { spanName: 'wait for RSC render task' },
+        waitAtLeastOneReactRenderTask
+      )
 
       // MARK: nodeStreams HTML
       if (process.env.__NEXT_USE_NODE_STREAMS) {
@@ -5562,23 +5611,25 @@ async function streamStagedRenderInDev({
       stageController.advanceStage(RenderStage.ShellStatic)
       startTime = performance.now() + performance.timeOrigin
 
-      const replayable = new ReplayableNodeStream(
-        workUnitAsyncStorage.run(
-          requestStore,
-          renderToNodeFlightStream,
-          ComponentMod,
-          rscPayload,
-          clientModules,
-          {
-            onError,
-            environmentName,
-            startTime,
-            filterStackFrame,
-            debugChannel: debugChannel?.serverSide,
-            signal: requestAbortSignal,
-          }
-        ) as Readable
+      const sourceStream = createTrackedRSCStream(
+        () =>
+          workUnitAsyncStorage.run(
+            requestStore,
+            renderToNodeFlightStream,
+            ComponentMod,
+            rscPayload,
+            clientModules,
+            {
+              onError,
+              environmentName,
+              startTime,
+              filterStackFrame,
+              debugChannel: debugChannel?.serverSide,
+              signal: requestAbortSignal,
+            }
+          ) as Readable
       )
+      const replayable = new ReplayableNodeStream(sourceStream)
 
       streamReady.resolve({
         stream: replayable.createReplayStream(),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -120,6 +120,7 @@ import { createOneShotTracePhase } from '../lib/trace/phase'
 import { traceLocalSpan } from '../lib/trace/local-span-recorder'
 import { isRequestInsightsEnabled } from '../lib/trace/request-insights'
 import { FlightRenderResult } from './flight-render-result'
+import { createHTMLRenderCompletionTracker } from './html-render-completion'
 import {
   createReactServerErrorHandler,
   createHTMLErrorHandler,
@@ -3675,9 +3676,19 @@ async function renderToStream(
     renderSpan.end()
   }
 
+  const htmlRenderCompletion = createHTMLRenderCompletionTracker(
+    (completion) => {
+      if (completion) {
+        endSpanWithError(completion.error)
+      } else if (renderSpan.isRecording()) {
+        renderSpan.end()
+      }
+    }
+  )
+
   // Run the rest of the function within the span's context so child spans
   // (like "build component tree", "generateMetadata") are properly parented.
-  return getTracer().withSpan(renderSpan, async () => {
+  const renderResult = getTracer().withSpan(renderSpan, async () => {
     // MARK: renderToStream errorHandlers
     const { reactServerErrorsByDigest } = workStore
 
@@ -4151,10 +4162,7 @@ async function renderToStream(
                 { onError: htmlRendererErrorHandler, nonce }
               )
 
-            // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-            allReady.finally(() => {
-              if (renderSpan.isRecording()) renderSpan.end()
-            })
+            htmlRenderCompletion.track(allReady)
 
             return await continueDynamicHTMLResumeNode(htmlStream, {
               delayDataUntilFirstHtmlChunk:
@@ -4219,10 +4227,7 @@ async function renderToStream(
             )
         )
 
-        // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-        allReady.finally(() => {
-          if (renderSpan.isRecording()) renderSpan.end()
-        })
+        htmlRenderCompletion.track(allReady)
 
         return await continueFizzStream(htmlStream, {
           inlinedDataStream: createNodeInlinedDataStream(
@@ -4292,10 +4297,7 @@ async function renderToStream(
                 { onError: htmlRendererErrorHandler, nonce }
               )
 
-            // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-            allReady.finally(() => {
-              if (renderSpan.isRecording()) renderSpan.end()
-            })
+            htmlRenderCompletion.track(allReady)
 
             return await continueDynamicHTMLResumeWeb(htmlStream, {
               delayDataUntilFirstHtmlChunk:
@@ -4354,10 +4356,7 @@ async function renderToStream(
           fizzOptions
         )
 
-        // End the render span only after React completed rendering (including anything inside Suspense boundaries)
-        allReady.finally(() => {
-          if (renderSpan.isRecording()) renderSpan.end()
-        })
+        htmlRenderCompletion.track(allReady)
 
         return await continueFizzStream(htmlStream, {
           inlinedDataStream: createWebInlinedDataStream(
@@ -4375,6 +4374,8 @@ async function renderToStream(
       }
       // MARK: renderToStream errorRecovery
     } catch (err) {
+      htmlRenderCompletion.supersede(err)
+
       if (
         isStaticGenBailoutError(err) ||
         (typeof err === 'object' &&
@@ -4516,9 +4517,7 @@ async function renderToStream(
               { waitForAllReady }
             )
 
-          errorAllReady.finally(() => {
-            if (renderSpan.isRecording()) renderSpan.end()
-          })
+          htmlRenderCompletion.track(errorAllReady)
 
           return await continueFizzStream(errorHtmlStream, {
             inlinedDataStream: createNodeInlinedDataStream(
@@ -4542,6 +4541,7 @@ async function renderToStream(
             validateRootLayout: !!process.env.__NEXT_DEV_SERVER,
           })
         } catch (finalErr: any) {
+          htmlRenderCompletion.supersede(finalErr)
           if (
             process.env.__NEXT_DEV_SERVER &&
             isHTTPAccessFallbackError(finalErr)
@@ -4611,9 +4611,7 @@ async function renderToStream(
               }
             )
 
-          errorAllReady.finally(() => {
-            if (renderSpan.isRecording()) renderSpan.end()
-          })
+          htmlRenderCompletion.track(errorAllReady)
 
           return await continueFizzStream(errorHtmlStream, {
             inlinedDataStream: createWebInlinedDataStream(
@@ -4637,6 +4635,7 @@ async function renderToStream(
             validateRootLayout: !!process.env.__NEXT_DEV_SERVER,
           })
         } catch (finalErr: any) {
+          htmlRenderCompletion.supersede(finalErr)
           if (
             process.env.__NEXT_DEV_SERVER &&
             isHTTPAccessFallbackError(finalErr)
@@ -4650,6 +4649,12 @@ async function renderToStream(
         }
       }
     }
+  })
+
+  return renderResult.catch((err) => {
+    htmlRenderCompletion.supersede(err)
+    endSpanWithError(err)
+    throw err
   })
   /* eslint-enable @next/internal/no-ambiguous-jsx */
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3193,29 +3193,34 @@ async function renderToHTMLOrFlightImpl(
   interpolatedParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ) {
-  const prepared = await prepareAppPageRender(
-    req,
-    res,
-    url,
-    pagePath,
-    query,
-    renderOpts,
-    workStore,
-    parsedRequestHeaders,
-    sharedContext,
-    interpolatedParams,
-    fallbackRouteParams,
-    generateRenderRequestId,
-    getMissingPrefetchHintPolicy(
-      renderOpts.isBuildTimePrerendering ?? false,
-      false,
-      renderOpts.cacheComponents
-    ),
-    {
-      canPostpone: false,
-      isPossiblyPartialResponse: false,
-      supportsPerSegmentPrefetching: renderOpts.cacheComponents,
-    }
+  const prepared = await getTracer().trace(
+    AppRenderSpan.initializeRender,
+    { spanName: 'initialize app render' },
+    () =>
+      prepareAppPageRender(
+        req,
+        res,
+        url,
+        pagePath,
+        query,
+        renderOpts,
+        workStore,
+        parsedRequestHeaders,
+        sharedContext,
+        interpolatedParams,
+        fallbackRouteParams,
+        generateRenderRequestId,
+        getMissingPrefetchHintPolicy(
+          renderOpts.isBuildTimePrerendering ?? false,
+          false,
+          renderOpts.cacheComponents
+        ),
+        {
+          canPostpone: false,
+          isPossiblyPartialResponse: false,
+          supportsPerSegmentPrefetching: renderOpts.cacheComponents,
+        }
+      )
   )
   return renderAppPage(prepared, postponedState, serverComponentsHmrCache)
 }
@@ -3234,31 +3239,36 @@ async function prerenderToHTMLOrFlightImpl(
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ) {
   const isRoutePPREnabled = renderOpts.experimental.isRoutePPREnabled === true
-  const prepared = await prepareAppPageRender(
-    req,
-    res,
-    url,
-    pagePath,
-    query,
-    renderOpts,
-    workStore,
-    parsedRequestHeaders,
-    sharedContext,
-    interpolatedParams,
-    fallbackRouteParams,
-    generatePrerenderRequestId,
-    getMissingPrefetchHintPolicy(
-      renderOpts.isBuildTimePrerendering ?? false,
-      true,
-      renderOpts.cacheComponents
-    ),
-    {
-      // These are distinct rendering and protocol properties even though they
-      // are both determined by route-level PPR support today.
-      canPostpone: isRoutePPREnabled,
-      isPossiblyPartialResponse: isRoutePPREnabled,
-      supportsPerSegmentPrefetching: true,
-    }
+  const prepared = await getTracer().trace(
+    AppRenderSpan.initializeRender,
+    { spanName: 'initialize app render' },
+    () =>
+      prepareAppPageRender(
+        req,
+        res,
+        url,
+        pagePath,
+        query,
+        renderOpts,
+        workStore,
+        parsedRequestHeaders,
+        sharedContext,
+        interpolatedParams,
+        fallbackRouteParams,
+        generatePrerenderRequestId,
+        getMissingPrefetchHintPolicy(
+          renderOpts.isBuildTimePrerendering ?? false,
+          true,
+          renderOpts.cacheComponents
+        ),
+        {
+          // These are distinct rendering and protocol properties even though they
+          // are both determined by route-level PPR support today.
+          canPostpone: isRoutePPREnabled,
+          isPossiblyPartialResponse: isRoutePPREnabled,
+          supportsPerSegmentPrefetching: true,
+        }
+      )
   )
   return prerenderAppPage(prepared)
 }

--- a/packages/next/src/server/app-render/html-render-completion.test.ts
+++ b/packages/next/src/server/app-render/html-render-completion.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+import { context, trace } from '@opentelemetry/api'
+import { AppRenderSpan, NextVanillaSpanAllowlist } from '../lib/trace/constants'
+import { registerLocalSpanRecorder } from '../lib/trace/local-span-recorder'
+import {
+  setSpanRecorderForTest,
+  type SpanStoreRecord,
+} from '../lib/trace/span-store'
+import { createHTMLRenderCompletionTracker } from './html-render-completion'
+
+const originalDevServer = process.env.__NEXT_DEV_SERVER
+const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
+const spanRecords: SpanStoreRecord[] = []
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('createHTMLRenderCompletionTracker', () => {
+  beforeEach(() => {
+    process.env.__NEXT_DEV_SERVER = '1'
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    setSpanRecorderForTest((span) => spanRecords.push(span))
+    registerLocalSpanRecorder()
+  })
+
+  afterEach(() => {
+    if (originalDevServer === undefined) {
+      delete process.env.__NEXT_DEV_SERVER
+    } else {
+      process.env.__NEXT_DEV_SERVER = originalDevServer
+    }
+    if (originalRequestInsights === undefined) {
+      delete process.env.__NEXT_REQUEST_INSIGHTS
+    } else {
+      process.env.__NEXT_REQUEST_INSIGHTS = originalRequestInsights
+    }
+    context.disable()
+    trace.disable()
+    setSpanRecorderForTest(undefined)
+    spanRecords.length = 0
+  })
+
+  it('keeps HTML completion out of default OpenTelemetry output', () => {
+    expect(
+      NextVanillaSpanAllowlist.has(AppRenderSpan.waitForHTMLCompletion)
+    ).toBe(false)
+  })
+
+  it('settles the render when the current HTML generation completes', async () => {
+    const finishRender = jest.fn()
+    const tracker = createHTMLRenderCompletionTracker(finishRender)
+
+    tracker.track(Promise.resolve())
+    await flushMicrotasks()
+
+    expect(finishRender).toHaveBeenCalledTimes(1)
+    expect(finishRender).toHaveBeenCalledWith(undefined)
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'wait for HTML completion',
+        status: 'ok',
+      }),
+    ])
+  })
+
+  it('lets a fallback generation own render completion', async () => {
+    const finishRender = jest.fn()
+    const tracker = createHTMLRenderCompletionTracker(finishRender)
+    let resolveInitial!: () => void
+    const initial = new Promise<void>((resolve) => {
+      resolveInitial = resolve
+    })
+    const initialError = new Error('initial render failed')
+
+    tracker.track(initial)
+    tracker.supersede(initialError)
+    tracker.track(Promise.resolve())
+    resolveInitial()
+    await flushMicrotasks()
+
+    expect(finishRender).toHaveBeenCalledTimes(1)
+    expect(finishRender).toHaveBeenCalledWith(undefined)
+    expect(spanRecords.map((span) => span.status)).toEqual(['error', 'ok'])
+    expect(spanRecords[0].error).toEqual(
+      expect.objectContaining({ message: initialError.message })
+    )
+  })
+
+  it('defers rejection so recovery can supersede the failed generation', async () => {
+    const finishRender = jest.fn()
+    const tracker = createHTMLRenderCompletionTracker(finishRender)
+    const initialError = new Error('initial render failed')
+
+    const initial = Promise.reject(initialError)
+    async function continueRender() {
+      await initial
+    }
+
+    tracker.track(initial)
+    try {
+      await continueRender()
+    } catch (error) {
+      tracker.supersede(error)
+      tracker.track(Promise.resolve())
+    }
+    await flushMicrotasks()
+
+    expect(finishRender).toHaveBeenCalledTimes(1)
+    expect(finishRender).toHaveBeenCalledWith(undefined)
+    expect(spanRecords.map((span) => span.status)).toEqual(['error', 'ok'])
+  })
+
+  it('fails the render when the current generation rejects', async () => {
+    const finishRender = jest.fn()
+    const tracker = createHTMLRenderCompletionTracker(finishRender)
+    const error = new TypeError('HTML render failed')
+
+    tracker.track(Promise.reject(error))
+    await flushMicrotasks()
+
+    expect(finishRender).toHaveBeenCalledTimes(1)
+    expect(finishRender).toHaveBeenCalledWith({ error })
+    expect(spanRecords).toEqual([
+      expect.objectContaining({
+        name: 'wait for HTML completion',
+        status: 'error',
+        error: expect.objectContaining({
+          type: 'TypeError',
+          message: error.message,
+        }),
+      }),
+    ])
+  })
+})

--- a/packages/next/src/server/app-render/html-render-completion.ts
+++ b/packages/next/src/server/app-render/html-render-completion.ts
@@ -1,0 +1,63 @@
+import { AppRenderSpan } from '../lib/trace/constants'
+import {
+  createOneShotTracePhase,
+  type TracePhaseCompletion,
+} from '../lib/trace/phase'
+
+type HTMLRenderCompletionOwner = {
+  readonly token: number
+  readonly finishPhase: ReturnType<typeof createOneShotTracePhase>
+}
+
+export function createHTMLRenderCompletionTracker(
+  finishRender: (completion?: TracePhaseCompletion) => void
+) {
+  let nextToken = 0
+  let currentOwner: HTMLRenderCompletionOwner | undefined
+
+  function settle(
+    owner: HTMLRenderCompletionOwner,
+    completion?: TracePhaseCompletion
+  ) {
+    if (currentOwner?.token !== owner.token) {
+      return
+    }
+
+    currentOwner = undefined
+    owner.finishPhase(completion)
+    finishRender(completion)
+  }
+
+  return {
+    track(allReady: Promise<unknown>) {
+      const owner: HTMLRenderCompletionOwner = {
+        token: ++nextToken,
+        finishPhase: createOneShotTracePhase(
+          AppRenderSpan.waitForHTMLCompletion,
+          'wait for HTML completion'
+        ),
+      }
+      currentOwner = owner
+
+      void allReady.then(
+        () => settle(owner),
+        (error) => {
+          queueMicrotask(() => {
+            // Let the caller's awaited continuation enter recovery first.
+            queueMicrotask(() => settle(owner, { error }))
+          })
+        }
+      )
+    },
+
+    supersede(error: unknown) {
+      const owner = currentOwner
+      if (!owner) {
+        return
+      }
+
+      currentOwner = undefined
+      owner.finishPhase({ error })
+    },
+  }
+}

--- a/packages/next/src/server/client-component-renderer-logger.test.ts
+++ b/packages/next/src/server/client-component-renderer-logger.test.ts
@@ -162,4 +162,30 @@ describe('client component renderer logger', () => {
       clientComponentLoadCount: 0,
     })
   })
+
+  it('tracks rejected chunk loads without changing the returned promise', async () => {
+    jest
+      .spyOn(performance, 'now')
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(150)
+
+    const error = new Error('chunk failed')
+    const chunk = Promise.reject(error)
+    const loader = wrapClientComponentLoader(
+      createComponentModule(
+        () => undefined,
+        () => chunk
+      ),
+      true
+    )
+
+    expect(loader.loadChunk('rejected')).toBe(chunk)
+    await expect(chunk).rejects.toBe(error)
+    expect(getClientComponentLoaderMetrics()).toEqual({
+      clientComponentLoadStart: 100,
+      clientComponentLoadEnd: 150,
+      clientComponentLoadTimes: 50,
+      clientComponentLoadCount: 0,
+    })
+  })
 })

--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -44,11 +44,12 @@ export function wrapClientComponentLoader(
       const result = ComponentMod.__next_app__.loadChunk(...args)
       // Avoid wrapping `loadChunk`'s result in an extra promise in case something like React depends on its identity.
       // We only need to know when it's settled.
-      result.finally(() => {
+      const onSettled = () => {
         const endTime = performance.now()
         clientComponentLoadEnd = endTime
         clientComponentLoadTimes += endTime - startTime
-      })
+      }
+      result.then(onSettled, onSettled)
       return result
     },
   }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -70,6 +70,11 @@ import {
 } from '../lib/router-utils/setup-dev-bundler'
 import { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
 import { findPagePathData } from './on-demand-entry-handler'
+import {
+  traceCompileRoutePhase,
+  traceCompileRouteResolution,
+} from './route-compilation-tracing'
+import { DevBundlerServiceSpan } from '../lib/trace/constants'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import {
   type EntryKey,
@@ -1811,7 +1816,11 @@ export async function createHotReloaderTurbopack(
             return
           }
 
-          await currentEntriesHandling
+          await traceCompileRoutePhase(
+            DevBundlerServiceSpan.waitForEntrypoints,
+            'wait for route entrypoints',
+            () => currentEntriesHandling
+          )
 
           // TODO We shouldn't look into the filesystem again. This should use the information from entrypoints
           let routeDef: Pick<
@@ -1819,13 +1828,15 @@ export async function createHotReloaderTurbopack(
             'filename' | 'bundlePath' | 'page'
           > =
             definition ??
-            (await findPagePathData(
-              projectPath,
-              inputPage,
-              nextConfig.pageExtensions,
-              opts.pagesDir,
-              opts.appDir,
-              !!nextConfig.experimental.globalNotFound
+            (await traceCompileRouteResolution(() =>
+              findPagePathData(
+                projectPath,
+                inputPage,
+                nextConfig.pageExtensions,
+                opts.pagesDir,
+                opts.appDir,
+                !!nextConfig.experimental.globalNotFound
+              )
             ))
 
           // If the route is actually an app page route, then we should have access
@@ -1866,24 +1877,29 @@ export async function createHotReloaderTurbopack(
           if (page === '/_error') {
             let finishBuilding = startBuilding(pathname, requestUrl, false)
             try {
-              await handlePagesErrorRoute({
-                currentEntryIssues,
-                entrypoints: currentEntrypoints,
-                manifestLoader,
-                devRewrites: opts.fsChecker.rewrites,
-                productionRewrites: undefined,
-                logErrors: true,
-                hooks: {
-                  subscribeToChanges: subscribeToClientChanges,
-                  handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-                    currentWrittenEntrypoints.set(id, result)
-                    assetMapper.setPathsForKey(id, result.clientPaths)
-                    return clearRequireCache(id, result, {
-                      force: forceDeleteCache,
-                    })
-                  },
-                },
-              })
+              await traceCompileRoutePhase(
+                DevBundlerServiceSpan.buildRoute,
+                'build route',
+                () =>
+                  handlePagesErrorRoute({
+                    currentEntryIssues,
+                    entrypoints: currentEntrypoints,
+                    manifestLoader,
+                    devRewrites: opts.fsChecker.rewrites,
+                    productionRewrites: undefined,
+                    logErrors: true,
+                    hooks: {
+                      subscribeToChanges: subscribeToClientChanges,
+                      handleWrittenEndpoint: (id, result, forceDeleteCache) => {
+                        currentWrittenEntrypoints.set(id, result)
+                        assetMapper.setPathsForKey(id, result.clientPaths)
+                        return clearRequireCache(id, result, {
+                          force: forceDeleteCache,
+                        })
+                      },
+                    },
+                  })
+              )
             } finally {
               finishBuilding()
             }
@@ -1928,36 +1944,41 @@ export async function createHotReloaderTurbopack(
 
           const finishBuilding = startBuilding(pathname, requestUrl, false)
           try {
-            await handleRouteType({
-              dev,
-              page,
-              pathname,
-              route,
-              currentEntryIssues,
-              entrypoints: currentEntrypoints,
-              manifestLoader,
-              readyIds,
-              devRewrites: opts.fsChecker.rewrites,
-              productionRewrites: undefined,
-              logErrors: true,
+            await traceCompileRoutePhase(
+              DevBundlerServiceSpan.buildRoute,
+              'build route',
+              () =>
+                handleRouteType({
+                  dev,
+                  page,
+                  pathname,
+                  route,
+                  currentEntryIssues,
+                  entrypoints: currentEntrypoints,
+                  manifestLoader,
+                  readyIds,
+                  devRewrites: opts.fsChecker.rewrites,
+                  productionRewrites: undefined,
+                  logErrors: true,
 
-              hooks: {
-                // Pass a no-o subscribeToChanges to skip wiring HMR subscriptions for
-                // one-shot compilations (e.g. compile_route MCP tool).
-                subscribeToChanges: subscribeToChanges
-                  ? subscribeToClientChanges
-                  : ((async () => {}) as StartChangeSubscription),
-                handleServerComponentChanges,
-                handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-                  currentWrittenEntrypoints.set(id, result)
-                  assetMapper.setPathsForKey(id, result.clientPaths)
-                  return clearRequireCache(id, result, {
-                    force: forceDeleteCache,
-                  })
-                },
-                serverFastRefresh,
-              },
-            })
+                  hooks: {
+                    // Pass a no-o subscribeToChanges to skip wiring HMR subscriptions for
+                    // one-shot compilations (e.g. compile_route MCP tool).
+                    subscribeToChanges: subscribeToChanges
+                      ? subscribeToClientChanges
+                      : ((async () => {}) as StartChangeSubscription),
+                    handleServerComponentChanges,
+                    handleWrittenEndpoint: (id, result, forceDeleteCache) => {
+                      currentWrittenEntrypoints.set(id, result)
+                      assetMapper.setPathsForKey(id, result.clientPaths)
+                      return clearRequireCache(id, result, {
+                        force: forceDeleteCache,
+                      })
+                    },
+                    serverFastRefresh,
+                  },
+                })
+            )
           } finally {
             finishBuilding()
             // Remove non-deferred entry from building set

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -48,6 +48,11 @@ import { PAGE_TYPES } from '../../lib/page-types'
 import { getNextFlightSegmentPath } from '../../client/flight-data-helpers'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
+import {
+  traceCompileRoutePhase,
+  traceCompileRouteResolution,
+} from './route-compilation-tracing'
+import { DevBundlerServiceSpan } from '../lib/trace/constants'
 
 const debug = createDebug('next:on-demand-entry-handler')
 
@@ -831,19 +836,18 @@ export function onDemandEntryHandler({
     }, stalledTime * 1000)
 
     try {
-      let route: Pick<RouteDefinition, 'filename' | 'bundlePath' | 'page'>
-      if (definition) {
-        route = definition
-      } else {
-        route = await findPagePathData(
-          rootDir,
-          page,
-          nextConfig.pageExtensions,
-          pagesDir,
-          appDir,
-          !!nextConfig.experimental.globalNotFound
-        )
-      }
+      const route: Pick<RouteDefinition, 'filename' | 'bundlePath' | 'page'> =
+        definition ??
+        (await traceCompileRouteResolution(() =>
+          findPagePathData(
+            rootDir,
+            page,
+            nextConfig.pageExtensions,
+            pagesDir,
+            appDir,
+            !!nextConfig.experimental.globalNotFound
+          )
+        ))
 
       const isInsideAppDir = !!appDir && route.filename.startsWith(appDir)
 
@@ -916,15 +920,20 @@ export function onDemandEntryHandler({
         }
       }
 
-      const staticInfo = await getStaticInfoIncludingLayouts({
-        page,
-        pageFilePath: route.filename,
-        isInsideAppDir,
-        pageExtensions: nextConfig.pageExtensions,
-        isDev: true,
-        config: nextConfig,
-        appDir,
-      })
+      const staticInfo = await traceCompileRoutePhase(
+        DevBundlerServiceSpan.analyzeRoute,
+        'analyze route',
+        () =>
+          getStaticInfoIncludingLayouts({
+            page,
+            pageFilePath: route.filename,
+            isInsideAppDir,
+            pageExtensions: nextConfig.pageExtensions,
+            isDev: true,
+            config: nextConfig,
+            appDir,
+          })
+      )
 
       const added = new Map<CompilerNameValues, ReturnType<typeof addEntry>>()
       const isServerComponent =
@@ -1020,8 +1029,14 @@ export function onDemandEntryHandler({
           })
         )
 
-        curInvalidator.invalidate([...added.keys()])
-        await invalidatePromise
+        await traceCompileRoutePhase(
+          DevBundlerServiceSpan.buildRoute,
+          'build route',
+          async () => {
+            curInvalidator.invalidate([...added.keys()])
+            await invalidatePromise
+          }
+        )
       }
     } finally {
       clearTimeout(stalledEnsureTimeout)

--- a/packages/next/src/server/dev/route-compilation-tracing.ts
+++ b/packages/next/src/server/dev/route-compilation-tracing.ts
@@ -8,17 +8,19 @@ import {
 } from '../lib/trace/phase'
 import { getTracer } from '../lib/trace/tracer'
 
-let compileRouteAsyncStorage: AsyncLocalStorage<Span> | undefined
-
-class ExpectedRouteResolutionMiss {
-  constructor(readonly error: PageNotFoundError) {}
+type CompileRouteContext = {
+  span: Span
+  expectedResolutionMisses: WeakSet<PageNotFoundError>
+  active: boolean
 }
+
+let compileRouteAsyncStorage: AsyncLocalStorage<CompileRouteContext> | undefined
 
 type CompileRouteOutcome<T> =
   | { kind: 'result'; value: T }
   | { kind: 'resolution-miss'; error: PageNotFoundError }
 
-function getCompileRouteAsyncStorage(): AsyncLocalStorage<Span> {
+function getCompileRouteAsyncStorage(): AsyncLocalStorage<CompileRouteContext> {
   if (!compileRouteAsyncStorage) {
     const { createAsyncLocalStorage } =
       require('../app-render/async-local-storage') as typeof import('../app-render/async-local-storage')
@@ -28,15 +30,23 @@ function getCompileRouteAsyncStorage(): AsyncLocalStorage<Span> {
 }
 
 async function runCompileRouteOperation<T>(
-  operation: () => Promise<T>
+  operation: () => Promise<T>,
+  compileRouteContext?: CompileRouteContext
 ): Promise<CompileRouteOutcome<T>> {
   try {
     return { kind: 'result', value: await operation() }
   } catch (error) {
-    if (error instanceof ExpectedRouteResolutionMiss) {
-      return { kind: 'resolution-miss', error: error.error }
+    if (
+      error instanceof PageNotFoundError &&
+      compileRouteContext?.expectedResolutionMisses.delete(error)
+    ) {
+      return { kind: 'resolution-miss', error }
     }
     throw error
+  } finally {
+    if (compileRouteContext) {
+      compileRouteContext.active = false
+    }
   }
 }
 
@@ -50,12 +60,20 @@ export async function traceCompileRoute<T>(
   const outcome = await getTracer().trace(
     DevBundlerServiceSpan.ensurePage,
     { spanName: 'compile route' },
-    (compileRouteSpan) =>
-      compileRouteSpan
-        ? getCompileRouteAsyncStorage().run(compileRouteSpan, () =>
-            runCompileRouteOperation(operation)
-          )
-        : runCompileRouteOperation(operation)
+    (compileRouteSpan) => {
+      if (!compileRouteSpan) {
+        return runCompileRouteOperation(operation)
+      }
+
+      const compileRouteContext: CompileRouteContext = {
+        span: compileRouteSpan,
+        expectedResolutionMisses: new WeakSet(),
+        active: true,
+      }
+      return getCompileRouteAsyncStorage().run(compileRouteContext, () =>
+        runCompileRouteOperation(operation, compileRouteContext)
+      )
+    }
   )
 
   if (outcome.kind === 'resolution-miss') {
@@ -64,23 +82,28 @@ export async function traceCompileRoute<T>(
   return outcome.value
 }
 
-function getCompileRouteParentSpan() {
+function getCompileRouteContext() {
   if (!isInternalTracingEnabled()) {
     return undefined
   }
 
-  const compileRouteSpan = compileRouteAsyncStorage?.getStore()
+  const compileRouteContext = compileRouteAsyncStorage?.getStore()
   const activeSpan = getTracer().getActiveScopeSpan()
-  if (!compileRouteSpan || !activeSpan) {
+  if (!compileRouteContext?.active || !activeSpan) {
     return undefined
   }
 
-  const compileRouteContext = compileRouteSpan.spanContext()
+  const compileRouteSpan = compileRouteContext.span
+  const compileRouteSpanContext = compileRouteSpan.spanContext()
   const activeContext = activeSpan.spanContext()
-  return compileRouteContext.traceId === activeContext.traceId &&
-    compileRouteContext.spanId === activeContext.spanId
-    ? compileRouteSpan
+  return compileRouteSpanContext.traceId === activeContext.traceId &&
+    compileRouteSpanContext.spanId === activeContext.spanId
+    ? compileRouteContext
     : undefined
+}
+
+function getCompileRouteParentSpan() {
+  return getCompileRouteContext()?.span
 }
 
 export async function traceCompileRoutePhase<T>(
@@ -102,7 +125,8 @@ export async function traceCompileRoutePhase<T>(
 export async function traceCompileRouteResolution<T>(
   operation: () => Promise<T>
 ): Promise<T> {
-  if (!getCompileRouteParentSpan()) {
+  const compileRouteContext = getCompileRouteContext()
+  if (!compileRouteContext) {
     return await operation()
   }
 
@@ -120,7 +144,10 @@ export async function traceCompileRouteResolution<T>(
     // failed child for a probe that its caller is expected to catch.
     if (error instanceof PageNotFoundError) {
       finishResolution()
-      throw new ExpectedRouteResolutionMiss(error)
+      if (compileRouteContext.active) {
+        compileRouteContext.expectedResolutionMisses.add(error)
+      }
+      throw error
     } else {
       finishResolution({ error })
       throw error

--- a/packages/next/src/server/dev/route-compilation-tracing.ts
+++ b/packages/next/src/server/dev/route-compilation-tracing.ts
@@ -1,0 +1,129 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+import type { Span } from 'next/dist/compiled/@opentelemetry/api'
+import { PageNotFoundError } from '../../shared/lib/utils'
+import { DevBundlerServiceSpan, type SpanTypes } from '../lib/trace/constants'
+import {
+  createOneShotTracePhase,
+  isInternalTracingEnabled,
+} from '../lib/trace/phase'
+import { getTracer } from '../lib/trace/tracer'
+
+let compileRouteAsyncStorage: AsyncLocalStorage<Span> | undefined
+
+class ExpectedRouteResolutionMiss {
+  constructor(readonly error: PageNotFoundError) {}
+}
+
+type CompileRouteOutcome<T> =
+  | { kind: 'result'; value: T }
+  | { kind: 'resolution-miss'; error: PageNotFoundError }
+
+function getCompileRouteAsyncStorage(): AsyncLocalStorage<Span> {
+  if (!compileRouteAsyncStorage) {
+    const { createAsyncLocalStorage } =
+      require('../app-render/async-local-storage') as typeof import('../app-render/async-local-storage')
+    compileRouteAsyncStorage = createAsyncLocalStorage()
+  }
+  return compileRouteAsyncStorage
+}
+
+async function runCompileRouteOperation<T>(
+  operation: () => Promise<T>
+): Promise<CompileRouteOutcome<T>> {
+  try {
+    return { kind: 'result', value: await operation() }
+  } catch (error) {
+    if (error instanceof ExpectedRouteResolutionMiss) {
+      return { kind: 'resolution-miss', error: error.error }
+    }
+    throw error
+  }
+}
+
+export async function traceCompileRoute<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  if (!isInternalTracingEnabled()) {
+    return await operation()
+  }
+
+  const outcome = await getTracer().trace(
+    DevBundlerServiceSpan.ensurePage,
+    { spanName: 'compile route' },
+    (compileRouteSpan) =>
+      compileRouteSpan
+        ? getCompileRouteAsyncStorage().run(compileRouteSpan, () =>
+            runCompileRouteOperation(operation)
+          )
+        : runCompileRouteOperation(operation)
+  )
+
+  if (outcome.kind === 'resolution-miss') {
+    throw outcome.error
+  }
+  return outcome.value
+}
+
+function getCompileRouteParentSpan() {
+  if (!isInternalTracingEnabled()) {
+    return undefined
+  }
+
+  const compileRouteSpan = compileRouteAsyncStorage?.getStore()
+  const activeSpan = getTracer().getActiveScopeSpan()
+  if (!compileRouteSpan || !activeSpan) {
+    return undefined
+  }
+
+  const compileRouteContext = compileRouteSpan.spanContext()
+  const activeContext = activeSpan.spanContext()
+  return compileRouteContext.traceId === activeContext.traceId &&
+    compileRouteContext.spanId === activeContext.spanId
+    ? compileRouteSpan
+    : undefined
+}
+
+export async function traceCompileRoutePhase<T>(
+  type: SpanTypes,
+  spanName: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const parentSpan = getCompileRouteParentSpan()
+
+  // These phases describe work within `compile route`. An unrelated active
+  // span or direct route probe must not become their owner.
+  if (!parentSpan) {
+    return await operation()
+  }
+
+  return await getTracer().trace(type, { spanName, parentSpan }, operation)
+}
+
+export async function traceCompileRouteResolution<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  if (!getCompileRouteParentSpan()) {
+    return await operation()
+  }
+
+  const finishResolution = createOneShotTracePhase(
+    DevBundlerServiceSpan.resolveRoute,
+    'resolve route'
+  )
+
+  try {
+    const result = await operation()
+    finishResolution()
+    return result
+  } catch (error) {
+    // Candidate-route misses are normal dev-server control flow. Do not emit a
+    // failed child for a probe that its caller is expected to catch.
+    if (error instanceof PageNotFoundError) {
+      finishResolution()
+      throw new ExpectedRouteResolutionMiss(error)
+    } else {
+      finishResolution({ error })
+      throw error
+    }
+  }
+}

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -9,9 +9,8 @@ import {
   type HmrMessageSentToBrowser,
   type NextJsHotReloaderInterface,
 } from '../dev/hot-reloader-types'
-import { DevBundlerServiceSpan } from './trace/constants'
 import { subscribeRequestInsights } from './trace/request-insights'
-import { getTracer } from './trace/tracer'
+import { traceCompileRoute } from '../dev/route-compilation-tracing'
 
 /**
  * The DevBundlerService provides an interface to perform tasks with the
@@ -63,10 +62,8 @@ export class DevBundlerService {
     definition
   ) => {
     // TODO: remove after ensure is pulled out of server
-    return await getTracer().trace(
-      DevBundlerServiceSpan.ensurePage,
-      { spanName: 'compile route' },
-      () => this.bundler.hotReloader.ensurePage(definition)
+    return await traceCompileRoute(() =>
+      this.bundler.hotReloader.ensurePage(definition)
     )
   }
 

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -85,6 +85,8 @@ enum RenderSpan {
 enum AppRenderSpan {
   prepareAppPageResponse = 'AppRender.prepareAppPageResponse',
   initializeRender = 'AppRender.initializeRender',
+  renderRSCResponse = 'AppRender.renderRSCResponse',
+  waitForRSC = 'AppRender.waitForRSC',
   renderToString = 'AppRender.renderToString',
   renderToReadableStream = 'AppRender.renderToReadableStream',
   getBodyResult = 'AppRender.getBodyResult',

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -83,6 +83,8 @@ enum RenderSpan {
 }
 
 enum AppRenderSpan {
+  prepareAppPageResponse = 'AppRender.prepareAppPageResponse',
+  initializeRender = 'AppRender.initializeRender',
   renderToString = 'AppRender.renderToString',
   renderToReadableStream = 'AppRender.renderToReadableStream',
   getBodyResult = 'AppRender.getBodyResult',

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -61,6 +61,7 @@ enum NextNodeServerSpan {
   renderError = 'NextNodeServer.renderError',
   renderErrorToHTML = 'NextNodeServer.renderErrorToHTML',
   render404 = 'NextNodeServer.render404',
+  matchRoute = 'NextNodeServer.matchRoute',
   startResponse = 'NextNodeServer.startResponse',
 
   // nested inner span, does not require parent scope name
@@ -105,6 +106,10 @@ enum DevRouteMatcherManagerSpan {
 
 enum DevBundlerServiceSpan {
   ensurePage = 'DevBundlerService.ensurePage',
+  waitForEntrypoints = 'DevBundlerService.waitForEntrypoints',
+  resolveRoute = 'DevBundlerService.resolveRoute',
+  analyzeRoute = 'DevBundlerService.analyzeRoute',
+  buildRoute = 'DevBundlerService.buildRoute',
 }
 
 enum RouterSpan {

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -63,6 +63,7 @@ enum NextNodeServerSpan {
   render404 = 'NextNodeServer.render404',
   matchRoute = 'NextNodeServer.matchRoute',
   startResponse = 'NextNodeServer.startResponse',
+  waitForFirstResponseChunk = 'NextNodeServer.waitForFirstResponseChunk',
 
   // nested inner span, does not require parent scope name
   route = 'route',

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -88,6 +88,7 @@ enum AppRenderSpan {
   initializeRender = 'AppRender.initializeRender',
   renderRSCResponse = 'AppRender.renderRSCResponse',
   waitForRSC = 'AppRender.waitForRSC',
+  waitForHTMLCompletion = 'AppRender.waitForHTMLCompletion',
   renderToString = 'AppRender.renderToString',
   renderToReadableStream = 'AppRender.renderToReadableStream',
   getBodyResult = 'AppRender.getBodyResult',

--- a/packages/next/src/server/lib/trace/phase.ts
+++ b/packages/next/src/server/lib/trace/phase.ts
@@ -1,17 +1,19 @@
 import type { SpanTypes } from './constants'
 import { getTracer, SpanStatusCode } from './tracer'
+import { isRequestInsightsEnabled } from './span-store'
 
 export type TracePhaseCompletion = { error: unknown }
 export type FinishTracePhase = (completion?: TracePhaseCompletion) => void
+
+export function isInternalTracingEnabled(): boolean {
+  return isRequestInsightsEnabled() || process.env.NEXT_OTEL_VERBOSE === '1'
+}
 
 export function createOneShotTracePhase(
   type: SpanTypes,
   spanName: string
 ): FinishTracePhase {
-  if (
-    !process.env.__NEXT_REQUEST_INSIGHTS &&
-    process.env.NEXT_OTEL_VERBOSE !== '1'
-  ) {
+  if (!isInternalTracingEnabled()) {
     return () => {}
   }
 

--- a/packages/next/src/server/lib/trace/phase.ts
+++ b/packages/next/src/server/lib/trace/phase.ts
@@ -1,0 +1,53 @@
+import type { SpanTypes } from './constants'
+import { getTracer, SpanStatusCode } from './tracer'
+
+export type TracePhaseCompletion = { error: unknown }
+export type FinishTracePhase = (completion?: TracePhaseCompletion) => void
+
+export function createOneShotTracePhase(
+  type: SpanTypes,
+  spanName: string
+): FinishTracePhase {
+  if (
+    !process.env.__NEXT_REQUEST_INSIGHTS &&
+    process.env.NEXT_OTEL_VERBOSE !== '1'
+  ) {
+    return () => {}
+  }
+
+  const tracer = getTracer()
+  const startTime = performance.timeOrigin + performance.now()
+  const parentSpan = tracer.getActiveScopeSpan()
+  let isFinished = false
+
+  return (completion) => {
+    if (isFinished) {
+      return
+    }
+    isFinished = true
+
+    tracer.trace(
+      type,
+      {
+        startTime,
+        parentSpan,
+        spanName,
+      },
+      (span) => {
+        if (!completion) {
+          return
+        }
+
+        const { error } = completion
+        if (error instanceof Error) {
+          span?.recordException(error)
+          span?.setAttribute('error.type', error.name)
+        }
+        span?.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : undefined,
+        })
+      }
+    )
+  }
+}

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -27,8 +27,10 @@ import {
 import {
   AppRenderSpan,
   BaseServerSpan,
+  DevBundlerServiceSpan,
   LoadComponentsSpan,
   NextNodeServerSpan,
+  NextVanillaSpanAllowlist,
   NodeSpan,
 } from './constants'
 import { createOneShotTracePhase } from './phase'
@@ -38,6 +40,12 @@ import {
   ReactServerResult,
   type AnyStream,
 } from '../../app-render/app-render-prerender-utils'
+import { PageNotFoundError } from '../../../shared/lib/utils'
+import {
+  traceCompileRoute,
+  traceCompileRoutePhase,
+  traceCompileRouteResolution,
+} from '../../dev/route-compilation-tracing'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
@@ -294,6 +302,140 @@ describe('local span recording', () => {
     )
   })
 
+  it('records a successful route compilation phase under its compile owner', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const result = await traceCompileRoute(() =>
+      traceCompileRoutePhase(
+        DevBundlerServiceSpan.analyzeRoute,
+        'analyze route',
+        async () => 'analyzed'
+      )
+    )
+
+    expect(result).toBe('analyzed')
+    const compileSpan = getSpanRecords({ name: 'compile route' })[0]
+    expect(getSpanRecords({ name: 'analyze route' })).toEqual([
+      expect.objectContaining({
+        parentSpanId: compileSpan.spanId,
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_type': DevBundlerServiceSpan.analyzeRoute,
+        }),
+      }),
+    ])
+  })
+
+  it('records candidate route misses as successful resolution work', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const miss = new PageNotFoundError('candidate route')
+
+    await expect(
+      traceCompileRoute(() =>
+        traceCompileRouteResolution(async () => {
+          throw miss
+        })
+      )
+    ).rejects.toBe(miss)
+
+    expect(getSpanRecords({ name: 'resolve route' })).toEqual([
+      expect.objectContaining({
+        status: 'ok',
+        error: undefined,
+        attributes: expect.objectContaining({
+          'next.span_type': DevBundlerServiceSpan.resolveRoute,
+        }),
+      }),
+    ])
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({
+        status: 'ok',
+        error: undefined,
+      }),
+    ])
+  })
+
+  it('records genuine route resolution failures as errors', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const failure = new TypeError('route analysis failed')
+
+    await expect(
+      traceCompileRoute(() =>
+        traceCompileRouteResolution(async () => {
+          throw failure
+        })
+      )
+    ).rejects.toBe(failure)
+
+    expect(getSpanRecords({ name: 'resolve route' })).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: {
+          type: 'TypeError',
+          message: 'route analysis failed',
+        },
+      }),
+    ])
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({
+        status: 'error',
+      }),
+    ])
+  })
+
+  it('keeps terminal page-not-found failures outside resolution probes failed', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const failure = new PageNotFoundError('terminal route')
+
+    await expect(
+      traceCompileRoute(async () => {
+        throw failure
+      })
+    ).rejects.toBe(failure)
+
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: {
+          type: 'PageNotFoundError',
+          message: 'Cannot find module for page: terminal route',
+        },
+      }),
+    ])
+  })
+
+  it('does not record route phases without a compile owner', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    await traceCompileRoutePhase(
+      DevBundlerServiceSpan.buildRoute,
+      'build route',
+      async () => undefined
+    )
+    await traceCompileRouteResolution(async () => undefined)
+
+    expect(getSpanRecords({ name: 'build route' })).toEqual([])
+    expect(getSpanRecords({ name: 'resolve route' })).toEqual([])
+  })
+
+  it('does not assign route phases to a different active parent', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    await traceCompileRoute(() =>
+      getTracer().trace(BaseServerSpan.render, () =>
+        traceCompileRoutePhase(
+          DevBundlerServiceSpan.buildRoute,
+          'build route',
+          async () => undefined
+        )
+      )
+    )
+
+    expect(getSpanRecords({ name: 'compile route' })).toHaveLength(1)
+    expect(getSpanRecords({ name: BaseServerSpan.render })).toHaveLength(1)
+    expect(getSpanRecords({ name: 'build route' })).toEqual([])
+  })
+
   async function createTrackedReactServerResult(
     createStream: () => AnyStream | Promise<AnyStream>
   ) {
@@ -419,6 +561,66 @@ describe('local span recording', () => {
     process.env.NEXT_OTEL_VERBOSE = '1'
     getTracer().trace(BaseServerSpan.render, () => undefined)
     expect(exportedSpans).toEqual([NodeSpan.runHandler, BaseServerSpan.render])
+  })
+
+  it('keeps route phases out of default public OTel while preserving verbose tracing', async () => {
+    const routeSpanTypes = [
+      NextNodeServerSpan.matchRoute,
+      DevBundlerServiceSpan.waitForEntrypoints,
+      DevBundlerServiceSpan.resolveRoute,
+      DevBundlerServiceSpan.analyzeRoute,
+      DevBundlerServiceSpan.buildRoute,
+    ]
+    for (const spanType of routeSpanTypes) {
+      expect(NextVanillaSpanAllowlist.has(spanType)).toBe(false)
+    }
+
+    context.disable()
+    context.setGlobalContextManager(new TestContextManager())
+    const exportedSpans: string[] = []
+    const delegateSpan = trace.wrapSpanContext({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    })
+    trace.setGlobalTracerProvider({
+      getTracer() {
+        return {
+          startSpan: () => delegateSpan,
+          startActiveSpan(...args: unknown[]) {
+            exportedSpans.push(args[0] as string)
+            const callback = args.at(-1) as (
+              span: typeof delegateSpan
+            ) => unknown
+            return context.with(
+              trace.setSpan(context.active(), delegateSpan),
+              callback,
+              undefined,
+              delegateSpan
+            )
+          },
+        }
+      },
+    })
+
+    await traceCompileRoute(() =>
+      traceCompileRoutePhase(
+        DevBundlerServiceSpan.buildRoute,
+        'build route',
+        async () => undefined
+      )
+    )
+    expect(exportedSpans).toEqual([])
+
+    process.env.NEXT_OTEL_VERBOSE = '1'
+    await traceCompileRoute(() =>
+      traceCompileRoutePhase(
+        DevBundlerServiceSpan.buildRoute,
+        'build route',
+        async () => undefined
+      )
+    )
+    expect(exportedSpans).toEqual(['compile route', 'build route'])
   })
 
   it('does not record or export hidden spans', () => {

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -41,6 +41,7 @@ import {
   type AnyStream,
 } from '../../app-render/app-render-prerender-utils'
 import { PageNotFoundError } from '../../../shared/lib/utils'
+import { Batcher } from '../../../lib/batcher'
 import {
   traceCompileRoute,
   traceCompileRoutePhase,
@@ -353,6 +354,128 @@ describe('local span recording', () => {
         error: undefined,
       }),
     ])
+  })
+
+  it('does not wrap candidate misses shared with an untraced caller', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const miss = new PageNotFoundError('shared candidate route')
+    const batcher = Batcher.create<string, void>()
+    let rejectSharedOperation!: (error: PageNotFoundError) => void
+    const sharedOperation = new Promise<void>((_, reject) => {
+      rejectSharedOperation = reject
+    })
+
+    const traced = traceCompileRoute(() =>
+      batcher.batch('candidate route', async () =>
+        traceCompileRouteResolution(() => sharedOperation)
+      )
+    )
+    const untraced = batcher.batch('candidate route', async () => {
+      throw new Error('deduplicated work unexpectedly ran twice')
+    })
+
+    rejectSharedOperation(miss)
+
+    const [tracedResult, untracedResult] = await Promise.allSettled([
+      traced,
+      untraced,
+    ])
+    expect(tracedResult.status).toBe('rejected')
+    expect(untracedResult.status).toBe('rejected')
+    if (
+      tracedResult.status !== 'rejected' ||
+      untracedResult.status !== 'rejected'
+    ) {
+      throw new Error('expected both callers to reject')
+    }
+    expect(tracedResult.reason).toBe(miss)
+    expect(untracedResult.reason).toBe(miss)
+    expect(getSpanRecords({ name: 'resolve route' })[0]).toEqual(
+      expect.objectContaining({ status: 'ok', error: undefined })
+    )
+    expect(getSpanRecords({ name: 'compile route' })[0]).toEqual(
+      expect.objectContaining({ status: 'ok', error: undefined })
+    )
+  })
+
+  it('only lets the traced work owner consume a shared candidate miss', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    const miss = new PageNotFoundError('shared traced candidate route')
+    const batcher = Batcher.create<string, void>()
+    let rejectSharedOperation!: (error: PageNotFoundError) => void
+    const sharedOperation = new Promise<void>((_, reject) => {
+      rejectSharedOperation = reject
+    })
+
+    const workOwner = traceCompileRoute(() =>
+      batcher.batch('candidate route', async () =>
+        traceCompileRouteResolution(() => sharedOperation)
+      )
+    )
+    const joiningOwner = traceCompileRoute(() =>
+      batcher.batch('candidate route', async () => {
+        throw new Error('deduplicated work unexpectedly ran twice')
+      })
+    )
+
+    rejectSharedOperation(miss)
+
+    const [workOwnerResult, joiningOwnerResult] = await Promise.allSettled([
+      workOwner,
+      joiningOwner,
+    ])
+    expect(workOwnerResult.status).toBe('rejected')
+    expect(joiningOwnerResult.status).toBe('rejected')
+    if (
+      workOwnerResult.status !== 'rejected' ||
+      joiningOwnerResult.status !== 'rejected'
+    ) {
+      throw new Error('expected both callers to reject')
+    }
+    expect(workOwnerResult.reason).toBe(miss)
+    expect(joiningOwnerResult.reason).toBe(miss)
+
+    const resolutionSpan = getSpanRecords({ name: 'resolve route' })[0]
+    const compileSpans = getSpanRecords({ name: 'compile route' })
+    expect(compileSpans).toHaveLength(2)
+    expect(
+      compileSpans.find((span) => span.spanId === resolutionSpan.parentSpanId)
+    ).toEqual(expect.objectContaining({ status: 'ok', error: undefined }))
+    expect(
+      compileSpans.find((span) => span.spanId !== resolutionSpan.parentSpanId)
+    ).toEqual(expect.objectContaining({ status: 'error' }))
+  })
+
+  it('does not attach late async descendants to a completed compile owner', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    let resumeDescendant!: () => void
+    const descendantCanResume = new Promise<void>((resolve) => {
+      resumeDescendant = resolve
+    })
+    let descendant!: Promise<void>
+    let descendantRan = false
+
+    await traceCompileRoute(async () => {
+      descendant = (async () => {
+        await descendantCanResume
+        await traceCompileRoutePhase(
+          DevBundlerServiceSpan.buildRoute,
+          'late build route',
+          async () => {
+            descendantRan = true
+          }
+        )
+      })()
+    })
+
+    resumeDescendant()
+    await descendant
+
+    expect(descendantRan).toBe(true)
+    expect(getSpanRecords({ name: 'compile route' })).toEqual([
+      expect.objectContaining({ status: 'ok' }),
+    ])
+    expect(getSpanRecords({ name: 'late build route' })).toEqual([])
   })
 
   it('records genuine route resolution failures as errors', async () => {

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -571,8 +571,9 @@ describe('local span recording', () => {
       DevBundlerServiceSpan.analyzeRoute,
       DevBundlerServiceSpan.buildRoute,
     ]
+    const vanillaSpanAllowlist = NextVanillaSpanAllowlist as ReadonlySet<string>
     for (const spanType of routeSpanTypes) {
-      expect(NextVanillaSpanAllowlist.has(spanType)).toBe(false)
+      expect(vanillaSpanAllowlist.has(spanType)).toBe(false)
     }
 
     context.disable()

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '@opentelemetry/api'
 import type { WorkStore } from '../../app-render/work-async-storage.external'
 import type { WorkUnitStore } from '../../app-render/work-unit-async-storage.external'
+import { PassThrough } from 'node:stream'
 import {
   ROOT_CONTEXT,
   context,
@@ -30,12 +31,19 @@ import {
   NextNodeServerSpan,
   NodeSpan,
 } from './constants'
+import { createOneShotTracePhase } from './phase'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
+import {
+  createTrackedStream,
+  ReactServerResult,
+  type AnyStream,
+} from '../../app-render/app-render-prerender-utils'
 
 const customContextKey = createContextKey('next.tracer.test.custom-context')
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const originalOtelVerbose = process.env.NEXT_OTEL_VERBOSE
+const originalUseNodeStreams = process.env.__NEXT_USE_NODE_STREAMS
 const spanRecords: SpanStoreRecord[] = []
 
 function getSpanRecords(filter: { name?: string } = {}): SpanStoreRecord[] {
@@ -186,6 +194,11 @@ describe('local span recording', () => {
     } else {
       process.env.NEXT_OTEL_VERBOSE = originalOtelVerbose
     }
+    if (originalUseNodeStreams === undefined) {
+      delete process.env.__NEXT_USE_NODE_STREAMS
+    } else {
+      process.env.__NEXT_USE_NODE_STREAMS = originalUseNodeStreams
+    }
     context.disable()
     trace.disable()
     setSpanRecorderForTest(undefined)
@@ -199,6 +212,150 @@ describe('local span recording', () => {
 
     expect(result).toBe('result')
     expect(getSpanRecords()).toEqual([])
+  })
+
+  it('does not create internal phases when their recording modes are disabled', () => {
+    const finishPhase = createOneShotTracePhase(
+      AppRenderSpan.initializeRender,
+      'initialize app render'
+    )
+
+    finishPhase()
+
+    expect(getSpanRecords()).toEqual([])
+  })
+
+  it('records a one-shot phase with its captured parent and elapsed timing', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    let finishPhase: ReturnType<typeof createOneShotTracePhase>
+
+    getTracer().trace(BaseServerSpan.render, () => {
+      finishPhase = createOneShotTracePhase(
+        AppRenderSpan.initializeRender,
+        'initialize app render'
+      )
+    })
+
+    finishPhase!()
+    finishPhase!()
+
+    const parentSpan = getSpanRecords({ name: BaseServerSpan.render })[0]
+    const phaseSpans = getSpanRecords({ name: 'initialize app render' })
+    expect(phaseSpans).toHaveLength(1)
+    expect(phaseSpans[0]).toEqual(
+      expect.objectContaining({
+        startTime: expect.any(Number),
+        durationMs: expect.any(Number),
+        parentSpanId: parentSpan.spanId,
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_name': 'initialize app render',
+          'next.span_type': AppRenderSpan.initializeRender,
+        }),
+      })
+    )
+    expect(phaseSpans[0].startTime).toBeLessThanOrEqual(parentSpan.timestamp)
+    expect(phaseSpans[0].durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('records Error and non-Error phase failures without throwing them', () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    const finishErrorPhase = createOneShotTracePhase(
+      AppRenderSpan.prepareAppPageResponse,
+      'prepare app page response'
+    )
+    finishErrorPhase({ error: new TypeError('prepare failed') })
+
+    const finishNonErrorPhase = createOneShotTracePhase(
+      AppRenderSpan.initializeRender,
+      'initialize app render'
+    )
+    finishNonErrorPhase({ error: 'initialize failed' })
+
+    expect(getSpanRecords({ name: 'prepare app page response' })[0]).toEqual(
+      expect.objectContaining({
+        status: 'error',
+        error: {
+          type: 'TypeError',
+          message: 'prepare failed',
+        },
+        events: [
+          expect.objectContaining({
+            name: 'exception',
+          }),
+        ],
+      })
+    )
+    expect(getSpanRecords({ name: 'initialize app render' })[0]).toEqual(
+      expect.objectContaining({
+        status: 'error',
+      })
+    )
+  })
+
+  async function createTrackedReactServerResult(
+    createStream: () => AnyStream | Promise<AnyStream>
+  ) {
+    return getTracer().trace(BaseServerSpan.render, async () => {
+      const finishPhase = createOneShotTracePhase(
+        AppRenderSpan.renderRSCResponse,
+        'render RSC response'
+      )
+      const stream = await createTrackedStream(createStream, finishPhase)
+      return new ReactServerResult(stream)
+    })
+  }
+
+  function expectSingleFailedRSCPhase() {
+    const parentSpan = getSpanRecords({ name: BaseServerSpan.render })[0]
+    const phaseSpans = getSpanRecords({ name: 'render RSC response' })
+
+    expect(phaseSpans).toHaveLength(1)
+    expect(phaseSpans[0]).toEqual(
+      expect.objectContaining({
+        parentSpanId: parentSpan.spanId,
+        status: 'error',
+        attributes: expect.objectContaining({
+          'next.span_type': AppRenderSpan.renderRSCResponse,
+        }),
+      })
+    )
+  }
+
+  it('records one failed RSC phase when a ReactServerResult source errors', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    process.env.__NEXT_USE_NODE_STREAMS = '1'
+    const source = new PassThrough()
+    const result = await createTrackedReactServerResult(() => source)
+    const replay = result.tee() as PassThrough
+    const replayError = new Promise<Error>((resolve) => {
+      replay.on('error', resolve)
+    })
+    const error = new TypeError('RSC render failed')
+
+    source.destroy(error)
+
+    await expect(replayError).resolves.toBe(error)
+    expectSingleFailedRSCPhase()
+  })
+
+  it('records one failed RSC phase when both tee branches are cancelled', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    delete process.env.__NEXT_USE_NODE_STREAMS
+    const cancel = jest.fn()
+    const source = new ReadableStream<Uint8Array>(
+      { cancel },
+      { highWaterMark: 0 }
+    )
+    const result = await createTrackedReactServerResult(() => source)
+    const branch = result.tee() as ReadableStream<Uint8Array>
+    const remaining = result.consume() as ReadableStream<Uint8Array>
+
+    await Promise.all([branch.cancel('branch'), remaining.cancel('remaining')])
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expectSingleFailedRSCPhase()
   })
 
   it('records non-vanilla trace and wrapped spans for request insights', () => {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -98,6 +98,7 @@ import type { PagesAPIRouteMatch } from './route-matches/pages-api-route-match'
 import type { MatchOptions } from './route-matcher-managers/route-matcher-manager'
 import { BubbledError, getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { isInternalTracingEnabled } from './lib/trace/phase'
 import { nodeFs } from './lib/node-fs-methods'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { pipeToNodeResponse } from './pipe-readable'
@@ -1128,7 +1129,14 @@ export default class NextNodeServer extends BaseServer<
       const options: MatchOptions = {
         i18n: this.i18nProvider?.fromRequest(req, pathname),
       }
-      const match = await this.matchers.match(pathname, options)
+      const matchPathname = pathname
+      const match = isInternalTracingEnabled()
+        ? await getTracer().trace(
+            NextNodeServerSpan.matchRoute,
+            { spanName: 'match route' },
+            () => this.matchers.match(matchPathname, options)
+          )
+        : await this.matchers.match(matchPathname, options)
 
       // If we don't have a match, try to render it anyways.
       if (!match) {

--- a/packages/next/src/server/pipe-readable.test.ts
+++ b/packages/next/src/server/pipe-readable.test.ts
@@ -198,8 +198,10 @@ describe('first response chunk tracing', () => {
 
   it('does not replace Web first-chunk success with a later error', async () => {
     const { controller, readable } = createPendingWebStream()
+    let writtenChunk: string | undefined
     const response = new MockedResponse({
-      resWriter() {
+      resWriter(chunk) {
+        writtenChunk = Buffer.from(chunk).toString()
         controller.error(new Error('failed after first chunk'))
         return true
       },
@@ -209,6 +211,7 @@ describe('first response chunk tracing', () => {
     controller.enqueue(new TextEncoder().encode('first'))
     await expect(piping).rejects.toThrow('failed to pipe response')
 
+    expect(writtenChunk).toBe('first')
     expect(getFirstResponseChunkSpans()).toEqual([
       expect.objectContaining({ status: 'ok' }),
     ])

--- a/packages/next/src/server/pipe-readable.test.ts
+++ b/packages/next/src/server/pipe-readable.test.ts
@@ -197,12 +197,16 @@ describe('first response chunk tracing', () => {
   })
 
   it('does not replace Web first-chunk success with a later error', async () => {
-    const response = new MockedResponse()
     const { controller, readable } = createPendingWebStream()
+    const response = new MockedResponse({
+      resWriter() {
+        controller.error(new Error('failed after first chunk'))
+        return true
+      },
+    })
     const piping = pipeToNodeResponse(readable, response)
 
     controller.enqueue(new TextEncoder().encode('first'))
-    controller.error(new Error('failed after first chunk'))
     await expect(piping).rejects.toThrow('failed to pipe response')
 
     expect(getFirstResponseChunkSpans()).toEqual([

--- a/packages/next/src/server/pipe-readable.test.ts
+++ b/packages/next/src/server/pipe-readable.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @jest-environment node
+ */
+
+import { context, trace } from '@opentelemetry/api'
+import { PassThrough } from 'node:stream'
+
+import { MockedResponse } from './lib/mock-request'
+import {
+  NextNodeServerSpan,
+  NextVanillaSpanAllowlist,
+} from './lib/trace/constants'
+import { registerLocalSpanRecorder } from './lib/trace/local-span-recorder'
+import {
+  setSpanRecorderForTest,
+  type SpanStoreRecord,
+} from './lib/trace/span-store'
+import {
+  pipeNodeReadableToNodeResponse,
+  pipeToNodeResponse,
+} from './pipe-readable'
+
+const originalDevServer = process.env.__NEXT_DEV_SERVER
+const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
+const originalOtelVerbose = process.env.NEXT_OTEL_VERBOSE
+const spanRecords: SpanStoreRecord[] = []
+
+function getFirstResponseChunkSpans() {
+  return spanRecords.filter(
+    (span) =>
+      span.attributes?.['next.span_type'] ===
+      'NextNodeServer.waitForFirstResponseChunk'
+  )
+}
+
+function createPendingWebStream() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>
+  const readable = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController
+    },
+  })
+
+  return { controller, readable }
+}
+
+describe('first response chunk tracing', () => {
+  beforeEach(() => {
+    process.env.__NEXT_DEV_SERVER = '1'
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+    setSpanRecorderForTest((span) => spanRecords.push(span))
+    registerLocalSpanRecorder()
+  })
+
+  afterEach(() => {
+    if (originalDevServer === undefined) {
+      delete process.env.__NEXT_DEV_SERVER
+    } else {
+      process.env.__NEXT_DEV_SERVER = originalDevServer
+    }
+    if (originalRequestInsights === undefined) {
+      delete process.env.__NEXT_REQUEST_INSIGHTS
+    } else {
+      process.env.__NEXT_REQUEST_INSIGHTS = originalRequestInsights
+    }
+    if (originalOtelVerbose === undefined) {
+      delete process.env.NEXT_OTEL_VERBOSE
+    } else {
+      process.env.NEXT_OTEL_VERBOSE = originalOtelVerbose
+    }
+    context.disable()
+    trace.disable()
+    setSpanRecorderForTest(undefined)
+    spanRecords.length = 0
+  })
+
+  it('keeps first response chunk timing out of default OpenTelemetry output', () => {
+    expect(
+      NextVanillaSpanAllowlist.has(NextNodeServerSpan.waitForFirstResponseChunk)
+    ).toBe(false)
+  })
+
+  it('does not record first response chunk timing when internal tracing is disabled', async () => {
+    delete process.env.__NEXT_REQUEST_INSIGHTS
+    delete process.env.NEXT_OTEL_VERBOSE
+    const response = new MockedResponse()
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    await pipeToNodeResponse(readable, response)
+
+    expect(getFirstResponseChunkSpans()).toEqual([])
+  })
+
+  it('finishes when a Web stream writes its first chunk', async () => {
+    const response = new MockedResponse()
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('first'))
+        controller.enqueue(new TextEncoder().encode('second'))
+        controller.close()
+      },
+    })
+
+    await pipeToNodeResponse(readable, response)
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        name: 'wait for first response chunk',
+        status: 'ok',
+      }),
+    ])
+  })
+
+  it('finishes cleanly when a Web stream closes without a chunk', async () => {
+    const response = new MockedResponse()
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    await pipeToNodeResponse(readable, response)
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({ status: 'ok' }),
+    ])
+  })
+
+  it('records a Web stream error before its first chunk', async () => {
+    const response = new MockedResponse()
+    const error = new TypeError('web stream failed')
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(error)
+      },
+    })
+
+    await expect(pipeToNodeResponse(readable, response)).rejects.toThrow(
+      'failed to pipe response'
+    )
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: expect.objectContaining({
+          type: 'TypeError',
+          message: error.message,
+        }),
+      }),
+    ])
+  })
+
+  it('records a Web stream abort before its first chunk', async () => {
+    const response = new MockedResponse()
+    const error = new Error('web stream aborted')
+    error.name = 'AbortError'
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(error)
+      },
+    })
+
+    await pipeToNodeResponse(readable, response)
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: expect.objectContaining({
+          type: 'AbortError',
+          message: error.message,
+        }),
+      }),
+    ])
+  })
+
+  it('records a Web response closing before its first chunk', async () => {
+    const response = new MockedResponse()
+    const { readable } = createPendingWebStream()
+    const piping = pipeToNodeResponse(readable, response)
+
+    response.destroy()
+    await piping
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: expect.objectContaining({
+          type: 'ResponseAborted',
+          message: 'Response closed before its first chunk',
+        }),
+      }),
+    ])
+  })
+
+  it('does not replace Web first-chunk success with a later error', async () => {
+    const response = new MockedResponse()
+    const { controller, readable } = createPendingWebStream()
+    const piping = pipeToNodeResponse(readable, response)
+
+    controller.enqueue(new TextEncoder().encode('first'))
+    controller.error(new Error('failed after first chunk'))
+    await expect(piping).rejects.toThrow('failed to pipe response')
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({ status: 'ok' }),
+    ])
+  })
+
+  it('finishes when a Node stream emits its first chunk', async () => {
+    const response = new MockedResponse()
+    const readable = new PassThrough()
+    const piping = pipeNodeReadableToNodeResponse(readable, response)
+
+    readable.write('first')
+    readable.end('second')
+    await piping
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        name: 'wait for first response chunk',
+        status: 'ok',
+      }),
+    ])
+  })
+
+  it('finishes cleanly when a Node stream ends without a chunk', async () => {
+    const response = new MockedResponse()
+    const readable = new PassThrough()
+    const piping = pipeNodeReadableToNodeResponse(readable, response)
+
+    readable.end()
+    await piping
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({ status: 'ok' }),
+    ])
+  })
+
+  it('records a Node stream error before its first chunk', async () => {
+    const response = new MockedResponse()
+    void response.hasStreamed.catch(() => {})
+    const readable = new PassThrough()
+    const piping = pipeNodeReadableToNodeResponse(readable, response)
+    const error = new TypeError('node stream failed')
+
+    readable.destroy(error)
+    await piping
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: expect.objectContaining({
+          type: 'TypeError',
+          message: error.message,
+        }),
+      }),
+    ])
+  })
+
+  it('records a Node response closing before its first chunk', async () => {
+    const response = new MockedResponse()
+    const readable = new PassThrough()
+    const piping = pipeNodeReadableToNodeResponse(readable, response)
+
+    response.destroy()
+    await piping
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        error: expect.objectContaining({
+          type: 'ResponseAborted',
+          message: 'Response closed before its first chunk',
+        }),
+      }),
+    ])
+  })
+
+  it('does not replace Node first-chunk success with a later error', async () => {
+    const response = new MockedResponse()
+    void response.hasStreamed.catch(() => {})
+    const readable = new PassThrough()
+    const piping = pipeNodeReadableToNodeResponse(readable, response)
+
+    readable.write('first')
+    readable.destroy(new Error('failed after first chunk'))
+    await piping
+
+    expect(getFirstResponseChunkSpans()).toEqual([
+      expect.objectContaining({ status: 'ok' }),
+    ])
+  })
+})

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -8,6 +8,7 @@ import {
 import { DetachedPromise } from '../lib/detached-promise'
 import { getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { createOneShotTracePhase } from './lib/trace/phase'
 import { getClientComponentLoaderMetrics } from './client-component-renderer-logger'
 
 export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
@@ -17,11 +18,41 @@ export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
 const HAS_CLIENT_COMPONENT_METRICS_ENABLED =
   'performance' in globalThis && process.env.NEXT_OTEL_PERFORMANCE_PREFIX
 
+function createResponseClosedBeforeFirstChunkError(): Error {
+  const error = new Error('Response closed before its first chunk')
+  error.name = ResponseAbortedName
+  return error
+}
+
+function trackFirstResponseChunk() {
+  const finishPhase = createOneShotTracePhase(
+    NextNodeServerSpan.waitForFirstResponseChunk,
+    'wait for first response chunk'
+  )
+
+  return (error?: unknown) => {
+    if (error === undefined) {
+      finishPhase()
+      return
+    }
+
+    finishPhase({
+      error:
+        error instanceof Error
+          ? error
+          : new Error('Response stream failed before its first chunk', {
+              cause: error,
+            }),
+    })
+  }
+}
+
 function createWriterFromResponse(
   res: ServerResponse,
   waitUntilForEnd?: Promise<unknown>
 ): WritableStream<Uint8Array> {
   let started = false
+  const completeFirstResponseChunk = trackFirstResponseChunk()
 
   // Create a promise that will resolve once the response has drained. See
   // https://nodejs.org/api/stream.html#stream_event_drain
@@ -34,6 +65,11 @@ function createWriterFromResponse(
   // If the finish event fires, it means we shouldn't block and wait for the
   // drain event.
   res.once('close', () => {
+    completeFirstResponseChunk(
+      !started && !res.writableFinished
+        ? createResponseClosedBeforeFirstChunkError()
+        : undefined
+    )
     res.off('drain', onDrain)
     drained.resolve()
   })
@@ -53,6 +89,7 @@ function createWriterFromResponse(
       // started writing chunks.
       if (!started) {
         started = true
+        completeFirstResponseChunk()
 
         if (HAS_CLIENT_COMPONENT_METRICS_ENABLED) {
           const metrics = getClientComponentLoaderMetrics()
@@ -102,11 +139,15 @@ function createWriterFromResponse(
       }
     },
     abort: (err) => {
+      completeFirstResponseChunk(
+        err ?? createResponseClosedBeforeFirstChunkError()
+      )
       if (res.writableFinished) return
 
       res.destroy(err)
     },
     close: async () => {
+      completeFirstResponseChunk()
       // if a waitUntil promise was passed, wait for it to resolve before
       // ending the response.
       if (waitUntilForEnd) {
@@ -156,10 +197,16 @@ export async function pipeNodeReadableToNodeResponse(
     if (errored || destroyed) return
 
     let started = false
+    const completeFirstResponseChunk = trackFirstResponseChunk()
 
     const finished = new DetachedPromise<void>()
 
     res.once('close', () => {
+      completeFirstResponseChunk(
+        !started && !res.writableFinished
+          ? createResponseClosedBeforeFirstChunkError()
+          : undefined
+      )
       readable.destroy()
       finished.resolve()
     })
@@ -167,6 +214,7 @@ export async function pipeNodeReadableToNodeResponse(
     readable.on('data', (chunk: Buffer) => {
       if (!started) {
         started = true
+        completeFirstResponseChunk()
 
         if (
           'performance' in globalThis &&
@@ -211,6 +259,7 @@ export async function pipeNodeReadableToNodeResponse(
     })
 
     readable.on('end', async () => {
+      completeFirstResponseChunk()
       if (waitUntilForEnd) {
         await waitUntilForEnd
       }
@@ -223,6 +272,7 @@ export async function pipeNodeReadableToNodeResponse(
     })
 
     readable.on('error', (err) => {
+      completeFirstResponseChunk(err)
       if (isAbortError(err)) {
         finished.resolve()
         return

--- a/test/development/app-dir/request-insights-route-preparation/next.config.js
+++ b/test/development/app-dir/request-insights-route-preparation/next.config.js
@@ -2,6 +2,7 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
+  cacheComponents: true,
   experimental: {
     requestInsights: true,
   },

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import {
+  NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_RSC_UNION_QUERY,
   RSC_HEADER,
 } from 'next/dist/client/components/app-router-headers'
+import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('request-insights-route-preparation', () => {
   const { next } = nextTestSetup({
@@ -33,6 +35,8 @@ describe('request-insights-route-preparation', () => {
   const routeCompilationSpanType = 'DevBundlerService.ensurePage'
   const appPagePreparationSpanType = 'AppRender.prepareAppPageResponse'
   const renderInitializationSpanType = 'AppRender.initializeRender'
+  const renderRSCResponseSpanType = 'AppRender.renderRSCResponse'
+  const waitForRSCSpanType = 'AppRender.waitForRSC'
 
   async function getRequestInsights() {
     return (await next
@@ -44,7 +48,8 @@ describe('request-insights-route-preparation', () => {
 
   async function captureRequest(
     route: string,
-    request: () => Promise<unknown>
+    request: () => Promise<unknown>,
+    requiredSpanTypes: string[] = []
   ) {
     const existingRequestIds = new Set(
       (await getRequestInsights()).requests
@@ -79,6 +84,11 @@ describe('request-insights-route-preparation', () => {
           insight.spans.some(
             (span) =>
               span.attributes?.['next.span_type'] === routeCompilationSpanType
+          ) &&
+          requiredSpanTypes.every((spanType) =>
+            insight.spans.some(
+              (span) => span.attributes?.['next.span_type'] === spanType
+            )
           )
       )
 
@@ -86,6 +96,70 @@ describe('request-insights-route-preparation', () => {
     }, 10_000)
 
     return capturedRequest!
+  }
+
+  function expectAppPageRSCSpans(
+    request: RequestInsight,
+    { expectWaitSpan = true }: { expectWaitSpan?: boolean } = {}
+  ) {
+    const bodyRenderSpan = request.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+    )
+    const renderRSCSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === renderRSCResponseSpanType
+    )
+    const waitForRSCSpans = request.spans.filter(
+      (span) => span.attributes?.['next.span_type'] === waitForRSCSpanType
+    )
+
+    expect(renderRSCSpans).toHaveLength(1)
+    expect(waitForRSCSpans).toHaveLength(expectWaitSpan ? 1 : 0)
+
+    const renderRSCSpan = renderRSCSpans[0]
+    const renderRSCParent = request.spans.find(
+      (span) => span.spanId === renderRSCSpan.parentSpanId
+    )
+    expect(renderRSCParent).toBeDefined()
+    if (expectWaitSpan) {
+      expect(bodyRenderSpan?.spanId).toBeDefined()
+      expect(renderRSCParent?.spanId).toBe(bodyRenderSpan?.spanId)
+    }
+
+    const expectedSpans = [
+      [renderRSCSpan, 'render RSC response', renderRSCResponseSpanType],
+      ...(expectWaitSpan
+        ? ([
+            [
+              waitForRSCSpans[0],
+              'wait for RSC render task',
+              waitForRSCSpanType,
+            ],
+          ] as const)
+        : []),
+    ] as const
+
+    for (const [span, name, type] of expectedSpans) {
+      expect(span).toEqual(
+        expect.objectContaining({
+          name,
+          startTime: expect.any(Number),
+          durationMs: expect.any(Number),
+          status: 'ok',
+          traceId: renderRSCParent?.traceId,
+          parentSpanId: renderRSCParent?.spanId,
+          attributes: {
+            'next.span_category': 'nextjs',
+            'next.span_name': name,
+            'next.span_type': type,
+          },
+        })
+      )
+      expect(Number.isFinite(span.startTime)).toBe(true)
+      expect(Number.isFinite(span.durationMs)).toBe(true)
+      expect(span.durationMs).toBeGreaterThanOrEqual(0)
+    }
   }
 
   function expectRoutePreparationSpans(request: RequestInsight) {
@@ -297,43 +371,92 @@ describe('request-insights-route-preparation', () => {
   }
 
   it('records route preparation for first and subsequent App Page requests', async () => {
-    const coldRequest = await captureRequest('/', async () => {
-      const response = await next.fetch('/')
-      expect(response.status).toBe(200)
-      expect(await response.text()).toContain('route preparation page')
-    })
-    const warmRequest = await captureRequest('/', async () => {
-      const response = await next.fetch('/')
-      expect(response.status).toBe(200)
-      await response.text()
-    })
+    const requiredSpanTypes = [renderRSCResponseSpanType, waitForRSCSpanType]
+    const coldRequest = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch('/')
+        expect(response.status).toBe(200)
+        expect(await response.text()).toContain('route preparation page')
+      },
+      requiredSpanTypes
+    )
+    const warmRequest = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch('/')
+        expect(response.status).toBe(200)
+        await response.text()
+      },
+      requiredSpanTypes
+    )
 
     expectRoutePreparationSpans(coldRequest)
     expectRoutePreparationSpans(warmRequest)
     expectAppPageRenderPreparationSpans(coldRequest)
     expectAppPageRenderPreparationSpans(warmRequest)
+    expectAppPageRSCSpans(coldRequest)
+    expectAppPageRSCSpans(warmRequest)
   })
 
   it('records App Page preparation and initialization for RSC requests', async () => {
-    const request = await captureRequest('/', async () => {
-      const response = await next.fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
-        headers: {
-          [RSC_HEADER]: '1',
-        },
-      })
-      expect(response.status).toBe(200)
-      expect(response.headers.get('content-type')).toContain('text/x-component')
-      await response.text()
-    })
+    const request = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
+          headers: {
+            [RSC_HEADER]: '1',
+          },
+        })
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toContain(
+          'text/x-component'
+        )
+        await response.text()
+      },
+      [renderRSCResponseSpanType]
+    )
 
     expectRoutePreparationSpans(request)
     expectAppPageRenderPreparationSpans(request, { expectBodyRender: false })
+    expectAppPageRSCSpans(request, { expectWaitSpan: false })
     expect(
       request.spans.find(
         (span) =>
           span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
       )?.attributes?.['next.rsc']
     ).toBe(true)
+  })
+
+  it('records RSC rendering for runtime prefetch requests', async () => {
+    const cacheBustingSearchParam = await computeCacheBustingSearchParam(
+      '2',
+      undefined,
+      undefined,
+      undefined
+    )
+    const request = await captureRequest(
+      '/',
+      async () => {
+        const response = await next.fetch(
+          `/?${NEXT_RSC_UNION_QUERY}=${cacheBustingSearchParam}`,
+          {
+            headers: {
+              [RSC_HEADER]: '1',
+              [NEXT_ROUTER_PREFETCH_HEADER]: '2',
+            },
+          }
+        )
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-type')).toContain(
+          'text/x-component'
+        )
+        await response.text()
+      },
+      [renderRSCResponseSpanType]
+    )
+
+    expectAppPageRSCSpans(request, { expectWaitSpan: false })
   })
 
   it('records route preparation for first and subsequent App Route requests', async () => {

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -1,5 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import {
+  NEXT_RSC_UNION_QUERY,
+  RSC_HEADER,
+} from 'next/dist/client/components/app-router-headers'
 
 describe('request-insights-route-preparation', () => {
   const { next } = nextTestSetup({
@@ -8,6 +12,7 @@ describe('request-insights-route-preparation', () => {
 
   type RequestInsightSpan = {
     name: string
+    startTime?: number
     durationMs?: number
     status?: 'ok' | 'error'
     traceId?: string
@@ -26,6 +31,8 @@ describe('request-insights-route-preparation', () => {
   const routePreparationSpanType = 'DevRouteMatcherManager.ensureRoute'
   const matcherReloadSpanType = 'DevRouteMatcherManager.reloadMatchers'
   const routeCompilationSpanType = 'DevBundlerService.ensurePage'
+  const appPagePreparationSpanType = 'AppRender.prepareAppPageResponse'
+  const renderInitializationSpanType = 'AppRender.initializeRender'
 
   async function getRequestInsights() {
     return (await next
@@ -173,6 +180,122 @@ describe('request-insights-route-preparation', () => {
     expect(routeCompilationSpan.traceId).toBe(rootSpan?.traceId)
   }
 
+  function expectAppPageRenderPreparationSpans(
+    request: RequestInsight,
+    { expectBodyRender = true }: { expectBodyRender?: boolean } = {}
+  ) {
+    const rootSpan = request.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+    )
+    const spanById = new Map(
+      request.spans.flatMap((span) =>
+        span.spanId ? [[span.spanId, span] as const] : []
+      )
+    )
+    const renderSpans = request.spans.filter(
+      (span) => span.attributes?.['next.span_type'] === 'BaseServer.render'
+    )
+
+    expect(renderSpans).toHaveLength(1)
+    const renderSpan = renderSpans[0]
+    const preparationSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === appPagePreparationSpanType
+    )
+    const initializationSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === renderInitializationSpanType
+    )
+
+    expect(preparationSpans).toHaveLength(1)
+    expect(initializationSpans).toHaveLength(1)
+
+    const preparationSpan = preparationSpans[0]
+    const initializationSpan = initializationSpans[0]
+    expect(preparationSpan.parentSpanId).toBe(initializationSpan.parentSpanId)
+    const phaseParent = preparationSpan.parentSpanId
+      ? spanById.get(preparationSpan.parentSpanId)
+      : undefined
+    expect(phaseParent?.attributes?.['next.span_type']).toBe(
+      'BaseServer.renderToResponseWithComponents'
+    )
+
+    let phaseAncestor = phaseParent
+    const visited = new Set<string>()
+    while (
+      phaseAncestor?.spanId !== renderSpan.spanId &&
+      phaseAncestor?.parentSpanId &&
+      !visited.has(phaseAncestor.parentSpanId)
+    ) {
+      visited.add(phaseAncestor.parentSpanId)
+      phaseAncestor = spanById.get(phaseAncestor.parentSpanId)
+    }
+    expect(phaseAncestor?.spanId).toBe(renderSpan.spanId)
+    expect(preparationSpan).toEqual(
+      expect.objectContaining({
+        name: 'prepare app page response',
+        startTime: expect.any(Number),
+        durationMs: expect.any(Number),
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_category': 'nextjs',
+          'next.span_name': 'prepare app page response',
+          'next.span_type': appPagePreparationSpanType,
+        }),
+      })
+    )
+    expect(initializationSpan).toEqual(
+      expect.objectContaining({
+        name: 'initialize app render',
+        startTime: expect.any(Number),
+        durationMs: expect.any(Number),
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'next.span_category': 'nextjs',
+          'next.span_name': 'initialize app render',
+          'next.span_type': renderInitializationSpanType,
+        }),
+      })
+    )
+
+    for (const span of [preparationSpan, initializationSpan]) {
+      expect(Number.isFinite(span.startTime)).toBe(true)
+      expect(Number.isFinite(span.durationMs)).toBe(true)
+      expect(span.durationMs).toBeGreaterThanOrEqual(0)
+      expect(span.traceId).toBe(rootSpan?.traceId)
+    }
+
+    expect(
+      preparationSpan.startTime! + preparationSpan.durationMs!
+    ).toBeLessThanOrEqual(initializationSpan.startTime!)
+
+    const bodyRenderSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+    )
+    if (expectBodyRender) {
+      expect(bodyRenderSpans).toHaveLength(1)
+      const bodyRenderSpan = bodyRenderSpans[0]
+      expect(bodyRenderSpan.parentSpanId).toBe(preparationSpan.parentSpanId)
+      expect(
+        initializationSpan.startTime! + initializationSpan.durationMs!
+      ).toBeLessThanOrEqual(bodyRenderSpan.startTime!)
+    } else {
+      expect(bodyRenderSpans).toHaveLength(0)
+    }
+  }
+
+  function expectNoAppPageRenderPreparationSpans(request: RequestInsight) {
+    expect(
+      request.spans.some((span) =>
+        [appPagePreparationSpanType, renderInitializationSpanType].includes(
+          String(span.attributes?.['next.span_type'])
+        )
+      )
+    ).toBe(false)
+  }
+
   it('records route preparation for first and subsequent App Page requests', async () => {
     const coldRequest = await captureRequest('/', async () => {
       const response = await next.fetch('/')
@@ -187,6 +310,30 @@ describe('request-insights-route-preparation', () => {
 
     expectRoutePreparationSpans(coldRequest)
     expectRoutePreparationSpans(warmRequest)
+    expectAppPageRenderPreparationSpans(coldRequest)
+    expectAppPageRenderPreparationSpans(warmRequest)
+  })
+
+  it('records App Page preparation and initialization for RSC requests', async () => {
+    const request = await captureRequest('/', async () => {
+      const response = await next.fetch(`/?${NEXT_RSC_UNION_QUERY}`, {
+        headers: {
+          [RSC_HEADER]: '1',
+        },
+      })
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toContain('text/x-component')
+      await response.text()
+    })
+
+    expectRoutePreparationSpans(request)
+    expectAppPageRenderPreparationSpans(request, { expectBodyRender: false })
+    expect(
+      request.spans.find(
+        (span) =>
+          span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+      )?.attributes?.['next.rsc']
+    ).toBe(true)
   })
 
   it('records route preparation for first and subsequent App Route requests', async () => {
@@ -204,5 +351,7 @@ describe('request-insights-route-preparation', () => {
 
     expectRoutePreparationSpans(coldRequest)
     expectRoutePreparationSpans(warmRequest)
+    expectNoAppPageRenderPreparationSpans(coldRequest)
+    expectNoAppPageRenderPreparationSpans(warmRequest)
   })
 })

--- a/test/development/app-dir/request-insights/app/html-completion-r5/page.tsx
+++ b/test/development/app-dir/request-insights/app/html-completion-r5/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>HTML completion</p>
+}

--- a/test/development/app-dir/request-insights/app/route-phases-r4/page.tsx
+++ b/test/development/app-dir/request-insights/app/route-phases-r4/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>route phases</p>
+}

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -359,6 +359,63 @@ describe('request insights', () => {
     })
   })
 
+  it('records HTML completion inside the app render span', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    await next.render('/html-completion-r5')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.route === '/html-completion-r5' &&
+          !existingRequestIds.has(candidate.requestId)
+      )
+      expect(request).toBeDefined()
+
+      const appRenderSpan = request!.spans.find(
+        (span) =>
+          span.attributes?.['next.span_type'] === 'AppRender.getBodyResult'
+      )
+      const completionSpan = request!.spans.find(
+        (span) =>
+          span.attributes?.['next.span_type'] ===
+          'AppRender.waitForHTMLCompletion'
+      )
+
+      expect(appRenderSpan).toBeDefined()
+      expect(completionSpan).toEqual(
+        expect.objectContaining({
+          name: 'wait for HTML completion',
+          parentSpanId: appRenderSpan!.spanId,
+          status: 'ok',
+          startTime: expect.any(Number),
+          durationMs: expect.any(Number),
+        })
+      )
+      expect(completionSpan!.startTime).toBeGreaterThanOrEqual(
+        appRenderSpan!.startTime! - 1
+      )
+      expect(
+        completionSpan!.startTime! + completionSpan!.durationMs!
+      ).toBeLessThanOrEqual(
+        appRenderSpan!.startTime! + appRenderSpan!.durationMs! + 1
+      )
+    })
+  })
+
   it('does not attribute Request Insights bookkeeping to the app', async () => {
     const outputIndex = next.cliOutput.length
     const browser = await next.browser('/safe-clock')

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -12,12 +12,16 @@ type RequestInsight = {
   kind?: 'request' | 'instant-insights'
   htmlRequestId: string
   route: string
+  url?: string
   startTime: number
   status: 'ok'
   spans: Array<{
     name?: string
     spanId?: string
     parentSpanId?: string
+    startTime?: number
+    durationMs?: number
+    status?: 'ok' | 'error'
     attributes?: Record<string, string | number | boolean>
   }>
   fetches: Array<{
@@ -30,7 +34,7 @@ type RequestInsight = {
 }
 
 describe('request insights', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
 
@@ -93,6 +97,191 @@ describe('request insights', () => {
       verbose: false,
     })
     shouldResetRequestInsightsConfig = false
+  })
+
+  describe('cold route resolution and compilation phases', () => {
+    // These spans only appear together on the first request, so both ownership
+    // assertions share one settled cold render.
+    let coldRenderRequestId: Promise<string> | undefined
+
+    function recordColdRender(): Promise<string> {
+      coldRenderRequestId ??= (async () => {
+        const existingRequestIds = new Set(
+          (
+            (await next
+              .fetch('/_next/development/request-insights')
+              .then((response) => response.json())) as {
+              requests: RequestInsight[]
+            }
+          ).requests.map((request) => request.requestId)
+        )
+
+        await next.render('/route-phases-r4')
+
+        let requestId: string
+        await retry(async () => {
+          const snapshot = (await next
+            .fetch('/_next/development/request-insights')
+            .then((response) => response.json())) as {
+            requests: RequestInsight[]
+          }
+          const request = snapshot.requests.find(
+            (candidate) =>
+              candidate.route === '/route-phases-r4' &&
+              !existingRequestIds.has(candidate.requestId)
+          )
+
+          expect(request).toBeDefined()
+          expect(request!.status).toBe('ok')
+          expect(
+            request!.spans.filter((span) => span.status === 'error')
+          ).toEqual([])
+          requestId = request!.requestId
+        })
+        return requestId!
+      })().catch((error) => {
+        coldRenderRequestId = undefined
+        throw error
+      })
+      return coldRenderRequestId
+    }
+
+    async function getColdRenderSpans(): Promise<RequestInsight['spans']> {
+      const requestId = await recordColdRender()
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((response) => response.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) => candidate.requestId === requestId
+      )
+      expect(request).toBeDefined()
+      return request!.spans
+    }
+
+    it('records route matching with route preparation ownership', async () => {
+      await retry(async () => {
+        const spans = await getColdRenderSpans()
+        const matchSpan = spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] === 'NextNodeServer.matchRoute'
+        )
+        expect(matchSpan).toBeDefined()
+        expect(
+          spans.some(
+            (span) =>
+              span.parentSpanId === matchSpan?.spanId &&
+              span.attributes?.['next.span_type'] ===
+                'DevRouteMatcherManager.ensureRoute'
+          )
+        ).toBe(true)
+      })
+    })
+
+    it('records bundler phases inside the compile route span', async () => {
+      await retry(async () => {
+        const spans = await getColdRenderSpans()
+        const compileSpan = spans.find(
+          (candidate) =>
+            candidate.attributes?.['next.span_type'] ===
+              'DevBundlerService.ensurePage' &&
+            spans.some(
+              (child) =>
+                child.parentSpanId === candidate.spanId &&
+                child.attributes?.['next.span_type'] ===
+                  'DevBundlerService.buildRoute'
+            )
+        )
+
+        expect(compileSpan).toBeDefined()
+        const compileChildren = spans.filter(
+          (span) => span.parentSpanId === compileSpan?.spanId
+        )
+        const expectedCompilePhases = isTurbopack
+          ? [
+              'DevBundlerService.waitForEntrypoints',
+              'DevBundlerService.buildRoute',
+            ]
+          : ['DevBundlerService.analyzeRoute', 'DevBundlerService.buildRoute']
+
+        expect(
+          compileChildren.map(
+            (span) => span.attributes?.['next.span_type'] as string
+          )
+        ).toEqual(expect.arrayContaining(expectedCompilePhases))
+
+        const compileStart = compileSpan!.startTime!
+        const compileEnd = compileStart + compileSpan!.durationMs!
+        for (const child of compileChildren) {
+          expect(child.startTime).toBeGreaterThanOrEqual(compileStart - 1)
+          expect(child.startTime! + child.durationMs!).toBeLessThanOrEqual(
+            compileEnd + 1
+          )
+        }
+      })
+    })
+
+    it('records definition-less resolution for a missing route', async () => {
+      const missingRoute = '/route-phases-r4-missing'
+      const existingRequestIds = new Set(
+        (
+          (await next
+            .fetch('/_next/development/request-insights')
+            .then((response) => response.json())) as {
+            requests: RequestInsight[]
+          }
+        ).requests.map((request) => request.requestId)
+      )
+
+      const response = await next.fetch(missingRoute)
+      expect(response.status).toBe(404)
+
+      await retry(async () => {
+        const snapshot = (await next
+          .fetch('/_next/development/request-insights')
+          .then((result) => result.json())) as {
+          requests: RequestInsight[]
+        }
+        const request = snapshot.requests.find(
+          (candidate) =>
+            candidate.url === missingRoute &&
+            !existingRequestIds.has(candidate.requestId)
+        )
+        expect(request).toBeDefined()
+        expect(request!.status).toBe('ok')
+
+        const compileSpan = request!.spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] ===
+              'DevBundlerService.ensurePage' &&
+            request!.spans.some(
+              (child) =>
+                child.parentSpanId === span.spanId &&
+                child.attributes?.['next.span_type'] ===
+                  'DevBundlerService.resolveRoute'
+            )
+        )
+        const resolutionSpan = request!.spans.find(
+          (span) =>
+            span.parentSpanId === compileSpan?.spanId &&
+            span.attributes?.['next.span_type'] ===
+              'DevBundlerService.resolveRoute'
+        )
+
+        expect(compileSpan).toBeDefined()
+        expect(resolutionSpan).toBeDefined()
+        expect(resolutionSpan!.status).toBe('ok')
+        expect(resolutionSpan!.startTime).toBeGreaterThanOrEqual(
+          compileSpan!.startTime! - 1
+        )
+        expect(
+          resolutionSpan!.startTime! + resolutionSpan!.durationMs!
+        ).toBeLessThanOrEqual(
+          compileSpan!.startTime! + compileSpan!.durationMs! + 1
+        )
+      })
+    })
   })
 
   async function runWithResponse(body: unknown, args: string[] = []) {

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -394,6 +394,11 @@ describe('request insights', () => {
           span.attributes?.['next.span_type'] ===
           'AppRender.waitForHTMLCompletion'
       )
+      const firstResponseChunkSpan = request!.spans.find(
+        (span) =>
+          span.attributes?.['next.span_type'] ===
+          'NextNodeServer.waitForFirstResponseChunk'
+      )
 
       expect(appRenderSpan).toBeDefined()
       expect(completionSpan).toEqual(
@@ -413,6 +418,21 @@ describe('request insights', () => {
       ).toBeLessThanOrEqual(
         appRenderSpan!.startTime! + appRenderSpan!.durationMs! + 1
       )
+      expect(firstResponseChunkSpan).toEqual(
+        expect.objectContaining({
+          name: 'wait for first response chunk',
+          status: 'ok',
+          startTime: expect.any(Number),
+          durationMs: expect.any(Number),
+        })
+      )
+      // Response delivery is a sibling of app rendering, not render work.
+      expect(firstResponseChunkSpan!.parentSpanId).toBe(
+        appRenderSpan!.parentSpanId
+      )
+      expect(
+        completionSpan!.startTime! + completionSpan!.durationMs!
+      ).toBeLessThanOrEqual(firstResponseChunkSpan!.startTime! + 1)
     })
   })
 


### PR DESCRIPTION
## Summary

This PR completes the internal App Router render timeline that Request Insights consumes. The spans remain internal or verbose by default and do not expand the public OpenTelemetry allowlist.

- `Trace App Router render preparation`
  - records `prepare app page response` and `initialize app render` around the bounded setup work that happens before the route starts producing RSC or HTML
  - keeps the instrumentation close to the actual phase boundaries instead of deriving durations later in the Request Insights viewer
- `Trace App Router RSC rendering`
  - records RSC response production and the wait for the RSC render task
  - handles fulfilled, rejected, cancelled, and prematurely closed streams with one-shot span completion
- `Trace route matching and compilation phases`
  - adds bounded internal phases for route matching, route preparation, route entrypoint readiness, and development route building
  - keeps reload work separate so matcher refresh time is not incorrectly charged to route ensuring
- `Fix route phase allowlist test types`
  - keeps the allowlist regression typed without weakening the assertion that these new phases are not default-public OTel spans
- `Fix route compilation error propagation`
  - preserves the original compilation failure while ensuring its tracing span is stopped exactly once
- `Trace HTML completion`
  - records the wait between starting HTML production and the stream actually completing
  - covers Node and Web streams without double-stopping on close/error races
- `Trace time to the first response chunk`
  - records response-start readiness through the first committed chunk
  - preserves streaming semantics and does not treat response construction as response delivery
- `Stabilize first response chunk coverage`
  - makes the later stream failure begin only after the response has observed the first write
  - proves first-chunk success cannot be overwritten by a later error without relying on scheduler timing
- `Verify first response chunk delivery`
  - asserts that the first payload reached the response writer before the synthetic late stream error begins
  - protects the regression test from passing on span state alone without proving real delivery ordering
- `Handle rejected client chunk loads`
  - observes fulfilled and rejected chunk promises without creating an unhandled rejected promise
  - preserves the exact promise returned by the bundler while still closing the client-loading measurement

Together these phases explain cold route preparation, compilation, App Router setup, RSC work, HTML completion, and first-byte readiness without importing the broad mutable BaseServer/Fizz instrumentation explored in earlier prototypes.

## Verification

- focused route-phase ownership, compilation-error, RSC completion, HTML completion, and first-response tests
- Request Insights development suite: 51/51 in Turbopack and 51/51 in Webpack at the final stack tree
- route-preparation development suite: 4/4 in Turbopack and 4/4 in Webpack
- public OTel audit confirms `NextVanillaSpanAllowlist` and `Middleware.execute` are unchanged
- focused first-chunk suite passes 13/13, including the deterministic late-error regression
- exact stack head is included in the final 50-commit linear-history and authorship audit
