### PR TITLE
docs: add `export const dynamic = 'force-static'` to Route Handlers example on Static Exports

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -232,15 +232,19 @@ export default function Page() {
 
 ### Route Handlers
 
-Route Handlers will render a static response when running `next build`. Only the `GET` HTTP verb is supported. This can be used to generate static HTML, JSON, TXT, or other files from cached or uncached data. For example:
+Route Handlers will render a static response when running `next build`. Only the `GET` HTTP verb is supported. This can be used to generate static HTML, JSON, TXT, or other files from cached or uncached data. To ensure Route Handlers are prerendered, you must explicitly mark the handler as static by adding `export const dynamic = 'force-static'` when a static export is enabled. For example:
 
 ```ts filename="app/data.json/route.ts" switcher
+export const dynamic = 'force-static'
+
 export async function GET() {
   return Response.json({ name: 'Lee' })
 }
 ```
 
 ```js filename="app/data.json/route.js" switcher
+export const dynamic = 'force-static'
+
 export async function GET() {
   return Response.json({ name: 'Lee' })
 }


### PR DESCRIPTION
What?
When a static export is enabled, route handlers require export const dynamic = 'force-static'. However, this instruction is missing in the documentation.

Why?
Without export const dynamic = 'force-static', next dev and next build fail when a static export is enabled.

How?
This PR adds the instruction to correct the usage of Route Handlers on static exports.