### PR TITLE
docs: fix broken links in contributing guide, devtools README, and ex…

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -168,7 +168,7 @@ $ pnpm unpack-next path/to/project
 
 ## Developing the Dev Overlay
 
-The dev overlay is a feature of Next.js that allows you to see the internal state of the app including the errors. To learn more about contributing to the dev overlay, see the [Dev Overlay README.md](../../packages/next/src/client/components/react-dev-overlay/README.md).
+The dev overlay is a feature of Next.js that allows you to see the internal state of the app including the errors. To learn more about contributing to the dev overlay, see the [Dev Overlay README.md](../../packages/next/src/next-devtools/README.md).
 
 ## `NODE_ENV` vs `__NEXT_DEV_SERVER`
 

--- a/examples/cms-graphcms/README.md
+++ b/examples/cms-graphcms/README.md
@@ -110,7 +110,7 @@ In GraphCMS, go to one of the posts in your project and:
 - **Update the title**. For example, you can add `[Draft]` in front of the title.
 - After you edit the document save the article as a draft, but **DO NOT** click **Publish**. By doing this, the post will be in the draft stage.
 
-Now, if you go to the post page on localhost, you won't see the updated title. However, if you use **Preview Mode**, you'll be able to see the change ([Documentation](/docs/advanced-features/preview-mode.md)).
+Now, if you go to the post page on localhost, you won't see the updated title. However, if you use **Preview Mode**, you'll be able to see the change ([Documentation](https://nextjs.org/docs/pages/guides/preview-mode)).
 
 To view the preview, transform the url to the following format: `http://localhost:3000/api/preview?secret=<YOUR_SECRET_TOKEN>&slug=<SLUG_TO_PREVIEW>` where `<YOUR_SECRET_TOKEN>` is the same secret you defined in the `.env.local` file and `<SLUG_TO_PREVIEW>` is the slug of one of the posts you want to preview.
 

--- a/examples/cms-umbraco-heartcore/README.md
+++ b/examples/cms-umbraco-heartcore/README.md
@@ -88,7 +88,7 @@ Then set each variable in `.env.local`:
 
 - `UMBRACO_PROJECT_ALIAS`: Set it to the project alias, which can be found under **Settings** -> **Headless**.
 - `UMBRACO_API_KEY`: Create a new API Key under **Users > "Your Username" > API Keys**.
-- `UMBRACO_PREVIEW_SECRET` can be any random string (but avoid spaces), like `MY_SECRET` - this is used for [Preview Mode](https://nextjs.org/docs/advanced-features/preview-mode).
+- `UMBRACO_PREVIEW_SECRET` can be any random string (but avoid spaces), like `MY_SECRET` - this is used for [Preview Mode](https://nextjs.org/docs/pages/guides/preview-mode).
 
 Your `.env.local` file should look like this:
 
@@ -119,7 +119,7 @@ Then click save and go back to the **Content** section, click on _Posts_ and the
 - **Update the title**. For example, you can add `[Draft]` in front of the title.
 - Click **Save**, but **DO NOT** click **Publish**. By doing this, the post will be in the draft state.
 
-Now, if you go to the post page on localhost, you won't see the updated title. However, if you use **Preview Mode**, you'll be able to see the change ([Documentation](/docs/advanced-features/preview-mode.md)).
+Now, if you go to the post page on localhost, you won't see the updated title. However, if you use **Preview Mode**, you'll be able to see the change ([Documentation](https://nextjs.org/docs/pages/guides/preview-mode)).
 
 To enable the Preview Mode, go to this URL:
 

--- a/examples/with-rematch/README.md
+++ b/examples/with-rematch/README.md
@@ -1,6 +1,6 @@
 # Rematch example
 
-This example has two pages. The first page has a counter which can be incremented synchronously or asynchronously. The second page is a page which shows a list of github users. It fetches data from the github api using this [endpoint](api.github.com/users).
+This example has two pages. The first page has a counter which can be incremented synchronously or asynchronously. The second page is a page which shows a list of github users. It fetches data from the github api using this [endpoint](https://api.github.com/users).
 
 Since rematch is utility which uses redux under the hood, some elements like `store.js` and `withRematch` are very similar to the `with-redux` example. Please go through the [`with-redux` example](https://github.com/vercel/next.js/tree/canary/examples/with-redux) before reading further if you are not familiar with how redux is integrated with Next.js. Rematch is just an extension for Redux so a lot of elements are the same.
 

--- a/packages/next/src/next-devtools/README.md
+++ b/packages/next/src/next-devtools/README.md
@@ -78,4 +78,4 @@ export function ComponentStyles() {
 
 The dev overlay implements a dark theme automatically by system preferences. Users can manually toggle between light and dark themes via the DevTools Indicator preferences panel.
 
-To make changes to the dark theme, you can edit the [`ui/styles/dark-theme.tsx`](./ui/styles/dark-theme.tsx) file.
+To make changes to the dark theme, you can edit the [`dev-overlay/styles/dark-theme.css`](./dev-overlay/styles/dark-theme.css) file.


### PR DESCRIPTION
This PR fixes 5 broken internal links found across the repository's contributing guides, component documentation, and examples.

Specifically, it updates:

- contributing/core/developing.md: Fixed the link to the dev overlay README (moved from react-dev-overlay/ to next-devtools/).
- packages/next/src/next-devtools/README.md: Fixed the link to the dark theme styling file (moved/renamed from ui/styles/dark-theme.tsx to dev-overlay/styles/dark-theme.css).
- examples/cms-graphcms/README.md: Updated the preview mode documentation link from the old advanced-features path to the current Next.js documentation URL.
- examples/cms-umbraco-heartcore/README.md: Updated two occurrences of the preview mode documentation link from the old advanced-features path to the current Next.js documentation URL.
- examples/with-rematch/README.md: Added the missing https:// scheme to the api.github.com/users markdown link so it correctly routes to an external URL instead of resolving as a relative file path.