### PR TITLE
Flush pending revalidations for forwarded action error responses

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1255,9 +1255,6 @@ export async function handleAction({
 
         // For form actions, we need to continue rendering the page.
         if (isFetchAction) {
-          // If we skip page rendering, we need to ensure pending revalidates
-          // are awaited before closing the response. Otherwise, this will be
-          // done after rendering the page.
           return {
             type: 'done',
             result: await actionAsyncStorage.exit(() =>

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -564,6 +564,18 @@ type HandleActionResult =
   /** The request turned out not to be a server action. */
   | null
 
+function getRevalidationWaitUntil(
+  workStore: WorkStore,
+  skipPageRendering: boolean
+): Promise<void> | undefined {
+  if (!skipPageRendering) {
+    return undefined
+  }
+
+  const revalidatesPromise = executeRevalidates(workStore)
+  return revalidatesPromise === false ? undefined : revalidatesPromise
+}
+
 export async function handleAction({
   req,
   res,
@@ -1244,10 +1256,6 @@ export async function handleAction({
           // If we skip page rendering, we need to ensure pending revalidates
           // are awaited before closing the response. Otherwise, this will be
           // done after rendering the page.
-          const maybeRevalidatesPromise = skipPageRendering
-            ? executeRevalidates(workStore)
-            : false
-
           return {
             type: 'done',
             result: await actionAsyncStorage.exit(() =>
@@ -1255,10 +1263,10 @@ export async function handleAction({
                 actionResult: Promise.resolve(actionResult),
                 skipPageRendering,
                 temporaryReferences,
-                waitUntil:
-                  maybeRevalidatesPromise === false
-                    ? undefined
-                    : maybeRevalidatesPromise,
+                waitUntil: getRevalidationWaitUntil(
+                  workStore,
+                  skipPageRendering
+                ),
               })
             ),
           }
@@ -1325,6 +1333,10 @@ export async function handleAction({
             skipPageRendering: shouldSkipPageRendering,
             actionResult: promise,
             temporaryReferences,
+            waitUntil: getRevalidationWaitUntil(
+              workStore,
+              shouldSkipPageRendering
+            ),
           }),
         }
       }
@@ -1355,17 +1367,20 @@ export async function handleAction({
         // swallow error, it's gonna be handled on the client
       }
 
+      const skipPageRendering =
+        workStore.pathWasRevalidated === undefined ||
+        workStore.pathWasRevalidated === ActionDidNotRevalidate ||
+        shouldSkipPageRendering
+
       return {
         type: 'done',
         result: await generateFlight(req, ctx, requestStore, {
           actionResult: promise,
           // If the page was not revalidated, or if this is an action-only
           // request, we can skip rendering the page.
-          skipPageRendering:
-            workStore.pathWasRevalidated === undefined ||
-            workStore.pathWasRevalidated === ActionDidNotRevalidate ||
-            shouldSkipPageRendering,
+          skipPageRendering,
           temporaryReferences,
+          waitUntil: getRevalidationWaitUntil(workStore, skipPageRendering),
         }),
       }
     }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -569,6 +569,8 @@ function getRevalidationWaitUntil(
   skipPageRendering: boolean
 ): Promise<void> | undefined {
   if (!skipPageRendering) {
+    // Page rendering executes pending revalidations before rendering. We only
+    // need to attach them to waitUntil when no page render will take place.
     return undefined
   }
 

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/action-only-fallback-resume-data-cache.test.ts
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/action-only-fallback-resume-data-cache.test.ts
@@ -9,6 +9,7 @@ describe('action-only fallback resume data cache', () => {
       : {
           NEXT_PRIVATE_TEST_HEADERS: '1',
           NEXT_PRIVATE_MINIMAL_MODE: '1',
+          TEST_CACHE_HANDLER: '1',
         },
   })
 
@@ -79,13 +80,19 @@ describe('action-only fallback resume data cache', () => {
       expect(responseBody).not.toContain('destination page rendered')
     })
 
-    it('does not render the fallback route when the action calls notFound', async () => {
+    it('applies pending revalidations without rendering the fallback route when the action calls notFound', async () => {
+      const outputIndex = next.cliOutput.length
+
       const response = await invokeAction('notFoundAfterRevalidation')
 
       expect(response.status).toBe(404)
       expect(response.headers.get('content-type')).toContain('text/x-component')
       const responseBody = await response.text()
       expect(responseBody).not.toContain('destination page rendered')
+
+      const output = next.cliOutput.slice(outputIndex)
+      expect(output).toContain('ActionOnlyFallbackCacheHandler::updateTags')
+      expect(output).toContain('_N_T_/events/foo/group')
     })
   }
 })

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/cache-handler.js
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/cache-handler.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+const defaultCacheHandler =
+  require('next/dist/server/lib/cache-handlers/default.external').default
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  get: defaultCacheHandler.get.bind(defaultCacheHandler),
+  set: defaultCacheHandler.set.bind(defaultCacheHandler),
+  refreshTags: defaultCacheHandler.refreshTags.bind(defaultCacheHandler),
+  getExpiration: defaultCacheHandler.getExpiration.bind(defaultCacheHandler),
+  async updateTags(tags) {
+    console.log(
+      'ActionOnlyFallbackCacheHandler::updateTags',
+      JSON.stringify(tags)
+    )
+    return defaultCacheHandler.updateTags(tags)
+  },
+}
+
+module.exports = cacheHandler

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/next.config.js
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/next.config.js
@@ -3,6 +3,11 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  cacheHandlers: process.env.TEST_CACHE_HANDLER
+    ? {
+        default: require.resolve('./cache-handler.js'),
+      }
+    : undefined,
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Bug

When a Server Action skips page rendering, the successful response path attaches pending revalidations to the response’s `waitUntil` promise. Error paths, including `notFound()`, did not.

As a result, a forwarded action that called `revalidatePath()` or `revalidateTag()` and then threw could return its error response without executing the pending invalidation.

## Fix

Centralize the skipped-render revalidation handling and attach its promise to successful and error responses.

Actions that continue into page rendering retain the existing behavior, where revalidations are executed before rendering.

## Test Plan

Add a production regression test that invokes an action which calls `revalidatePath()` followed by `notFound()` and verifies:

- The fallback route’s page is not rendered.
- The cache handler receives the expected path-tag invalidation.
- Removing the new `waitUntil` attachment causes the test to fail.