### PR TITLE
Keep the dev validation worker alive across HMR updates

### DIFF
--- a/bench/dev-validation/README.md
+++ b/bench/dev-validation/README.md
@@ -28,6 +28,17 @@ prints the speedup. Options:
 - `--port=<n>`, `--headless=false`, `--settle-ms=<n>`.
 - `--json-out=<path>` — write the raw stats as JSON.
 
+Set `BENCH_DEV_VALIDATION_INSIGHTS=1` to give every family's leaf page an
+uncached data access, so validation reports one insight per navigation. Without
+it the run only covers the validation renders; with it, it also covers what
+follows an insight — encoding the errors and printing them with a source-mapped
+stack and code frame — which is the part that moves when that printing changes
+threads. The access sits below the family's heavy subtree, so validation still
+does that work before it reaches it: a page that suspends before it returns
+leaves the subtree unrendered in the validation pass. The routes become
+dynamic, so the absolute numbers are not comparable with a run without the
+flag; the worker-versus-in-process comparison within a run is.
+
 This depends on `experimental.devValidationWorker` existing, so it stacks on the
 PR that adds the flag. Until the worker implementation lands, both
 configurations run in-process and the A/B shows no delta; once it lands, the

--- a/bench/dev-validation/scripts/generate.mjs
+++ b/bench/dev-validation/scripts/generate.mjs
@@ -25,7 +25,15 @@ import { fileURLToPath } from 'node:url'
 
 // Bump VERSION whenever the generation logic or shape changes; the marker file
 // short-circuits regeneration when nothing changed.
-const VERSION = 'v6-3families-nested4-noinstant-48leaves-d4-b3-400symbols'
+// Set BENCH_DEV_VALIDATION_INSIGHTS=1 to give every family's leaf page an
+// uncached data access. Validation then reports one insight per navigation, so
+// the run also exercises the error path (encoding the errors, and printing them
+// with a source-mapped stack and code frame) rather than only the validation
+// render. Off by default, so the numbers the README describes stay comparable.
+const WITH_INSIGHTS = process.env.BENCH_DEV_VALIDATION_INSIGHTS === '1'
+const VERSION =
+  'v6-3families-nested4-noinstant-48leaves-d4-b3-400symbols' +
+  (WITH_INSIGHTS ? '-insights-below-tree' : '')
 const LEAF_COMPONENTS = 48
 const TREE_DEPTH = 4
 const TREE_BRANCH = 3
@@ -221,27 +229,56 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 `
 }
 
+// The uncached access that makes validation report an insight. It renders last,
+// below the family's heavy subtree, so validation does that work before it
+// reaches the access. It is not wrapped in a `<Suspense>`, which is what makes
+// validation report the route as blocking.
+const insightImport = WITH_INSIGHTS
+  ? "import { connection } from 'next/server'\n"
+  : ''
+const insightComponent = WITH_INSIGHTS
+  ? `
+async function Insight() {
+  await connection()
+  return null
+}
+`
+  : ''
+
 function leafPageSource(family, depthFromApp) {
   if (family === 'sprite') {
-    return `// Generated. See scripts/generate.mjs. The sprite renders in the
+    if (!WITH_INSIGHTS) {
+      return `// Generated. See scripts/generate.mjs. The sprite renders in the
 // shared layout above, so the leaf page only carries the route marker.
 export default function Page() {
   return <h1 id="route">sprite</h1>
 }
 `
+    }
+    return `${insightImport}// Generated. See scripts/generate.mjs. The sprite renders in the
+// shared layout above, so the leaf page only carries the route marker.
+export default function Page() {
+  return (
+    <>
+      <h1 id="route">sprite</h1>
+      <Insight />
+    </>
+  )
+}
+${insightComponent}`
   }
-  return `import { HeavyTree } from '${up(depthFromApp)}_generated/${family}-tree'
+  return `${insightImport}import { HeavyTree } from '${up(depthFromApp)}_generated/${family}-tree'
 
 // Generated. See scripts/generate.mjs.
 export default function Page() {
   return (
     <section>
       <h1 id="route">${family}</h1>
-      <HeavyTree seed={7} />
+      <HeavyTree seed={7} />${WITH_INSIGHTS ? '\n      <Insight />' : ''}
     </section>
   )
 }
