### PR TITLE
render global error for failed cache regeneration

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -74,7 +74,10 @@ import {
   NEXT_RESUME_HEADER,
   NEXT_RESUME_STATE_LENGTH_HEADER,
 } from '../../lib/constants' with { 'turbopack-transition': 'next-server-utility' }
-import type { CacheControl } from '../../server/lib/cache-control'
+import {
+  getCacheControlHeader,
+  type CacheControl,
+} from '../../server/lib/cache-control' with { 'turbopack-transition': 'next-server-utility' }
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags' with { 'turbopack-transition': 'next-server-utility' }
 import { sendRenderResult } from '../../server/send-payload' with { 'turbopack-transition': 'next-server-utility' }
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external' with { 'turbopack-transition': 'next-server-utility' }
@@ -827,9 +830,11 @@ export function createAppPageEntrypoint({
         fallbackRouteParams,
         renderOperation,
         allowEmptyStaticShell,
+        forceDynamicResponse,
       }: {
         span?: Span
         allowEmptyStaticShell?: boolean
+        forceDynamicResponse?: boolean
 
         /**
          * The postponed data for this render. This is only provided when resuming
@@ -872,8 +877,9 @@ export function createAppPageEntrypoint({
             allowEmptyStaticShell,
             serveStreamingMetadata,
             supportsDynamicResponse:
-              renderOperation === 'render' &&
-              (typeof postponed === 'string' || supportsDynamicResponse),
+              forceDynamicResponse ||
+              (renderOperation === 'render' &&
+                (typeof postponed === 'string' || supportsDynamicResponse)),
             buildManifest,
             nextFontManifest,
             reactLoadableManifest,
@@ -1606,22 +1612,55 @@ export function createAppPageEntrypoint({
       }
 
       const handleResponse = async (span?: Span): Promise<null | void> => {
-        const cacheEntry = await routeModule.handleResponse({
-          cacheKey: ssgCacheKey,
-          responseGenerator: (c) =>
-            responseGenerator({
-              span,
-              ...c,
-            }),
-          routeKind: RouteKind.APP_PAGE,
-          isOnDemandRevalidate,
-          isRoutePPREnabled,
-          req,
-          nextConfig,
-          prerenderManifest,
-          waitUntil: ctx.waitUntil,
-          isMinimalMode,
-        })
+        let cacheEntry: ResponseCacheEntry | null
+
+        try {
+          cacheEntry = await routeModule.handleResponse({
+            cacheKey: ssgCacheKey,
+            responseGenerator: (c) =>
+              responseGenerator({
+                span,
+                ...c,
+              }),
+            routeKind: RouteKind.APP_PAGE,
+            isOnDemandRevalidate,
+            isRoutePPREnabled,
+            req,
+            nextConfig,
+            prerenderManifest,
+            waitUntil: ctx.waitUntil,
+            isMinimalMode,
+          })
+        } catch (err) {
+          if (
+            !ssgCacheKey ||
+            err instanceof NoFallbackError ||
+            typeof err !== 'object' ||
+            err === null ||
+            !('digest' in err) ||
+            res.headersSent
+          ) {
+            throw err
+          }
+
+          // A static route render can fail after the response cache has started
+          // materializing its result. Render the current request dynamically so
+          // React can produce the route's error boundary instead of falling back
+          // to the server's plain-text 500 response.
+          cacheEntry = await doRender({
+            span,
+            postponed: undefined,
+            fallbackRouteParams: null,
+            renderOperation: 'render',
+            forceDynamicResponse: true,
+          })
+          cacheEntry.cacheControl = undefined
+          cacheEntry.isMiss = true
+          res.setHeader(
+            'Cache-Control',
+            getCacheControlHeader({ revalidate: 0, expire: undefined })
+          )
+        }
 
         if (isDraftMode) {
           res.setHeader(

--- a/test/e2e/app-dir/cache-regeneration-global-error/app/api/invalidate/route.ts
+++ b/test/e2e/app-dir/cache-regeneration-global-error/app/api/invalidate/route.ts
@@ -1,0 +1,7 @@
+import { revalidateTag } from 'next/cache'
+
+export function POST() {
+  revalidateTag('cached-page', { expire: 0 })
+
+  return new Response(null, { status: 204 })
+}

--- a/test/e2e/app-dir/cache-regeneration-global-error/app/cached/page.tsx
+++ b/test/e2e/app-dir/cache-regeneration-global-error/app/cached/page.tsx
@@ -1,0 +1,20 @@
+import { cacheTag } from 'next/cache'
+import { PHASE_PRODUCTION_BUILD } from 'next/constants'
+
+const isProductionBuild = process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+
+async function getData() {
+  'use cache'
+
+  cacheTag('cached-page')
+
+  if (!isProductionBuild) {
+    throw new Error('regeneration failed')
+  }
+
+  return 'generated during build'
+}
+
+export default async function Page() {
+  return <p>{await getData()}</p>
+}

--- a/test/e2e/app-dir/cache-regeneration-global-error/app/global-error.tsx
+++ b/test/e2e/app-dir/cache-regeneration-global-error/app/global-error.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+export default function GlobalError() {
+  return (
+    <html>
+      <body>
+        <p id="global-error">global error</p>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-regeneration-global-error/app/layout.tsx
+++ b/test/e2e/app-dir/cache-regeneration-global-error/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-regeneration-global-error/cache-regeneration-global-error.test.ts
+++ b/test/e2e/app-dir/cache-regeneration-global-error/cache-regeneration-global-error.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('cache regeneration global error', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders the global error boundary when regeneration fails', async () => {
+    if (isNextDev) {
+      return
+    }
+
+    const initialResponse = await next.fetch('/cached')
+    expect(initialResponse.status).toBe(200)
+    expect(await initialResponse.text()).toContain('generated during build')
+
+    const invalidationResponse = await next.fetch('/api/invalidate', {
+      method: 'POST',
+    })
+    expect(invalidationResponse.status).toBe(204)
+
+    const errorResponse = await next.fetch('/cached')
+    expect(errorResponse.status).toBe(500)
+    expect(errorResponse.headers.get('content-type')).toContain('text/html')
+    expect(errorResponse.headers.get('cache-control')).toBe(
+      'private, no-cache, no-store, max-age=0, must-revalidate'
+    )
+    expect(errorResponse.headers.get('x-nextjs-cache')).toBe('MISS')
+
+    const browser = await next.browser('/cached')
+    expect(await browser.elementByCss('#global-error').text()).toBe(
+      'global error'
+    )
+  })
+})

--- a/test/e2e/app-dir/cache-regeneration-global-error/next.config.js
+++ b/test/e2e/app-dir/cache-regeneration-global-error/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## summary

so we were using `use cache` for a static app router, and nextjs was storing the generated page to serve later reqs quickly. if that cache was invalidated, the next request was regenerating the page.

currently, for an uncaught rendering during the regeneration, the error escapes the app rendering system and returns a plain-text internal server error. since the response is no longer a regular nextjs html document, the browser cannot load and display the app’s `global-error.tsx` component.

so, my change detects that rendering failure and renders the current request through an existing dynamic error handling path that gives react the chance to prepare an error response and letting the browser display the app's custom error screen.

## why

a failed page should never be written to the router cache, otherwise nextjs will accidentally serve the error screen as the real cached page to later visitors.

the existing static regeneration process already prevents the failed page from being cached. this change keeps that behavior by only creating a dynamic error response for the visitor whose request triggered the failed regeneration.

the response still uses a 500 status because the page failed to render and it is also marked as a cache miss and receives private no-cache headers, so the error response cannot replace the valid cached page.

and also, the recovery is limited to digested react rendering errors from static routes with a cache key, and it does not change `nofallback` behavior, cache infrastructure errors, or responses that have already started sending data.

## testing

i have added a new production regression test that verifies whether:

- the page is generated successfully during the production build

- its use cache entry can be invalidated

- failed regeneration returns a 500 html response instead of plain text

- the response is marked as a cache miss and cannot be cached

- the browser hydrates and displays the custom global-error.tsx component

and this focused production test passes with both turbopack and webpack.

also, the next.js package type check, focused eslint check, prettier check, and git diff --check also pass.

fixes #96567
