### PR TITLE
docs: fix Link prefetch grammar and Client Components wording

### DIFF
--- a/docs/01-app/02-guides/migrating/from-create-react-app.mdx
+++ b/docs/01-app/02-guides/migrating/from-create-react-app.mdx
@@ -355,7 +355,7 @@ This tells Next.js to generate a single route for the empty slug (`/`), effectiv
 
 ### Step 7: Add a Client-Only Entrypoint
 
-Next, we’ll embed your CRA’s root App component inside a [Client Component](/docs/app/getting-started/server-and-client-components) so that all logic remains client-side. If this is your first time using Next.js, it's worth knowing that clients components (by default) are still prerendered on the server. You can think about them as having the additional capability of running client-side JavaScript.
+Next, we’ll embed your CRA’s root App component inside a [Client Component](/docs/app/getting-started/server-and-client-components) so that all logic remains client-side. If this is your first time using Next.js, it's worth knowing that Client Components (by default) are still prerendered on the server. You can think about them as having the additional capability of running client-side JavaScript.
 
 Create a `client.tsx` (or `client.js`) in `app/[[...slug]]/`:
 

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -333,7 +333,7 @@ export default function Page() {
 
 <PagesOnly>
 
-Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and data in the background to improve the performance of client-side navigation's. **Prefetching is only enabled in production**.
+Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and data in the background to improve the performance of client-side navigation. **Prefetching is only enabled in production**.
 
 The following values can be passed to the `prefetch` prop:
 


### PR DESCRIPTION
## Summary
- Fix wording in Link prefetch docs: `navigation's` -> `navigation`
- Fix wording in CRA migration guide: `clients components` -> `Client Components`

## Why
These are user-facing documentation wording issues. This change improves clarity and readability for readers following these guides.

## Scope
Docs-only changes. No runtime behavior changes.