### PR TITLE
[PPF] unstable_navigation()

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1475,5 +1475,12 @@
   "1474": "Invariant: cannot write an empty buffer to the image cache",
   "1475": "Invariant: no direct app page entry found for %s",
   "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled.",
-  "1477": "unstable_navigation() is not implemented yet."
+  "1477": "unstable_navigation() is not implemented yet.",
+  "1478": "`unstable_navigation` must not be used within a Client Component. Next.js should be preventing `unstable_navigation` from being included in Client Components statically, but did not in this case.",
+  "1479": "Route %s used \\`unstable_navigation()\\` inside a function cached with \\`unstable_cache()\\`. The \\`unstable_navigation()\\` function is used to indicate the subsequent code must only run during an actual navigation, but \\`unstable_cache()\\` caches must be able to be produced before a navigation, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
+  "1480": "Route %s used \\`unstable_navigation()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without a navigation. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
+  "1481": "Route %s used \\`unstable_navigation()\\`, which requires Cache Components to be enabled. Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents",
+  "1482": "Route %s used \\`unstable_navigation()\\` inside \\`after()\\` while rendering. The \\`unstable_navigation()\\` function is used to indicate the subsequent code must only run during an actual navigation, but \\`after()\\` executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after",
+  "1483": "Route %s used \\`unstable_navigation()\\` inside \"use cache: private\". This is not currently supported. Instead, move the \"use cache\" directive to a function that's called below \\`await unstable_navigation()\\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+  "1484": "Route %s used \\`unstable_navigation()\\` inside \"use cache\". This is not currently supported. Instead, move the \"use cache\" directive to a function that's called below \\`await unstable_navigation()\\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache"
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1220,8 +1220,8 @@ async function spawnRuntimePrefetchWithFilledCaches(
     const staleTimeIterable = new StaleTimeIterable()
 
     // We want to be able to rewind the result to a session shell.
-    const mode: RuntimePrerenderMode = {
-      type: 'rewindable-session-shell',
+    const mode: RuntimePrerenderMode & { type: 'navigation' } = {
+      type: 'navigation',
       shellUsedSessionDataDeferred: createPromiseWithResolvers(),
       shellByteLengthDeferred: createPromiseWithResolvers(),
     }
@@ -1231,10 +1231,7 @@ async function spawnRuntimePrefetchWithFilledCaches(
       ctx,
       generateDynamicRSCPayload.bind(null, ctx, {
         staleTimeIterable,
-        shellByteLengthPromise:
-          mode.type === 'rewindable-session-shell'
-            ? mode.shellByteLengthDeferred.promise
-            : undefined,
+        shellByteLengthPromise: mode.shellByteLengthDeferred.promise,
         shellUsedSessionDataPromise: mode.shellUsedSessionDataDeferred.promise,
       }),
       prerenderResumeDataCache,
@@ -1338,6 +1335,7 @@ function getEnvironmentNameForStageWithoutCaches(stage: RenderStage) {
       return 'Prerender'
     case RenderStage.ShellRuntime:
     case RenderStage.Runtime:
+    case RenderStage.NavigationRuntime:
     case RenderStage.Dynamic:
     case RenderStage.Abandoned:
       return 'Server'
@@ -1824,6 +1822,11 @@ type RuntimePrerenderMode =
       shellUsedSessionDataDeferred: PromiseWithResolvers<boolean>
       shellByteLengthDeferred: PromiseWithResolvers<number | null>
     }
+  | {
+      type: 'navigation'
+      shellUsedSessionDataDeferred: PromiseWithResolvers<boolean>
+      shellByteLengthDeferred: PromiseWithResolvers<number | null>
+    }
 
 async function finalRuntimeServerPrerender(
   mode: RuntimePrerenderMode,
@@ -1849,6 +1852,18 @@ async function finalRuntimeServerPrerender(
     isDebugDynamicAccesses
   )
 
+  let finalStage: AdvanceableRenderStage
+  switch (mode.type) {
+    case 'session-shell-only':
+      finalStage = RenderStage.ShellRuntime
+      break
+    case 'rewindable-session-shell':
+      finalStage = RenderStage.Runtime
+      break
+    case 'navigation':
+      finalStage = RenderStage.NavigationRuntime
+      break
+  }
   const finalStageController = new StagedRenderingController({
     abortSignal: finalServerController.signal,
     abandonController: null,
@@ -1857,11 +1872,7 @@ async function finalRuntimeServerPrerender(
     // (or App Shell) is stricter and never allows sync IO in any stage
     // that we go through here (i.e. < Dynamic)
     syncIO: SyncIOMode.AllowedInDynamic,
-    // we only reach the runtime stage if we're doing a rewindable render
-    finalStage:
-      mode.type === 'session-shell-only'
-        ? RenderStage.ShellRuntime
-        : RenderStage.Runtime,
+    finalStage,
   })
 
   const varyParamsAccumulator = createResponseVaryParamsAccumulator()
@@ -1985,18 +1996,13 @@ async function finalRuntimeServerPrerender(
     () => {
       if (checkUnexpectedAbort()) return
 
-      if (mode.type === 'session-shell-only') {
-        // We're only rendering a shell, so we do not advance to stages where link data is resolved.
-        return
-      }
+      // We may not reach this stage depending on the mode.
+      if (finalStage < RenderStage.Runtime) return
+
       finalStageController.advanceStage(RenderStage.Runtime)
     },
     () => {
       if (checkUnexpectedAbort()) return
-
-      // Finish the accumulators. We need to wait for Flight to flush the result into the stream,
-      // which is scheduled in a (fast) immediate, so we do this in a separate task
-      // (fast immediates will be drained at the end of the task, so in the next task we know we're done flushing)
 
       // Check if session data unblocked new content in the shell.
       const didSessionDataUnblockNewContent =
@@ -2004,7 +2010,7 @@ async function finalRuntimeServerPrerender(
         stageByteLengths[RenderStage.Static]
       mode.shellUsedSessionDataDeferred.resolve(didSessionDataUnblockNewContent)
 
-      if (mode.type === 'rewindable-session-shell') {
+      if ('shellByteLengthDeferred' in mode) {
         // If advancing to the runtime stage didn't unblock new content,
         // then the result does not depend on link data and can be used as a shell (indicated via `null`).
         // Otherwise, send a byte length to indicate where the shell content ends.
@@ -2017,6 +2023,19 @@ async function finalRuntimeServerPrerender(
             : null
         )
       }
+    },
+    () => {
+      if (checkUnexpectedAbort()) return
+
+      // We may not reach this stage depending on the mode.
+      if (finalStage < RenderStage.NavigationRuntime) return
+
+      finalStageController.advanceStage(RenderStage.NavigationRuntime)
+    },
+    () => {
+      // Finish the accumulators. We need to wait for Flight to flush the result into the stream,
+      // which is scheduled in a (fast) immediate, so we do this in a separate task
+      // (fast immediates will be drained at the end of the task, so in the next task we know we're done flushing)
 
       staleTimeIterable.close()
       finishAccumulatingVaryParams(varyParamsAccumulator)
@@ -2025,8 +2044,10 @@ async function finalRuntimeServerPrerender(
       if (checkUnexpectedAbort()) return
 
       if (streamState.isPending) {
-        // If the prerender is still pending then it must depend on dynamic data
-        // (or, if this is a shell prefetch, link data)
+        // If the prerender is still pending then it must be blocked by
+        // - prefetch(), navigation(), or dynamic data (for shell prefetches)
+        // - navigation() or dynamic data (for runtime prefetches)
+        // - dynamic data (for runtime prefetch streams embedded in navigations)
         resultIsPartial = true
       }
 
@@ -5362,6 +5383,7 @@ function getEnvironmentNameForStage(stage: RenderStage) {
       return 'Prerender'
     case RenderStage.ShellRuntime:
     case RenderStage.Runtime:
+    case RenderStage.NavigationRuntime:
       return 'Prefetch'
     case RenderStage.Dynamic:
     case RenderStage.Abandoned:
@@ -5588,6 +5610,8 @@ async function streamStagedRenderInDev({
     () => checkCacheMissAndAdvance(RenderStage.Runtime),
     () => checkReveal(RenderStage.Runtime),
 
+    () => checkCacheMissAndAdvance(RenderStage.NavigationRuntime),
+
     () => {
       // Advance to the dynamic stage even while caches are still filling, so
       // dynamic content streams to the browser right away instead of being
@@ -5740,6 +5764,7 @@ async function renderWithWarmCachesForValidationInDev(
     () => stageController.advanceStage(RenderStage.Static),
     () => stageController.advanceStage(RenderStage.ShellRuntime),
     () => stageController.advanceStage(RenderStage.Runtime),
+    () => stageController.advanceStage(RenderStage.NavigationRuntime),
     () => stageController.advanceStage(RenderStage.Dynamic)
   )
 
@@ -5871,8 +5896,9 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
     () => stageController.advanceStage(RenderStage.Static),
     () => stageController.advanceStage(RenderStage.ShellRuntime),
     () => stageController.advanceStage(RenderStage.Runtime),
+    // NOTE: We don't need `NavigationRuntime`, because we set `needsAppShell: false`
+    // so `navigation()` resolves in the static stages.
     () => {
-      // Do not advance to the dynamic stage, abort instead.
       abortInRenderContext(requestStore, finalReactController)
     }
   )
@@ -7805,18 +7831,11 @@ async function renderWithRestartOnCacheMissInValidation(
       accumulatedChunksPromise.catch(() => {})
       return { accumulatedChunksPromise }
     },
-    () => {
-      advanceStageIfNoCacheMiss(RenderStage.Static)
-    },
-    () => {
-      advanceStageIfNoCacheMiss(RenderStage.ShellRuntime)
-    },
-    () => {
-      advanceStageIfNoCacheMiss(RenderStage.Runtime)
-    },
-    () => {
-      advanceStageIfNoCacheMiss(RenderStage.Dynamic)
-    }
+    () => advanceStageIfNoCacheMiss(RenderStage.Static),
+    () => advanceStageIfNoCacheMiss(RenderStage.ShellRuntime),
+    () => advanceStageIfNoCacheMiss(RenderStage.Runtime),
+    () => advanceStageIfNoCacheMiss(RenderStage.NavigationRuntime),
+    () => advanceStageIfNoCacheMiss(RenderStage.Dynamic)
   )
 
   if (initialStageController.currentStage !== RenderStage.Abandoned) {
@@ -7916,6 +7935,7 @@ async function renderWithRestartOnCacheMissInValidation(
     () => finalStageController.advanceStage(RenderStage.Static),
     () => finalStageController.advanceStage(RenderStage.ShellRuntime),
     () => finalStageController.advanceStage(RenderStage.Runtime),
+    () => finalStageController.advanceStage(RenderStage.NavigationRuntime),
     () => finalStageController.advanceStage(RenderStage.Dynamic)
   )
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6057,22 +6057,14 @@ async function stagedRenderWithCachesInDev({
   }
 }
 
-interface AccumulatedStreamChunks {
-  readonly shellStaticChunks: Array<Uint8Array>
-  readonly staticChunks: Array<Uint8Array>
-  readonly shellRuntimeChunks: Array<Uint8Array>
-  readonly runtimeChunks: Array<Uint8Array>
-  readonly dynamicChunks: Array<Uint8Array>
-}
+type AccumulatedStreamChunks = Record<AdvanceableRenderStage, Array<Uint8Array>>
 
 function createStageChunksAccumulator(): AccumulatedStreamChunks {
-  return {
-    shellStaticChunks: [],
-    staticChunks: [],
-    shellRuntimeChunks: [],
-    runtimeChunks: [],
-    dynamicChunks: [],
+  const result: Partial<AccumulatedStreamChunks> = {}
+  for (const stage of RENDER_STAGE_ADVANCE_ORDER) {
+    result[stage] = []
   }
+  return result as AccumulatedStreamChunks
 }
 
 async function accumulateStreamChunks(
@@ -6152,32 +6144,21 @@ async function accumulateStreamChunksInto(
 
 function collectStageChunk(
   accumulator: AccumulatedStreamChunks,
-  stage: RenderStage,
+  currentStage: RenderStage,
   value: Uint8Array
 ): void {
-  switch (stage) {
-    case RenderStage.Before:
-      throw new InvariantError('Unexpected stream chunk while in Before stage')
-    case RenderStage.ShellStatic:
-      accumulator.shellStaticChunks.push(value)
-    // fall through
-    case RenderStage.Static:
-      accumulator.staticChunks.push(value)
-    // fall through
-    case RenderStage.ShellRuntime:
-      accumulator.shellRuntimeChunks.push(value)
-    // fall through
-    case RenderStage.Runtime:
-      accumulator.runtimeChunks.push(value)
-    // fall through
-    case RenderStage.Dynamic:
-      accumulator.dynamicChunks.push(value)
+  if (currentStage === RenderStage.Before) {
+    throw new InvariantError('Unexpected stream chunk while in Before stage')
+  }
+  // Stage N+1 contains all the chunks of the stages 1..N,
+  // so add the chunk to the array for the current stage and all the stages that follow it.
+  // Starting at the end saves us from having to find the current stage in the order array.
+  for (let i = RENDER_STAGE_ADVANCE_ORDER.length - 1; i >= 0; i--) {
+    const stage = RENDER_STAGE_ADVANCE_ORDER[i]
+    if (stage < currentStage) {
       break
-    case RenderStage.Abandoned:
-      break
-    default:
-      stage satisfies never
-      break
+    }
+    accumulator[stage].push(value)
   }
 }
 
@@ -6717,8 +6698,7 @@ async function runValidationInDev(
   {
     // For warmup, we have to use the shared inputs if present -- the static inputs
     // may not have a proper dynamic stage.
-    const { runtimeChunks, dynamicChunks } = (instantInputs ?? staticInputs)
-      .accumulatedChunks
+    const { accumulatedChunks } = instantInputs ?? staticInputs
 
     // First we warmup SSR with the runtime chunks. This ensures that when we do
     // the full prerender pass with dynamic tracking module loading won't
@@ -6728,8 +6708,10 @@ async function runValidationInDev(
       // otherwise, for static shell validation, we only need to warm up to the runtime stage.
       // we also need to use a different store type, because instant validation allows more APIs to resolve.
       needsInstantValidation ? 'validation-client' : 'prerender-client',
-      needsInstantValidation ? dynamicChunks : runtimeChunks,
-      dynamicChunks,
+      needsInstantValidation
+        ? accumulatedChunks[RenderStage.Dynamic]
+        : accumulatedChunks[RenderStage.Runtime],
+      accumulatedChunks[RenderStage.Dynamic],
       rootParams,
       fallbackRouteParams,
       ctx,
@@ -6871,15 +6853,14 @@ async function validateStaticShell(
   const loaderTree = ComponentMod.routeModule.userland.loaderTree
 
   const { accumulatedChunks, stageEndTimes } = inputs
-  const { staticChunks, runtimeChunks, dynamicChunks } = accumulatedChunks
 
   const allowEmptyStaticShell =
     (renderOpts.allowEmptyStaticShell ?? false) ||
     (await isPageAllowedToBlock(loaderTree))
 
   const runtimeResult = await validateStagedShell(
-    runtimeChunks,
-    dynamicChunks,
+    accumulatedChunks[RenderStage.Runtime],
+    accumulatedChunks[RenderStage.Dynamic],
     debugChunks,
     stageEndTimes[RenderStage.Runtime],
     rootParams,
@@ -6903,8 +6884,8 @@ async function validateStaticShell(
   }
 
   const staticResult = await validateStagedShell(
-    staticChunks,
-    dynamicChunks,
+    accumulatedChunks[RenderStage.Static],
+    accumulatedChunks[RenderStage.Dynamic],
     debugChunks,
     stageEndTimes[RenderStage.Static],
     rootParams,
@@ -7328,12 +7309,7 @@ async function validateInstantConfigs(
     prefetchKind,
     ctx.componentMod,
     renderFlightStream,
-    {
-      [RenderStage.Static]: accumulatedChunks.staticChunks,
-      [RenderStage.ShellRuntime]: accumulatedChunks.shellRuntimeChunks,
-      [RenderStage.Runtime]: accumulatedChunks.runtimeChunks,
-      [RenderStage.Dynamic]: accumulatedChunks.dynamicChunks,
-    },
+    accumulatedChunks,
     debugChunks,
     startTime,
     stageEndTimes,
@@ -8334,8 +8310,8 @@ async function validateInstantConfigInBuildWithSample(
     const validationRenderCtx = toValidationRenderContext(validationCtx)
     await warmupClientModulesForStagedValidation(
       'validation-client',
-      accumulatedChunks.dynamicChunks,
-      accumulatedChunks.dynamicChunks,
+      accumulatedChunks[RenderStage.Dynamic],
+      accumulatedChunks[RenderStage.Dynamic],
       sampleRootParams,
       fallbackRouteParams,
       validationRenderCtx,
@@ -9218,8 +9194,8 @@ async function prerenderToStream(
           // NOTE: we must capture this *before* resolving staleTime/varyParams,
           // which always emit new static chunks.
           didLinkDataUnblockNewContent =
-            collectedChunksByStage.staticChunks.length >
-            collectedChunksByStage.shellStaticChunks.length
+            collectedChunksByStage[RenderStage.Static].length >
+            collectedChunksByStage[RenderStage.ShellStatic].length
 
           // Now that the prerendering is complete, we know the final stale
           // time and vary params. Close the stale time iterable and resolve
@@ -9237,7 +9213,7 @@ async function prerenderToStream(
 
           shellByteLengthDeferred.resolve(
             didLinkDataUnblockNewContent
-              ? collectedChunksByStage.shellStaticChunks.reduce(
+              ? collectedChunksByStage[RenderStage.ShellStatic].reduce(
                   (acc, chunk) => acc + chunk.byteLength,
                   0
                 )

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1178,9 +1178,9 @@ async function generateStagedDynamicFlightRenderResultNode(
 
       return dynamicStream
     },
-    () => {
-      stageController.advanceStage(RenderStage.Static)
-    },
+    () => stageController.advanceStage(RenderStage.PrefetchStatic),
+    () => stageController.advanceStage(RenderStage.NavigationStatic),
+    () => stageController.advanceStage(RenderStage.Static),
     () => {
       // This is a separate task that doesn't advance a stage. It forces
       // draining the immediate queue so that the stale time iterable and vary
@@ -1190,9 +1190,7 @@ async function generateStagedDynamicFlightRenderResultNode(
         finishAccumulatingVaryParams(requestStore.varyParamsAccumulator)
       }
     },
-    () => {
-      stageController.advanceStage(RenderStage.Dynamic)
-    }
+    () => stageController.advanceStage(RenderStage.Dynamic)
   )
 
   return new FlightRenderResult(flightStream, {
@@ -1318,12 +1316,10 @@ async function stagedRenderWithoutCachesInDevNode(
         }
       )
     },
-    () => {
-      stageController.advanceStage(RenderStage.Static)
-    },
-    () => {
-      stageController.advanceStage(RenderStage.Dynamic)
-    }
+    () => stageController.advanceStage(RenderStage.PrefetchStatic),
+    () => stageController.advanceStage(RenderStage.NavigationStatic),
+    () => stageController.advanceStage(RenderStage.Static),
+    () => stageController.advanceStage(RenderStage.Dynamic)
   )
 }
 
@@ -1331,6 +1327,8 @@ function getEnvironmentNameForStageWithoutCaches(stage: RenderStage) {
   switch (stage) {
     case RenderStage.Before:
     case RenderStage.ShellStatic:
+    case RenderStage.PrefetchStatic:
+    case RenderStage.NavigationStatic:
     case RenderStage.Static:
       return 'Prerender'
     case RenderStage.ShellRuntime:
@@ -1984,6 +1982,14 @@ async function finalRuntimeServerPrerender(
         collectChunk,
         streamState
       )
+    },
+    () => {
+      if (checkUnexpectedAbort()) return
+      finalStageController.advanceStage(RenderStage.PrefetchStatic)
+    },
+    () => {
+      if (checkUnexpectedAbort()) return
+      finalStageController.advanceStage(RenderStage.NavigationStatic)
     },
     () => {
       if (checkUnexpectedAbort()) return
@@ -3946,9 +3952,9 @@ async function renderToStream(
 
             return dynamicStream
           },
-          () => {
-            stageController.advanceStage(RenderStage.Static)
-          },
+          () => stageController.advanceStage(RenderStage.PrefetchStatic),
+          () => stageController.advanceStage(RenderStage.NavigationStatic),
+          () => stageController.advanceStage(RenderStage.Static),
           () => {
             // This is a separate task that doesn't advance a stage. It forces
             // draining the immediate queue so that the stale time iterable and vary
@@ -3958,9 +3964,7 @@ async function renderToStream(
               finishAccumulatingVaryParams(requestStore.varyParamsAccumulator)
             }
           },
-          () => {
-            stageController.advanceStage(RenderStage.Dynamic)
-          }
+          () => stageController.advanceStage(RenderStage.Dynamic)
         )
 
         reactServerResult = new ReactServerResult(flightStream)
@@ -5379,6 +5383,8 @@ function getEnvironmentNameForStage(stage: RenderStage) {
   switch (stage) {
     case RenderStage.Before:
     case RenderStage.ShellStatic:
+    case RenderStage.PrefetchStatic:
+    case RenderStage.NavigationStatic:
     case RenderStage.Static:
       return 'Prerender'
     case RenderStage.ShellRuntime:
@@ -5601,6 +5607,8 @@ async function streamStagedRenderInDev({
         ),
       })
     },
+    () => checkCacheMissAndAdvance(RenderStage.PrefetchStatic),
+    () => checkCacheMissAndAdvance(RenderStage.NavigationStatic),
     () => checkCacheMissAndAdvance(RenderStage.Static),
     () => checkReveal(RenderStage.Static),
 
@@ -5761,6 +5769,8 @@ async function renderWithWarmCachesForValidationInDev(
         validationAbortSignal
       )
     },
+    () => stageController.advanceStage(RenderStage.PrefetchStatic),
+    () => stageController.advanceStage(RenderStage.NavigationStatic),
     () => stageController.advanceStage(RenderStage.Static),
     () => stageController.advanceStage(RenderStage.ShellRuntime),
     () => stageController.advanceStage(RenderStage.Runtime),
@@ -5893,6 +5903,8 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
         collectChunk
       )
     },
+    () => stageController.advanceStage(RenderStage.PrefetchStatic),
+    () => stageController.advanceStage(RenderStage.NavigationStatic),
     () => stageController.advanceStage(RenderStage.Static),
     () => stageController.advanceStage(RenderStage.ShellRuntime),
     () => stageController.advanceStage(RenderStage.Runtime),
@@ -7831,6 +7843,8 @@ async function renderWithRestartOnCacheMissInValidation(
       accumulatedChunksPromise.catch(() => {})
       return { accumulatedChunksPromise }
     },
+    () => advanceStageIfNoCacheMiss(RenderStage.PrefetchStatic),
+    () => advanceStageIfNoCacheMiss(RenderStage.NavigationStatic),
     () => advanceStageIfNoCacheMiss(RenderStage.Static),
     () => advanceStageIfNoCacheMiss(RenderStage.ShellRuntime),
     () => advanceStageIfNoCacheMiss(RenderStage.Runtime),
@@ -7932,6 +7946,8 @@ async function renderWithRestartOnCacheMissInValidation(
         accumulatedChunksPromise,
       }
     },
+    () => finalStageController.advanceStage(RenderStage.PrefetchStatic),
+    () => finalStageController.advanceStage(RenderStage.NavigationStatic),
     () => finalStageController.advanceStage(RenderStage.Static),
     () => finalStageController.advanceStage(RenderStage.ShellRuntime),
     () => finalStageController.advanceStage(RenderStage.Runtime),
@@ -9153,7 +9169,6 @@ async function prerenderToStream(
       }
 
       let debugEndTime: number | undefined = undefined
-      let didLinkDataUnblockNewContent = false
 
       await runInSequentialTasks(
         async () => {
@@ -9208,6 +9223,14 @@ async function prerenderToStream(
         },
         () => {
           if (checkUnexpectedAbort()) return
+          finalStageController.advanceStage(RenderStage.PrefetchStatic)
+        },
+        () => {
+          if (checkUnexpectedAbort()) return
+          finalStageController.advanceStage(RenderStage.NavigationStatic)
+        },
+        () => {
+          if (checkUnexpectedAbort()) return
           finalStageController.advanceStage(RenderStage.Static)
         },
         () => {
@@ -9217,12 +9240,10 @@ async function prerenderToStream(
           // which is scheduled in a (fast) immediate, so we do this in a separate task
           // (fast immediates will be drained at the end of the task, so in the next task we know we're done flushing)
 
-          // If new chunks were emitted in the static stage
-          // (after unblocking link data, i.e. static params)
-          // then the prerender uses link data.
+          // Check if new chunks were emitted after unblocking link data or navigation().
           // NOTE: we must capture this *before* resolving staleTime/varyParams,
           // which always emit new static chunks.
-          didLinkDataUnblockNewContent =
+          const hasMoreContentThanShell =
             collectedChunksByStage[RenderStage.Static].length >
             collectedChunksByStage[RenderStage.ShellStatic].length
 
@@ -9241,7 +9262,7 @@ async function prerenderToStream(
           finishAccumulatingVaryParams(varyParamsAccumulator)
 
           shellByteLengthDeferred.resolve(
-            didLinkDataUnblockNewContent
+            hasMoreContentThanShell
               ? collectedChunksByStage[RenderStage.ShellStatic].reduce(
                   (acc, chunk) => acc + chunk.byteLength,
                   0

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -5,6 +5,7 @@ import type { PrefetchingMode } from './app-render'
 import type { NextConfigComplete, ValidationLevel } from '../config-shared'
 import type { ImageConfigComplete } from '../../shared/lib/image-config'
 import type { StageEndTimes } from './instant-validation/instant-validation'
+import type { AdvanceableRenderStage } from './staged-rendering'
 
 /**
  * Cross-module handoff for the dev validation worker (client-module warmup,
@@ -22,13 +23,10 @@ const SYMBOL: unique symbol = Symbol.for('next.dev.validationWorker')
  * Per-stage RSC chunks, the serializable form of `AccumulatedStreamChunks` that
  * the worker replays. No live streams cross the boundary.
  */
-export interface SerializedAccumulatedChunks {
-  shellStaticChunks: Uint8Array[]
-  staticChunks: Uint8Array[]
-  shellRuntimeChunks: Uint8Array[]
-  runtimeChunks: Uint8Array[]
-  dynamicChunks: Uint8Array[]
-}
+export type SerializedAccumulatedChunks = Record<
+  AdvanceableRenderStage,
+  Uint8Array[]
+>
 
 /**
  * Serializable view of one validation input (the shape `DevValidationInputs`

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -4,14 +4,14 @@ import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolv
 export enum RenderStage {
   Before = 1,
   //
-  ShellStatic = 11,
-  Static = 13,
+  ShellStatic = 10,
+  Static = 11,
   //
-  ShellRuntime = 21,
-  Runtime = 23,
+  ShellRuntime = 20,
+  Runtime = 21,
+  NavigationRuntime = 22,
   //
   Dynamic = 30,
-  //
   Abandoned = 40,
 }
 
@@ -26,6 +26,7 @@ export const RENDER_STAGE_ADVANCE_ORDER: AdvanceableRenderStage[] = [
   //
   RenderStage.ShellRuntime,
   RenderStage.Runtime,
+  RenderStage.NavigationRuntime,
   //
   RenderStage.Dynamic,
 ]

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -63,15 +63,8 @@ export class StagedRenderingController {
 
   syncInterruptReason: Error | null = null
 
-  triggers: Record<AdvanceableRenderStage, StageTrigger> = {
-    [RenderStage.ShellStatic]: createStageTrigger(),
-    [RenderStage.Static]: createStageTrigger(),
-    //
-    [RenderStage.ShellRuntime]: createStageTrigger(),
-    [RenderStage.Runtime]: createStageTrigger(),
-    //
-    [RenderStage.Dynamic]: createStageTrigger(),
-  }
+  triggers: Record<AdvanceableRenderStage, StageTrigger> =
+    createAdvanceableStageTriggers()
 
   constructor({
     abortSignal,
@@ -120,36 +113,29 @@ export class StagedRenderingController {
   }
 
   shouldTrackSyncInterrupt(): boolean {
-    if (this.syncIOMode === SyncIOMode.Untracked) {
-      return false
-    }
-
-    switch (this.currentStage) {
-      case RenderStage.Before:
-        // If we haven't started the render yet, it can't be interrupted.
+    const { syncIOMode, currentStage } = this
+    switch (syncIOMode) {
+      case SyncIOMode.Untracked: {
         return false
-      case RenderStage.ShellStatic:
-      case RenderStage.Static:
-        return true
-      case RenderStage.ShellRuntime:
-      case RenderStage.Runtime: {
-        switch (this.syncIOMode) {
-          case SyncIOMode.AllowedInRuntimeOrDynamic: {
-            // Before `partialPrefetching`: Sync IO only errors in static stages.
-            return false
-          }
-          case SyncIOMode.AllowedInDynamic: {
-            return true
-          }
-        }
-        // NOT a fallthrough, but eslint doesn't understand that
       }
-      case RenderStage.Dynamic:
-      case RenderStage.Abandoned:
-        return false
-      default:
-        this.currentStage satisfies never
-        return false
+      case SyncIOMode.AllowedInRuntimeOrDynamic: {
+        // Legacy: track Sync IO only in static stages.
+        // Do not track it before the render, or in runtime/dynamic stages.
+        return (
+          currentStage > RenderStage.Before &&
+          currentStage <= RenderStage.Static
+        )
+      }
+      case SyncIOMode.AllowedInDynamic: {
+        // Track sync IO in all cacheable stages.
+        // This means all stages except:
+        // - before the render
+        // - in the dynamic stage
+        return (
+          currentStage > RenderStage.Before &&
+          currentStage < RenderStage.Dynamic
+        )
+      }
     }
   }
 
@@ -305,6 +291,17 @@ export class StagedRenderingController {
     }
     return promise
   }
+}
+
+function createAdvanceableStageTriggers(): Record<
+  AdvanceableRenderStage,
+  StageTrigger
+> {
+  const triggers: Partial<Record<AdvanceableRenderStage, StageTrigger>> = {}
+  for (const stage of RENDER_STAGE_ADVANCE_ORDER) {
+    triggers[stage] = createStageTrigger()
+  }
+  return triggers as Record<AdvanceableRenderStage, StageTrigger>
 }
 
 function ignoreReject() {}

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -5,7 +5,9 @@ export enum RenderStage {
   Before = 1,
   //
   ShellStatic = 10,
-  Static = 11,
+  PrefetchStatic = 11,
+  NavigationStatic = 12,
+  Static = 13,
   //
   ShellRuntime = 20,
   Runtime = 21,
@@ -22,6 +24,8 @@ export type AdvanceableRenderStage = Exclude<
 
 export const RENDER_STAGE_ADVANCE_ORDER: AdvanceableRenderStage[] = [
   RenderStage.ShellStatic,
+  RenderStage.PrefetchStatic,
+  RenderStage.NavigationStatic,
   RenderStage.Static,
   //
   RenderStage.ShellRuntime,

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -248,6 +248,19 @@ function trackRuntimeDataAccessedImpl(
 ): void {
   switch (workUnitStore.type) {
     case 'prerender': {
+      const { stagedRendering } = workUnitStore
+      if (
+        stagedRendering &&
+        stagedRendering.currentStage >= RenderStage.NavigationStatic
+      ) {
+        // Ignore any accesses that happen after `navigation()` resolves.
+        // The purpose of this tracking is to judge whether a runtime prefetch
+        // would give us a more complete result than a static one.
+        // But `navigation()` wouldn't have resolved in a runtime prefetch,
+        // so e.g. `await navigation(); await cookies()` wouldn't have more content
+        // in those, and we shouldn't count it.
+        return
+      }
       // Response-level flag (the payload's `u`, forwarded to segment
       // responses as `needsRuntimeRequest`): resolved for every kind of
       // access — a pre-upgrade fallback response must keep reporting that
@@ -412,7 +425,7 @@ export function trackPromiseUsed<T>(promise: Promise<T>, onUse: () => void) {
 
 export const RENDER_STAGES_BY_DATA_KIND = {
   sessionData: RenderStage.ShellRuntime as const,
-  staticLinkData: RenderStage.Static as const,
+  staticLinkData: RenderStage.PrefetchStatic as const,
   runtimeLinkData: RenderStage.Runtime as const,
 }
 

--- a/packages/next/src/server/node-environment-extensions/io-utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/io-utils.tsx
@@ -66,7 +66,8 @@ export function io(expression: string, type: SyncIOApiType) {
             break
           }
           case RenderStage.ShellRuntime:
-          case RenderStage.Runtime: {
+          case RenderStage.Runtime:
+          case RenderStage.NavigationRuntime: {
             // We're in the Runtime stage.
             // We only error for Sync IO in the Runtime stage if the route has partialPrefetching enabled.
             syncIOError = createSyncIORuntimeError(

--- a/packages/next/src/server/node-environment-extensions/io-utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/io-utils.tsx
@@ -61,6 +61,8 @@ export function io(expression: string, type: SyncIOApiType) {
         // `shouldTrackSyncInterrupt`/`syncInterruptCurrentStageWithReason`
         switch (stageController.currentStage) {
           case RenderStage.ShellStatic:
+          case RenderStage.PrefetchStatic:
+          case RenderStage.NavigationStatic:
           case RenderStage.Static: {
             syncIOError = createSyncIOError(workStore.route, expression, type)
             break

--- a/packages/next/src/server/request/cache-stages.ts
+++ b/packages/next/src/server/request/cache-stages.ts
@@ -1,3 +1,16 @@
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import {
+  throwForMissingRequestStore,
+  workUnitAsyncStorage,
+} from '../app-render/work-unit-async-storage.external'
+import {
+  applyOwnerStack,
+  trackIncompatibleShellContent,
+} from '../dynamic-rendering-utils'
+import { isRequestApiAllowedInCurrentPhase } from './utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
+import { RenderStage } from '../app-render/staged-rendering'
+
 /**
  * This function allows you to indicate that the subsequent code should be
  * deferred to the actual navigation instead of rendering during a runtime
@@ -13,5 +26,129 @@
  * content below `await unstable_navigation()` remains fully cacheable.
  */
 export function unstable_navigation(): Promise<void> {
-  throw new Error('unstable_navigation() is not implemented yet.')
+  const workStore = workAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (!workStore || !workUnitStore) {
+    const callingExpression = 'unstable_navigation'
+    throwForMissingRequestStore(callingExpression)
+  }
+  if (!process.env.__NEXT_CACHE_COMPONENTS) {
+    throw new Error(
+      `Route ${workStore.route} used \`unstable_navigation()\`, which requires Cache Components to be enabled. Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents`
+    )
+  }
+
+  if (!isRequestApiAllowedInCurrentPhase(workUnitStore)) {
+    throw new Error(
+      `Route ${workStore.route} used \`unstable_navigation()\` inside \`after()\` while rendering. The \`unstable_navigation()\` function is used to indicate the subsequent code must only run during an actual navigation, but \`after()\` executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after`
+    )
+  }
+
+  switch (workUnitStore.type) {
+    case 'prerender': {
+      // Static prerenders are computed once and shared across many
+      // clients, so there's no per-request prefetch cost to save by
+      // deferring the content — it's deliberately included in the static
+      // output (and thus in static prefetches).
+      // However, it's excluded from the shell, and has to be separated from
+      // unstable_prefetch(), so we have to delay it.
+      const { stagedRendering } = workUnitStore
+      if (!stagedRendering) {
+        // Prospective prerender
+        return Promise.resolve(undefined)
+      } else {
+        // Final prerender
+        return stagedRendering.delayUntilStage(
+          RenderStage.Static,
+          'unstable_navigation',
+          undefined
+        )
+      }
+    }
+    case 'prerender-runtime': {
+      // In a shell or runtime prefetch, navigation() doesn't resolve,
+      // because they don't reach `NavigationRuntime`.
+      // It'll only resolve in a runtime prerender produced during a navigation.
+      // Note that this does not mark the subtree as dynamic -- content guarded by
+      // navigation() is still considered cacheable.
+      const { stagedRendering } = workUnitStore
+      if (!stagedRendering) {
+        // Prospective prerender
+        return Promise.resolve(undefined)
+      } else {
+        // Final prerender
+        return stagedRendering.delayUntilStage(
+          RenderStage.NavigationRuntime,
+          'unstable_navigation',
+          undefined
+        )
+      }
+    }
+    case 'request': {
+      const { stagedRendering } = workUnitStore
+      if (stagedRendering) {
+        // We can either recover a static shell or a runtime shell, but not both.
+        trackIncompatibleShellContent(workUnitStore)
+        const stage = workUnitStore.needsAppShell
+          ? RenderStage.NavigationRuntime // Match the timing of 'prerender-runtime'.
+          : RenderStage.Static // Match the timing of 'prerender'.
+
+        return stagedRendering.delayUntilStage(
+          stage,
+          'unstable_navigation',
+          undefined
+        )
+      }
+      return Promise.resolve(undefined)
+    }
+
+    case 'cache': {
+      const error = new Error(
+        `Route ${workStore.route} used \`unstable_navigation()\` inside "use cache". This is not currently supported. Instead, move the "use cache" directive to a function that's called below \`await unstable_navigation()\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+      )
+      Error.captureStackTrace(error, unstable_navigation)
+      applyOwnerStack(error)
+      workStore.invalidDynamicUsageError ??= error
+      throw error
+    }
+    case 'private-cache': {
+      const error = new Error(
+        `Route ${workStore.route} used \`unstable_navigation()\` inside "use cache: private". This is not currently supported. Instead, move the "use cache" directive to a function that's called below \`await unstable_navigation()\`, so that the cached content is deferred to the navigation without caching the stage boundary itself. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+      )
+      Error.captureStackTrace(error, unstable_navigation)
+      applyOwnerStack(error)
+      workStore.invalidDynamicUsageError ??= error
+      throw error
+    }
+    case 'unstable-cache': {
+      throw new Error(
+        `Route ${workStore.route} used \`unstable_navigation()\` inside a function cached with \`unstable_cache()\`. The \`unstable_navigation()\` function is used to indicate the subsequent code must only run during an actual navigation, but \`unstable_cache()\` caches must be able to be produced before a navigation, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+      )
+    }
+    case 'generate-static-params': {
+      throw new Error(
+        `Route ${workStore.route} used \`unstable_navigation()\` inside \`generateStaticParams\`. This is not supported because \`generateStaticParams\` runs at build time without a navigation. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
+      )
+    }
+    case 'prerender-client':
+    case 'validation-client': {
+      const exportName = '`unstable_navigation`'
+      throw new InvariantError(
+        `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
+      )
+    }
+    case 'prerender-legacy': {
+      // NOTE: Should not be reachable, because we don't use this mode in cacheComponents,
+      // which we require at the top
+      throw new Error(
+        `Route ${workStore.route} used \`unstable_navigation()\`, which requires Cache Components to be enabled. Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents`
+      )
+    }
+
+    default: {
+      workUnitStore satisfies never
+      return Promise.resolve(undefined)
+    }
+  }
 }

--- a/packages/next/src/server/request/cache-stages.ts
+++ b/packages/next/src/server/request/cache-stages.ts
@@ -60,7 +60,7 @@ export function unstable_navigation(): Promise<void> {
       } else {
         // Final prerender
         return stagedRendering.delayUntilStage(
-          RenderStage.Static,
+          RenderStage.NavigationStatic,
           'unstable_navigation',
           undefined
         )
@@ -92,7 +92,7 @@ export function unstable_navigation(): Promise<void> {
         trackIncompatibleShellContent(workUnitStore)
         const stage = workUnitStore.needsAppShell
           ? RenderStage.NavigationRuntime // Match the timing of 'prerender-runtime'.
-          : RenderStage.Static // Match the timing of 'prerender'.
+          : RenderStage.NavigationStatic // Match the timing of 'prerender'.
 
         return stagedRendering.delayUntilStage(
           stage,

--- a/test/development/app-dir/cache-components-dev-warmup/dev-warmup.util.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/dev-warmup.util.ts
@@ -341,6 +341,19 @@ export function runDevWarmupTests({
           assertLog(logs, `after params`, 'Prefetch')
           assertLog(logs, `after searchParams`, 'Prefetch')
 
+          assertLog(
+            logs,
+            `after navigation`,
+            // For initial load, navigation() follows static prerender timing.
+            // For client nav, it follows app-shell timing if `partialPrefetching` is on,
+            // and static timing otherwise.
+            isInitialLoad
+              ? 'Prerender'
+              : partialPrefetching || hasRuntimePrefetch
+                ? 'Prefetch'
+                : 'Prerender'
+          )
+
           assertLog(logs, 'after connection', 'Server')
         }
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -1,6 +1,7 @@
 import { cookies, headers } from 'next/headers'
 import { CachedData } from '../../data-fetching'
 import { connection } from 'next/server'
+import { unstable_navigation as navigation } from 'next/cache'
 import { Suspense } from 'react'
 
 export const instant = true
@@ -18,11 +19,12 @@ export default function Page({ params, searchParams }) {
       <CachedData cacheKey={CACHE_KEY} label="page" />
       <LogAfter label="--- dynamic stage ---" api={() => connection()} />
 
-      {/* Runtime */}
       <LogAfter label="cookies" api={() => cookies()} />
       <LogAfter label="headers" api={() => headers()} />
       <LogAfter label="params" api={() => params} />
       <LogAfter label="searchParams" api={() => searchParams} />
+      <LogAfter label="navigation" api={() => navigation()} />
+
       {/* Dynamic */}
       <LogAfter label="connection" api={() => connection()} />
     </main>

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/apis/[param]/page.tsx
@@ -1,6 +1,7 @@
 import { cookies, headers } from 'next/headers'
 import { CachedData } from '../../data-fetching'
 import { connection } from 'next/server'
+import { unstable_navigation as navigation } from 'next/cache'
 import { Suspense } from 'react'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
@@ -15,11 +16,12 @@ export default function Page({ params, searchParams }) {
       <CachedData cacheKey={CACHE_KEY} label="page" />
       <LogAfter label="--- dynamic stage ---" api={() => connection()} />
 
-      {/* Runtime */}
       <LogAfter label="cookies" api={() => cookies()} />
       <LogAfter label="headers" api={() => headers()} />
       <LogAfter label="params" api={() => params} />
       <LogAfter label="searchParams" api={() => searchParams} />
+      <LogAfter label="navigation" api={() => navigation()} />
+
       {/* Dynamic */}
       <LogAfter label="connection" api={() => connection()} />
     </main>

--- a/test/e2e/app-dir/instant-validation/app/shells/(default)/invalid-navigation-without-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shells/(default)/invalid-navigation-without-suspense/page.tsx
@@ -1,0 +1,25 @@
+import { Instant } from 'next'
+import { unstable_navigation as navigation } from 'next/cache'
+
+export const instant: Instant = {
+  level: 'experimental-error',
+}
+
+export const prefetch = 'partial'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>
+        This page is missing a suspense around navigation(), so we can't render
+        a shell.
+      </p>
+      <NavigationContent />
+    </main>
+  )
+}
+
+async function NavigationContent() {
+  await navigation()
+  return <div>{`Navigation content`}</div>
+}

--- a/test/e2e/app-dir/instant-validation/app/shells/(default)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shells/(default)/page.tsx
@@ -38,6 +38,12 @@ export default async function Page() {
         <li>
           <DebugLinks href="/shells/invalid-static-with-gsp-metadata/123" />
         </li>
+        <li>
+          <DebugLinks href="/shells/invalid-navigation-without-suspense" />
+        </li>
+        <li>
+          <DebugLinks href="/shells/valid-navigation-with-suspense" />
+        </li>
       </ul>
     </main>
   )

--- a/test/e2e/app-dir/instant-validation/app/shells/(default)/valid-navigation-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shells/(default)/valid-navigation-with-suspense/page.tsx
@@ -1,0 +1,28 @@
+import { Instant } from 'next'
+import { unstable_navigation as navigation } from 'next/cache'
+import { Suspense } from 'react'
+
+export const instant: Instant = {
+  level: 'experimental-error',
+}
+
+export const prefetch = 'partial'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>
+        This page has a suspense around navigation(), so we can render a shell
+        and should have no validation errors.
+      </p>
+      <Suspense>
+        <NavigationContent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function NavigationContent() {
+  await navigation()
+  return <div>{`Navigation content`}</div>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/non-app-shell/valid-unguarded-navigation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/non-app-shell/valid-unguarded-navigation/page.tsx
@@ -1,0 +1,23 @@
+import { Instant } from 'next'
+import { unstable_navigation as navigation } from 'next/cache'
+
+export const instant: Instant = {
+  level: 'experimental-error',
+}
+
+export default async function Page() {
+  return (
+    <main>
+      <p>
+        This page is missing a suspense around navigation(), but that's allowed
+        if we're not in partialPrefetching and aren't rendering App Shells.
+      </p>
+      <NavigationContent />
+    </main>
+  )
+}
+
+async function NavigationContent() {
+  await navigation()
+  return <div>{`Navigation content`}</div>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -52,6 +52,9 @@ export default async function Page() {
           <DebugLinks href="/suspense-in-root/sync-io/sync-io-after-cookies" />
         </li>
         <li>
+          <DebugLinks href="/suspense-in-root/sync-io/sync-io-after-navigation" />
+        </li>
+        <li>
           <DebugLinks href="/suspense-in-root/sync-io/sync-io-after-cookies-in-generate-metadata" />
         </li>
         <li>
@@ -298,6 +301,9 @@ export default async function Page() {
       <ul>
         <li>
           <DebugLinks href="/suspense-in-root/non-app-shell/valid-unguarded-static-params/123" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/non-app-shell/valid-unguarded-navigation" />
         </li>
       </ul>
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/sync-io/sync-io-after-navigation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/sync-io/sync-io-after-navigation/page.tsx
@@ -1,0 +1,28 @@
+import { unstable_navigation as navigation } from 'next/cache'
+import { Suspense } from 'react'
+
+export const instant = { level: 'experimental-error' }
+
+export default async function Page() {
+  return (
+    <main>
+      <p>
+        This page uses sync IO after awaiting navigation():
+        {/*
+        In partialPrefetching, navigation() is not allowed in shells,
+        so we need a Suspense.
+        Before partialPrefetching everything is static, so we could skip it,
+        but that's not relevant to this test. 
+        */}
+        <Suspense>
+          <SyncIOAfterNavigation />
+        </Suspense>
+      </p>
+    </main>
+  )
+}
+
+async function SyncIOAfterNavigation() {
+  await navigation()
+  return Date.now()
+}

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -785,8 +785,6 @@ export function registerHeadAndReportingTests(
       })
 
       it('invalid - unguarded static params in metadata', async () => {
-        // TODO(app-shells): static params currently aren't excluded from the shell.
-        // This should be failing validation.
         if (isNextDev) {
           const browser = await navigateTo(
             '/shells/invalid-static-with-gsp-metadata/123'
@@ -896,6 +894,82 @@ export function registerHeadAndReportingTests(
         }
       })
 
+      it('invalid - unguarded navigation() in a shell', async () => {
+        // TODO(cache-stages): navigation() should not be reported as uncached data.
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/shells/invalid-navigation-without-suspense'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/shells/(default)/invalid-navigation-without-suspense/page.tsx (4:33) @ instant
+           > 4 | export const instant: Instant = {
+               |                                 ^",
+                 "stack": [
+                   "instant app/shells/(default)/invalid-navigation-without-suspense/page.tsx (4:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1437",
+             "description": "Next.js encountered uncached data during a navigation.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/shells/(default)/invalid-navigation-without-suspense/page.tsx (23:19) @ NavigationContent
+           > 23 |   await navigation()
+                |                   ^",
+             "stack": [
+               "NavigationContent app/shells/(default)/invalid-navigation-without-suspense/page.tsx (23:19)",
+               "Page app/shells/(default)/invalid-navigation-without-suspense/page.tsx (17:7)",
+             ],
+           }
+          `)
+        } else {
+          const result = await prerender(
+            '/shells/(default)/invalid-navigation-without-suspense'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/shells/invalid-navigation-without-suspense": Next.js encountered uncached data during prerendering or a navigation.
+
+           \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered or the navigation from being instant, leading to a slower user experience.
+
+           Ways to fix this:
+             - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+             - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+             - [block] Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+               at main (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Build-time instant validation failed for route "/shells/invalid-navigation-without-suspense".
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/shells/invalid-navigation-without-suspense" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
+
+      it('valid - navigation() with suspense in a shell', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/shells/valid-navigation-with-suspense'
+          )
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          const result = await prerender(
+            '/shells/(default)/valid-navigation-with-suspense'
+          )
+          expectNoBuildValidationErrors(result)
+        }
+      })
+
       it('valid - unguarded root param', async () => {
         if (isNextDev) {
           const browser = await navigateTo(
@@ -935,6 +1009,19 @@ export function registerHeadAndReportingTests(
         } else {
           const result = await prerender(
             '/suspense-in-root/non-app-shell/valid-unguarded-static-params/[slug]'
+          )
+          expectNoBuildValidationErrors(result)
+        }
+      })
+      it('valid - unguarded navigation', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/non-app-shell/valid-unguarded-navigation'
+          )
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/non-app-shell/valid-unguarded-navigation'
           )
           expectNoBuildValidationErrors(result)
         }

--- a/test/e2e/app-dir/instant-validation/sync-io-and-blocking.util.ts
+++ b/test/e2e/app-dir/instant-validation/sync-io-and-blocking.util.ts
@@ -2,7 +2,7 @@ import {
   expectNoBuildValidationErrors,
   extractBuildValidationError,
 } from 'e2e-utils/instant-validation'
-import { getDeterministicOutput } from '../cache-components-errors/utils'
+import { getPrerenderOutput } from '../cache-components-errors/utils'
 import { type InstantValidationCaseContext } from './harness.util'
 
 const partialPrefetching = !!process.env.__NEXT_PARTIAL_PREFETCHING
@@ -75,6 +75,65 @@ export function registerSyncIoAndBlockingTests(
       }
     })
 
+    it('sync IO after navigation()', async () => {
+      if (isNextDev) {
+        const browser = await navigateTo(
+          '/suspense-in-root/sync-io/sync-io-after-navigation'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E1432",
+           "description": "Next.js encountered the unstable value Date.now() while prerendering.",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/sync-io/sync-io-after-navigation/page.tsx (27:15) @ SyncIOAfterNavigation
+         > 27 |   return Date.now()
+              |               ^",
+           "stack": [
+             "SyncIOAfterNavigation app/suspense-in-root/sync-io/sync-io-after-navigation/page.tsx (27:15)",
+             "Page app/suspense-in-root/sync-io/sync-io-after-navigation/page.tsx (18:11)",
+           ],
+         }
+        `)
+      } else {
+        const result = await prerender(
+          '/suspense-in-root/sync-io/sync-io-after-navigation'
+        )
+        // `await navigation()` resolves during a static prerender, so
+        // we hit the sync IO there and error before reaching instant validation.
+        expect(
+          getPrerenderOutput(result.cliOutput, {
+            isMinified: true,
+          })
+        ).toMatchInlineSnapshot(`
+         "Error: Route "/suspense-in-root/sync-io/sync-io-after-navigation": Next.js encountered the unstable value \`Date.now()\` while prerendering.
+
+         This value can change between renders, so it must be either prerendered or computed later.
+
+         Ways to fix this:
+           - [dynamic] Render at request time by adding a dynamic data access (e.g. \`await connection()\`) before this call
+           - [cache] Prerender and cache the value with \`"use cache"\`
+           - [client] Render the value on the client with \`"use client"\`
+           - [measure] If the value is for telemetry, use a timing API such as \`performance.now()\`
+
+         Learn more: https://nextjs.org/docs/messages/blocking-prerender-current-time
+             at a (app/suspense-in-root/sync-io/sync-io-after-navigation/page.tsx:27:15)
+           25 | async function SyncIOAfterNavigation() {
+           26 |   await navigation()
+         > 27 |   return Date.now()
+              |               ^
+           28 | }
+           29 |
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/sync-io/sync-io-after-navigation" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Error occurred prerendering page "/suspense-in-root/sync-io/sync-io-after-navigation". Read more: https://nextjs.org/docs/messages/prerender-error
+         Export encountered an error on /suspense-in-root/sync-io/sync-io-after-navigation/page: /suspense-in-root/sync-io/sync-io-after-navigation, exiting the build."
+        `)
+        expect(result.exitCode).toBe(1)
+      }
+    })
+
     it('sync IO after cache with session data input', async () => {
       if (isNextDev) {
         const browser = await navigateTo(
@@ -113,9 +172,8 @@ export function registerSyncIoAndBlockingTests(
         // defer until its args serialize, so the cache function (and the
         // Date.now() that follows) lands in the runtime stage.
         expect(
-          getDeterministicOutput(result.cliOutput, {
+          getPrerenderOutput(result.cliOutput, {
             isMinified: true,
-            startingLineMatch: 'Collecting page data',
           })
         ).toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/sync-io/sync-io-after-cache-with-cookie-input": Next.js encountered the unstable value \`Date.now()\` while prerendering.

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations-partial-prefetching.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations-partial-prefetching.test.ts
@@ -72,6 +72,9 @@ describe('cached navigations - global partialPrefetching', () => {
       expect(await browser.elementById('headers-boundary').text()).toContain(
         'Header:'
       )
+      expect(await browser.elementById('navigation-boundary').text()).toContain(
+        'Navigation content'
+      )
 
       // Only connection() shows a Suspense fallback — it's truly dynamic.
       expect(await browser.elementById('connection-boundary').text()).toBe(

--- a/test/e2e/app-dir/segment-cache/cached-navigations/partial-prefetching/app/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/partial-prefetching/app/runtime-prefetchable/page.tsx
@@ -1,5 +1,6 @@
 import { cookies, headers } from 'next/headers'
 import { connection } from 'next/server'
+import { unstable_navigation as navigation } from 'next/cache'
 import { Suspense } from 'react'
 
 // Note: intentionally no `export const prefetch` and no `instant` config. This
@@ -32,6 +33,11 @@ export default async function Page({
       <div id="connection-boundary">
         <Suspense fallback={<p>Loading connection...</p>}>
           <ConnectionContent />
+        </Suspense>
+      </div>
+      <div id="navigation-boundary">
+        <Suspense fallback={<p>Loading navigation...</p>}>
+          <NavigationContent />
         </Suspense>
       </div>
     </main>
@@ -67,4 +73,9 @@ async function HeadersContent() {
 async function ConnectionContent() {
   await connection()
   return <p>Dynamic content</p>
+}
+
+async function NavigationContent() {
+  await navigation()
+  return <p>Navigation content</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/page.tsx
@@ -116,6 +116,38 @@ export default function Page() {
           </LinkAccordion>
         </li>
       </ul>
+
+      <h2>Navigation posts</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/static-navigation/1">
+            Static navigation post 1
+          </LinkAccordion>
+        </li>
+        <li>
+          <Link href="/static-navigation/2" prefetch={false}>
+            Static navigation post 2 (unprefetched)
+          </Link>
+        </li>
+        <li>
+          <LinkAccordion href="/runtime-navigation/1">
+            Runtime navigation post 1
+          </LinkAccordion>
+        </li>
+        <li>
+          <Link href="/runtime-navigation/2" prefetch={false}>
+            Runtime navigation post 2 (unprefetched)
+          </Link>
+        </li>
+        <li>
+          <LinkAccordion
+            href="/runtime-navigation/speculative-1"
+            prefetch={true}
+          >
+            Runtime navigation post "speculative-1" (prefetch=true)
+          </LinkAccordion>
+        </li>
+      </ul>
     </main>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/runtime-navigation/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/runtime-navigation/[id]/page.tsx
@@ -1,0 +1,48 @@
+import { Suspense } from 'react'
+import { unstable_navigation as navigation } from 'next/cache'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+
+type Params = { id: string }
+
+export const prefetch = 'partial'
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="navigation-loading">Loading navigation...</p>}>
+        <Navigation />
+      </Suspense>
+      {/* The fallback is the App Shell — the part of the page that
+          doesn't depend on params. */}
+      <Suspense fallback={<p id="shell">App shell for navigation</p>}>
+        <ParamsDependent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Navigation() {
+  await cookies() // Makes sure this page uses a runtime prefetch
+  await navigation() // Exclude the contents below from runtime prefetching and runtime app shells
+  return <div id="navigation-content">Navigation content</div>
+}
+
+async function ParamsDependent({ params }: { params: Promise<Params> }) {
+  const { id } = await params
+  return (
+    <>
+      <p id="param-value">{`Post ${id}`}</p>
+      <Suspense
+        fallback={<p id="dynamic-loading">Loading dynamic content...</p>}
+      >
+        <Dynamic id={id} />
+      </Suspense>
+    </>
+  )
+}
+
+async function Dynamic({ id }: { id: string }) {
+  await connection()
+  return <p id="dynamic-content">{`Post body for ${id}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/static-navigation/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/static-navigation/[id]/page.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from 'react'
+import { unstable_navigation as navigation } from 'next/cache'
+import { connection } from 'next/server'
+
+export async function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }]
+}
+
+type Params = { id: string }
+
+export const prefetch = 'partial'
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="shell">App shell for navigation</p>}>
+        <ParamsDependent params={params} />
+      </Suspense>
+      <Suspense fallback={<p id="navigation-loading">Loading navigation...</p>}>
+        <Navigation />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Navigation() {
+  await navigation() // Exclude the contents below from the shell
+  return <div id="navigation-content">Navigation content</div>
+}
+
+async function ParamsDependent({ params }: { params: Promise<Params> }) {
+  // Make sure the static prefetch varies on params so that the client router
+  // has to extract a static shell from it when navigating to another param value.
+  // If the static prefetch doesn't vary on params, it'll be used instead of
+  // the app shell
+  const { id } = await params
+  return (
+    <>
+      <p id="param-value">{`Post ${id}`}</p>
+      <Suspense
+        fallback={<p id="dynamic-loading">Loading dynamic content...</p>}
+      >
+        <Dynamic id={id} />
+      </Suspense>
+    </>
+  )
+}
+
+async function Dynamic({ id }: { id: string }) {
+  await connection()
+  return <p id="dynamic-content">{`Post body for ${id}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -377,6 +377,220 @@ describe('App Shell prefetching', () => {
     )
   })
 
+  describe('navigation()', () => {
+    it('excludes navigation() from a static App Shell', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Reveal the LinkAccordion for /static-navigation/1. This caches the App Shell
+      // for the route. The page renders a component that uses navigation(),
+      // which should be excluded from the shell.
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/static-navigation/1"]')
+          .click()
+      }, [{ includes: 'App shell for navigation', kind: 'static' }])
+
+      await act(async () => {
+        // Click the link to /static-navigation/2. This link is rendered with
+        // prefetch={false}, so it was never prefetched. The cached App Shell
+        // should render immediately, before any navigation response arrives.
+        await browser.elementByCss('a[href="/static-navigation/2"]').click()
+
+        // While the navigation response is blocked (we're still in the `act`
+        // block), the cached App Shell should already be visible.
+        expect(await browser.elementById('shell').text()).toEqual(
+          'App shell for navigation'
+        )
+        // The navigation-gated content is NOT part of the App Shell, only its fallback.
+        expect(await browser.locator('#navigation-content').count()).toBe(0)
+        expect(await browser.elementByCss('#navigation-loading').text()).toBe(
+          'Loading navigation...'
+        )
+      })
+
+      // After the outer act unblocks the navigation, the navigation-gated
+      // content streams in with the navigation response, along with the
+      // dynamic content.
+      expect(await browser.elementById('navigation-content').text()).toEqual(
+        'Navigation content'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Post body for 2'
+      )
+    })
+
+    it('excludes navigation() from a runtime App Shell', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Reveal the LinkAccordion for /runtime-navigation/1. This caches the App Shell
+      // for the route. The page renders a component that uses navigation(),
+      // which should be excluded from the runtime shell.
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/runtime-navigation/1"]')
+          .click()
+      }, [
+        { includes: 'App shell for navigation', kind: 'runtime' },
+        { includes: 'param-value', block: 'reject' }, // Only a shell, no URL data.
+      ])
+
+      await act(async () => {
+        // Click the link to /runtime-navigation/2. This link is rendered with
+        // prefetch={false}, so it was never prefetched. The cached App Shell
+        // should render immediately, before any navigation response arrives.
+        await browser.elementByCss('a[href="/runtime-navigation/2"]').click()
+
+        // While the navigation response is blocked (we're still in the `act`
+        // block), the cached App Shell should already be visible.
+        expect(await browser.elementById('shell').text()).toEqual(
+          'App shell for navigation'
+        )
+        // The navigation-gated content is NOT part of the App Shell, only its fallback.
+        expect(await browser.locator('#navigation-content').count()).toBe(0)
+        expect(await browser.elementByCss('#navigation-loading').text()).toBe(
+          'Loading navigation...'
+        )
+      })
+
+      // After the outer act unblocks the navigation, the navigation-gated
+      // content streams in with the navigation response, along with the
+      // dynamic content.
+      expect(await browser.elementById('navigation-content').text()).toEqual(
+        'Navigation content'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Post body for 2'
+      )
+    })
+
+    it('includes navigation() in a static prefetch', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Reveal the LinkAccordion for /static-navigation/1,
+      // Triggering a static prefetch request.
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/static-navigation/1"]')
+          .click()
+      }, [{ includes: 'App shell for navigation', kind: 'static' }])
+
+      await act(async () => {
+        // Navigate to the prefetched route.
+        await browser.elementByCss('a[href="/static-navigation/1"]').click()
+
+        // While the navigation response is blocked (we're still in the `act`
+        // block), the prefetched content should already be visible.
+
+        // Param-dependent content is visible because the params are static.
+        expect(await browser.elementById('param-value').text()).toEqual(
+          'Post 1'
+        )
+        // The navigation-gated content is included.
+        expect(await browser.locator('#navigation-loading').count()).toBe(0)
+        expect(await browser.elementByCss('#navigation-content').text()).toBe(
+          'Navigation content'
+        )
+        // Dynamic content is not included.
+        expect(await browser.locator('#dynamic-content').count()).toBe(0)
+        expect(await browser.elementByCss('#dynamic-loading').text()).toBe(
+          'Loading dynamic content...'
+        )
+      })
+
+      expect(await browser.elementById('navigation-content').text()).toEqual(
+        'Navigation content'
+      )
+      // After the outer act unblocks the navigation, the dynamic content streams in.
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Post body for 1'
+      )
+    })
+
+    it('excludes navigation() from a speculative runtime prefetch', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Reveal the LinkAccordion for /runtime-navigation/speculative-1,
+      // Triggering a shell request and then a speculative prefetch request.
+      // The page renders a component that uses navigation(),
+      // which should be excluded from both.
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/runtime-navigation/speculative-1"]'
+          )
+          .click()
+      }, [
+        // Two runtime responses carry the shell text, in order: the Shell
+        // phase's runtime App Shell request, then the Speculative phase's
+        // batched per-link runtime prefetch. The route reads request data,
+        // so its static-attempt hint is unset and the prefetch deopts to
+        // runtime requests — the runtime-completeness contract of Partial
+        // Prefetching routes.
+        { includes: 'App shell for navigation', kind: 'runtime' }, // Shell
+        { includes: 'Post speculative-1', kind: 'runtime' }, // Speculative
+      ])
+
+      await act(async () => {
+        // Navigate to the prefetched route.
+        await browser
+          .elementByCss('a[href="/runtime-navigation/speculative-1"]')
+          .click()
+
+        // While the navigation response is blocked (we're still in the `act`
+        // block), the prefetched content should already be visible.
+
+        // Param-dependent content is visible because we used a speculative prefetch.
+        expect(await browser.elementById('param-value').text()).toEqual(
+          'Post speculative-1'
+        )
+        // The navigation-gated content is not included.
+        expect(await browser.locator('#navigation-content').count()).toBe(0)
+        expect(await browser.elementByCss('#navigation-loading').text()).toBe(
+          'Loading navigation...'
+        )
+        // Dynamic content is not included.
+        expect(await browser.locator('#dynamic-content').count()).toBe(0)
+        expect(await browser.elementByCss('#dynamic-loading').text()).toBe(
+          'Loading dynamic content...'
+        )
+      })
+
+      // After the outer act unblocks the navigation, the navigation-gated
+      // content streams in with the navigation response, along with the
+      // dynamic content.
+      expect(await browser.elementById('navigation-content').text()).toEqual(
+        'Navigation content'
+      )
+      expect(await browser.elementById('dynamic-content').text()).toEqual(
+        'Post body for speculative-1'
+      )
+    })
+  })
+
   describe('root params', () => {
     it('includes root params in a runtime App Shell', async () => {
       let page: Playwright.Page

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/dynamic-param/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/dynamic-param/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { unstable_navigation as navigation } from 'next/cache'
 
 type Params = { slug: string }
 
@@ -24,6 +25,11 @@ export default function Page({ params }: { params: Promise<Params> }) {
       <Suspense fallback={<p id="slug-loading">Loading param content...</p>}>
         <SlugContent params={params} />
       </Suspense>
+      <Suspense
+        fallback={<p id="navigation-loading">Loading navigation content...</p>}
+      >
+        <NavigationContent />
+      </Suspense>
     </main>
   )
 }
@@ -31,4 +37,9 @@ export default function Page({ params }: { params: Promise<Params> }) {
 async function SlugContent({ params }: { params: Promise<Params> }) {
   const { slug } = await params
   return <p id="slug-content">{`Dynamic param content: ${slug}`}</p>
+}
+
+async function NavigationContent() {
+  await navigation()
+  return <p id="navigation-content">Navigation content</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/page.tsx
@@ -26,6 +26,16 @@ export default function Page() {
           <LinkAccordion href="/uses-connection">Uses connection</LinkAccordion>
         </li>
         <li>
+          <LinkAccordion href="/uses-runtime-after-navigation">
+            Uses runtime APIs after navigation()
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/uses-navigation-static">
+            Uses navigation() on a static page
+          </LinkAccordion>
+        </li>
+        <li>
           <LinkAccordion href="/dynamic-param/one">
             Dynamic param one
           </LinkAccordion>

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-navigation-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-navigation-static/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { unstable_navigation as navigation } from 'next/cache'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p id="navigation-loading">Loading navigation...</p>}>
+        <NavigationContent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function NavigationContent() {
+  await navigation()
+  return <p id="page-content">Fully static page content (with navigation())</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-runtime-after-navigation/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/uses-runtime-after-navigation/page.tsx
@@ -1,0 +1,52 @@
+// A page that calls cookies and headers, but only after awaiting `navigation()`
+// which means it can still be prefetched statically.
+//
+// Note the Shell phase is always permitted to issue a runtime shell request,
+// so the absence of one in the test is attributable to the static shell
+// attempt succeeding, not to configuration forbidding runtime requests.
+
+import { cacheLife } from 'next/dist/server/use-cache/cache-life'
+import { cookies, headers } from 'next/headers'
+import { unstable_navigation as navigation } from 'next/cache'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <main>
+      <p id="page-content">Runtime APIs called after navigation()</p>
+      <Suspense
+        fallback={<p id="navigation-loading">Loading navigation content...</p>}
+      >
+        <Navigation />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Navigation() {
+  // The runtime data tracking should end here, so the prerender
+  // shouldn't track the awaits of cookies/headers inside DynamicContent.
+  await navigation()
+
+  return (
+    <>
+      <div id="navigation-content">Navigation content</div>
+      <Suspense
+        fallback={<p id="dynamic-loading">Loading dynamic content...</p>}
+      >
+        <DynamicContent />
+      </Suspense>
+    </>
+  )
+}
+
+async function shortStaleCache() {
+  'use cache'
+  cacheLife({ stale: 300 - 1 }) // smaller than MIN_SHELL_STALE
+  return Date.now()
+}
+
+async function DynamicContent() {
+  await Promise.all([cookies(), headers(), shortStaleCache()])
+  return <p id="dynamic-content">Dynamic content</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
@@ -102,6 +102,48 @@ describe('static App Shell prefetch attempt', () => {
     }, 'no-requests')
   })
 
+  it('prefetches a fully static route that uses navigation() with static requests only, then navigates instantly from cache', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /uses-navigation-static. The route accesses no
+    // runtime data, so its tree carries the static-prefetch hint and the
+    // Shell phase attempts static per-segment prefetches. The static
+    // responses are complete, so no runtime shell request fires.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/uses-navigation-static"]')
+        .click()
+    }, [
+      // The shell content arrives in a static per-segment response...
+      {
+        includes: 'Fully static page content (with navigation())',
+        kind: 'static',
+      },
+      // ...and must NOT arrive in a runtime prefetch response — the
+      // static attempt was sufficient, so no runtime request fires.
+      {
+        includes: 'Fully static page content (with navigation())',
+        kind: 'runtime',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to the prefetched route. Everything was cached by the static
+    // prefetch, so the navigation completes without any requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/uses-navigation-static"]').click()
+      expect(await browser.elementById('page-content').text()).toBe(
+        'Fully static page content (with navigation())'
+      )
+    }, 'no-requests')
+  })
+
   it('goes straight to a runtime shell prefetch when the shell reads cookies (hint unset)', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
@@ -232,6 +274,67 @@ describe('static App Shell prefetch attempt', () => {
     )
   })
 
+  it('does not fall back to a runtime shell prefetch for a partial segment that calls runtime APIs after navigation()', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/uses-runtime-after-navigation"]'
+        )
+        .click()
+    }, [
+      // In a static prerender, navigation() is allowed to resolve,
+      // so content behind navigation() will be part of a static prefetch.
+      { includes: 'Navigation content', kind: 'static' },
+      // No runtime request should fire.
+      {
+        includes: 'Runtime APIs called after navigation()',
+        kind: 'runtime',
+        block: 'reject',
+      },
+      // Dynamic data should not be included.
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate. The prefetched shell renders instantly; the dynamic hole is
+    // filled by the navigation-time dynamic request, as always.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('a[href="/uses-runtime-after-navigation"]')
+          .click()
+
+        // While the navigation response is blocked (we're still inside the
+        // `act` scope), the prefetched shell is already visible, with the
+        // loading fallback in place of the dynamic content.
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Runtime APIs called after navigation()'
+        )
+        expect(await browser.elementById('navigation-content').text()).toBe(
+          'Navigation content'
+        )
+        expect(await browser.elementById('dynamic-loading').text()).toBe(
+          'Loading dynamic content...'
+        )
+      },
+      // The dynamic content streams in with the navigation response.
+      { includes: 'Dynamic content' }
+    )
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Dynamic content'
+    )
+  })
+
   it('reuses the static App Shell across different param values of a dynamic route', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
@@ -291,12 +394,16 @@ describe('static App Shell prefetch attempt', () => {
 
         // While the navigation response is blocked (we're still inside the
         // `act` scope), the reused shell is already visible, with the
-        // loading fallback in place of the param content.
+        // loading fallback in place of the param content and content
+        // behind navigation()
         expect(await browser.elementById('page-content').text()).toBe(
           'Dynamic-param page shell text'
         )
         expect(await browser.elementById('slug-loading').text()).toBe(
           'Loading param content...'
+        )
+        expect(await browser.elementById('navigation-loading').text()).toBe(
+          'Loading navigation content...'
         )
       },
       // The param content arrives with the navigation response.


### PR DESCRIPTION
`navigation()` is a new API that allows omitting contents from runtime shells and runtime prefetches. Conceptually, the point is to express that something is expensive to compute, so we shouldn't do it for requests that may not get used (shells and prefetches). Notably, this means that it's fine to include it in a static prerender -- it'll be computed once and used for many requests, so it doesn't make sense to exclude it.



## Implementation

The split in behavior across static and runtime prerenders is a departure from how most of our APIs behave -- usually, if something resolves statically, then it also resolves in "more complete" prerender. Departing from this leads to some implementation complexity.

We include three new stages, used by two facets of the implementation:

```diff
export enum RenderStage {
  Before = 1,
  //
  ShellStatic = 10,
+ PrefetchStatic = 11, <------- params, prefetch()  [static prerenders]
+ NavigationStatic = 12  <------navigation()        [static prerenders]
  Static = 13, <--------------- finish accumulators [static prerenders]
  //
  ShellRuntime = 20,
  Runtime = 21, <-------------- params, prefetch() [runtime prerenders]
+ NavigationRuntime = 22, <---- navigation()       [runtime prerenders]
  //
  Dynamic = 30,
  Abandoned = 40,
}
```

### NavigationRuntime

In runtime prerenders (or dev renders that simulate them), `navigation()` resolves in `NavigationRuntime`
We only reach this stage in 1. the embedded runtime prerender produced for Cached Navigations and 2. during dev/prod full staged renders -- runtime shells end in `ShellRuntime`, and runtime prefetches end in `Runtime`.

Notably, this means that content gated behind `navigation()` is included in the embedded runtime prefetch stream.

### PrefetchStatic & NavigationStatic

This is a helper stage added before `Static`. Static prefetches still use the `Static` stage for their output. This new stage exists so that we can resolve static `params` (and `prefetch()` when we implement it) which the stage is named after) separately from `navigation()`, which resolves in `NavigationStatic`, after which the prerender ends in `Static`. This separation is important, because during static prerenders we track whether or not runtime APIs are used (see `trackRuntimeDataAccessed`) to determine if a runtime shell (or runtime prefetch) might give us more content than the static ones. However, a runtime shell/prefethc **would not resolve navigation()**, so `await navigation(); await cookies()` would not reveal more content, and thus shouldn't count as a usage that prevents static optimization.
We achieve this by checking the stage inside `trackRuntimeDataAccessedImpl` and not tracking anything if we reached the `NavigationStatic` stage.

### Behavior of shells and validation

As noted before, `navigation()` has an incompatible resolution order between static and runtime prerenders. In #97040, we did some groundwork to deal with this in validation.

Static prerenders resolve `navigation()`, which means that static shells include content gated behind navigation(). This means that Static Shell Validation allows them.

On the other hand, App shells **do not** resolve `navigation()`. This leads to an inconsistency for Instant Validation -- a `await navigation()` might be fine if a page is prefetched statically, but would become blocking as soon as the page starts using runtime data and switches to a runtime shell. To avoid this pitfall, we pessimistically assume that any `navigation()` _might_ be part of a runtime shell/prefetch, so any `navigation()` unguarded by Suspense will error in IV.

In practice, this is handled analogously to static params: we do a dev render with `needsAppShell: true`, which makes `navigation()` resolve in `NavigationRuntime`, and then we use the `ShellRuntime` stage when validating, which means that `navigation()` will be a hole. Note that the discriminated error message logic currently only retries errors using the `Runtime` stage, which won't have `navigation()` resolved either, so it will be incorrectly reported as dynamic data. This will be improved in a follow up.