### PR TITLE
Add font metrics to font-data.json

### DIFF
--- a/packages/font/src/google/font-data.json
+++ b/packages/font/src/google/font-data.json
@@ -3446,7 +3446,15 @@
       "latin-ext",
       "symbols2",
       "vietnamese"
-    ]
+    ],
+    "metrics": {
+      "unitsPerEm": 2048,
+      "ascent": 2226,
+      "descent": 480,
+      "lineGap": 0,
+      "xHeight": 1060,
+      "capHeight": 1420
+    }
   },
   "Cascadia Mono": {
     "weights": ["200", "300", "400", "500", "600", "700", "variable"],


### PR DESCRIPTION
Added metrics for font data including unitsPerEm, ascent, descent, lineGap, xHeight, and capHeight.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

Add font metrics data for Cascadia Code in font-data.json to enable font fallback optimization.

### Why?

Next.js currently throws Failed to find font override values build warnings when developers use Cascadia Code because its metrics are absent from the internal dataset.

### How?

Extracted raw OpenType font metrics (unitsPerEm, ascent, descent, lineGap, xHeight, and capHeight) directly from the Cascadia Code font file and populated its entry in the font configuration block.

Closes NEXT-
Fixes #

-->
