### PR TITLE
test: cover blocking not-found status stability

### DIFF
--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/partial-prefetching-disabled/app/blocking/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/partial-prefetching-disabled/app/blocking/[[...slug]]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation'
+
+const prerenderedSlugs = ['known']
+const runtimeSlugs = ['runtime']
+
+export const instant = false
+
+export function generateStaticParams() {
+  return prerenderedSlugs.map((slug) => ({ slug: [slug] }))
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>
+}) {
+  const { slug } = await params
+  const pathname = slug?.join('/') ?? ''
+
+  if (
+    !prerenderedSlugs.includes(pathname) &&
+    !runtimeSlugs.includes(pathname)
+  ) {
+    notFound()
+  }
+
+  return <p id="blocking-slug">{pathname}</p>
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -240,4 +240,25 @@ describe('partial-fallback-shell-upgrade - partialPrefetching disabled', () => {
       'generic shell should remain shared without partialPrefetching'
     )
   })
+
+  it('keeps blocking not-found responses stable after the first request', async () => {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await next.fetch('/blocking/missing')
+      const html = await response.text()
+
+      expect(response.status).toBe(404)
+      expect(html).toContain('<meta name="robots" content="noindex"')
+    }
+  })
+
+  it('serves valid ungenerated params before and after the first request', async () => {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await next.fetch('/blocking/runtime')
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain(
+        '<p id="blocking-slug">runtime</p>'
+      )
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Add production coverage for the cold and warm HTTP status of a blocking Cache Components route that calls `notFound()` for an unknown optional catch-all value.

#95380 reported cold `200` followed by warm `404`. The mismatch reproduces through `16.3.0-canary.102`; merged #96297 makes both requests return `404` starting in `.103`. This PR does not change runtime scheduling. It locks that corrected boundary into the fixture owned by #96297 and also proves that a valid param omitted from `generateStaticParams()` remains available on demand.

The broader streamed contract remains unchanged: if a shell has already started streaming before `notFound()` is discovered, the response can be `200` with `noindex`.

## Verification

- `pnpm test-start-turbo test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts`
- Changed-file Prettier, ESLint, and `git diff --check`

<!-- NEXT_JS_LLM -->
