### PR TITLE
[CI] Native builder downloads should retry and fail their own layer

### DIFF
--- a/scripts/native-builder.Dockerfile
+++ b/scripts/native-builder.Dockerfile
@@ -45,6 +45,13 @@ RUN HOST_ARCH=$(dpkg --print-architecture) && \
       "deb [arch=${FOREIGN_ARCH}] ${FOREIGN_MIRROR} focal-security main universe" \
       > /etc/apt/sources.list
   
+# Every download below retries with a backoff. Fetches from CI runners fail
+# intermittently at the connection level (the canary.10 build got "OpenSSL
+# SSL_connect: Connection reset by peer" from sh.rustup.rs), and a single lost
+# download costs a whole canary release. curl's own --retry does not cover
+# connection-level errors, and --retry-all-errors needs curl 7.71 while Ubuntu
+# 20.04 ships 7.68, so the retry is an explicit loop.
+
 # Core build tools + GNU cross-compilation sysroots.
 # crossbuild-essential installs headers + libs in the multiarch layout
 # that clang finds via --target. Both archs installed so the image
@@ -68,8 +75,12 @@ RUN case "$(dpkg --print-architecture)" in \
       arm64) NODE_ARCH=arm64 ;; \
       *) echo "unsupported host architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
     esac && \
-    curl -fsSLo /tmp/node.tar.xz \
-      "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
+    for attempt in 1 2 3 4 5; do \
+      curl -fsSLo /tmp/node.tar.xz \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && break; \
+      if [ "$attempt" = 5 ]; then echo "node: download failed after 5 attempts" >&2; exit 1; fi; \
+      sleep $((attempt * 3)); \
+    done && \
     tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
       --exclude CHANGELOG.md --exclude LICENSE --exclude README.md && \
     rm /tmp/node.tar.xz && \
@@ -92,11 +103,22 @@ RUN ln -s x86_64-unknown-linux-musl /opt/x86_64-linux-musl-cross/x86_64-linux-mu
 
 # Install Rust — pinned nightly from rust-toolchain.toml
 # The COPY of rust-toolchain.toml ensures the image rebuilds when the toolchain changes.
+# The installer is downloaded to a file and then run, rather than piped straight
+# into sh. A pipeline reports the exit status of its last command, so when the
+# download failed the layer still succeeded and produced an image with no Rust
+# toolchain; the build then failed one layer later on `rustup target add` with a
+# misleading "rustup: not found". That is what broke the v16.3.1-canary.10
+# publish. `rustup --version` below asserts the install actually happened.
 COPY rust-toolchain.toml /tmp/rust-toolchain.toml
 RUN TOOLCHAIN=$(grep 'channel' /tmp/rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/') && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-      sh -s -- -y --default-toolchain "$TOOLCHAIN" --profile minimal && \
-    rm /tmp/rust-toolchain.toml
+    for attempt in 1 2 3 4 5; do \
+      curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/rustup-init.sh https://sh.rustup.rs && break; \
+      if [ "$attempt" = 5 ]; then echo "rustup: download failed after 5 attempts" >&2; exit 1; fi; \
+      sleep $((attempt * 3)); \
+    done && \
+    sh /tmp/rustup-init.sh -y --default-toolchain "$TOOLCHAIN" --profile minimal && \
+    /root/.cargo/bin/rustup --version && \
+    rm /tmp/rustup-init.sh /tmp/rust-toolchain.toml
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -110,8 +132,14 @@ RUN rustup target add \
 # Install cargo-binstall, then use it for Rust tools.
 ARG CARGO_BINSTALL_VERSION=1.18.1
 RUN ARCH=$(uname -m) && \
-    curl -fsSL "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-${ARCH}-unknown-linux-musl.tgz" \
-      | tar xz -C /root/.cargo/bin && \
+    for attempt in 1 2 3 4 5; do \
+      curl -fsSL -o /tmp/cargo-binstall.tgz \
+        "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-${ARCH}-unknown-linux-musl.tgz" && break; \
+      if [ "$attempt" = 5 ]; then echo "cargo-binstall: download failed after 5 attempts" >&2; exit 1; fi; \
+      sleep $((attempt * 3)); \
+    done && \
+    tar xzf /tmp/cargo-binstall.tgz -C /root/.cargo/bin && \
+    rm /tmp/cargo-binstall.tgz && \
     npm i -g @napi-rs/cli@2.18.4 && \
     cargo binstall --no-confirm --targets "${ARCH}-unknown-linux-musl" cargo-rustflags@0.4.0 && \
     cargo binstall --no-confirm --git https://github.com/vercel/sccache sccache && \


### PR DESCRIPTION
The `v16.3.1-canary.10` publish failed because a connection reset while fetching the rustup installer produced a successful layer with no Rust toolchain.

`scripts/native-builder.Dockerfile:96-99`:

```dockerfile
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
  sh -s -- -y --default-toolchain "$TOOLCHAIN" --profile minimal && \
rm /tmp/rust-toolchain.toml
```

From run 31341780479:

```
#19 0.258 curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to sh.rustup.rs:443
#19 DONE 0.3s                  # pipeline status is sh's, and sh on empty stdin exits 0
#20 0.060 /bin/sh: 1: rustup: not found
#20 ERROR: process "/bin/sh -c rustup target add ..." did not complete successfully: exit code: 127
```

`16.3.1-canary.10` never reached npm and `dist-tags.canary` is still `canary.9`, which then failed the same commit's `build-and-test`: create-next-app pins the generated project to `pkg.version` (`packages/create-next-app/templates/index.ts:240`), so npm returned `ETARGET` for `@next/env@16.3.1-canary.10` across the turbopack shards and `test integration windows`.

The installer now downloads to a file and runs as a separate command, with `rustup --version` asserting it installed. The node tarball and cargo-binstall downloads get the same retry loop, neither of which retried before. `--retry-all-errors` needs curl 7.71 and Ubuntu 20.04 ships 7.68, so the retry is a shell loop rather than a curl flag.

Verified by extracting each fetching `RUN` body and executing it under `/bin/sh` with a stub `curl`, reporting exit status and number of `curl` invocations:

```
                  download always fails      transient, succeeds on 3rd try
                  before        after        before        after
rustup installer  exit 0  (1)   exit 1  (5)  exit 0  (1)   exit 0  (3)
node tarball      exit 35 (1)   exit 1  (5)  exit 35 (1)   exit 0  (3)
cargo-binstall    exit 0  (1)   exit 1  (5)  exit 0  (1)   exit 0  (3)
```

The rustup row is the reported bug: a failed download left the layer green. Before, a transient failure was fatal everywhere because nothing retried. The cargo-binstall pipe discards `curl`'s status the same way, though whether `tar` independently rejects the empty input was not confirmed against GNU tar.
