### PR TITLE
fix: percent-encode search values in unstable_cache fetchUrl

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.test.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.test.ts
@@ -1,0 +1,75 @@
+import { getFetchUrlPrefix } from './unstable-cache'
+import type { WorkStore } from '../../app-render/work-async-storage.external'
+import type { WorkUnitStore } from '../../app-render/work-unit-async-storage.external'
+
+const workStore = { route: '/route' } as unknown as WorkStore
+
+function requestStore(url: string): WorkUnitStore {
+  const { pathname, search } = new URL(url, 'http://n')
+  return { type: 'request', url: { pathname, search } } as unknown as WorkUnitStore
+}
+
+const prefixFor = (url: string) =>
+  getFetchUrlPrefix(workStore, requestStore(url))
+
+const isAscii = (value: string) => /^[\x00-\x7F]*$/.test(value)
+
+describe('getFetchUrlPrefix', () => {
+  it('sorts search params by key', () => {
+    expect(prefixFor('/?b=2&a=1')).toBe('/?a=1&b=2')
+  })
+
+  it('omits the "?" when there is no search', () => {
+    expect(prefixFor('/some/path')).toBe('/some/path')
+  })
+
+  it('leaves plain ASCII values readable', () => {
+    expect(prefixFor('/?key=bar&extra=english')).toBe(
+      '/?extra=english&key=bar'
+    )
+  })
+
+  // Regression: the prefix becomes part of `fetchUrl`, which cache handlers may
+  // send as an HTTP header value. Header values are ByteStrings, so any
+  // codepoint above U+00FF made the header impossible to construct; handlers
+  // caught the TypeError and reported it as a cache miss, silently disabling
+  // the cache on every request carrying such a query value.
+  // See https://github.com/vercel/next.js/issues/76286
+  describe.each([
+    ['CJK', '中國人'],
+    ['emoji', '🎉'],
+    ['Cyrillic', 'Привет'],
+    // U+0100 is the first codepoint above the ByteString ceiling.
+    ['first non-Latin-1 codepoint', 'Ā'],
+    // Latin-1 passed the ByteString check but was still emitted raw, so the
+    // header carried an ambiguous 8-bit byte.
+    ['Latin-1', 'café'],
+    ['last Latin-1 codepoint', 'ÿ'],
+  ])('with a %s search value', (_label, value) => {
+    const url = `/?key=bar&extra=${encodeURIComponent(value)}`
+
+    it('produces an ASCII-only prefix', () => {
+      expect(isAscii(prefixFor(url))).toBe(true)
+    })
+
+    it('produces a usable HTTP header value', () => {
+      expect(
+        () => new Headers({ 'x-cache-item-name': prefixFor(url) })
+      ).not.toThrow()
+    })
+  })
+
+  it('keeps repeated keys distinct', () => {
+    // Previously `.get()` returned only the first value while the key was
+    // emitted once per occurrence, so this collapsed to "a=1&a=1" and collided
+    // with `?a=1&a=1`.
+    expect(prefixFor('/?a=1&a=2')).toBe('/?a=1&a=2')
+    expect(prefixFor('/?a=1&a=2')).not.toBe(prefixFor('/?a=1&a=1'))
+  })
+
+  it('falls back to the route outside a request', () => {
+    expect(
+      getFetchUrlPrefix(workStore, { type: 'cache' } as unknown as WorkUnitStore)
+    ).toBe('/route')
+  })
+})

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -402,7 +402,9 @@ export function unstable_cache<T extends Callback>(
   return cachedCb as unknown as T
 }
 
