### PR TITLE
fix(next/routing): compare i18n domains by hostname when redirecting

### DIFF
--- a/packages/next-routing/src/__tests__/i18n-resolve-routes.test.ts
+++ b/packages/next-routing/src/__tests__/i18n-resolve-routes.test.ts
@@ -197,6 +197,31 @@ describe('resolveRoutes with i18n', () => {
       expect(result.redirect?.url.hostname).toBe('example.de')
       expect(result.redirect?.url.pathname).toBe('/')
     })
+
+    it('should stay on the current origin when the domain carries a port', async () => {
+      const result = await resolveRoutes({
+        ...baseParams,
+        url: new URL('http://example.de:3000/'),
+        headers: new Headers({
+          'accept-language': 'fr',
+        }),
+        i18n: {
+          defaultLocale: 'en',
+          locales: ['en', 'fr', 'de'],
+          domains: [
+            {
+              domain: 'example.de:3000',
+              defaultLocale: 'de',
+              locales: ['de', 'fr'],
+            },
+          ],
+        },
+      })
+
+      expect(result.redirect).toBeDefined()
+      expect(result.redirect?.url.origin).toBe('http://example.de:3000')
+      expect(result.redirect?.url.pathname).toBe('/fr/')
+    })
   })
 
   describe('locale prefix in pathname', () => {

--- a/packages/next-routing/src/i18n.ts
+++ b/packages/next-routing/src/i18n.ts
@@ -17,6 +17,13 @@ export interface I18nConfig {
 }
 
 /**
+ * Returns the hostname of a configured domain, without its port
+ */
+export function getDomainHostname(domain: I18nDomain): string {
+  return domain.domain.split(':', 1)[0].toLowerCase()
+}
+
+/**
  * Detects the domain locale based on hostname or detected locale
  */
 export function detectDomainLocale(
@@ -30,8 +37,7 @@ export function detectDomainLocale(
   const normalizedLocale = detectedLocale?.toLowerCase()
 
   for (const domain of domains) {
-    // Remove port if present
-    const domainHostname = domain.domain.split(':', 1)[0].toLowerCase()
+    const domainHostname = getDomainHostname(domain)
 
     if (
       normalizedHostname === domainHostname ||

--- a/packages/next-routing/src/resolve-routes.ts
+++ b/packages/next-routing/src/resolve-routes.ts
@@ -13,7 +13,12 @@ import {
   hasRedirectHeaders,
 } from './destination'
 import { normalizeNextDataUrl, denormalizeNextDataUrl } from './next-data'
-import { detectLocale, detectDomainLocale, normalizeLocalePath } from './i18n'
+import {
+  detectLocale,
+  detectDomainLocale,
+  getDomainHostname,
+  normalizeLocalePath,
+} from './i18n'
 
 function getHeaderValueCaseInsensitive(
   headers: Record<string, string>,
@@ -649,8 +654,11 @@ export async function resolveRoutes(
             targetLocale
           )
 
+          const isTargetDomainCurrent =
+            !!targetDomain && getDomainHostname(targetDomain) === hostname
+
           // Redirect to different domain if target locale has a different configured domain
-          if (targetDomain && targetDomain.domain !== hostname) {
+          if (targetDomain && !isTargetDomainCurrent) {
             const scheme = targetDomain.http ? 'http' : 'https'
             const localePrefix =
               targetLocale === targetDomain.defaultLocale
@@ -668,10 +676,7 @@ export async function resolveRoutes(
 
           // If no dedicated domain for target locale, or we're already on the right domain,
           // redirect to add locale prefix on same domain
-          if (
-            !targetDomain ||
-            (targetDomain && targetDomain.domain === hostname)
-          ) {
+          if (!targetDomain || isTargetDomainCurrent) {
             const redirectUrl = new URL(currentUrl.toString())
             redirectUrl.pathname = `${basePath}/${targetLocale}${pathname}`
 


### PR DESCRIPTION
### What?

A locale redirect for an i18n domain configured **with a port** sent the user to the wrong scheme. A request to `http://example.de:3000/` with `domains: [{ domain: 'example.de:3000', defaultLocale: 'de', locales: ['de', 'fr'] }]` and `Accept-Language: fr` redirected to `https://example.de:3000/fr/` instead of staying on `http`.

### Why?

Two places compared the configured domain against the request hostname, but only one of them normalized:

- `detectDomainLocale` strips the port and lowercases before matching, so it correctly resolved `example.de:3000` for the `example.de` host we were already serving.
- `resolveRoutes` compared the raw `targetDomain.domain` against `hostname` — `'example.de:3000' !== 'example.de'` — so it concluded we were on a *different* domain.

That took the cross-domain branch, which rebuilds the URL from the config, and the rebuilt URL derives its scheme from `targetDomain.http` rather than the incoming request. Hence the silent `http` → `https` switch on a same-origin redirect.

### How?

Extract the normalization `detectDomainLocale` was already doing inline into an exported `getDomainHostname(domain)` in `i18n.ts` (strip port, lowercase), and use it in `resolveRoutes` for the comparison. Both call sites now agree on what "same domain" means, so the port-carrying config takes the same-origin branch and keeps the request's scheme, host and port.

The comparison result is hoisted into `isTargetDomainCurrent` and reused by both branches, which also removes the redundant `targetDomain &&` re-check in the second condition.

Test added in `packages/next-routing/src/__tests__/i18n-resolve-routes.test.ts` asserting the redirect keeps `origin === 'http://example.de:3000'` and gains the `/fr/` prefix.