-`
+${insightComponent}`
 }
 
 for (const family of FAMILIES) {

--- a/packages/next/src/server/dev/dev-validation-worker-pool.ts
+++ b/packages/next/src/server/dev/dev-validation-worker-pool.ts
@@ -1,5 +1,10 @@
 import type { NextConfigComplete } from '../config-shared'
-import type { runDevValidation } from './dev-validation-worker'
+import type { NodeJsPartialHmrUpdate } from '../../build/swc/types'
+import type {
+  applyHmrUpdate,
+  invalidateCaches,
+  runDevValidation,
+} from './dev-validation-worker'
 import type {
   DevValidationSnapshot,
   DevValidationWorkerMessage,
@@ -21,6 +26,52 @@ interface InstallOptions {
 
 type ValidationPool = { [key: string]: any } & {
   runDevValidation: typeof runDevValidation
+  applyHmrUpdate: typeof applyHmrUpdate
+  invalidateCaches: typeof invalidateCaches
+}
+
+/**
+ * One change the dev server made to its own module state — the modules it has
+ * loaded, and the manifest caches that describe them.
+ *
+ * The worker holds the same state, seeded from the same build output, and
+ * replays every change the dev server reports, so its state is the dev server's
+ * state by construction.
+ */
+type DevModuleStateChange =
+  | { type: 'apply'; update: NodeJsPartialHmrUpdate }
+  | { type: 'invalidate'; filePaths: string[]; evictModules: boolean }
+
+/**
+ * Replays a change the dev server made to its own module state in the
+ * validation worker. Installed alongside the worker, so it is absent when no
+ * worker runs (`experimental.devValidationWorker: false`, or Webpack).
+ */
+let mirrorModuleState: ((change: DevModuleStateChange) => void) | undefined
+
+/**
+ * Drops the validation worker. Called when the dev server cannot repair its own
+ * module state in place and re-evaluates every module from disk, which the
+ * worker matches by starting over: the next validation spawns a worker that
+ * loads the current build output.
+ *
+ * A worker dropped on its own, by a failed replay or a crash, is the one case
+ * where the two can diverge. The dev server keeps the modules it evaluated from
+ * earlier updates, and a worker spawned afterwards has no way to obtain those
+ * scripts, so frames naming them stay unresolved until those modules change
+ * again. The validation itself is unaffected, because the worker loads the
+ * current code from disk.
+ */
+let dropWorker: (() => void) | undefined
+
+export function mirrorModuleStateToDevValidationWorker(
+  change: DevModuleStateChange
+): void {
+  mirrorModuleState?.(change)
+}
+
+export function dropDevValidationWorker(): void {
+  dropWorker?.()
 }
 
 /**
@@ -43,8 +94,45 @@ export function installDevValidationWorker(options: InstallOptions): void {
   //
   // TODO(dev-validation-worker): raise `numWorkers` if concurrent navigations
   // across independent requests (e.g. multiple tabs) show a validation-latency
-  // tail.
+  // tail. Raising it means `mirrorChange` has to reach every worker instead of
+  // whichever one the pool hands the call to, and the ordering it relies on
+  // holds per worker rather than across them.
   let pool: ValidationPool | undefined
+
+  const mirrorChange = (change: DevModuleStateChange): void => {
+    const current = pool
+    if (!current) {
+      // No worker to keep current, and nothing to replay into a later one: the
+      // compilation that produced this change also wrote the updated chunk to
+      // disk, so a worker spawning after it reads the current code through
+      // `loadComponents`. Evaluating the update is what an isolate that is
+      // already running needs, not what a new one does.
+      return
+    }
+
+    // The worker runs one call at a time, in the order the calls were made
+    // (see `numWorkers` below), so this is replayed before any validation
+    // requested after it, and never in the middle of one. That ordering is by
+    // call time, which is why the call is made here, as the change arrives,
+    // rather than deferred onto a queue of our own. A validation already
+    // queued runs first, which is what its render needs: it was produced
+    // before this change. The dev server does not hold its own updates back
+    // for a validation running in process either.
+    const replayed =
+      change.type === 'invalidate'
+        ? current.invalidateCaches(change.filePaths, change.evictModules)
+        : current.applyHmrUpdate(change.update).then(async (outcome) => {
+            if (outcome === 'failed') {
+              await tearDownPool()
+            }
+          })
+
+    void replayed.catch(async () => {
+      // A replay that failed leaves the worker's state unknown, so it is
+      // dropped rather than trusted.
+      await tearDownPool()
+    })
+  }
 
   const getPool = (): ValidationPool => {
     if (pool) {
@@ -84,7 +172,11 @@ export function installDevValidationWorker(options: InstallOptions): void {
       // the module's exports. This worker's top-level imports (`require-hook`,
       // `node-environment`) run runtime setup meant only for the isolated
       // worker thread, so they must not be evaluated in the parent.
-      exposedMethods: ['runDevValidation'],
+      exposedMethods: [
+        'runDevValidation',
+        'applyHmrUpdate',
+        'invalidateCaches',
+      ],
       forkOptions: {
         env: {
           ...process.env,
@@ -169,13 +261,20 @@ export function installDevValidationWorker(options: InstallOptions): void {
     }
   }
 
-  // The dev server can't reach into the worker to clear its `require.cache` or
-  // manifest caches, so we drop the worker whenever the parent's caches are
-  // invalidated (HMR, route recompile). The next validation lazy-spawns a fresh
-  // worker with empty caches.
-  onCacheInvalidation(() => {
-    void tearDownPool()
+  // The dev server just cleared these paths from its own `require.cache` and
+  // manifest caches. The worker clears them from its copies.
+  onCacheInvalidation((filePaths) => {
+    mirrorChange({
+      type: 'invalidate',
+      filePaths,
+      evictModules: true,
+    })
   })
+
+  mirrorModuleState = mirrorChange
+  dropWorker = () => {
+    void tearDownPool()
+  }
 
   setDevValidationWorker(runValidation)
 }

--- a/packages/next/src/server/dev/dev-validation-worker.ts
+++ b/packages/next/src/server/dev/dev-validation-worker.ts
@@ -3,6 +3,7 @@ import type {
   DevValidationWorkerMessage,
   DevValidationWorkerResult,
 } from '../app-render/dev-validation-worker-globals'
+import type { NodeJsPartialHmrUpdate } from '../../build/swc/types'
 
 import '../require-hook'
 import '../node-environment'
@@ -19,6 +20,8 @@ import {
 import { setHttpClientAndAgentOptions } from '../setup-http-agent-env'
 import { serializeValidationErrorsToFlight } from '../app-render/dev-validation-error-delivery'
 import { formatValidationEvent } from '../app-render/dev-validation-events'
+import { clearManifestCache } from '../load-manifest.external'
+import { deleteCache } from './require-cache'
 import {
   getServerActionsManifest,
   setManifestsSingleton,
@@ -38,11 +41,12 @@ import type { ModernSourceMapPayload } from '../lib/source-maps'
  * `loadComponents` pulled in. Frames arriving in the transported payload can
  * point at any chunk the main render touched.
  *
- * This only helps Turbopack, which writes a `.map` beside every chunk. Webpack
- * keeps its dev source maps in the compiler rather than on disk, so its frames
- * from chunks this thread never evaluated stay unresolved, and its module URLs
- * (`webpack-internal://…`) are declined below for the same reason. Frames from
- * dependencies that are not bundled never reach this point, because
+ * Reading from disk covers the chunks, because the worker only runs under
+ * Turbopack (see `next-dev-server.ts`), which writes a `.map` beside every one
+ * of them. A module the server updated in place has no chunk of its own and is
+ * covered instead by this thread applying the same update (see
+ * `applyHmrUpdate`), which leaves its inline map in Node.js' cache here. Frames
+ * from dependencies that are not bundled never reach this point, because
  * `filterStackFrameDEV` drops `node_modules` and `node:` frames; bundled
  * dependencies appear as chunks inside `distDir` like any other code.
  */
@@ -71,7 +75,7 @@ function createDiskSourceMapLookup(
     }
 
     if (!isAbsolute(chunkPath)) {
-      // Not an emitted chunk, e.g. `webpack-internal://` or `<anonymous>`.
+      // Not an emitted chunk, e.g. `<anonymous>`.
       return undefined
     }
 
@@ -226,6 +230,70 @@ async function registerAdditionalClientReferenceManifests(
       }
     })
   )
