### PR TITLE
fix(swc): avoid treating Pages Router sitemap and robots routes as app entries

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -910,7 +910,21 @@ impl ReactServerComponentValidator {
             r"[\\/](page|layout|route|icon\d?|apple-icon\d?|opengraph-image\d?|twitter-image\d?|sitemap|robots|manifest)\.{ext_pattern}$",
         ))
         .unwrap();
-        let is_app_entry = re.is_match(&self.filepath);
+        let is_in_app_dir = self
+            .app_dir
+            .as_ref()
+            .and_then(|app_dir| app_dir.to_str())
+            .map_or(false, |app_dir| self.filepath.starts_with(app_dir));
+
+        let is_app_entry = if is_in_app_dir {
+            re.is_match(&self.filepath)
+        } else if self.app_dir.is_none() {
+            let app_core_re =
+                Regex::new(&format!(r"[\\/](page|layout|route)\.{ext_pattern}$")).unwrap();
+            app_core_re.is_match(&self.filepath)
+        } else {
+            false
+        };
 
         if is_app_entry {
             let mut possibly_invalid_exports: FxIndexMap<Atom, (InvalidExportKind, Span)> =

--- a/test/e2e/pages-sitemap-getstaticprops/index.test.ts
+++ b/test/e2e/pages-sitemap-getstaticprops/index.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('pages sitemap with getStaticProps', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render sitemap page with getStaticProps successfully', async () => {
+    const browser = await next.browser('/sitemap')
+    expect(await browser.elementById('message').text()).toBe(
+      'Hello from sitemap getStaticProps'
+    )
+  })
+})

--- a/test/e2e/pages-sitemap-getstaticprops/pages/sitemap.js
+++ b/test/e2e/pages-sitemap-getstaticprops/pages/sitemap.js
@@ -1,0 +1,11 @@
+export async function getStaticProps() {
+  return {
+    props: {
+      message: 'Hello from sitemap getStaticProps',
+    },
+  }
+}
+
+export default function Sitemap({ message }) {
+  return <h1 id="message">{message}</h1>
+}


### PR DESCRIPTION
### What?

Prevents the SWC `react_server_components` transform from treating Pages Router routes named `sitemap` or `robots` (e.g., `pages/sitemap.js`) as App Router metadata entries.

### Why?

When building a Pages Router site with Turbopack, pages named `pages/sitemap.js` or `pages/robots.js` exporting `getStaticProps` or `getServerSideProps` failed during build with `"getStaticProps" is not supported in app/`. The transform was matching these route names with a metadata regex without checking if the file actually resided inside `app_dir`.

### How?

In `ReactServerComponentValidator::assert_invalid_api`, updated `is_app_entry` to verify that `self.filepath` is located inside `self.app_dir` before treating metadata route names (`sitemap`, `robots`, `manifest`, etc.) as App Router entries. Added an e2e test covering `pages/sitemap.js` with `getStaticProps`.

Fixes #96859

<!-- NEXT_JS_LLM -->