-function getFetchUrlPrefix(
+// Exported for unit tests. `next/cache` re-exports `unstable_cache` by name,
+// so this is not reachable as public API.
+export function getFetchUrlPrefix(
   workStore: WorkStore,
   workUnitStore: WorkUnitStore
 ): string {
@@ -411,10 +413,28 @@ function getFetchUrlPrefix(
       const pathname = workUnitStore.url.pathname
       const searchParams = new URLSearchParams(workUnitStore.url.search)
 
-      const sortedSearch = [...searchParams.keys()]
-        .sort((a, b) => a.localeCompare(b))
-        .map((key) => `${key}=${searchParams.get(key)}`)
-        .join('&')
+      // Re-serialize through URLSearchParams so the result is percent-encoded,
+      // and therefore always ASCII. This string becomes part of `fetchUrl`,
+      // which cache handlers may send as an HTTP header value. Header values
+      // are ByteStrings (<= U+00FF), so interpolating a raw `.get()` value
+      // containing e.g. CJK, Cyrillic or emoji makes the header impossible to
+      // construct. Handlers that build the header inside a try/catch then
+      // report that as a cache miss, silently disabling the cache for every
+      // request carrying such a query value. `patch-fetch` upholds the same
+      // invariant for ordinary fetches by using the already-encoded `url.href`.
+      //
+      // Using getAll() also keeps repeated keys distinct: `.get()` returned
+      // only the first value, so `?a=1&a=2` and `?a=1&a=9` produced the same
+      // prefix.
+      const sortedSearchParams = new URLSearchParams()
+      for (const key of [...new Set(searchParams.keys())].sort((a, b) =>
+        a.localeCompare(b)
+      )) {
+        for (const value of searchParams.getAll(key)) {
+          sortedSearchParams.append(key, value)
+        }
+      }
+      const sortedSearch = sortedSearchParams.toString()
 
       return `${pathname}${sortedSearch.length ? '?' : ''}${sortedSearch}`
     case 'prerender':


### PR DESCRIPTION
Fixes: #76286

### What?

`unstable_cache` builds `fetchUrl`, a label describing the current request, by interpolating **decoded** search values — ``.map((key) => `${key}=${searchParams.get(key)}`)``. This rebuilds that label with `URLSearchParams` instead, so the values come out percent-encoded and the label is always ASCII.

> fetchUrl is not part of the cache key

```js
// For: https://my-app.com/?key=bar&extra=中國人:
window.location.search // '?key=bar&extra=%E4%B8%AD%E5%9C%8B%E4%BA%BA'
let sp = new URLSearchParams(window.location.search);
sp.get("extra") // '中國人'
```

### Why?

`fetchUrl` is handed to the incremental cache.

https://github.com/vercel/next.js/blob/d67e1f34eaa51d8c7f597fa18ea460b4c171b4a1/packages/next/src/server/lib/incremental-cache/index.ts#L203-L215

When a `FetchCache` is available, like on Vercel, the handler makes an HTTP request to the data cache and sends `fetchUrl` as the `x-vercel-cache-item-name` header, and header values are ByteStrings, so a codepoint above U+00FF makes `new Headers()` throw before the request is even sent. 

```js
let h = new Headers({foo: '中國人'}) //  Uncaught TypeError: Failed to construct 'Headers': String contains non ISO-8859-1 code point.
//     at <anonymous>:1:9
// Node.js prints a different error
```

We see no errors and the request succeeds, so combined with the v14 history below, the likely explanation is that the throw is caught and returned as `null`, which looks like a MISS, and `set()` fails the same way, so nothing is ever written either. 

- https://github.com/vercel/next.js/blob/v14.2.24/packages/next/src/server/lib/incremental-cache/fetch-cache.ts#L245-L252
- https://github.com/vercel/next.js/blob/v14.2.24/packages/next/src/server/lib/incremental-cache/fetch-cache.ts#L323-L331
- https://github.com/vercel/next.js/blob/v14.2.24/packages/next/src/server/lib/incremental-cache/fetch-cache.ts#L413

The result is that `unstable_cache` silently stops caching for any URL carrying a non-Latin-1 query value, including one the app never reads. 

Under `next start`, `FileSystemCache` there's no such path for `fetchUrl`, all good.

### How?

Each value is appended to a `URLSearchParams` and serialized with `toString()`, which percent-encodes. 

Using `getAll()` also keeps repeated keys distinct — `?a=1&a=2` previously produced `a=1&a=1`.

Verified on a Vercel deployment: https://issue-76286-patched-next.vercel.app/?key=bar&extra=%E4%B8%AD%E5%9C%8B%E4%BA%BA

Control without the patch: https://throwaway-phi.vercel.app/?key=bar&extra=%E4%B8%AD%E5%9C%8B%E4%BA%BA 

