### PR TITLE
Track Request Insights lifecycle and causality

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1472,5 +1472,6 @@
   "1471": "Response stream failed before its first chunk",
   "1472": "Request Insights maxRequestGroupsPerBucket must be an integer from 1 to %s.",
   "1473": "Request Insights MCP output exceeded its byte limit.",
-  "1474": "Invariant: missing Request Insights runtime"
+  "1474": "Invariant: missing Request Insights runtime",
+  "1475": "Cannot call onResponseEnd on a WebNextResponse that is already closed"
 }

--- a/packages/next/src/cli/next-request-insights-schema.test.ts
+++ b/packages/next/src/cli/next-request-insights-schema.test.ts
@@ -1,0 +1,71 @@
+import type { RequestInsight } from '../next-devtools/shared/request-insights'
+import { isRequestInsightsSnapshot } from './next-request-insights'
+
+function createRequest(
+  requestId: string,
+  overrides: Partial<RequestInsight> = {}
+): RequestInsight {
+  return {
+    requestId,
+    source: 'page',
+    htmlRequestId: requestId,
+    route: `/${requestId}`,
+    startTime: 0,
+    status: 'ok',
+    spans: [],
+    fetches: [],
+    ...overrides,
+  }
+}
+
+describe('next experimental-request-insights schema', () => {
+  it('accepts the combined response lifecycle and causality fields', () => {
+    const snapshot = {
+      requests: [
+        createRequest('child', {
+          rootRequestId: 'child',
+          parentRootRequestId: 'parent',
+          parentFetchIndex: 2,
+          status: 'aborted',
+          response: {
+            trackingStartTime: 1,
+            endTime: 2,
+            statusCode: 200,
+            outcome: 'aborted',
+            error: { type: 'ResponseAborted' },
+          },
+        }),
+      ],
+    }
+
+    expect(isRequestInsightsSnapshot(snapshot)).toBe(true)
+    expect(
+      isRequestInsightsSnapshot({
+        requests: [
+          {
+            ...snapshot.requests[0],
+            parentFetchIndex: -1,
+          },
+        ],
+      })
+    ).toBe(false)
+    expect(
+      isRequestInsightsSnapshot({
+        requests: [
+          {
+            ...snapshot.requests[0],
+            response: {
+              ...snapshot.requests[0].response,
+              outcome: 'closed',
+            },
+          },
+        ],
+      })
+    ).toBe(false)
+    expect(
+      isRequestInsightsSnapshot({
+        requests: [{ ...snapshot.requests[0], spans: [null] }],
+      })
+    ).toBe(false)
+  })
+})

--- a/packages/next/src/cli/next-request-insights.ts
+++ b/packages/next/src/cli/next-request-insights.ts
@@ -4,6 +4,8 @@ import { getProjectDir } from '../lib/get-project-dir'
 import type {
   RequestInsight,
   RequestInsightFetch,
+  RequestInsightResponse,
+  RequestInsightSpan,
   RequestInsightsCaptureState,
   RequestInsightsSnapshot,
 } from '../next-devtools/shared/request-insights'
@@ -39,6 +41,7 @@ const MAX_DEV_SERVER_URL_LENGTH = 2048
 const MAX_REQUEST_INSIGHT_ROUTE_LENGTH = 1024
 const MAX_REQUEST_INSIGHT_URL_LENGTH = 2048
 const MAX_REQUEST_INSIGHT_LABEL_LENGTH = 256
