### PR TITLE
Document route handler prerender interruptions

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -828,7 +828,46 @@ async function getProducts() {
 }
 ```
 
-> **Good to know:** Reading uncached or runtime data in a `GET` handler bails out of prerendering by **throwing**. A `try/catch` you already have around other operations will catch that bail-out. If the `catch` block logs the error, it adds noise to the build output. Set `experimental.hideLogsAfterAbort: true` to hide logs emitted after a bail-out.
+Reading uncached or runtime data in a `GET` handler interrupts prerendering by **throwing**. A broad `try/catch` around other operations will also catch this framework-controlled exception. If the `catch` block handles application errors, call [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) first so Next.js can stop prerendering before your error handling runs:
+
+```ts filename="app/api/products/route.ts" switcher highlight={11}
+import { unstable_rethrow } from 'next/navigation'
+import type { NextRequest } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  try {
+    const id = request.nextUrl.searchParams.get('id')
+    const product = await getProduct(id)
+
+    return Response.json(product)
+  } catch (error) {
+    unstable_rethrow(error)
+
+    console.error(error)
+    return Response.json({ error: 'Failed to load product' }, { status: 500 })
+  }
+}
+```
+
+```js filename="app/api/products/route.js" switcher highlight={10}
+import { unstable_rethrow } from 'next/navigation'
+
+export async function GET(request) {
+  try {
+    const id = request.nextUrl.searchParams.get('id')
+    const product = await getProduct(id)
+
+    return Response.json(product)
+  } catch (error) {
+    unstable_rethrow(error)
+
+    console.error(error)
+    return Response.json({ error: 'Failed to load product' }, { status: 500 })
+  }
+}
+```
+
+`unstable_rethrow` preserves Next.js control flow. The `experimental.hideLogsAfterAbort: true` option only hides logs emitted after a prerender has already been aborted; it does not replace rethrowing framework-controlled exceptions.
 
 ## `generateMetadata` and `generateViewport`
 


### PR DESCRIPTION
### What?

Documents how broad error handling in Cache Components `GET` Route Handlers should preserve framework-controlled prerender interruptions.

Adds TypeScript and JavaScript examples that call `unstable_rethrow(error)` before application error handling, and distinguishes that behavior from `experimental.hideLogsAfterAbort`.

### Why?

Request-bound and uncached reads intentionally throw while Next.js prospectively executes a `GET` handler during the build. An existing `try/catch` can intercept that signal, log a scary-looking error, and make an expected dynamic opt-out look like a failed build.

The migration guide currently mentions log suppression but does not directly connect this Route Handler behavior to `unstable_rethrow`. Log suppression changes visibility only; it does not preserve framework control flow in a catch block that otherwise handles every error.

### How?

Shows `request.nextUrl.searchParams` inside a mixed application error handler and places `unstable_rethrow` at the top of the catch. The surrounding text explains what each mechanism does.

### Stack

Stacked on #96979, which removes the redundant second prospective execution when dynamic access was already recorded.

### Verification

- `npx eslint --config eslint.config.mjs docs/01-app/02-guides/migrating-to-cache-components.mdx`
- Changed-file Prettier check
- Verified code-block highlight line numbers for both switcher examples