### PR TITLE
turbo-persistence: add key-value tombstones for MultiValue families

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10001,6 +10001,7 @@ name = "turbo-persistence"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "auto-hash-map",
  "bitfield",
  "byteorder",
  "codspeed-criterion-compat",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -14,6 +14,7 @@ verbose_log = []
 
 [dependencies]
 anyhow = { workspace = true }
+auto-hash-map = { workspace = true }
 bitfield = { workspace = true }
 byteorder = { workspace = true }
 crc32fast = { workspace = true }

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -29,7 +29,10 @@ Therefore there are these value types:
 - SMALL: Values 9–4096 bytes packed into shared value blocks within `*.sst` files.
 - MEDIUM: Values 4097 bytes – 64 MB stored in dedicated value blocks within `*.sst` files.
 - BLOB: Values > 64 MB stored in separate `*.blob` files.
-- DELETED: Values that are deleted. (Tombstone)
+- KEY DELETED: Every value for the key is deleted. (Key tombstone)
+- KEY-VALUE DELETED: Only one named key → value pair is deleted, leaving other values for the same
+  key intact. (Key-value tombstone) Only meaningful for `MultiValue` families; see
+  [Key-value tombstones](#key-value-tombstones).
 - Future:
   - MERGE: An application specific update operation that is applied on the old value.
 
@@ -138,7 +141,7 @@ Depending on the `type` field entry has a different format:
   - 8 bytes key hash (if block type 1)
   - key data
   - 4 bytes sequence number
-- 2: deleted key / tombstone (no data)
+- 2: deleted key / key tombstone (no data)
   - 8 bytes key hash (if block type 1)
   - key data
 - 3: normal key (medium sized value)
@@ -150,25 +153,62 @@ Depending on the `type` field entry has a different format:
   - 2 byte block index
   - 3 bytes size
   - 4 bytes position in block
-- 8..255: inlined value (currently only values ≤8 bytes are inlined, though the format supports up to 247)
+- 8..=16: inlined value, size = type - 8 (the format supports up to 247, but `MAX_INLINE_VALUE_SIZE`
+  currently caps it at 8)
   - 8 bytes key hash (if block type 1)
   - key data
   - (type - 8) bytes value data (inline, no separate value block)
+- 17..=25: key-value tombstone, deleted value size = type - 17 (mirrors the inline range and shifts
+  with `MAX_INLINE_VALUE_SIZE`)
+  - 8 bytes key hash (if block type 1)
+  - key data
+  - (type - 17) bytes of the deleted value, stored inline
+
+Both ranged kinds are open-ended, so a decoder must test the key-value tombstone range **before**
+the inline range.
 
 The entries are sorted by key hash and key.
 
+##### Key-value tombstones
+
+A key-value tombstone names the exact pair to remove, so it must carry a copy of the deleted
+value's bytes. Since the value lives inline in the key block and its length is encoded in the type
+byte, only inline-sized values can be deleted this way — hence `MAX_INLINE_VALUE_SIZE` bounds
+`delete_value`.
+
+The size limit is a consequence of that encoding, not of the comparison logic: matching is a plain
+byte comparison and does not care how a value is stored. Supporting larger deleted values is
+therefore possible but unmotivated — the tombstone stores a second copy of the value, so the cost
+of deleting approaches the cost of the value itself, and reclaiming space is the whole point.
+
+If it is ever needed, the natural encoding is a dedicated is-tombstone bit (e.g. the top bit) on the
+entry type, making "deleted" orthogonal to storage class rather than a parallel type range. That
+would also collapse the current duplication where the tombstone representation mirrors the inline
+one at every layer. Note that blob-backed values need a separate design: comparing against a blob
+means reading it, which would put unbounded I/O in the compaction path, and blob liveness
+accounting would have to handle a tombstone holding a blob reference.
+
 #### Key Block (fixed-size)
 
-Used when all entries in a block have the same key size and value type. Eliminates the per-entry offset table, enabling direct arithmetic indexing during binary search.
+Used when all entries in a block have the same key size, and either the same value type or at least
+the same value size. Eliminates the per-entry offset table, enabling direct arithmetic indexing
+during binary search.
 
 - 1 byte block type (3: fixed-size with hash, 4: fixed-size without hash)
 - 3 bytes entry count
 - 1 byte key size (uniform across all entries)
-- 1 byte value type (shared by all entries, same encoding as variable-size type field)
+- 1 byte value type (shared by all entries, same encoding as variable-size type field), or
+  `FIXED_KEY_BLOCK_MIXED_VALUE_TYPE` (4) when entries share a value size but not a value type
+- 1 byte value size — only present when the value type is `FIXED_KEY_BLOCK_MIXED_VALUE_TYPE`
 - foreach entry (packed at stride = hash_len + key_size + val_size):
   - 8 bytes key hash (if block type 3)
   - key data (key_size bytes)
-  - value data (size determined by value type)
+  - 1 byte value type — only present when the block is mixed-type
+  - value data (size determined by the block's or the entry's value type)
+
+The mixed-type form exists so that same-sized inline values and key-value tombstones can share a
+fixed-size block: they have equal value sizes but different type bytes. Tag 4 is available as the
+mixed marker because it is not itself a valid entry type.
 
 Entry position for index `i` is computed as `header_size + i * stride` with no indirection. The writer automatically selects fixed-size format when all entries in a block qualify; otherwise falls back to the variable-size format above.
 
@@ -321,3 +361,7 @@ Configuration options for compactions are:
 
 - fsync!
 - (this also deleted enqueued files)
+
+## Compatibility
+
+Currently, the database does not support cross version compatibility. Therefore all updates should be considered breaking changes and the only approach is to rewrite the databases.

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -6,8 +6,9 @@
 //! Entry types:
 //! - 0: Small value (stored in value block)
 //! - 1: Blob reference
-//! - 2: Deleted/tombstone
+//! - 2: Key tombstone (deletes all values for the key)
 //! - 3: Medium value
+//! - 4: Key-value tombstone (deletes one value from the key's group)
 //! - 8-255: Inline value where (type - 8) = value byte count
 
 use std::{
@@ -28,8 +29,9 @@ use turbo_persistence::{
     sst_filter::SstFilter,
     static_sorted_file::{
         BLOCK_TYPE_FIXED_KEY_NO_HASH, BLOCK_TYPE_FIXED_KEY_WITH_HASH, BLOCK_TYPE_KEY_NO_HASH,
-        BLOCK_TYPE_KEY_WITH_HASH, KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED,
-        KEY_BLOCK_ENTRY_TYPE_INLINE_MIN, KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
+        BLOCK_TYPE_KEY_WITH_HASH, KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED,
+        KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
     },
 };
 
@@ -96,10 +98,11 @@ struct SstStats {
 
     /// Value sizes by type (inline values track actual bytes)
     inline_value_bytes: u64,
-    small_value_refs: u64,  // Count of references to value blocks
-    medium_value_refs: u64, // Count of references to medium values
-    blob_refs: u64,         // Count of blob references
-    deleted_count: u64,     // Count of deleted entries
+    small_value_refs: u64,        // Count of references to value blocks
+    medium_value_refs: u64,       // Count of references to medium values
+    blob_refs: u64,               // Count of blob references
+    deleted_count: u64,           // Count of key tombstones
+    key_value_deleted_count: u64, // Count of key-value tombstones
 
     /// File size in bytes
     file_size: u64,
@@ -122,6 +125,7 @@ impl SstStats {
         self.medium_value_refs += other.medium_value_refs;
         self.blob_refs += other.blob_refs;
         self.deleted_count += other.deleted_count;
+        self.key_value_deleted_count += other.key_value_deleted_count;
         self.file_size += other.file_size;
     }
 }
@@ -144,8 +148,11 @@ fn track_entry_type(stats: &mut SstStats, entry_type: u8) {
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
             stats.blob_refs += 1;
         }
-        KEY_BLOCK_ENTRY_TYPE_DELETED => {
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => {
             stats.deleted_count += 1;
+        }
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => {
+            stats.key_value_deleted_count += 1;
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             stats.medium_value_refs += 1;
@@ -162,7 +169,8 @@ fn entry_type_description(ty: u8) -> String {
     match ty {
         KEY_BLOCK_ENTRY_TYPE_SMALL => "small value (in value block)".to_string(),
         KEY_BLOCK_ENTRY_TYPE_BLOB => "blob reference".to_string(),
-        KEY_BLOCK_ENTRY_TYPE_DELETED => "deleted/tombstone".to_string(),
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => "key tombstone".to_string(),
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => "key-value tombstone".to_string(),
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => "medium value".to_string(),
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             let inline_size = ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN;
@@ -647,9 +655,16 @@ fn print_value_storage(stats: &SstStats, prefix: &str) {
     }
     if stats.deleted_count > 0 {
         println!(
-            "{}  Deleted: {} entries",
+            "{}  Key tombstones: {} entries",
             prefix,
             format_number(stats.deleted_count)
+        );
+    }
+    if stats.key_value_deleted_count > 0 {
+        println!(
+            "{}  Key-value tombstones: {} entries",
+            prefix,
+            format_number(stats.key_value_deleted_count)
         );
     }
 }
@@ -832,8 +847,9 @@ fn main() -> Result<()> {
             eprintln!("Entry types:");
             eprintln!("  0: Small value (stored in separate value block)");
             eprintln!("  1: Blob reference");
-            eprintln!("  2: Deleted/tombstone");
+            eprintln!("  2: Key tombstone (deletes all values for the key)");
             eprintln!("  3: Medium value");
+            eprintln!("  4: Key-value tombstone (deletes one value from the key's group)");
             eprintln!("  8+: Inline value (size = type - 8)");
             eprintln!();
             eprintln!("For TaskCache (family 3), values are 4-byte TaskIds.");

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -8,8 +8,8 @@
 //! - 1: Blob reference
 //! - 2: Key tombstone (deletes all values for the key)
 //! - 3: Medium value
-//! - 4: Key-value tombstone (deletes one value from the key's group)
-//! - 8-255: Inline value where (type - 8) = value byte count
+//! - 8-16: Inline value where (type - 8) = value byte count
+//! - 17-25: Key-value tombstone where (type - 17) = deleted value byte count
 
 use std::{
     collections::{BTreeMap, HashSet},
@@ -30,7 +30,7 @@ use turbo_persistence::{
     static_sorted_file::{
         BLOCK_TYPE_FIXED_KEY_NO_HASH, BLOCK_TYPE_FIXED_KEY_WITH_HASH, BLOCK_TYPE_KEY_NO_HASH,
         BLOCK_TYPE_KEY_WITH_HASH, KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
-        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED,
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN,
         KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
     },
 };
@@ -151,11 +151,12 @@ fn track_entry_type(stats: &mut SstStats, entry_type: u8) {
         KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => {
             stats.deleted_count += 1;
         }
-        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => {
-            stats.key_value_deleted_count += 1;
-        }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             stats.medium_value_refs += 1;
+        }
+        // Must precede the inline arm: both are open-ended and the tombstone range sits above it.
+        ty if ty >= KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN => {
+            stats.key_value_deleted_count += 1;
         }
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             let inline_size = (ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN) as u64;
@@ -170,8 +171,12 @@ fn entry_type_description(ty: u8) -> String {
         KEY_BLOCK_ENTRY_TYPE_SMALL => "small value (in value block)".to_string(),
         KEY_BLOCK_ENTRY_TYPE_BLOB => "blob reference".to_string(),
         KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => "key tombstone".to_string(),
-        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => "key-value tombstone".to_string(),
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => "medium value".to_string(),
+        // Must precede the inline arm: both are open-ended and the tombstone range sits above it.
+        ty if ty >= KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN => {
+            let size = ty - KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN;
+            format!("key-value tombstone ({size} byte value)")
+        }
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             let inline_size = ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN;
             format!("inline {} bytes", inline_size)
@@ -849,8 +854,8 @@ fn main() -> Result<()> {
             eprintln!("  1: Blob reference");
             eprintln!("  2: Key tombstone (deletes all values for the key)");
             eprintln!("  3: Medium value");
-            eprintln!("  4: Key-value tombstone (deletes one value from the key's group)");
-            eprintln!("  8+: Inline value (size = type - 8)");
+            eprintln!("  8-16: Inline value (size = type - 8)");
+            eprintln!("  17-25: Key-value tombstone (deleted value size = type - 17)");
             eprintln!();
             eprintln!("For TaskCache (family 3), values are 4-byte TaskIds.");
             eprintln!("Expected entry type is 12 (8 + 4) for inline optimization.");

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -102,7 +102,7 @@ struct SstStats {
     small_value_refs: u64,        // Count of references to value blocks
     medium_value_refs: u64,       // Count of references to medium values
     blob_refs: u64,               // Count of blob references
-    deleted_count: u64,           // Count of key tombstones
+    key_deleted_count: u64,       // Count of key tombstones
     key_value_deleted_count: u64, // Count of key-value tombstones
 
     /// File size in bytes
@@ -125,7 +125,7 @@ impl SstStats {
         self.small_value_refs += other.small_value_refs;
         self.medium_value_refs += other.medium_value_refs;
         self.blob_refs += other.blob_refs;
-        self.deleted_count += other.deleted_count;
+        self.key_deleted_count += other.key_deleted_count;
         self.key_value_deleted_count += other.key_value_deleted_count;
         self.file_size += other.file_size;
     }
@@ -150,7 +150,7 @@ fn track_entry_type(stats: &mut SstStats, entry_type: u8) {
             stats.blob_refs += 1;
         }
         KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => {
-            stats.deleted_count += 1;
+            stats.key_deleted_count += 1;
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             stats.medium_value_refs += 1;
@@ -696,11 +696,11 @@ fn print_value_storage(stats: &SstStats, prefix: &str) {
             format_number(stats.blob_refs)
         );
     }
-    if stats.deleted_count > 0 {
+    if stats.key_deleted_count > 0 {
         println!(
             "{}  Key tombstones: {} entries",
             prefix,
-            format_number(stats.deleted_count)
+            format_number(stats.key_deleted_count)
         );
     }
     if stats.key_value_deleted_count > 0 {

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -3,13 +3,11 @@
 //! This tool inspects SST files to report entry type statistics per family,
 //! useful for verifying that inline value optimization is being used.
 //!
-//! Entry types:
-//! - 0: Small value (stored in value block)
-//! - 1: Blob reference
-//! - 2: Key tombstone (deletes all values for the key)
-//! - 3: Medium value
-//! - 8-16: Inline value where (type - 8) = value byte count
-//! - 17-25: Key-value tombstone where (type - 17) = deleted value byte count
+//! Entry types are the `KEY_BLOCK_ENTRY_TYPE_*` constants in
+//! [`turbo_persistence::static_sorted_file`]; the `--help` output lists them with their current
+//! values. The two ranged kinds encode a size in the type byte: an inline value's byte count is
+//! `type - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN`, and a key-value tombstone's deleted byte count is
+//! `type - KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN`.
 
 use std::{
     collections::{BTreeMap, HashSet},
@@ -22,7 +20,7 @@ use fs_err::{self as fs, File};
 use lzzzz::lz4::decompress;
 use memmap2::Mmap;
 use turbo_persistence::{
-    BLOCK_HEADER_SIZE, checksum_block,
+    BLOCK_HEADER_SIZE, MAX_INLINE_VALUE_SIZE, checksum_block,
     meta_file::MetaFile,
     mmap_helper::advise_mmap_for_persistence,
     read_current_version,
@@ -420,13 +418,13 @@ fn parse_key_block_header(block: &[u8]) -> Result<KeyBlockHeader> {
                     0
                 };
                 let key_size = block[4] as usize;
-                // +1 for the per-entry type byte.
-                let val_size = block[6] as usize + 1;
+                let val_size = block[6] as usize;
                 Ok(KeyBlockHeader::FixedMixedType {
                     entry_count,
                     hash_len,
                     key_size,
-                    stride: hash_len + key_size + val_size,
+                    // +1 for the per-entry type byte.
+                    stride: hash_len + key_size + val_size + 1,
                 })
             } else {
                 Ok(KeyBlockHeader::Fixed {
@@ -888,15 +886,32 @@ fn main() -> Result<()> {
             eprintln!("  -v, --verbose    Show per-SST file details (default: family totals only)");
             eprintln!();
             eprintln!("Entry types:");
-            eprintln!("  0: Small value (stored in separate value block)");
-            eprintln!("  1: Blob reference");
-            eprintln!("  2: Key tombstone (deletes all values for the key)");
-            eprintln!("  3: Medium value");
-            eprintln!("  8-16: Inline value (size = type - 8)");
-            eprintln!("  17-25: Key-value tombstone (deleted value size = type - 17)");
+            eprintln!(
+                "  {KEY_BLOCK_ENTRY_TYPE_SMALL}: Small value (stored in separate value block)"
+            );
+            eprintln!("  {KEY_BLOCK_ENTRY_TYPE_BLOB}: Blob reference");
+            eprintln!(
+                "  {KEY_BLOCK_ENTRY_TYPE_KEY_DELETED}: Key tombstone (deletes all values for the \
+                 key)"
+            );
+            eprintln!("  {KEY_BLOCK_ENTRY_TYPE_MEDIUM}: Medium value");
+            eprintln!(
+                "  {KEY_BLOCK_ENTRY_TYPE_INLINE_MIN}-{}: Inline value (size = type - \
+                 {KEY_BLOCK_ENTRY_TYPE_INLINE_MIN})",
+                KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + MAX_INLINE_VALUE_SIZE as u8
+            );
+            eprintln!(
+                "  {KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN}-{}: Key-value tombstone (deleted \
+                 value size = type - {KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN})",
+                KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN + MAX_INLINE_VALUE_SIZE as u8
+            );
             eprintln!();
             eprintln!("For TaskCache (family 3), values are 4-byte TaskIds.");
-            eprintln!("Expected entry type is 12 (8 + 4) for inline optimization.");
+            eprintln!(
+                "Expected entry type is {} ({KEY_BLOCK_ENTRY_TYPE_INLINE_MIN} + 4) for inline \
+                 optimization.",
+                KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + 4
+            );
             std::process::exit(1);
         }
     };

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -29,9 +29,10 @@ use turbo_persistence::{
     sst_filter::SstFilter,
     static_sorted_file::{
         BLOCK_TYPE_FIXED_KEY_NO_HASH, BLOCK_TYPE_FIXED_KEY_WITH_HASH, BLOCK_TYPE_KEY_NO_HASH,
-        BLOCK_TYPE_KEY_WITH_HASH, KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
-        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN,
-        KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
+        BLOCK_TYPE_KEY_WITH_HASH, FIXED_KEY_BLOCK_MIXED_VALUE_TYPE, KEY_BLOCK_ENTRY_TYPE_BLOB,
+        KEY_BLOCK_ENTRY_TYPE_INLINE_MIN, KEY_BLOCK_ENTRY_TYPE_KEY_DELETED,
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN, KEY_BLOCK_ENTRY_TYPE_MEDIUM,
+        KEY_BLOCK_ENTRY_TYPE_SMALL,
     },
 };
 
@@ -381,9 +382,23 @@ fn parse_key_block_indices(index_block: &[u8]) -> HashSet<u16> {
 }
 
 /// Parsed header of a key block.
+#[derive(Clone, Copy)]
 enum KeyBlockHeader {
-    Variable { entry_count: u32 },
-    Fixed { entry_count: u32, value_type: u8 },
+    Variable {
+        entry_count: u32,
+    },
+    Fixed {
+        entry_count: u32,
+        value_type: u8,
+    },
+    /// Fixed-size layout whose entries share a value size but not a value type, so each carries
+    /// its own type byte between its key and its value.
+    FixedMixedType {
+        entry_count: u32,
+        hash_len: usize,
+        key_size: usize,
+        stride: usize,
+    },
 }
 
 /// Parses the header of a key block from the full decompressed block data.
@@ -397,10 +412,28 @@ fn parse_key_block_header(block: &[u8]) -> Result<KeyBlockHeader> {
         }
         BLOCK_TYPE_FIXED_KEY_WITH_HASH | BLOCK_TYPE_FIXED_KEY_NO_HASH => {
             assert!(block.len() >= 6, "Fixed key block header too small");
-            Ok(KeyBlockHeader::Fixed {
-                entry_count,
-                value_type: block[5],
-            })
+            if block[5] == FIXED_KEY_BLOCK_MIXED_VALUE_TYPE {
+                assert!(block.len() >= 7, "Mixed-type key block header too small");
+                let hash_len = if block_type == BLOCK_TYPE_FIXED_KEY_WITH_HASH {
+                    8
+                } else {
+                    0
+                };
+                let key_size = block[4] as usize;
+                // +1 for the per-entry type byte.
+                let val_size = block[6] as usize + 1;
+                Ok(KeyBlockHeader::FixedMixedType {
+                    entry_count,
+                    hash_len,
+                    key_size,
+                    stride: hash_len + key_size + val_size,
+                })
+            } else {
+                Ok(KeyBlockHeader::Fixed {
+                    entry_count,
+                    value_type: block[5],
+                })
+            }
         }
         _ => bail!("Invalid key block type: {block_type}"),
     }
@@ -408,27 +441,32 @@ fn parse_key_block_header(block: &[u8]) -> Result<KeyBlockHeader> {
 
 /// Iterates over entry type bytes in a key block.
 ///
-/// For variable-size key blocks, reads byte 0 of each 4-byte offset table entry.
-/// For fixed-size key blocks, yields the single `value_type` repeated `entry_count` times.
+/// For variable-size key blocks, reads byte 0 of each 4-byte offset table entry. For fixed-size
+/// key blocks, yields the single `value_type` repeated `entry_count` times, or reads the per-entry
+/// type byte when the block has mixed types.
 fn iter_key_block_entry_types(
     header: KeyBlockHeader,
     block: &[u8],
 ) -> impl Iterator<Item = u8> + '_ {
-    let (entry_count, fixed_type) = match header {
-        KeyBlockHeader::Variable { entry_count } => (entry_count, None),
-        KeyBlockHeader::Fixed {
-            entry_count,
-            value_type,
-        } => (entry_count, Some(value_type)),
+    let entry_count = match header {
+        KeyBlockHeader::Variable { entry_count }
+        | KeyBlockHeader::Fixed { entry_count, .. }
+        | KeyBlockHeader::FixedMixedType { entry_count, .. } => entry_count,
     };
-    (0..entry_count).map(move |i| {
-        if let Some(vt) = fixed_type {
-            vt
-        } else {
-            // Variable block: offset table starts at byte 4 (after 1B type + 3B count),
-            // each entry is 4 bytes, first byte is the entry type.
-            let header_offset = KEY_BLOCK_HEADER_SIZE + i as usize * 4;
-            block[header_offset]
+    (0..entry_count).map(move |i| match header {
+        // Variable block: offset table starts at byte 4 (after 1B type + 3B count),
+        // each entry is 4 bytes, first byte is the entry type.
+        KeyBlockHeader::Variable { .. } => block[KEY_BLOCK_HEADER_SIZE + i as usize * 4],
+        KeyBlockHeader::Fixed { value_type, .. } => value_type,
+        KeyBlockHeader::FixedMixedType {
+            hash_len,
+            key_size,
+            stride,
+            ..
+        } => {
+            // Entry data starts after the 7-byte mixed-type header; the type byte sits between
+            // the entry's key and its value.
+            block[7 + i as usize * stride + hash_len + key_size]
         }
     })
 }
@@ -515,7 +553,7 @@ fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
                     raw.was_compressed,
                 );
             }
-            KeyBlockHeader::Fixed { .. } => {
+            KeyBlockHeader::Fixed { .. } | KeyBlockHeader::FixedMixedType { .. } => {
                 stats.fixed_key_blocks.add(
                     raw.compressed_size,
                     raw.actual_size,

--- a/turbopack/crates/turbo-persistence/src/collector.rs
+++ b/turbopack/crates/turbo-persistence/src/collector.rs
@@ -4,10 +4,10 @@ use crate::{
     FamilyKind, ValueBuffer,
     collector_entry::{CollectorEntry, CollectorEntryValue, EntryKey, TINY_VALUE_THRESHOLD},
     constants::{
-        DATA_THRESHOLD_PER_INITIAL_FILE, MAX_ENTRIES_PER_INITIAL_FILE, MAX_SMALL_VALUE_SIZE,
+        DATA_THRESHOLD_PER_INITIAL_FILE, MAX_ENTRIES_PER_INITIAL_FILE, MAX_INLINE_VALUE_SIZE,
+        MAX_SMALL_VALUE_SIZE,
     },
     key::{StoreKey, hash_key},
-    static_sorted_file::KEY_VALUE_DELETED_REF_SIZE,
     value_block_count_tracker::ValueBlockCountTracker,
 };
 
@@ -105,15 +105,23 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
     ///
     /// Only meaningful for [`FamilyKind::MultiValue`] families. Callers must not insert and delete
     /// the same key-value pair in one batch; the resolution order between them is undefined.
-    pub fn delete_value(&mut self, key: K, value: [u8; KEY_VALUE_DELETED_REF_SIZE]) {
+    ///
+    /// `value` must be at most [`MAX_INLINE_VALUE_SIZE`] bytes; callers validate this.
+    pub fn delete_value(&mut self, key: K, value: &[u8]) {
+        debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
         let key = EntryKey {
             hash: hash_key(&key),
             data: key,
         };
         self.total_key_size += key.len();
+        let mut data = [0u8; MAX_INLINE_VALUE_SIZE];
+        data[..value.len()].copy_from_slice(value);
         self.entries.push(CollectorEntry {
             key,
-            value: CollectorEntryValue::KeyValueDeleted { value },
+            value: CollectorEntryValue::KeyValueDeleted {
+                value: data,
+                len: value.len() as u8,
+            },
         });
     }
 

--- a/turbopack/crates/turbo-persistence/src/collector.rs
+++ b/turbopack/crates/turbo-persistence/src/collector.rs
@@ -103,8 +103,14 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
     /// Adds a key-value tombstone to the collector: deletes only the single `key` -> `value` pair,
     /// leaving any other values for `key` intact.
     ///
-    /// Only meaningful for [`FamilyKind::MultiValue`] families. Deleting a pair written in the
-    /// same batch is not supported; see [`WriteBatch::delete_value`][crate::WriteBatch].
+    /// Only meaningful for [`FamilyKind::MultiValue`] families, where a key can map to several
+    /// values and [`Collector::delete`] is too coarse: it would drop the unrelated values too.
+    /// The motivating case is the task cache, which is keyed by a hash and so holds more than one
+    /// value whenever two tasks collide. Removing one task must leave the colliding task's entry
+    /// readable, which requires naming the exact pair to delete.
+    ///
+    /// Deleting a pair written in the same batch is not supported; see
+    /// [`WriteBatch::delete_value`][crate::WriteBatch].
     ///
     /// `value` must be at most [`MAX_INLINE_VALUE_SIZE`] bytes; callers must validate this.  Larger
     /// values could be supported in the future but there is currently no usecase.

--- a/turbopack/crates/turbo-persistence/src/collector.rs
+++ b/turbopack/crates/turbo-persistence/src/collector.rs
@@ -106,7 +106,8 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
     /// Only meaningful for [`FamilyKind::MultiValue`] families. Deleting a pair written in the
     /// same batch is not supported; see [`WriteBatch::delete_value`][crate::WriteBatch].
     ///
-    /// `value` must be at most [`MAX_INLINE_VALUE_SIZE`] bytes; callers validate this.
+    /// `value` must be at most [`MAX_INLINE_VALUE_SIZE`] bytes; callers must validate this.  Larger
+    /// values could be supported in the future but there is currently no usecase.
     pub fn delete_value(&mut self, key: K, value: &[u8]) {
         debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
         let key = EntryKey {

--- a/turbopack/crates/turbo-persistence/src/collector.rs
+++ b/turbopack/crates/turbo-persistence/src/collector.rs
@@ -7,6 +7,7 @@ use crate::{
         DATA_THRESHOLD_PER_INITIAL_FILE, MAX_ENTRIES_PER_INITIAL_FILE, MAX_SMALL_VALUE_SIZE,
     },
     key::{StoreKey, hash_key},
+    static_sorted_file::KEY_VALUE_DELETED_REF_SIZE,
     value_block_count_tracker::ValueBlockCountTracker,
 };
 
@@ -86,7 +87,7 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
         });
     }
 
-    /// Adds a tombstone pair to the collector.
+    /// Adds a tombstone pair to the collector. This deletes *all* values for `key`.
     pub fn delete(&mut self, key: K) {
         let key = EntryKey {
             hash: hash_key(&key),
@@ -95,7 +96,24 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
         self.total_key_size += key.len();
         self.entries.push(CollectorEntry {
             key,
-            value: CollectorEntryValue::Deleted,
+            value: CollectorEntryValue::KeyDeleted,
+        });
+    }
+
+    /// Adds a key-value tombstone to the collector: deletes only the single `key` -> `value` pair,
+    /// leaving any other values for `key` intact.
+    ///
+    /// Only meaningful for [`FamilyKind::MultiValue`] families. Callers must not insert and delete
+    /// the same key-value pair in one batch; the resolution order between them is undefined.
+    pub fn delete_value(&mut self, key: K, value: [u8; KEY_VALUE_DELETED_REF_SIZE]) {
+        let key = EntryKey {
+            hash: hash_key(&key),
+            data: key,
+        };
+        self.total_key_size += key.len();
+        self.entries.push(CollectorEntry {
+            key,
+            value: CollectorEntryValue::KeyValueDeleted { value },
         });
     }
 
@@ -110,19 +128,19 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
         self.entries.push(entry);
     }
 
-    /// Sorts entries by key. Tombstones are placed last within each key group.
+    /// Sorts entries by key. Within a key group, key-value tombstones are placed first and key
+    /// tombstones last (see [`CollectorEntryValue::sort_rank`]).
     /// This method does not deduplicate entries.
     ///
     /// In debug builds, asserts that SingleValue families have no duplicate keys.
     pub fn sorted(&mut self, family_kind: FamilyKind) -> (&[CollectorEntry<K>], usize) {
-        // Sort by (hash, key) with tombstones placed last within each key group.
         // We can use unstable sort because the relative order of equal elements
         // doesn't matter — duplicates are either disallowed (SingleValue) or
         // allowed without deduplication (MultiValue).
         self.entries.sort_unstable_by(|a, b| {
             a.key
                 .cmp(&b.key)
-                .then_with(|| a.value.is_deleted().cmp(&b.value.is_deleted()))
+                .then_with(|| a.value.sort_rank().cmp(&b.value.sort_rank()))
         });
 
         #[cfg(debug_assertions)]

--- a/turbopack/crates/turbo-persistence/src/collector.rs
+++ b/turbopack/crates/turbo-persistence/src/collector.rs
@@ -103,8 +103,8 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
     /// Adds a key-value tombstone to the collector: deletes only the single `key` -> `value` pair,
     /// leaving any other values for `key` intact.
     ///
-    /// Only meaningful for [`FamilyKind::MultiValue`] families. Callers must not insert and delete
-    /// the same key-value pair in one batch; the resolution order between them is undefined.
+    /// Only meaningful for [`FamilyKind::MultiValue`] families. Deleting a pair written in the
+    /// same batch is not supported; see [`WriteBatch::delete_value`][crate::WriteBatch].
     ///
     /// `value` must be at most [`MAX_INLINE_VALUE_SIZE`] bytes; callers validate this.
     pub fn delete_value(&mut self, key: K, value: &[u8]) {

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -58,6 +58,19 @@ impl CollectorEntryValue {
         matches!(self, CollectorEntryValue::Medium { .. })
     }
 
+    /// The value bytes, or `None` for variants that carry no value data of their own (blob
+    /// references and key tombstones).
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),
+            CollectorEntryValue::Small { value } | CollectorEntryValue::Medium { value } => {
+                Some(value)
+            }
+            CollectorEntryValue::KeyValueDeleted { value, len } => Some(&value[..*len as usize]),
+            CollectorEntryValue::Large { .. } | CollectorEntryValue::KeyDeleted => None,
+        }
+    }
+
     /// Returns the value size if it will be packed into a small value block, or 0 otherwise.
     pub fn small_value_size(&self) -> usize {
         match self {

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -60,6 +60,7 @@ impl CollectorEntryValue {
 
     /// The value bytes, or `None` for variants that carry no value data of their own (blob
     /// references and key tombstones).
+    #[cfg(feature = "verify_sst_content")]
     pub fn as_bytes(&self) -> Option<&[u8]> {
         match self {
             CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use crate::{
     constants::MAX_INLINE_VALUE_SIZE,
     key::StoreKey,
+    static_sorted_file::KEY_VALUE_DELETED_REF_SIZE,
     static_sorted_file_builder::{Entry, EntryValue},
 };
 
@@ -32,7 +33,11 @@ pub enum CollectorEntryValue {
     Large {
         blob: u32,
     },
-    Deleted,
+    KeyDeleted,
+    /// Key-value tombstone: deletes only this one value from the key's group. MultiValue only.
+    KeyValueDeleted {
+        value: [u8; KEY_VALUE_DELETED_REF_SIZE],
+    },
 }
 
 impl CollectorEntryValue {
@@ -42,7 +47,8 @@ impl CollectorEntryValue {
             CollectorEntryValue::Small { value } => value.len(),
             CollectorEntryValue::Medium { value } => value.len(),
             CollectorEntryValue::Large { blob: _ } => 0,
-            CollectorEntryValue::Deleted => 0,
+            CollectorEntryValue::KeyDeleted => 0,
+            CollectorEntryValue::KeyValueDeleted { .. } => 0,
         }
     }
 
@@ -62,9 +68,21 @@ impl CollectorEntryValue {
         }
     }
 
-    /// Returns true if this value is a deletion tombstone.
-    pub fn is_deleted(&self) -> bool {
-        matches!(self, CollectorEntryValue::Deleted)
+    /// Sort rank within a key group. The two tombstone kinds sit at opposite ends:
+    ///
+    /// - Key-value tombstones (rank 0) go **first**, so a reader collects them before the values
+    ///   they filter and can apply them in one forward pass.
+    /// - Values (rank 1) go in the middle.
+    /// - Key tombstones (rank 2) go **last**, because they shadow only entries older than
+    ///   themselves — including entries in this same SST. A batch doing `put(A); delete; put(B)`
+    ///   must keep A and B, so a reader that stops at the first key tombstone it sees still returns
+    ///   the same-batch values it already collected.
+    pub fn sort_rank(&self) -> u8 {
+        match self {
+            CollectorEntryValue::KeyValueDeleted { .. } => 0,
+            CollectorEntryValue::KeyDeleted => 2,
+            _ => 1,
+        }
     }
 }
 
@@ -133,7 +151,8 @@ impl<K: StoreKey> Entry for CollectorEntry<K> {
             }
             CollectorEntryValue::Medium { value } => EntryValue::Medium { value },
             CollectorEntryValue::Large { blob } => EntryValue::Large { blob: *blob },
-            CollectorEntryValue::Deleted => EntryValue::Deleted,
+            CollectorEntryValue::KeyDeleted => EntryValue::KeyDeleted,
+            CollectorEntryValue::KeyValueDeleted { value } => EntryValue::KeyValueDeleted { value },
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -63,11 +63,11 @@ impl CollectorEntryValue {
     #[cfg(feature = "verify_sst_content")]
     pub fn as_bytes(&self) -> Option<&[u8]> {
         match self {
-            CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),
+            CollectorEntryValue::KeyValueDeleted { value, len }
+            | CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),
             CollectorEntryValue::Small { value } | CollectorEntryValue::Medium { value } => {
                 Some(value)
             }
-            CollectorEntryValue::KeyValueDeleted { value, len } => Some(&value[..*len as usize]),
             CollectorEntryValue::Large { .. } | CollectorEntryValue::KeyDeleted => None,
         }
     }

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -44,12 +44,12 @@ pub enum CollectorEntryValue {
 impl CollectorEntryValue {
     pub fn len(&self) -> usize {
         match self {
-            CollectorEntryValue::Tiny { len, .. } => *len as usize,
+            CollectorEntryValue::KeyValueDeleted { len, .. }
+            | CollectorEntryValue::Tiny { len, .. } => *len as usize,
             CollectorEntryValue::Small { value } => value.len(),
             CollectorEntryValue::Medium { value } => value.len(),
             CollectorEntryValue::Large { blob: _ } => 0,
             CollectorEntryValue::KeyDeleted => 0,
-            CollectorEntryValue::KeyValueDeleted { .. } => 0,
         }
     }
 

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -63,8 +63,10 @@ impl CollectorEntryValue {
     #[cfg(feature = "verify_sst_content")]
     pub fn as_bytes(&self) -> Option<&[u8]> {
         match self {
-            CollectorEntryValue::KeyValueDeleted { value, len }
-            | CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),
+            // Separate arms: the inline buffers have different sizes, so they cannot be bound by
+            // a single or-pattern.
+            CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),
+            CollectorEntryValue::KeyValueDeleted { value, len } => Some(&value[..*len as usize]),
             CollectorEntryValue::Small { value } | CollectorEntryValue::Medium { value } => {
                 Some(value)
             }

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use crate::{
     constants::MAX_INLINE_VALUE_SIZE,
     key::StoreKey,
-    static_sorted_file::KEY_VALUE_DELETED_REF_SIZE,
     static_sorted_file_builder::{Entry, EntryValue},
 };
 
@@ -35,8 +34,10 @@ pub enum CollectorEntryValue {
     },
     KeyDeleted,
     /// Key-value tombstone: deletes only this one value from the key's group. MultiValue only.
+    /// The deleted value is stored inline, so it is capped at [`MAX_INLINE_VALUE_SIZE`].
     KeyValueDeleted {
-        value: [u8; KEY_VALUE_DELETED_REF_SIZE],
+        value: [u8; MAX_INLINE_VALUE_SIZE],
+        len: u8,
     },
 }
 
@@ -152,7 +153,9 @@ impl<K: StoreKey> Entry for CollectorEntry<K> {
             CollectorEntryValue::Medium { value } => EntryValue::Medium { value },
             CollectorEntryValue::Large { blob } => EntryValue::Large { blob: *blob },
             CollectorEntryValue::KeyDeleted => EntryValue::KeyDeleted,
-            CollectorEntryValue::KeyValueDeleted { value } => EntryValue::KeyValueDeleted { value },
+            CollectorEntryValue::KeyValueDeleted { value, len } => EntryValue::KeyValueDeleted {
+                value: &value[..*len as usize],
+            },
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1570,8 +1570,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     .collect::<Vec<_>>();
 
                                 // A tombstone is dead if no older SST contains a matching key
-                                // This can have false negatives due to the filters but no false
-                                // positives.
+                                // This can have false negatives (report dead tombstones as live)
+                                // due to the filters but no false positives.
                                 move |hash: u64| {
                                     !older_filters.iter().any(|(min, max, amqf)| {
                                         hash >= *min

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1524,6 +1524,33 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         .parallel_scheduler
                         .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(merge_jobs, |indices| {
                             let _span = span.clone().entered();
+                            // Filters of every SST older than this job. "Older than the job" is
+                            // the safe cut: `MergeIter` yields newest-first and the loop below
+                            // already drops the older values a tombstone shadows, so only SSTs
+                            // the job cannot see can still resurrect a value. Sequence numbers
+                            // come from a monotonic counter, so `seq` orders by recency.
+                            let oldest_seq_in_job = indices
+                                .iter()
+                                .map(|&i| ssts_with_ranges[i].seq)
+                                .min()
+                                .unwrap_or(0);
+                            let older_filters = ssts_with_ranges
+                                .iter()
+                                .filter(|sst| sst.seq < oldest_seq_in_job)
+                                .map(|sst| {
+                                    let entry = meta_files[sst.meta_index].entry(sst.index_in_meta);
+                                    (entry.min_hash(), entry.max_hash(), entry.amqf())
+                                })
+                                .collect::<Vec<_>>();
+                            // A tombstone is dead once no SST outside this job could still hold a
+                            // matching key. The AMQF's error is one-sided — `false` means
+                            // *definitely absent* — so a false positive only retains a tombstone
+                            // for another round, and the resurrection direction is unreachable.
+                            let tombstone_is_dead = |hash: u64| {
+                                !older_filters.iter().any(|(min, max, amqf)| {
+                                    hash >= *min && hash <= *max && amqf.contains_fingerprint(hash)
+                                })
+                            };
                             if indices.len() == 1 {
                                 // If we only have one file, we can just move it
                                 let index = indices[0];
@@ -1675,6 +1702,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             // - MultiValue: skip all older entries after encountering a tombstone
                             //   (which signals deletion of all prior values for this key)
                             let mut skip_remaining_for_this_key = false;
+                            // Values deleted by key-value tombstones in the current key group.
+                            // Reset at each key boundary.
+                            let mut deleted_values_for_this_key: SmallVec<[RcBytes; 1]> =
+                                SmallVec::new();
                             let family_config = &self.config.family_configs[family as usize];
 
                             for entry in iter {
@@ -1682,7 +1713,24 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 if current_key.as_ref() != Some(&entry.key) {
                                     // we changed keys so undo this flag
                                     skip_remaining_for_this_key = false;
+                                    deleted_values_for_this_key.clear();
                                     current_key = Some(entry.key.clone());
+                                }
+                                // Key-value tombstones sort first within a group, so each is
+                                // recorded before the values it might delete.
+                                if let IterValue::KeyValueDeleted { value } = &entry.value {
+                                    deleted_values_for_this_key.push(value.clone());
+                                    // Applied to this job's values above; keep it only if an SST
+                                    // outside the job could still hold a matching key.
+                                    if tombstone_is_dead(entry.hash) {
+                                        continue;
+                                    }
+                                } else if !deleted_values_for_this_key.is_empty()
+                                    && let IterValue::Slice { value } = &entry.value
+                                    && deleted_values_for_this_key.iter().any(|d| **d == **value)
+                                {
+                                    // Deleted by a key-value tombstone seen earlier in this group.
+                                    continue;
                                 }
                                 if !skip_remaining_for_this_key {
                                     let is_used = used_key_hashes
@@ -1696,8 +1744,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     match family_config.kind {
                                         FamilyKind::MultiValue => {
                                             // For MultiValue families we only skip remaining if we
-                                            // see a tombstone
-                                            if matches!(entry.value, IterValue::Deleted) {
+                                            // see a key tombstone. Key-value tombstones are
+                                            // handled above and never reach here.
+                                            if matches!(entry.value, IterValue::KeyDeleted) {
                                                 skip_remaining_for_this_key = true;
                                             }
                                         }
@@ -1706,6 +1755,15 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             // else that comes out must be skipped
                                             skip_remaining_for_this_key = true;
                                         }
+                                    }
+                                    // Same liveness rule as a key-value tombstone. Dropping it
+                                    // here is safe because it already set
+                                    // `skip_remaining_for_this_key` above, so the rest of the
+                                    // group stays shadowed within this job.
+                                    if matches!(entry.value, IterValue::KeyDeleted)
+                                        && tombstone_is_dead(entry.hash)
+                                    {
+                                        continue;
                                     }
                                     collector.add_entry(
                                         entry,
@@ -1944,6 +2002,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         #[cfg(feature = "stats")]
         let mut found_in_sst = false;
 
+        // Values deleted by key-value tombstones seen so far. Because we walk meta files newest
+        // first, and tombstones sort first within a key group, every tombstone that could apply to
+        // a value has already been seen by the time we reach that value.
+        let mut deleted_values: SmallVec<[ArcBytes; 1]> = SmallVec::new();
+
         let mut size = 0;
 
         for meta in inner.meta_files.iter().rev() {
@@ -1973,20 +2036,18 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             found_in_sst = true;
                         }
                         inner.accessed_key_hashes[family].insert(hash);
-                        // Process values. Tombstones sort last within a key group,
-                        // so when we see a tombstone, we can return immediately.
                         for value in values {
                             match value {
-                                LookupValue::Deleted => {
+                                LookupValue::KeyDeleted => {
                                     #[cfg(feature = "stats")]
                                     self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
                                     if !FIND_ALL {
                                         span.record("result_size", "deleted");
                                         return Ok(SmallVec::new());
                                     }
-                                    // Tombstone is last in key group. Return accumulated
-                                    // values (from this SST and newer layers). Stop
-                                    // searching older SSTs.
+                                    // A key tombstone deletes every older value for this
+                                    // key. Return what we accumulated from this SST and newer
+                                    // layers and stop searching older SSTs.
                                     if output.is_empty() {
                                         span.record("result_size", "deleted");
                                     } else {
@@ -1994,9 +2055,19 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     }
                                     return Ok(output);
                                 }
+                                LookupValue::KeyValueDeleted { value } => {
+                                    #[cfg(feature = "stats")]
+                                    self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
+                                    // Cannot terminate the search: older layers may hold other
+                                    // values for the same key.
+                                    deleted_values.push(value);
+                                }
                                 LookupValue::Slice { value } => {
                                     #[cfg(feature = "stats")]
                                     self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
+                                    if deleted_values.iter().any(|d| **d == *value) {
+                                        continue;
+                                    }
                                     if !FIND_ALL {
                                         span.record("result_size", value.len());
                                         return Ok(SmallVec::from_buf([value]));
@@ -2008,6 +2079,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     #[cfg(feature = "stats")]
                                     self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
                                     let blob = self.read_blob(sequence_number)?;
+                                    if deleted_values.iter().any(|d| **d == *blob) {
+                                        continue;
+                                    }
                                     if !FIND_ALL {
                                         span.record("result_size", blob.len());
                                         return Ok(SmallVec::from_buf([blob]));
@@ -2120,11 +2194,19 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             if let Some(result) = result {
                 inner.accessed_key_hashes[family].insert(hash);
                 let result = match result {
-                    LookupValue::Deleted => {
+                    LookupValue::KeyDeleted => {
                         #[cfg(feature = "stats")]
                         self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
                         deleted += 1;
                         None
+                    }
+                    LookupValue::KeyValueDeleted { .. } => {
+                        // Key-value tombstones are only written to MultiValue families, and
+                        // `batch_get` rejects those above.
+                        bail!(
+                            "unexpected key-value tombstone in SingleValue family {}",
+                            self.config.family_configs[family].name
+                        )
                     }
                     LookupValue::Slice { value } => {
                         #[cfg(feature = "stats")]

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -2017,7 +2017,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         // Values deleted by key-value tombstones seen so far. Because we walk meta files newest
         // first, and tombstones sort first within a key group, every tombstone that could apply to
         // a value has already been seen by the time we reach that value.
-        let mut deleted_values: SmallVec<[ArcBytes; 1]> = SmallVec::new();
+        let mut deleted_values: AutoSet<ArcBytes, BuildHasherDefault<FxHasher>, 1> =
+            AutoSet::default();
 
         let mut size = 0;
 
@@ -2072,12 +2073,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
                                     // Cannot terminate the search: older layers may hold other
                                     // values for the same key.
-                                    deleted_values.push(value);
+                                    deleted_values.insert(value);
                                 }
                                 LookupValue::Slice { value } => {
                                     #[cfg(feature = "stats")]
                                     self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
-                                    if deleted_values.iter().any(|d| **d == *value) {
+                                    if deleted_values.contains(&value) {
                                         continue;
                                     }
                                     if !FIND_ALL {

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -20,7 +20,6 @@ use jiff::Timestamp;
 use memmap2::Mmap;
 use nohash_hasher::BuildNoHashHasher;
 use parking_lot::{Mutex, RwLock};
-use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tracing::span::EnteredSpan;
@@ -1525,34 +1524,37 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         .parallel_scheduler
                         .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(merge_jobs, |indices| {
                             let _span = span.clone().entered();
-                            // Filters of every SST this job does not merge.
+                            // Filters of every SST older than this job.
                             //
-                            // Membership must be tested by index, not by a sequence number
-                            // threshold: `get_merge_segments` picks members by hash-range overlap
-                            // and skips already-claimed candidates, so a job's indices can have
-                            // gaps. A threshold would treat a skipped SST as part of the job and
-                            // miss it here. Sequence numbers are no help either — a moved SST
-                            // keeps its original number while merged output takes a fresh one, and
-                            // readers walk meta files and entries by position, not by `seq`.
-                            let in_job = indices.iter().copied().collect::<FxHashSet<_>>();
-                            let outside_filters = ssts_with_ranges
+                            // A tombstone only suppresses values older than itself, and within the
+                            // job `MergeIter` yields newest-first so the loop below already drops
+                            // those. What remains is everything older than the job's oldest member.
+                            //
+                            // This must be an index, not a sequence number. `ssts_with_ranges` is
+                            // built by walking meta files and their entries in order, which is the
+                            // order readers traverse in reverse, so a higher index is newer. `seq`
+                            // does not track that: a moved SST keeps its original number while
+                            // merged output takes a fresh one, so a real compaction produces
+                            // index-ordered sequences like [19, 20, 18, 17].
+                            //
+                            // Indices below the job's oldest member stay older than its output:
+                            // `get_merge_segments` returns segments in ascending index order and
+                            // they are re-added to the new meta file in that order, so relative
+                            // order is preserved. SSTs the job skips over sit above its oldest
+                            // member, and so cannot resurrect a value it deletes.
+                            let oldest_index_in_job = indices.iter().copied().min().unwrap_or(0);
+                            let older_filters = ssts_with_ranges[..oldest_index_in_job]
                                 .iter()
-                                .enumerate()
-                                .filter(|(i, _)| !in_job.contains(i))
-                                .map(|(_, sst)| {
+                                .map(|sst| {
                                     let entry = meta_files[sst.meta_index].entry(sst.index_in_meta);
                                     (entry.min_hash(), entry.max_hash(), entry.amqf())
                                 })
                                 .collect::<Vec<_>>();
-                            // A tombstone is dead once no SST outside this job could still hold a
-                            // matching key: within the job, `MergeIter` yields newest-first and the
-                            // loop below already drops the older values the tombstone shadows.
-                            //
                             // The AMQF's error is one-sided — `false` means *definitely absent* —
                             // so a false positive only retains a tombstone for another round, and
                             // the resurrection direction is unreachable.
                             let tombstone_is_dead = |hash: u64| {
-                                !outside_filters.iter().any(|(min, max, amqf)| {
+                                !older_filters.iter().any(|(min, max, amqf)| {
                                     hash >= *min && hash <= *max && amqf.contains_fingerprint(hash)
                                 })
                             };

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashSet,
     fmt::Display,
+    hash::BuildHasherDefault,
     io::{BufWriter, ErrorKind, Write},
     mem::take,
     ops::RangeInclusive,
@@ -13,6 +14,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
+use auto_hash_map::AutoSet;
 use byteorder::{BE, ReadBytesExt, WriteBytesExt};
 use dashmap::DashSet;
 use fs_err::{self as fs, File, OpenOptions, ReadDir};
@@ -20,6 +22,7 @@ use jiff::Timestamp;
 use memmap2::Mmap;
 use nohash_hasher::BuildNoHashHasher;
 use parking_lot::{Mutex, RwLock};
+use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tracing::span::EnteredSpan;
@@ -1547,6 +1550,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     meta,
                                 });
                             }
+
+                            // A tombstone is dead if no older SST contains a matching key.
+                            // Returns `true`` if the tombstone is definitely dead (no false
+                            // positives), if `false` is returned then the tomstone is only likely
+                            // to be alive since the amqf may have  false positive match for the
                             let tombstone_is_dead = {
                                 // Filters of every SST older than this job.
                                 //
@@ -1568,10 +1576,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         (entry.min_hash(), entry.max_hash(), entry.amqf())
                                     })
                                     .collect::<Vec<_>>();
-
-                                // A tombstone is dead if no older SST contains a matching key
-                                // This can have false negatives (report dead tombstones as live)
-                                // due to the filters but no false positives.
                                 move |hash: u64| {
                                     !older_filters.iter().any(|(min, max, amqf)| {
                                         hash >= *min
@@ -1710,8 +1714,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             let mut skip_remaining_for_this_key = false;
                             // Values deleted by key-value tombstones in the current key group.
                             // Reset at each key boundary.
-                            let mut deleted_values_for_this_key: SmallVec<[RcBytes; 1]> =
-                                SmallVec::new();
+                            let mut deleted_values_for_this_key: AutoSet<
+                                RcBytes,
+                                BuildHasherDefault<FxHasher>,
+                                1,
+                            > = AutoSet::default();
                             let family_config = &self.config.family_configs[family as usize];
 
                             for entry in iter {
@@ -1724,8 +1731,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 }
                                 // Key-value tombstones sort first within a group, so each is
                                 // recorded before the values it might delete.
+                                // See: `crate::collector_entry::sort_rank`
                                 if let IterValue::KeyValueDeleted { value } = &entry.value {
-                                    deleted_values_for_this_key.push(value.clone());
+                                    deleted_values_for_this_key.insert(value.clone());
                                     // Applied to this job's values above; keep it only if an SST
                                     // outside the job could still hold a matching key.
                                     if tombstone_is_dead(entry.hash) {
@@ -1734,8 +1742,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 } else if !deleted_values_for_this_key.is_empty()
                                     // Deleted values cannot match blobs, just normal payloads.
                                     && let IterValue::Slice { value } = &entry.value
-                                    // O(N) but in practice there is never more than 1 element.
-                                    && deleted_values_for_this_key.iter().any(|d| **d == **value)
+                                    && deleted_values_for_this_key.contains(value)
                                 {
                                     // Deleted by a key-value tombstone seen earlier in this group.
                                     continue;

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -20,6 +20,7 @@ use jiff::Timestamp;
 use memmap2::Mmap;
 use nohash_hasher::BuildNoHashHasher;
 use parking_lot::{Mutex, RwLock};
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tracing::span::EnteredSpan;
@@ -1524,30 +1525,34 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         .parallel_scheduler
                         .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(merge_jobs, |indices| {
                             let _span = span.clone().entered();
-                            // Filters of every SST older than this job. "Older than the job" is
-                            // the safe cut: `MergeIter` yields newest-first and the loop below
-                            // already drops the older values a tombstone shadows, so only SSTs
-                            // the job cannot see can still resurrect a value. Sequence numbers
-                            // come from a monotonic counter, so `seq` orders by recency.
-                            let oldest_seq_in_job = indices
+                            // Filters of every SST this job does not merge.
+                            //
+                            // Membership must be tested by index, not by a sequence number
+                            // threshold: `get_merge_segments` picks members by hash-range overlap
+                            // and skips already-claimed candidates, so a job's indices can have
+                            // gaps. A threshold would treat a skipped SST as part of the job and
+                            // miss it here. Sequence numbers are no help either — a moved SST
+                            // keeps its original number while merged output takes a fresh one, and
+                            // readers walk meta files and entries by position, not by `seq`.
+                            let in_job = indices.iter().copied().collect::<FxHashSet<_>>();
+                            let outside_filters = ssts_with_ranges
                                 .iter()
-                                .map(|&i| ssts_with_ranges[i].seq)
-                                .min()
-                                .unwrap_or(0);
-                            let older_filters = ssts_with_ranges
-                                .iter()
-                                .filter(|sst| sst.seq < oldest_seq_in_job)
-                                .map(|sst| {
+                                .enumerate()
+                                .filter(|(i, _)| !in_job.contains(i))
+                                .map(|(_, sst)| {
                                     let entry = meta_files[sst.meta_index].entry(sst.index_in_meta);
                                     (entry.min_hash(), entry.max_hash(), entry.amqf())
                                 })
                                 .collect::<Vec<_>>();
                             // A tombstone is dead once no SST outside this job could still hold a
-                            // matching key. The AMQF's error is one-sided — `false` means
-                            // *definitely absent* — so a false positive only retains a tombstone
-                            // for another round, and the resurrection direction is unreachable.
+                            // matching key: within the job, `MergeIter` yields newest-first and the
+                            // loop below already drops the older values the tombstone shadows.
+                            //
+                            // The AMQF's error is one-sided — `false` means *definitely absent* —
+                            // so a false positive only retains a tombstone for another round, and
+                            // the resurrection direction is unreachable.
                             let tombstone_is_dead = |hash: u64| {
-                                !older_filters.iter().any(|(min, max, amqf)| {
+                                !outside_filters.iter().any(|(min, max, amqf)| {
                                     hash >= *min && hash <= *max && amqf.contains_fingerprint(hash)
                                 })
                             };

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1524,40 +1524,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         .parallel_scheduler
                         .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(merge_jobs, |indices| {
                             let _span = span.clone().entered();
-                            // Filters of every SST older than this job.
-                            //
-                            // A tombstone only suppresses values older than itself, and within the
-                            // job `MergeIter` yields newest-first so the loop below already drops
-                            // those. What remains is everything older than the job's oldest member.
-                            //
-                            // This must be an index, not a sequence number. `ssts_with_ranges` is
-                            // built by walking meta files and their entries in order, which is the
-                            // order readers traverse in reverse, so a higher index is newer. `seq`
-                            // does not track that: a moved SST keeps its original number while
-                            // merged output takes a fresh one, so a real compaction produces
-                            // index-ordered sequences like [19, 20, 18, 17].
-                            //
-                            // Indices below the job's oldest member stay older than its output:
-                            // `get_merge_segments` returns segments in ascending index order and
-                            // they are re-added to the new meta file in that order, so relative
-                            // order is preserved. SSTs the job skips over sit above its oldest
-                            // member, and so cannot resurrect a value it deletes.
-                            let oldest_index_in_job = indices.iter().copied().min().unwrap_or(0);
-                            let older_filters = ssts_with_ranges[..oldest_index_in_job]
-                                .iter()
-                                .map(|sst| {
-                                    let entry = meta_files[sst.meta_index].entry(sst.index_in_meta);
-                                    (entry.min_hash(), entry.max_hash(), entry.amqf())
-                                })
-                                .collect::<Vec<_>>();
-                            // The AMQF's error is one-sided — `false` means *definitely absent* —
-                            // so a false positive only retains a tombstone for another round, and
-                            // the resurrection direction is unreachable.
-                            let tombstone_is_dead = |hash: u64| {
-                                !older_filters.iter().any(|(min, max, amqf)| {
-                                    hash >= *min && hash <= *max && amqf.contains_fingerprint(hash)
-                                })
-                            };
+
                             if indices.len() == 1 {
                                 // If we only have one file, we can just move it
                                 let index = indices[0];
@@ -1580,7 +1547,39 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     meta,
                                 });
                             }
+                            let tombstone_is_dead = {
+                                // Filters of every SST older than this job.
+                                //
+                                // A tombstone only suppresses values older than itself, and within
+                                // the job `MergeIter` yields
+                                // newest-first so the loop below already drops
+                                // those. What remains is everything older than the job's oldest
+                                // member.
+                                let oldest_index_in_job = indices
+                                    .iter()
+                                    .copied()
+                                    .min()
+                                    .expect("merge jobs are not empty");
+                                let older_filters = ssts_with_ranges[..oldest_index_in_job]
+                                    .iter()
+                                    .map(|sst| {
+                                        let entry =
+                                            meta_files[sst.meta_index].entry(sst.index_in_meta);
+                                        (entry.min_hash(), entry.max_hash(), entry.amqf())
+                                    })
+                                    .collect::<Vec<_>>();
 
+                                // A tombstone is dead if no older SST contains a matching key
+                                // This can have false negatives due to the filters but no false
+                                // positives.
+                                move |hash: u64| {
+                                    !older_filters.iter().any(|(min, max, amqf)| {
+                                        hash >= *min
+                                            && hash <= *max
+                                            && amqf.contains_fingerprint(hash)
+                                    })
+                                }
+                            };
                             // Open SST files independently for compaction.
                             // Uses MADV_SEQUENTIAL for better OS page management
                             // and avoids caching mmaps on MetaEntry's OnceLock.
@@ -1733,7 +1732,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         continue;
                                     }
                                 } else if !deleted_values_for_this_key.is_empty()
+                                    // Deleted values cannot match blobs, just normal payloads.
                                     && let IterValue::Slice { value } = &entry.value
+                                    // O(N) but in practice there is never more than 1 element.
                                     && deleted_values_for_this_key.iter().any(|d| **d == **value)
                                 {
                                     // Deleted by a key-value tombstone seen earlier in this group.
@@ -1763,10 +1764,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             skip_remaining_for_this_key = true;
                                         }
                                     }
-                                    // Same liveness rule as a key-value tombstone. Dropping it
-                                    // here is safe because it already set
-                                    // `skip_remaining_for_this_key` above, so the rest of the
-                                    // group stays shadowed within this job.
+                                    // If this is a tombstone, see if we need to retain it or not.
                                     if matches!(entry.value, IterValue::KeyDeleted)
                                         && tombstone_is_dead(entry.hash)
                                     {

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -75,6 +75,9 @@ impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
         }
     }
 }
+/// The largest value that [`WriteBatch::delete_value`] can delete, since the tombstone stores
+/// a copy of the value inline.
+pub use constants::MAX_INLINE_VALUE_SIZE;
 pub use key::{KeyBase, QueryKey, StoreKey, hash_key};
 pub use meta_file::MetaEntryFlags;
 pub use parallel_scheduler::{ParallelScheduler, SerialScheduler};

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -11,7 +11,10 @@ use crate::{
 #[derive(PartialEq)]
 pub enum LookupValue<B = ArcBytes> {
     /// The value was deleted.
-    Deleted,
+    KeyDeleted,
+    /// A single value was deleted from this key's group (MultiValue families only). Other values
+    /// for the same key are unaffected. The bytes are the deleted value.
+    KeyValueDeleted { value: B },
     /// The value is stored in the SST file.
     ///
     /// The bytes will be pointing either at a keyblock or a value block in the SST
@@ -24,7 +27,9 @@ pub enum LookupValue<B = ArcBytes> {
 /// non-atomic refcounting).
 pub enum IterValue {
     /// The value was deleted.
-    Deleted,
+    KeyDeleted,
+    /// A single value was deleted from this key's group (MultiValue families only).
+    KeyValueDeleted { value: RcBytes },
     /// The value is stored in the SST file.
     Slice { value: RcBytes },
     /// The value is stored in a blob file.
@@ -39,7 +44,8 @@ pub enum IterValue {
 impl From<LookupValue<RcBytes>> for IterValue {
     fn from(v: LookupValue<RcBytes>) -> Self {
         match v {
-            LookupValue::Deleted => IterValue::Deleted,
+            LookupValue::KeyDeleted => IterValue::KeyDeleted,
+            LookupValue::KeyValueDeleted { value } => IterValue::KeyValueDeleted { value },
             LookupValue::Slice { value } => IterValue::Slice { value },
             LookupValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
         }
@@ -70,7 +76,8 @@ impl Entry for LookupEntry {
 
     fn value(&self) -> EntryValue<'_> {
         match &self.value {
-            IterValue::Deleted => EntryValue::Deleted,
+            IterValue::KeyDeleted => EntryValue::KeyDeleted,
+            IterValue::KeyValueDeleted { value } => EntryValue::KeyValueDeleted { value },
             IterValue::Slice { value } => {
                 if value.len() <= MAX_INLINE_VALUE_SIZE {
                     EntryValue::Inline { value }

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -49,6 +49,14 @@ impl Display for MetaEntryFlags {
     }
 }
 
+/// Magic number identifying a `.meta` file, and implicitly its format version.
+///
+/// Bump this whenever [`EntryHeader`]'s layout changes. The header is a fixed-size struct read at a
+/// computed stride, so an older file parsed by newer code would not fail — it would silently
+/// misinterpret every field after the change. Rejecting the file outright is the only safe
+/// outcome; callers handle the error by discarding and rebuilding the database.
+pub(crate) const META_FILE_MAGIC: u32 = 0xFE4ADA4A;
+
 /// On-disk layout of a single entry header in the `.meta` file.
 ///
 /// Fields are big-endian to match the existing wire format written by [`MetaFileBuilder`].
@@ -137,6 +145,14 @@ impl MetaEntry {
 
     pub fn amqf_size(&self) -> u32 {
         self.amqf_data_offset.end - self.amqf_data_offset.start
+    }
+
+    /// The AMQF filter for this SST, for membership probes that must not open the file.
+    ///
+    /// The error is one-sided: `contains_fingerprint` returning `false` means the key is
+    /// definitely absent, `true` means it is probably present.
+    pub fn amqf(&self) -> &qfilter::FilterRef<'static> {
+        &self.amqf
     }
 
     /// Returns the raw serialized AMQF bytes from the mmap.
@@ -276,7 +292,7 @@ impl MetaFile {
         // Parse the header from the mmap via ReadBytesExt on &[u8].
         let mut reader: &[u8] = &mmap;
         let magic = reader.read_u32::<BE>()?;
-        if magic != 0xFE4ADA4A {
+        if magic != META_FILE_MAGIC {
             bail!("Invalid magic number");
         }
         let family = reader.read_u32::<BE>()?;
@@ -480,10 +496,12 @@ impl MetaFile {
                         // Return immediately with the first result
                         return Ok(MetaLookupResult::SstLookup(SstLookupResult::Found(values)));
                     }
-                    // Check for tombstone — stops search across older SSTs within this meta file.
-                    // Since tombstones sort last within a key group, if the last value is Deleted,
-                    // we have a tombstone.
-                    let has_tombstone = values.last().is_some_and(|v| *v == LookupValue::Deleted);
+                    // A key tombstone stops the search across older SSTs within this meta file.
+                    // It sorts last within a key group, so it is the last value if present.
+                    // Key-value tombstones do not stop the search: they delete a single value,
+                    // and older SSTs may hold others for this key.
+                    let has_tombstone =
+                        values.last().is_some_and(|v| *v == LookupValue::KeyDeleted);
                     all_results.extend(values);
                     if has_tombstone {
                         return Ok(MetaLookupResult::SstLookup(SstLookupResult::Found(

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -49,12 +49,7 @@ impl Display for MetaEntryFlags {
     }
 }
 
-/// Magic number identifying a `.meta` file, and implicitly its format version.
-///
-/// Bump this whenever [`EntryHeader`]'s layout changes. The header is a fixed-size struct read at a
-/// computed stride, so an older file parsed by newer code would not fail — it would silently
-/// misinterpret every field after the change. Rejecting the file outright is the only safe
-/// outcome; callers handle the error by discarding and rebuilding the database.
+/// Magic number identifying a `.meta` file.
 pub(crate) const META_FILE_MAGIC: u32 = 0xFE4ADA4A;
 
 /// On-disk layout of a single entry header in the `.meta` file.

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -147,10 +147,6 @@ impl MetaEntry {
         self.amqf_data_offset.end - self.amqf_data_offset.start
     }
 
-    /// The AMQF filter for this SST, for membership probes that must not open the file.
-    ///
-    /// The error is one-sided: `contains_fingerprint` returning `false` means the key is
-    /// definitely absent, `true` means it is probably present.
     pub fn amqf(&self) -> &qfilter::FilterRef<'static> {
         &self.amqf
     }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -9,7 +9,10 @@ use fs_err::File;
 use qfilter::Filter;
 use zerocopy::IntoBytes;
 
-use crate::{meta_file::EntryHeader, static_sorted_file_builder::StaticSortedFileBuilderMeta};
+use crate::{
+    meta_file::{EntryHeader, META_FILE_MAGIC},
+    static_sorted_file_builder::StaticSortedFileBuilderMeta,
+};
 
 pub struct MetaFileBuilder<'a> {
     family: u32,
@@ -54,7 +57,7 @@ impl<'a> MetaFileBuilder<'a> {
         // Wrap the writer to count the bytes written, so callers can accumulate written-byte totals
         // without stat'ing the file afterwards.
         let mut file = CountingWriter::new(BufWriter::new(File::create(file)?));
-        file.write_u32::<BE>(0xFE4ADA4A)?; // Magic number
+        file.write_u32::<BE>(META_FILE_MAGIC)?; // Magic number
         file.write_u32::<BE>(self.family)?;
 
         self.obsolete_sst_files.sort();

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Borrow,
     fmt::{self, Debug, Formatter},
+    hash::{Hash, Hasher},
     ops::{Deref, Range},
     rc::Rc,
 };
@@ -74,6 +75,12 @@ impl Debug for RcBytes {
 }
 
 impl Eq for RcBytes {}
+
+impl Hash for RcBytes {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Hash::hash(self.deref(), state);
+    }
+}
 
 impl SharedBytes for RcBytes {
     type MmapHandle = Rc<Mmap>;

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -42,9 +42,6 @@ pub const BLOCK_TYPE_FIXED_KEY_NO_HASH: u8 = 4;
 
 /// Written in a fixed-size key block header's value type field when entries share a value size but
 /// not a value type. Each entry then carries its own type byte ahead of its value.
-///
-/// Tag 4 is safe as a sentinel because it is not a valid entry type: it was the old key-value
-/// tombstone tag, freed when tombstones moved to their own range above the inline range.
 pub const FIXED_KEY_BLOCK_MIXED_VALUE_TYPE: u8 = 4;
 
 /// The tag for a small-sized value.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -40,6 +40,13 @@ pub const BLOCK_TYPE_FIXED_KEY_WITH_HASH: u8 = 3;
 /// The block header for a fixed-size key block without hash.
 pub const BLOCK_TYPE_FIXED_KEY_NO_HASH: u8 = 4;
 
+/// Written in a fixed-size key block header's value type field when entries share a value size but
+/// not a value type. Each entry then carries its own type byte ahead of its value.
+///
+/// Tag 4 is safe as a sentinel because it is not a valid entry type: it was the old key-value
+/// tombstone tag, freed when tombstones moved to their own range above the inline range.
+pub const FIXED_KEY_BLOCK_MIXED_VALUE_TYPE: u8 = 4;
+
 /// The tag for a small-sized value.
 pub const KEY_BLOCK_ENTRY_TYPE_SMALL: u8 = 0;
 /// The tag for the blob value.
@@ -380,19 +387,21 @@ impl StaticSortedFile {
         ensure!(block.len() >= 6, "fixed key block too short");
         let entry_count = be::read_u24(&block[1..]) as usize;
         let key_size = be::read_u8(&block[4..]) as usize;
-        let value_type = be::read_u8(&block[5..]);
-        let val_size = entry_val_size(value_type)?;
+        let header_type = be::read_u8(&block[5..]);
+        let FixedValueLayout {
+            value_type,
+            val_size,
+            header_size,
+        } = fixed_value_layout(&block, header_type)?;
         let stride = hash_len as usize + key_size + val_size;
-        let entries = &block[6..];
+        let entries = &block[header_size..];
         ensure!(
             entries.len() == entry_count * stride,
             "fixed key block for {entry_count} entries must is the wrong size"
         );
 
         self.lookup_block_inner::<K, FIND_ALL>(&block, entry_count, key_hash, key, reader, |i| {
-            Ok(get_fixed_key_entry(
-                entries, i, hash_len, key_size, value_type, stride,
-            ))
+            get_fixed_key_entry(entries, i, hash_len, key_size, value_type, stride)
         })
     }
 
@@ -762,11 +771,12 @@ pub struct StaticSortedFileIter {
 enum CurrentKeyBlockKind {
     /// Variable-size entries with an offset table for random access.
     Variable { offsets: RcBytes, hash_len: u8 },
-    /// Fixed-size entries with uniform key size and value type (no offset table).
+    /// Fixed-size entries with uniform key size and value size (no offset table).
     Fixed {
         hash_len: u8,
         key_size: usize,
-        value_type: u8,
+        /// The type shared by every entry, or `None` if each entry carries its own type byte.
+        value_type: Option<u8>,
         stride: usize,
     },
 }
@@ -880,11 +890,13 @@ impl StaticSortedFileIter {
                     0
                 };
                 let key_size = data[4] as usize;
-                let value_type = data[5];
-                let val_size = entry_val_size(value_type)?;
+                let FixedValueLayout {
+                    value_type,
+                    val_size,
+                    header_size,
+                } = fixed_value_layout(data, data[5])?;
                 let stride = hash_len as usize + key_size + val_size;
-                // Header is 6 bytes for fixed-size blocks
-                let entries_range = 6..block.len();
+                let entries_range = header_size..block.len();
                 let entries = block.slice(entries_range);
                 Ok(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Fixed {
@@ -927,7 +939,7 @@ impl StaticSortedFileIter {
                         *key_size,
                         *value_type,
                         *stride,
-                    ),
+                    )?,
                 };
                 let full_hash = if hash.is_empty() {
                     crate::key::hash_key(&key)
@@ -1086,20 +1098,58 @@ fn get_key_entry<'l>(
 ///
 /// All entries have the same key size and value type, so positions are computed
 /// arithmetically with no offset table indirection.
+/// How a fixed-size key block encodes its entry values, decoded from the block header.
+struct FixedValueLayout {
+    /// The type shared by every entry, or `None` if each entry carries its own type byte.
+    value_type: Option<u8>,
+    /// Value bytes per entry, including any per-entry type byte.
+    val_size: usize,
+    /// Total header size, which the entry data follows.
+    header_size: usize,
+}
+
+/// Decodes the value layout from a fixed-size key block header.
+fn fixed_value_layout(block: &[u8], header_type: u8) -> Result<FixedValueLayout> {
+    if header_type == FIXED_KEY_BLOCK_MIXED_VALUE_TYPE {
+        // Mixed-type block: the value size follows the header's type byte, and each entry
+        // carries its own type.
+        ensure!(block.len() >= 7, "mixed-type fixed key block too short");
+        Ok(FixedValueLayout {
+            value_type: None,
+            // +1 for the per-entry type byte, which is part of the stride.
+            val_size: be::read_u8(&block[6..]) as usize + 1,
+            header_size: 7,
+        })
+    } else {
+        Ok(FixedValueLayout {
+            value_type: Some(header_type),
+            val_size: entry_val_size(header_type)?,
+            header_size: 6,
+        })
+    }
+}
+
 fn get_fixed_key_entry<'l>(
     entries: &'l [u8],
     index: usize,
     hash_len: u8,
     key_size: usize,
-    value_type: u8,
+    value_type: Option<u8>,
     stride: usize,
-) -> GetKeyEntryResult<'l> {
+) -> Result<GetKeyEntryResult<'l>> {
     let hash_len_usize = hash_len as usize;
     let start = index * stride;
-    GetKeyEntryResult {
-        hash: &entries[start..start + hash_len_usize],
-        key: &entries[start + hash_len_usize..start + hash_len_usize + key_size],
-        ty: value_type,
-        val: &entries[start + hash_len_usize + key_size..(index + 1) * stride],
-    }
+    let key_start = start + hash_len_usize;
+    let key_end = key_start + key_size;
+    // In a mixed-type block the entry's type byte sits between its key and its value.
+    let (ty, val_start) = match value_type {
+        Some(ty) => (ty, key_end),
+        None => (be::read_u8(&entries[key_end..]), key_end + 1),
+    };
+    Ok(GetKeyEntryResult {
+        hash: &entries[start..key_start],
+        key: &entries[key_start..key_end],
+        ty,
+        val: &entries[val_start..(index + 1) * stride],
+    })
 }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -48,16 +48,18 @@ pub const KEY_BLOCK_ENTRY_TYPE_BLOB: u8 = 1;
 pub const KEY_BLOCK_ENTRY_TYPE_KEY_DELETED: u8 = 2;
 /// The tag for a medium-sized value.
 pub const KEY_BLOCK_ENTRY_TYPE_MEDIUM: u8 = 3;
-/// The tag for a valued (key-value pair) tombstone: it deletes only the one value it carries,
-/// leaving other values for the same key intact. Only meaningful for
-/// [`FamilyKind::MultiValue`][crate::FamilyKind::MultiValue] families.
-///
-/// The payload is a fixed [`KEY_VALUE_DELETED_REF_SIZE`]-byte value. Keeping it fixed-size rather
-/// than length-prefixed keeps a block of these eligible for the fixed-size key block layout, and
-/// it suffices for the only current user: `TaskCache`, whose values are 4-byte task ids.
-pub const KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED: u8 = 4;
 /// The minimum tag for inline values. The actual size is (tag - INLINE_MIN).
 pub const KEY_BLOCK_ENTRY_TYPE_INLINE_MIN: u8 = 8;
+/// The minimum tag for a key-value tombstone, which deletes only the one value it carries and
+/// leaves other values for the same key intact. Only meaningful for
+/// [`FamilyKind::MultiValue`][crate::FamilyKind::MultiValue] families.
+///
+/// This mirrors the inline value range: the deleted value is stored inline in the key block and
+/// its size is (tag - KEY_VALUE_DELETED_MIN). Only inline-sized values can be deleted this way —
+/// a tombstone for a larger value would have to store a second copy of it, costing more than the
+/// value it reclaims.
+pub const KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN: u8 =
+    KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + MAX_INLINE_VALUE_SIZE as u8 + 1;
 
 /// Encoded size of a small value reference: 2B block index + 2B size + 4B offset.
 pub(crate) const SMALL_VALUE_REF_SIZE: usize = 8;
@@ -67,13 +69,12 @@ pub(crate) const MEDIUM_VALUE_REF_SIZE: usize = 2;
 pub(crate) const BLOB_VALUE_REF_SIZE: usize = 4;
 /// Encoded size of a deleted (tombstone) value reference.
 pub(crate) const KEY_DELETED_REF_SIZE: usize = 0;
-/// Encoded size of a key-value tombstone's payload: the deleted value itself.
-pub(crate) const KEY_VALUE_DELETED_REF_SIZE: usize = 4;
 
-// Static assertion: MAX_INLINE_VALUE_SIZE must fit in the key type encoding.
-// Key types 8-255 encode inline values of size 0-247, so max is 255 - 8 = 247.
+// Static assertion: both the inline range and the key-value tombstone range that follows it must
+// fit in the key type byte. The tombstone range starts after the inline range and is the same
+// width, so the tombstone range's top is the binding constraint.
 const _: () = assert!(
-    MAX_INLINE_VALUE_SIZE <= (u8::MAX - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN) as usize,
+    MAX_INLINE_VALUE_SIZE <= (u8::MAX - KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN) as usize,
     "MAX_INLINE_VALUE_SIZE exceeds what can be encoded in key type byte"
 );
 
@@ -720,7 +721,9 @@ fn handle_key_match_generic<B: SharedBytes>(
             LookupValue::Blob { sequence_number }
         }
         KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => LookupValue::KeyDeleted,
-        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => {
+        // Must precede the inline arm: both are open-ended and the tombstone range sits above it.
+        ty if ty >= KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN => {
+            // The deleted value is stored inline, so `val` is already the correct slice.
             // SAFETY: val points into key_block's data
             let value = unsafe { key_block.slice_from_subslice(val) };
             LookupValue::KeyValueDeleted { value }
@@ -1030,7 +1033,10 @@ fn entry_val_size(ty: u8) -> Result<usize> {
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => Ok(MEDIUM_VALUE_REF_SIZE),
         KEY_BLOCK_ENTRY_TYPE_BLOB => Ok(BLOB_VALUE_REF_SIZE),
         KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => Ok(KEY_DELETED_REF_SIZE),
-        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => Ok(KEY_VALUE_DELETED_REF_SIZE),
+        // Must precede the inline arm: both are open-ended and the tombstone range sits above it.
+        ty if ty >= KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN => {
+            Ok((ty - KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN) as usize)
+        }
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             Ok((ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN) as usize)
         }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -44,10 +44,18 @@ pub const BLOCK_TYPE_FIXED_KEY_NO_HASH: u8 = 4;
 pub const KEY_BLOCK_ENTRY_TYPE_SMALL: u8 = 0;
 /// The tag for the blob value.
 pub const KEY_BLOCK_ENTRY_TYPE_BLOB: u8 = 1;
-/// The tag for the deleted value.
-pub const KEY_BLOCK_ENTRY_TYPE_DELETED: u8 = 2;
+/// The tag for the deleted value. This is a *key* tombstone: it deletes every value for the key.
+pub const KEY_BLOCK_ENTRY_TYPE_KEY_DELETED: u8 = 2;
 /// The tag for a medium-sized value.
 pub const KEY_BLOCK_ENTRY_TYPE_MEDIUM: u8 = 3;
+/// The tag for a valued (key-value pair) tombstone: it deletes only the one value it carries,
+/// leaving other values for the same key intact. Only meaningful for
+/// [`FamilyKind::MultiValue`][crate::FamilyKind::MultiValue] families.
+///
+/// The payload is a fixed [`KEY_VALUE_DELETED_REF_SIZE`]-byte value. Keeping it fixed-size rather
+/// than length-prefixed keeps a block of these eligible for the fixed-size key block layout, and
+/// it suffices for the only current user: `TaskCache`, whose values are 4-byte task ids.
+pub const KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED: u8 = 4;
 /// The minimum tag for inline values. The actual size is (tag - INLINE_MIN).
 pub const KEY_BLOCK_ENTRY_TYPE_INLINE_MIN: u8 = 8;
 
@@ -58,7 +66,9 @@ pub(crate) const MEDIUM_VALUE_REF_SIZE: usize = 2;
 /// Encoded size of a blob value reference: 4B blob id.
 pub(crate) const BLOB_VALUE_REF_SIZE: usize = 4;
 /// Encoded size of a deleted (tombstone) value reference.
-pub(crate) const DELETED_VALUE_REF_SIZE: usize = 0;
+pub(crate) const KEY_DELETED_REF_SIZE: usize = 0;
+/// Encoded size of a key-value tombstone's payload: the deleted value itself.
+pub(crate) const KEY_VALUE_DELETED_REF_SIZE: usize = 4;
 
 // Static assertion: MAX_INLINE_VALUE_SIZE must fit in the key type encoding.
 // Key types 8-255 encode inline values of size 0-247, so max is 255 - 8 = 247.
@@ -422,10 +432,9 @@ impl StaticSortedFile {
                         return Ok(SstLookupResult::Found(SmallVec::from_buf([result])));
                     }
                     // FIND_ALL (MultiValue) mode: collect all values for this key.
-                    // Tombstones (Deleted) sort last within each key group, so we
-                    // scan backward to find the start of the key group, then forward
-                    // to collect all entries. The tombstone, if present, will be the
-                    // last entry in the results.
+                    // Within a key group, key-value tombstones sort first and key tombstones
+                    // last. We scan backward to find the start of the key group, then forward to
+                    // collect all entries.
                     let mut results = SmallVec::new();
                     for i in (l..m).rev() {
                         let GetKeyEntryResult {
@@ -439,12 +448,10 @@ impl StaticSortedFile {
                         }
                         results.push(self.handle_key_match(ty, val, block, reader)?);
                     }
-                    // Technically we could `.reverse()` the items collected by the backwards
-                    // scan, but the only ordering constraint we need to maintain for single
-                    // sst multivalue reads is that a deleted token, if it exists comes last.
-                    // Because all the backwards scan items are strictly before the found item
-                    // we know they don't contain the _last_ item. So we don't care about
-                    // their order.
+                    // Restore on-disk order: callers depend on both ends of the key group, with
+                    // key-value tombstones preceding the values they filter and a key tombstone
+                    // landing last.
+                    results.reverse();
 
                     // Add the entry at `m`
                     results.push(self.handle_key_match(ty, val, block, reader)?);
@@ -712,7 +719,12 @@ fn handle_key_match_generic<B: SharedBytes>(
             let sequence_number = be::read_u32(val);
             LookupValue::Blob { sequence_number }
         }
-        KEY_BLOCK_ENTRY_TYPE_DELETED => LookupValue::Deleted,
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => LookupValue::KeyDeleted,
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => {
+            // SAFETY: val points into key_block's data
+            let value = unsafe { key_block.slice_from_subslice(val) };
+            LookupValue::KeyValueDeleted { value }
+        }
         _ => {
             // Inline value — val is already the correct slice
             // SAFETY: val points into key_block's data
@@ -1017,7 +1029,8 @@ fn entry_val_size(ty: u8) -> Result<usize> {
         KEY_BLOCK_ENTRY_TYPE_SMALL => Ok(SMALL_VALUE_REF_SIZE),
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => Ok(MEDIUM_VALUE_REF_SIZE),
         KEY_BLOCK_ENTRY_TYPE_BLOB => Ok(BLOB_VALUE_REF_SIZE),
-        KEY_BLOCK_ENTRY_TYPE_DELETED => Ok(DELETED_VALUE_REF_SIZE),
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => Ok(KEY_DELETED_REF_SIZE),
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => Ok(KEY_VALUE_DELETED_REF_SIZE),
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             Ok((ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN) as usize)
         }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -17,9 +17,9 @@ use crate::{
         BLOB_VALUE_REF_SIZE, BLOCK_TYPE_FIXED_KEY_NO_HASH, BLOCK_TYPE_FIXED_KEY_WITH_HASH,
         BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY_NO_HASH, BLOCK_TYPE_KEY_WITH_HASH,
         KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
-        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED,
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN,
         KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL, KEY_DELETED_REF_SIZE,
-        KEY_VALUE_DELETED_REF_SIZE, MEDIUM_VALUE_REF_SIZE, SMALL_VALUE_REF_SIZE,
+        MEDIUM_VALUE_REF_SIZE, SMALL_VALUE_REF_SIZE,
     },
 };
 
@@ -253,8 +253,8 @@ pub enum EntryValue<'l> {
     /// Tombstone. The value was removed.
     KeyDeleted,
     /// Key-value tombstone. Only the one carried value was removed; other values for the same key
-    /// survive. MultiValue families only. The value must be exactly
-    /// [`KEY_VALUE_DELETED_REF_SIZE`] bytes.
+    /// survive. MultiValue families only. The value must be at most [`MAX_INLINE_VALUE_SIZE`]
+    /// bytes.
     KeyValueDeleted { value: &'l [u8] },
 }
 
@@ -398,9 +398,11 @@ enum ValueRef {
     Blob { blob_id: u32 },
     /// Tombstone.
     KeyDeleted,
-    /// Key-value tombstone: deletes only the carried value from the key's group.
+    /// Key-value tombstone: deletes only the carried value from the key's group. The value is
+    /// stored inline, exactly like [`ValueRef::Inline`].
     KeyValueDeleted {
-        data: [u8; KEY_VALUE_DELETED_REF_SIZE],
+        data: [u8; MAX_INLINE_VALUE_SIZE],
+        len: u8,
     },
 }
 
@@ -413,7 +415,9 @@ impl ValueRef {
             ValueRef::Inline { len, .. } => KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + *len,
             ValueRef::Blob { .. } => KEY_BLOCK_ENTRY_TYPE_BLOB,
             ValueRef::KeyDeleted => KEY_BLOCK_ENTRY_TYPE_KEY_DELETED,
-            ValueRef::KeyValueDeleted { .. } => KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED,
+            ValueRef::KeyValueDeleted { len, .. } => {
+                KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN + *len
+            }
         })
     }
 
@@ -448,8 +452,8 @@ impl ValueRef {
                 buffer.extend(scratch);
             }
             ValueRef::KeyDeleted => { /* no value bytes */ }
-            ValueRef::KeyValueDeleted { data } => {
-                buffer.extend(data);
+            ValueRef::KeyValueDeleted { data, len } => {
+                buffer.extend(&data[..*len as usize]);
             }
             ValueRef::PendingSmall { .. } => {
                 unreachable!("PendingSmall should have been resolved");
@@ -718,15 +722,14 @@ impl<E: Entry> StreamingSstWriter<E> {
             EntryValue::Large { blob } => ValueRef::Blob { blob_id: blob },
             EntryValue::KeyDeleted => ValueRef::KeyDeleted,
             EntryValue::KeyValueDeleted { value } => {
-                assert_eq!(
-                    value.len(),
-                    KEY_VALUE_DELETED_REF_SIZE,
-                    "key-value tombstone payload must be exactly {KEY_VALUE_DELETED_REF_SIZE} \
-                     bytes"
-                );
-                let mut data = [0u8; KEY_VALUE_DELETED_REF_SIZE];
-                data.copy_from_slice(value);
-                ValueRef::KeyValueDeleted { data }
+                // Enforced by `WriteBatch::delete_value`, which rejects oversized values.
+                debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
+                let mut data = [0u8; MAX_INLINE_VALUE_SIZE];
+                data[..value.len()].copy_from_slice(value);
+                ValueRef::KeyValueDeleted {
+                    data,
+                    len: value.len() as u8,
+                }
             }
         };
 
@@ -1211,7 +1214,10 @@ fn value_type_val_size(ty: EntryType) -> usize {
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => MEDIUM_VALUE_REF_SIZE,
         KEY_BLOCK_ENTRY_TYPE_BLOB => BLOB_VALUE_REF_SIZE,
         KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => KEY_DELETED_REF_SIZE,
-        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => KEY_VALUE_DELETED_REF_SIZE,
+        // Must precede the inline arm: both are open-ended and the tombstone range sits above it.
+        ty if ty >= KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN => {
+            (ty - KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN) as usize
+        }
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             (ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN) as usize
         }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -15,10 +15,11 @@ use crate::{
     meta_file::MetaEntryFlags,
     static_sorted_file::{
         BLOB_VALUE_REF_SIZE, BLOCK_TYPE_FIXED_KEY_NO_HASH, BLOCK_TYPE_FIXED_KEY_WITH_HASH,
-        BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY_NO_HASH, BLOCK_TYPE_KEY_WITH_HASH, DELETED_VALUE_REF_SIZE,
-        KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
-        KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL, MEDIUM_VALUE_REF_SIZE,
-        SMALL_VALUE_REF_SIZE,
+        BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY_NO_HASH, BLOCK_TYPE_KEY_WITH_HASH,
+        KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED,
+        KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL, KEY_DELETED_REF_SIZE,
+        KEY_VALUE_DELETED_REF_SIZE, MEDIUM_VALUE_REF_SIZE, SMALL_VALUE_REF_SIZE,
     },
 };
 
@@ -250,7 +251,11 @@ pub enum EntryValue<'l> {
     /// Large-sized value. They are stored in a blob file.
     Large { blob: u32 },
     /// Tombstone. The value was removed.
-    Deleted,
+    KeyDeleted,
+    /// Key-value tombstone. Only the one carried value was removed; other values for the same key
+    /// survive. MultiValue families only. The value must be exactly
+    /// [`KEY_VALUE_DELETED_REF_SIZE`] bytes.
+    KeyValueDeleted { value: &'l [u8] },
 }
 
 #[derive(Debug, Clone)]
@@ -392,7 +397,11 @@ enum ValueRef {
     /// Large blob stored externally.
     Blob { blob_id: u32 },
     /// Tombstone.
-    Deleted,
+    KeyDeleted,
+    /// Key-value tombstone: deletes only the carried value from the key's group.
+    KeyValueDeleted {
+        data: [u8; KEY_VALUE_DELETED_REF_SIZE],
+    },
 }
 
 impl ValueRef {
@@ -403,7 +412,8 @@ impl ValueRef {
             ValueRef::Medium { .. } => KEY_BLOCK_ENTRY_TYPE_MEDIUM,
             ValueRef::Inline { len, .. } => KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + *len,
             ValueRef::Blob { .. } => KEY_BLOCK_ENTRY_TYPE_BLOB,
-            ValueRef::Deleted => KEY_BLOCK_ENTRY_TYPE_DELETED,
+            ValueRef::KeyDeleted => KEY_BLOCK_ENTRY_TYPE_KEY_DELETED,
+            ValueRef::KeyValueDeleted { .. } => KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED,
         })
     }
 
@@ -437,7 +447,10 @@ impl ValueRef {
                 BE::write_u32(&mut scratch, *blob_id);
                 buffer.extend(scratch);
             }
-            ValueRef::Deleted => { /* no value bytes */ }
+            ValueRef::KeyDeleted => { /* no value bytes */ }
+            ValueRef::KeyValueDeleted { data } => {
+                buffer.extend(data);
+            }
             ValueRef::PendingSmall { .. } => {
                 unreachable!("PendingSmall should have been resolved");
             }
@@ -703,7 +716,18 @@ impl<E: Entry> StreamingSstWriter<E> {
                 }
             }
             EntryValue::Large { blob } => ValueRef::Blob { blob_id: blob },
-            EntryValue::Deleted => ValueRef::Deleted,
+            EntryValue::KeyDeleted => ValueRef::KeyDeleted,
+            EntryValue::KeyValueDeleted { value } => {
+                assert_eq!(
+                    value.len(),
+                    KEY_VALUE_DELETED_REF_SIZE,
+                    "key-value tombstone payload must be exactly {KEY_VALUE_DELETED_REF_SIZE} \
+                     bytes"
+                );
+                let mut data = [0u8; KEY_VALUE_DELETED_REF_SIZE];
+                data.copy_from_slice(value);
+                ValueRef::KeyValueDeleted { data }
+            }
         };
 
         self.push_pending_key_entry(entry, value_ref);
@@ -1186,7 +1210,8 @@ fn value_type_val_size(ty: EntryType) -> usize {
         KEY_BLOCK_ENTRY_TYPE_SMALL => SMALL_VALUE_REF_SIZE,
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => MEDIUM_VALUE_REF_SIZE,
         KEY_BLOCK_ENTRY_TYPE_BLOB => BLOB_VALUE_REF_SIZE,
-        KEY_BLOCK_ENTRY_TYPE_DELETED => DELETED_VALUE_REF_SIZE,
+        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED => KEY_DELETED_REF_SIZE,
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED => KEY_VALUE_DELETED_REF_SIZE,
         ty if ty >= KEY_BLOCK_ENTRY_TYPE_INLINE_MIN => {
             (ty - KEY_BLOCK_ENTRY_TYPE_INLINE_MIN) as usize
         }
@@ -1260,7 +1285,7 @@ mod tests {
         /// Already-formatted block with `uncompressed_size = 0` (stored as-is).
         MediumRaw(Vec<u8>),
         Blob(u32),
-        Deleted,
+        KeyDeleted,
     }
 
     impl TestEntry {
@@ -1292,7 +1317,7 @@ mod tests {
         }
 
         fn deleted(key: &[u8]) -> Self {
-            Self::new(key, TestValueKind::Deleted)
+            Self::new(key, TestValueKind::KeyDeleted)
         }
 
         fn medium_raw(key: &[u8], value: &[u8]) -> Self {
@@ -1335,7 +1360,7 @@ mod tests {
                     block: v,
                 },
                 TestValueKind::Blob(id) => EntryValue::Large { blob: *id },
-                TestValueKind::Deleted => EntryValue::Deleted,
+                TestValueKind::KeyDeleted => EntryValue::KeyDeleted,
             }
         }
     }
@@ -1409,8 +1434,8 @@ mod tests {
                 };
                 assert_eq!(*sequence_number, *expected_id);
             }
-            (TestValueKind::Deleted, SstLookupResult::Found(values))
-                if values.len() == 1 && matches!(values[0], LookupValue::Deleted) => {}
+            (TestValueKind::KeyDeleted, SstLookupResult::Found(values))
+                if values.len() == 1 && matches!(values[0], LookupValue::KeyDeleted) => {}
             _ => {
                 panic!(
                     "Unexpected lookup result for key {:?}",
@@ -1710,7 +1735,7 @@ mod tests {
                                 std::str::from_utf8(&entry.key)
                             );
                         }
-                        (LookupValue::Deleted, LookupValue::Deleted) => {}
+                        (LookupValue::KeyDeleted, LookupValue::KeyDeleted) => {}
                         (
                             LookupValue::Blob {
                                 sequence_number: s1,

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -16,10 +16,11 @@ use crate::{
     static_sorted_file::{
         BLOB_VALUE_REF_SIZE, BLOCK_TYPE_FIXED_KEY_NO_HASH, BLOCK_TYPE_FIXED_KEY_WITH_HASH,
         BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY_NO_HASH, BLOCK_TYPE_KEY_WITH_HASH,
-        KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
-        KEY_BLOCK_ENTRY_TYPE_KEY_DELETED, KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN,
-        KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL, KEY_DELETED_REF_SIZE,
-        MEDIUM_VALUE_REF_SIZE, SMALL_VALUE_REF_SIZE,
+        FIXED_KEY_BLOCK_MIXED_VALUE_TYPE, KEY_BLOCK_ENTRY_TYPE_BLOB,
+        KEY_BLOCK_ENTRY_TYPE_INLINE_MIN, KEY_BLOCK_ENTRY_TYPE_KEY_DELETED,
+        KEY_BLOCK_ENTRY_TYPE_KEY_VALUE_DELETED_MIN, KEY_BLOCK_ENTRY_TYPE_MEDIUM,
+        KEY_BLOCK_ENTRY_TYPE_SMALL, KEY_DELETED_REF_SIZE, MEDIUM_VALUE_REF_SIZE,
+        SMALL_VALUE_REF_SIZE,
     },
 };
 
@@ -66,6 +67,12 @@ const MIN_KEY_SIZE_FOR_COMPRESSION: usize = 16;
 /// fall back to variable-size layout.
 const MAX_FIXED_KEY_LEN: usize = u8::MAX as usize;
 
+/// Maximum value size that can use fixed-size key block layout.
+///
+/// Mixed-type fixed blocks store the value size in a single header byte, since it can no longer be
+/// derived from a single shared entry type.
+const MAX_FIXED_VAL_SIZE: usize = u8::MAX as usize;
+
 /// Newtype for the key block entry type byte.
 ///
 /// This encodes what kind of value reference an entry has (small, medium, blob, deleted, or
@@ -75,33 +82,46 @@ struct EntryType(u8);
 
 /// Tracks whether a key block's entries are uniform enough for fixed-size layout.
 ///
+/// Fixed layout needs a uniform *stride*, which requires a uniform key length and a uniform value
+/// size. A uniform value *type* is a stronger condition that additionally lets the type be hoisted
+/// into the block header; when types differ but sizes agree, the type is stored per entry instead
+/// (1 byte, still cheaper than the 4-byte offset table entry a variable block would need).
+///
 /// State transitions:
-/// - `Unknown` → first entry → `Fixed { key_len, value_type }`
-/// - `Fixed` + matching entry → stays `Fixed`
-/// - `Fixed` + mismatched key_len or value_type → `Variable`
+/// - `Unknown` → first entry → `Fixed`
+/// - `Fixed` + matching key_len and value type → stays `Fixed`
+/// - `Fixed` + matching key_len and value *size* → `Fixed` with `value_type: None`
+/// - `Fixed` + mismatched key_len or value size → `Variable`
 /// - `Variable` → stays `Variable`
 #[derive(Clone, Copy)]
 enum KeyBlockFormat {
     /// No entries yet — format undetermined.
     Unknown,
-    /// All entries so far have uniform key length and value type.
-    Fixed { key_len: u8, value_type: EntryType },
-    /// Entries have mixed key lengths or value types; must use offset table.
+    /// All entries so far have uniform key length and value size.
+    Fixed {
+        key_len: u8,
+        val_size: u8,
+        /// The shared entry type, or `None` if entries have differing types of the same size.
+        value_type: Option<EntryType>,
+    },
+    /// Entries have mixed key lengths or value sizes; must use offset table.
     Variable,
 }
 
 impl KeyBlockFormat {
     /// Updates the format after seeing an entry with the given key length and value type.
     ///
-    /// A `Fixed` state is only reachable when all entries have matching key length and value type,
+    /// A `Fixed` state is only reachable when all entries have matching key length and value size,
     /// and the key length fits in a u8 (required by the on-disk header).
     fn update(&mut self, key_len: usize, value_type: EntryType) {
+        let val_size = value_type_val_size(value_type);
         *self = match *self {
             KeyBlockFormat::Unknown => {
-                if key_len <= MAX_FIXED_KEY_LEN {
+                if key_len <= MAX_FIXED_KEY_LEN && val_size <= MAX_FIXED_VAL_SIZE {
                     KeyBlockFormat::Fixed {
                         key_len: key_len as u8,
-                        value_type,
+                        val_size: val_size as u8,
+                        value_type: Some(value_type),
                     }
                 } else {
                     KeyBlockFormat::Variable
@@ -109,10 +129,13 @@ impl KeyBlockFormat {
             }
             KeyBlockFormat::Fixed {
                 key_len: k,
+                val_size: s,
                 value_type: v,
-            } if k as usize == key_len && v == value_type => KeyBlockFormat::Fixed {
+            } if k as usize == key_len && s as usize == val_size => KeyBlockFormat::Fixed {
                 key_len: k,
-                value_type: v,
+                val_size: s,
+                // Collapse to `None` as soon as two entries disagree on type.
+                value_type: v.filter(|v| *v == value_type),
             },
             KeyBlockFormat::Fixed { .. } | KeyBlockFormat::Variable => KeyBlockFormat::Variable,
         };
@@ -870,6 +893,7 @@ impl<E: Entry> StreamingSstWriter<E> {
 
         if let KeyBlockFormat::Fixed {
             key_len: key_size,
+            val_size,
             value_type,
         } = info.format
         {
@@ -878,6 +902,7 @@ impl<E: Entry> StreamingSstWriter<E> {
                 entry_count as u32,
                 has_hash,
                 key_size,
+                val_size,
                 value_type,
             );
             for i in start..end {
@@ -1150,13 +1175,18 @@ impl<'l> KeyBlockBuilder<'l> {
 // ---------------------------------------------------------------------------
 
 /// The size of the fixed-size key block header (block type + entry count + key size + value type).
+/// Mixed-type blocks append one more byte for the value size.
 const FIXED_KEY_BLOCK_HEADER_SIZE: usize = 6;
 
-/// Builder for a fixed-size key block where all entries share the same key size and value type.
+/// Builder for a fixed-size key block where all entries share the same key size and value size.
 ///
-/// No offset table is written — entry positions are computed arithmetically from the stride.
+/// No offset table is written — entry positions are computed arithmetically from the stride. When
+/// entries share a value size but not a value type, the header records
+/// [`FIXED_KEY_BLOCK_MIXED_VALUE_TYPE`] and each entry carries its own type byte before its value.
 struct FixedKeyBlockBuilder<'l> {
     buffer: &'l mut Vec<u8>,
+    /// Whether each entry writes its own type byte (set for mixed-type blocks).
+    per_entry_type: bool,
 }
 
 impl<'l> FixedKeyBlockBuilder<'l> {
@@ -1165,11 +1195,12 @@ impl<'l> FixedKeyBlockBuilder<'l> {
         entry_count: u32,
         has_hash: bool,
         key_size: u8,
-        value_type: EntryType,
+        val_size: u8,
+        value_type: Option<EntryType>,
     ) -> Self {
         let hash_len: usize = if has_hash { 8 } else { 0 };
-        let val_size = value_type_val_size(value_type);
-        let stride = hash_len + key_size as usize + val_size;
+        let per_entry_type = value_type.is_none();
+        let stride = hash_len + key_size as usize + val_size as usize + usize::from(per_entry_type);
         buffer.reserve(FIXED_KEY_BLOCK_HEADER_SIZE + entry_count as usize * stride);
 
         let block_type = if has_hash {
@@ -1183,19 +1214,30 @@ impl<'l> FixedKeyBlockBuilder<'l> {
             (entry_count >> 8) as u8,
             entry_count as u8,
             key_size,
-            value_type.0,
+            value_type.map_or(FIXED_KEY_BLOCK_MIXED_VALUE_TYPE, |ty| ty.0),
         ]);
+        // Mixed-type blocks cannot derive the value size from the header's type byte, so it is
+        // written explicitly.
+        if per_entry_type {
+            buffer.push(val_size);
+        }
 
-        Self { buffer }
+        Self {
+            buffer,
+            per_entry_type,
+        }
     }
 
-    /// Writes a single entry (hash + key + value data) to the block.
+    /// Writes a single entry (hash + key + optional type byte + value data) to the block.
     fn put<E: Entry>(&mut self, entry: &E, value_ref: &ValueRef, has_hash: bool) {
         if has_hash {
             self.buffer
                 .extend_from_slice(&entry.key_hash().to_be_bytes());
         }
         entry.write_key_to(self.buffer);
+        if self.per_entry_type {
+            self.buffer.push(value_ref.entry_type().0);
+        }
         value_ref.write_value_to(self.buffer);
     }
 
@@ -1292,6 +1334,7 @@ mod tests {
         MediumRaw(Vec<u8>),
         Blob(u32),
         KeyDeleted,
+        KeyValueDeleted(Vec<u8>),
     }
 
     impl TestEntry {
@@ -1367,6 +1410,7 @@ mod tests {
                 },
                 TestValueKind::Blob(id) => EntryValue::Large { blob: *id },
                 TestValueKind::KeyDeleted => EntryValue::KeyDeleted,
+                TestValueKind::KeyValueDeleted(v) => EntryValue::KeyValueDeleted { value: v },
             }
         }
     }
@@ -1442,6 +1486,20 @@ mod tests {
             }
             (TestValueKind::KeyDeleted, SstLookupResult::Found(values))
                 if values.len() == 1 && matches!(values[0], LookupValue::KeyDeleted) => {}
+            (TestValueKind::KeyValueDeleted(expected), SstLookupResult::Found(values))
+                if values.len() == 1
+                    && matches!(values[0], LookupValue::KeyValueDeleted { .. }) =>
+            {
+                let LookupValue::KeyValueDeleted { value } = &values[0] else {
+                    unreachable!()
+                };
+                assert_eq!(
+                    value.as_ref(),
+                    expected.as_slice(),
+                    "tombstone value mismatch for key {:?}",
+                    std::str::from_utf8(&entry.key)
+                );
+            }
             _ => {
                 panic!(
                     "Unexpected lookup result for key {:?}",
@@ -1795,6 +1853,108 @@ mod tests {
         assert!(
             meta.block_count >= 3,
             "expected at least 2 key blocks + 1 index block"
+        );
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        for entry in &entries {
+            assert_lookup(&sst, entry, &kc, &vc)?;
+        }
+        Ok(())
+    }
+
+    /// Reads the first key block of an SST, returning its raw (uncompressed) bytes.
+    ///
+    /// Block 0 is always a key block; the block offset table sits at the end of the file.
+    fn read_first_block(dir: &Path, seq: u32, block_count: u16) -> Result<Vec<u8>> {
+        let data = fs_err::read(dir.join(format!("{seq:08}.sst")))?;
+        let offsets_start = data.len() - block_count as usize * size_of::<u32>();
+        let end = BE::read_u32(&data[offsets_start..]) as usize;
+        let raw = &data[..end];
+        // Each block is prefixed by BLOCK_HEADER_SIZE bytes: 4B uncompressed size + 4B checksum.
+        // An uncompressed size of 0 means the block is stored as-is.
+        let uncompressed_size = BE::read_u32(raw) as usize;
+        let body = &raw[BLOCK_HEADER_SIZE..];
+        Ok(if uncompressed_size == 0 {
+            body.to_vec()
+        } else {
+            let mut out = vec![0u8; uncompressed_size];
+            lzzzz::lz4::decompress(body, &mut out)?;
+            out
+        })
+    }
+
+    /// A tombstone and a value of the same size keep the block in fixed layout.
+    ///
+    /// This is what makes tombstones cheap for uniform-key families like the task cache: without
+    /// the mixed-type layout, one tombstone would demote its whole block to the variable format
+    /// and add a 4-byte offset table entry for every entry in it.
+    #[test]
+    fn fixed_layout_survives_mixed_value_types_of_equal_size() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        // Uniform 8-byte keys, uniform 4-byte values, but two different entry types.
+        let mut entries: Vec<TestEntry> = (0..64u64)
+            .map(|i| {
+                let key = format!("k-{i:06}");
+                if i % 4 == 0 {
+                    TestEntry::new(
+                        key.as_bytes(),
+                        TestValueKind::KeyValueDeleted(vec![0xAAu8; 4]),
+                    )
+                } else {
+                    TestEntry::inline(key.as_bytes(), &[0xBBu8; 4])
+                }
+            })
+            .collect();
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        let block = read_first_block(dir.path(), 1, meta.block_count)?;
+
+        assert!(
+            block[0] == BLOCK_TYPE_FIXED_KEY_WITH_HASH || block[0] == BLOCK_TYPE_FIXED_KEY_NO_HASH,
+            "mixed value types of equal size should stay in fixed layout, got block type {}",
+            block[0]
+        );
+        assert_eq!(
+            block[5], FIXED_KEY_BLOCK_MIXED_VALUE_TYPE,
+            "block should be marked mixed-type"
+        );
+        assert_eq!(block[6], 4, "value size should be recorded in the header");
+
+        // The layout is only useful if it still reads back correctly.
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        for entry in &entries {
+            assert_lookup(&sst, entry, &kc, &vc)?;
+        }
+        Ok(())
+    }
+
+    /// Differing value *sizes* cannot share a stride, so the block must fall back to variable
+    /// layout rather than silently misreading entries.
+    #[test]
+    fn mixed_value_sizes_fall_back_to_variable_layout() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let mut entries: Vec<TestEntry> = (0..64u64)
+            .map(|i| {
+                let key = format!("k-{i:06}");
+                let len = if i % 4 == 0 { 2 } else { 4 };
+                TestEntry::inline(key.as_bytes(), &vec![0xCCu8; len])
+            })
+            .collect();
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        let block = read_first_block(dir.path(), 1, meta.block_count)?;
+        assert!(
+            block[0] == BLOCK_TYPE_KEY_WITH_HASH || block[0] == BLOCK_TYPE_KEY_NO_HASH,
+            "differing value sizes should use variable layout, got block type {}",
+            block[0]
         );
 
         let sst = open_sst(dir.path(), 1, &meta)?;

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -5,7 +5,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
     DbConfig, FamilyConfig, FamilyKind,
-    constants::{MAX_MEDIUM_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
+    constants::{MAX_INLINE_VALUE_SIZE, MAX_MEDIUM_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
     db::{CompactConfig, TurboPersistence, read_current_version},
     parallel_scheduler::ParallelScheduler,
     write_batch::WriteBatch,
@@ -2286,7 +2286,7 @@ fn valued_tombstone_deletes_only_its_pair() -> Result<()> {
 
     // Delete just the middle one.
     let batch = db.write_batch()?;
-    batch.delete_value(0, key.clone(), 20u32.to_be_bytes())?;
+    batch.delete_value(0, key.clone(), 20u32.to_be_bytes().to_vec().into())?;
     db.commit_write_batch(batch)?;
 
     let mut results = db
@@ -2328,7 +2328,7 @@ fn valued_tombstone_survives_partial_compaction() -> Result<()> {
     }
 
     let batch = db.write_batch()?;
-    batch.delete_value(0, key.clone(), 42u32.to_be_bytes())?;
+    batch.delete_value(0, key.clone(), 42u32.to_be_bytes().to_vec().into())?;
     db.commit_write_batch(batch)?;
 
     // Compact repeatedly; whatever coverage the selector chooses, 42 must stay deleted.
@@ -2368,7 +2368,7 @@ fn valued_tombstone_persists_across_reopen() -> Result<()> {
         db.commit_write_batch(batch)?;
 
         let batch = db.write_batch()?;
-        batch.delete_value(0, key.clone(), 100u32.to_be_bytes())?;
+        batch.delete_value(0, key.clone(), 100u32.to_be_bytes().to_vec().into())?;
         db.commit_write_batch(batch)?;
         db.shutdown()?;
     }
@@ -2410,7 +2410,7 @@ fn whole_key_tombstone_still_deletes_all_values() -> Result<()> {
     db.commit_write_batch(batch)?;
 
     let batch = db.write_batch()?;
-    batch.delete_value(0, key.clone(), 1u32.to_be_bytes())?;
+    batch.delete_value(0, key.clone(), 1u32.to_be_bytes().to_vec().into())?;
     db.commit_write_batch(batch)?;
 
     let batch = db.write_batch()?;
@@ -2490,7 +2490,11 @@ fn compaction_reclaims_tombstones_when_no_older_sst_has_the_key() -> Result<()> 
     // Delete one of the two values for every key.
     let batch = db.write_batch()?;
     for k in 0..KEYS {
-        batch.delete_value(0, k.to_be_bytes().to_vec(), 1u32.to_be_bytes())?;
+        batch.delete_value(
+            0,
+            k.to_be_bytes().to_vec(),
+            1u32.to_be_bytes().to_vec().into(),
+        )?;
     }
     db.commit_write_batch(batch)?;
 
@@ -2570,7 +2574,11 @@ fn compaction_keeps_tombstone_when_older_sst_has_the_key() -> Result<()> {
 
     let batch = db.write_batch()?;
     for k in 0..KEYS {
-        batch.delete_value(0, k.to_be_bytes().to_vec(), 1u32.to_be_bytes())?;
+        batch.delete_value(
+            0,
+            k.to_be_bytes().to_vec(),
+            1u32.to_be_bytes().to_vec().into(),
+        )?;
     }
     db.commit_write_batch(batch)?;
 
@@ -2599,6 +2607,100 @@ fn compaction_keeps_tombstone_when_older_sst_has_the_key() -> Result<()> {
             );
         }
     }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// Tombstones carry the deleted value inline, so every size up to the inline limit round-trips.
+/// The boundary sizes matter: the tag range is packed directly above the inline value range, so an
+/// off-by-one in either bound would decode a tombstone as a value or vice versa.
+#[test]
+fn valued_tombstone_supports_all_inline_value_sizes() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    // One key per value size, each holding a deleted value of that size plus a survivor.
+    for len in 0..=MAX_INLINE_VALUE_SIZE {
+        let key = vec![len as u8];
+        let doomed = vec![0xAAu8; len];
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), doomed.clone().into())?;
+        batch.put(0, key.clone(), vec![0xBBu8; 3].into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.delete_value(0, key.clone(), doomed.clone().into())?;
+        db.commit_write_batch(batch)?;
+
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.iter().map(|v| v.to_vec()).collect::<Vec<_>>(),
+            vec![vec![0xBBu8; 3]],
+            "{len}-byte value should have been deleted, and only it"
+        );
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// Values too large to store inline are rejected rather than silently truncated: the tombstone
+/// carries a copy of the value, so deleting a large value would cost more than it reclaims.
+#[test]
+fn valued_tombstone_rejects_values_larger_than_inline() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    let batch = db.write_batch()?;
+    let too_big = vec![0u8; MAX_INLINE_VALUE_SIZE + 1];
+    let err = batch
+        .delete_value(0, vec![1u8], too_big.into())
+        .expect_err("oversized value should be rejected");
+    assert!(
+        err.to_string().contains("at most"),
+        "unexpected error: {err}"
+    );
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// Key-value tombstones are meaningless in a SingleValue family, where `delete` already removes
+/// the single value exactly. Rejecting at the API keeps the tombstone off disk, where it would
+/// otherwise only surface as an error at read time.
+#[test]
+fn valued_tombstone_rejects_single_value_families() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        DbConfig::<1>::default(),
+        RayonParallelScheduler,
+    )?;
+
+    let batch = db.write_batch()?;
+    let err = batch
+        .delete_value(0, vec![1u8], 1u32.to_be_bytes().to_vec().into())
+        .expect_err("SingleValue family should be rejected");
+    assert!(
+        err.to_string().contains("MultiValue"),
+        "unexpected error: {err}"
+    );
 
     db.shutdown()?;
     Ok(())

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2261,6 +2261,345 @@ fn current_file_is_json_with_commit_time() -> Result<()> {
         "commit_time {} outside [{before}, {after}]",
         version.commit_time
     );
+    Ok(())
+}
 
+/// A key-value tombstone deletes only the pair it names, leaving other values for the same key.
+#[test]
+fn valued_tombstone_deletes_only_its_pair() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+    let key = vec![1u8];
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    // Three values under one key, each in its own SST.
+    for v in [10u32, 20, 30] {
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), v.to_be_bytes().to_vec().into())?;
+        db.commit_write_batch(batch)?;
+    }
+
+    // Delete just the middle one.
+    let batch = db.write_batch()?;
+    batch.delete_value(0, key.clone(), 20u32.to_be_bytes())?;
+    db.commit_write_batch(batch)?;
+
+    let mut results = db
+        .get_multiple(0, &key.as_slice())?
+        .iter()
+        .map(|v| u32::from_be_bytes((**v).try_into().unwrap()))
+        .collect::<Vec<_>>();
+    results.sort();
+    assert_eq!(results, vec![10, 30], "only the named pair should be gone");
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// A partial compaction must NOT drop a key-value tombstone: an unmerged older SST may still hold a
+/// matching value, and dropping the tombstone would resurrect it.
+#[test]
+fn valued_tombstone_survives_partial_compaction() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+    let key = vec![7u8];
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    // Oldest SST holds the value that the tombstone must keep suppressing.
+    let batch = db.write_batch()?;
+    batch.put(0, key.clone(), 42u32.to_be_bytes().to_vec().into())?;
+    db.commit_write_batch(batch)?;
+
+    // A few unrelated SSTs so compaction has something to merge partially.
+    for v in [1u32, 2, 3] {
+        let batch = db.write_batch()?;
+        batch.put(0, vec![8u8], v.to_be_bytes().to_vec().into())?;
+        db.commit_write_batch(batch)?;
+    }
+
+    let batch = db.write_batch()?;
+    batch.delete_value(0, key.clone(), 42u32.to_be_bytes())?;
+    db.commit_write_batch(batch)?;
+
+    // Compact repeatedly; whatever coverage the selector chooses, 42 must stay deleted.
+    for _ in 0..3 {
+        db.compact(&CompactConfig {
+            optimal_merge_count: 2,
+            min_merge_duplication_bytes: 1,
+            optimal_merge_duplication_bytes: 1,
+            ..Default::default()
+        })?;
+        assert!(
+            db.get_multiple(0, &key.as_slice())?.is_empty(),
+            "42 was resurrected by compaction"
+        );
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// Deletes must survive a reopen: the tombstone is persisted, not just held in memory.
+#[test]
+fn valued_tombstone_persists_across_reopen() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+    let key = vec![3u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            multi_value_config(),
+            RayonParallelScheduler,
+        )?;
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), 100u32.to_be_bytes().to_vec().into())?;
+        batch.put(0, key.clone(), 200u32.to_be_bytes().to_vec().into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.delete_value(0, key.clone(), 100u32.to_be_bytes())?;
+        db.commit_write_batch(batch)?;
+        db.shutdown()?;
+    }
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            multi_value_config(),
+            RayonParallelScheduler,
+        )?;
+        let results = db
+            .get_multiple(0, &key.as_slice())?
+            .iter()
+            .map(|v| u32::from_be_bytes((**v).try_into().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(results, vec![200], "tombstone lost across reopen");
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+/// A key tombstone still deletes everything, including values a key-value tombstone left alone.
+#[test]
+fn whole_key_tombstone_still_deletes_all_values() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+    let key = vec![5u8];
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    let batch = db.write_batch()?;
+    batch.put(0, key.clone(), 1u32.to_be_bytes().to_vec().into())?;
+    batch.put(0, key.clone(), 2u32.to_be_bytes().to_vec().into())?;
+    db.commit_write_batch(batch)?;
+
+    let batch = db.write_batch()?;
+    batch.delete_value(0, key.clone(), 1u32.to_be_bytes())?;
+    db.commit_write_batch(batch)?;
+
+    let batch = db.write_batch()?;
+    batch.delete(0, key.clone())?;
+    db.commit_write_batch(batch)?;
+
+    assert!(
+        db.get_multiple(0, &key.as_slice())?.is_empty(),
+        "key tombstone should remove everything"
+    );
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// Counts tombstone entries (both kinds) across every live SST, by reading the files directly.
+/// Tombstone counts are not tracked in the meta file, so there is nothing cheaper to read.
+fn count_tombstones(
+    path: &std::path::Path,
+    db: &TurboPersistence<RayonParallelScheduler, 1>,
+) -> Result<usize> {
+    use crate::{lookup_entry::IterValue, static_sorted_file::StaticSortedFileIter};
+
+    let mut count = 0;
+    for meta in db.meta_info()? {
+        for entry in &meta.entries {
+            let sst = crate::static_sorted_file::StaticSortedFileMetaData {
+                sequence_number: entry.sequence_number,
+                block_count: entry.block_count,
+            };
+            for item in StaticSortedFileIter::open(path, sst)? {
+                if matches!(
+                    item?.value,
+                    IterValue::KeyDeleted | IterValue::KeyValueDeleted { .. }
+                ) {
+                    count += 1;
+                }
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// Compaction reclaims tombstones once no *older* SST outside the job can still hold the key.
+/// Without this, tombstones accumulate forever.
+#[test]
+fn compaction_reclaims_tombstones_when_no_older_sst_has_the_key() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    // Enough distinct keys that the SSTs span a real hash range: the compaction selector
+    // estimates duplication by scaling sizes against the key-space spread, and a handful of
+    // keys sharing one hash makes that estimate degenerate.
+    const KEYS: u32 = 2000;
+
+    let batch = db.write_batch()?;
+    for k in 0..KEYS {
+        batch.put(
+            0,
+            k.to_be_bytes().to_vec(),
+            1u32.to_be_bytes().to_vec().into(),
+        )?;
+        batch.put(
+            0,
+            k.to_be_bytes().to_vec(),
+            2u32.to_be_bytes().to_vec().into(),
+        )?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Delete one of the two values for every key.
+    let batch = db.write_batch()?;
+    for k in 0..KEYS {
+        batch.delete_value(0, k.to_be_bytes().to_vec(), 1u32.to_be_bytes())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    assert_eq!(
+        count_tombstones(path, &db)?,
+        KEYS as usize,
+        "tombstones should be on disk before compaction"
+    );
+
+    db.compact(&CompactConfig {
+        min_merge_count: 2,
+        optimal_merge_count: 2,
+        min_merge_duplication_bytes: 1,
+        optimal_merge_duplication_bytes: 1,
+        ..Default::default()
+    })?;
+
+    // No older SST holds these keys, so every tombstone is dead weight and must be gone. Assert
+    // on the tombstone entries themselves: total file size would shrink from dropping the deleted
+    // values alone, so it cannot distinguish a working probe from one that never fires.
+    assert_eq!(
+        count_tombstones(path, &db)?,
+        0,
+        "compaction should have reclaimed every tombstone"
+    );
+
+    // ...and the deletes must still hold after reclamation.
+    for k in [0u32, KEYS / 2, KEYS - 1] {
+        let results = db
+            .get_multiple(0, &k.to_be_bytes().to_vec().as_slice())?
+            .iter()
+            .map(|v| u32::from_be_bytes((**v).try_into().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(results, vec![2], "value 1 must stay deleted for key {k}");
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// When an older SST *outside* the compaction job still holds the key, the tombstone must be
+/// kept. Dropping it would resurrect the value.
+#[test]
+fn compaction_keeps_tombstone_when_older_sst_has_the_key() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    const KEYS: u32 = 2000;
+
+    // Oldest layer: the values that must stay suppressed.
+    let batch = db.write_batch()?;
+    for k in 0..KEYS {
+        batch.put(
+            0,
+            k.to_be_bytes().to_vec(),
+            1u32.to_be_bytes().to_vec().into(),
+        )?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Newer layers: an unrelated value per key, then a tombstone for the old one.
+    let batch = db.write_batch()?;
+    for k in 0..KEYS {
+        batch.put(
+            0,
+            k.to_be_bytes().to_vec(),
+            2u32.to_be_bytes().to_vec().into(),
+        )?;
+    }
+    db.commit_write_batch(batch)?;
+
+    let batch = db.write_batch()?;
+    for k in 0..KEYS {
+        batch.delete_value(0, k.to_be_bytes().to_vec(), 1u32.to_be_bytes())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Compact repeatedly. Whatever subset each job picks, value 1 must never come back: while an
+    // older SST still holds it, the probe has to keep the tombstone alive.
+    for round in 0..4 {
+        db.compact(&CompactConfig {
+            min_merge_count: 2,
+            optimal_merge_count: 2,
+            min_merge_duplication_bytes: 1,
+            optimal_merge_duplication_bytes: 1,
+            ..Default::default()
+        })?;
+
+        for k in [0u32, KEYS / 2, KEYS - 1] {
+            let mut results = db
+                .get_multiple(0, &k.to_be_bytes().to_vec().as_slice())?
+                .iter()
+                .map(|v| u32::from_be_bytes((**v).try_into().unwrap()))
+                .collect::<Vec<_>>();
+            results.sort();
+            assert_eq!(
+                results,
+                vec![2],
+                "value 1 resurrected for key {k} in round {round}"
+            );
+        }
+    }
+
+    db.shutdown()?;
     Ok(())
 }

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -7,7 +7,9 @@ use crate::{
     DbConfig, FamilyConfig, FamilyKind,
     constants::{MAX_INLINE_VALUE_SIZE, MAX_MEDIUM_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
     db::{CompactConfig, TurboPersistence, read_current_version},
+    lookup_entry::IterValue,
     parallel_scheduler::ParallelScheduler,
+    static_sorted_file::{StaticSortedFileIter, StaticSortedFileMetaData},
     write_batch::WriteBatch,
 };
 
@@ -2456,15 +2458,13 @@ fn whole_key_tombstone_still_deletes_all_values() -> Result<()> {
 /// Counts tombstone entries (both kinds) across every live SST, by reading the files directly.
 /// Tombstone counts are not tracked in the meta file, so there is nothing cheaper to read.
 fn count_tombstones(
-    path: &std::path::Path,
+    path: &Path,
     db: &TurboPersistence<RayonParallelScheduler, 1>,
 ) -> Result<usize> {
-    use crate::{lookup_entry::IterValue, static_sorted_file::StaticSortedFileIter};
-
     let mut count = 0;
     for meta in db.meta_info()? {
         for entry in &meta.entries {
-            let sst = crate::static_sorted_file::StaticSortedFileMetaData {
+            let sst = StaticSortedFileMetaData {
                 sequence_number: entry.sequence_number,
                 block_count: entry.block_count,
             };

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2307,7 +2307,6 @@ fn valued_tombstone_deletes_only_its_pair() -> Result<()> {
 fn valued_tombstone_survives_partial_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-    let key = vec![7u8];
 
     let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
@@ -2315,34 +2314,62 @@ fn valued_tombstone_survives_partial_compaction() -> Result<()> {
         RayonParallelScheduler,
     )?;
 
-    // Oldest SST holds the value that the tombstone must keep suppressing.
+    // Enough distinct keys that each SST spans a real slice of the hash space. The compaction
+    // selector estimates duplication by scaling sizes against that spread, so a couple of keys
+    // sharing one hash makes the estimate degenerate and no merge is ever chosen — which would
+    // leave this test passing without compacting anything.
+    const KEYS: u32 = 2000;
+
+    // Oldest layer holds the values that the tombstones must keep suppressing.
     let batch = db.write_batch()?;
-    batch.put(0, key.clone(), 42u32.to_be_bytes().to_vec().into())?;
+    for k in 0..KEYS {
+        batch.put(
+            0,
+            k.to_be_bytes().to_vec(),
+            42u32.to_be_bytes().to_vec().into(),
+        )?;
+    }
     db.commit_write_batch(batch)?;
 
-    // A few unrelated SSTs so compaction has something to merge partially.
+    // Newer layers so compaction has overlapping candidates to merge partially.
     for v in [1u32, 2, 3] {
         let batch = db.write_batch()?;
-        batch.put(0, vec![8u8], v.to_be_bytes().to_vec().into())?;
+        for k in 0..KEYS {
+            batch.put(0, k.to_be_bytes().to_vec(), v.to_be_bytes().to_vec().into())?;
+        }
         db.commit_write_batch(batch)?;
     }
 
     let batch = db.write_batch()?;
-    batch.delete_value(0, key.clone(), 42u32.to_be_bytes().to_vec().into())?;
+    for k in 0..KEYS {
+        batch.delete_value(
+            0,
+            k.to_be_bytes().to_vec(),
+            42u32.to_be_bytes().to_vec().into(),
+        )?;
+    }
     db.commit_write_batch(batch)?;
 
     // Compact repeatedly; whatever coverage the selector chooses, 42 must stay deleted.
-    for _ in 0..3 {
+    for round in 0..3 {
         db.compact(&CompactConfig {
+            min_merge_count: 2,
             optimal_merge_count: 2,
             min_merge_duplication_bytes: 1,
             optimal_merge_duplication_bytes: 1,
             ..Default::default()
         })?;
-        assert!(
-            db.get_multiple(0, &key.as_slice())?.is_empty(),
-            "42 was resurrected by compaction"
-        );
+        for k in [0u32, KEYS / 2, KEYS - 1] {
+            let results = db
+                .get_multiple(0, &k.to_be_bytes().to_vec().as_slice())?
+                .iter()
+                .map(|v| u32::from_be_bytes((**v).try_into().unwrap()))
+                .collect::<Vec<_>>();
+            assert!(
+                !results.contains(&42),
+                "42 was resurrected for key {k} in round {round}: {results:?}"
+            );
+        }
     }
 
     db.shutdown()?;
@@ -2604,6 +2631,86 @@ fn compaction_keeps_tombstone_when_older_sst_has_the_key() -> Result<()> {
                 results,
                 vec![2],
                 "value 1 resurrected for key {k} in round {round}"
+            );
+        }
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+/// A compaction job's SSTs need not be contiguous: the selector picks members by hash-range
+/// overlap and skips already-claimed candidates, so an SST can sit "between" two job members
+/// without belonging to the job. A tombstone must still be kept for it.
+///
+/// This is the case a sequence-number threshold gets wrong — it would treat the skipped SST as
+/// part of the job and drop a tombstone that is still load-bearing.
+#[test]
+fn compaction_keeps_tombstone_when_skipped_sst_has_the_key() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        multi_value_config(),
+        RayonParallelScheduler,
+    )?;
+
+    const KEYS: u32 = 2000;
+
+    // Every SST spans a wide, overlapping slice of the hash space. That is what lets the selector
+    // form jobs that skip over an intervening file: with narrow or identical ranges it only ever
+    // picks contiguous runs, and the bug this guards against stays hidden.
+    let key_for = |round: u32, i: u32| {
+        let mut k = vec![0u8; 8];
+        k[..4].copy_from_slice(&i.to_be_bytes());
+        k[4..].copy_from_slice(&round.to_be_bytes());
+        k
+    };
+
+    // Oldest layer: the values that must stay suppressed once deleted.
+    let batch = db.write_batch()?;
+    for i in 0..KEYS {
+        batch.put(0, key_for(0, i), 1u32.to_be_bytes().to_vec().into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Several more layers touching the same keys, so the selector has many overlapping candidates.
+    for round in 1..7u32 {
+        let batch = db.write_batch()?;
+        for i in 0..KEYS {
+            batch.put(0, key_for(0, i), (round + 1).to_be_bytes().to_vec().into())?;
+            batch.put(0, key_for(round, i), 9u32.to_be_bytes().to_vec().into())?;
+        }
+        db.commit_write_batch(batch)?;
+    }
+
+    // Delete the oldest value for every key in the first layer.
+    let batch = db.write_batch()?;
+    for i in 0..KEYS {
+        batch.delete_value(0, key_for(0, i), 1u32.to_be_bytes().to_vec().into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    for round in 0..6 {
+        db.compact(&CompactConfig {
+            min_merge_count: 2,
+            max_merge_count: 3,
+            optimal_merge_count: 2,
+            min_merge_duplication_bytes: 1,
+            optimal_merge_duplication_bytes: 1,
+            ..Default::default()
+        })?;
+
+        for i in [0u32, KEYS / 2, KEYS - 1] {
+            let results = db
+                .get_multiple(0, &key_for(0, i).as_slice())?
+                .iter()
+                .map(|v| u32::from_be_bytes((**v).try_into().unwrap()))
+                .collect::<Vec<_>>();
+            assert!(
+                !results.contains(&1),
+                "deleted value resurrected for key {i} in round {round}: {results:?}"
             );
         }
     }

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2692,6 +2692,18 @@ fn compaction_keeps_tombstone_when_skipped_sst_has_the_key() -> Result<()> {
     }
     db.commit_write_batch(batch)?;
 
+    // More layers *after* the tombstone, so it sits in the middle of the stack rather than at the
+    // newest end. A job containing the tombstone's SST can then skip over older SSTs that still
+    // hold value 1 — those are only caught by probing every older SST the job does not merge, not
+    // just the ones below the job's oldest member.
+    for round in 7..12u32 {
+        let batch = db.write_batch()?;
+        for i in 0..KEYS {
+            batch.put(0, key_for(round, i), 9u32.to_be_bytes().to_vec().into())?;
+        }
+        db.commit_write_batch(batch)?;
+    }
+
     for round in 0..6 {
         db.compact(&CompactConfig {
             min_merge_count: 2,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -267,7 +267,8 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     /// is undefined, and it is the caller's job to resolve that before writing.
     ///
     /// Only values of at most [`MAX_INLINE_VALUE_SIZE`] bytes can be deleted this way.  This is a
-    /// simplifying limitation that could be relaxed if needed.
+    /// simplifying limitation that could be relaxed if needed. Of course in general the storage
+    /// overhead of deleting large values by value makes it apriori inefficient.
     pub fn delete_value(&self, family: u32, key: K, value: ValueBuffer<'_>) -> Result<()> {
         let family_config = &self.family_configs[usize_from_u32(family)];
         if family_config.kind != FamilyKind::MultiValue {

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -6,7 +6,7 @@ use std::{
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use byteorder::{BE, WriteBytesExt};
 use either::Either;
 use fs_err::File;
@@ -19,13 +19,12 @@ use crate::{
     collector::Collector,
     collector_entry::CollectorEntry,
     compression::{checksum_block, compress_into_buffer},
-    constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
+    constants::{MAX_INLINE_VALUE_SIZE, MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
     db::WriteOperationGuard,
     key::StoreKey,
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
-    static_sorted_file::KEY_VALUE_DELETED_REF_SIZE,
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
 };
 
@@ -265,20 +264,28 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     ///
     /// Callers must not insert and delete the same key-value pair in the same batch; the
     /// resolution order between them is undefined (debug builds assert against it).
-    pub fn delete_value(
-        &self,
-        family: u32,
-        key: K,
-        value: [u8; KEY_VALUE_DELETED_REF_SIZE],
-    ) -> Result<()> {
-        debug_assert_eq!(
-            self.family_configs[usize_from_u32(family)].kind,
-            FamilyKind::MultiValue,
-            "delete_value is only valid for MultiValue families"
-        );
+    ///
+    /// Only values of at most [`MAX_INLINE_VALUE_SIZE`] bytes can be deleted this way; larger
+    /// values are an error. The tombstone carries a copy of the value so that reads can match it,
+    /// so deleting a large value would cost more than the value it reclaims.
+    pub fn delete_value(&self, family: u32, key: K, value: ValueBuffer<'_>) -> Result<()> {
+        let family_config = &self.family_configs[usize_from_u32(family)];
+        if family_config.kind != FamilyKind::MultiValue {
+            bail!(
+                "delete_value is only valid for MultiValue families, but family {} is SingleValue",
+                family_config.name
+            );
+        }
+        if value.len() > MAX_INLINE_VALUE_SIZE {
+            bail!(
+                "delete_value only supports values of at most {MAX_INLINE_VALUE_SIZE} bytes, got \
+                 {} bytes",
+                value.len()
+            );
+        }
         let state = self.thread_local_state();
         let collector = self.thread_local_collector_mut(state, family)?;
-        collector.delete_value(key, value);
+        collector.delete_value(key, &value);
         Ok(())
     }
 

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -246,6 +246,13 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     }
 
     /// Puts a delete operation into the write batch. This deletes *all* values for `key`.
+    ///
+    /// Combining this with a [`WriteBatch::put`] of the same key in the same batch is **not
+    /// supported**: which one wins is undefined, and callers are expected to resolve the intent
+    /// themselves before writing. A batch is not an ordered log — writes are buffered in
+    /// thread-local collectors that are sealed into SST files whenever they fill up, so two
+    /// operations on one key can land in different files, and the relative order of those files
+    /// within the batch is not guaranteed.
     pub fn delete(&self, family: u32, key: K) -> Result<()> {
         let state = self.thread_local_state();
         let collector = self.thread_local_collector_mut(state, family)?;
@@ -262,8 +269,11 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     /// and applied lazily by reads and compaction, so deleting N pairs costs N buffered writes
     /// rather than N read-modify-write cycles.
     ///
-    /// Callers must not insert and delete the same key-value pair in the same batch; the
-    /// resolution order between them is undefined (debug builds assert against it).
+    /// Deleting a pair that is written in the same batch — by this or any other operation on the
+    /// key — is **not supported**, for the reason given on [`WriteBatch::delete`]: which one wins
+    /// is undefined, and it is the caller's job to resolve that before writing. Nothing detects
+    /// the conflict, so a batch that does this silently keeps or drops the value depending on how
+    /// collectors happened to fill.
     ///
     /// Only values of at most [`MAX_INLINE_VALUE_SIZE`] bytes can be deleted this way; larger
     /// values are an error. The tombstone carries a copy of the value so that reads can match it,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -249,10 +249,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     ///
     /// Combining this with a [`WriteBatch::put`] of the same key in the same batch is **not
     /// supported**: which one wins is undefined, and callers are expected to resolve the intent
-    /// themselves before writing. A batch is not an ordered log — writes are buffered in
-    /// thread-local collectors that are sealed into SST files whenever they fill up, so two
-    /// operations on one key can land in different files, and the relative order of those files
-    /// within the batch is not guaranteed.
+    /// themselves before writing.
     pub fn delete(&self, family: u32, key: K) -> Result<()> {
         let state = self.thread_local_state();
         let collector = self.thread_local_collector_mut(state, family)?;
@@ -265,19 +262,12 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
     /// Only valid for [`FamilyKind::MultiValue`] families: in a `SingleValue` family a key has one
     /// value and [`WriteBatch::delete`] already removes it exactly.
     ///
-    /// Does not read the existing values for `key` first — the tombstone is written optimistically
-    /// and applied lazily by reads and compaction, so deleting N pairs costs N buffered writes
-    /// rather than N read-modify-write cycles.
-    ///
     /// Deleting a pair that is written in the same batch — by this or any other operation on the
     /// key — is **not supported**, for the reason given on [`WriteBatch::delete`]: which one wins
-    /// is undefined, and it is the caller's job to resolve that before writing. Nothing detects
-    /// the conflict, so a batch that does this silently keeps or drops the value depending on how
-    /// collectors happened to fill.
+    /// is undefined, and it is the caller's job to resolve that before writing.
     ///
-    /// Only values of at most [`MAX_INLINE_VALUE_SIZE`] bytes can be deleted this way; larger
-    /// values are an error. The tombstone carries a copy of the value so that reads can match it,
-    /// so deleting a large value would cost more than the value it reclaims.
+    /// Only values of at most [`MAX_INLINE_VALUE_SIZE`] bytes can be deleted this way.  This is a
+    /// simplifying limitation that could be relaxed if needed.
     pub fn delete_value(&self, family: u32, key: K, value: ValueBuffer<'_>) -> Result<()> {
         let family_config = &self.family_configs[usize_from_u32(family)];
         if family_config.kind != FamilyKind::MultiValue {

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -583,10 +583,22 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                                     "we wrote a blob but did not read it"
                                 );
                             }
+                            // Key tombstones sort last within a key group, so a same-batch
+                            // `put(K, v); delete(K)` reads back as [v, KeyDeleted].
                             CollectorEntryValue::KeyDeleted => assert!(
-                                values.first() == Some(&LookupValue::KeyDeleted),
-                                "we wrote a deleted tombstone but it was not first in results"
+                                values.last() == Some(&LookupValue::KeyDeleted),
+                                "we wrote a key tombstone but it was not last in results"
                             ),
+                            CollectorEntryValue::KeyValueDeleted { value, len } => {
+                                let expected = &value[..*len as usize];
+                                assert!(
+                                    values.iter().any(|lv| matches!(
+                                        lv,
+                                        LookupValue::KeyValueDeleted { value } if &**value == expected
+                                    )),
+                                    "we wrote a key-value tombstone but did not read it back"
+                                )
+                            }
                             v => {
                                 assert!(
                                     values.into_iter().any(|lv| {

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 use thread_local::ThreadLocal;
 
 use crate::{
-    FamilyConfig, ValueBuffer,
+    FamilyConfig, FamilyKind, ValueBuffer,
     collector::Collector,
     collector_entry::CollectorEntry,
     compression::{checksum_block, compress_into_buffer},
@@ -25,6 +25,7 @@ use crate::{
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
+    static_sorted_file::KEY_VALUE_DELETED_REF_SIZE,
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
 };
 
@@ -245,11 +246,39 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         Ok(())
     }
 
-    /// Puts a delete operation into the write batch.
+    /// Puts a delete operation into the write batch. This deletes *all* values for `key`.
     pub fn delete(&self, family: u32, key: K) -> Result<()> {
         let state = self.thread_local_state();
         let collector = self.thread_local_collector_mut(state, family)?;
         collector.delete(key);
+        Ok(())
+    }
+
+    /// Deletes a single key-value pair, leaving any other values for `key` intact.
+    ///
+    /// Only valid for [`FamilyKind::MultiValue`] families: in a `SingleValue` family a key has one
+    /// value and [`WriteBatch::delete`] already removes it exactly.
+    ///
+    /// Does not read the existing values for `key` first — the tombstone is written optimistically
+    /// and applied lazily by reads and compaction, so deleting N pairs costs N buffered writes
+    /// rather than N read-modify-write cycles.
+    ///
+    /// Callers must not insert and delete the same key-value pair in the same batch; the
+    /// resolution order between them is undefined (debug builds assert against it).
+    pub fn delete_value(
+        &self,
+        family: u32,
+        key: K,
+        value: [u8; KEY_VALUE_DELETED_REF_SIZE],
+    ) -> Result<()> {
+        debug_assert_eq!(
+            self.family_configs[usize_from_u32(family)].kind,
+            FamilyKind::MultiValue,
+            "delete_value is only valid for MultiValue families"
+        );
+        let state = self.thread_local_state();
+        let collector = self.thread_local_collector_mut(state, family)?;
+        collector.delete_value(key, value);
         Ok(())
     }
 
@@ -547,8 +576,8 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                                     "we wrote a blob but did not read it"
                                 );
                             }
-                            CollectorEntryValue::Deleted => assert!(
-                                values.first() == Some(&LookupValue::Deleted),
+                            CollectorEntryValue::KeyDeleted => assert!(
+                                values.first() == Some(&LookupValue::KeyDeleted),
                                 "we wrote a deleted tombstone but it was not first in results"
                             ),
                             v => {


### PR DESCRIPTION
Add a new `tombstone` format to the persistence layer so we can delete key-value pairs out of MultiValued tables

This is in service of the upcoming GC support, but also fills a basic API gap in the db.

To delete a key-value-pair you need to call `value_delete` and currently the values are limited to only those that are able to be stored inline in key blocks.  This is a non-trivial limitation but it fits our current usecase, and makes the compaction/query algorithms a bit simpler (don't need to 'resolve' values)

One non-trivial complexity was maintaining the 'FixedLayout' block optimization for a mix of tombstones and values, so now we support a slightly different mode where all keys have the same length but possibly different types.

Finally, this branch solves a problem with deleting tombstones.  Tombstones 'shadow' older values and allow us to drop them during compaction.  With GC getting ready to start writing tombstones the risk becomes 'when can we delete a tombstone! This is solved probabilistically using the amqf filters, during compaction we drop tombstones if they could not possibly match anything in an older SST.    Without this, tombstones in the TaskCache table would fill up over time.