+}
+
+declare const __turbopack_server_hmr_apply__:
+  | ((update: NodeJsPartialHmrUpdate) => void)
+  | undefined
+
+/**
+ * What this thread did with a forwarded HMR update.
+ *
+ * `no-runtime` is not a failure: no runtime the update routes to had been
+ * loaded here, so there was nothing to patch, and whatever loads that route
+ * later reads the updated chunk from disk.
+ */
+export type HmrApplyOutcome = 'applied' | 'no-runtime' | 'failed'
+
+/**
+ * Applies a server HMR update to this thread's module registry, mirroring the
+ * apply the dev server performed on its own.
+ *
+ * Turbopack's Node.js runtime registers the apply machinery per isolate (see
+ * `dev-nodejs.ts`), and `loadComponents` evaluates that runtime here, so this
+ * thread patches the same modules the dev server does. The apply also leaves
+ * the updated module's inline source map in this thread's Node.js cache, which
+ * is what makes a stack frame in that module source-mappable here.
+ */
+export async function applyHmrUpdate(
+  update: NodeJsPartialHmrUpdate
+): Promise<HmrApplyOutcome> {
+  if (typeof __turbopack_server_hmr_apply__ !== 'function') {
+    return 'no-runtime'
+  }
+
+  try {
+    __turbopack_server_hmr_apply__(update)
+  } catch {
+    // The dev server responds to the same failure by re-evaluating every
+    // module from disk. This thread cannot be repaired in place either, so the
+    // caller drops it.
+    return 'failed'
+  }
+
+  return 'applied'
+}
+
+/**
+ * Clears the same caches the dev server cleared, for the same paths.
+ *
+ * `evictModules` follows the dev server's own split: an applied update patches
+ * modules in place and clears only the manifest cache for the updated chunks,
+ * while a recompile evicts `require.cache` as well. This thread follows both,
+ * so its module state stays the dev server's module state.
+ */
+export async function invalidateCaches(
+  filePaths: string[],
+  evictModules: boolean
+): Promise<void> {
+  if (evictModules) {
+    deleteCache(filePaths)
+    return
+  }
+
+  for (const filePath of filePaths) {
+    clearManifestCache(filePath)
+  }
 }
 
 /**

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -41,6 +41,10 @@ import { debounce } from '../utils'
 import { clearManifestCache } from '../load-manifest.external'
 import { deleteCache } from './require-cache'
 import {
+  dropDevValidationWorker,
+  mirrorModuleStateToDevValidationWorker,
+} from './dev-validation-worker-pool'
+import {
   clearAllModuleContexts,
   clearModuleContext,
 } from '../lib/render-server'
@@ -261,6 +265,9 @@ function setupServerHmr(
       if (typeof __turbopack_server_hmr_apply__ === 'function') {
         try {
           __turbopack_server_hmr_apply__(update)
+          // The validation worker keeps its own copy of the module graph, and
+          // applies the same update to it.
+          mirrorModuleStateToDevValidationWorker({ type: 'apply', update })
         } catch {
           // A matching runtime tried the apply and threw. Evict require.cache
           // so the next request loads fresh, then skip onApplied. (A no-match
@@ -2138,6 +2145,11 @@ export async function createHotReloaderTurbopack(
 
         resetFetch()
 
+        // This thread gave up on repairing its module graph in place. The
+        // validation worker cannot repair its own either, so it is dropped and
+        // the next validation loads the build output afresh.
+        dropDevValidationWorker()
+
         notifyServerComponentChanges()
       },
       onApplied: (chunkPaths: string[]) => {
@@ -2145,9 +2157,22 @@ export async function createHotReloaderTurbopack(
         // next RSC render picks up the HMR-applied module changes. Unlike
         // a full restart, this does NOT clear require.cache — the HMR-applied
         // modules in devModuleCache must persist for dep preservation.
-        for (const chunkPath of chunkPaths) {
-          clearManifestCache(join(distDir, chunkPath))
+        const manifestPaths = chunkPaths.map((chunkPath) =>
+          join(distDir, chunkPath)
+        )
+
+        for (const manifestPath of manifestPaths) {
+          clearManifestCache(manifestPath)
         }
+
+        // This path clears the manifest cache without going through
+        // `deleteCache`, so `onCacheInvalidation` does not report it to the
+        // validation worker. Report it here instead.
+        mirrorModuleStateToDevValidationWorker({
+          type: 'invalidate',
+          filePaths: manifestPaths,
+          evictModules: false,
+        })
 
         notifyServerComponentChanges()
       },

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/neighbor/page.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/neighbor/page.tsx
@@ -1,0 +1,3 @@
+export default function NeighborPage() {
+  return <p>neighbor</p>
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/shared/page.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/shared/page.tsx
@@ -1,0 +1,5 @@
+import { readValue } from './read-value'
+
+export default async function SharedPage() {
+  return <p>{await readValue()}</p>
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/shared/read-value.ts
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/shared/read-value.ts
@@ -1,0 +1,10 @@
+// import { connection } from 'next/server'
+
+export async function readValue(): Promise<string> {
+  // The test uncomments the line below, and the import above, while the dev
+  // server runs, so the update lands in a module the page imports.
+
+  // await connection()
+
+  return 'shared'
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/app/updated/page.tsx
+++ b/test/development/app-dir/dev-validation-worker-source-maps/app/updated/page.tsx
@@ -1,0 +1,8 @@
+export default async function UpdatedPage() {
+  // The test uncomments the line below while the dev server is running, so the
+  // module is updated in place after the route has already been loaded.
+
+  // await new Promise((resolve) => setTimeout(resolve, 0))
+
+  return <p>updated</p>
+}

--- a/test/development/app-dir/dev-validation-worker-source-maps/dev-validation-worker-source-maps.test.ts
+++ b/test/development/app-dir/dev-validation-worker-source-maps/dev-validation-worker-source-maps.test.ts
@@ -1,22 +1,24 @@
 import { nextTestSetup } from 'e2e-utils'
 import { getDevCliValidationOutput } from 'e2e-utils/instant-validation'
+import { retry } from 'next-test-utils'
 
 // Validation errors are logged with source-mapped frames, and the routes below
-// cover the two cases that differ in where that source map comes from. Node.js
-// caches source maps per isolate and per chunk file, so a validation pass
-// running on a worker thread only has maps for the chunks that thread loaded.
-// It currently never renders server components, and the built entry reaches
-// segment modules through lazy getters, so it loads whatever `loadComponents`
-// pulls in and nothing else: code in the route's own chunk resolves, a module
-// the bundler splits into a chunk of its own does not, and the worker reads the
-// `.map` emitted next to that chunk instead. Only Turbopack emits one, which is
-// why validation runs in process under Webpack, so the two bundlers arrive at
-// the same frames by different means. Each route owns its copy of the module,
-// because a module shared between routes lands in whichever chunk the first
-// compiled route put it in, which would make these snapshots depend on the
-// order the routes run in.
+// cover the cases that differ in where that source map comes from. Node.js
+// caches source maps per isolate, so a validation pass running on a worker
+// thread resolves a frame only if that thread holds the script it names. A
+// chunk loaded from disk has its map beside it, but a module the server updated
+// in place runs as a script of its own with the map inline, which exists only
+// in the thread that evaluated it. The worker therefore applies the same
+// updates the dev server does; the routes that edit a file while the server
+// runs are what covers that. Under Webpack there is no worker and validation
+// runs in process, so the two bundlers reach the same frames by different
+// means.
+//
+// Each route owns its copy of the module it edits, because a module shared
+// between routes lands in whichever chunk the first compiled route put it in,
+// which would make these snapshots depend on the order the routes run in.
 describe('dev-validation-worker-source-maps', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     env: { NEXT_TEST_LOG_VALIDATION: '1' },
   })
@@ -67,81 +69,199 @@ describe('dev-validation-worker-source-maps', () => {
       content.replace('// await new Promise', 'await new Promise')
     )
 
-    if (isTurbopack) {
-      // TODO: The frame is not symbolicated. Turbopack gives a module updated
-      // in place a source URL of its own, and the validation worker cannot
-      // resolve a source map for it, so the chunk shows through instead of the
-      // page. Webpack validates in process, where it resolves.
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1440",
-         "description": "Next.js encountered uncached data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": null,
-         "stack": [
-           "<FIXME-file-protocol>",
-         ],
-       }
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(`
-       {
-         "code": "E1440",
-         "description": "Next.js encountered uncached data during prerendering.",
-         "environmentLabel": "Server",
-         "label": "Blocking Route",
-         "source": "app/updated/page.tsx (5:9) @ UpdatedPage
-       > 5 |   await new Promise((resolve) => setTimeout(resolve, 0))
-           |         ^",
-         "stack": [
-           "UpdatedPage app/updated/page.tsx (5:9)",
-         ],
-       }
-      `)
-    }
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1440",
+       "description": "Next.js encountered uncached data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/updated/page.tsx (5:9) @ UpdatedPage
+     > 5 |   await new Promise((resolve) => setTimeout(resolve, 0))
+         |         ^",
+       "stack": [
+         "UpdatedPage app/updated/page.tsx (5:9)",
+       ],
+     }
+    `)
 
     const output = await getDevCliValidationOutput(await browser.url(), () =>
       next.cliOutput.slice(outputIndex)
     )
 
-    if (isTurbopack) {
-      // TODO: Same unresolved frame as above.
-      expect(output).toMatchInlineSnapshot(`
-       "Error: Route "/updated": Next.js encountered uncached data during prerendering.
+    expect(output).toMatchInlineSnapshot(`
+     "Error: Route "/updated": Next.js encountered uncached data during prerendering.
 
-       \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+     \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
 
-       Ways to fix this:
-         - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-         - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
-         - [block] Set \`export const instant = false\` to allow a blocking route
+     Ways to fix this:
+       - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+       - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+       - [block] Set \`export const instant = false\` to allow a blocking route
 
-       Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
-           at UpdatedPage (<next-dist-dir>)"
-      `)
-    } else {
-      expect(output).toMatchInlineSnapshot(`
-       "Error: Route "/updated": Next.js encountered uncached data during prerendering.
+     Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+         at UpdatedPage (app/updated/page.tsx:5:9)
+       3 |   // module is updated in place after the route has already been loaded.
+       4 |
+     > 5 |   await new Promise((resolve) => setTimeout(resolve, 0))
+         |         ^
+       6 |
+       7 |   return <p>updated</p>
+       8 | }"
+    `)
 
-       \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+    // Edit the same module again, moving the access two lines down. The line
+    // below is what the thread that validates would report from the update it
+    // last applied, so a thread left behind on the first edit reports 5 again.
+    const secondEditIndex = next.cliOutput.length
 
-       Ways to fix this:
-         - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
-         - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
-         - [block] Set \`export const instant = false\` to allow a blocking route
+    await next.patchFile('app/updated/page.tsx', (content) =>
+      content.replace(
+        'export default async function UpdatedPage() {',
+        'export default async function UpdatedPage() {\n  // A second edit,\n  // moving the access down.'
+      )
+    )
 
-       Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
-           at UpdatedPage (app/updated/page.tsx:5:9)
-         3 |   // module is updated in place after the route has already been loaded.
-         4 |
-       > 5 |   await new Promise((resolve) => setTimeout(resolve, 0))
-           |         ^
-         6 |
-         7 |   return <p>updated</p>
-         8 | }"
-      `)
-    }
+    await expect(browser).toDisplayRedbox(`
+     {
+       "code": "E1440",
+       "description": "Next.js encountered uncached data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/updated/page.tsx (7:9) @ UpdatedPage
+     >  7 |   await new Promise((resolve) => setTimeout(resolve, 0))
+          |         ^",
+       "stack": [
+         "UpdatedPage app/updated/page.tsx (7:9)",
+       ],
+     }
+    `)
+
+    expect(
+      await getDevCliValidationOutput(await browser.url(), () =>
+        next.cliOutput.slice(secondEditIndex)
+      )
+    ).toMatchInlineSnapshot(`
+     "Error: Route "/updated": Next.js encountered uncached data during prerendering.
+
+     \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+     Ways to fix this:
+       - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+       - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+       - [block] Set \`export const instant = false\` to allow a blocking route
+
+     Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+         at UpdatedPage (app/updated/page.tsx:7:9)
+        5 |   // module is updated in place after the route has already been loaded.
+        6 |
+     >  7 |   await new Promise((resolve) => setTimeout(resolve, 0))
+          |         ^
+        8 |
+        9 |   return <p>updated</p>
+       10 | }"
+    `)
+  })
+
+  it('symbolicates a frame in an imported module updated while the server runs', async () => {
+    const browser = await next.browser('/shared')
+
+    await getDevCliValidationOutput(await browser.url(), () => next.cliOutput)
+    const outputIndex = next.cliOutput.length
+
+    // The update lands in a module the page imports rather than in the page
+    // itself, so the reported frames span both: the access in the imported
+    // module, and the page that called it.
+    await next.patchFile('app/shared/read-value.ts', (content) =>
+      content
+        .replace('// import { connection }', 'import { connection }')
+        .replace('// await connection()', 'await connection()')
+    )
+
+    await expect(browser).toDisplayCollapsedRedbox(`
+     {
+       "code": "E1440",
+       "description": "Next.js encountered uncached data during prerendering.",
+       "environmentLabel": "Server",
+       "label": "Blocking Route",
+       "source": "app/shared/read-value.ts (7:19) @ readValue
+     >  7 |   await connection()
+          |                   ^",
+       "stack": [
+         "readValue app/shared/read-value.ts (7:19)",
+         "SharedPage app/shared/page.tsx (4:29)",
+       ],
+     }
+    `)
+
+    expect(
+      await getDevCliValidationOutput(await browser.url(), () =>
+        next.cliOutput.slice(outputIndex)
+      )
+    ).toMatchInlineSnapshot(`
+     "Error: Route "/shared": Next.js encountered uncached data during prerendering.
+
+     \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+     Ways to fix this:
+       - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+       - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+       - [block] Set \`export const instant = false\` to allow a blocking route
+
+     Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+         at readValue (app/shared/read-value.ts:7:19)
+         at SharedPage (app/shared/page.tsx:4:29)
+        5 |   // server runs, so the update lands in a module the page imports.
+        6 |
+     >  7 |   await connection()
+          |                   ^
+        8 |
+        9 |   return 'shared'
+       10 | }"
+    `)
+  })
+
+  it("symbolicates a route that another route's update did not touch", async () => {
+    // Validate the neighbour first, so the thread that validates holds its
+    // module state, then update it. The route asserted below shares that
+    // thread, and reports the same frames as it did before the update.
+    const neighbor = await next.browser('/neighbor')
+    await getDevCliValidationOutput(await neighbor.url(), () => next.cliOutput)
+
+    await next.patchFile('app/neighbor/page.tsx', (content) =>
+      content.replace('<p>neighbor</p>', '<p>neighbor edited</p>')
+    )
+
+    await retry(async () => {
+      expect(await neighbor.elementByCss('p').text()).toBe('neighbor edited')
+    })
+
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser('/static')
+
+    expect(
+      await getDevCliValidationOutput(await browser.url(), () =>
+        next.cliOutput.slice(outputIndex)
+      )
+    ).toMatchInlineSnapshot(`
+     "Error: Route "/static": Next.js encountered runtime data during prerendering.
+
+     \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+     Ways to fix this:
+       - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+       - [block] Set \`export const instant = false\` to allow a blocking route
+
+     Learn more: https://nextjs.org/docs/messages/blocking-prerender-runtime
+         at readCookie (app/static/read-cookie.ts:4:30)
+         at StaticPage (app/static/page.tsx:4:41)
+       2 |
+       3 | export async function readCookie(): Promise<string> {
+     > 4 |   const store = await cookies()
+         |                              ^
+       5 |   return store.get('probe')?.value ?? 'none'
+       6 | }
+       7 |"
+    `)
   })
 
   it('symbolicates a cookie read in a dynamically imported module', async () => {

--- a/test/development/app-dir/dev-validation-worker-source-maps/dev-validation-worker-source-maps.test.ts
+++ b/test/development/app-dir/dev-validation-worker-source-maps/dev-validation-worker-source-maps.test.ts
@@ -16,7 +16,7 @@ import { getDevCliValidationOutput } from 'e2e-utils/instant-validation'
 // compiled route put it in, which would make these snapshots depend on the
 // order the routes run in.
 describe('dev-validation-worker-source-maps', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     env: { NEXT_TEST_LOG_VALIDATION: '1' },
   })
@@ -48,6 +48,100 @@ describe('dev-validation-worker-source-maps', () => {
        6 | }
        7 |"
     `)
+  })
+
+  it('symbolicates a frame in a module updated while the server runs', async () => {
+    // Load the route first so its chunk is evaluated, then edit it. The update
+    // gives the module a source URL of its own, which is a different input to
+    // source map resolution than the chunk path a freshly loaded module has.
+    // The edit refreshes the route on its own, so the frames below come from
+    // the render that follows it.
+    const browser = await next.browser('/updated')
+
+    // That first load is validated as well, and passes. Wait for it to finish
+    // and mark the output, so what is read below is what the edit produced.
+    await getDevCliValidationOutput(await browser.url(), () => next.cliOutput)
+    const outputIndex = next.cliOutput.length
+
+    await next.patchFile('app/updated/page.tsx', (content) =>
+      content.replace('// await new Promise', 'await new Promise')
+    )
+
+    if (isTurbopack) {
+      // TODO: The frame is not symbolicated. Turbopack gives a module updated
+      // in place a source URL of its own, and the validation worker cannot
+      // resolve a source map for it, so the chunk shows through instead of the
+      // page. Webpack validates in process, where it resolves.
+      await expect(browser).toDisplayCollapsedRedbox(`
+       {
+         "code": "E1440",
+         "description": "Next.js encountered uncached data during prerendering.",
+         "environmentLabel": "Server",
+         "label": "Blocking Route",
+         "source": null,
+         "stack": [
+           "<FIXME-file-protocol>",
+         ],
+       }
+      `)
+    } else {
+      await expect(browser).toDisplayCollapsedRedbox(`
+       {
+         "code": "E1440",
+         "description": "Next.js encountered uncached data during prerendering.",
+         "environmentLabel": "Server",
+         "label": "Blocking Route",
+         "source": "app/updated/page.tsx (5:9) @ UpdatedPage
+       > 5 |   await new Promise((resolve) => setTimeout(resolve, 0))
+           |         ^",
+         "stack": [
+           "UpdatedPage app/updated/page.tsx (5:9)",
+         ],
+       }
+      `)
+    }
+
+    const output = await getDevCliValidationOutput(await browser.url(), () =>
+      next.cliOutput.slice(outputIndex)
+    )
+
+    if (isTurbopack) {
+      // TODO: Same unresolved frame as above.
+      expect(output).toMatchInlineSnapshot(`
+       "Error: Route "/updated": Next.js encountered uncached data during prerendering.
+
+       \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+       Ways to fix this:
+         - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+         - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+         - [block] Set \`export const instant = false\` to allow a blocking route
+
+       Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+           at UpdatedPage (<next-dist-dir>)"
+      `)
+    } else {
+      expect(output).toMatchInlineSnapshot(`
+       "Error: Route "/updated": Next.js encountered uncached data during prerendering.
+
+       \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
+
+       Ways to fix this:
+         - [stream] Provide a placeholder with \`<Suspense fallback={...}>\` around the data access
+         - [cache] Cache the data access with \`"use cache"\` (does not apply to \`connection()\`)
+         - [block] Set \`export const instant = false\` to allow a blocking route
+
+       Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
+           at UpdatedPage (app/updated/page.tsx:5:9)
+         3 |   // module is updated in place after the route has already been loaded.
+         4 |
+       > 5 |   await new Promise((resolve) => setTimeout(resolve, 0))
+           |         ^
+         6 |
+         7 |   return <p>updated</p>
+         8 | }"
+      `)
+    }
   })
 
   it('symbolicates a cookie read in a dynamically imported module', async () => {


### PR DESCRIPTION
Cache Components dev validation reported stack frames that pointed at build output whenever a module had been updated while the dev server ran. This affected both the static shell validation and the instant-navigation validation, since both run on the same worker. The overlay showed a raw `file:` URL and the terminal named the chunk rather than the page, and because the frame never resolved to a source position there was no code frame either, so nothing indicated which line caused the error.

Turbopack's server HMR evaluates an updated module as a script of its own, named `<chunk>?<module id>` and carrying its source map inline rather than on disk, so only the isolate that ran that `eval` can resolve a frame in it. The validation worker never ran it, and the map beside the chunk describes the chunk's lines, not the running module's, so nothing the worker could reach described the frame. React then wrote the frame in its form for scripts without a source map, which encodes an already-encoded URL a second time, leaving a frame no reader reverses.

The worker now mirrors what the dev server does to its own module state rather than being dropped whenever that state changes. The dev server reports each applied update, the manifest cache entries it cleared, and the paths it evicted, and the worker replays them in the same order, so its module state is the dev server's module state by construction. That leaves each updated module's inline source map in the worker's own Node.js cache, which is what makes the frame resolvable there.

The worker needs no coordination around a validation in flight. It runs one call at a time, in the order the calls were made, so an update is replayed before any validation requested after it, and never in the middle of one. The dev server does not hold its own updates back for a validation running in process either. Where it gives up and re-evaluates every module from disk the worker is dropped, so that case keeps the behaviour it had.

Not dropping the worker helps beyond the frames. Dropping it meant the next validation had to spawn a worker thread and run `loadComponents` again before it could start, and it paid that on every edit, which delayed the insight at exactly the moment the user is waiting for it. The case in the test suite that covers this went from around 870ms to around 240ms.

The simpler fix was to revive the transported errors on the main thread and print them there, where the scripts already are. It works, and it is why this PR also touches the benchmark: the fixture produced no validation errors, so nothing in the benchmark reached the error reporting at all, and the cost of moving it was invisible. With insights generated, the cost showed plainly. Printing an error costs around 218ms the first time a source map is read and about a millisecond after that, and moving it to the main thread cut the worker's p95 advantage on the heaviest route from around 15ms to between 2ms and 5ms. Mirroring the updates keeps the printing on the worker and leaves that advantage intact.

The three commits are worth reading in order. The first adds the test with the broken output snapshotted, so its snapshots deliberately record what a user saw, a frame naming the chunk with no code frame beneath it. The second is the benchmark change above. The third is the fix, and its diff turns those snapshots into resolved frames, adds cases that edit the same module twice, edit a module the page imports, and validate a route that another route's update did not touch, and rewrites the suite's header comment, which described the mechanism this replaces.

Verified on both bundlers, since the worker is gated on Turbopack and Webpack validates in process, along with `instant-validation-scheduling`, `instant-validation/{server-errors,parallel-slots}`, `instant-validation-causes`, `instant-validation-level-default` and `hmr-rsc-cancellation`. Run with `BENCH_DEV_VALIDATION_INSIGHTS=1`, the benchmark shows no steady-state regression: the worker column matches canary at 106ms sprite p95 against 110ms and 109ms, and keeps its margin over in-process.

Two things are deliberately left out. The benchmark still cannot measure the edit case, because it never edits, so the timing above comes from a test's wall clock rather than a purpose-built measurement. And `use-cache-probe-pool` subscribes to the same invalidation and tears down the same way, which is the obvious follow-up if this holds up.

One known gap remains. A worker dropped by its own failure, rather than by the dev server giving up, cannot obtain the scripts the dev server evaluated from earlier updates, so frames naming them stay unresolved until those modules change again. The validation itself is unaffected, because the worker loads the current code from disk.
