### PR TITLE
Remove unused `hasWarnings` and `warnings`

### DIFF
--- a/packages/next/src/lib/typescript/runTypeCheck.ts
+++ b/packages/next/src/lib/typescript/runTypeCheck.ts
@@ -8,8 +8,6 @@ import { CompileError } from '../compile-error'
 import { warn } from '../../build/output/log'
 
 export interface TypeCheckResult {
-  hasWarnings: boolean
-  warnings?: string[]
   inputFilesCount?: number
   totalFilesCount?: number
   incremental: boolean
@@ -108,7 +106,6 @@ export async function runTypeCheck(
 
   if (fileNames.length < 1) {
     return {
-      hasWarnings: false,
       inputFilesCount: 0,
       totalFilesCount: 0,
       incremental: false,
@@ -214,15 +211,7 @@ export async function runTypeCheck(
     )
   }
 
-  const warnings = allDiagnostics
-    .filter((d) => d.category === typescript.DiagnosticCategory.Warning)
-    .map((d) =>
-      getFormattedDiagnostic(typescript, baseDir, distDir, d, isAppDirEnabled)
-    )
-
   return {
-    hasWarnings: true,
-    warnings,
     inputFilesCount: fileNames.length,
     totalFilesCount: program.getSourceFiles().length,
     incremental,

--- a/packages/next/src/lib/typescript/runTypeCheckCli.ts
+++ b/packages/next/src/lib/typescript/runTypeCheckCli.ts
@@ -59,7 +59,6 @@ export async function runTypeCheckCli({
   }
 
   return {
-    hasWarnings: false,
     incremental,
   }
 }


### PR DESCRIPTION
### Fixing a bug

Nothing reads the two fields `hasWarnings` and `warnings` on `TypeCheckResult`.

`verifyAndRunTypeScript` has four callers:

- `build/type-check.ts` only reads `inputFilesCount`, `totalFilesCount` and `incremental`
- `next-test` only reads `version`
- `setup-dev-bundler` only reads `version`
- `next-typegen` throws the result away

`warnings` is also always empty. It looks for diagnostics with the `Warning` category, but I checked, and TypeScript 6.0.2 has no messages in that category. Deprecation messages use `Suggestion` instead.

So on every build, we filtered and formatted every diagnostic to build a list that was always empty, and that nobody read.

So I'm suggesting removing it instead, as it is clearly not being used. I also checked the GitHub code search across all public repositories and couldn't find anyone using either of them. That aside, it also never really worked correctly, as it would always return `hasWarnings: true` even if `warnings` was empty.

No test added since the fields are being removed. Also since this is such a small change I didn't create an issue to link here, I'd be happy to file one if you prefer me to.

Thanks for the hard work and taking the time for reviewing this PR! 😊 