+const MAX_REQUEST_INSIGHT_SPAN_NAME_LENGTH = 8 * 1024
 
 export type NextRequestInsightsOptions = {
   url?: string
@@ -354,10 +357,10 @@ function getResponseError(data: unknown, status: number): string {
   return `Request failed with ${status}`
 }
 
-function isRequestInsightsSnapshot(
+export function isRequestInsightsSnapshot(
   data: unknown
 ): data is RequestInsightsSnapshot {
-  if (typeof data !== 'object' || data === null) return false
+  if (!isRecord(data)) return false
   const candidate = data as Partial<RequestInsightsSnapshot>
   return (
     Array.isArray(candidate.requests) &&
@@ -406,17 +409,18 @@ function isRequestInsightsProjection(
 function isRequestInsightsCaptureState(
   capture: unknown
 ): capture is RequestInsightsCaptureState {
-  if (typeof capture !== 'object' || capture === null) return false
+  if (!isRecord(capture)) return false
   const candidate = capture as Partial<RequestInsightsCaptureState>
   return (
-    typeof candidate.limits === 'object' &&
-    candidate.limits !== null &&
-    Number.isSafeInteger(candidate.limits.maxRequestGroupsPerBucket)
+    isRecord(candidate.limits) &&
+    Number.isSafeInteger(candidate.limits.maxRequestGroupsPerBucket) &&
+    isRecord(candidate.usage) &&
+    Array.isArray(candidate.usage.buckets)
   )
 }
 
 function isRequestInsight(request: unknown): request is RequestInsight {
-  if (typeof request !== 'object' || request === null) return false
+  if (!isRecord(request)) return false
   const candidate = request as Partial<RequestInsight>
   return (
     isBoundedString(candidate.requestId, REQUEST_INSIGHTS_MAX_ID_LENGTH) &&
@@ -425,6 +429,11 @@ function isRequestInsight(request: unknown): request is RequestInsight {
       candidate.rootRequestId,
       REQUEST_INSIGHTS_MAX_ID_LENGTH
     ) &&
+    isOptionalBoundedString(
+      candidate.parentRootRequestId,
+      REQUEST_INSIGHTS_MAX_ID_LENGTH
+    ) &&
+    isOptionalNonNegativeSafeInteger(candidate.parentFetchIndex) &&
     isRequestInsightSource(candidate.source) &&
     (candidate.kind === undefined ||
       candidate.kind === 'request' ||
@@ -438,15 +447,54 @@ function isRequestInsight(request: unknown): request is RequestInsight {
     isOptionalFiniteNumber(candidate.durationMs) &&
     (candidate.status === 'ok' ||
       candidate.status === 'error' ||
+      candidate.status === 'aborted' ||
       candidate.status === 'pending') &&
+    (candidate.response === undefined ||
+      isRequestInsightResponse(candidate.response)) &&
     Array.isArray(candidate.spans) &&
+    candidate.spans.every(isRequestInsightSpan) &&
     Array.isArray(candidate.fetches) &&
     candidate.fetches.every(isRequestInsightFetch)
   )
 }
 
+function isRequestInsightResponse(
+  response: unknown
+): response is RequestInsightResponse {
+  if (!isRecord(response)) return false
+  const candidate = response as Partial<RequestInsightResponse>
+  return (
+    Number.isFinite(candidate.trackingStartTime) &&
+    isOptionalFiniteNumber(candidate.endTime) &&
+    isOptionalNonNegativeSafeInteger(candidate.statusCode) &&
+    (candidate.outcome === 'pending' ||
+      candidate.outcome === 'finished' ||
+      candidate.outcome === 'aborted' ||
+      candidate.outcome === 'errored') &&
+    (candidate.error === undefined ||
+      (isRecord(candidate.error) &&
+        isOptionalBoundedString(
+          candidate.error.type,
+          MAX_REQUEST_INSIGHT_LABEL_LENGTH
+        )))
+  )
+}
+
+function isRequestInsightSpan(span: unknown): span is RequestInsightSpan {
+  if (!isRecord(span)) return false
+  const candidate = span as Partial<RequestInsightSpan>
+  return (
+    isBoundedString(candidate.name, MAX_REQUEST_INSIGHT_SPAN_NAME_LENGTH) &&
+    Number.isFinite(candidate.startTime) &&
+    isOptionalFiniteNumber(candidate.durationMs) &&
+    (candidate.status === undefined ||
+      candidate.status === 'ok' ||
+      candidate.status === 'error')
+  )
+}
+
 function isRequestInsightFetch(fetch: unknown): fetch is RequestInsightFetch {
-  if (typeof fetch !== 'object' || fetch === null) return false
+  if (!isRecord(fetch)) return false
   const candidate = fetch as RequestInsightFetch
   return (
     isOptionalBoundedString(candidate.url, MAX_REQUEST_INSIGHT_URL_LENGTH) &&
@@ -459,7 +507,8 @@ function isRequestInsightFetch(fetch: unknown): fetch is RequestInsightFetch {
       MAX_REQUEST_INSIGHT_LABEL_LENGTH
     ) &&
     isOptionalFiniteNumber(candidate.statusCode) &&
-    isOptionalFiniteNumber(candidate.durationMs)
+    isOptionalFiniteNumber(candidate.durationMs) &&
+    isOptionalNonNegativeSafeInteger(candidate.index)
   )
 }
 
@@ -476,6 +525,10 @@ function isRequestInsightSource(
     source === 'instant-insights' ||
     source === 'unknown'
   )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function isBoundedString(value: unknown, maxLength: number): value is string {
@@ -497,6 +550,12 @@ function isOptionalFiniteNumber(value: unknown): value is number | undefined {
 
 function isNonNegativeSafeInteger(value: unknown): value is number {
   return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function isOptionalNonNegativeSafeInteger(
+  value: unknown
+): value is number | undefined {
+  return value === undefined || isNonNegativeSafeInteger(value)
 }
 
 function formatEndpoint(endpoint: URL): string {

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -260,6 +260,7 @@ export function getRequestInsightDeliveryPresentation(
     case 'errored':
       return { filter: 'delivery:errored', label: 'Delivery errored' }
     case undefined:
+    default:
       return { filter: 'delivery:unknown' }
   }
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-filters.ts
@@ -29,6 +29,11 @@ export type RequestInsightFilter =
   | 'status:error'
   | 'status:http-4xx'
   | 'status:http-5xx'
+  | 'delivery:active'
+  | 'delivery:finished'
+  | 'delivery:aborted'
+  | 'delivery:errored'
+  | 'delivery:unknown'
   | 'fetches:present'
   | 'fetches:none'
   | 'cache:hit'
@@ -81,6 +86,16 @@ export const REQUEST_INSIGHT_FILTER_GROUPS: readonly RequestInsightFilterGroup[]
         { value: 'status:error', label: 'Recorded error' },
         { value: 'status:http-4xx', label: 'HTTP 4xx' },
         { value: 'status:http-5xx', label: 'HTTP 5xx' },
+      ],
+    },
+    {
+      label: 'Response delivery',
+      options: [
+        { value: 'delivery:active', label: 'Active or streaming' },
+        { value: 'delivery:finished', label: 'Finished' },
+        { value: 'delivery:aborted', label: 'Aborted' },
+        { value: 'delivery:errored', label: 'Errored' },
+        { value: 'delivery:unknown', label: 'Unavailable' },
       ],
     },
     {
@@ -208,6 +223,8 @@ function getRequestInsightTags(
     tags.add('status:http-5xx')
   }
 
+  tags.add(getRequestInsightDeliveryPresentation(request).filter)
+
   if (request.fetches.length === 0) {
     tags.add('fetches:none')
     tags.add('cache:none')
@@ -225,6 +242,26 @@ function getRequestInsightTags(
   }
 
   return tags
+}
+
+export function getRequestInsightDeliveryPresentation(
+  request: Pick<RequestInsight, 'response'>
+): Readonly<{
+  filter: Extract<RequestInsightFilter, `delivery:${string}`>
+  label?: string
+}> {
+  switch (request.response?.outcome) {
+    case 'pending':
+      return { filter: 'delivery:active', label: 'Delivery active' }
+    case 'finished':
+      return { filter: 'delivery:finished', label: 'Delivery finished' }
+    case 'aborted':
+      return { filter: 'delivery:aborted', label: 'Delivery aborted' }
+    case 'errored':
+      return { filter: 'delivery:errored', label: 'Delivery errored' }
+    case undefined:
+      return { filter: 'delivery:unknown' }
+  }
 }
 
 function getRequestSourceFilter(

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -32,6 +32,7 @@ import {
 import { getFetchUrlPresentation } from './fetch-label'
 import { formatDuration } from './format-duration'
 import {
+  getRequestInsightDeliveryPresentation,
   getRequestInsightFilterResult,
   REQUEST_INSIGHT_FILTER_GROUPS,
   toggleRequestInsightFilter,
@@ -803,6 +804,7 @@ function RequestOverview({
     <div className="request-insights-overview">
       {overview.method ? <span>Method {overview.method}</span> : null}
       <span>Status {overview.statusLabel}</span>
+      {overview.delivery ? <span>{overview.delivery}</span> : null}
       <span>{overview.kind}</span>
       <span>{overview.fetchSummary}</span>
       <span>{overview.cacheSummary}</span>
@@ -1154,11 +1156,13 @@ function getRequestOverview(request: RequestInsight) {
     { hit: 0, miss: 0, skip: 0, unknown: 0 }
   )
   const knownCacheCount = cacheCounts.hit + cacheCounts.miss + cacheCounts.skip
+  const delivery = getRequestInsightDeliveryPresentation(request)
 
   return {
     method,
     statusCode,
     statusLabel: statusCode ?? request.status,
+    delivery: delivery.label,
     kind: getRequestInsightSummaryTypeLabel(request),
     fetchSummary: request.fetches.length
       ? `${request.fetches.length} fetch${request.fetches.length === 1 ? '' : 'es'}`

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -2,7 +2,10 @@ import {
   REQUEST_INSIGHT_REQUEST_SPAN_TYPE,
   type RequestInsight,
 } from '../../../shared/request-insights'
-import { getRequestInsightFilterResult } from './request-filters'
+import {
+  getRequestInsightDeliveryPresentation,
+  getRequestInsightFilterResult,
+} from './request-filters'
 import {
   getActiveRequestKey,
   getRequestInsightRowType,
@@ -229,6 +232,18 @@ describe('request insights trace viewer', () => {
     expect(getRequestInsightRowType(action).label).toBe('Action')
     expect(getRequestInsightRowType(api).label).toBe('API')
     expect(getRequestInsightRowType(asset).label).toBe('Asset')
+    expect(
+      getRequestInsightRowType(
+        createRequest({ source: 'future-source' as RequestInsight['source'] })
+      ).label
+    ).toBe('Unknown')
+    expect(
+      getRequestInsightDeliveryPresentation({
+        response: {
+          outcome: 'future-outcome',
+        } as unknown as RequestInsight['response'],
+      })
+    ).toEqual({ filter: 'delivery:unknown' })
     expect(
       getRequestInsightFilterResult(entries, [
         'source:page',

--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/trace-viewer.test.ts
@@ -184,6 +184,22 @@ describe('request insights trace viewer', () => {
     })
     const api = createRequest({ requestId: 'api', source: 'app-route' })
     const asset = createRequest({ requestId: 'asset', source: 'asset' })
+    const active = createRequest({
+      requestId: 'active',
+      response: { trackingStartTime: 100, outcome: 'pending' },
+    })
+    const finished = createRequest({
+      requestId: 'finished',
+      response: { trackingStartTime: 100, outcome: 'finished' },
+    })
+    const aborted = createRequest({
+      requestId: 'aborted',
+      response: { trackingStartTime: 100, outcome: 'aborted' },
+    })
+    const errored = createRequest({
+      requestId: 'errored',
+      response: { trackingStartTime: 100, outcome: 'errored' },
+    })
     const instantInsights = createRequest({
       requestId: 'page',
       kind: 'instant-insights',
@@ -245,6 +261,32 @@ describe('request insights trace viewer', () => {
         ({ request }) => request
       )
     ).toEqual([page])
+
+    const deliveryEntries = getRequestListEntries(
+      [active, finished, aborted, errored, api],
+      false
+    )
+    expect(
+      getRequestInsightFilterResult(deliveryEntries, [
+        'delivery:active',
+        'delivery:finished',
+      ]).entries.map(({ request }) => request.requestId)
+    ).toEqual(['active', 'finished'])
+    expect(
+      getRequestInsightFilterResult(deliveryEntries, [
+        'delivery:aborted',
+      ]).entries.map(({ request }) => request.requestId)
+    ).toEqual(['aborted'])
+    expect(
+      getRequestInsightFilterResult(deliveryEntries, [
+        'delivery:errored',
+      ]).entries.map(({ request }) => request.requestId)
+    ).toEqual(['errored'])
+    expect(
+      getRequestInsightFilterResult(deliveryEntries, [
+        'delivery:unknown',
+      ]).entries.map(({ request }) => request.requestId)
+    ).toEqual(['api'])
   })
 
   it('only marks the exact initial document request as the page load', () => {

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -108,6 +108,10 @@ export type RequestInsightResponse = {
 export type RequestInsight = {
   requestId: string
   rootRequestId?: string
+  /** A distinct request root causally started by a same-origin server fetch. */
+  parentRootRequestId?: string
+  /** The parent request's retained fetch index when available. */
+  parentFetchIndex?: number
   kind?: RequestInsightKind
   source: RequestInsightSource
   proxyStatus?: RequestInsightProxyStatus

--- a/packages/next/src/next-devtools/shared/request-insights.ts
+++ b/packages/next/src/next-devtools/shared/request-insights.ts
@@ -91,6 +91,20 @@ export type RequestInsightFetch = {
   index?: number
 }
 
+export type RequestInsightResponse = {
+  /**
+   * The time lifecycle tracking was attached to the response. This is not a
+   * first-byte timestamp.
+   */
+  trackingStartTime: number
+  endTime?: number
+  statusCode?: number
+  outcome: 'pending' | 'finished' | 'aborted' | 'errored'
+  error?: {
+    type?: string
+  }
+}
+
 export type RequestInsight = {
   requestId: string
   rootRequestId?: string
@@ -104,7 +118,8 @@ export type RequestInsight = {
   url?: string
   startTime: number
   durationMs?: number
-  status: 'ok' | 'error' | 'pending'
+  status: 'ok' | 'error' | 'aborted' | 'pending'
+  response?: RequestInsightResponse
   spans: RequestInsightSpan[]
   fetches: RequestInsightFetch[]
   truncatedSpanCount?: number

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5104,28 +5104,31 @@ async function runInstantInsightsWithTracing<T>(
   if (process.env.__NEXT_DEV_SERVER) {
     const requestInsightsRuntime = getAppRenderRequestInsightsRuntime()
     if (requestInsightsRuntime?.isRequestInsightsEnabled()) {
+      const outerIdentity = requestInsightsRuntime.getRequestInsightsIdentity()
+      const instantInsightsIdentity = {
+        requestId: outerIdentity?.requestId ?? ctx.requestId,
+        rootRequestId: outerIdentity?.rootRequestId ?? ctx.requestId,
+        retention: requestInsightsRuntime.createRequestInsightsRetentionContext(
+          outerIdentity?.retention
+        ),
+        debugRequestId: outerIdentity?.debugRequestId,
+        kind: 'instant-insights' as const,
+        htmlRequestId: outerIdentity?.htmlRequestId ?? ctx.htmlRequestId,
+        url: ctx.url.href,
+      }
       const { createInstantInsightsWorkStore } =
         require('./instant-insights-work-store') as typeof import('./instant-insights-work-store')
-      const workStore = createInstantInsightsWorkStore(ctx.workStore)
+      const workStore = createInstantInsightsWorkStore(
+        ctx.workStore,
+        instantInsightsIdentity
+      )
       const instantInsightsCtx: AppRenderContext = {
         ...ctx,
         workStore,
       }
-      const outerIdentity = requestInsightsRuntime.getRequestInsightsIdentity()
 
       return requestInsightsRuntime.runWithRequestInsightsIdentity(
-        {
-          requestId: outerIdentity?.requestId ?? ctx.requestId,
-          rootRequestId: outerIdentity?.rootRequestId ?? ctx.requestId,
-          retention:
-            requestInsightsRuntime.createRequestInsightsRetentionContext(
-              outerIdentity?.retention
-            ),
-          debugRequestId: outerIdentity?.debugRequestId,
-          kind: 'instant-insights',
-          htmlRequestId: outerIdentity?.htmlRequestId ?? ctx.htmlRequestId,
-          url: ctx.url.href,
-        },
+        instantInsightsIdentity,
         () =>
           workAsyncStorage.run(workStore, () =>
             traceLocalSpan(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2863,6 +2863,7 @@ async function prepareAppPageRender(
     requestId
   workStore.requestId = requestId
   workStore.htmlRequestId = htmlRequestId
+  workStore.requestInsightsIdentity = requestInsightsIdentity
 
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
     interpolatedParams,

--- a/packages/next/src/server/app-render/instant-insights-work-store.test.ts
+++ b/packages/next/src/server/app-render/instant-insights-work-store.test.ts
@@ -75,6 +75,7 @@ describe('Instant Insights work store', () => {
       kind: 'instant-insights',
     }
     const foregroundWorkStore = createTestWorkStore()
+    foregroundWorkStore.requestInsightsIdentity = foregroundIdentity
     const foregroundWorkUnitStore = {
       type: 'request',
       phase: 'render',
@@ -92,8 +93,10 @@ describe('Instant Insights work store', () => {
       )
     )
 
-    const instantInsightsWorkStore =
-      createInstantInsightsWorkStore(foregroundWorkStore)
+    const instantInsightsWorkStore = createInstantInsightsWorkStore(
+      foregroundWorkStore,
+      instantInsightsIdentity
+    )
     const instantInsightsSpan = createLocalSpan({ name: 'Instant Insights' })
 
     let observed:
@@ -128,6 +131,12 @@ describe('Instant Insights work store', () => {
       workUnitStore: undefined,
       span: instantInsightsSpan,
     })
+    expect(instantInsightsWorkStore.requestInsightsIdentity).toBe(
+      instantInsightsIdentity
+    )
+    expect(instantInsightsWorkStore.requestInsightsIdentity).not.toBe(
+      foregroundIdentity
+    )
     expect(instantInsightsWorkStore.fetchMetrics).toEqual([])
     expect(instantInsightsWorkStore.fetchMetrics).not.toBe(
       foregroundWorkStore.fetchMetrics

--- a/packages/next/src/server/app-render/instant-insights-work-store.ts
+++ b/packages/next/src/server/app-render/instant-insights-work-store.ts
@@ -8,6 +8,7 @@ import {
 import {
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
+  type RequestInsightsIdentity,
 } from '../lib/trace/request-insights-identity'
 
 type WorkStoreFieldTreatment = 'inherit' | 'reset'
@@ -74,7 +75,8 @@ type _AssertInstantInsightsWorkStoreTreatmentsAreExhaustive = AssertNever<
 >
 
 export function createInstantInsightsWorkStore(
-  outerWorkStore: WorkStore
+  outerWorkStore: WorkStore,
+  requestInsightsIdentity: RequestInsightsIdentity
 ): WorkStore {
   const { AfterContext } =
     require('../after/after-context') as typeof import('../after/after-context')
@@ -94,6 +96,7 @@ export function createInstantInsightsWorkStore(
     refreshTagsByCacheKind: new Map(),
     fetchMetrics: [],
     shouldTrackFetchMetrics: false,
+    requestInsightsIdentity,
     pendingCacheInvocations: new Map(),
     completedCacheInvocations: new Map(),
     reactServerErrorsByDigest: new Map(),
@@ -112,7 +115,7 @@ export function createInstantInsightsWorkStore(
       fn: (...args: TArgs) => R,
       ...args: TArgs
     ): R {
-      const requestInsightsIdentity = getRequestInsightsIdentity()
+      const activeRequestInsightsIdentity = getRequestInsightsIdentity()
       const activeLocalSpan = getActiveLocalSpan()
 
       return outerWorkStore.runInCleanSnapshot(() =>
@@ -120,8 +123,11 @@ export function createInstantInsightsWorkStore(
           workAsyncStorage.run(workStore, () => {
             const run = () => fn(...args)
             const runWithIdentity = () =>
-              requestInsightsIdentity
-                ? runWithRequestInsightsIdentity(requestInsightsIdentity, run)
+              activeRequestInsightsIdentity
+                ? runWithRequestInsightsIdentity(
+                    activeRequestInsightsIdentity,
+                    run
+                  )
                 : run()
 
             return activeLocalSpan

--- a/packages/next/src/server/base-http/web.test.ts
+++ b/packages/next/src/server/base-http/web.test.ts
@@ -3,6 +3,7 @@ import { WebNextResponse } from './web'
 describe('WebNextResponse onClose', () => {
   it('stream body', async () => {
     const cb = jest.fn()
+    const onResponseEnd = jest.fn()
     const ts = new TransformStream({
       transform(chunk, controller) {
         controller.enqueue(chunk)
@@ -10,7 +11,9 @@ describe('WebNextResponse onClose', () => {
     })
 
     const webNextResponse = new WebNextResponse(ts)
+    webNextResponse.statusCode = 202
     webNextResponse.onClose(cb)
+    webNextResponse.onResponseEnd(onResponseEnd)
     webNextResponse.send()
     expect(cb).toHaveBeenCalledTimes(0)
     const response = await webNextResponse.toResponse()
@@ -25,19 +28,62 @@ describe('WebNextResponse onClose', () => {
 
     const text = await t
     expect(cb).toHaveBeenCalledTimes(1)
+    expect(onResponseEnd).toHaveBeenCalledWith({
+      outcome: 'finished',
+      statusCode: 202,
+    })
     expect(text).toBe('abcdef')
   })
 
   it('string body', async () => {
     const cb = jest.fn()
+    const onResponseEnd = jest.fn()
     const webNextResponse = new WebNextResponse(undefined).body('abcdef')
     webNextResponse.onClose(cb)
+    webNextResponse.onResponseEnd(onResponseEnd)
     webNextResponse.send()
     expect(cb).toHaveBeenCalledTimes(0)
     const response = await webNextResponse.toResponse()
     expect(cb).toHaveBeenCalledTimes(0)
     const text = await response.text()
     expect(cb).toHaveBeenCalledTimes(1)
+    expect(onResponseEnd).toHaveBeenCalledWith({
+      outcome: 'finished',
+      statusCode: 200,
+    })
     expect(text).toBe('abcdef')
+  })
+
+  it('distinguishes cancellation from a source stream error', async () => {
+    const cancelled = new WebNextResponse()
+    const onCancelled = jest.fn()
+    cancelled.onResponseEnd(onCancelled)
+    cancelled.send()
+    const cancelledResponse = await cancelled.toResponse()
+    const cancelledReader = cancelledResponse.body!.getReader()
+    const cancellationReason = new Error('consumer cancelled')
+    await cancelledReader.cancel(cancellationReason)
+
+    expect(onCancelled).toHaveBeenCalledWith({
+      outcome: 'aborted',
+      error: cancellationReason,
+      statusCode: 200,
+    })
+
+    const erroredStream = new TransformStream()
+    const errored = new WebNextResponse(erroredStream)
+    const onErrored = jest.fn()
+    errored.onResponseEnd(onErrored)
+    errored.send()
+    const erroredResponse = await errored.toResponse()
+    const streamError = new Error('source failed')
+    await erroredStream.writable.abort(streamError)
+
+    await expect(erroredResponse.text()).rejects.toThrow(streamError)
+    expect(onErrored).toHaveBeenCalledWith({
+      outcome: 'errored',
+      error: streamError,
+      statusCode: 200,
+    })
   })
 })

--- a/packages/next/src/server/base-http/web.ts
+++ b/packages/next/src/server/base-http/web.ts
@@ -5,7 +5,11 @@ import { toNodeOutgoingHttpHeaders } from '../web/utils'
 import { BaseNextRequest, BaseNextResponse } from './index'
 import { DetachedPromise } from '../../lib/detached-promise'
 import type { NextRequestHint } from '../web/adapter'
-import { CloseController, trackBodyConsumed } from '../web/web-on-close'
+import {
+  CloseController,
+  trackBodyConsumed,
+  type ResponseBodyConsumption,
+} from '../web/web-on-close'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 export class WebNextRequest extends BaseNextRequest<ReadableStream | null> {
@@ -38,6 +42,7 @@ export class WebNextRequest extends BaseNextRequest<ReadableStream | null> {
 export class WebNextResponse extends BaseNextResponse<WritableStream> {
   private headers = new Headers()
   private textBody: string | undefined = undefined
+  private committedStatusCode: number | undefined
 
   private closeController = new CloseController()
 
@@ -116,15 +121,17 @@ export class WebNextResponse extends BaseNextResponse<WritableStream> {
       ? true
       : this.closeController.listeners > 0
 
+    const statusCode = this.statusCode ?? 200
+    this.committedStatusCode = statusCode
     if (shouldTrackBody) {
-      bodyInit = trackBodyConsumed(body, () => {
-        this.closeController.dispatchClose()
+      bodyInit = trackBodyConsumed(body, (result) => {
+        this.closeController.dispatchClose(result)
       })
     }
 
     return new Response(bodyInit, {
       headers: this.headers,
-      status: this.statusCode,
+      status: statusCode,
       statusText: this.statusMessage,
     })
   }
@@ -135,6 +142,22 @@ export class WebNextResponse extends BaseNextResponse<WritableStream> {
         'Cannot call onClose on a WebNextResponse that is already closed'
       )
     }
-    return this.closeController.onClose(callback)
+    return this.closeController.onClose(() => callback())
+  }
+
+  public onResponseEnd(
+    callback: (result: ResponseBodyConsumption & { statusCode: number }) => void
+  ) {
+    if (this.closeController.isClosed) {
+      throw new InvariantError(
+        'Cannot call onResponseEnd on a WebNextResponse that is already closed'
+      )
+    }
+    return this.closeController.onClose((result) => {
+      callback({
+        ...result,
+        statusCode: this.committedStatusCode ?? this.statusCode ?? 200,
+      })
+    })
   }
 }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -138,7 +138,11 @@ import { getIsPossibleServerAction } from './lib/server-action-request-meta'
 import { isInterceptionRouteAppPath } from '../shared/lib/router/utils/interception-routes'
 import { toRoute } from './lib/to-route'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
-import { isNodeNextRequest, isNodeNextResponse } from './base-http/helpers'
+import {
+  isNodeNextRequest,
+  isNodeNextResponse,
+  isWebNextResponse,
+} from './base-http/helpers'
 import { patchSetHeaderWithCookieSupport } from './lib/patch-set-header'
 import { checkIsAppPPREnabled } from './lib/experimental/ppr'
 import {
@@ -174,6 +178,8 @@ type BaseServerRequestInsightsRuntime = {
   resolveRequestInsightsIdentity: typeof import('./lib/trace/request-insights-identity').resolveRequestInsightsIdentity
   runWithRequestInsights: typeof import('./lib/trace/request-insights-runtime').runWithRequestInsights
   runWithRequestInsightsIdentity: typeof import('./lib/trace/request-insights-identity').runWithRequestInsightsIdentity
+  trackRequestInsightNodeResponse: typeof import('./lib/trace/request-insights-response').trackRequestInsightNodeResponse
+  trackRequestInsightWebResponse: typeof import('./lib/trace/request-insights-response').trackRequestInsightWebResponse
 }
 
 let baseServerRequestInsightsRuntime:
@@ -191,12 +197,19 @@ function getBaseServerRequestInsightsRuntime():
         require('./lib/trace/request-insights-identity') as typeof import('./lib/trace/request-insights-identity')
       const { runWithRequestInsights } =
         require('./lib/trace/request-insights-runtime') as typeof import('./lib/trace/request-insights-runtime')
+      const {
+        trackRequestInsightNodeResponse,
+        trackRequestInsightWebResponse,
+      } =
+        require('./lib/trace/request-insights-response') as typeof import('./lib/trace/request-insights-response')
 
       baseServerRequestInsightsRuntime = {
         RequestInsights,
         resolveRequestInsightsIdentity,
         runWithRequestInsights,
         runWithRequestInsightsIdentity,
+        trackRequestInsightNodeResponse,
+        trackRequestInsightWebResponse,
       }
     }
     return baseServerRequestInsightsRuntime
@@ -1057,6 +1070,7 @@ export default abstract class Server<
         : handleRequest()
     }
 
+    const requestInsights = this.requestInsights
     const requestInsightsIdentity =
       requestInsightsRuntime.resolveRequestInsightsIdentity({
         previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
@@ -1072,12 +1086,37 @@ export default abstract class Server<
     }
     addRequestMeta(req, 'requestInsightsIdentity', requestInsightsIdentity)
 
+    const responseCallbacks = {
+      onAttach(trackingStartTime: number) {
+        requestInsights.startResponse(
+          requestInsightsIdentity,
+          trackingStartTime
+        )
+      },
+      onComplete(
+        response: Parameters<typeof requestInsights.completeResponse>[1]
+      ) {
+        requestInsights.completeResponse(requestInsightsIdentity, response)
+      },
+    }
+    if (isNodeNextResponse(res)) {
+      requestInsightsRuntime.trackRequestInsightNodeResponse(
+        res.originalResponse,
+        responseCallbacks
+      )
+    } else if (isWebNextResponse(res)) {
+      requestInsightsRuntime.trackRequestInsightWebResponse(
+        res,
+        responseCallbacks
+      )
+    }
+
     // The request root and route-matching spans start before App Render creates
     // its workStore. Carry their identity in this outer scope; App Render copies
     // it into the workStore so the complete timeline uses one request ID.
     try {
       return await requestInsightsRuntime.runWithRequestInsights(
-        this.requestInsights,
+        requestInsights,
         () =>
           requestInsightsRuntime.runWithRequestInsightsIdentity(
             requestInsightsIdentity,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -175,6 +175,7 @@ import {
 
 type BaseServerRequestInsightsRuntime = {
   RequestInsights: typeof import('./lib/trace/request-insights').RequestInsights
+  getRequestInsightsExecutionOrigin: typeof import('./lib/trace/request-insights-causal').getRequestInsightsExecutionOrigin
   resolveRequestInsightsIdentity: typeof import('./lib/trace/request-insights-identity').resolveRequestInsightsIdentity
   runWithRequestInsights: typeof import('./lib/trace/request-insights-runtime').runWithRequestInsights
   runWithRequestInsightsIdentity: typeof import('./lib/trace/request-insights-identity').runWithRequestInsightsIdentity
@@ -193,6 +194,8 @@ function getBaseServerRequestInsightsRuntime():
     if (!baseServerRequestInsightsRuntime) {
       const { RequestInsights } =
         require('./lib/trace/request-insights') as typeof import('./lib/trace/request-insights')
+      const { getRequestInsightsExecutionOrigin } =
+        require('./lib/trace/request-insights-causal') as typeof import('./lib/trace/request-insights-causal')
       const { resolveRequestInsightsIdentity, runWithRequestInsightsIdentity } =
         require('./lib/trace/request-insights-identity') as typeof import('./lib/trace/request-insights-identity')
       const { runWithRequestInsights } =
@@ -205,6 +208,7 @@ function getBaseServerRequestInsightsRuntime():
 
       baseServerRequestInsightsRuntime = {
         RequestInsights,
+        getRequestInsightsExecutionOrigin,
         resolveRequestInsightsIdentity,
         runWithRequestInsights,
         runWithRequestInsightsIdentity,
@@ -1071,11 +1075,23 @@ export default abstract class Server<
     }
 
     const requestInsights = this.requestInsights
+    const originalRequest = isNodeNextRequest(req)
+      ? req.originalRequest
+      : undefined
+    const requestInsightsExecutionOrigin =
+      requestInsightsRuntime.getRequestInsightsExecutionOrigin({
+        experimentalHttpsServer: this.serverOptions.experimentalHttpsServer,
+        fallbackPort: this.port,
+        socket: originalRequest?.socket,
+      })
     const requestInsightsIdentity =
       requestInsightsRuntime.resolveRequestInsightsIdentity({
         previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
         requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
         htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+        executionOrigin: requestInsightsExecutionOrigin,
+        origin:
+          process.env.__NEXT_PRIVATE_ORIGIN ?? requestInsightsExecutionOrigin,
         url: req.url,
         createRequestId: nanoid,
       })

--- a/packages/next/src/server/lib/dedupe-fetch.test.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.test.ts
@@ -64,6 +64,38 @@ describe('dedupe-fetch', () => {
       expect(await response2.text()).toBe('test response')
     })
 
+    it('runs a request decorator only for the deduped network request', async () => {
+      originalFetch.mockResolvedValue(new Response('test response'))
+      const networkFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+        (resource, options) => {
+          const headers = new Headers(options?.headers)
+          headers.set(
+            'cookie',
+            `${headers.get('cookie')}; __next_request_insights_causal=network-capability`
+          )
+          return originalFetch(resource, { ...options, headers })
+        }
+      )
+      const options = {
+        headers: { cookie: 'session=user-cookie' },
+      }
+
+      const [first, second] = await Promise.all([
+        dedupeFetch('https://example.com/api', options, networkFetch),
+        dedupeFetch('https://example.com/api', options, networkFetch),
+      ])
+
+      expect(await first.text()).toBe('test response')
+      expect(await second.text()).toBe('test response')
+      expect(networkFetch).toHaveBeenCalledTimes(1)
+      expect(originalFetch).toHaveBeenCalledTimes(1)
+      expect(
+        new Headers(originalFetch.mock.calls[0][1]?.headers).get('cookie')
+      ).toBe(
+        'session=user-cookie; __next_request_insights_causal=network-capability'
+      )
+    })
+
     it('should dedupe identical HEAD requests', async () => {
       const mockResponse = new Response(null, { status: 200 })
       originalFetch.mockResolvedValue(mockResponse)

--- a/packages/next/src/server/lib/dedupe-fetch.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.ts
@@ -49,7 +49,8 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
 
   return function dedupeFetch(
     resource: URL | RequestInfo,
-    options?: RequestInit
+    options?: RequestInit,
+    networkFetch: typeof fetch = originalFetch
   ): Promise<Response> {
     if (options && options.signal) {
       // If we're passed a signal, then we assume that
@@ -59,7 +60,7 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
       // it always gets initialized with its own signal so we don't
       // know if it's supposed to override - unless we also override the
       // Request constructor.
-      return originalFetch(resource, options)
+      return networkFetch(resource, options)
     }
     // Normalize the Request
     let url: string
@@ -85,7 +86,7 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
         // have to be explicitly cached. We assume that the request doesn't have a
         // body if it's GET or HEAD.
         // keepalive gets treated the same as if you passed a custom cache signal.
-        return originalFetch(resource, options)
+        return networkFetch(resource, options)
       }
       cacheKey = generateCacheKey(request)
       url = request.url
@@ -112,7 +113,7 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
 
     // We pass the original arguments here in case normalizing the Request
     // doesn't include all the options in this environment.
-    const promise = originalFetch(resource, options)
+    const promise = networkFetch(resource, options)
     const entry: CacheEntry = [cacheKey, promise, null]
     cacheEntries.push(entry)
 

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -286,6 +286,7 @@ describe('createPatchedFetcher', () => {
     const identity: RequestInsightsIdentity = {
       requestId: 'mixed-runtime-parent',
       rootRequestId: 'mixed-runtime-parent-root',
+      retention: createRequestInsightsRetentionContext(),
       htmlRequestId: 'mixed-runtime-parent',
       origin: 'http://app.localhost',
       url: '/',

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -13,8 +13,10 @@ import {
   createRequestInsightsRetentionContext,
   getRequestInsightsIdentity,
   runWithRequestInsightsIdentity,
+  type RequestInsightsIdentity,
 } from './trace/request-insights-identity'
 import { runWithRequestInsights } from './trace/request-insights-runtime'
+import { prepareRequestInsightsSandboxFetch } from './trace/request-insights-sandbox-fetch'
 import {
   setSpanRecorderForTest,
   type SpanStoreRecord,
@@ -107,6 +109,67 @@ describe('createPatchedFetcher', () => {
     expect(requestInsights.getSnapshot().requests[0]?.fetches[0]).toEqual(
       expect.objectContaining({ index: 1, statusCode: 201 })
     )
+    requestInsights.dispose()
+  })
+
+  it('shares fetch indexes with the Edge sandbox bridge', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const identity: RequestInsightsIdentity = {
+      requestId: 'mixed-runtime-parent',
+      htmlRequestId: 'mixed-runtime-parent',
+      origin: 'http://app.localhost',
+      url: '/',
+    }
+    prepareRequestInsightsSandboxFetch({
+      context: { identity, requestInsights },
+      init: {},
+      url: 'https://example.com/from-edge',
+    }).complete({ status: 200 })
+
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/from-node'),
+      'GET'
+    )!
+    let causalParent:
+      | { parentRequestId: string; parentFetchIndex: number }
+      | undefined
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, init) => {
+        const token = takeRequestInsightsCausalToken(
+          Object.fromEntries(new Headers(init?.headers))
+        )
+        causalParent = token
+          ? requestInsights.consumeCausalToken(token, target)
+          : undefined
+        return new Response('ok', { status: 201 })
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = { page: '/', route: '/' } as WorkStore
+
+    await runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(identity, () =>
+        workAsyncStorage.run(workStore, () =>
+          patchedFetch('http://app.localhost/api/from-node', {
+            cache: 'no-store',
+          })
+        )
+      )
+    )
+
+    expect(causalParent).toEqual({
+      parentRequestId: 'mixed-runtime-parent',
+      parentFetchIndex: 2,
+    })
+    expect(requestInsights.getSnapshot().requests[0].fetches).toEqual([
+      expect.objectContaining({ index: 1, statusCode: 200 }),
+      expect.objectContaining({ index: 2, statusCode: 201 }),
+    ])
     requestInsights.dispose()
   })
 

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -4,6 +4,17 @@ import type { WorkStore } from '../app-render/work-async-storage.external'
 import type { IncrementalCache } from './incremental-cache'
 import { createPatchedFetcher } from './patch-fetch'
 import { registerLocalSpanRecorder } from './trace/local-span-recorder'
+import { RequestInsights } from './trace/request-insights'
+import {
+  getRequestInsightsCausalTarget,
+  takeRequestInsightsCausalToken,
+} from './trace/request-insights-causal'
+import {
+  createRequestInsightsRetentionContext,
+  getRequestInsightsIdentity,
+  runWithRequestInsightsIdentity,
+} from './trace/request-insights-identity'
+import { runWithRequestInsights } from './trace/request-insights-runtime'
 import {
   setSpanRecorderForTest,
   type SpanStoreRecord,
@@ -11,6 +22,17 @@ import {
 
 const originalDevServer = process.env.__NEXT_DEV_SERVER
 const spanRecords: SpanStoreRecord[] = []
+
+function createTestRequestInsightsIdentity(requestId: string) {
+  return {
+    requestId,
+    rootRequestId: `${requestId}-root`,
+    retention: createRequestInsightsRetentionContext(),
+    htmlRequestId: requestId,
+    origin: 'http://app.localhost',
+    url: '/',
+  }
+}
 
 describe('createPatchedFetcher', () => {
   beforeEach(() => {
@@ -27,6 +49,364 @@ describe('createPatchedFetcher', () => {
     setSpanRecorderForTest(undefined)
     spanRecords.length = 0
   })
+
+  it('keeps a same-origin causal link on the captured controller after context exit', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/child'),
+      'GET'
+    )!
+    let causalParent:
+      | { parentRootRequestId: string; parentFetchIndex: number }
+      | undefined
+    let releaseFetch!: () => void
+    const fetchCanFinish = new Promise<void>((resolve) => {
+      releaseFetch = resolve
+    })
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, init) => {
+        const headers = Object.fromEntries(new Headers(init?.headers))
+        const token = takeRequestInsightsCausalToken(headers)
+        causalParent = token
+          ? requestInsights.consumeCausalToken(token, target)
+          : undefined
+        await fetchCanFinish
+        return new Response('ok', { status: 201 })
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = {
+      page: '/',
+      route: '/',
+    } as WorkStore
+
+    const responsePromise = runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('parent-request'),
+        () =>
+          workAsyncStorage.run(workStore, () =>
+            patchedFetch('http://app.localhost/api/child', {
+              cache: 'no-store',
+            })
+          )
+      )
+    )
+
+    expect(getRequestInsightsIdentity()).toBeUndefined()
+    expect(causalParent).toEqual({
+      parentRootRequestId: 'parent-request-root',
+      parentFetchIndex: 1,
+    })
+    releaseFetch()
+    expect((await responsePromise).status).toBe(201)
+    expect(requestInsights.getSnapshot().requests[0]?.fetches[0]).toEqual(
+      expect.objectContaining({ index: 1, statusCode: 201 })
+    )
+    requestInsights.dispose()
+  })
+
+  it('revokes a causal token when the original fetch throws synchronously', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/child'),
+      'GET'
+    )!
+    let causalToken: string | undefined
+    const error = new Error('synchronous fetch failure')
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      (_input, init) => {
+        causalToken = takeRequestInsightsCausalToken(
+          Object.fromEntries(new Headers(init?.headers))
+        )
+        throw error
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = {
+      page: '/',
+      route: '/',
+    } as WorkStore
+
+    const response = runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('parent-request'),
+        () =>
+          workAsyncStorage.run(workStore, () =>
+            patchedFetch('http://app.localhost/api/child', {
+              cache: 'no-store',
+            })
+          )
+      )
+    )
+
+    await expect(response).rejects.toBe(error)
+    expect(causalToken).toBeDefined()
+    expect(
+      requestInsights.consumeCausalToken(causalToken!, target)
+    ).toBeUndefined()
+    requestInsights.dispose()
+  })
+
+  it('leaves draft-mode fetch state and headers unchanged', async () => {
+    setSpanRecorderForTest((span) => spanRecords.push(span))
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const init = {
+      cache: 'no-store' as const,
+      headers: {
+        cookie: '__next_request_insights_causal=user-value; user=value',
+      },
+    }
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, receivedInit) => {
+        expect(receivedInit).toBe(init)
+        return new Response('ok')
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = {
+      isDraftMode: true,
+      nextFetchId: 7,
+      page: '/',
+      route: '/',
+      shouldTrackFetchMetrics: true,
+    } as WorkStore
+
+    await runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('draft-request'),
+        () =>
+          workAsyncStorage.run(workStore, () =>
+            patchedFetch('http://app.localhost/api/child', init)
+          )
+      )
+    )
+
+    expect(workStore.nextFetchId).toBe(7)
+    expect(workStore.fetchMetrics).toBeUndefined()
+    expect(requestInsights.getSnapshot().requests[0]?.fetches[0]).toEqual(
+      expect.objectContaining({
+        cacheStatus: undefined,
+        index: undefined,
+        statusCode: undefined,
+      })
+    )
+    expect(
+      spanRecords.find(
+        (span) => span.name === 'fetch GET http://app.localhost/api/child'
+      )?.attributes
+    ).not.toEqual(
+      expect.objectContaining({
+        'next.fetch.idx': expect.anything(),
+      })
+    )
+    requestInsights.dispose()
+  })
+
+  it('does not reserve a user cookie while Request Insights is disabled', async () => {
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const cookie = '__next_request_insights_causal=user-value; user=value'
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, init) => {
+        expect(new Headers(init?.headers).get('cookie')).toBe(cookie)
+        return new Response('ok')
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = { page: '/', route: '/' } as WorkStore
+
+    await workAsyncStorage.run(workStore, () =>
+      patchedFetch('http://app.localhost/api/child', {
+        cache: 'no-store',
+        headers: { cookie },
+      })
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attach causality when credentials are omitted', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    let causalToken: string | undefined
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, init) => {
+        const headers = Object.fromEntries(new Headers(init?.headers))
+        causalToken = takeRequestInsightsCausalToken(headers)
+        expect(headers.cookie).toBe('session=value')
+        return new Response('ok')
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = { page: '/', route: '/' } as WorkStore
+
+    await runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('parent-request'),
+        () =>
+          workAsyncStorage.run(workStore, () =>
+            patchedFetch('http://app.localhost/api/child', {
+              cache: 'no-store',
+              credentials: 'omit',
+              headers: { cookie: 'session=value' },
+            })
+          )
+      )
+    )
+
+    expect(causalToken).toBeUndefined()
+    requestInsights.dispose()
+  })
+
+  it('preserves a streamed POST Request body while attaching causality', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/child'),
+      'POST'
+    )!
+    let causalParent:
+      | { parentRootRequestId: string; parentFetchIndex: number }
+      | undefined
+    let receivedBody: string | undefined
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (input, init) => {
+        const request = new Request(input, init)
+        const headers = Object.fromEntries(request.headers)
+        const token = takeRequestInsightsCausalToken(headers)
+        causalParent = token
+          ? requestInsights.consumeCausalToken(token, target)
+          : undefined
+        expect(headers.cookie).toBe('session=value')
+        receivedBody = await request.text()
+        return new Response('ok')
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const workStore = { page: '/', route: '/' } as WorkStore
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('streamed body'))
+        controller.close()
+      },
+    })
+    const request = new Request('http://app.localhost/api/child', {
+      body,
+      // @ts-expect-error -- Node fetch requires duplex for streamed bodies.
+      duplex: 'half',
+      headers: { cookie: 'session=value' },
+      method: 'POST',
+    })
+
+    await runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('parent-request'),
+        () =>
+          workAsyncStorage.run(workStore, () =>
+            patchedFetch(request, undefined)
+          )
+      )
+    )
+
+    expect(receivedBody).toBe('streamed body')
+    expect(causalParent).toEqual({
+      parentRootRequestId: 'parent-request-root',
+      parentFetchIndex: 1,
+    })
+    requestInsights.dispose()
+  })
+
+  it.each([
+    { isStale: false, expectedOriginCalls: 0 },
+    { isStale: true, expectedOriginCalls: 1 },
+  ])(
+    'does not attach causality for a cache hit with isStale=$isStale',
+    async ({ isStale, expectedOriginCalls }) => {
+      const requestInsights = new RequestInsights()
+      const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+      const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+      let causalToken: string | undefined
+      const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+        async (_input, init) => {
+          causalToken = takeRequestInsightsCausalToken(
+            Object.fromEntries(new Headers(init?.headers))
+          )
+          return new Response('fresh')
+        }
+      )
+      const incrementalCache = {
+        generateCacheKey: jest.fn(() => 'cache-key'),
+        get: jest.fn(() => ({
+          isStale,
+          value: {
+            kind: 'FETCH',
+            data: {
+              body: Buffer.from('cached').toString('base64'),
+              headers: {},
+              status: 200,
+              url: 'http://app.localhost/api/child',
+            },
+            revalidate: 60,
+          },
+        })),
+        lock: jest.fn(() => () => {}),
+        set: jest.fn(),
+      } as unknown as IncrementalCache
+      const patchedFetch = createPatchedFetcher(mockFetch, {
+        workAsyncStorage,
+        workUnitAsyncStorage,
+      })
+      const workStore = {
+        incrementalCache,
+        page: '/',
+        route: '/',
+      } as WorkStore
+
+      const response = await runWithRequestInsights(requestInsights, () =>
+        runWithRequestInsightsIdentity(
+          createTestRequestInsightsIdentity('parent-request'),
+          () =>
+            workAsyncStorage.run(workStore, () =>
+              patchedFetch('http://app.localhost/api/child', {
+                cache: 'force-cache',
+              })
+            )
+        )
+      )
+
+      expect(await response.text()).toBe('cached')
+      await workStore.pendingRevalidates?.['cache-key']
+      expect(mockFetch).toHaveBeenCalledTimes(expectedOriginCalls)
+      expect(causalToken).toBeUndefined()
+      requestInsights.dispose()
+    }
+  )
 
   it('should not buffer a streamed response', async () => {
     const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn()

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -112,12 +112,14 @@ describe('createPatchedFetcher', () => {
     requestInsights.dispose()
   })
 
-  it('shares fetch indexes with the Edge sandbox bridge', async () => {
+  it('deduplicates mixed Edge and Node fetches with shared insight indexes', async () => {
+    setSpanRecorderForTest((span) => spanRecords.push(span))
     const requestInsights = new RequestInsights()
     const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
     const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
     const identity: RequestInsightsIdentity = {
       requestId: 'mixed-runtime-parent',
+      rootRequestId: 'mixed-runtime-parent-root',
       htmlRequestId: 'mixed-runtime-parent',
       origin: 'http://app.localhost',
       url: '/',
@@ -133,7 +135,7 @@ describe('createPatchedFetcher', () => {
       'GET'
     )!
     let causalParent:
-      | { parentRequestId: string; parentFetchIndex: number }
+      | { parentRootRequestId: string; parentFetchIndex: number }
       | undefined
     const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
       async (_input, init) => {
@@ -150,7 +152,7 @@ describe('createPatchedFetcher', () => {
       workAsyncStorage,
       workUnitAsyncStorage,
     })
-    const workStore = { page: '/', route: '/' } as WorkStore
+    const workStore = { nextFetchId: 7, page: '/', route: '/' } as WorkStore
 
     await runWithRequestInsights(requestInsights, () =>
       runWithRequestInsightsIdentity(identity, () =>
@@ -163,12 +165,32 @@ describe('createPatchedFetcher', () => {
     )
 
     expect(causalParent).toEqual({
-      parentRequestId: 'mixed-runtime-parent',
+      parentRootRequestId: 'mixed-runtime-parent-root',
       parentFetchIndex: 2,
     })
+    expect(
+      spanRecords.find(
+        (span) =>
+          span.attributes?.['next.span_type'] === 'AppRender.fetch' &&
+          span.url === 'http://app.localhost/api/from-node'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        requestInsightFetchIndex: 2,
+        attributes: expect.objectContaining({ 'next.fetch.idx': 8 }),
+      })
+    )
     expect(requestInsights.getSnapshot().requests[0].fetches).toEqual([
-      expect.objectContaining({ index: 1, statusCode: 200 }),
-      expect.objectContaining({ index: 2, statusCode: 201 }),
+      expect.objectContaining({
+        index: 1,
+        statusCode: 200,
+        url: 'https://example.com/from-edge',
+      }),
+      expect.objectContaining({
+        index: 2,
+        statusCode: 201,
+        url: 'http://app.localhost/api/from-node',
+      }),
     ])
     requestInsights.dispose()
   })

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -112,7 +112,173 @@ describe('createPatchedFetcher', () => {
     requestInsights.dispose()
   })
 
-  it('deduplicates mixed Edge and Node fetches with shared insight indexes', async () => {
+  it('records a Node proxy fetch before App Render creates a work store', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/proxy-child'),
+      'GET'
+    )!
+    let causalParent:
+      | { parentRootRequestId: string; parentFetchIndex: number }
+      | undefined
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, init) => {
+        const token = takeRequestInsightsCausalToken(
+          Object.fromEntries(new Headers(init?.headers))
+        )
+        causalParent = token
+          ? requestInsights.consumeCausalToken(token, target)
+          : undefined
+        return new Response('ok', { status: 200 })
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+
+    await runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('proxy-parent'),
+        () => patchedFetch('http://app.localhost/api/proxy-child')
+      )
+    )
+
+    expect(causalParent).toEqual({
+      parentRootRequestId: 'proxy-parent-root',
+      parentFetchIndex: 1,
+    })
+    expect(requestInsights.getSnapshot().requests[0]?.fetches[0]).toEqual(
+      expect.objectContaining({ index: 1, statusCode: 200 })
+    )
+    requestInsights.dispose()
+  })
+
+  it('records a Request-input proxy fetch without dropping its headers', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/proxy-request-child'),
+      'GET'
+    )!
+    let causalParent:
+      | { parentRootRequestId: string; parentFetchIndex: number }
+      | undefined
+    let receivedRequest: Request | undefined
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (input, init) => {
+        receivedRequest = new Request(input, init)
+        const headers = Object.fromEntries(receivedRequest.headers)
+        const token = takeRequestInsightsCausalToken(headers)
+        causalParent = token
+          ? requestInsights.consumeCausalToken(token, target)
+          : undefined
+        return new Response('ok', { status: 202 })
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const input = new Request('http://app.localhost/api/proxy-request-child', {
+      headers: {
+        cookie: 'user=value',
+        'x-user-header': 'preserved',
+      },
+    })
+
+    await runWithRequestInsights(requestInsights, () =>
+      runWithRequestInsightsIdentity(
+        createTestRequestInsightsIdentity('proxy-request-parent'),
+        () => patchedFetch(input)
+      )
+    )
+
+    expect(causalParent).toEqual({
+      parentRootRequestId: 'proxy-request-parent-root',
+      parentFetchIndex: 1,
+    })
+    expect(receivedRequest?.headers.get('x-user-header')).toBe('preserved')
+    expect(receivedRequest?.headers.get('cookie')).toContain('user=value')
+    expect(input.headers.get('cookie')).toBe('user=value')
+    expect(requestInsights.getSnapshot().requests[0]?.fetches[0]).toEqual(
+      expect.objectContaining({ index: 1, statusCode: 202 })
+    )
+    requestInsights.dispose()
+  })
+
+  it('links a direct server fetch from a Cache Component identity', async () => {
+    const requestInsights = new RequestInsights()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workUnitAsyncStorage = new AsyncLocalStorage<WorkUnitStore>()
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://localhost:3012/api/cache-child'),
+      'GET'
+    )!
+    let causalParent:
+      | { parentRootRequestId: string; parentFetchIndex: number }
+      | undefined
+    const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn(
+      async (_input, init) => {
+        const token = takeRequestInsightsCausalToken(
+          Object.fromEntries(new Headers(init?.headers))
+        )
+        causalParent = token
+          ? requestInsights.consumeCausalToken(token, target)
+          : undefined
+        return new Response('ok', { status: 200 })
+      }
+    )
+    const patchedFetch = createPatchedFetcher(mockFetch, {
+      workAsyncStorage,
+      workUnitAsyncStorage,
+    })
+    const identity: RequestInsightsIdentity = {
+      requestId: 'cache-parent',
+      rootRequestId: 'cache-parent-root',
+      retention: createRequestInsightsRetentionContext(),
+      htmlRequestId: 'cache-parent',
+      origin: 'https://app.localhost',
+      executionOrigin: 'http://localhost:3012',
+      url: '/cache-parent',
+    }
+    const workStore = {
+      page: '/cache-parent',
+      route: '/cache-parent',
+      requestInsightsIdentity: identity,
+    } as WorkStore
+    const cacheStore = {
+      type: 'cache',
+      tags: null,
+      revalidate: 900,
+      expire: 900,
+      stale: 900,
+    } as WorkUnitStore
+
+    await runWithRequestInsights(requestInsights, () =>
+      workAsyncStorage.run(workStore, () =>
+        workUnitAsyncStorage.run(cacheStore, () =>
+          patchedFetch('http://localhost:3012/api/cache-child', {
+            cache: 'no-store',
+          })
+        )
+      )
+    )
+
+    expect(causalParent).toEqual({
+      parentRootRequestId: 'cache-parent-root',
+      parentFetchIndex: 1,
+    })
+    expect(requestInsights.getSnapshot().requests[0]?.fetches[0]).toEqual(
+      expect.objectContaining({ index: 1, statusCode: 200 })
+    )
+    requestInsights.dispose()
+  })
+
+  it('keeps a shared index sequence after an Edge fetch rejects', async () => {
     setSpanRecorderForTest((span) => spanRecords.push(span))
     const requestInsights = new RequestInsights()
     const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
@@ -128,7 +294,7 @@ describe('createPatchedFetcher', () => {
       context: { identity, requestInsights },
       init: {},
       url: 'https://example.com/from-edge',
-    }).complete({ status: 200 })
+    }).complete()
 
     const target = getRequestInsightsCausalTarget(
       new URL('http://app.localhost/api/from-node'),
@@ -183,7 +349,7 @@ describe('createPatchedFetcher', () => {
     expect(requestInsights.getSnapshot().requests[0].fetches).toEqual([
       expect.objectContaining({
         index: 1,
-        statusCode: 200,
+        statusCode: undefined,
         url: 'https://example.com/from-edge',
       }),
       expect.objectContaining({

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -43,6 +43,7 @@ type PatchFetchRequestInsightsRuntime = {
   getNextRequestInsightsFetchIndex: typeof import('./trace/request-insights-sandbox-fetch').getNextRequestInsightsFetchIndex
   getRequestInsightsIdentity: typeof import('./trace/request-insights-identity').getRequestInsightsIdentity
   isRequestInsightsSameOriginTarget: typeof import('./trace/request-insights-causal').isRequestInsightsSameOriginTarget
+  setRequestInsightsFetchIndex: typeof import('./trace/local-span-recorder').setRequestInsightsFetchIndex
   setRequestInsightsCausalCookie: typeof import('./trace/request-insights-causal').setRequestInsightsCausalCookie
 }
 
@@ -61,6 +62,8 @@ function getPatchFetchRequestInsightsRuntime():
         require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
       const { getNextRequestInsightsFetchIndex } =
         require('./trace/request-insights-sandbox-fetch') as typeof import('./trace/request-insights-sandbox-fetch')
+      const { setRequestInsightsFetchIndex } =
+        require('./trace/local-span-recorder') as typeof import('./trace/local-span-recorder')
       const {
         getRequestInsightsCausalTarget,
         isRequestInsightsSameOriginTarget,
@@ -73,6 +76,7 @@ function getPatchFetchRequestInsightsRuntime():
         getNextRequestInsightsFetchIndex,
         getRequestInsightsIdentity,
         isRequestInsightsSameOriginTarget,
+        setRequestInsightsFetchIndex,
         setRequestInsightsCausalCookie,
       }
     }
@@ -222,6 +226,14 @@ function trackFetchMetric(
     end: performance.timeOrigin + performance.now(),
     idx: workStore.nextFetchId || 0,
   }
+  const requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
+
+  if (requestInsightsIndex !== undefined) {
+    requestInsightsRuntime?.setRequestInsightsFetchIndex(
+      span,
+      requestInsightsIndex
+    )
+  }
 
   span?.setAttributes({
     'http.status_code': metric.status,
@@ -230,7 +242,6 @@ function trackFetchMetric(
     'next.fetch.cache_reason': metric.cacheReason,
   })
 
-  const requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
   const requestInsights = requestInsightsRuntime?.getActiveRequestInsights()
   if (requestInsights) {
     const requestInsightsIdentity =
@@ -1083,7 +1094,7 @@ export function createPatchedFetcher(
         let requestInsightsIdentity:
           | import('./trace/request-insights-identity').RequestInsightsIdentity
           | undefined
-        let requestInsightsFetchIdx = fetchIdx
+        let requestInsightsFetchIdx: number | undefined
         if (process.env.__NEXT_DEV_SERVER) {
           requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
           requestInsightsIdentity =

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -39,7 +39,10 @@ const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
 type PatchFetchRequestInsightsRuntime = {
   getActiveRequestInsights: typeof import('./trace/request-insights-runtime').getActiveRequestInsights
+  getRequestInsightsCausalTarget: typeof import('./trace/request-insights-causal').getRequestInsightsCausalTarget
   getRequestInsightsIdentity: typeof import('./trace/request-insights-identity').getRequestInsightsIdentity
+  isRequestInsightsSameOriginTarget: typeof import('./trace/request-insights-causal').isRequestInsightsSameOriginTarget
+  setRequestInsightsCausalCookie: typeof import('./trace/request-insights-causal').setRequestInsightsCausalCookie
 }
 
 let patchFetchRequestInsightsRuntime:
@@ -55,14 +58,24 @@ function getPatchFetchRequestInsightsRuntime():
         require('./trace/request-insights-runtime') as typeof import('./trace/request-insights-runtime')
       const { getRequestInsightsIdentity } =
         require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
+      const {
+        getRequestInsightsCausalTarget,
+        isRequestInsightsSameOriginTarget,
+        setRequestInsightsCausalCookie,
+      } =
+        require('./trace/request-insights-causal') as typeof import('./trace/request-insights-causal')
       patchFetchRequestInsightsRuntime = {
         getActiveRequestInsights,
+        getRequestInsightsCausalTarget,
         getRequestInsightsIdentity,
+        isRequestInsightsSameOriginTarget,
+        setRequestInsightsCausalCookie,
       }
     }
     return patchFetchRequestInsightsRuntime
+  } else {
+    return undefined
   }
-  return undefined
 }
 
 /**
@@ -195,10 +208,13 @@ export function validateTags(tags: any[], description: string) {
 function trackFetchMetric(
   workStore: WorkStore,
   span: Span | undefined,
-  ctx: Omit<FetchMetric, 'end' | 'idx'>
+  ctx: Omit<FetchMetric, 'end' | 'idx'> & {
+    requestInsightsIndex?: number
+  }
 ) {
+  const { requestInsightsIndex, ...metricContext } = ctx
   const metric = {
-    ...ctx,
+    ...metricContext,
     end: performance.timeOrigin + performance.now(),
     idx: workStore.nextFetchId || 0,
   }
@@ -238,7 +254,7 @@ function trackFetchMetric(
           durationMs: metric.end - metric.start,
           cacheStatus: metric.cacheStatus,
           cacheReason: metric.cacheReason,
-          index: metric.idx,
+          index: requestInsightsIndex ?? metric.idx,
         }
       )
     }
@@ -251,6 +267,144 @@ function trackFetchMetric(
   workStore.fetchMetrics ??= []
 
   workStore.fetchMetrics.push(metric)
+}
+
+function prepareRequestInsightsCausalFetch({
+  allowCausalLink,
+  fetchIndex,
+  init,
+  input,
+  isStale,
+  method,
+  targetUrl,
+}: {
+  allowCausalLink: boolean
+  fetchIndex: number
+  init: RequestInit
+  input: RequestInfo | URL
+  isStale: boolean
+  method: string
+  targetUrl: URL | undefined
+}): { init: RequestInit; revoke: () => void } {
+  const runtime = getPatchFetchRequestInsightsRuntime()
+  if (!runtime) {
+    return { init, revoke: () => {} }
+  }
+
+  const requestInsights = runtime.getActiveRequestInsights()
+  if (!requestInsights) {
+    return { init, revoke: () => {} }
+  }
+  let token: string | undefined
+  try {
+    const identity = runtime.getRequestInsightsIdentity()
+    const target = targetUrl
+      ? runtime.getRequestInsightsCausalTarget(targetUrl, method)
+      : undefined
+    const credentials =
+      init.credentials ??
+      (input instanceof Request ? input.credentials : undefined)
+    const headers = new Headers(
+      init.headers ?? (input instanceof Request ? input.headers : undefined)
+    )
+    const originalCookie = headers.get('cookie')
+
+    token =
+      allowCausalLink &&
+      !isStale &&
+      credentials !== 'omit' &&
+      identity?.kind !== 'instant-insights' &&
+      identity?.rootRequestId &&
+      runtime.isRequestInsightsSameOriginTarget(identity.origin, target) &&
+      target
+        ? requestInsights.mintCausalToken({
+            parentRootRequestId: identity.rootRequestId,
+            parentFetchIndex: fetchIndex,
+            target,
+          })
+        : undefined
+
+    const tokenAttached = runtime.setRequestInsightsCausalCookie(headers, token)
+    if (token && !tokenAttached) {
+      requestInsights?.revokeCausalToken(token)
+      token = undefined
+    }
+    const attachedToken = token
+    const revoke = attachedToken
+      ? () => requestInsights?.revokeCausalToken(attachedToken)
+      : () => {}
+
+    if (headers.get('cookie') === originalCookie) {
+      return { init, revoke }
+    }
+
+    return {
+      init: { ...init, headers },
+      revoke,
+    }
+  } catch {
+    if (token) {
+      requestInsights?.revokeCausalToken(token)
+    }
+    return { init, revoke: () => {} }
+  }
+}
+
+function revokeRequestInsightsCausalToken(revoke: () => void): void {
+  try {
+    revoke()
+  } catch {
+    // Request Insights bookkeeping must not affect fetch behavior.
+  }
+}
+
+function fetchWithRequestInsightsCausality({
+  allowCausalLink,
+  fetchIndex,
+  init,
+  input,
+  isStale,
+  method,
+  originFetch,
+  targetUrl,
+}: {
+  allowCausalLink: boolean
+  fetchIndex: number
+  init: RequestInit
+  input: RequestInfo | URL
+  isStale: boolean
+  method: string
+  originFetch: Fetcher
+  targetUrl: URL | undefined
+}): Promise<Response> {
+  const prepared = prepareRequestInsightsCausalFetch({
+    allowCausalLink,
+    fetchIndex,
+    init,
+    input,
+    isStale,
+    method,
+    targetUrl,
+  })
+
+  let fetchPromise: Promise<Response>
+  try {
+    fetchPromise = originFetch(input, prepared.init)
+  } catch (error) {
+    revokeRequestInsightsCausalToken(prepared.revoke)
+    throw error
+  }
+
+  return fetchPromise.then(
+    (response) => {
+      revokeRequestInsightsCausalToken(prepared.revoke)
+      return response
+    },
+    (error) => {
+      revokeRequestInsightsCausalToken(prepared.revoke)
+      throw error
+    }
+  )
 }
 
 async function createCachedPrerenderResponse(
@@ -378,14 +532,18 @@ export function createPatchedFetcher(
   originFetch: Fetcher,
   { workAsyncStorage, workUnitAsyncStorage }: PatchableModule
 ): PatchedFetcher {
+  const dedupeFetch = createDedupeFetch(originFetch)
+
   // Create the patched fetch function.
   const patched = async function fetch(
     input: RequestInfo | URL,
     init: RequestInit | undefined
   ): Promise<Response> {
     let url: URL | undefined
+    let hasUrlCredentials = false
     try {
       url = new URL(input instanceof Request ? input.url : input)
+      hasUrlCredentials = url.username !== '' || url.password !== ''
       url.username = ''
       url.password = ''
     } catch {
@@ -431,20 +589,20 @@ export function createPatchedFetcher(
       async (span) => {
         // If this is an internal fetch, we should not do any special treatment.
         if (isInternal) {
-          return originFetch(input, init)
+          return dedupeFetch(input, init)
         }
 
         // If the workStore is not available, we can't do any
         // special treatment of fetch, therefore fallback to the original
         // fetch implementation.
         if (!workStore) {
-          return originFetch(input, init)
+          return dedupeFetch(input, init)
         }
 
         // We should also fallback to the original fetch implementation if we
         // are in draft mode, it does not constitute a static generation.
         if (workStore.isDraftMode) {
-          return originFetch(input, init)
+          return dedupeFetch(input, init)
         }
 
         const isRequestInput =
@@ -969,10 +1127,26 @@ export function createPatchedFetcher(
             next: { ...init?.next, fetchType: 'origin', fetchIdx },
           }
 
-          return originFetch(input, clonedInit)
+          const effectiveMethod = (
+            clonedInit.method ??
+            (input instanceof Request ? input.method : method)
+          ).toUpperCase()
+          return dedupeFetch(input, clonedInit, (networkInput, networkInit) =>
+            fetchWithRequestInsightsCausality({
+              allowCausalLink: !hasUrlCredentials,
+              fetchIndex: fetchIdx,
+              init: networkInit ?? {},
+              input: networkInput,
+              isStale: Boolean(isStale),
+              method: effectiveMethod,
+              originFetch,
+              targetUrl: url,
+            })
+          )
             .then(async (res) => {
               if (!isStale && fetchStart) {
                 trackFetchMetric(workStore, span, {
+                  requestInsightsIndex: fetchIdx,
                   start: fetchStart,
                   url: fetchUrl,
                   cacheReason: cacheReasonOverride || cacheReason,
@@ -1185,6 +1359,7 @@ export function createPatchedFetcher(
           if (cachedFetchData) {
             if (fetchStart) {
               trackFetchMetric(workStore, span, {
+                requestInsightsIndex: fetchIdx,
                 start: fetchStart,
                 url: fetchUrl,
                 cacheReason,
@@ -1432,7 +1607,7 @@ export function patchFetch(options: PatchableModule) {
 
   // Grab the original fetch function. We'll attach this so we can use it in
   // the patched fetch function.
-  const original = createDedupeFetch(globalThis.fetch)
+  const original = globalThis.fetch
 
   // Set the global fetch to the patched fetch.
   globalThis.fetch = createPatchedFetcher(original, options)

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -34,6 +34,7 @@ import type { IncrementalCache } from './incremental-cache'
 import { RenderStage } from '../app-render/staged-rendering'
 import { encodeCacheTag } from './encode-cache-tag'
 import type { Span } from './trace/tracer'
+import type { RequestInsightsIdentity } from './trace/request-insights-identity'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
@@ -42,7 +43,9 @@ type PatchFetchRequestInsightsRuntime = {
   getRequestInsightsCausalTarget: typeof import('./trace/request-insights-causal').getRequestInsightsCausalTarget
   getNextRequestInsightsFetchIndex: typeof import('./trace/request-insights-sandbox-fetch').getNextRequestInsightsFetchIndex
   getRequestInsightsIdentity: typeof import('./trace/request-insights-identity').getRequestInsightsIdentity
+  isRequestInsightsExecutionOriginTarget: typeof import('./trace/request-insights-causal').isRequestInsightsExecutionOriginTarget
   isRequestInsightsSameOriginTarget: typeof import('./trace/request-insights-causal').isRequestInsightsSameOriginTarget
+  prepareRequestInsightsSandboxFetch: typeof import('./trace/request-insights-sandbox-fetch').prepareRequestInsightsSandboxFetch
   setRequestInsightsFetchIndex: typeof import('./trace/local-span-recorder').setRequestInsightsFetchIndex
   setRequestInsightsCausalCookie: typeof import('./trace/request-insights-causal').setRequestInsightsCausalCookie
 }
@@ -60,12 +63,16 @@ function getPatchFetchRequestInsightsRuntime():
         require('./trace/request-insights-runtime') as typeof import('./trace/request-insights-runtime')
       const { getRequestInsightsIdentity } =
         require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
-      const { getNextRequestInsightsFetchIndex } =
+      const {
+        getNextRequestInsightsFetchIndex,
+        prepareRequestInsightsSandboxFetch,
+      } =
         require('./trace/request-insights-sandbox-fetch') as typeof import('./trace/request-insights-sandbox-fetch')
       const { setRequestInsightsFetchIndex } =
         require('./trace/local-span-recorder') as typeof import('./trace/local-span-recorder')
       const {
         getRequestInsightsCausalTarget,
+        isRequestInsightsExecutionOriginTarget,
         isRequestInsightsSameOriginTarget,
         setRequestInsightsCausalCookie,
       } =
@@ -75,7 +82,9 @@ function getPatchFetchRequestInsightsRuntime():
         getRequestInsightsCausalTarget,
         getNextRequestInsightsFetchIndex,
         getRequestInsightsIdentity,
+        isRequestInsightsExecutionOriginTarget,
         isRequestInsightsSameOriginTarget,
+        prepareRequestInsightsSandboxFetch,
         setRequestInsightsFetchIndex,
         setRequestInsightsCausalCookie,
       }
@@ -245,7 +254,8 @@ function trackFetchMetric(
   const requestInsights = requestInsightsRuntime?.getActiveRequestInsights()
   if (requestInsights) {
     const requestInsightsIdentity =
-      requestInsightsRuntime?.getRequestInsightsIdentity()
+      requestInsightsRuntime?.getRequestInsightsIdentity() ??
+      workStore.requestInsightsIdentity
     const requestInsightsRequestId =
       requestInsightsIdentity?.requestId ?? workStore.requestId
 
@@ -259,7 +269,10 @@ function trackFetchMetric(
           kind: requestInsightsIdentity?.kind,
           htmlRequestId:
             requestInsightsIdentity?.htmlRequestId ?? workStore.htmlRequestId,
-          route: workStore.route,
+          route:
+            requestInsightsIdentity?.source === 'proxy'
+              ? undefined
+              : workStore.route,
         },
         {
           url: metric.url,
@@ -291,6 +304,7 @@ function prepareRequestInsightsCausalFetch({
   input,
   isStale,
   method,
+  requestInsightsIdentity,
   targetUrl,
 }: {
   allowCausalLink: boolean
@@ -299,6 +313,7 @@ function prepareRequestInsightsCausalFetch({
   input: RequestInfo | URL
   isStale: boolean
   method: string
+  requestInsightsIdentity: RequestInsightsIdentity | undefined
   targetUrl: URL | undefined
 }): { init: RequestInit; revoke: () => void } {
   const runtime = getPatchFetchRequestInsightsRuntime()
@@ -312,7 +327,6 @@ function prepareRequestInsightsCausalFetch({
   }
   let token: string | undefined
   try {
-    const identity = runtime.getRequestInsightsIdentity()
     const target = targetUrl
       ? runtime.getRequestInsightsCausalTarget(targetUrl, method)
       : undefined
@@ -328,12 +342,19 @@ function prepareRequestInsightsCausalFetch({
       allowCausalLink &&
       !isStale &&
       credentials !== 'omit' &&
-      identity?.kind !== 'instant-insights' &&
-      identity?.rootRequestId &&
-      runtime.isRequestInsightsSameOriginTarget(identity.origin, target) &&
+      requestInsightsIdentity?.kind !== 'instant-insights' &&
+      requestInsightsIdentity?.rootRequestId &&
+      (runtime.isRequestInsightsSameOriginTarget(
+        requestInsightsIdentity.origin,
+        target
+      ) ||
+        runtime.isRequestInsightsExecutionOriginTarget(
+          requestInsightsIdentity.executionOrigin,
+          target
+        )) &&
       target
         ? requestInsights.mintCausalToken({
-            parentRootRequestId: identity.rootRequestId,
+            parentRootRequestId: requestInsightsIdentity.rootRequestId,
             parentFetchIndex: fetchIndex,
             target,
           })
@@ -381,6 +402,7 @@ function fetchWithRequestInsightsCausality({
   isStale,
   method,
   originFetch,
+  requestInsightsIdentity,
   targetUrl,
 }: {
   allowCausalLink: boolean
@@ -390,6 +412,7 @@ function fetchWithRequestInsightsCausality({
   isStale: boolean
   method: string
   originFetch: Fetcher
+  requestInsightsIdentity: RequestInsightsIdentity | undefined
   targetUrl: URL | undefined
 }): Promise<Response> {
   const prepared = prepareRequestInsightsCausalFetch({
@@ -399,6 +422,7 @@ function fetchWithRequestInsightsCausality({
     input,
     isStale,
     method,
+    requestInsightsIdentity,
     targetUrl,
   })
 
@@ -607,10 +631,53 @@ export function createPatchedFetcher(
           return dedupeFetch(input, init)
         }
 
-        // If the workStore is not available, we can't do any
-        // special treatment of fetch, therefore fallback to the original
-        // fetch implementation.
         if (!workStore) {
+          const requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
+          const requestInsights =
+            requestInsightsRuntime?.getActiveRequestInsights()
+          const requestInsightsIdentity =
+            requestInsightsRuntime?.getRequestInsightsIdentity()
+
+          if (
+            requestInsightsRuntime &&
+            requestInsights &&
+            requestInsightsIdentity &&
+            url
+          ) {
+            const effectiveRequest =
+              input instanceof Request ? new Request(input, init) : undefined
+            const requestInsightsFetch =
+              requestInsightsRuntime.prepareRequestInsightsSandboxFetch({
+                context: {
+                  identity: requestInsightsIdentity,
+                  requestInsights,
+                },
+                init: effectiveRequest
+                  ? {
+                      credentials: effectiveRequest.credentials,
+                      headers: effectiveRequest.headers,
+                      method: effectiveRequest.method,
+                    }
+                  : (init ?? {}),
+                url: fetchUrl,
+              })
+
+            try {
+              const response = await (effectiveRequest
+                ? dedupeFetch(
+                    new Request(effectiveRequest, {
+                      headers: requestInsightsFetch.init.headers,
+                    })
+                  )
+                : dedupeFetch(input, requestInsightsFetch.init))
+              requestInsightsFetch.complete(response)
+              return response
+            } catch (error) {
+              requestInsightsFetch.complete()
+              throw error
+            }
+          }
+
           return dedupeFetch(input, init)
         }
 
@@ -1091,14 +1158,13 @@ export function createPatchedFetcher(
         const fetchIdx = workStore.nextFetchId ?? 1
         workStore.nextFetchId = fetchIdx + 1
         let requestInsightsRuntime: PatchFetchRequestInsightsRuntime | undefined
-        let requestInsightsIdentity:
-          | import('./trace/request-insights-identity').RequestInsightsIdentity
-          | undefined
+        let requestInsightsIdentity: RequestInsightsIdentity | undefined
         let requestInsightsFetchIdx: number | undefined
         if (process.env.__NEXT_DEV_SERVER) {
           requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
           requestInsightsIdentity =
-            requestInsightsRuntime?.getRequestInsightsIdentity()
+            requestInsightsRuntime?.getRequestInsightsIdentity() ??
+            workStore.requestInsightsIdentity
           if (requestInsightsIdentity && requestInsightsRuntime) {
             requestInsightsFetchIdx =
               requestInsightsRuntime.getNextRequestInsightsFetchIndex(
@@ -1171,6 +1237,7 @@ export function createPatchedFetcher(
               isStale: Boolean(isStale),
               method: effectiveMethod,
               originFetch,
+              requestInsightsIdentity,
               targetUrl: url,
             })
           )

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -40,6 +40,7 @@ const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 type PatchFetchRequestInsightsRuntime = {
   getActiveRequestInsights: typeof import('./trace/request-insights-runtime').getActiveRequestInsights
   getRequestInsightsCausalTarget: typeof import('./trace/request-insights-causal').getRequestInsightsCausalTarget
+  getNextRequestInsightsFetchIndex: typeof import('./trace/request-insights-sandbox-fetch').getNextRequestInsightsFetchIndex
   getRequestInsightsIdentity: typeof import('./trace/request-insights-identity').getRequestInsightsIdentity
   isRequestInsightsSameOriginTarget: typeof import('./trace/request-insights-causal').isRequestInsightsSameOriginTarget
   setRequestInsightsCausalCookie: typeof import('./trace/request-insights-causal').setRequestInsightsCausalCookie
@@ -58,6 +59,8 @@ function getPatchFetchRequestInsightsRuntime():
         require('./trace/request-insights-runtime') as typeof import('./trace/request-insights-runtime')
       const { getRequestInsightsIdentity } =
         require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
+      const { getNextRequestInsightsFetchIndex } =
+        require('./trace/request-insights-sandbox-fetch') as typeof import('./trace/request-insights-sandbox-fetch')
       const {
         getRequestInsightsCausalTarget,
         isRequestInsightsSameOriginTarget,
@@ -67,6 +70,7 @@ function getPatchFetchRequestInsightsRuntime():
       patchFetchRequestInsightsRuntime = {
         getActiveRequestInsights,
         getRequestInsightsCausalTarget,
+        getNextRequestInsightsFetchIndex,
         getRequestInsightsIdentity,
         isRequestInsightsSameOriginTarget,
         setRequestInsightsCausalCookie,
@@ -1075,6 +1079,22 @@ export function createPatchedFetcher(
 
         const fetchIdx = workStore.nextFetchId ?? 1
         workStore.nextFetchId = fetchIdx + 1
+        let requestInsightsRuntime: PatchFetchRequestInsightsRuntime | undefined
+        let requestInsightsIdentity:
+          | import('./trace/request-insights-identity').RequestInsightsIdentity
+          | undefined
+        let requestInsightsFetchIdx = fetchIdx
+        if (process.env.__NEXT_DEV_SERVER) {
+          requestInsightsRuntime = getPatchFetchRequestInsightsRuntime()
+          requestInsightsIdentity =
+            requestInsightsRuntime?.getRequestInsightsIdentity()
+          if (requestInsightsIdentity && requestInsightsRuntime) {
+            requestInsightsFetchIdx =
+              requestInsightsRuntime.getNextRequestInsightsFetchIndex(
+                requestInsightsIdentity
+              )
+          }
+        }
 
         let handleUnlock: () => Promise<void> | void = () => {}
 
@@ -1134,7 +1154,7 @@ export function createPatchedFetcher(
           return dedupeFetch(input, clonedInit, (networkInput, networkInit) =>
             fetchWithRequestInsightsCausality({
               allowCausalLink: !hasUrlCredentials,
-              fetchIndex: fetchIdx,
+              fetchIndex: requestInsightsFetchIdx ?? fetchIdx,
               init: networkInit ?? {},
               input: networkInput,
               isStale: Boolean(isStale),
@@ -1146,7 +1166,7 @@ export function createPatchedFetcher(
             .then(async (res) => {
               if (!isStale && fetchStart) {
                 trackFetchMetric(workStore, span, {
-                  requestInsightsIndex: fetchIdx,
+                  requestInsightsIndex: requestInsightsFetchIdx,
                   start: fetchStart,
                   url: fetchUrl,
                   cacheReason: cacheReasonOverride || cacheReason,
@@ -1359,7 +1379,7 @@ export function createPatchedFetcher(
           if (cachedFetchData) {
             if (fetchStart) {
               trackFetchMetric(workStore, span, {
-                requestInsightsIndex: fetchIdx,
+                requestInsightsIndex: requestInsightsFetchIdx,
                 start: fetchStart,
                 url: fetchUrl,
                 cacheReason,

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -81,9 +81,11 @@ type RouterServerRequestInsightsRuntime = {
   REQUEST_INSIGHTS_ID_PATTERN: typeof import('./trace/request-insights').REQUEST_INSIGHTS_ID_PATTERN
   REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET: typeof import('./trace/request-insights').REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET
   REQUEST_INSIGHTS_MAX_ID_LENGTH: typeof import('./trace/request-insights').REQUEST_INSIGHTS_MAX_ID_LENGTH
+  getRequestInsightsCausalTargetFromRequest: typeof import('./trace/request-insights-causal').getRequestInsightsCausalTargetFromRequest
   resolveRequestInsightsIdentity: typeof import('./trace/request-insights-identity').resolveRequestInsightsIdentity
   runWithRequestInsights: typeof import('./trace/request-insights-runtime').runWithRequestInsights
   runWithRequestInsightsIdentity: typeof import('./trace/request-insights-identity').runWithRequestInsightsIdentity
+  takeRequestInsightsCausalToken: typeof import('./trace/request-insights-causal').takeRequestInsightsCausalToken
 }
 
 let routerServerRequestInsightsRuntime:
@@ -102,6 +104,11 @@ function getRouterServerRequestInsightsRuntime():
         REQUEST_INSIGHTS_MAX_ID_LENGTH,
       } =
         require('./trace/request-insights') as typeof import('./trace/request-insights')
+      const {
+        getRequestInsightsCausalTargetFromRequest,
+        takeRequestInsightsCausalToken,
+      } =
+        require('./trace/request-insights-causal') as typeof import('./trace/request-insights-causal')
       const { resolveRequestInsightsIdentity, runWithRequestInsightsIdentity } =
         require('./trace/request-insights-identity') as typeof import('./trace/request-insights-identity')
       const { runWithRequestInsights } =
@@ -111,14 +118,17 @@ function getRouterServerRequestInsightsRuntime():
         REQUEST_INSIGHTS_ID_PATTERN,
         REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET,
         REQUEST_INSIGHTS_MAX_ID_LENGTH,
+        getRequestInsightsCausalTargetFromRequest,
         resolveRequestInsightsIdentity,
         runWithRequestInsights,
         runWithRequestInsightsIdentity,
+        takeRequestInsightsCausalToken,
       }
     }
     return routerServerRequestInsightsRuntime
+  } else {
+    return undefined
   }
-  return undefined
 }
 
 const debug = setupDebug('next:router-server:main')
@@ -943,8 +953,34 @@ export async function initialize(opts: {
     }
   }
 
+  const requestInsightsOrigin =
+    process.env.__NEXT_PRIVATE_ORIGIN ??
+    `${opts.experimentalHttpsServer ? 'https' : 'http'}://${opts.hostname ?? 'localhost'}:${opts.port}`
+
   const requestHandlerImpl: WorkerRequestHandler = (req, res) => {
     addRequestMeta(req, 'relativeProjectDir', relativeProjectDir)
+
+    let causalTarget: ReturnType<
+      RouterServerRequestInsightsRuntime['getRequestInsightsCausalTargetFromRequest']
+    >
+    let causalParent: ReturnType<
+      NonNullable<typeof requestInsights>['consumeCausalToken']
+    >
+    if (requestInsights && requestInsightsRuntime) {
+      const causalToken = requestInsightsRuntime.takeRequestInsightsCausalToken(
+        req.headers
+      )
+      causalTarget =
+        requestInsightsRuntime.getRequestInsightsCausalTargetFromRequest({
+          method: req.method,
+          origin: requestInsightsOrigin,
+          url: req.url,
+        })
+      causalParent =
+        causalToken && causalTarget
+          ? requestInsights.consumeCausalToken(causalToken, causalTarget)
+          : undefined
+    }
 
     // Internal and invalid debug headers must be removed before they can be
     // considered while creating the server-owned request identity.
@@ -971,6 +1007,8 @@ export async function initialize(opts: {
       previousIdentity: getRequestMeta(req, 'requestInsightsIdentity'),
       requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
       htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
+      causalParent,
+      origin: causalTarget?.origin,
       url: req.url,
       createRequestId: nanoid,
     })

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -81,6 +81,7 @@ type RouterServerRequestInsightsRuntime = {
   REQUEST_INSIGHTS_ID_PATTERN: typeof import('./trace/request-insights').REQUEST_INSIGHTS_ID_PATTERN
   REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET: typeof import('./trace/request-insights').REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET
   REQUEST_INSIGHTS_MAX_ID_LENGTH: typeof import('./trace/request-insights').REQUEST_INSIGHTS_MAX_ID_LENGTH
+  getRequestInsightsExecutionOrigin: typeof import('./trace/request-insights-causal').getRequestInsightsExecutionOrigin
   getRequestInsightsCausalTargetFromRequest: typeof import('./trace/request-insights-causal').getRequestInsightsCausalTargetFromRequest
   resolveRequestInsightsIdentity: typeof import('./trace/request-insights-identity').resolveRequestInsightsIdentity
   runWithRequestInsights: typeof import('./trace/request-insights-runtime').runWithRequestInsights
@@ -105,6 +106,7 @@ function getRouterServerRequestInsightsRuntime():
       } =
         require('./trace/request-insights') as typeof import('./trace/request-insights')
       const {
+        getRequestInsightsExecutionOrigin,
         getRequestInsightsCausalTargetFromRequest,
         takeRequestInsightsCausalToken,
       } =
@@ -118,6 +120,7 @@ function getRouterServerRequestInsightsRuntime():
         REQUEST_INSIGHTS_ID_PATTERN,
         REQUEST_INSIGHTS_MAX_GROUPS_PER_RETENTION_BUCKET,
         REQUEST_INSIGHTS_MAX_ID_LENGTH,
+        getRequestInsightsExecutionOrigin,
         getRequestInsightsCausalTargetFromRequest,
         resolveRequestInsightsIdentity,
         runWithRequestInsights,
@@ -960,6 +963,13 @@ export async function initialize(opts: {
   const requestHandlerImpl: WorkerRequestHandler = (req, res) => {
     addRequestMeta(req, 'relativeProjectDir', relativeProjectDir)
 
+    const requestInsightsExecutionOrigin =
+      requestInsightsRuntime?.getRequestInsightsExecutionOrigin({
+        experimentalHttpsServer: opts.experimentalHttpsServer,
+        fallbackPort: opts.port,
+        socket: req.socket,
+      })
+
     let causalTarget: ReturnType<
       RouterServerRequestInsightsRuntime['getRequestInsightsCausalTargetFromRequest']
     >
@@ -973,7 +983,7 @@ export async function initialize(opts: {
       causalTarget =
         requestInsightsRuntime.getRequestInsightsCausalTargetFromRequest({
           method: req.method,
-          origin: requestInsightsOrigin,
+          origin: requestInsightsExecutionOrigin ?? requestInsightsOrigin,
           url: req.url,
         })
       causalParent =
@@ -1008,7 +1018,8 @@ export async function initialize(opts: {
       requestIdHeader: req.headers[NEXT_REQUEST_ID_HEADER],
       htmlRequestIdHeader: req.headers[NEXT_HTML_REQUEST_ID_HEADER],
       causalParent,
-      origin: causalTarget?.origin,
+      executionOrigin: requestInsightsExecutionOrigin,
+      origin: requestInsightsOrigin,
       url: req.url,
       createRequestId: nanoid,
     })

--- a/packages/next/src/server/lib/trace/local-span-recorder.test.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.test.ts
@@ -5,7 +5,11 @@
 import { runInNewContext } from 'node:vm'
 import { setFlagsFromString } from 'node:v8'
 import { SpanStatusCode, trace } from 'next/dist/compiled/@opentelemetry/api'
-import { createLocalSpan, traceLocalSpan } from './local-span-recorder'
+import {
+  createLocalSpan,
+  setRequestInsightsFetchIndex,
+  traceLocalSpan,
+} from './local-span-recorder'
 import {
   createRequestInsightsRetentionContext,
   resolveRequestInsightsIdentity,
@@ -74,6 +78,17 @@ describe('local recording span', () => {
         },
       }),
     ])
+  })
+
+  it('sets fetch indices on spans created by another module instance', () => {
+    const setFetchIndex = jest.fn()
+    const span = {
+      [Symbol.for('@next/request-insights-fetch-index-setter')]: setFetchIndex,
+    } as unknown as Parameters<typeof setRequestInsightsFetchIndex>[0]
+
+    setRequestInsightsFetchIndex(span, 7)
+
+    expect(setFetchIndex).toHaveBeenCalledWith(7)
   })
 
   it('records on the controller captured when a span started after its scope exits', () => {

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -603,44 +603,46 @@ function getSpanStoreExceptionAttributes(
 }
 
 function getCurrentRequestIdentity(): RequestIdentity {
-  try {
-    const { getRequestInsightsIdentity } =
-      require('./request-insights-identity') as typeof import('./request-insights-identity')
-    const { workAsyncStorage } =
-      require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
-    const { workUnitAsyncStorage } =
-      require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
-    let requestInsights: RequestInsights | undefined
-    if (process.env.__NEXT_DEV_SERVER) {
+  if (process.env.__NEXT_DEV_SERVER) {
+    try {
+      const { getRequestInsightsIdentity } =
+        require('./request-insights-identity') as typeof import('./request-insights-identity')
+      const { workAsyncStorage } =
+        require('../../app-render/work-async-storage.external') as typeof import('../../app-render/work-async-storage.external')
+      const { workUnitAsyncStorage } =
+        require('../../app-render/work-unit-async-storage.external') as typeof import('../../app-render/work-unit-async-storage.external')
       const { getActiveRequestInsights } =
         require('./request-insights-runtime') as typeof import('./request-insights-runtime')
-      requestInsights = getActiveRequestInsights()
-    } else {
-      requestInsights = undefined
-    }
-    const workStore = workAsyncStorage.getStore()
-    const workUnitStore = workUnitAsyncStorage.getStore()
-    const requestInsightsIdentity = getRequestInsightsIdentity()
-    const url =
-      workUnitStore && 'url' in workUnitStore ? workUnitStore.url : undefined
+      const requestInsights: RequestInsights | undefined =
+        getActiveRequestInsights()
+      const workStore = workAsyncStorage.getStore()
+      const workUnitStore = workUnitAsyncStorage.getStore()
+      const requestInsightsIdentity = getRequestInsightsIdentity()
+      const url =
+        workUnitStore && 'url' in workUnitStore ? workUnitStore.url : undefined
 
-    return {
-      requestInsights,
-      requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
-      rootRequestId:
-        requestInsightsIdentity?.rootRequestId ?? workStore?.requestId,
-      requestInsightsRetention: requestInsightsIdentity?.retention,
-      requestInsightKind: requestInsightsIdentity?.kind,
-      requestInsightSource: requestInsightsIdentity?.source,
-      requestInsightProxyStatus: requestInsightsIdentity?.proxyStatus,
-      requestInsightRouterActivity: requestInsightsIdentity?.routerActivity,
-      requestInsightServerAction: requestInsightsIdentity?.serverAction,
-      htmlRequestId:
-        requestInsightsIdentity?.htmlRequestId ?? workStore?.htmlRequestId,
-      route: workStore?.route,
-      url: url ? `${url.pathname}${url.search}` : requestInsightsIdentity?.url,
+      return {
+        requestInsights,
+        requestId: requestInsightsIdentity?.requestId ?? workStore?.requestId,
+        rootRequestId:
+          requestInsightsIdentity?.rootRequestId ?? workStore?.requestId,
+        requestInsightsRetention: requestInsightsIdentity?.retention,
+        requestInsightKind: requestInsightsIdentity?.kind,
+        requestInsightSource: requestInsightsIdentity?.source,
+        requestInsightProxyStatus: requestInsightsIdentity?.proxyStatus,
+        requestInsightRouterActivity: requestInsightsIdentity?.routerActivity,
+        requestInsightServerAction: requestInsightsIdentity?.serverAction,
+        htmlRequestId:
+          requestInsightsIdentity?.htmlRequestId ?? workStore?.htmlRequestId,
+        route: workStore?.route,
+        url: url
+          ? `${url.pathname}${url.search}`
+          : requestInsightsIdentity?.url,
+      }
+    } catch {
+      return {}
     }
-  } catch {
+  } else {
     return {}
   }
 }

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -141,8 +141,18 @@ export type LocalSpanRecorder = {
   isOpenTelemetryIsolatedSpan: typeof isOpenTelemetryIsolatedSpan
   isLocalSpanRecordingEnabled: typeof isLocalSpanRecordingEnabled
   isRequestInsightsEnabled: typeof isRequestInsightsEnabled
+  setRequestInsightsFetchIndex: typeof setRequestInsightsFetchIndex
   traceLocalSpan: typeof traceLocalSpan
   withLocalSpan: typeof withLocalSpan
+}
+
+export function setRequestInsightsFetchIndex(
+  span: Span | undefined,
+  index: number
+): void {
+  if (span instanceof LocalRecordingSpan) {
+    span.setRequestInsightsFetchIndex(index)
+  }
 }
 
 export function registerLocalSpanRecorder(): void {
@@ -158,6 +168,7 @@ export function registerLocalSpanRecorder(): void {
     isOpenTelemetryIsolatedSpan,
     isLocalSpanRecordingEnabled,
     isRequestInsightsEnabled,
+    setRequestInsightsFetchIndex,
     traceLocalSpan,
     withLocalSpan,
   }
@@ -199,6 +210,7 @@ class LocalRecordingSpan implements Span {
   private links?: SpanStoreLink[]
   private readonly parentSpanId?: string
   private requestIdentity: RequestIdentity
+  private requestInsightsFetchIndex: number | undefined
   private readonly startTime: number
   private statusCode: number | undefined
   private statusMessage: string | undefined
@@ -246,6 +258,7 @@ class LocalRecordingSpan implements Span {
     this.links = getSpanStoreLinks(links)
     this.parentSpanId = parentSpanId
     this.requestIdentity = requestIdentity
+    this.requestInsightsFetchIndex = undefined
     this.startTime = getTimestamp(startTime)
     this.statusCode = undefined
     this.statusMessage = undefined
@@ -286,6 +299,12 @@ class LocalRecordingSpan implements Span {
     }
     this.delegateSpan?.setAttributes(attributes)
     return this
+  }
+
+  setRequestInsightsFetchIndex(index: number): void {
+    if (!this.ended) {
+      this.requestInsightsFetchIndex = index
+    }
   }
 
   addEvent(
@@ -395,6 +414,7 @@ class LocalRecordingSpan implements Span {
           this.requestIdentity.requestInsightRouterActivity,
         requestInsightServerAction:
           this.requestIdentity.requestInsightServerAction,
+        requestInsightFetchIndex: this.requestInsightsFetchIndex,
         htmlRequestId: this.requestIdentity.htmlRequestId,
         route:
           getStringAttribute(recordAttributes, 'next.route') ??
@@ -422,6 +442,7 @@ class LocalRecordingSpan implements Span {
     this.delegateSpan = undefined
     this.links = undefined
     this.requestIdentity = {}
+    this.requestInsightsFetchIndex = undefined
     this.statusMessage = undefined
     this.exception = undefined
   }

--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -22,6 +22,10 @@ import type {
 import type { RequestInsights } from './request-insights'
 import type { RequestInsightsRetentionContext } from './request-insights-identity'
 
+const REQUEST_INSIGHTS_FETCH_INDEX_SETTER = Symbol.for(
+  '@next/request-insights-fetch-index-setter'
+)
+
 export { isLocalSpanRecordingEnabled } from './span-store'
 
 const TRACE_ID_HEX_LENGTH = 32
@@ -150,8 +154,11 @@ export function setRequestInsightsFetchIndex(
   span: Span | undefined,
   index: number
 ): void {
-  if (span instanceof LocalRecordingSpan) {
-    span.setRequestInsightsFetchIndex(index)
+  const setter = (span as (Span & Record<PropertyKey, unknown>) | undefined)?.[
+    REQUEST_INSIGHTS_FETCH_INDEX_SETTER
+  ]
+  if (typeof setter === 'function') {
+    setter.call(span, index)
   }
 }
 
@@ -301,7 +308,7 @@ class LocalRecordingSpan implements Span {
     return this
   }
 
-  setRequestInsightsFetchIndex(index: number): void {
+  [REQUEST_INSIGHTS_FETCH_INDEX_SETTER](index: number): void {
     if (!this.ended) {
       this.requestInsightsFetchIndex = index
     }

--- a/packages/next/src/server/lib/trace/request-insights-causal.ts
+++ b/packages/next/src/server/lib/trace/request-insights-causal.ts
@@ -211,6 +211,69 @@ export function isRequestInsightsSameOriginTarget(
   return origin !== undefined && target?.origin === origin
 }
 
+export function isRequestInsightsExecutionOriginTarget(
+  origin: string | undefined,
+  target: RequestInsightsCausalTarget | undefined
+): boolean {
+  if (!origin || !target) return false
+  if (target.origin === origin) return true
+
+  try {
+    const executionOrigin = new URL(origin)
+    const targetOrigin = new URL(target.origin)
+    return (
+      executionOrigin.protocol === targetOrigin.protocol &&
+      executionOrigin.port === targetOrigin.port &&
+      isRequestInsightsLoopbackHostname(executionOrigin.hostname) &&
+      isRequestInsightsLoopbackHostname(targetOrigin.hostname)
+    )
+  } catch {
+    return false
+  }
+}
+
+export function getRequestInsightsExecutionOrigin({
+  experimentalHttpsServer,
+  fallbackPort,
+  socket,
+}: {
+  experimentalHttpsServer: boolean | undefined
+  fallbackPort: number | undefined
+  socket:
+    | {
+        encrypted?: boolean
+        localPort?: number
+      }
+    | null
+    | undefined
+}): string | undefined {
+  let encrypted = false
+  let port = fallbackPort
+
+  try {
+    encrypted = Boolean(socket?.encrypted)
+  } catch {
+    // Optional socket metadata must not affect request handling.
+  }
+  try {
+    port = socket?.localPort ?? fallbackPort
+  } catch {
+    // Some internal requests use socket mocks without readable metadata.
+  }
+
+  if (
+    port === undefined ||
+    !Number.isInteger(port) ||
+    port < 1 ||
+    port > 65_535
+  ) {
+    return undefined
+  }
+
+  const protocol = encrypted || experimentalHttpsServer ? 'https' : 'http'
+  return `${protocol}://localhost:${port}`
+}
+
 export function takeRequestInsightsCausalToken(
   headers: RequestInsightsCausalHeaders
 ): string | undefined {
@@ -352,7 +415,7 @@ function targetsEqual(
   second: RequestInsightsCausalTarget
 ): boolean {
   return (
-    first.origin === second.origin &&
+    isRequestInsightsExecutionOriginTarget(first.origin, second) &&
     first.pathname === second.pathname &&
     first.method === second.method
   )

--- a/packages/next/src/server/lib/trace/request-insights-causal.ts
+++ b/packages/next/src/server/lib/trace/request-insights-causal.ts
@@ -1,0 +1,416 @@
+export const REQUEST_INSIGHTS_CAUSAL_COOKIE = '__next_request_insights_causal'
+
+const DEFAULT_MAX_ENTRIES = 2_048
+const DEFAULT_TTL_MS = 30_000
+const CAUSAL_TOKEN_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-'
+const CAUSAL_TOKEN_LENGTH = 32
+const MAX_CAUSAL_COOKIE_HEADER_LENGTH = 16 * 1024
+const MAX_ORIGIN_LENGTH = 256
+const MAX_PATHNAME_LENGTH = 2_048
+const MAX_METHOD_LENGTH = 16
+const MAX_PARENT_ROOT_REQUEST_ID_LENGTH = 128
+const MAX_FETCH_INDEX = 1_000_000
+const CAUSAL_TOKEN_PATTERN = /^[A-Za-z0-9_-]{16,64}$/
+const PARENT_ROOT_REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const METHOD_PATTERN = /^[A-Z]+$/
+
+export type RequestInsightsCausalTarget = {
+  origin: string
+  pathname: string
+  method: string
+}
+
+export type RequestInsightsCausalParent = {
+  parentRootRequestId: string
+  parentFetchIndex: number
+}
+
+type RequestInsightsCausalHeaders = Record<
+  string,
+  string | string[] | undefined
+>
+
+type RequestInsightsCausalEntry = RequestInsightsCausalParent & {
+  target: RequestInsightsCausalTarget
+  expiresAt: number
+}
+
+type RequestInsightsCausalRegistryOptions = {
+  createToken?: () => string
+  maxEntries?: number
+  now?: () => number
+  ttlMs?: number
+}
+
+/**
+ * Keeps causal data inside one Request Insights controller. Only an opaque,
+ * short-lived capability crosses the loopback HTTP boundary.
+ */
+export class RequestInsightsCausalRegistry {
+  private readonly createToken: () => string
+  private readonly entries = new Map<string, RequestInsightsCausalEntry>()
+  private readonly maxEntries: number
+  private readonly now: () => number
+  private readonly ttlMs: number
+
+  constructor(options: RequestInsightsCausalRegistryOptions = {}) {
+    this.createToken = options.createToken ?? createCausalToken
+    this.maxEntries = getPositiveInteger(
+      options.maxEntries,
+      DEFAULT_MAX_ENTRIES
+    )
+    this.now = options.now ?? (() => performance.timeOrigin + performance.now())
+    this.ttlMs = getPositiveInteger(options.ttlMs, DEFAULT_TTL_MS)
+  }
+
+  mintCausalToken({
+    parentRootRequestId,
+    parentFetchIndex,
+    target,
+  }: RequestInsightsCausalParent & {
+    target: RequestInsightsCausalTarget
+  }): string | undefined {
+    const parent = normalizeRequestInsightsCausalParent({
+      parentRootRequestId,
+      parentFetchIndex,
+    })
+    const normalizedTarget = normalizeTarget(target)
+    if (!parent || !normalizedTarget) {
+      return undefined
+    }
+
+    const now = this.now()
+    this.prune(now)
+    while (this.entries.size >= this.maxEntries) {
+      const oldestToken = this.entries.keys().next().value
+      if (oldestToken === undefined) break
+      this.entries.delete(oldestToken)
+    }
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const token = this.createToken()
+      if (!CAUSAL_TOKEN_PATTERN.test(token) || this.entries.has(token)) {
+        continue
+      }
+
+      this.entries.set(token, {
+        ...parent,
+        target: normalizedTarget,
+        expiresAt: now + this.ttlMs,
+      })
+      return token
+    }
+  }
+
+  consumeCausalToken(
+    token: string,
+    target: RequestInsightsCausalTarget
+  ): RequestInsightsCausalParent | undefined {
+    if (!CAUSAL_TOKEN_PATTERN.test(token)) {
+      return undefined
+    }
+
+    const now = this.now()
+    this.prune(now)
+    const entry = this.entries.get(token)
+    if (!entry) {
+      return undefined
+    }
+
+    // A mismatched redirect or replay also consumes the capability.
+    this.entries.delete(token)
+    const normalizedTarget = normalizeTarget(target)
+    if (
+      !normalizedTarget ||
+      entry.expiresAt <= now ||
+      !targetsEqual(entry.target, normalizedTarget)
+    ) {
+      return undefined
+    }
+
+    return Object.freeze({
+      parentRootRequestId: entry.parentRootRequestId,
+      parentFetchIndex: entry.parentFetchIndex,
+    })
+  }
+
+  revokeCausalToken(token: string): void {
+    if (CAUSAL_TOKEN_PATTERN.test(token)) {
+      this.entries.delete(token)
+    }
+  }
+
+  clear(): void {
+    this.entries.clear()
+  }
+
+  private prune(now: number): void {
+    for (const [token, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(token)
+      }
+    }
+  }
+}
+
+export function getRequestInsightsCausalTarget(
+  url: URL,
+  method: string
+): RequestInsightsCausalTarget | undefined {
+  if (
+    (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+    url.username !== '' ||
+    url.password !== '' ||
+    !isRequestInsightsLoopbackHostname(url.hostname)
+  ) {
+    return undefined
+  }
+
+  return normalizeTarget({
+    origin: url.origin,
+    pathname: url.pathname,
+    method,
+  })
+}
+
+export function getRequestInsightsCausalTargetFromRequest({
+  method,
+  origin,
+  url,
+}: {
+  method: string | undefined
+  origin: string | undefined
+  url: string | undefined
+}): RequestInsightsCausalTarget | undefined {
+  if (!origin || !url) return undefined
+
+  try {
+    const trustedOrigin = new URL(origin)
+    const requestUrl = new URL(url, trustedOrigin)
+    if (
+      trustedOrigin.username !== '' ||
+      trustedOrigin.password !== '' ||
+      trustedOrigin.pathname !== '/' ||
+      trustedOrigin.search !== '' ||
+      trustedOrigin.hash !== '' ||
+      requestUrl.origin !== trustedOrigin.origin
+    ) {
+      return undefined
+    }
+    return getRequestInsightsCausalTarget(requestUrl, method ?? 'GET')
+  } catch {
+    return undefined
+  }
+}
+
+export function isRequestInsightsSameOriginTarget(
+  origin: string | undefined,
+  target: RequestInsightsCausalTarget | undefined
+): boolean {
+  return origin !== undefined && target?.origin === origin
+}
+
+export function takeRequestInsightsCausalToken(
+  headers: RequestInsightsCausalHeaders
+): string | undefined {
+  const { cookies, tokens, withinLimit } = parseCausalCookies(headers.cookie)
+  if (tokens.length > 0) {
+    setCookieHeader(headers, cookies)
+  }
+  return withinLimit &&
+    tokens.length === 1 &&
+    CAUSAL_TOKEN_PATTERN.test(tokens[0])
+    ? tokens[0]
+    : undefined
+}
+
+export function setRequestInsightsCausalCookie(
+  headers: Headers,
+  token: string | undefined
+): boolean {
+  const { cookies, tokens, withinLimit } = parseCausalCookies(
+    headers.get('cookie') ?? undefined
+  )
+  const causalCookie =
+    token && CAUSAL_TOKEN_PATTERN.test(token)
+      ? `${REQUEST_INSIGHTS_CAUSAL_COOKIE}=${token}`
+      : undefined
+  const currentLength = cookies.join('; ').length
+  const canAppend = Boolean(
+    causalCookie &&
+      withinLimit &&
+      currentLength + (currentLength === 0 ? 0 : 2) + causalCookie.length <=
+        MAX_CAUSAL_COOKIE_HEADER_LENGTH
+  )
+
+  if (!canAppend && tokens.length === 0) {
+    return false
+  }
+  if (canAppend && causalCookie) {
+    cookies.push(causalCookie)
+  }
+  if (cookies.length === 0) {
+    headers.delete('cookie')
+  } else {
+    headers.set('cookie', cookies.join('; '))
+  }
+  return canAppend
+}
+
+function createCausalToken(): string {
+  const bytes = new Uint8Array(CAUSAL_TOKEN_LENGTH)
+  globalThis.crypto.getRandomValues(bytes)
+  let token = ''
+  for (const byte of bytes) {
+    token += CAUSAL_TOKEN_ALPHABET[byte & 0x3f]
+  }
+  return token
+}
+
+function isRequestInsightsLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase()
+  if (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized === '[::1]'
+  ) {
+    return true
+  }
+
+  const parts = normalized.split('.')
+  return (
+    parts.length === 4 &&
+    parts.every((part) => /^\d{1,3}$/.test(part)) &&
+    Number(parts[0]) === 127 &&
+    parts.every((part) => Number(part) <= 255)
+  )
+}
+
+export function normalizeRequestInsightsCausalParent(parent: {
+  parentRootRequestId: string | undefined
+  parentFetchIndex: number | undefined
+}): Readonly<RequestInsightsCausalParent> | undefined {
+  if (
+    parent.parentRootRequestId === undefined ||
+    parent.parentRootRequestId.length > MAX_PARENT_ROOT_REQUEST_ID_LENGTH ||
+    !PARENT_ROOT_REQUEST_ID_PATTERN.test(parent.parentRootRequestId) ||
+    parent.parentFetchIndex === undefined ||
+    !Number.isSafeInteger(parent.parentFetchIndex) ||
+    parent.parentFetchIndex < 0 ||
+    parent.parentFetchIndex > MAX_FETCH_INDEX
+  ) {
+    return undefined
+  }
+  return Object.freeze({
+    parentRootRequestId: parent.parentRootRequestId,
+    parentFetchIndex: parent.parentFetchIndex,
+  })
+}
+
+function normalizeTarget(
+  target: RequestInsightsCausalTarget
+): RequestInsightsCausalTarget | undefined {
+  if (
+    target.origin.length > MAX_ORIGIN_LENGTH ||
+    target.pathname.length > MAX_PATHNAME_LENGTH ||
+    target.method.length === 0 ||
+    target.method.length > MAX_METHOD_LENGTH
+  ) {
+    return undefined
+  }
+
+  let originUrl: URL
+  try {
+    originUrl = new URL(target.origin)
+  } catch {
+    return undefined
+  }
+
+  const method = target.method.toUpperCase()
+  if (
+    (originUrl.protocol !== 'http:' && originUrl.protocol !== 'https:') ||
+    originUrl.username !== '' ||
+    originUrl.password !== '' ||
+    originUrl.pathname !== '/' ||
+    originUrl.search !== '' ||
+    originUrl.hash !== '' ||
+    !isRequestInsightsLoopbackHostname(originUrl.hostname) ||
+    !target.pathname.startsWith('/') ||
+    target.pathname.includes('?') ||
+    target.pathname.includes('#') ||
+    !METHOD_PATTERN.test(method)
+  ) {
+    return undefined
+  }
+
+  return { origin: originUrl.origin, pathname: target.pathname, method }
+}
+
+function targetsEqual(
+  first: RequestInsightsCausalTarget,
+  second: RequestInsightsCausalTarget
+): boolean {
+  return (
+    first.origin === second.origin &&
+    first.pathname === second.pathname &&
+    first.method === second.method
+  )
+}
+
+function getPositiveInteger(
+  value: number | undefined,
+  fallback: number
+): number {
+  return value !== undefined && Number.isInteger(value) && value > 0
+    ? value
+    : fallback
+}
+
+function parseCausalCookies(value: string | string[] | undefined): {
+  cookies: string[]
+  tokens: string[]
+  withinLimit: boolean
+} {
+  const cookies: string[] = []
+  const tokens: string[] = []
+  const values = Array.isArray(value)
+    ? value
+    : value === undefined
+      ? []
+      : [value]
+  const withinLimit =
+    !Array.isArray(value) &&
+    values.reduce((length, item) => length + item.length, 0) <=
+      MAX_CAUSAL_COOKIE_HEADER_LENGTH
+
+  for (const headerValue of values) {
+    for (const rawCookie of headerValue.split(';')) {
+      const cookie = rawCookie.trim()
+      if (!cookie) continue
+      const separatorIndex = cookie.indexOf('=')
+      const name =
+        separatorIndex === -1 ? cookie : cookie.slice(0, separatorIndex).trim()
+      if (name === REQUEST_INSIGHTS_CAUSAL_COOKIE) {
+        tokens.push(
+          separatorIndex === -1 ? '' : cookie.slice(separatorIndex + 1).trim()
+        )
+      } else {
+        cookies.push(cookie)
+      }
+    }
+  }
+
+  return { cookies, tokens, withinLimit }
+}
+
+function setCookieHeader(
+  headers: RequestInsightsCausalHeaders,
+  cookies: string[]
+): void {
+  if (cookies.length === 0) {
+    delete headers.cookie
+  } else {
+    headers.cookie = cookies.join('; ')
+  }
+}

--- a/packages/next/src/server/lib/trace/request-insights-fetch-init.ts
+++ b/packages/next/src/server/lib/trace/request-insights-fetch-init.ts
@@ -1,0 +1,105 @@
+type RequestInitRead =
+  | { status: 'fulfilled'; value: unknown }
+  | { status: 'rejected'; reason: unknown }
+
+export type RequestInsightsFetchInitSnapshot = {
+  init: RequestInit
+  readHeaders(): Headers
+  readString(property: 'credentials' | 'method'): string | undefined
+}
+
+/**
+ * Shares lazy RequestInit dictionary reads between Request Insights and fetch.
+ * This preserves inherited properties and replays getters (including errors)
+ * without invoking application code more than once.
+ */
+export function createRequestInsightsFetchInitSnapshot(
+  init: RequestInit
+): RequestInsightsFetchInitSnapshot {
+  const reads = new Map<PropertyKey, RequestInitRead>()
+  const source = (init as RequestInit | null) ?? {}
+  const target = Object.create(null) as RequestInit
+
+  function read(property: PropertyKey): unknown {
+    const cached = reads.get(property)
+    if (cached?.status === 'rejected') {
+      throw cached.reason
+    }
+    if (cached?.status === 'fulfilled') {
+      return cached.value
+    }
+
+    try {
+      const value = Reflect.get(source, property, source)
+      reads.set(property, { status: 'fulfilled', value })
+      return value
+    } catch (reason) {
+      reads.set(property, { status: 'rejected', reason })
+      throw reason
+    }
+  }
+
+  function write(property: PropertyKey, value: unknown): void {
+    reads.set(property, { status: 'fulfilled', value })
+    Reflect.defineProperty(target, property, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    })
+  }
+
+  const snapshot = new Proxy(target, {
+    get(_target, property) {
+      return read(property)
+    },
+    getOwnPropertyDescriptor(snapshotTarget, property) {
+      const override = Reflect.getOwnPropertyDescriptor(
+        snapshotTarget,
+        property
+      )
+      if (override) return override
+
+      const descriptor = Reflect.getOwnPropertyDescriptor(source, property)
+      return descriptor ? { ...descriptor, configurable: true } : undefined
+    },
+    ownKeys(snapshotTarget) {
+      return Array.from(
+        new Set([
+          ...Reflect.ownKeys(source),
+          ...Reflect.ownKeys(snapshotTarget),
+        ])
+      )
+    },
+    set(_snapshotTarget, property, value) {
+      write(property, value)
+      return true
+    },
+  })
+
+  return {
+    init: snapshot,
+    readHeaders() {
+      try {
+        const headers = new Headers(read('headers') as HeadersInit | undefined)
+        write('headers', headers)
+        return headers
+      } catch (reason) {
+        reads.set('headers', { status: 'rejected', reason })
+        throw reason
+      }
+    },
+    readString(property) {
+      try {
+        const value = read(property)
+        if (value === undefined) return undefined
+        const normalized = `${value}`
+        write(property, normalized)
+        return normalized
+      } catch (reason) {
+        reads.set(property, { status: 'rejected', reason })
+        throw reason
+      }
+    },
+  }
+}

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -27,6 +27,9 @@ export type RequestInsightsIdentity = {
   htmlRequestId: string
   url: string | undefined
   origin?: string
+  // Direct, server-owned listener origin. This can differ from `origin` when
+  // the development server is reached through a reverse proxy.
+  executionOrigin?: string
   parentRootRequestId?: string
   parentFetchIndex?: number
 }
@@ -36,6 +39,7 @@ export function resolveRequestInsightsIdentity({
   requestIdHeader,
   htmlRequestIdHeader,
   causalParent,
+  executionOrigin,
   origin,
   url,
   createRequestId,
@@ -44,6 +48,7 @@ export function resolveRequestInsightsIdentity({
   requestIdHeader: string | string[] | undefined
   htmlRequestIdHeader: string | string[] | undefined
   causalParent?: RequestInsightsCausalParent
+  executionOrigin?: string
   origin?: string
   url: string | undefined
   createRequestId: () => string
@@ -62,6 +67,7 @@ export function resolveRequestInsightsIdentity({
       getValidatedDevHtmlRequestId(htmlRequestIdHeader) ?? requestId,
     url,
     origin,
+    executionOrigin,
     ...(causalParent?.parentRootRequestId !== requestId
       ? causalParent
       : undefined),

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -10,6 +10,7 @@ import {
   getValidatedDevHtmlRequestId,
   getValidatedDevRequestId,
 } from '../dev-request-id'
+import type { RequestInsightsCausalParent } from './request-insights-causal'
 
 export type RequestInsightsIdentity = {
   // This is a server-owned storage key. Browser-provided IDs are only used by
@@ -25,18 +26,25 @@ export type RequestInsightsIdentity = {
   serverAction?: true
   htmlRequestId: string
   url: string | undefined
+  origin?: string
+  parentRootRequestId?: string
+  parentFetchIndex?: number
 }
 
 export function resolveRequestInsightsIdentity({
   previousIdentity,
   requestIdHeader,
   htmlRequestIdHeader,
+  causalParent,
+  origin,
   url,
   createRequestId,
 }: {
   previousIdentity: RequestInsightsIdentity | undefined
   requestIdHeader: string | string[] | undefined
   htmlRequestIdHeader: string | string[] | undefined
+  causalParent?: RequestInsightsCausalParent
+  origin?: string
   url: string | undefined
   createRequestId: () => string
 }): RequestInsightsIdentity {
@@ -53,6 +61,10 @@ export function resolveRequestInsightsIdentity({
     htmlRequestId:
       getValidatedDevHtmlRequestId(htmlRequestIdHeader) ?? requestId,
     url,
+    origin,
+    ...(causalParent?.parentRootRequestId !== requestId
+      ? causalParent
+      : undefined),
   }
 }
 

--- a/packages/next/src/server/lib/trace/request-insights-response.ts
+++ b/packages/next/src/server/lib/trace/request-insights-response.ts
@@ -1,0 +1,265 @@
+import type { ServerResponse } from 'node:http'
+
+import type { WebNextResponse } from '../../base-http/web'
+import type { RequestInsightResponse } from '../../../next-devtools/shared/request-insights'
+
+export type RequestInsightResponseLifecycle = RequestInsightResponse & {
+  endTime: number
+  outcome: 'finished' | 'aborted' | 'errored'
+}
+
+type RequestInsightResponseCallbacks = {
+  /** Lifecycle observation was attached. This is not a first-byte signal. */
+  onAttach(trackingStartTime: number): void
+  onComplete(lifecycle: RequestInsightResponseLifecycle): void
+}
+
+const trackedResponses = new WeakSet<object>()
+const knownResponseErrorTypes = new Set([
+  'AbortError',
+  'AggregateError',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'ResponseAborted',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+])
+
+/**
+ * Observes the actual Node response lifetime without changing the lifetime of
+ * the public OpenTelemetry request span.
+ */
+export function trackRequestInsightNodeResponse(
+  response: ServerResponse,
+  callbacks: RequestInsightResponseCallbacks
+): void {
+  if (trackedResponses.has(response)) {
+    return
+  }
+
+  trackedResponses.add(response)
+  const trackingStartTime = getCurrentTimestamp()
+  let completed = false
+  let committedStatusCode = response.headersSent
+    ? response.statusCode
+    : undefined
+  const restoreWriteHead = captureCommittedStatusCode(
+    response,
+    (statusCode) => {
+      committedStatusCode = statusCode
+    }
+  )
+
+  const cleanup = () => {
+    restoreWriteHead()
+    response.off('finish', onFinish)
+    response.off('close', onClose)
+  }
+  const complete = (
+    outcome: RequestInsightResponseLifecycle['outcome'],
+    error?: unknown
+  ) => {
+    if (completed) {
+      return
+    }
+
+    completed = true
+    cleanup()
+    safelyInvokeCallback(() => {
+      callbacks.onComplete({
+        trackingStartTime,
+        endTime: getCurrentTimestamp(),
+        statusCode:
+          committedStatusCode ??
+          (response.headersSent || response.writableFinished
+            ? response.statusCode
+            : undefined),
+        outcome,
+        error: getResponseError(error, outcome),
+      })
+    })
+  }
+  const onFinish = () => complete('finished')
+  const onClose = () => {
+    if (response.writableFinished) {
+      complete('finished')
+      return
+    }
+
+    const responseError = response.errored
+    if (
+      responseError !== null &&
+      responseError !== undefined &&
+      !isResponseAbortError(responseError)
+    ) {
+      complete('errored', responseError)
+    } else {
+      complete('aborted', responseError)
+    }
+  }
+
+  safelyInvokeCallback(() => callbacks.onAttach(trackingStartTime))
+
+  if (response.writableFinished) {
+    complete('finished')
+    return
+  }
+  if (response.destroyed) {
+    onClose()
+    return
+  }
+
+  response.once('finish', onFinish)
+  response.once('close', onClose)
+}
+
+/**
+ * Observes consumption of a Web response. The Web response records its status
+ * when `toResponse()` commits it and distinguishes completion, cancellation,
+ * and source-stream errors.
+ */
+export function trackRequestInsightWebResponse(
+  response: WebNextResponse,
+  callbacks: RequestInsightResponseCallbacks
+): void {
+  if (trackedResponses.has(response)) {
+    return
+  }
+
+  trackedResponses.add(response)
+  const trackingStartTime = getCurrentTimestamp()
+
+  try {
+    response.onResponseEnd((result) => {
+      safelyInvokeCallback(() => {
+        callbacks.onComplete({
+          trackingStartTime,
+          endTime: getCurrentTimestamp(),
+          statusCode: result.statusCode,
+          outcome: result.outcome,
+          error: getResponseError(
+            'error' in result ? result.error : undefined,
+            result.outcome
+          ),
+        })
+      })
+    })
+  } catch (error) {
+    safelyInvokeCallback(() => {
+      console.error(
+        '[request-insights] failed to attach response lifecycle tracking',
+        error
+      )
+    })
+    return
+  }
+
+  safelyInvokeCallback(() => callbacks.onAttach(trackingStartTime))
+}
+
+function captureCommittedStatusCode(
+  response: ServerResponse,
+  onCommit: (statusCode: number) => void
+): () => void {
+  if (response.headersSent || typeof response.writeHead !== 'function') {
+    return () => {}
+  }
+
+  const originalWriteHead = response.writeHead
+  let restored = false
+  const restore = () => {
+    if (restored) {
+      return
+    }
+    restored = true
+    if (response.writeHead === wrappedWriteHead) {
+      response.writeHead = originalWriteHead
+    }
+  }
+  const wrappedWriteHead = function (this: ServerResponse, ...args: unknown[]) {
+    restore()
+    const result = Reflect.apply(
+      originalWriteHead,
+      this,
+      args
+    ) as ServerResponse
+    onCommit(this.statusCode)
+    return result
+  } as ServerResponse['writeHead']
+
+  response.writeHead = wrappedWriteHead
+  return restore
+}
+
+function isResponseAbortError(error: unknown): boolean {
+  const name = getErrorName(error)
+  if (name === 'AbortError' || name === 'ResponseAborted') {
+    return true
+  }
+  if (
+    (typeof error !== 'object' || error === null) &&
+    typeof error !== 'function'
+  ) {
+    return false
+  }
+
+  try {
+    return (error as { code?: unknown }).code === 'ECONNRESET'
+  } catch {
+    return false
+  }
+}
+
+function getResponseError(
+  error: unknown,
+  outcome: RequestInsightResponseLifecycle['outcome']
+): RequestInsightResponseLifecycle['error'] {
+  if (outcome === 'aborted') {
+    return { type: 'ResponseAborted' }
+  }
+
+  const errorName = getErrorName(error)
+  if (errorName !== undefined) {
+    return {
+      type: knownResponseErrorTypes.has(errorName) ? errorName : 'Error',
+    }
+  }
+  if (error === undefined || error === null) {
+    return undefined
+  }
+  return { type: 'UnknownResponseError' }
+}
+
+function getErrorName(error: unknown): string | undefined {
+  if (
+    (typeof error !== 'object' || error === null) &&
+    typeof error !== 'function'
+  ) {
+    return undefined
+  }
+
+  try {
+    const name = (error as { name?: unknown }).name
+    return typeof name === 'string' ? name : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function safelyInvokeCallback(callback: () => void): void {
+  try {
+    callback()
+  } catch (error) {
+    console.error(
+      '[request-insights] response lifecycle callback failed',
+      error
+    )
+  }
+}
+
+function getCurrentTimestamp(): number {
+  return performance.timeOrigin + performance.now()
+}

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
@@ -52,6 +52,7 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     const requestInsights = new RequestInsights()
     const identity = {
       requestId: 'edge-parent',
+      rootRequestId: 'edge-parent-root',
       htmlRequestId: 'edge-parent',
       origin: 'http://app.localhost',
       url: '/edge',
@@ -80,7 +81,7 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     expect(headers.cookie).toBe('user=value')
     expect(token).toBeDefined()
     expect(requestInsights.consumeCausalToken(token!, target)).toEqual({
-      parentRequestId: 'edge-parent',
+      parentRootRequestId: 'edge-parent-root',
       parentFetchIndex: 1,
     })
 
@@ -125,6 +126,7 @@ describe('prepareRequestInsightsSandboxFetch', () => {
       context: {
         identity: {
           requestId: 'edge-request',
+          rootRequestId: 'edge-request-root',
           htmlRequestId: 'edge-request',
           origin: 'http://app.localhost',
           url: '/edge',
@@ -326,6 +328,7 @@ describe('prepareRequestInsightsSandboxFetch', () => {
       context: {
         identity: {
           requestId: 'edge-request',
+          rootRequestId: 'edge-request-root',
           htmlRequestId: 'edge-request',
           origin: 'http://app.localhost',
           url: '/edge',

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
@@ -90,6 +90,42 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     requestInsights.dispose()
   })
 
+  it('links a direct server fetch when the ingress origin is proxied', () => {
+    const requestInsights = new RequestInsights()
+    const identity = {
+      requestId: 'proxied-edge-parent',
+      rootRequestId: 'proxied-edge-parent-root',
+      htmlRequestId: 'proxied-edge-parent',
+      origin: 'https://app.localhost',
+      executionOrigin: 'http://localhost:3012',
+      url: '/edge',
+    }
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://localhost:3012/api/child'),
+      'GET'
+    )!
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity,
+        origin: 'https://app.localhost',
+        requestInsights,
+      },
+      init: {},
+      url: target.origin + target.pathname,
+    })
+    const headers = Object.fromEntries(new Headers(prepared.init.headers))
+    const token = takeRequestInsightsCausalToken(headers)
+
+    expect(token).toBeDefined()
+    expect(requestInsights.consumeCausalToken(token!, target)).toEqual({
+      parentRootRequestId: 'proxied-edge-parent-root',
+      parentFetchIndex: 1,
+    })
+
+    prepared.complete({ status: 200 })
+    requestInsights.dispose()
+  })
+
   it('uses unique indexes and completes each fetch once', () => {
     const requestInsights = new RequestInsights()
     const identity = {

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
@@ -1,0 +1,348 @@
+import { RequestInsights } from './request-insights'
+import {
+  getRequestInsightsCausalTarget,
+  takeRequestInsightsCausalToken,
+} from './request-insights-causal'
+import { prepareRequestInsightsSandboxFetch } from './request-insights-sandbox-fetch'
+
+describe('prepareRequestInsightsSandboxFetch', () => {
+  it('keeps fetches isolated by controller and identity', () => {
+    const first = new RequestInsights()
+    const second = new RequestInsights()
+    const firstIdentity = {
+      requestId: 'first-edge-request',
+      htmlRequestId: 'first-edge-request',
+      url: '/first',
+    }
+    const secondIdentity = {
+      requestId: 'second-edge-request',
+      htmlRequestId: 'second-edge-request',
+      url: '/second',
+    }
+
+    prepareRequestInsightsSandboxFetch({
+      context: { identity: firstIdentity, requestInsights: first },
+      init: {},
+      url: 'https://example.com/first',
+    }).complete({ status: 201 })
+    prepareRequestInsightsSandboxFetch({
+      context: { identity: secondIdentity, requestInsights: second },
+      init: {},
+      url: 'https://example.com/second',
+    }).complete({ status: 202 })
+
+    expect(first.getSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: 'first-edge-request',
+        fetches: [expect.objectContaining({ statusCode: 201 })],
+      }),
+    ])
+    expect(second.getSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: 'second-edge-request',
+        fetches: [expect.objectContaining({ statusCode: 202 })],
+      }),
+    ])
+
+    first.dispose()
+    second.dispose()
+  })
+
+  it('links and revokes a same-origin causal capability', () => {
+    const requestInsights = new RequestInsights()
+    const identity = {
+      requestId: 'edge-parent',
+      htmlRequestId: 'edge-parent',
+      origin: 'http://app.localhost',
+      url: '/edge',
+    }
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://app.localhost/api/child'),
+      'POST'
+    )!
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity,
+        origin: 'http://app.localhost',
+        requestInsights,
+      },
+      init: {
+        method: 'POST',
+        headers: {
+          cookie: '__next_request_insights_causal=caller; user=value',
+        },
+      },
+      url: target.origin + target.pathname,
+    })
+    const headers = Object.fromEntries(new Headers(prepared.init.headers))
+    const token = takeRequestInsightsCausalToken(headers)
+
+    expect(headers.cookie).toBe('user=value')
+    expect(token).toBeDefined()
+    expect(requestInsights.consumeCausalToken(token!, target)).toEqual({
+      parentRequestId: 'edge-parent',
+      parentFetchIndex: 1,
+    })
+
+    expect(() => prepared.complete()).not.toThrow()
+    expect(requestInsights.consumeCausalToken(token!, target)).toBeUndefined()
+    requestInsights.dispose()
+  })
+
+  it('uses unique indexes and completes each fetch once', () => {
+    const requestInsights = new RequestInsights()
+    const identity = {
+      requestId: 'edge-request',
+      htmlRequestId: 'edge-request',
+      url: '/edge',
+    }
+    const first = prepareRequestInsightsSandboxFetch({
+      context: { identity, requestInsights },
+      init: {},
+      url: 'https://example.com/first',
+    })
+    const second = prepareRequestInsightsSandboxFetch({
+      context: { identity, requestInsights },
+      init: {},
+      url: 'https://example.com/second',
+    })
+
+    first.complete({ status: 200 })
+    first.complete({ status: 500 })
+    second.complete({ status: 201 })
+
+    expect(requestInsights.getSnapshot().requests[0].fetches).toEqual([
+      expect.objectContaining({ index: 1, statusCode: 200 }),
+      expect.objectContaining({ index: 2, statusCode: 201 }),
+    ])
+    requestInsights.dispose()
+  })
+
+  it('normalizes boxed method and credentials values', () => {
+    const requestInsights = new RequestInsights()
+    const mintCausalToken = jest.spyOn(requestInsights, 'mintCausalToken')
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity: {
+          requestId: 'edge-request',
+          htmlRequestId: 'edge-request',
+          origin: 'http://app.localhost',
+          url: '/edge',
+        },
+        requestInsights,
+      },
+      init: {
+        method: Object('POST') as string,
+        credentials: Object('omit') as RequestCredentials,
+        headers: {
+          cookie: '__next_request_insights_causal=caller; user=value',
+        },
+      },
+      url: 'http://app.localhost/api/child',
+    })
+
+    expect(prepared.init.method).toBe('POST')
+    expect(prepared.init.credentials).toBe('omit')
+    expect(new Headers(prepared.init.headers).get('cookie')).toBe('user=value')
+    expect(mintCausalToken).not.toHaveBeenCalled()
+    prepared.complete({ status: 204 })
+    expect(requestInsights.getSnapshot().requests[0].fetches).toEqual([
+      expect.objectContaining({ method: 'POST', statusCode: 204 }),
+    ])
+    requestInsights.dispose()
+  })
+
+  it('reads and coerces RequestInit strings once', () => {
+    const requestInsights = new RequestInsights()
+    let methodReads = 0
+    let methodCoercions = 0
+    const init = Object.defineProperty({}, 'method', {
+      get() {
+        methodReads++
+        return {
+          toString() {
+            methodCoercions++
+            return 'POST'
+          },
+        }
+      },
+    }) as RequestInit
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity: {
+          requestId: 'edge-request',
+          htmlRequestId: 'edge-request',
+          url: '/edge',
+        },
+        requestInsights,
+      },
+      init,
+      url: 'https://example.com',
+    })
+
+    expect(prepared.init.method).toBe('POST')
+    expect(prepared.init.method).toBe('POST')
+    expect(methodReads).toBe(1)
+    expect(methodCoercions).toBe(1)
+    prepared.complete({ status: 200 })
+    requestInsights.dispose()
+  })
+
+  it('replays RequestInit getter errors without recording a fetch', () => {
+    const requestInsights = new RequestInsights()
+    const error = new Error('method failed')
+    const init = Object.defineProperty({}, 'method', {
+      get() {
+        throw error
+      },
+    }) as RequestInit
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity: {
+          requestId: 'edge-request',
+          htmlRequestId: 'edge-request',
+          url: '/edge',
+        },
+        requestInsights,
+      },
+      init,
+      url: 'https://example.com',
+    })
+
+    expect(() => prepared.init.method).toThrow(error)
+    expect(requestInsights.getSnapshot().requests).toEqual([])
+    requestInsights.dispose()
+  })
+
+  it('sanitizes reserved cookies before replaying coercion errors', () => {
+    const requestInsights = new RequestInsights()
+    const error = new Error('method coercion failed')
+    let methodReads = 0
+    let methodCoercions = 0
+    const init = Object.defineProperties(
+      {},
+      {
+        headers: {
+          value: {
+            cookie: '__next_request_insights_causal=caller; user=value',
+          },
+        },
+        method: {
+          get() {
+            methodReads++
+            return {
+              toString() {
+                methodCoercions++
+                throw error
+              },
+            }
+          },
+        },
+      }
+    ) as RequestInit
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity: {
+          requestId: 'edge-request',
+          htmlRequestId: 'edge-request',
+          url: '/edge',
+        },
+        requestInsights,
+      },
+      init,
+      url: 'https://example.com',
+    })
+
+    expect(new Headers(prepared.init.headers).get('cookie')).toBe('user=value')
+    expect(() => prepared.init.method).toThrow(error)
+    expect(methodReads).toBe(1)
+    expect(methodCoercions).toBe(1)
+    expect(requestInsights.getSnapshot().requests).toEqual([])
+    requestInsights.dispose()
+  })
+
+  it('replays HeadersInit conversion errors without network access', async () => {
+    const requestInsights = new RequestInsights()
+    const error = new Error('headers conversion failed')
+    let iteratorCreations = 0
+    let networkRequests = 0
+    const headers = {
+      [Symbol.iterator]() {
+        iteratorCreations++
+        if (iteratorCreations > 1) {
+          return [['cookie', '__next_request_insights_causal=caller']][
+            Symbol.iterator
+          ]()
+        }
+
+        let yieldedCookie = false
+        return {
+          next() {
+            if (!yieldedCookie) {
+              yieldedCookie = true
+              return {
+                done: false,
+                value: ['cookie', '__next_request_insights_causal=caller'],
+              }
+            }
+            throw error
+          },
+        }
+      },
+    } as unknown as HeadersInit
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity: {
+          requestId: 'edge-request',
+          htmlRequestId: 'edge-request',
+          url: '/edge',
+        },
+        requestInsights,
+      },
+      init: { headers },
+      url: 'https://example.com',
+    })
+    const underlyingFetch = async (_url: string, init: RequestInit) => {
+      new Headers(init.headers)
+      networkRequests++
+      return new Response('unexpected request')
+    }
+
+    await expect(
+      underlyingFetch('https://example.com', prepared.init)
+    ).rejects.toThrow(error)
+    expect(iteratorCreations).toBe(1)
+    expect(networkRequests).toBe(0)
+    expect(requestInsights.getSnapshot().requests).toEqual([])
+    requestInsights.dispose()
+  })
+
+  it('strips reserved cookies when causal token minting fails', () => {
+    const requestInsights = new RequestInsights()
+    jest.spyOn(requestInsights, 'mintCausalToken').mockImplementation(() => {
+      throw new Error('mint failed')
+    })
+    const prepared = prepareRequestInsightsSandboxFetch({
+      context: {
+        identity: {
+          requestId: 'edge-request',
+          htmlRequestId: 'edge-request',
+          origin: 'http://app.localhost',
+          url: '/edge',
+        },
+        requestInsights,
+      },
+      init: {
+        headers: {
+          cookie: '__next_request_insights_causal=caller; user=value',
+        },
+      },
+      url: 'http://app.localhost/api/child',
+    })
+
+    expect(new Headers(prepared.init.headers).get('cookie')).toBe('user=value')
+    expect(() => prepared.complete()).not.toThrow()
+    expect(requestInsights.getSnapshot().requests).toEqual([])
+    requestInsights.dispose()
+  })
+})

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.test.ts
@@ -1,24 +1,39 @@
 import { RequestInsights } from './request-insights'
 import {
+  createRequestInsightsRetentionContext,
+  type RequestInsightsIdentity,
+} from './request-insights-identity'
+import {
   getRequestInsightsCausalTarget,
   takeRequestInsightsCausalToken,
 } from './request-insights-causal'
 import { prepareRequestInsightsSandboxFetch } from './request-insights-sandbox-fetch'
 
+function createTestIdentity(
+  identity: Pick<RequestInsightsIdentity, 'requestId'> &
+    Partial<RequestInsightsIdentity>
+): RequestInsightsIdentity {
+  return {
+    rootRequestId: identity.requestId,
+    retention: createRequestInsightsRetentionContext(),
+    htmlRequestId: identity.requestId,
+    url: undefined,
+    ...identity,
+  }
+}
+
 describe('prepareRequestInsightsSandboxFetch', () => {
   it('keeps fetches isolated by controller and identity', () => {
     const first = new RequestInsights()
     const second = new RequestInsights()
-    const firstIdentity = {
+    const firstIdentity = createTestIdentity({
       requestId: 'first-edge-request',
-      htmlRequestId: 'first-edge-request',
       url: '/first',
-    }
-    const secondIdentity = {
+    })
+    const secondIdentity = createTestIdentity({
       requestId: 'second-edge-request',
-      htmlRequestId: 'second-edge-request',
       url: '/second',
-    }
+    })
 
     prepareRequestInsightsSandboxFetch({
       context: { identity: firstIdentity, requestInsights: first },
@@ -50,13 +65,13 @@ describe('prepareRequestInsightsSandboxFetch', () => {
 
   it('links and revokes a same-origin causal capability', () => {
     const requestInsights = new RequestInsights()
-    const identity = {
+    const identity = createTestIdentity({
       requestId: 'edge-parent',
       rootRequestId: 'edge-parent-root',
       htmlRequestId: 'edge-parent',
       origin: 'http://app.localhost',
       url: '/edge',
-    }
+    })
     const target = getRequestInsightsCausalTarget(
       new URL('http://app.localhost/api/child'),
       'POST'
@@ -92,14 +107,14 @@ describe('prepareRequestInsightsSandboxFetch', () => {
 
   it('links a direct server fetch when the ingress origin is proxied', () => {
     const requestInsights = new RequestInsights()
-    const identity = {
+    const identity = createTestIdentity({
       requestId: 'proxied-edge-parent',
       rootRequestId: 'proxied-edge-parent-root',
       htmlRequestId: 'proxied-edge-parent',
       origin: 'https://app.localhost',
       executionOrigin: 'http://localhost:3012',
       url: '/edge',
-    }
+    })
     const target = getRequestInsightsCausalTarget(
       new URL('http://localhost:3012/api/child'),
       'GET'
@@ -128,11 +143,11 @@ describe('prepareRequestInsightsSandboxFetch', () => {
 
   it('uses unique indexes and completes each fetch once', () => {
     const requestInsights = new RequestInsights()
-    const identity = {
+    const identity = createTestIdentity({
       requestId: 'edge-request',
       htmlRequestId: 'edge-request',
       url: '/edge',
-    }
+    })
     const first = prepareRequestInsightsSandboxFetch({
       context: { identity, requestInsights },
       init: {},
@@ -160,13 +175,13 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     const mintCausalToken = jest.spyOn(requestInsights, 'mintCausalToken')
     const prepared = prepareRequestInsightsSandboxFetch({
       context: {
-        identity: {
+        identity: createTestIdentity({
           requestId: 'edge-request',
           rootRequestId: 'edge-request-root',
           htmlRequestId: 'edge-request',
           origin: 'http://app.localhost',
           url: '/edge',
-        },
+        }),
         requestInsights,
       },
       init: {
@@ -207,11 +222,11 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     }) as RequestInit
     const prepared = prepareRequestInsightsSandboxFetch({
       context: {
-        identity: {
+        identity: createTestIdentity({
           requestId: 'edge-request',
           htmlRequestId: 'edge-request',
           url: '/edge',
-        },
+        }),
         requestInsights,
       },
       init,
@@ -236,11 +251,11 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     }) as RequestInit
     const prepared = prepareRequestInsightsSandboxFetch({
       context: {
-        identity: {
+        identity: createTestIdentity({
           requestId: 'edge-request',
           htmlRequestId: 'edge-request',
           url: '/edge',
-        },
+        }),
         requestInsights,
       },
       init,
@@ -280,11 +295,11 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     ) as RequestInit
     const prepared = prepareRequestInsightsSandboxFetch({
       context: {
-        identity: {
+        identity: createTestIdentity({
           requestId: 'edge-request',
           htmlRequestId: 'edge-request',
           url: '/edge',
-        },
+        }),
         requestInsights,
       },
       init,
@@ -330,11 +345,11 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     } as unknown as HeadersInit
     const prepared = prepareRequestInsightsSandboxFetch({
       context: {
-        identity: {
+        identity: createTestIdentity({
           requestId: 'edge-request',
           htmlRequestId: 'edge-request',
           url: '/edge',
-        },
+        }),
         requestInsights,
       },
       init: { headers },
@@ -362,13 +377,13 @@ describe('prepareRequestInsightsSandboxFetch', () => {
     })
     const prepared = prepareRequestInsightsSandboxFetch({
       context: {
-        identity: {
+        identity: createTestIdentity({
           requestId: 'edge-request',
           rootRequestId: 'edge-request-root',
           htmlRequestId: 'edge-request',
           origin: 'http://app.localhost',
           url: '/edge',
-        },
+        }),
         requestInsights,
       },
       init: {

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.ts
@@ -1,5 +1,6 @@
 import {
   getRequestInsightsCausalTarget,
+  isRequestInsightsExecutionOriginTarget,
   isRequestInsightsSameOriginTarget,
   setRequestInsightsCausalCookie,
 } from './request-insights-causal'
@@ -58,14 +59,18 @@ export function prepareRequestInsightsSandboxFetch({
     const method = (initSnapshot.readString('method') ?? 'GET').toUpperCase()
     const fetchIndex = getNextRequestInsightsFetchIndex(context.identity)
     const target = getRequestInsightsCausalTarget(targetUrl, method)
-    const origin = context.origin ?? context.identity.origin
     const credentials = initSnapshot.readString('credentials')
 
     causalToken =
       credentials !== 'omit' &&
       context.identity.kind !== 'instant-insights' &&
       context.identity.rootRequestId &&
-      isRequestInsightsSameOriginTarget(origin, target) &&
+      (isRequestInsightsSameOriginTarget(context.origin, target) ||
+        isRequestInsightsSameOriginTarget(context.identity.origin, target) ||
+        isRequestInsightsExecutionOriginTarget(
+          context.identity.executionOrigin,
+          target
+        )) &&
       target
         ? context.requestInsights.mintCausalToken({
             parentRootRequestId: context.identity.rootRequestId,

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.ts
@@ -64,11 +64,11 @@ export function prepareRequestInsightsSandboxFetch({
     causalToken =
       credentials !== 'omit' &&
       context.identity.kind !== 'instant-insights' &&
-      context.identity.requestId &&
+      context.identity.rootRequestId &&
       isRequestInsightsSameOriginTarget(origin, target) &&
       target
         ? context.requestInsights.mintCausalToken({
-            parentRequestId: context.identity.requestId,
+            parentRootRequestId: context.identity.rootRequestId,
             parentFetchIndex: fetchIndex,
             target,
           })

--- a/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.ts
+++ b/packages/next/src/server/lib/trace/request-insights-sandbox-fetch.ts
@@ -1,0 +1,117 @@
+import {
+  getRequestInsightsCausalTarget,
+  isRequestInsightsSameOriginTarget,
+  setRequestInsightsCausalCookie,
+} from './request-insights-causal'
+import type { RequestInsightsIdentity } from './request-insights-identity'
+import type { RequestInsights } from './request-insights'
+import { createRequestInsightsFetchInitSnapshot } from './request-insights-fetch-init'
+
+export type RequestInsightsSandboxFetchContext = {
+  identity: RequestInsightsIdentity
+  origin?: string
+  requestInsights: RequestInsights
+}
+
+export type RequestInsightsSandboxFetch = {
+  init: RequestInit
+  complete(response?: Pick<Response, 'status'>): void
+}
+
+const REQUEST_INSIGHTS_FETCH_INDEX = Symbol.for(
+  '@next/request-insights-fetch-index'
+)
+
+type RequestInsightsFetchIdentity = RequestInsightsIdentity & {
+  [REQUEST_INSIGHTS_FETCH_INDEX]?: number
+}
+
+// This allocator lives in the dev-only sandbox bridge rather than the identity
+// module so its state and export cannot enter production server bundles.
+export function getNextRequestInsightsFetchIndex(
+  identity: RequestInsightsIdentity
+): number {
+  const fetchIdentity = identity as RequestInsightsFetchIdentity
+  const index = fetchIdentity[REQUEST_INSIGHTS_FETCH_INDEX] ?? 1
+  fetchIdentity[REQUEST_INSIGHTS_FETCH_INDEX] = index + 1
+  return index
+}
+
+export function prepareRequestInsightsSandboxFetch({
+  context,
+  init: originalInit,
+  url,
+}: {
+  context: RequestInsightsSandboxFetchContext
+  init: RequestInit
+  url: string
+}): RequestInsightsSandboxFetch {
+  const initSnapshot = createRequestInsightsFetchInitSnapshot(originalInit)
+  const { init } = initSnapshot
+  const fallback = { init, complete() {} }
+  let causalToken: string | undefined
+
+  try {
+    const headers = initSnapshot.readHeaders()
+    setRequestInsightsCausalCookie(headers, undefined)
+    const targetUrl = new URL(url)
+    const method = (initSnapshot.readString('method') ?? 'GET').toUpperCase()
+    const fetchIndex = getNextRequestInsightsFetchIndex(context.identity)
+    const target = getRequestInsightsCausalTarget(targetUrl, method)
+    const origin = context.origin ?? context.identity.origin
+    const credentials = initSnapshot.readString('credentials')
+
+    causalToken =
+      credentials !== 'omit' &&
+      context.identity.kind !== 'instant-insights' &&
+      context.identity.requestId &&
+      isRequestInsightsSameOriginTarget(origin, target) &&
+      target
+        ? context.requestInsights.mintCausalToken({
+            parentRequestId: context.identity.requestId,
+            parentFetchIndex: fetchIndex,
+            target,
+          })
+        : undefined
+
+    if (causalToken && !setRequestInsightsCausalCookie(headers, causalToken)) {
+      context.requestInsights.revokeCausalToken(causalToken)
+      causalToken = undefined
+    }
+
+    const startTime = performance.timeOrigin + performance.now()
+    let completed = false
+    return {
+      init,
+      complete(response) {
+        if (completed) return
+        completed = true
+        try {
+          if (causalToken) {
+            context.requestInsights.revokeCausalToken(causalToken)
+          }
+          const endTime = performance.timeOrigin + performance.now()
+          context.requestInsights.recordFetch(context.identity, {
+            url,
+            method,
+            statusCode: response?.status,
+            startTime,
+            durationMs: endTime - startTime,
+            cacheStatus: 'skip',
+            cacheReason: 'outside app render',
+            index: fetchIndex,
+          })
+        } catch {
+          // Request Insights bookkeeping must not affect fetch behavior.
+        }
+      },
+    }
+  } catch {
+    if (causalToken) {
+      try {
+        context.requestInsights.revokeCausalToken(causalToken)
+      } catch {}
+    }
+    return fallback
+  }
+}

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -55,6 +55,8 @@ import {
 import {
   getRequestInsightsCausalTarget,
   getRequestInsightsCausalTargetFromRequest,
+  getRequestInsightsExecutionOrigin,
+  isRequestInsightsExecutionOriginTarget,
   RequestInsightsCausalRegistry,
   setRequestInsightsCausalCookie,
   takeRequestInsightsCausalToken,
@@ -929,7 +931,33 @@ describe('request insights', () => {
     expect(registry.consumeCausalToken(second, target)).toBeUndefined()
   })
 
-  it('matches only exact loopback origins, paths, protocols, ports, and methods', () => {
+  it('consumes a capability through an equivalent loopback hostname', () => {
+    const registry = new RequestInsightsCausalRegistry({
+      createToken: () => 'L'.repeat(32),
+    })
+    const token = registry.mintCausalToken({
+      parentRootRequestId: 'parent-root',
+      parentFetchIndex: 1,
+      target: {
+        origin: 'http://127.0.0.1:3000',
+        pathname: '/api/child',
+        method: 'GET',
+      },
+    })
+
+    expect(
+      registry.consumeCausalToken(token!, {
+        origin: 'http://localhost:3000',
+        pathname: '/api/child',
+        method: 'GET',
+      })
+    ).toEqual({
+      parentRootRequestId: 'parent-root',
+      parentFetchIndex: 1,
+    })
+  })
+
+  it('validates loopback origins and exact paths, protocols, ports, and methods', () => {
     expect(
       getRequestInsightsCausalTarget(
         new URL('http://app.localhost:3000/api/child?ignored=1'),
@@ -971,6 +999,51 @@ describe('request insights', () => {
         url: 'http://attacker.localhost:3000/api/child',
       })
     ).toBeUndefined()
+  })
+
+  it('derives the direct execution origin only from server-owned socket data', () => {
+    expect(
+      getRequestInsightsExecutionOrigin({
+        experimentalHttpsServer: false,
+        fallbackPort: 3000,
+        socket: { localPort: 3012 },
+      })
+    ).toBe('http://localhost:3012')
+    expect(
+      getRequestInsightsExecutionOrigin({
+        experimentalHttpsServer: false,
+        fallbackPort: 3000,
+        socket: { encrypted: true, localPort: 3013 },
+      })
+    ).toBe('https://localhost:3013')
+    expect(
+      getRequestInsightsExecutionOrigin({
+        experimentalHttpsServer: true,
+        fallbackPort: 3014,
+        socket: undefined,
+      })
+    ).toBe('https://localhost:3014')
+    expect(
+      getRequestInsightsExecutionOrigin({
+        experimentalHttpsServer: false,
+        fallbackPort: 0,
+        socket: undefined,
+      })
+    ).toBeUndefined()
+
+    const target = getRequestInsightsCausalTarget(
+      new URL('http://127.0.0.1:3012/api/child'),
+      'GET'
+    )
+    expect(
+      isRequestInsightsExecutionOriginTarget('http://localhost:3012', target)
+    ).toBe(true)
+    expect(
+      isRequestInsightsExecutionOriginTarget('http://localhost:3013', target)
+    ).toBe(false)
+    expect(
+      isRequestInsightsExecutionOriginTarget('https://localhost:3012', target)
+    ).toBe(false)
   })
 
   it('strips malformed, duplicate, and oversized causal cookies', () => {
@@ -1100,6 +1173,25 @@ describe('request insights', () => {
           }),
         ],
       })
+    )
+  })
+
+  test('refines a provisional root route with the matched app route', () => {
+    requestInsights.recordSpan({
+      name: 'GET',
+      requestId: 'refined-route',
+      htmlRequestId: 'refined-route',
+      route: '/',
+    })
+    requestInsights.recordSpan({
+      name: 'render route (app) /proxy-causal',
+      requestId: 'refined-route',
+      htmlRequestId: 'refined-route',
+      route: '/proxy-causal',
+    })
+
+    expect(requestInsights.getSnapshot().requests[0]?.route).toBe(
+      '/proxy-causal'
     )
   })
 
@@ -3125,7 +3217,9 @@ describe('request insights', () => {
     process.env.__NEXT_DEV_SERVER = '1'
     const first = new RequestInsights()
     const second = new RequestInsights()
-    const response = new WebNextResponse(undefined).body('complete')
+    const stream = new TransformStream<Uint8Array, Uint8Array>()
+    const writer = stream.writable.getWriter()
+    const response = new WebNextResponse(stream)
     response.statusCode = 202
     const identity = { requestId: 'owned-web-response' }
 
@@ -3138,9 +3232,21 @@ describe('request insights', () => {
           first.completeResponse(identity, lifecycle)
         },
       })
+      expect(first.getSnapshot().requests[0]).toEqual(
+        expect.objectContaining({
+          status: 'pending',
+          response: expect.objectContaining({ outcome: 'pending' }),
+        })
+      )
       response.send()
       const webResponse = await response.toResponse()
-      await runWithRequestInsights(second, () => webResponse.text())
+      const bodyPromise = runWithRequestInsights(second, () =>
+        webResponse.text()
+      )
+      await writer.write(new TextEncoder().encode('complete'))
+      expect(first.getSnapshot().requests[0]?.response?.outcome).toBe('pending')
+      await writer.close()
+      await bodyPromise
 
       expect(first.getSnapshot().requests[0]).toEqual(
         expect.objectContaining({
@@ -3156,6 +3262,63 @@ describe('request insights', () => {
       first.dispose()
       second.dispose()
     }
+  })
+
+  it('records Web response cancellation as an abort', async () => {
+    const response = new WebNextResponse()
+    const identity = { requestId: 'aborted-web-response' }
+
+    trackRequestInsightWebResponse(response, {
+      onAttach(trackingStartTime) {
+        requestInsights.startResponse(identity, trackingStartTime)
+      },
+      onComplete(lifecycle) {
+        requestInsights.completeResponse(identity, lifecycle)
+      },
+    })
+    response.send()
+    const webResponse = await response.toResponse()
+    await webResponse.body!.cancel(new Error('consumer cancelled'))
+
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        status: 'aborted',
+        response: expect.objectContaining({
+          outcome: 'aborted',
+          error: { type: 'ResponseAborted' },
+        }),
+      })
+    )
+  })
+
+  it('records Web source-stream failure as a response error', async () => {
+    const stream = new TransformStream()
+    const response = new WebNextResponse(stream)
+    const identity = { requestId: 'errored-web-response' }
+
+    trackRequestInsightWebResponse(response, {
+      onAttach(trackingStartTime) {
+        requestInsights.startResponse(identity, trackingStartTime)
+      },
+      onComplete(lifecycle) {
+        requestInsights.completeResponse(identity, lifecycle)
+      },
+    })
+    response.send()
+    const webResponse = await response.toResponse()
+    const streamError = new Error('source failed')
+    await stream.writable.abort(streamError)
+    await expect(webResponse.text()).rejects.toThrow(streamError)
+
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        status: 'error',
+        response: expect.objectContaining({
+          outcome: 'errored',
+          error: { type: 'Error' },
+        }),
+      })
+    )
   })
 
   it('ignores late response callbacks after controller disposal', () => {

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable jest/no-standalone-expect -- Assertions run inside the controller-scoped test wrapper. */
 
+import { EventEmitter } from 'node:events'
+import type { ServerResponse } from 'node:http'
+
+import { WebNextResponse } from '../../base-http/web'
 import {
   RequestInsights,
   getRequestInsightsSnapshot,
@@ -16,6 +20,11 @@ import {
   createRequestInsightsRetentionContext,
   isRequestInsightsRetentionContextOpen,
 } from './request-insights-identity'
+import {
+  trackRequestInsightNodeResponse,
+  trackRequestInsightWebResponse,
+  type RequestInsightResponseLifecycle,
+} from './request-insights-response'
 import {
   createBoundedRequestInsightsSnapshotProjection,
   REQUEST_INSIGHTS_MAX_BYTES_PER_RETENTION_BUCKET,
@@ -2588,5 +2597,392 @@ describe('request insights', () => {
     } finally {
       controller.dispose()
     }
+  })
+
+  test('keeps a response pending until delivery actually finishes', () => {
+    const identity = { requestId: 'response-pending' }
+
+    requestInsights.startResponse(identity, 100)
+    recordSpan({
+      name: 'GET /stream',
+      requestId: identity.requestId,
+      startTime: 110,
+      durationMs: 20,
+      status: 'ok',
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        status: 'pending',
+        response: {
+          trackingStartTime: 100,
+          outcome: 'pending',
+        },
+      })
+    )
+
+    requestInsights.completeResponse(identity, {
+      trackingStartTime: 100,
+      endTime: 175,
+      statusCode: 202,
+      outcome: 'finished',
+    })
+
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        startTime: 100,
+        durationMs: 75,
+        status: 'ok',
+        response: {
+          trackingStartTime: 100,
+          endTime: 175,
+          statusCode: 202,
+          outcome: 'finished',
+          error: undefined,
+        },
+      })
+    )
+  })
+
+  test('accounts for response lifecycle bytes and isolates published response data', () => {
+    const unsubscribe = requestInsights.subscribe((insight) => {
+      if (insight.response?.outcome !== 'errored') {
+        return
+      }
+
+      insight.response.endTime = 1
+      if (insight.response.error) {
+        insight.response.error.type = 'mutated'
+      }
+    })
+
+    requestInsights.startResponse({ requestId: 'isolated-response' }, 100)
+    requestInsights.completeResponse(
+      { requestId: 'isolated-response' },
+      {
+        trackingStartTime: 100,
+        endTime: 150,
+        statusCode: 500,
+        outcome: 'errored',
+        error: { type: 'private-error-name' },
+      }
+    )
+
+    const snapshot = requestInsights.getSnapshot()
+    expect(snapshot.requests[0].response).toEqual({
+      trackingStartTime: 100,
+      endTime: 150,
+      statusCode: 500,
+      outcome: 'errored',
+      error: { type: 'Error' },
+    })
+    expect(snapshot.capture?.usage.retainedBytes).toBe(
+      Buffer.byteLength(JSON.stringify(snapshot.requests[0]), 'utf8')
+    )
+    unsubscribe()
+  })
+
+  test('keeps delivery timing when the request span arrives after completion', () => {
+    const identity = { requestId: 'response-before-request-span' }
+
+    requestInsights.startResponse(identity, 100)
+    requestInsights.completeResponse(identity, {
+      trackingStartTime: 100,
+      endTime: 200,
+      statusCode: 200,
+      outcome: 'finished',
+    })
+    recordSpan({
+      name: 'GET /stream',
+      requestId: identity.requestId,
+      startTime: 110,
+      durationMs: 20,
+      status: 'ok',
+      attributes: {
+        'next.span_type': 'BaseServer.handleRequest',
+      },
+    })
+
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        startTime: 100,
+        durationMs: 100,
+        status: 'ok',
+        response: expect.objectContaining({
+          endTime: 200,
+          outcome: 'finished',
+        }),
+      })
+    )
+  })
+
+  test('keeps aborts and errors sticky after response completion', () => {
+    const abortedIdentity = { requestId: 'response-aborted' }
+    requestInsights.startResponse(abortedIdentity, 100)
+    requestInsights.completeResponse(abortedIdentity, {
+      trackingStartTime: 100,
+      endTime: 125,
+      statusCode: 200,
+      outcome: 'aborted',
+      error: { type: 'ResponseAborted' },
+    })
+    recordSpan({
+      name: 'late abort cleanup',
+      requestId: abortedIdentity.requestId,
+      startTime: 120,
+      durationMs: 10,
+      status: 'error',
+      error: { type: 'AbortError' },
+    })
+    requestInsights.completeResponse(abortedIdentity, {
+      trackingStartTime: 100,
+      endTime: 150,
+      statusCode: 200,
+      outcome: 'finished',
+    })
+
+    const erroredIdentity = { requestId: 'response-errored' }
+    requestInsights.startResponse(erroredIdentity, 200)
+    requestInsights.completeResponse(erroredIdentity, {
+      trackingStartTime: 200,
+      endTime: 225,
+      statusCode: 200,
+      outcome: 'errored',
+      error: { type: 'private-error-name' },
+    })
+    recordSpan({
+      name: 'late successful cleanup',
+      requestId: erroredIdentity.requestId,
+      startTime: 225,
+      durationMs: 5,
+      status: 'ok',
+    })
+
+    const routeErrorIdentity = { requestId: 'route-error-then-abort' }
+    requestInsights.startResponse(routeErrorIdentity, 300)
+    recordSpan({
+      name: 'route failed',
+      requestId: routeErrorIdentity.requestId,
+      startTime: 310,
+      durationMs: 5,
+      status: 'error',
+      error: { type: 'Error' },
+    })
+    requestInsights.completeResponse(routeErrorIdentity, {
+      trackingStartTime: 300,
+      endTime: 325,
+      statusCode: 200,
+      outcome: 'aborted',
+      error: { type: 'ResponseAborted' },
+    })
+
+    expect(requestInsights.getSnapshot().requests).toEqual([
+      expect.objectContaining({
+        requestId: abortedIdentity.requestId,
+        status: 'aborted',
+        response: expect.objectContaining({ outcome: 'aborted' }),
+      }),
+      expect.objectContaining({
+        requestId: erroredIdentity.requestId,
+        status: 'error',
+        response: expect.objectContaining({
+          outcome: 'errored',
+          error: { type: 'Error' },
+        }),
+      }),
+      expect.objectContaining({
+        requestId: routeErrorIdentity.requestId,
+        status: 'error',
+        response: expect.objectContaining({ outcome: 'aborted' }),
+      }),
+    ])
+  })
+
+  test('captures the committed Node status and completes only once', () => {
+    const originalWriteHead = function (
+      this: ServerResponse,
+      statusCode: number
+    ) {
+      Object.assign(this, { headersSent: true, statusCode })
+      return this
+    } as ServerResponse['writeHead']
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: false,
+      errored: null,
+      headersSent: false,
+      statusCode: 200,
+      writableFinished: false,
+      writeHead: originalWriteHead,
+    }) as unknown as ServerResponse
+    const identity = { requestId: 'node-response' }
+    const onComplete = jest.fn((lifecycle: RequestInsightResponseLifecycle) => {
+      requestInsights.completeResponse(identity, lifecycle)
+    })
+
+    trackRequestInsightNodeResponse(response, {
+      onAttach(trackingStartTime) {
+        requestInsights.startResponse(identity, trackingStartTime)
+      },
+      onComplete,
+    })
+    response.writeHead(202)
+    expect(response.writeHead).toBe(originalWriteHead)
+
+    Object.assign(response, {
+      statusCode: 500,
+      writableFinished: true,
+    })
+    response.emit('finish')
+    response.emit('close')
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        status: 'ok',
+        response: expect.objectContaining({
+          statusCode: 202,
+          outcome: 'finished',
+        }),
+      })
+    )
+    expect(response.listenerCount('finish')).toBe(0)
+    expect(response.listenerCount('close')).toBe(0)
+  })
+
+  test('does not let diagnostic callback failures affect a Node response', () => {
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: false,
+      errored: null,
+      headersSent: true,
+      statusCode: 200,
+      writableFinished: false,
+    }) as unknown as ServerResponse
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    try {
+      expect(() =>
+        trackRequestInsightNodeResponse(response, {
+          onAttach() {
+            throw new Error('attach failed')
+          },
+          onComplete() {
+            throw new Error('complete failed')
+          },
+        })
+      ).not.toThrow()
+
+      Object.assign(response, { writableFinished: true })
+      expect(() => response.emit('finish')).not.toThrow()
+      expect(consoleError).toHaveBeenCalledTimes(2)
+      expect(response.listenerCount('finish')).toBe(0)
+      expect(response.listenerCount('close')).toBe(0)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('completes the controller captured at attachment after ALS exits', () => {
+    process.env.__NEXT_DEV_SERVER = '1'
+    const first = new RequestInsights()
+    const second = new RequestInsights()
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: false,
+      errored: null,
+      headersSent: true,
+      statusCode: 200,
+      writableFinished: false,
+    }) as unknown as ServerResponse
+    const identity = { requestId: 'owned-response' }
+
+    try {
+      trackRequestInsightNodeResponse(response, {
+        onAttach(trackingStartTime) {
+          first.startResponse(identity, trackingStartTime)
+        },
+        onComplete(lifecycle) {
+          first.completeResponse(identity, lifecycle)
+        },
+      })
+
+      Object.assign(response, { writableFinished: true })
+      runWithRequestInsights(second, () => response.emit('finish'))
+
+      expect(first.getSnapshot().requests[0]).toEqual(
+        expect.objectContaining({
+          response: expect.objectContaining({ outcome: 'finished' }),
+        })
+      )
+      expect(second.getSnapshot()).toEqual({ requests: [] })
+    } finally {
+      first.dispose()
+      second.dispose()
+    }
+  })
+
+  it('records Web completion on the controller captured before consumption', async () => {
+    process.env.__NEXT_DEV_SERVER = '1'
+    const first = new RequestInsights()
+    const second = new RequestInsights()
+    const response = new WebNextResponse(undefined).body('complete')
+    response.statusCode = 202
+    const identity = { requestId: 'owned-web-response' }
+
+    try {
+      trackRequestInsightWebResponse(response, {
+        onAttach(trackingStartTime) {
+          first.startResponse(identity, trackingStartTime)
+        },
+        onComplete(lifecycle) {
+          first.completeResponse(identity, lifecycle)
+        },
+      })
+      response.send()
+      const webResponse = await response.toResponse()
+      await runWithRequestInsights(second, () => webResponse.text())
+
+      expect(first.getSnapshot().requests[0]).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          response: expect.objectContaining({
+            outcome: 'finished',
+            statusCode: 202,
+          }),
+        })
+      )
+      expect(second.getSnapshot()).toEqual({ requests: [] })
+    } finally {
+      first.dispose()
+      second.dispose()
+    }
+  })
+
+  it('ignores late response callbacks after controller disposal', () => {
+    process.env.__NEXT_DEV_SERVER = '1'
+    const controller = new RequestInsights()
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: false,
+      errored: null,
+      headersSent: true,
+      statusCode: 200,
+      writableFinished: false,
+    }) as unknown as ServerResponse
+    const identity = { requestId: 'disposed-response' }
+
+    trackRequestInsightNodeResponse(response, {
+      onAttach(trackingStartTime) {
+        controller.startResponse(identity, trackingStartTime)
+      },
+      onComplete(lifecycle) {
+        controller.completeResponse(identity, lifecycle)
+      },
+    })
+    controller.dispose()
+    Object.assign(response, { writableFinished: true })
+
+    expect(() => response.emit('finish')).not.toThrow()
+    expect(controller.getSnapshot()).toEqual({ requests: [] })
   })
 })

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -3114,7 +3114,7 @@ describe('request insights', () => {
           response: expect.objectContaining({ outcome: 'finished' }),
         })
       )
-      expect(second.getSnapshot()).toEqual({ requests: [] })
+      expect(second.getSnapshot().requests).toEqual([])
     } finally {
       first.dispose()
       second.dispose()
@@ -3151,7 +3151,7 @@ describe('request insights', () => {
           }),
         })
       )
-      expect(second.getSnapshot()).toEqual({ requests: [] })
+      expect(second.getSnapshot().requests).toEqual([])
     } finally {
       first.dispose()
       second.dispose()

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -52,6 +52,13 @@ import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type RequestInsightsUpdateMessage,
 } from '../../dev/hot-reloader-types'
+import {
+  getRequestInsightsCausalTarget,
+  getRequestInsightsCausalTargetFromRequest,
+  RequestInsightsCausalRegistry,
+  setRequestInsightsCausalCookie,
+  takeRequestInsightsCausalToken,
+} from './request-insights-causal'
 
 const originalRequestInsights = process.env.__NEXT_REQUEST_INSIGHTS
 const originalDevServer = process.env.__NEXT_DEV_SERVER
@@ -797,6 +804,198 @@ describe('request insights', () => {
       first.dispose()
       second.dispose()
     }
+  })
+
+  test('records an immutable causal relationship on the child request', () => {
+    requestInsights.startResponse(
+      {
+        requestId: 'child',
+        rootRequestId: 'child-root',
+        parentRootRequestId: 'parent-root',
+        parentFetchIndex: 3,
+      },
+      100
+    )
+
+    const initialSnapshot = requestInsights.getSnapshot()
+    expect(initialSnapshot.requests[0]).toEqual(
+      expect.objectContaining({
+        requestId: 'child',
+        rootRequestId: 'child-root',
+        parentRootRequestId: 'parent-root',
+        parentFetchIndex: 3,
+      })
+    )
+    expect(initialSnapshot.capture?.usage.retainedBytes).toBe(
+      getRequestInsightsSerializedByteLength(initialSnapshot.requests[0])
+    )
+
+    requestInsights.startResponse(
+      {
+        requestId: 'child',
+        rootRequestId: 'child-root',
+        parentRootRequestId: 'different-parent-root',
+        parentFetchIndex: 4,
+      },
+      101
+    )
+    expect(requestInsights.getSnapshot().requests[0]).toEqual(
+      expect.objectContaining({
+        parentRootRequestId: 'parent-root',
+        parentFetchIndex: 3,
+      })
+    )
+  })
+
+  test('sanitizes causal metadata and rejects self-links', () => {
+    requestInsights.startResponse(
+      {
+        requestId: 'invalid-parent',
+        rootRequestId: 'invalid-parent-root',
+        parentRootRequestId: '../private',
+        parentFetchIndex: Number.MAX_SAFE_INTEGER,
+      },
+      100
+    )
+    requestInsights.startResponse(
+      {
+        requestId: 'self-parent',
+        rootRequestId: 'self-parent-root',
+        parentRootRequestId: 'self-parent-root',
+        parentFetchIndex: 1,
+      },
+      101
+    )
+
+    const [invalidParent, selfParent] = requestInsights.getSnapshot().requests
+    expect(invalidParent.parentRootRequestId).toBeUndefined()
+    expect(invalidParent.parentFetchIndex).toBeUndefined()
+    expect(selfParent.parentRootRequestId).toBeUndefined()
+    expect(selfParent.parentFetchIndex).toBeUndefined()
+  })
+
+  it('uses bounded single-use capabilities scoped to one controller', () => {
+    const target = {
+      origin: 'http://localhost:3000',
+      pathname: '/api/child',
+      method: 'GET',
+    }
+    const first = new RequestInsightsCausalRegistry({
+      createToken: () => 'A'.repeat(32),
+    })
+    const second = new RequestInsightsCausalRegistry()
+    const token = first.mintCausalToken({
+      parentRootRequestId: 'parent-root',
+      parentFetchIndex: 1,
+      target,
+    })
+
+    expect(token).toBe('A'.repeat(32))
+    expect(second.consumeCausalToken(token!, target)).toBeUndefined()
+    expect(
+      first.consumeCausalToken(token!, { ...target, pathname: '/wrong' })
+    ).toBeUndefined()
+    expect(first.consumeCausalToken(token!, target)).toBeUndefined()
+  })
+
+  it('evicts old capabilities and expires retained capabilities', () => {
+    const target = {
+      origin: 'http://localhost:3000',
+      pathname: '/api/child',
+      method: 'GET',
+    }
+    let now = 1_000
+    let tokenIndex = 0
+    const tokens = ['A'.repeat(32), 'B'.repeat(32), 'C'.repeat(32)]
+    const registry = new RequestInsightsCausalRegistry({
+      createToken: () => tokens[tokenIndex++],
+      maxEntries: 1,
+      now: () => now,
+      ttlMs: 10,
+    })
+    const first = registry.mintCausalToken({
+      parentRootRequestId: 'parent-root',
+      parentFetchIndex: 1,
+      target,
+    })!
+    const second = registry.mintCausalToken({
+      parentRootRequestId: 'parent-root',
+      parentFetchIndex: 2,
+      target,
+    })!
+
+    expect(registry.consumeCausalToken(first, target)).toBeUndefined()
+    now += 11
+    expect(registry.consumeCausalToken(second, target)).toBeUndefined()
+  })
+
+  it('matches only exact loopback origins, paths, protocols, ports, and methods', () => {
+    expect(
+      getRequestInsightsCausalTarget(
+        new URL('http://app.localhost:3000/api/child?ignored=1'),
+        'post'
+      )
+    ).toEqual({
+      origin: 'http://app.localhost:3000',
+      pathname: '/api/child',
+      method: 'POST',
+    })
+    expect(
+      getRequestInsightsCausalTarget(
+        new URL('https://example.com/api/child'),
+        'GET'
+      )
+    ).toBeUndefined()
+    expect(
+      getRequestInsightsCausalTargetFromRequest({
+        method: 'GET',
+        origin: 'https://localhost:3000',
+        url: '/api/child',
+      })
+    ).toEqual({
+      origin: 'https://localhost:3000',
+      pathname: '/api/child',
+      method: 'GET',
+    })
+    expect(
+      getRequestInsightsCausalTargetFromRequest({
+        method: 'GET',
+        origin: 'https://example.com',
+        url: '/api/child',
+      })
+    ).toBeUndefined()
+    expect(
+      getRequestInsightsCausalTargetFromRequest({
+        method: 'GET',
+        origin: 'http://localhost:3000',
+        url: 'http://attacker.localhost:3000/api/child',
+      })
+    ).toBeUndefined()
+  })
+
+  it('strips malformed, duplicate, and oversized causal cookies', () => {
+    const token = 'B'.repeat(32)
+    const outgoing = new Headers({ cookie: 'user=value' })
+    expect(setRequestInsightsCausalCookie(outgoing, token)).toBe(true)
+    expect(outgoing.get('cookie')).toBe(
+      `user=value; __next_request_insights_causal=${token}`
+    )
+
+    const incoming = { cookie: outgoing.get('cookie') ?? undefined }
+    expect(takeRequestInsightsCausalToken(incoming)).toBe(token)
+    expect(incoming.cookie).toBe('user=value')
+
+    const duplicate = {
+      cookie: `__next_request_insights_causal=${token}; __next_request_insights_causal=${token}`,
+    }
+    expect(takeRequestInsightsCausalToken(duplicate)).toBeUndefined()
+    expect(duplicate.cookie).toBeUndefined()
+
+    const oversized = {
+      cookie: `user=${'x'.repeat(17 * 1024)}; __next_request_insights_causal=${token}`,
+    }
+    expect(takeRequestInsightsCausalToken(oversized)).toBeUndefined()
+    expect(oversized.cookie).not.toContain('__next_request_insights_causal')
   })
 
   test('derives request history from local span records', () => {

--- a/packages/next/src/server/lib/trace/request-insights.test.ts
+++ b/packages/next/src/server/lib/trace/request-insights.test.ts
@@ -1182,12 +1182,14 @@ describe('request insights', () => {
       requestId: 'refined-route',
       htmlRequestId: 'refined-route',
       route: '/',
+      timestamp: 1,
     })
     requestInsights.recordSpan({
       name: 'render route (app) /proxy-causal',
       requestId: 'refined-route',
       htmlRequestId: 'refined-route',
       route: '/proxy-causal',
+      timestamp: 2,
     })
 
     expect(requestInsights.getSnapshot().requests[0]?.route).toBe(

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -2,6 +2,7 @@ import type { AttributeValue } from 'next/dist/compiled/@opentelemetry/api'
 import type {
   RequestInsight,
   RequestInsightFetch,
+  RequestInsightResponse,
   RequestInsightSpan,
   RequestInsightsCaptureState,
   RequestInsightsLiveSnapshot,
@@ -69,6 +70,19 @@ const MAX_REQUEST_INSIGHT_RAW_URL_LENGTH = 64 * 1024
 const MAX_REQUEST_INSIGHT_ATTRIBUTE_ARRAY_LENGTH = 8
 const CLIENT_COMPONENT_LOADING_SPAN_TYPE =
   'NextNodeServer.clientComponentLoading'
+const SAFE_RESPONSE_ERROR_TYPES = new Set([
+  'AbortError',
+  'AggregateError',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'ResponseAborted',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'UnknownResponseError',
+])
 
 export type RequestInsightsListener = (
   insight: RequestInsight,
@@ -273,12 +287,16 @@ export class RequestInsights {
       span.durationMs,
       span.attributes?.['next.span_type'] === REQUEST_INSIGHT_REQUEST_SPAN_TYPE
     )
-    insight.status =
-      insight.status === 'error' || span.status === 'error'
-        ? 'error'
-        : span.status === 'ok'
-          ? 'ok'
-          : insight.status
+    if (insight.status === 'aborted') {
+      // An actual client disconnect is authoritative over abort-shaped errors
+      // emitted later while the response stream is being cleaned up.
+    } else if (insight.status === 'error' || span.status === 'error') {
+      insight.status = 'error'
+    } else if (insight.response?.outcome === 'pending') {
+      insight.status = 'pending'
+    } else if (span.status === 'ok') {
+      insight.status = 'ok'
+    }
 
     this.recordSpanForInsight(insight, sanitizeSpan(span, spanStartTime))
     const fetch = getFetchInsight(span)
@@ -539,6 +557,99 @@ export class RequestInsights {
     this.nextRootRequestSequence = 0
   }
 
+  startResponse(identity: RequestInsightIdentity, trackingStartTime: number) {
+    if (this.disposed || !identity.requestId) {
+      return
+    }
+
+    const sanitizedTrackingStartTime = Number.isFinite(trackingStartTime)
+      ? trackingStartTime
+      : getCurrentTimestamp()
+    const insight = this.getOrCreateRequest(
+      identity,
+      sanitizedTrackingStartTime
+    )
+    if (!insight) {
+      return
+    }
+    if (insight.response) {
+      return
+    }
+
+    insight.response = {
+      trackingStartTime: sanitizedTrackingStartTime,
+      outcome: 'pending',
+    }
+    if (insight.status !== 'error' && insight.status !== 'aborted') {
+      insight.status = 'pending'
+    }
+    this.updateTiming(insight, sanitizedTrackingStartTime, undefined, false)
+    this.enforceInsightByteBudget(insight)
+    this.finishMutation(insight)
+  }
+
+  completeResponse(
+    identity: RequestInsightIdentity,
+    response: RequestInsightResponse
+  ) {
+    if (
+      this.disposed ||
+      !identity.requestId ||
+      response.outcome === 'pending'
+    ) {
+      return
+    }
+
+    const insight = this.requests.get(
+      getRequestInsightKey({
+        requestId: identity.requestId,
+        kind: identity.kind,
+      })
+    )
+    if (insight?.response?.outcome !== 'pending') {
+      return
+    }
+
+    const trackingStartTime = Number.isFinite(response.trackingStartTime)
+      ? response.trackingStartTime
+      : insight.response.trackingStartTime
+    const endTime = Math.max(
+      trackingStartTime,
+      Number.isFinite(response.endTime) ? response.endTime! : trackingStartTime
+    )
+    const statusCode = Number.isFinite(response.statusCode)
+      ? response.statusCode
+      : undefined
+
+    insight.response = {
+      trackingStartTime,
+      endTime,
+      statusCode,
+      outcome: response.outcome,
+      error: sanitizeResponseError(response.error),
+    }
+    this.updateTiming(
+      insight,
+      trackingStartTime,
+      endTime - trackingStartTime,
+      false
+    )
+
+    if (
+      insight.status === 'error' ||
+      response.outcome === 'errored' ||
+      (statusCode !== undefined && statusCode >= 500)
+    ) {
+      insight.status = 'error'
+    } else if (response.outcome === 'aborted') {
+      insight.status = 'aborted'
+    } else {
+      insight.status = 'ok'
+    }
+    this.enforceInsightByteBudget(insight)
+    this.finishMutation(insight)
+  }
+
   private updateTiming(
     insight: RequestInsight,
     startTime: number,
@@ -550,15 +661,20 @@ export class RequestInsights {
     if (isRequestSpan && durationMs !== undefined) {
       const timing = { startTime, durationMs: nextDurationMs }
       this.requestTimings.set(requestKey, timing)
-      insight.startTime = timing.startTime
-      insight.durationMs = timing.durationMs
-      return
     }
 
     const requestTiming = this.requestTimings.get(requestKey)
     if (requestTiming) {
-      insight.startTime = requestTiming.startTime
-      insight.durationMs = requestTiming.durationMs
+      const response = insight.response
+      const combinedStartTime = response
+        ? Math.min(requestTiming.startTime, response.trackingStartTime)
+        : requestTiming.startTime
+      const endTime = Math.max(
+        requestTiming.startTime + requestTiming.durationMs,
+        response?.endTime ?? combinedStartTime
+      )
+      insight.startTime = combinedStartTime
+      insight.durationMs = endTime - combinedStartTime
       return
     }
 
@@ -1438,6 +1554,18 @@ function sanitizeSpanName(
   )
 }
 
+function sanitizeResponseError(
+  error: RequestInsightResponse['error']
+): RequestInsightResponse['error'] {
+  if (!error?.type) {
+    return undefined
+  }
+
+  return {
+    type: SAFE_RESPONSE_ERROR_TYPES.has(error.type) ? error.type : 'Error',
+  }
+}
+
 function sanitizeSpanAttributes(
   attributes: SpanStoreRecord['attributes'],
   sanitizedSpanName: string | undefined,
@@ -1730,6 +1858,14 @@ function hasSameRequestInsightOrder(
 function cloneRequestInsight(insight: RequestInsight): RequestInsight {
   return {
     ...insight,
+    response: insight.response
+      ? {
+          ...insight.response,
+          error: insight.response.error
+            ? { ...insight.response.error }
+            : undefined,
+        }
+      : undefined,
     spans: insight.spans.map((span) => ({
       ...span,
       attributes: cloneAttributes(span.attributes),

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -55,6 +55,12 @@ import {
   isRequestInsightsRetentionContextOpen,
   type RequestInsightsRetentionContext,
 } from './request-insights-identity'
+import {
+  normalizeRequestInsightsCausalParent,
+  RequestInsightsCausalRegistry,
+  type RequestInsightsCausalParent,
+  type RequestInsightsCausalTarget,
+} from './request-insights-causal'
 export { isRequestInsightsEnabled } from './span-store'
 export {
   REQUEST_INSIGHTS_ID_PATTERN,
@@ -104,6 +110,8 @@ type RequestInsightIdentity = {
   requestId?: string
   rootRequestId?: string
   retention?: RequestInsightsRetentionContext
+  parentRootRequestId?: string
+  parentFetchIndex?: number
   kind?: RequestInsightKind
   source?: RequestInsightSource
   proxyStatus?: RequestInsightProxyStatus
@@ -167,6 +175,7 @@ type SanitizationState = {
 }
 
 export class RequestInsights {
+  private readonly causalRegistry = new RequestInsightsCausalRegistry()
   private readonly requests = new Map<string, RequestInsight>()
   private readonly requestTimings = new Map<
     string,
@@ -233,6 +242,31 @@ export class RequestInsights {
 
   constructor(options: RequestInsightsOptions = {}) {
     this.limits = normalizeRequestInsightsLimits(options)
+  }
+
+  mintCausalToken(
+    input: RequestInsightsCausalParent & {
+      target: RequestInsightsCausalTarget
+    }
+  ): string | undefined {
+    return this.disposed
+      ? undefined
+      : this.causalRegistry.mintCausalToken(input)
+  }
+
+  consumeCausalToken(
+    token: string,
+    target: RequestInsightsCausalTarget
+  ): RequestInsightsCausalParent | undefined {
+    return this.disposed
+      ? undefined
+      : this.causalRegistry.consumeCausalToken(token, target)
+  }
+
+  revokeCausalToken(token: string): void {
+    if (!this.disposed) {
+      this.causalRegistry.revokeCausalToken(token)
+    }
   }
 
   recordSpan(span: SpanStoreRecord): void {
@@ -537,6 +571,7 @@ export class RequestInsights {
   }
 
   private clearRetainedState(): void {
+    this.causalRegistry.clear()
     for (const retention of this.retentionContextsByRequestKey.values()) {
       closeRequestInsightsRetentionRoot(retention)
       closeRequestInsightsRetentionRecord(retention)
@@ -814,6 +849,15 @@ export class RequestInsights {
 
     const rootRequestId =
       sanitizeRequestInsightId(identity.rootRequestId) ?? requestId
+    const normalizedCausalParent = normalizeRequestInsightsCausalParent({
+      parentRootRequestId: identity.parentRootRequestId,
+      parentFetchIndex: identity.parentFetchIndex,
+    })
+    const causalParent =
+      normalizedCausalParent?.parentRootRequestId !== requestId &&
+      normalizedCausalParent?.parentRootRequestId !== rootRequestId
+        ? normalizedCausalParent
+        : undefined
     const requestKey = getRequestInsightKey({
       requestId,
       kind: identity.kind,
@@ -845,6 +889,7 @@ export class RequestInsights {
       insight = {
         requestId,
         rootRequestId,
+        ...causalParent,
         kind: getRequestInsightKind(identity),
         source: getRequestInsightSource(identity),
         proxyStatus: identity.proxyStatus,
@@ -892,6 +937,16 @@ export class RequestInsights {
       sanitizeText(identity.route, MAX_REQUEST_INSIGHT_ROUTE_LENGTH)
     insight.url = insight.url ?? sanitizeUrl(identity.url)
     this.updateClassification(insight, identity)
+    if (
+      causalParent !== undefined &&
+      insight.parentRootRequestId === undefined &&
+      insight.parentFetchIndex === undefined &&
+      causalParent.parentRootRequestId !== requestId &&
+      causalParent.parentRootRequestId !== rootRequestId
+    ) {
+      insight.parentRootRequestId = causalParent.parentRootRequestId
+      insight.parentFetchIndex = causalParent.parentFetchIndex
+    }
     return insight
   }
 

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -1485,7 +1485,9 @@ function getFetchInsight(span: SpanStoreRecord): RequestInsightFetch | null {
     durationMs: span.durationMs,
     cacheStatus: getStringAttribute(attributes['next.fetch.cache_status']),
     cacheReason: getStringAttribute(attributes['next.fetch.cache_reason']),
-    index: getNumberAttribute(attributes['next.fetch.idx']),
+    index:
+      sanitizeFiniteNumber(span.requestInsightFetchIndex) ??
+      getNumberAttribute(attributes['next.fetch.idx']),
   }
 }
 

--- a/packages/next/src/server/lib/trace/request-insights.ts
+++ b/packages/next/src/server/lib/trace/request-insights.ts
@@ -313,7 +313,7 @@ export class RequestInsights {
       span
     )
     const route = sanitizeText(span.route, MAX_REQUEST_INSIGHT_ROUTE_LENGTH)
-    insight.route = insight.route ?? route
+    insight.route = refineRequestInsightRoute(insight.route, route)
     insight.url = insight.url ?? sanitizeUrl(span.url)
     this.updateTiming(
       insight,
@@ -932,9 +932,10 @@ export class RequestInsights {
 
     insight.htmlRequestId =
       sanitizeRequestInsightId(identity.htmlRequestId) ?? insight.htmlRequestId
-    insight.route =
-      insight.route ??
+    insight.route = refineRequestInsightRoute(
+      insight.route,
       sanitizeText(identity.route, MAX_REQUEST_INSIGHT_ROUTE_LENGTH)
+    )
     insight.url = insight.url ?? sanitizeUrl(identity.url)
     this.updateClassification(insight, identity)
     if (
@@ -1801,6 +1802,15 @@ function sanitizeText(
     if (charCode >= 0xd800 && charCode <= 0xdbff) end--
   }
   return `${value.slice(0, end)}…`
+}
+
+function refineRequestInsightRoute(
+  current: string | undefined,
+  candidate: string | undefined
+): string | undefined {
+  if (!candidate) return current
+  if (!current || (current === '/' && candidate !== '/')) return candidate
+  return current
 }
 
 function sanitizeRequestInsightId(value: string | undefined) {

--- a/packages/next/src/server/lib/trace/span-store.ts
+++ b/packages/next/src/server/lib/trace/span-store.ts
@@ -56,6 +56,7 @@ export type SpanStoreRecord = {
   requestInsightProxyStatus?: RequestInsightProxyStatus
   requestInsightRouterActivity?: RequestInsightRouterActivity
   requestInsightServerAction?: true
+  requestInsightFetchIndex?: number
   htmlRequestId?: string
   route?: string
   url?: string

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -7,7 +7,6 @@ import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
 import { registerCompileRouteTool } from './tools/compile-route'
-import { registerGetRequestInsightsTool } from './tools/get-request-insights'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
 import type { Project } from '../../build/swc/types'
@@ -60,7 +59,11 @@ export const createMcpServer = (options: McpServerOptions) => {
     pagesDir: options.pagesDir,
     appDir: options.appDir,
   })
-  registerGetRequestInsightsTool(mcpServer, options.getRequestInsights)
+  if (process.env.__NEXT_DEV_SERVER) {
+    const { registerGetRequestInsightsTool } =
+      require('./tools/get-request-insights') as typeof import('./tools/get-request-insights')
+    registerGetRequestInsightsTool(mcpServer, options.getRequestInsights)
+  }
 
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1686,6 +1686,15 @@ export default class NextNodeServer extends BaseServer<
       process.env.__NEXT_DEV_SERVER && this.requestInsights
         ? getRequestMeta(params.request, 'requestInsightsIdentity')
         : undefined
+    if (requestInsightsIdentity) {
+      const { patchFetch } =
+        require('./lib/patch-fetch') as typeof import('./lib/patch-fetch')
+      const { workAsyncStorage } =
+        require('./app-render/work-async-storage.external') as typeof import('./app-render/work-async-storage.external')
+      const { workUnitAsyncStorage } =
+        require('./app-render/work-unit-async-storage.external') as typeof import('./app-render/work-unit-async-storage.external')
+      patchFetch({ workAsyncStorage, workUnitAsyncStorage })
+    }
 
     const page: {
       name?: string
@@ -2092,10 +2101,17 @@ export default class NextNodeServer extends BaseServer<
     if (
       process.env.__NEXT_DEV_SERVER &&
       this.requestInsights &&
-      requestInsightsIdentity &&
-      match?.definition.kind === RouteKind.APP_ROUTE
+      requestInsightsIdentity
     ) {
-      this.requestInsights.recordSource(requestInsightsIdentity, 'app-route')
+      const source =
+        match?.definition.kind === RouteKind.APP_ROUTE
+          ? 'app-route'
+          : match?.definition.kind === RouteKind.PAGES_API
+            ? 'pages-api'
+            : undefined
+      if (source) {
+        this.requestInsights.recordSource(requestInsightsIdentity, source)
+      }
     }
 
     const { run } = require('./web/sandbox') as typeof import('./web/sandbox')

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1682,6 +1682,10 @@ export default class NextNodeServer extends BaseServer<
         'To use middleware you must provide a `hostname` and `port` to the Next.js Server'
       )
     }
+    const requestInsightsIdentity =
+      process.env.__NEXT_DEV_SERVER && this.requestInsights
+        ? getRequestMeta(params.request, 'requestInsightsIdentity')
+        : undefined
 
     const page: {
       name?: string
@@ -1784,6 +1788,16 @@ export default class NextNodeServer extends BaseServer<
         clientAssetToken: this.nextConfig.supportsImmutableAssets
           ? ''
           : this.deploymentId,
+        requestInsightsFetchContext:
+          process.env.__NEXT_DEV_SERVER &&
+          this.requestInsights &&
+          requestInsightsIdentity
+            ? {
+                identity: requestInsightsIdentity,
+                origin: new URL(url).origin,
+                requestInsights: this.requestInsights,
+              }
+            : undefined,
       })
     }
 
@@ -2070,6 +2084,20 @@ export default class NextNodeServer extends BaseServer<
       )
     }
 
+    const requestInsightsIdentity =
+      process.env.__NEXT_DEV_SERVER && this.requestInsights
+        ? getRequestMeta(params.req, 'requestInsightsIdentity')
+        : undefined
+
+    if (
+      process.env.__NEXT_DEV_SERVER &&
+      this.requestInsights &&
+      requestInsightsIdentity &&
+      match?.definition.kind === RouteKind.APP_ROUTE
+    ) {
+      this.requestInsights.recordSource(requestInsightsIdentity, 'app-route')
+    }
+
     const { run } = require('./web/sandbox') as typeof import('./web/sandbox')
     const result = await run({
       distDir: this.distDir,
@@ -2106,10 +2134,54 @@ export default class NextNodeServer extends BaseServer<
       clientAssetToken: this.nextConfig.supportsImmutableAssets
         ? ''
         : this.deploymentId,
+      requestInsightsFetchContext:
+        process.env.__NEXT_DEV_SERVER &&
+        this.requestInsights &&
+        requestInsightsIdentity
+          ? {
+              identity: requestInsightsIdentity,
+              origin: new URL(url).origin,
+              requestInsights: this.requestInsights,
+            }
+          : undefined,
     })
 
     if (result.fetchMetrics) {
       params.req.fetchMetrics = result.fetchMetrics
+    }
+
+    if (
+      process.env.__NEXT_DEV_SERVER &&
+      this.requestInsights &&
+      requestInsightsIdentity &&
+      (match?.definition.kind === RouteKind.APP_PAGE ||
+        Array.isArray(params.appPaths)) &&
+      result.response.status < 400
+    ) {
+      const { ACTION_HEADER } =
+        require('../client/components/app-router-headers') as typeof import('../client/components/app-router-headers')
+      const { extractInfoFromServerReferenceId, mightBeServerReferenceId } =
+        require('../shared/lib/server-reference-info') as typeof import('../shared/lib/server-reference-info')
+      const { getRequestInsightRouterActivity } =
+        require('./lib/trace/request-insights-router-activity') as typeof import('./lib/trace/request-insights-router-activity')
+      const routerActivity = getRequestInsightRouterActivity(params.req.headers)
+      if (routerActivity) {
+        this.requestInsights.recordRouterActivity(
+          requestInsightsIdentity,
+          routerActivity
+        )
+      }
+
+      const actionId = params.req.headers[ACTION_HEADER]
+      if (
+        params.req.method === 'POST' &&
+        typeof actionId === 'string' &&
+        mightBeServerReferenceId(actionId) &&
+        /^[0-9a-f]+$/i.test(actionId) &&
+        extractInfoFromServerReferenceId(actionId).type === 'server-action'
+      ) {
+        this.requestInsights.recordServerAction(requestInsightsIdentity)
+      }
     }
 
     if (!params.res.statusCode || params.res.statusCode < 400) {

--- a/packages/next/src/server/web/sandbox/context.test.ts
+++ b/packages/next/src/server/web/sandbox/context.test.ts
@@ -1,4 +1,5 @@
 import { RequestInsights } from '../../lib/trace/request-insights'
+import { createRequestInsightsRetentionContext } from '../../lib/trace/request-insights-identity'
 import { getModuleContext, requestStore } from './context'
 import { validateURL } from '../utils'
 
@@ -111,6 +112,8 @@ describe('Next.js sandbox Request constructor', () => {
           requestInsightsFetchContext: {
             identity: {
               requestId: 'edge-fetch',
+              rootRequestId: 'edge-fetch',
+              retention: createRequestInsightsRetentionContext(),
               htmlRequestId: 'edge-fetch',
               url: '/edge',
             },
@@ -183,6 +186,8 @@ describe('Next.js sandbox Request constructor', () => {
           requestInsightsFetchContext: {
             identity: {
               requestId: 'edge-boxed-fetch',
+              rootRequestId: 'edge-boxed-fetch',
+              retention: createRequestInsightsRetentionContext(),
               htmlRequestId: 'edge-boxed-fetch',
               url: '/edge',
             },

--- a/packages/next/src/server/web/sandbox/context.test.ts
+++ b/packages/next/src/server/web/sandbox/context.test.ts
@@ -1,10 +1,28 @@
-import { getModuleContext } from './context'
+import { RequestInsights } from '../../lib/trace/request-insights'
+import { getModuleContext, requestStore } from './context'
 import { validateURL } from '../utils'
+
+const mockPrepareRequestInsightsSandboxFetch = jest.fn()
 
 jest.mock('../utils', () => ({
   ...jest.requireActual('../utils'),
   validateURL: jest.fn(jest.requireActual('../utils').validateURL),
 }))
+
+jest.mock('../../lib/trace/request-insights-sandbox-fetch', () => {
+  const actual = jest.requireActual<
+    typeof import('../../lib/trace/request-insights-sandbox-fetch')
+  >('../../lib/trace/request-insights-sandbox-fetch')
+  return {
+    ...actual,
+    prepareRequestInsightsSandboxFetch: (
+      ...args: Parameters<typeof actual.prepareRequestInsightsSandboxFetch>
+    ) => {
+      mockPrepareRequestInsightsSandboxFetch(...args)
+      return actual.prepareRequestInsightsSandboxFetch(...args)
+    },
+  }
+})
 
 const mockedValidateURL = jest.mocked(validateURL)
 
@@ -68,5 +86,150 @@ describe('Next.js sandbox Request constructor', () => {
     expect(() => new NextRequest('/urls-b')).toThrow(
       'Please use only absolute URLs'
     )
+  })
+
+  it('shares one RequestInit method read between Request Insights and fetch', async () => {
+    const originalDevServer = process.env.__NEXT_DEV_SERVER
+    process.env.__NEXT_DEV_SERVER = '1'
+    const requestInsights = new RequestInsights()
+    let methodReads = 0
+    const init = Object.defineProperty({}, 'method', {
+      enumerable: true,
+      get() {
+        methodReads++
+        if (methodReads > 1) {
+          throw new Error('method was read more than once')
+        }
+        return 'GET'
+      },
+    }) as RequestInit
+
+    try {
+      const response = await requestStore.run(
+        {
+          headers: new Headers(),
+          requestInsightsFetchContext: {
+            identity: {
+              requestId: 'edge-fetch',
+              htmlRequestId: 'edge-fetch',
+              url: '/edge',
+            },
+            requestInsights,
+          },
+        },
+        () => moduleContext.runtime.context.fetch('data:text/plain,edge', init)
+      )
+
+      expect(await response.text()).toBe('edge')
+      expect(methodReads).toBe(1)
+      expect(
+        requestInsights
+          .getSnapshot()
+          .requests.find((request) => request.requestId === 'edge-fetch')
+          ?.fetches
+      ).toEqual([expect.objectContaining({ method: 'GET', statusCode: 200 })])
+    } finally {
+      requestInsights.dispose()
+      if (originalDevServer === undefined) {
+        delete process.env.__NEXT_DEV_SERVER
+      } else {
+        process.env.__NEXT_DEV_SERVER = originalDevServer
+      }
+    }
+  })
+
+  it('shares boxed RequestInit string coercion with fetch', async () => {
+    const originalDevServer = process.env.__NEXT_DEV_SERVER
+    process.env.__NEXT_DEV_SERVER = '1'
+    const requestInsights = new RequestInsights()
+    let methodReads = 0
+    let methodCoercions = 0
+    let credentialsReads = 0
+    let credentialsCoercions = 0
+    const init = Object.defineProperties(
+      {},
+      {
+        credentials: {
+          enumerable: true,
+          get() {
+            credentialsReads++
+            return {
+              toString() {
+                credentialsCoercions++
+                return 'omit'
+              },
+            }
+          },
+        },
+        method: {
+          enumerable: true,
+          get() {
+            methodReads++
+            return {
+              toString() {
+                methodCoercions++
+                return 'GET'
+              },
+            }
+          },
+        },
+      }
+    ) as RequestInit
+
+    try {
+      const response = await requestStore.run(
+        {
+          headers: new Headers(),
+          requestInsightsFetchContext: {
+            identity: {
+              requestId: 'edge-boxed-fetch',
+              htmlRequestId: 'edge-boxed-fetch',
+              url: '/edge',
+            },
+            requestInsights,
+          },
+        },
+        () => moduleContext.runtime.context.fetch('data:text/plain,edge', init)
+      )
+
+      expect(await response.text()).toBe('edge')
+      expect(methodReads).toBe(1)
+      expect(methodCoercions).toBe(1)
+      expect(credentialsReads).toBe(1)
+      expect(credentialsCoercions).toBe(1)
+      expect(
+        requestInsights
+          .getSnapshot()
+          .requests.find((request) => request.requestId === 'edge-boxed-fetch')
+          ?.fetches
+      ).toEqual([expect.objectContaining({ method: 'GET', statusCode: 200 })])
+    } finally {
+      requestInsights.dispose()
+      if (originalDevServer === undefined) {
+        delete process.env.__NEXT_DEV_SERVER
+      } else {
+        process.env.__NEXT_DEV_SERVER = originalDevServer
+      }
+    }
+  })
+
+  it('does not invoke Request Insights fetch bookkeeping without context', async () => {
+    const originalDevServer = process.env.__NEXT_DEV_SERVER
+    process.env.__NEXT_DEV_SERVER = '1'
+    mockPrepareRequestInsightsSandboxFetch.mockClear()
+
+    try {
+      const response = await moduleContext.runtime.context.fetch(
+        'data:text/plain,edge'
+      )
+      expect(await response.text()).toBe('edge')
+      expect(mockPrepareRequestInsightsSandboxFetch).not.toHaveBeenCalled()
+    } finally {
+      if (originalDevServer === undefined) {
+        delete process.env.__NEXT_DEV_SERVER
+      } else {
+        process.env.__NEXT_DEV_SERVER = originalDevServer
+      }
+    }
   })
 })

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -35,6 +35,9 @@ interface ModuleContext {
 
 let getServerError: typeof import('../../dev/node-stack-frames').getServerError
 let decorateServerError: typeof import('../../../shared/lib/error-source').decorateServerError
+let requestInsightsSandboxFetchRuntime:
+  | typeof import('../../lib/trace/request-insights-sandbox-fetch')
+  | undefined
 
 if (process.env.NODE_ENV === 'development') {
   getServerError = (
@@ -46,6 +49,17 @@ if (process.env.NODE_ENV === 'development') {
 } else {
   getServerError = (error) => error
   decorateServerError = () => {}
+}
+
+function getRequestInsightsSandboxFetchRuntime():
+  | typeof import('../../lib/trace/request-insights-sandbox-fetch')
+  | undefined {
+  if (process.env.__NEXT_DEV_SERVER) {
+    return (requestInsightsSandboxFetchRuntime ??=
+      require('../../lib/trace/request-insights-sandbox-fetch') as typeof import('../../lib/trace/request-insights-sandbox-fetch'))
+  } else {
+    return undefined
+  }
 }
 
 /**
@@ -248,6 +262,7 @@ const NativeModuleMap = (() => {
 
 export const requestStore = new AsyncLocalStorage<{
   headers: Headers
+  requestInsightsFetchContext?: import('../../lib/trace/request-insights-sandbox-fetch').RequestInsightsSandboxFetchContext
 }>()
 
 export const edgeSandboxNextRequestContext = createLocalRequestContext()
@@ -367,35 +382,56 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
           init.headers.set(`user-agent`, `Next.js Middleware`)
         }
 
-        const response =
-          typeof input === 'object' && 'url' in input
-            ? __fetch(input.url, {
-                ...pick(input, [
-                  'method',
-                  'body',
-                  'cache',
-                  'credentials',
-                  'integrity',
-                  'keepalive',
-                  'mode',
-                  'redirect',
-                  'referrer',
-                  'referrerPolicy',
-                  'signal',
-                ]),
-                ...init,
-                headers: {
-                  ...Object.fromEntries(input.headers),
-                  ...Object.fromEntries(init.headers),
-                },
-              })
-            : __fetch(String(input), init)
+        const isRequestInput = typeof input === 'object' && 'url' in input
+        const fetchUrl = isRequestInput ? input.url : String(input)
+        const fetchInit = isRequestInput
+          ? {
+              ...pick(input, [
+                'method',
+                'body',
+                'cache',
+                'credentials',
+                'integrity',
+                'keepalive',
+                'mode',
+                'redirect',
+                'referrer',
+                'referrerPolicy',
+                'signal',
+              ]),
+              ...init,
+              headers: {
+                ...Object.fromEntries(input.headers),
+                ...Object.fromEntries(init.headers),
+              },
+            }
+          : init
+        const requestInsightsFetchContext =
+          requestStore.getStore()?.requestInsightsFetchContext
+        const requestInsightsFetch = requestInsightsFetchContext
+          ? getRequestInsightsSandboxFetchRuntime()?.prepareRequestInsightsSandboxFetch(
+              {
+                context: requestInsightsFetchContext,
+                init: fetchInit,
+                url: fetchUrl,
+              }
+            )
+          : undefined
 
-        return await response.catch((err) => {
-          callingError.message = err.message
-          err.stack = callingError.stack
+        try {
+          const response = await __fetch(
+            fetchUrl,
+            requestInsightsFetch?.init ?? fetchInit
+          )
+          requestInsightsFetch?.complete(response)
+          return response
+        } catch (err) {
+          requestInsightsFetch?.complete()
+          const fetchError = err as Error
+          callingError.message = fetchError.message
+          fetchError.stack = callingError.stack
           throw err
-        })
+        }
       }
 
       const __Request = context.Request

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -38,6 +38,7 @@ interface RunnerFnParams {
   incrementalCache?: any
   serverComponentsHmrCache?: ServerComponentsHmrCache
   clientAssetToken: string
+  requestInsightsFetchContext?: import('../../lib/trace/request-insights-sandbox-fetch').RequestInsightsSandboxFetchContext
 }
 
 type RunnerFn = (params: RunnerFnParams) => Promise<FetchEventResult>
@@ -140,19 +141,25 @@ export const run = withTaggedErrors(async function runWithTaggedErrors(params) {
       waitUntil: params.request.waitUntil,
     }
     await edgeSandboxNextRequestContext.run(builtinRequestCtx, () =>
-      requestStore.run({ headers }, async () => {
-        result = await edgeFunction({
-          request: {
-            ...params.request,
-            body:
-              cloned &&
-              requestToBodyStream(runtime.context, KUint8Array, cloned),
-          },
-        })
-        for (const headerName of FORBIDDEN_HEADERS) {
-          result.response.headers.delete(headerName)
+      requestStore.run(
+        {
+          headers,
+          requestInsightsFetchContext: params.requestInsightsFetchContext,
+        },
+        async () => {
+          result = await edgeFunction({
+            request: {
+              ...params.request,
+              body:
+                cloned &&
+                requestToBodyStream(runtime.context, KUint8Array, cloned),
+            },
+          })
+          for (const headerName of FORBIDDEN_HEADERS) {
+            result.response.headers.delete(headerName)
+          }
         }
-      })
+      )
     )
 
     if (!result) throw new Error('Edge function did not return a response')

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -22,6 +22,36 @@ import type {
   WorkUnitStore,
 } from '../../app-render/work-unit-async-storage.external'
 
+type UnstableCacheRequestInsightsRuntime = {
+  getNextRequestInsightsFetchIndex: typeof import('../../lib/trace/request-insights-sandbox-fetch').getNextRequestInsightsFetchIndex
+  getRequestInsightsIdentity: typeof import('../../lib/trace/request-insights-identity').getRequestInsightsIdentity
+}
+
+let unstableCacheRequestInsightsRuntime:
+  | UnstableCacheRequestInsightsRuntime
+  | undefined
+
+function getUnstableCacheRequestInsightsRuntime():
+  | UnstableCacheRequestInsightsRuntime
+  | undefined {
+  if (!process.env.__NEXT_DEV_SERVER) {
+    return undefined
+  }
+
+  if (!unstableCacheRequestInsightsRuntime) {
+    const { getNextRequestInsightsFetchIndex } =
+      require('../../lib/trace/request-insights-sandbox-fetch') as typeof import('../../lib/trace/request-insights-sandbox-fetch')
+    const { getRequestInsightsIdentity } =
+      require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
+    unstableCacheRequestInsightsRuntime = {
+      getNextRequestInsightsFetchIndex,
+      getRequestInsightsIdentity,
+    }
+  }
+
+  return unstableCacheRequestInsightsRuntime
+}
+
 type Callback = (...args: any[]) => Promise<any>
 
 let noStoreFetchIdx = 0
@@ -139,8 +169,17 @@ export function unstable_cache<T extends Callback>(
         await incrementalCache.generateSimpleCacheKey(invocationKey)
       // $urlWithPath,$sortedQueryStringKeys,$hashOfEveryThingElse
       const fetchUrl = `unstable_cache ${fetchUrlPrefix} ${cb.name ? ` ${cb.name}` : cacheKey}`
+      const requestInsightsRuntime = getUnstableCacheRequestInsightsRuntime()
+      const requestInsightsIdentity = requestInsightsRuntime
+        ? (requestInsightsRuntime.getRequestInsightsIdentity() ??
+          workStore?.requestInsightsIdentity)
+        : undefined
       const fetchIdx =
-        (workStore ? workStore.nextFetchId : noStoreFetchIdx) ?? 1
+        requestInsightsIdentity && requestInsightsRuntime
+          ? requestInsightsRuntime.getNextRequestInsightsFetchIndex(
+              requestInsightsIdentity
+            )
+          : ((workStore ? workStore.nextFetchId : noStoreFetchIdx) ?? 1)
 
       const implicitTags = workUnitStore?.implicitTags
 
@@ -338,7 +377,9 @@ export function unstable_cache<T extends Callback>(
 
         return result
       } else {
-        noStoreFetchIdx += 1
+        if (!requestInsightsIdentity) {
+          noStoreFetchIdx += 1
+        }
         // We are in Pages Router or were called outside of a render. We don't have a store
         // so we just call the callback directly when it needs to run.
         // If the entry is fresh we return it. If the entry is stale we return it but revalidate the entry in

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -34,22 +34,22 @@ let unstableCacheRequestInsightsRuntime:
 function getUnstableCacheRequestInsightsRuntime():
   | UnstableCacheRequestInsightsRuntime
   | undefined {
-  if (!process.env.__NEXT_DEV_SERVER) {
+  if (process.env.__NEXT_DEV_SERVER) {
+    if (!unstableCacheRequestInsightsRuntime) {
+      const { getNextRequestInsightsFetchIndex } =
+        require('../../lib/trace/request-insights-sandbox-fetch') as typeof import('../../lib/trace/request-insights-sandbox-fetch')
+      const { getRequestInsightsIdentity } =
+        require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
+      unstableCacheRequestInsightsRuntime = {
+        getNextRequestInsightsFetchIndex,
+        getRequestInsightsIdentity,
+      }
+    }
+
+    return unstableCacheRequestInsightsRuntime
+  } else {
     return undefined
   }
-
-  if (!unstableCacheRequestInsightsRuntime) {
-    const { getNextRequestInsightsFetchIndex } =
-      require('../../lib/trace/request-insights-sandbox-fetch') as typeof import('../../lib/trace/request-insights-sandbox-fetch')
-    const { getRequestInsightsIdentity } =
-      require('../../lib/trace/request-insights-identity') as typeof import('../../lib/trace/request-insights-identity')
-    unstableCacheRequestInsightsRuntime = {
-      getNextRequestInsightsFetchIndex,
-      getRequestInsightsIdentity,
-    }
-  }
-
-  return unstableCacheRequestInsightsRuntime
 }
 
 type Callback = (...args: any[]) => Promise<any>

--- a/packages/next/src/server/web/web-on-close.test.ts
+++ b/packages/next/src/server/web/web-on-close.test.ts
@@ -1,5 +1,5 @@
 import { DetachedPromise } from '../../lib/detached-promise'
-import { trackStreamConsumed } from './web-on-close'
+import { CloseController, trackStreamConsumed } from './web-on-close'
 
 describe('trackStreamConsumed', () => {
   it('calls onEnd when the stream finishes', async () => {
@@ -26,6 +26,7 @@ describe('trackStreamConsumed', () => {
 
     await endPromise.promise
     expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith({ outcome: 'finished' })
   })
 
   it('calls onEnd when the stream errors', async () => {
@@ -51,6 +52,7 @@ describe('trackStreamConsumed', () => {
 
     await endPromise.promise
     expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith({ outcome: 'errored', error })
   })
 
   it('calls onEnd when the stream is cancelled', async () => {
@@ -83,10 +85,57 @@ describe('trackStreamConsumed', () => {
 
     await endPromise.promise
     expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith({
+      outcome: 'aborted',
+      error: cancellationReason,
+    })
 
     //  the cancellation should propagate to back to the underlying stream
     await cancelledPromise.promise
     expect(onCancel).toHaveBeenCalledWith(cancellationReason)
+  })
+
+  it('isolates close callback failures from stream completion and other listeners', async () => {
+    const queuedMicrotasks: Array<() => void> = []
+    const queueMicrotaskSpy = jest
+      .spyOn(globalThis, 'queueMicrotask')
+      .mockImplementation((callback) => {
+        queuedMicrotasks.push(callback)
+      })
+    const closeController = new CloseController()
+    const secondCallback = jest.fn()
+
+    try {
+      closeController.onClose(() => {
+        throw new Error('callback failed')
+      })
+      closeController.onClose(secondCallback)
+
+      const trackedStream = trackStreamConsumed(
+        new ReadableStream<string>({
+          start(controller) {
+            controller.enqueue('value')
+            controller.close()
+          },
+        }),
+        (result) => closeController.dispatchClose(result)
+      )
+      const reader = trackedStream.getReader()
+
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: 'value',
+      })
+      await expect(reader.read()).resolves.toEqual({
+        done: true,
+        value: undefined,
+      })
+      expect(secondCallback).toHaveBeenCalledWith({ outcome: 'finished' })
+      expect(queuedMicrotasks).toHaveLength(1)
+      expect(closeController.listeners).toBe(0)
+    } finally {
+      queueMicrotaskSpy.mockRestore()
+    }
   })
 })
 

--- a/packages/next/src/server/web/web-on-close.test.ts
+++ b/packages/next/src/server/web/web-on-close.test.ts
@@ -1,9 +1,13 @@
 import { DetachedPromise } from '../../lib/detached-promise'
-import { CloseController, trackStreamConsumed } from './web-on-close'
+import {
+  CloseController,
+  trackStreamConsumed,
+  type ResponseBodyConsumption,
+} from './web-on-close'
 
 describe('trackStreamConsumed', () => {
   it('calls onEnd when the stream finishes', async () => {
-    const endPromise = new DetachedPromise<void>()
+    const endPromise = new DetachedPromise<ResponseBodyConsumption>()
     const onEnd = jest.fn(endPromise.resolve)
 
     const { stream: inputStream, controller } =
@@ -30,7 +34,7 @@ describe('trackStreamConsumed', () => {
   })
 
   it('calls onEnd when the stream errors', async () => {
-    const endPromise = new DetachedPromise<void>()
+    const endPromise = new DetachedPromise<ResponseBodyConsumption>()
     const onEnd = jest.fn(endPromise.resolve)
 
     const { stream: inputStream, controller } =
@@ -56,7 +60,7 @@ describe('trackStreamConsumed', () => {
   })
 
   it('calls onEnd when the stream is cancelled', async () => {
-    const endPromise = new DetachedPromise<void>()
+    const endPromise = new DetachedPromise<ResponseBodyConsumption>()
     const onEnd = jest.fn(endPromise.resolve)
 
     const cancelledPromise = new DetachedPromise<unknown>()

--- a/packages/next/src/server/web/web-on-close.ts
+++ b/packages/next/src/server/web/web-on-close.ts
@@ -1,18 +1,27 @@
-/** Monitor when the consumer finishes reading the response body.
-that's as close as we can get to `res.on('close')` using web APIs.
-*/
+export type ResponseBodyConsumption =
+  | { outcome: 'finished' }
+  | { outcome: 'aborted'; error?: unknown }
+  | { outcome: 'errored'; error: unknown }
+
+/**
+ * Monitor how the consumer finishes reading the response body. This is as
+ * close as we can get to `res.on('close')` using web APIs.
+ */
 export function trackBodyConsumed(
   body: string | ReadableStream,
-  onEnd: () => void
+  onEnd: (result: ResponseBodyConsumption) => void
 ): BodyInit {
   if (typeof body === 'string') {
-    const generator = async function* generate() {
-      const encoder = new TextEncoder()
-      yield encoder.encode(body)
-      onEnd()
-    }
-    // @ts-expect-error BodyInit typings doesn't seem to include AsyncIterables even though it's supported in practice
-    return generator()
+    const encodedBody = new TextEncoder().encode(body)
+    return trackStreamConsumed(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encodedBody)
+          controller.close()
+        },
+      }),
+      onEnd
+    )
   } else {
     return trackStreamConsumed(body, onEnd)
   }
@@ -20,42 +29,74 @@ export function trackBodyConsumed(
 
 export function trackStreamConsumed<TChunk>(
   stream: ReadableStream<TChunk>,
-  onEnd: () => void
+  onEnd: (result: ResponseBodyConsumption) => void
 ): ReadableStream<TChunk> {
-  // NOTE: This function must handle `stream` being aborted or cancelled,
-  // so it can't just be this:
-  //
-  //   return stream.pipeThrough(new TransformStream({ flush() { onEnd() } }))
-  //
-  // because that doesn't handle cancellations.
-  // (and cancellation handling via `Transformer.cancel` is only available in node >20)
-  const dest = new TransformStream()
-  const runOnEnd = () => onEnd()
-  stream.pipeTo(dest.writable).then(runOnEnd, runOnEnd)
-  return dest.readable
+  const reader = stream.getReader()
+  let completed = false
+
+  const complete = (result: ResponseBodyConsumption) => {
+    if (completed) {
+      return
+    }
+    completed = true
+    onEnd(result)
+  }
+
+  return new ReadableStream<TChunk>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read()
+        if (done) {
+          controller.close()
+          complete({ outcome: 'finished' })
+        } else {
+          controller.enqueue(value)
+        }
+      } catch (error) {
+        controller.error(error)
+        complete({ outcome: 'errored', error })
+      }
+    },
+    async cancel(error) {
+      complete({ outcome: 'aborted', error })
+      await reader.cancel(error)
+    },
+  })
 }
 
 export class CloseController {
-  private target = new EventTarget()
+  private callbacks = new Set<(result: ResponseBodyConsumption) => void>()
   listeners = 0
   isClosed = false
 
-  onClose(callback: () => void) {
+  onClose(callback: (result: ResponseBodyConsumption) => void) {
     if (this.isClosed) {
       throw new Error('Cannot subscribe to a closed CloseController')
     }
 
-    this.target.addEventListener('close', callback)
+    this.callbacks.add(callback)
     this.listeners++
   }
 
-  dispatchClose() {
+  dispatchClose(result: ResponseBodyConsumption = { outcome: 'finished' }) {
     if (this.isClosed) {
       throw new Error('Cannot close a CloseController multiple times')
     }
-    if (this.listeners > 0) {
-      this.target.dispatchEvent(new Event('close'))
-    }
+
     this.isClosed = true
+    const callbacks = Array.from(this.callbacks)
+    this.callbacks.clear()
+    this.listeners = 0
+    for (const callback of callbacks) {
+      try {
+        callback(result)
+      } catch (error) {
+        // Match EventTarget dispatch: one listener must not block the others or
+        // turn successful body consumption into a stream error.
+        queueMicrotask(() => {
+          throw error
+        })
+      }
+    }
   }
 }

--- a/packages/next/src/shared/lib/request-insights.ts
+++ b/packages/next/src/shared/lib/request-insights.ts
@@ -59,7 +59,20 @@ export function getRequestInsightSource(
   if (getRequestInsightKind(insight) === 'instant-insights') {
     return 'instant-insights'
   }
-  return insight.source ?? 'unknown'
+  switch (insight.source) {
+    case 'page':
+    case 'app-route':
+    case 'pages-api':
+    case 'image':
+    case 'asset':
+    case 'proxy':
+    case 'instant-insights':
+      return insight.source
+    case 'unknown':
+    case undefined:
+    default:
+      return 'unknown'
+  }
 }
 
 export function getRequestInsightRetentionBucket(

--- a/test/development/app-dir/request-insights-edge-bridge/app/api/edge-causal/[step]/route.ts
+++ b/test/development/app-dir/request-insights-edge-bridge/app/api/edge-causal/[step]/route.ts
@@ -1,0 +1,69 @@
+const CAUSAL_COOKIE = '__next_request_insights_causal='
+
+export const runtime = 'edge'
+
+function isCausalCookieVisible(request: Request): boolean {
+  return (request.headers.get('cookie') ?? '')
+    .split(';')
+    .some((cookie) => cookie.trim().startsWith(CAUSAL_COOKIE))
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ step: string }> }
+) {
+  const { step } = await params
+  if (step === 'one') {
+    const response = await fetch(new URL('/api/edge-causal/two', request.url))
+    return Response.json(await response.json())
+  }
+
+  if (step === 'external') {
+    const target = new URL(request.url).searchParams.get('target')!
+    try {
+      const response = await fetch(target, {
+        headers: {
+          cookie: `${CAUSAL_COOKIE}caller-value; user=value`,
+        },
+      })
+      return new Response(await response.text(), { status: response.status })
+    } catch {
+      return new Response('fetch failed', { status: 502 })
+    }
+  }
+
+  return Response.json({
+    causalCookieVisible: isCausalCookieVisible(request),
+    step,
+  })
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ step: string }> }
+) {
+  const { step } = await params
+  const body = await request.text()
+  if (step === 'one') {
+    const bytes = new TextEncoder().encode(body)
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes)
+        controller.close()
+      },
+    })
+    const response = await fetch(new URL('/api/edge-causal/two', request.url), {
+      method: 'POST',
+      body: stream,
+      // Required by the host fetch implementation for streaming bodies.
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' })
+    return Response.json(await response.json())
+  }
+
+  return Response.json({
+    body,
+    causalCookieVisible: isCausalCookieVisible(request),
+    step,
+  })
+}

--- a/test/development/app-dir/request-insights-edge-bridge/app/edge-action/page.tsx
+++ b/test/development/app-dir/request-insights-edge-bridge/app/edge-action/page.tsx
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers'
+
+export const runtime = 'edge'
+
+export default function EdgeActionPage() {
+  async function runAction() {
+    'use server'
+    const cookieStore = await cookies()
+    cookieStore.set('edge-action', 'complete')
+  }
+
+  return (
+    <form action={runAction}>
+      <button id="run-edge-action" type="submit">
+        Run Edge action
+      </button>
+    </form>
+  )
+}

--- a/test/development/app-dir/request-insights-edge-bridge/app/edge-proxy/page.tsx
+++ b/test/development/app-dir/request-insights-edge-bridge/app/edge-proxy/page.tsx
@@ -1,0 +1,10 @@
+import { headers } from 'next/headers'
+
+export const runtime = 'edge'
+
+export default async function EdgeProxyPage() {
+  const requestHeaders = await headers()
+  return (
+    <p id="proxy-fetch-status">{requestHeaders.get('x-proxy-fetch-status')}</p>
+  )
+}

--- a/test/development/app-dir/request-insights-edge-bridge/app/edge-rsc/page.tsx
+++ b/test/development/app-dir/request-insights-edge-bridge/app/edge-rsc/page.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function EdgeRscPage() {
+  return <p>Edge RSC response</p>
+}

--- a/test/development/app-dir/request-insights-edge-bridge/app/layout.tsx
+++ b/test/development/app-dir/request-insights-edge-bridge/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/request-insights-edge-bridge/app/page.tsx
+++ b/test/development/app-dir/request-insights-edge-bridge/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <>
+      <p>Request Insights Edge bridge</p>
+      <Link id="edge-rsc-link" href="/edge-rsc">
+        Edge RSC page
+      </Link>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights-edge-bridge/middleware.ts
+++ b/test/development/app-dir/request-insights-edge-bridge/middleware.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  const response = await fetch(new URL('/api/edge-causal/proxy', request.url))
+  const payload = (await response.json()) as { causalCookieVisible: boolean }
+  if (payload.causalCookieVisible) {
+    throw new Error('Request Insights causal cookie reached userland')
+  }
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-proxy-fetch-status', String(response.status))
+  return NextResponse.next({ request: { headers: requestHeaders } })
+}
+
+export const config = {
+  matcher: '/edge-proxy',
+}

--- a/test/development/app-dir/request-insights-edge-bridge/next.config.js
+++ b/test/development/app-dir/request-insights-edge-bridge/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    requestInsights: true,
+  },
+}

--- a/test/development/app-dir/request-insights-edge-bridge/request-insights-edge-bridge.test.ts
+++ b/test/development/app-dir/request-insights-edge-bridge/request-insights-edge-bridge.test.ts
@@ -5,7 +5,8 @@ import { retry } from 'next-test-utils'
 
 type RequestInsight = {
   requestId: string
-  parentRequestId?: string
+  rootRequestId?: string
+  parentRootRequestId?: string
   parentFetchIndex?: number
   url?: string
   source?: string
@@ -61,7 +62,7 @@ describe('Request Insights Edge bridge', () => {
 
     expect(parent).toEqual(expect.objectContaining({ source: 'app-route' }))
     expect(child).toEqual(
-      expect.objectContaining({ parentRequestId: parent?.requestId })
+      expect.objectContaining({ parentRootRequestId: parent?.rootRequestId })
     )
     expect(
       parent?.fetches.some(
@@ -139,7 +140,7 @@ describe('Request Insights Edge bridge', () => {
     expect(page?.fetches).toEqual([
       expect.objectContaining({ statusCode: 200 }),
     ])
-    expect(child?.parentRequestId).toBe(page?.requestId)
+    expect(child?.parentRootRequestId).toBe(page?.rootRequestId)
   })
 
   it('classifies successful Edge Server Actions without retaining action IDs', async () => {

--- a/test/development/app-dir/request-insights-edge-bridge/request-insights-edge-bridge.test.ts
+++ b/test/development/app-dir/request-insights-edge-bridge/request-insights-edge-bridge.test.ts
@@ -20,7 +20,11 @@ type RequestInsight = {
   }>
 }
 
-describe('Request Insights Edge bridge', () => {
+const describeEdgeBridge = process.env.__NEXT_CACHE_COMPONENTS
+  ? describe.skip
+  : describe
+
+describeEdgeBridge('Request Insights Edge bridge', () => {
   const { next } = nextTestSetup({ files: __dirname })
 
   async function snapshot(): Promise<RequestInsight[]> {

--- a/test/development/app-dir/request-insights-edge-bridge/request-insights-edge-bridge.test.ts
+++ b/test/development/app-dir/request-insights-edge-bridge/request-insights-edge-bridge.test.ts
@@ -1,0 +1,263 @@
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+type RequestInsight = {
+  requestId: string
+  parentRequestId?: string
+  parentFetchIndex?: number
+  url?: string
+  source?: string
+  routerActivity?: string
+  serverAction?: true
+  fetches: Array<{
+    index?: number
+    method: string
+    statusCode?: number
+    url: string
+  }>
+}
+
+describe('Request Insights Edge bridge', () => {
+  const { next } = nextTestSetup({ files: __dirname })
+
+  async function snapshot(): Promise<RequestInsight[]> {
+    return next
+      .fetch('/_next/development/request-insights')
+      .then((response) => response.json())
+      .then((value) => value.requests)
+  }
+
+  async function captureNewRequests(run: () => Promise<unknown>) {
+    const previous = new Set(
+      (await snapshot()).map((request) => request.requestId)
+    )
+    await run()
+    let requests: RequestInsight[] = []
+    await retry(async () => {
+      requests = (await snapshot()).filter(
+        (request) => !previous.has(request.requestId)
+      )
+      expect(requests.length).toBeGreaterThan(0)
+    })
+    return requests
+  }
+
+  it('records and causally links same-origin Edge route fetches', async () => {
+    const requests = await captureNewRequests(async () => {
+      const response = await next.fetch('/api/edge-causal/one')
+      expect(await response.json()).toEqual({
+        causalCookieVisible: false,
+        step: 'two',
+      })
+    })
+    const parent = requests.find(
+      (request) => request.url === '/api/edge-causal/one'
+    )
+    const child = requests.find(
+      (request) => request.url === '/api/edge-causal/two'
+    )
+
+    expect(parent).toEqual(expect.objectContaining({ source: 'app-route' }))
+    expect(child).toEqual(
+      expect.objectContaining({ parentRequestId: parent?.requestId })
+    )
+    expect(
+      parent?.fetches.some(
+        (fetch) =>
+          fetch.url.includes('/api/edge-causal/two') &&
+          fetch.index === child?.parentFetchIndex
+      )
+    ).toBe(true)
+  })
+
+  it('preserves an Edge streaming POST body and records the child request', async () => {
+    const requests = await captureNewRequests(async () => {
+      const response = await next.fetch('/api/edge-causal/one', {
+        method: 'POST',
+        body: 'streamed body',
+      })
+      expect(await response.json()).toEqual({
+        body: 'streamed body',
+        causalCookieVisible: false,
+        step: 'two',
+      })
+    })
+    const parent = requests.find(
+      (request) => request.url === '/api/edge-causal/one'
+    )
+    expect(parent?.fetches).toEqual([
+      expect.objectContaining({ method: 'POST', statusCode: 200 }),
+    ])
+  })
+
+  it('records failed external Edge fetches without forwarding reserved cookies', async () => {
+    const receivedCookies: Array<string | undefined> = []
+    const server = createServer((request, response) => {
+      receivedCookies.push(request.headers.cookie)
+      request.socket.destroy()
+      response.destroy()
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address() as AddressInfo
+      const target = `http://127.0.0.1:${address.port}/abort`
+      const requests = await captureNewRequests(async () => {
+        const response = await next.fetch(
+          `/api/edge-causal/external?target=${encodeURIComponent(target)}`
+        )
+        expect(response.status).toBe(502)
+      })
+      const parent = requests.find((request) =>
+        request.url?.startsWith('/api/edge-causal/external')
+      )
+      expect(parent?.fetches).toEqual([
+        expect.objectContaining({ url: target }),
+      ])
+      expect(parent?.fetches[0].statusCode).toBeUndefined()
+      expect(receivedCookies).toEqual(['user=value'])
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  it('records Edge middleware fetches on the page request', async () => {
+    const requests = await captureNewRequests(async () => {
+      const response = await next.fetch('/edge-proxy')
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('proxy-fetch-status">200')
+    })
+    const page = requests.find(
+      (request) => request.url === '/edge-proxy' && request.fetches.length > 0
+    )
+    const child = requests.find(
+      (request) => request.url === '/api/edge-causal/proxy'
+    )
+
+    expect(page?.fetches).toEqual([
+      expect.objectContaining({ statusCode: 200 }),
+    ])
+    expect(child?.parentRequestId).toBe(page?.requestId)
+  })
+
+  it('classifies successful Edge Server Actions without retaining action IDs', async () => {
+    const previous = new Set(
+      (await snapshot()).map((request) => request.requestId)
+    )
+    const actionIds: string[] = []
+    const browser = await next.browser('/edge-action', {
+      beforePageLoad(page) {
+        page.route('**/edge-action**', async (route) => {
+          const actionId = (await route.request().allHeaders())['next-action']
+          if (actionId) actionIds.push(actionId)
+          await route.continue()
+        })
+      },
+    })
+    await browser.elementByCss('#run-edge-action').click()
+    await retry(async () => {
+      expect(await browser.eval(() => document.cookie)).toContain(
+        'edge-action=complete'
+      )
+    })
+
+    await retry(async () => {
+      const requests = (await snapshot()).filter(
+        (request) => !previous.has(request.requestId)
+      )
+      expect(
+        requests.find(
+          (request) =>
+            request.url === '/edge-action' && request.serverAction === true
+        )
+      ).toBeDefined()
+      expect(actionIds).toHaveLength(1)
+      expect(JSON.stringify(requests)).not.toContain(actionIds[0])
+      expect(JSON.stringify(requests)).not.toContain('next-action')
+    })
+  })
+
+  it('does not classify a forged action header on an Edge App Route', async () => {
+    const forgedActionId = '00'.repeat(21)
+    const requests = await captureNewRequests(async () => {
+      const response = await next.fetch('/api/edge-causal/two', {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/plain',
+          'next-action': forgedActionId,
+        },
+        body: 'forged action',
+      })
+      expect(response.status).toBe(200)
+    })
+    const request = requests.find(
+      (candidate) => candidate.url === '/api/edge-causal/two'
+    )
+
+    expect(request).toEqual(expect.objectContaining({ source: 'app-route' }))
+    expect(request?.serverAction).toBeUndefined()
+    expect(JSON.stringify(request)).not.toContain(forgedActionId)
+  })
+
+  it('does not classify an unknown action on an Edge App Page', async () => {
+    const forgedActionId = '00'.repeat(21)
+    const requests = await captureNewRequests(async () => {
+      const response = await next.fetch('/edge-action', {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/plain',
+          'next-action': forgedActionId,
+        },
+        body: '[]',
+      })
+      expect(response.ok).toBe(false)
+    })
+    const request = requests.find(
+      (candidate) => candidate.url === '/edge-action'
+    )
+
+    expect(request).toBeDefined()
+    expect(request?.serverAction).toBeUndefined()
+    expect(JSON.stringify(request)).not.toContain(forgedActionId)
+  })
+
+  it('classifies Edge RSC refresh activity', async () => {
+    let rscHeaders: Record<string, string> | undefined
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        page.on('request', async (request) => {
+          if (request.url().includes('/edge-rsc')) {
+            rscHeaders = await request.allHeaders()
+          }
+        })
+      },
+    })
+    await browser.elementByCss('#edge-rsc-link').click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/edge-rsc')
+      expect(rscHeaders).toBeDefined()
+    }, 15_000)
+
+    const requests = await captureNewRequests(async () => {
+      const response = await next.fetch('/edge-rsc', {
+        headers: {
+          rsc: '1',
+          'next-hmr-refresh': '1',
+          'next-router-state-tree': rscHeaders!['next-router-state-tree'],
+          'next-url': rscHeaders!['next-url'],
+        },
+      })
+      expect(response.status).toBe(200)
+    })
+
+    expect(
+      requests.find(
+        (request) =>
+          request.url?.startsWith('/edge-rsc') &&
+          request.routerActivity === 'hmr-refresh'
+      )
+    ).toBeDefined()
+  })
+})

--- a/test/development/app-dir/request-insights/app/api/cache-causal/[key]/route.ts
+++ b/test/development/app-dir/request-insights/app/api/cache-causal/[key]/route.ts
@@ -1,0 +1,13 @@
+import { headers } from 'next/headers'
+
+export async function GET() {
+  const cookie = (await headers()).get('cookie')
+  const causalCookieVisible =
+    cookie
+      ?.split(';')
+      .some((part) =>
+        part.trim().startsWith('__next_request_insights_causal=')
+      ) ?? false
+
+  return Response.json({ causalCookieVisible })
+}

--- a/test/development/app-dir/request-insights/app/api/cache-causal/[key]/route.ts
+++ b/test/development/app-dir/request-insights/app/api/cache-causal/[key]/route.ts
@@ -1,13 +1,9 @@
-import { headers } from 'next/headers'
+const CAUSAL_COOKIE = '__next_request_insights_causal='
 
-export async function GET() {
-  const cookie = (await headers()).get('cookie')
-  const causalCookieVisible =
-    cookie
-      ?.split(';')
-      .some((part) =>
-        part.trim().startsWith('__next_request_insights_causal=')
-      ) ?? false
+export async function GET(request: Request) {
+  const causalCookieVisible = (request.headers.get('cookie') ?? '')
+    .split(';')
+    .some((cookie) => cookie.trim().startsWith(CAUSAL_COOKIE))
 
   return Response.json({ causalCookieVisible })
 }

--- a/test/development/app-dir/request-insights/app/api/causal/[step]/route.ts
+++ b/test/development/app-dir/request-insights/app/api/causal/[step]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+
+const CAUSAL_COOKIE = '__next_request_insights_causal='
+const dedupeRequestCounts = new Map<string, number>()
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ step: string }> }
+) {
+  const { step } = await params
+  if (step === 'redirect') {
+    const destination = new URL(request.url).searchParams.get('to')
+    return destination
+      ? NextResponse.redirect(destination)
+      : new Response(null, { status: 400 })
+  }
+
+  const causalCookieVisible = (request.headers.get('cookie') ?? '')
+    .split(';')
+    .some((cookie) => cookie.trim().startsWith(CAUSAL_COOKIE))
+
+  if (step === 'one') {
+    const dedupeKey = new URL(request.url).searchParams.get('dedupe')
+    const requestCount = dedupeKey
+      ? (dedupeRequestCounts.get(dedupeKey) ?? 0) + 1
+      : undefined
+    if (dedupeKey && requestCount !== undefined) {
+      dedupeRequestCounts.set(dedupeKey, requestCount)
+    }
+    const requestHeaders = await headers()
+    const target = new URL(
+      '/api/causal/two',
+      `${requestHeaders.get('x-forwarded-proto') ?? 'http'}://${requestHeaders.get('host')}`
+    )
+    const response = await fetch(target, {
+      cache: 'no-store',
+    })
+    return Response.json({
+      causalCookieVisible,
+      nested: await response.json(),
+      requestCount,
+    })
+  }
+
+  return Response.json({ causalCookieVisible, step })
+}

--- a/test/development/app-dir/request-insights/app/api/causal/[step]/route.ts
+++ b/test/development/app-dir/request-insights/app/api/causal/[step]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server'
-import { headers } from 'next/headers'
 
 const CAUSAL_COOKIE = '__next_request_insights_causal='
 const dedupeRequestCounts = new Map<string, number>()
@@ -28,11 +27,7 @@ export async function GET(
     if (dedupeKey && requestCount !== undefined) {
       dedupeRequestCounts.set(dedupeKey, requestCount)
     }
-    const requestHeaders = await headers()
-    const target = new URL(
-      '/api/causal/two',
-      `${requestHeaders.get('x-forwarded-proto') ?? 'http'}://${requestHeaders.get('host')}`
-    )
+    const target = new URL('/api/causal/two', request.url)
     const response = await fetch(target, {
       cache: 'no-store',
     })

--- a/test/development/app-dir/request-insights/app/api/proxy-causal/[source]/route.ts
+++ b/test/development/app-dir/request-insights/app/api/proxy-causal/[source]/route.ts
@@ -1,0 +1,17 @@
+import { headers } from 'next/headers'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ source: string }> }
+) {
+  const { source } = await params
+  const cookie = (await headers()).get('cookie')
+  const causalCookieVisible =
+    cookie
+      ?.split(';')
+      .some((part) =>
+        part.trim().startsWith('__next_request_insights_causal=')
+      ) ?? false
+
+  return Response.json({ causalCookieVisible, source })
+}

--- a/test/development/app-dir/request-insights/app/api/proxy-causal/[source]/route.ts
+++ b/test/development/app-dir/request-insights/app/api/proxy-causal/[source]/route.ts
@@ -1,17 +1,13 @@
-import { headers } from 'next/headers'
+const CAUSAL_COOKIE = '__next_request_insights_causal='
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ source: string }> }
 ) {
   const { source } = await params
-  const cookie = (await headers()).get('cookie')
-  const causalCookieVisible =
-    cookie
-      ?.split(';')
-      .some((part) =>
-        part.trim().startsWith('__next_request_insights_causal=')
-      ) ?? false
+  const causalCookieVisible = (request.headers.get('cookie') ?? '')
+    .split(';')
+    .some((cookie) => cookie.trim().startsWith(CAUSAL_COOKIE))
 
   return Response.json({ causalCookieVisible, source })
 }

--- a/test/development/app-dir/request-insights/app/cache-causal/page.tsx
+++ b/test/development/app-dir/request-insights/app/cache-causal/page.tsx
@@ -1,0 +1,37 @@
+export const instant = false
+
+async function fetchCachedChild(origin: string, key: string) {
+  'use cache'
+
+  const response = await fetch(
+    `${origin}/api/cache-causal/${encodeURIComponent(key)}`,
+    { cache: 'no-store' }
+  )
+  const payload = (await response.json()) as {
+    causalCookieVisible: boolean
+  }
+
+  return {
+    causalCookieVisible: payload.causalCookieVisible,
+    status: response.status,
+  }
+}
+
+export default async function CacheCausalPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ key?: string; origin?: string }>
+}) {
+  const { key = 'default', origin } = await searchParams
+  if (!origin) {
+    throw new Error('Expected the direct development server origin')
+  }
+  const result = await fetchCachedChild(origin, key)
+
+  return (
+    <>
+      <p>Cache child: {result.status}</p>
+      <p>Causal cookie visible: {String(result.causalCookieVisible)}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/app/causal/page.tsx
+++ b/test/development/app-dir/request-insights/app/causal/page.tsx
@@ -1,0 +1,69 @@
+import { headers } from 'next/headers'
+
+export const instant = false
+
+function getOrigin(requestHeaders: Headers): string {
+  const protocol = requestHeaders.get('x-forwarded-proto') ?? 'http'
+  return `${protocol}://${requestHeaders.get('host')}`
+}
+
+export default async function CausalPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    dedupe?: string
+    external?: string
+    redirect?: string
+    spoof?: string
+  }>
+}) {
+  const requestHeaders = await headers()
+  const origin = getOrigin(requestHeaders)
+  const query = await searchParams
+  const target = query.external
+    ? query.external
+    : query.redirect
+      ? `${origin}/api/causal/redirect?to=${encodeURIComponent(query.redirect)}`
+      : query.spoof
+        ? `${origin}/api/causal/two?spoof=1`
+        : `${origin}/api/causal/one${query.dedupe ? `?dedupe=${encodeURIComponent(query.dedupe)}` : ''}`
+  const responses = await Promise.all(
+    Array.from({ length: query.dedupe ? 2 : 1 }, () =>
+      fetch(target, {
+        cache: 'no-store',
+        headers: query.spoof
+          ? {
+              'x-forwarded-host': 'attacker.localhost:4444',
+              'x-forwarded-proto': 'https',
+            }
+          : undefined,
+      })
+    )
+  )
+  const bodies = await Promise.all(responses.map((response) => response.text()))
+  const requestCounts = query.dedupe
+    ? bodies.map((body) => JSON.parse(body).requestCount as number).join(',')
+    : undefined
+  const causalCookieVisible =
+    query.dedupe || query.spoof
+      ? bodies.some(
+          (body) =>
+            (JSON.parse(body) as { causalCookieVisible: boolean })
+              .causalCookieVisible
+        )
+      : undefined
+
+  return (
+    <p
+      id="causal-result"
+      data-request-counts={requestCounts}
+      data-causal-cookie-visible={
+        causalCookieVisible === undefined
+          ? undefined
+          : String(causalCookieVisible)
+      }
+    >
+      {JSON.stringify(bodies)}
+    </p>
+  )
+}

--- a/test/development/app-dir/request-insights/app/proxy-causal/page.tsx
+++ b/test/development/app-dir/request-insights/app/proxy-causal/page.tsx
@@ -1,0 +1,27 @@
+import { headers } from 'next/headers'
+import { connection } from 'next/server'
+
+export const instant = false
+
+export default async function ProxyCausalPage() {
+  await connection()
+  const requestHeaders = await headers()
+  const origin = requestHeaders.get('x-proxy-causal-origin')
+  if (!origin) {
+    throw new Error('Expected the proxy to provide its direct server origin')
+  }
+  const response = await fetch(new URL('/api/proxy-causal/page', origin), {
+    cache: 'no-store',
+  })
+  const payload = (await response.json()) as {
+    causalCookieVisible: boolean
+  }
+
+  return (
+    <>
+      <p>Proxy fetch: {requestHeaders.get('x-proxy-causal-status')}</p>
+      <p>Page fetch: {response.status}</p>
+      <p>Causal cookie visible: {String(payload.causalCookieVisible)}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/request-insights/pages/api/edge-response-lifecycle.ts
+++ b/test/development/app-dir/request-insights/pages/api/edge-response-lifecycle.ts
@@ -1,0 +1,25 @@
+export const config = { runtime: 'edge' }
+
+export default function handler() {
+  const encoder = new TextEncoder()
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('started\n'))
+        timer = setTimeout(() => {
+          controller.enqueue(encoder.encode('finished\n'))
+          controller.close()
+        }, 50)
+      },
+      cancel() {
+        if (timer) clearTimeout(timer)
+      },
+    }),
+    {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 203,
+    }
+  )
+}

--- a/test/development/app-dir/request-insights/pages/api/response-lifecycle.ts
+++ b/test/development/app-dir/request-insights/pages/api/response-lifecycle.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.on('error', () => {
+    // The fixture intentionally fails one response after headers are committed.
+  })
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.flushHeaders()
+  res.write('data: started\n\n')
+
+  const timer = setTimeout(() => {
+    if (req.query.outcome === 'error') {
+      res.destroy(new Error('intentional response stream failure'))
+      return
+    }
+
+    if (req.query.outcome !== 'abort') {
+      res.end('data: finished\n\n')
+    }
+  }, 50)
+
+  res.on('close', () => clearTimeout(timer))
+}

--- a/test/development/app-dir/request-insights/proxy.ts
+++ b/test/development/app-dir/request-insights/proxy.ts
@@ -8,9 +8,27 @@ export function proxy(request: NextRequest) {
     return NextResponse.rewrite(new URL('/behind-proxy', request.url))
   }
 
+  if (request.nextUrl.pathname === '/proxy-causal') {
+    return fetch(new URL('/api/proxy-causal/proxy', request.nextUrl.origin), {
+      cache: 'no-store',
+    }).then(async (response) => {
+      const payload = (await response.json()) as {
+        causalCookieVisible: boolean
+      }
+      if (payload.causalCookieVisible) {
+        throw new Error('The Request Insights causal cookie reached userland')
+      }
+
+      const requestHeaders = new Headers(request.headers)
+      requestHeaders.set('x-proxy-causal-origin', request.nextUrl.origin)
+      requestHeaders.set('x-proxy-causal-status', String(response.status))
+      return NextResponse.next({ request: { headers: requestHeaders } })
+    })
+  }
+
   return NextResponse.next()
 }
 
 export const config = {
-  matcher: ['/api/:path*', '/request-insights-asset.svg'],
+  matcher: ['/api/:path*', '/proxy-causal', '/request-insights-asset.svg'],
 }

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -1853,6 +1853,48 @@ describe('request insights', () => {
         request?.response?.trackingStartTime ?? Infinity
       )
     })
+
+    const browser = await next.browser('/instant-insights')
+    await openRequestInsightsPanel(browser)
+    await retry(async () => {
+      const selected = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        const row = Array.from(
+          root?.querySelectorAll<HTMLButtonElement>('.request-insights-row') ??
+            []
+        ).find((candidate) =>
+          candidate.textContent?.includes('/api/response-lifecycle')
+        )
+        row?.click()
+        return row !== undefined
+      })
+      expect(selected).toBe(true)
+    })
+    await retry(async () => {
+      const overviewLabels = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-overview > span') ?? []
+        ).map((item) => item.textContent?.trim())
+      })
+      expect(overviewLabels).toContain('Delivery finished')
+    })
+
+    await browser.elementByCss('.request-insights-filter-trigger').click()
+    await browser
+      .elementByCss(
+        '.request-insights-filter-item[data-filter-value="delivery:finished"]'
+      )
+      .click()
+    await retry(async () => {
+      const routes = await browser.eval(() => {
+        const root = document.querySelector('nextjs-portal')?.shadowRoot
+        return Array.from(
+          root?.querySelectorAll('.request-insights-route-label') ?? []
+        ).map((item) => item.textContent?.trim())
+      })
+      expect(routes).toContain('/api/response-lifecycle')
+    })
   })
 
   it('distinguishes a client disconnect from a late stream error', async () => {

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -10,6 +10,8 @@ import {
 type RequestInsight = {
   requestId: string
   rootRequestId?: string
+  parentRootRequestId?: string
+  parentFetchIndex?: number
   kind?: 'request' | 'instant-insights'
   source:
     | 'page'
@@ -45,6 +47,7 @@ type RequestInsight = {
     attributes?: Record<string, string | number | boolean>
   }>
   fetches: Array<{
+    index?: number
     durationMs: number
     statusCode: number
     cacheStatus: string
@@ -385,6 +388,183 @@ describe('request insights', () => {
           'AppRender.getBodyResult',
         ])
       )
+    })
+  })
+
+  it('links nested same-origin server fetches without merging their requests', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const response = await next.fetch('/causal?dedupe=nested-chain')
+    expect(response.status).toBe(200)
+    const responseBody = await response.text()
+    expect(responseBody).toContain('data-request-counts="1,1"')
+    expect(responseBody).toContain('data-causal-cookie-visible="false"')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const requests = snapshot.requests.filter(
+        (request) =>
+          !existingRequestIds.has(request.requestId) &&
+          request.kind !== 'instant-insights'
+      )
+      const page = requests.find((request) => request.route === '/causal')
+      const first = requests.find(
+        (request) =>
+          request.route === '/api/causal/[step]' &&
+          request.url?.startsWith('/api/causal/one')
+      )
+      const second = requests.find(
+        (request) =>
+          request.route === '/api/causal/[step]' &&
+          request.url?.startsWith('/api/causal/two')
+      )
+
+      expect(page).toBeDefined()
+      expect(first).toEqual(
+        expect.objectContaining({ parentRootRequestId: page?.rootRequestId })
+      )
+      expect(second).toEqual(
+        expect.objectContaining({ parentRootRequestId: first?.rootRequestId })
+      )
+      expect(first?.requestId).not.toBe(second?.requestId)
+      expect(
+        page?.fetches.some(
+          (fetch) =>
+            fetch.url.includes('/api/causal/one') &&
+            fetch.index === first?.parentFetchIndex
+        )
+      ).toBe(true)
+      expect(
+        first?.fetches.some(
+          (fetch) =>
+            fetch.url.includes('/api/causal/two') &&
+            fetch.index === second?.parentFetchIndex
+        )
+      ).toBe(true)
+    })
+  })
+
+  it('ignores spoofed forwarded headers when matching the router-owned origin', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const response = await next.fetch('/causal?spoof=1')
+    expect(await response.text()).toContain(
+      'data-causal-cookie-visible="false"'
+    )
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const requests = snapshot.requests.filter(
+        (request) => !existingRequestIds.has(request.requestId)
+      )
+      const page = requests.find((request) => request.route === '/causal')
+      const child = requests.find(
+        (request) =>
+          request.route === '/api/causal/[step]' &&
+          request.url?.startsWith('/api/causal/two')
+      )
+
+      expect(page).toBeDefined()
+      expect(child).toEqual(
+        expect.objectContaining({ parentRootRequestId: page?.rootRequestId })
+      )
+    })
+  })
+
+  it('does not propagate causality to an external fetch or redirect', async () => {
+    const receivedCookies: Array<string | undefined> = []
+    const server = createServer((request, response) => {
+      receivedCookies.push(request.headers.cookie)
+      response.statusCode = 200
+      response.end('external')
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address() as AddressInfo
+      const externalUrl = `http://127.0.0.1:${address.port}/external`
+
+      expect(
+        await next
+          .fetch(`/causal?external=${encodeURIComponent(externalUrl)}`)
+          .then((response) => response.text())
+      ).toContain('external')
+      expect(
+        await next
+          .fetch(`/causal?redirect=${encodeURIComponent(externalUrl)}`)
+          .then((response) => response.text())
+      ).toContain('external')
+
+      expect(receivedCookies).toHaveLength(2)
+      for (const cookie of receivedCookies) {
+        expect(cookie ?? '').not.toContain('__next_request_insights_causal')
+      }
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
+  it('strips forged causal cookies without creating a relationship', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((insightsResponse) => insightsResponse.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const forgedToken = 'A'.repeat(32)
+    const response = await next.fetch('/api/causal/two?forged=1', {
+      headers: {
+        cookie: `user=value; __next_request_insights_causal=${forgedToken}`,
+      },
+    })
+    expect(await response.json()).toEqual({
+      causalCookieVisible: false,
+      step: 'two',
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const forgedRequest = snapshot.requests.find(
+        (request) =>
+          request.route === '/api/causal/[step]' &&
+          !existingRequestIds.has(request.requestId)
+      )
+      expect(forgedRequest).toBeDefined()
+      expect(forgedRequest?.parentRootRequestId).toBeUndefined()
+      expect(forgedRequest?.parentFetchIndex).toBeUndefined()
     })
   })
 
@@ -1870,6 +2050,31 @@ describe('request insights', () => {
       expect(forgedRequest?.serverAction).toBeUndefined()
       expect(JSON.stringify(forgedRequest)).not.toContain(forgedActionId)
     })
+  })
+
+  it('does not reserve the causal cookie when Request Insights is disabled', async () => {
+    await next.patchFile(
+      'next.config.js',
+      (content) =>
+        content.replace('requestInsights: true', 'requestInsights: false'),
+      async () => {
+        await retry(async () => {
+          expect(
+            (await next.fetch('/_next/development/request-insights')).status
+          ).toBe(404)
+        })
+
+        const response = await next.fetch('/api/causal/two', {
+          headers: {
+            cookie: '__next_request_insights_causal=user-value; user=value',
+          },
+        })
+        expect(await response.json()).toEqual({
+          causalCookieVisible: true,
+          step: 'two',
+        })
+      }
+    )
   })
 
   it('queries complete logical request groups from the CLI in human and JSON output', async () => {

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { createServer } from 'http'
+import { createServer, request as httpRequest } from 'http'
 import type { AddressInfo } from 'net'
 import {
   retry,
@@ -27,7 +27,14 @@ type RequestInsight = {
   route: string
   url?: string
   startTime: number
-  status: 'ok'
+  status: 'ok' | 'error' | 'aborted' | 'pending'
+  response?: {
+    trackingStartTime: number
+    endTime?: number
+    statusCode?: number
+    outcome: 'pending' | 'finished' | 'aborted' | 'errored'
+    error?: { type?: string }
+  }
   spans: Array<{
     name?: string
     spanId?: string
@@ -362,6 +369,12 @@ describe('request insights', () => {
       )
 
       expect(requestsWithRelevantSpans).toHaveLength(1)
+      expect(requestsWithRelevantSpans[0].response).toEqual(
+        expect.objectContaining({
+          statusCode: 200,
+          outcome: 'finished',
+        })
+      )
       expect(
         requestsWithRelevantSpans[0].spans.map(
           (span) => span.attributes?.['next.span_type']
@@ -1559,6 +1572,10 @@ describe('request insights', () => {
           expect.objectContaining({
             source: 'app-route',
             proxyStatus: 'matched',
+            status: 'pending',
+            response: expect.objectContaining({
+              outcome: 'pending',
+            }),
           })
         )
       })
@@ -1591,6 +1608,15 @@ describe('request insights', () => {
       )
 
       expect(matchingRequests).toHaveLength(1)
+      expect(matchingRequests[0]).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          response: expect.objectContaining({
+            statusCode: 202,
+            outcome: 'finished',
+          }),
+        })
+      )
       expect(
         matchingRequests[0].spans.map(
           (span) => span.attributes?.['next.span_type']
@@ -1601,6 +1627,154 @@ describe('request insights', () => {
           'BaseServer.handleRequest',
           'AppRouteRouteHandlers.runHandler',
         ])
+      )
+    })
+  })
+
+  it('tracks a streamed Pages API response through delivery completion', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+
+    const response = await next.fetch('/api/response-lifecycle')
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('data: finished')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/api/response-lifecycle' &&
+          !existingRequestIds.has(candidate.requestId)
+      )
+
+      expect(request).toEqual(
+        expect.objectContaining({
+          source: 'pages-api',
+          status: 'ok',
+          response: expect.objectContaining({
+            statusCode: 200,
+            outcome: 'finished',
+          }),
+        })
+      )
+      expect(request?.response?.endTime).toEqual(expect.any(Number))
+      expect(request?.response?.endTime).toBeGreaterThanOrEqual(
+        request?.response?.trackingStartTime ?? Infinity
+      )
+    })
+  })
+
+  it('distinguishes a client disconnect from a late stream error', async () => {
+    const requestIdsBeforeAbort = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    await new Promise<void>((resolve, reject) => {
+      const clientRequest = httpRequest(
+        new URL('/api/response-lifecycle?outcome=abort', next.url),
+        (response) => {
+          response.once('data', () => {
+            response.destroy()
+            resolve()
+          })
+        }
+      )
+      clientRequest.once('error', reject)
+      clientRequest.end()
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/api/response-lifecycle?query=redacted' &&
+          !requestIdsBeforeAbort.has(candidate.requestId)
+      )
+
+      expect(request).toEqual(
+        expect.objectContaining({
+          status: 'aborted',
+          response: expect.objectContaining({
+            statusCode: 200,
+            outcome: 'aborted',
+            error: { type: 'ResponseAborted' },
+          }),
+        })
+      )
+    })
+
+    const requestIdsBeforeError = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    await new Promise<void>((resolve, reject) => {
+      let responseStarted = false
+      const clientRequest = httpRequest(
+        new URL('/api/response-lifecycle?outcome=error', next.url),
+        (response) => {
+          responseStarted = true
+          response.once('aborted', resolve)
+          response.once('close', resolve)
+          response.once('error', resolve)
+          response.resume()
+        }
+      )
+      clientRequest.once('error', (error) => {
+        if (responseStarted) {
+          resolve()
+        } else {
+          reject(error)
+        }
+      })
+      clientRequest.end()
+    })
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/api/response-lifecycle?query=redacted' &&
+          !requestIdsBeforeError.has(candidate.requestId)
+      )
+
+      expect(request).toEqual(
+        expect.objectContaining({
+          status: 'error',
+          response: expect.objectContaining({
+            statusCode: 200,
+            outcome: 'errored',
+            error: { type: 'Error' },
+          }),
+        })
       )
     })
   })

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -98,6 +98,45 @@ describe('request insights', () => {
     })
   }
 
+  async function createReverseProxy() {
+    const upstreamOrigin = new URL(next.url)
+    const server = createServer((request, response) => {
+      const upstreamRequest = httpRequest(
+        new URL(request.url ?? '/', upstreamOrigin),
+        {
+          method: request.method,
+          headers: {
+            ...request.headers,
+            host: upstreamOrigin.host,
+          },
+        },
+        (upstreamResponse) => {
+          response.writeHead(
+            upstreamResponse.statusCode ?? 500,
+            upstreamResponse.headers
+          )
+          upstreamResponse.pipe(response)
+        }
+      )
+      upstreamRequest.once('error', (error) => response.destroy(error))
+      request.pipe(upstreamRequest)
+    })
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address() as AddressInfo
+
+    return {
+      origin: `http://127.0.0.1:${address.port}`,
+      async close() {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()))
+        })
+      },
+    }
+  }
+
   async function patchRequestInsightsConfig(patch: {
     showInternal?: boolean
     verbose?: boolean
@@ -453,6 +492,147 @@ describe('request insights', () => {
             fetch.index === second?.parentFetchIndex
         )
       ).toBe(true)
+    })
+  })
+
+  it('links a Cache Component child request through the direct server behind a proxy', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const key = `request-${Date.now()}`
+    const childPath = `/api/cache-causal/${key}`
+    const reverseProxy = await createReverseProxy()
+    const directServerOrigin = new URL(next.url)
+    directServerOrigin.hostname =
+      directServerOrigin.hostname === 'localhost' ? '127.0.0.1' : 'localhost'
+
+    try {
+      const response = await fetch(
+        `${reverseProxy.origin}/cache-causal?key=${encodeURIComponent(key)}&origin=${encodeURIComponent(directServerOrigin.origin)}`
+      )
+      const body = await response.text()
+      expect(body).toContain('Cache child: <!-- -->200')
+      expect(body).toContain('Causal cookie visible: <!-- -->false')
+
+      await retry(async () => {
+        const snapshot = (await next
+          .fetch('/_next/development/request-insights')
+          .then((insightsResponse) => insightsResponse.json())) as {
+          requests: RequestInsight[]
+        }
+        const parent = snapshot.requests
+          .filter(
+            (request) =>
+              request.route === '/cache-causal' &&
+              request.kind !== 'instant-insights' &&
+              request.parentRootRequestId === undefined &&
+              !existingRequestIds.has(request.requestId)
+          )
+          .at(-1)
+        const parentRootRequestId = parent?.rootRequestId ?? parent?.requestId
+        const child = snapshot.requests.find(
+          (request) =>
+            request.route === '/api/cache-causal/[key]' &&
+            request.url?.includes(childPath) &&
+            request.parentRootRequestId === parentRootRequestId
+        )
+        const parentFetch = snapshot.requests
+          .filter(
+            (request) =>
+              (request.rootRequestId ?? request.requestId) ===
+              parentRootRequestId
+          )
+          .flatMap((request) => request.fetches)
+          .find(
+            (fetchMetric) =>
+              fetchMetric.url.includes(childPath) &&
+              fetchMetric.index === child?.parentFetchIndex
+          )
+
+        expect(parent).toBeDefined()
+        expect(child).toBeDefined()
+        expect(parentFetch).toBeDefined()
+        expect(child?.parentFetchIndex).toBe(parentFetch?.index)
+      })
+    } finally {
+      await reverseProxy.close()
+    }
+  })
+
+  it('links proxy and App Render fetches with one index sequence', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const response = await next.fetch('/proxy-causal')
+    const body = await response.text()
+    expect(body).toContain('Proxy fetch: <!-- -->200')
+    expect(body).toContain('Page fetch: <!-- -->200')
+    expect(body).toContain('Causal cookie visible: <!-- -->false')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const parent = snapshot.requests
+        .filter(
+          (request) =>
+            request.route === '/proxy-causal' &&
+            request.kind !== 'instant-insights' &&
+            request.parentRootRequestId === undefined &&
+            !existingRequestIds.has(request.requestId)
+        )
+        .at(-1)
+      const parentRootRequestId = parent?.rootRequestId ?? parent?.requestId
+      const proxyFetch = parent?.fetches.find((fetchMetric) =>
+        fetchMetric.url.includes('/api/proxy-causal/proxy')
+      )
+      const pageFetch = parent?.fetches.find((fetchMetric) =>
+        fetchMetric.url.includes('/api/proxy-causal/page')
+      )
+      const children = snapshot.requests.filter(
+        (request) =>
+          request.route === '/api/proxy-causal/[source]' &&
+          request.parentRootRequestId === parentRootRequestId
+      )
+      const proxyChild = children.find((request) =>
+        request.url?.includes('/api/proxy-causal/proxy')
+      )
+      const pageChild = children.find((request) =>
+        request.url?.includes('/api/proxy-causal/page')
+      )
+
+      expect(proxyFetch).toEqual(
+        expect.objectContaining({ index: 1, statusCode: 200 })
+      )
+      expect(pageFetch).toEqual(
+        expect.objectContaining({ index: 2, statusCode: 200 })
+      )
+      expect(proxyChild).toEqual(
+        expect.objectContaining({
+          parentFetchIndex: proxyFetch?.index,
+          parentRootRequestId,
+        })
+      )
+      expect(pageChild).toEqual(
+        expect.objectContaining({
+          parentFetchIndex: pageFetch?.index,
+          parentRootRequestId,
+        })
+      )
     })
   })
 
@@ -1807,6 +1987,46 @@ describe('request insights', () => {
           'BaseServer.handleRequest',
           'AppRouteRouteHandlers.runHandler',
         ])
+      )
+    })
+  })
+
+  it('records a delivered Edge API response', async () => {
+    const existingRequestIds = new Set(
+      (
+        (await next
+          .fetch('/_next/development/request-insights')
+          .then((response) => response.json())) as {
+          requests: RequestInsight[]
+        }
+      ).requests.map((request) => request.requestId)
+    )
+    const responsePromise = next.fetch('/api/edge-response-lifecycle')
+    const response = await responsePromise
+    expect(response.status).toBe(203)
+    expect(await response.text()).toContain('finished')
+
+    await retry(async () => {
+      const snapshot = (await next
+        .fetch('/_next/development/request-insights')
+        .then((insightsResponse) => insightsResponse.json())) as {
+        requests: RequestInsight[]
+      }
+      const request = snapshot.requests.find(
+        (candidate) =>
+          candidate.url === '/api/edge-response-lifecycle' &&
+          !existingRequestIds.has(candidate.requestId)
+      )
+
+      expect(request).toEqual(
+        expect.objectContaining({
+          source: 'pages-api',
+          status: 'ok',
+          response: expect.objectContaining({
+            statusCode: 203,
+            outcome: 'finished',
+          }),
+        })
       )
     })
   })

--- a/test/unit/request-insights-production-dce/index.test.ts
+++ b/test/unit/request-insights-production-dce/index.test.ts
@@ -103,6 +103,12 @@ describe('Request Insights production module graph', () => {
           nextPackageDir,
           'src/server/route-modules/app-route/module.ts'
         )
+      ).mtimeMs,
+      statSync(
+        path.join(
+          nextPackageDir,
+          'src/server/lib/trace/request-insights-response.ts'
+        )
       ).mtimeMs
     )
     const runtimeArtifacts = readdirSync(productionRuntimeDir)
@@ -128,6 +134,7 @@ describe('Request Insights production module graph', () => {
 
       const contents = readFileSync(artifactPath, 'utf8')
       expect(contents).not.toContain('request-insights-runtime')
+      expect(contents).not.toContain('request-insights-response')
       expect(contents).not.toContain('@next/request-insights-runtime-storage')
     }
   })


### PR DESCRIPTION
## Summary

This PR completes Request Insights lifecycle, causality, Edge-runtime, and cross-bundle correctness on top of the bounded per-server controller.

- `Record Request Insights response delivery lifecycle`
  - records response start, active streaming, completion, abort, committed status, and late delivery errors
  - handles Node and Web response paths with one-shot terminal transitions
- `Link same-origin Request Insights causality`
  - issues bounded opaque single-use capabilities for same-origin server work
  - validates origin, method, expiry, and ownership before linking
  - keeps causal children as distinct request roots rather than creating an infinitely nested request list
- `Bridge Request Insights into the Edge sandbox`
  - carries the host controller and validated request identity into Edge execution
  - keeps Node and Edge work under the same retention, lifecycle, and causality semantics
- `Harden Request Insights lifecycle integration`
  - covers double-write, close/error races, aborted streams, committed errors, and cleanup ordering
  - preserves framework response behavior while making lifecycle publication deterministic
- `Stabilize nested causality coverage`
  - uses bounded same-origin fixtures and deterministic capability consumption
  - rejects replay, cross-origin, malformed, expired, and forged causal tokens
- `Expose Request Insights response delivery state`
  - adds Active/streaming, Finished, Aborted, Errored, and Unknown delivery filters and overview badges
  - keeps selection stable as an active response transitions to a terminal state
- `Harden Request Insights lifecycle and causality`
  - propagates exact server-owned identity through App Render, Router Server, BaseServer, NextServer, fetch patching, unstable cache, Proxy, Pages, and Edge paths
  - reads sanitized Route Handler test headers directly so webpack fixtures do not depend on ambient async request storage
  - treats non-standard request-ID headers as bounded dev-only hints, never trusted storage keys
- `Deduplicate cross-bundle Request Insights fetches`
  - shares fetch-index ownership through `Symbol.for('@next/request-insights-fetch-index-setter')`
  - avoids cross-bundle `instanceof` assumptions when separate `LocalRecordingSpan` constructors exist
  - proves one foreground fetch and one Instant fetch produce exactly one record each
  - stores the exact Instant identity on the cloned WorkStore so foreground and validation allocators cannot mix
- `Fix Request Insights CI regressions`
  - keeps strict test fixtures aligned with the final identity and timestamp contracts
  - skips the Edge-only bridge suite under Cache Components, which intentionally requires the Node.js runtime, while retaining normal Turbopack and Webpack Edge coverage
- `Keep Request Insights out of production traces`
  - loads the MCP Request Insights tool only inside the compile-time development branch
  - restores the existing standalone NFT snapshot instead of accepting DevTools code in production output
- `Handle unknown Request Insights values`
  - maps future or version-skewed request sources to the existing Unknown presentation
  - maps future response outcomes to the bounded Unknown delivery filter instead of returning an undefined UI model
- `Guard Request Insights identity loading`
  - places identity, WorkStore, and controller imports inside an explicit compile-time dev-server branch
  - preserves production dead-code elimination while retaining the same development identity precedence

Deliberate boundary: this does not add a public Server Action OTel span, retain raw action IDs, add per-component React-private RSC timings, or introduce per-use cache ownership UI.

## Verification

- focused lifecycle, stream, sandbox, and Instant suites: 28/28 tests
- controller ownership: 4/4 tests
- Request Insights development suite: 51/51 in Turbopack and 51/51 in Webpack
- Edge bridge: 8/8 in Turbopack and 8/8 in Webpack
- route preparation: 4/4 in Turbopack and 4/4 in Webpack
- `pnpm build-all`: 18/18 at the unchanged final tree
- exact layer head passes `pnpm --filter=next types`
- Cache Components correctly skips the unsupported Edge-runtime bridge matrix rather than producing fixture 500s
- production standalone NFT coverage retains its original snapshot; Request Insights DevTools code is eliminated
- changed-file Prettier, ESLint, `git diff --check`, authorship, subject-only commit message, forbidden-attribution, production-DCE, public-OTel, and 50-commit linear-history audits pass
- exact CI type/precompiled reproduction passes after moving package-internal tests to their owning package
- focused package-boundary, production-DCE, version-skew, rejected-chunk, and identity hardening coverage passes 47/47
- the previously frozen Fable 5 review returned `SHIP` with zero blockers; its concrete current-tree findings are fixed and a new exact-head review will run after GitHub CI is green
