### PR TITLE
Stop app route prerenders after caught request access

### DIFF
--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -639,17 +639,16 @@ export class AppRouteRouteModule extends RouteModule<
 
         // The handler may catch the prerender interruption and resolve
         // normally, but dynamic tracking still records the request access.
-        const dynamicRequestAccess = dynamicTracking.dynamicAccesses.find(
+        const hasDynamicRequestAccess = dynamicTracking.dynamicAccesses.some(
           ({ expression }) =>
             expression.startsWith('nextUrl.') ||
             expression.startsWith('request.')
-        )?.expression
+        )
 
-        if (prospectiveRenderIsDynamic || dynamicRequestAccess) {
+        if (prospectiveRenderIsDynamic || hasDynamicRequestAccess) {
           // the route handler called an API which is always dynamic
           // there is no need to try again
-          const dynamicReason =
-            dynamicRequestAccess ?? getFirstDynamicReason(dynamicTracking)
+          const dynamicReason = getFirstDynamicReason(dynamicTracking)
           if (dynamicReason) {
             throw new DynamicServerError(
               `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -637,10 +637,13 @@ export class AppRouteRouteModule extends RouteModule<
         trackPendingModules(cacheSignal)
         await cacheSignal.cacheReady()
 
-        if (prospectiveRenderIsDynamic) {
+        // The handler may catch the prerender interruption and resolve
+        // normally, but dynamic tracking still records the request access.
+        const dynamicReason = getFirstDynamicReason(dynamicTracking)
+
+        if (prospectiveRenderIsDynamic || dynamicReason) {
           // the route handler called an API which is always dynamic
           // there is no need to try again
-          const dynamicReason = getFirstDynamicReason(dynamicTracking)
           if (dynamicReason) {
             throw new DynamicServerError(
               `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -639,11 +639,17 @@ export class AppRouteRouteModule extends RouteModule<
 
         // The handler may catch the prerender interruption and resolve
         // normally, but dynamic tracking still records the request access.
-        const dynamicReason = getFirstDynamicReason(dynamicTracking)
+        const dynamicRequestAccess = dynamicTracking.dynamicAccesses.find(
+          ({ expression }) =>
+            expression.startsWith('nextUrl.') ||
+            expression.startsWith('request.')
+        )?.expression
 
-        if (prospectiveRenderIsDynamic || dynamicReason) {
+        if (prospectiveRenderIsDynamic || dynamicRequestAccess) {
           // the route handler called an API which is always dynamic
           // there is no need to try again
+          const dynamicReason =
+            dynamicRequestAccess ?? getFirstDynamicReason(dynamicTracking)
           if (dynamicReason) {
             throw new DynamicServerError(
               `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`

--- a/test/e2e/app-dir/cache-components/app/routes/caught-dynamic-url/route.ts
+++ b/test/e2e/app-dir/cache-components/app/routes/caught-dynamic-url/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest) {
+  let search = ''
+
+  try {
+    search = request.nextUrl.search
+  } catch {
+    console.log('caught dynamic URL access')
+  }
+
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      search,
+    })
+  )
+}

--- a/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
@@ -50,6 +50,22 @@ describe('cache-components', () => {
     expect(json.search).toEqual('?foo=bar')
   })
 
+  it('should stop the prospective render when a dynamic API error is caught', async () => {
+    if (!isNextDev) {
+      const prospectiveRenderLogs = next.cliOutput
+        .split('\n')
+        .filter((line) => line.includes('caught dynamic URL access'))
+
+      expect(prospectiveRenderLogs).toHaveLength(1)
+    }
+
+    const str = await next.render('/routes/caught-dynamic-url?foo=bar', {})
+    const json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(json.search).toEqual('?foo=bar')
+  })
+
   it('should prerender GET route handlers that have entirely cached io (fetches)', async () => {
     let str = await next.render('/routes/fetch-cached', {})
     let json = JSON.parse(str)


### PR DESCRIPTION
### What?

Stops the Cache Components prospective render of a `GET` Route Handler as soon as `NextRequest` or `nextUrl` access has already been recorded, even when userland catches the thrown prerender interruption and returns normally.

Adds regression coverage for a handler that reads `request.nextUrl.search` inside a broad `try/catch`.

### Why?

Cache Components prospectively executes `GET` handlers during the build to determine whether their result can be prerendered. Request-bound reads interrupt that probe by throwing. If a broad userland catch swallows the interruption, dynamic tracking still records the access, but Next.js currently runs the handler again in the final prerender probe before classifying it as dynamic.

That second execution duplicates catch logging and any other work in the caught path. This is especially confusing for OG and API handlers because the expected control-flow interruption looks like a build failure in user logs.

The thrown interruption itself remains intentional. This change only removes the redundant final probe after Next.js already knows the handler accessed the request.

Related context: https://github.com/vercel/next.js/discussions/74858

### How?

After prospective caches settle, the route module checks the dynamic tracking entries produced by the `NextRequest` proxy for `request.*` and `nextUrl.*` access. It treats those entries as authoritative alongside rejected-promise detection and throws the existing `DynamicServerError` before entering the final prerender pass.

The check is deliberately limited to request-proxy access. Other dynamic tracking recorded while prospective caches are being filled remains eligible for the final prerender pass.

The regression fixture verifies that the caught build-time path runs once instead of twice and that the request-time handler still receives the real query string.

### Verification

- `pnpm --filter=next build`
- `__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-start-turbo test/e2e/app-dir/cache-components/cache-components.routes.test.ts` (10/10)
- `IS_WEBPACK_TEST=1 __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-start-webpack test/e2e/app-dir/cache-components/cache-components.routes.test.ts` (10/10)
- Changed-file Prettier and ESLint checks

The regression test fails on `canary` with two build-time catch executions and passes with this change with one execution.
