### PR TITLE
Revert "[turbopack] Enable CJS tree shaking by default (#96779)"

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2536,7 +2536,11 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn turbopack_cjs_tree_shaking(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.turbopack_cjs_tree_shaking.unwrap_or(true))
+        Vc::cell(
+            self.experimental
+                .turbopack_cjs_tree_shaking
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -962,7 +962,7 @@ export interface ExperimentalConfig {
   /**
    * Enable tree shaking of unused exports from analyzable CommonJS modules in Turbopack.
    *
-   * Defaults to `true`
+   * Defaults to `false`
    */
   turbopackCjsTreeShaking?: boolean
 


### PR DESCRIPTION
Reverts vercel/next.js#96779

With this flag enabled, CJS modules written as `var X = module.exports = { … }` lose properties that are only read back through the alias.

`@mixmark-io/domino` (Turndown's server DOM), `lib/LinkedList.js`:

```js
// source
var LinkedList = module.exports = {
    valid: function(a) { /* … */ return true; },
    insertBefore: function(a, b) {
        utils.assert(LinkedList.valid(a) && LinkedList.valid(b));
```

```js
// emitted with turbopackCjsTreeShaking: true
var LinkedList = module.exports = {
    ...void function(a) { /* … */ return true; },   // `valid:` key dropped
```

`valid` is only referenced via the alias, so it is judged unused and elided, and the elision emits `...void <fnExpr>`, i.e. `...undefined`, which spreads nothing. Result: `TypeError: LinkedList.valid is not a function`.

Not domino-specific (same corruption in its `NodeUtils.js`), and the failure mode is a silent property elision rather than a build error.