### PR TITLE
docs: clarify generateBuildId wording for multi-container deployments

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/generateBuildId.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/generateBuildId.mdx
@@ -5,7 +5,7 @@ description: Configure the build id, which is used to identify the current build
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-Next.js generates an ID during `next build` to identify which version of your application is being served. The same build should be used and boot up multiple containers.
+Next.js generates an ID during `next build` to identify which version of your application is being served. The same build should be used to boot up multiple containers.
 
 If you are rebuilding for each stage of your environment, you will need to generate a consistent build ID to use between containers. Use the `generateBuildId` command in `next.config.js`:
 
@@ -17,3 +17,4 @@ module.exports = {
   },
 }
 ```
+


### PR DESCRIPTION
## Summary
This PR clarifies one sentence in the `generateBuildId` docs for better readability.

## What changed
- Reworded: "The same build should be used and boot up multiple containers."
- To: "The same build should be used to boot up multiple containers."

## Validation
- Manual docs review.
- Docs-only change; no runtime/API behavior impact.