### PR TITLE
Detach local spans from propagated contexts

### DIFF
--- a/packages/next/src/server/lib/trace/local-span-recorder.ts
+++ b/packages/next/src/server/lib/trace/local-span-recorder.ts
@@ -96,6 +96,14 @@ export function withLocalSpan<T>(span: Span, fn: () => T): T {
   return getLocalSpanAsyncStorage().run(span, fn)
 }
 
+/** Runs a callback without retaining the currently active local span. */
+export function runWithoutLocalSpan<T>(fn: () => T): T {
+  if (!localSpanAsyncStorage) {
+    return fn()
+  }
+  return localSpanAsyncStorage.exit(fn)
+}
+
 /**
  * Records an async operation without replacing or exporting through the active
  * OpenTelemetry context. Nested Next.js spans remain in the local trace.
@@ -134,6 +142,7 @@ export type LocalSpanRecorder = {
   isOpenTelemetryIsolatedSpan: typeof isOpenTelemetryIsolatedSpan
   isLocalSpanRecordingEnabled: typeof isLocalSpanRecordingEnabled
   isRequestInsightsEnabled: typeof isRequestInsightsEnabled
+  runWithoutLocalSpan: typeof runWithoutLocalSpan
   traceLocalSpan: typeof traceLocalSpan
   withLocalSpan: typeof withLocalSpan
 }
@@ -151,6 +160,7 @@ export function registerLocalSpanRecorder(): void {
     isOpenTelemetryIsolatedSpan,
     isLocalSpanRecordingEnabled,
     isRequestInsightsEnabled,
+    runWithoutLocalSpan,
     traceLocalSpan,
     withLocalSpan,
   }

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -29,6 +29,7 @@ import {
   BaseServerSpan,
   InstrumentationSpan,
   LoadComponentsSpan,
+  MiddlewareSpan,
   NextNodeServerSpan,
   NodeSpan,
   RouteModuleSpan,
@@ -228,6 +229,48 @@ describe('local span recording', () => {
         }),
       }),
     ])
+  })
+
+  it('detaches in-process middleware from the active local request span', async () => {
+    process.env.__NEXT_REQUEST_INSIGHTS = 'true'
+
+    await getTracer().trace(
+      BaseServerSpan.handleRequest,
+      async (requestSpan) => {
+        expect(requestSpan).toBeDefined()
+        expect(getTracer().getActiveScopeSpan()).toBe(requestSpan)
+
+        await getTracer().runWithDetachedContext(async () => {
+          expect(getTracer().getActiveScopeSpan()).toBeUndefined()
+          await new Promise<void>((resolve) => setImmediate(resolve))
+          expect(getTracer().getActiveScopeSpan()).toBeUndefined()
+
+          await getTracer().trace(
+            MiddlewareSpan.execute,
+            async (middlewareSpan) => {
+              expect(middlewareSpan).toBeDefined()
+              await new Promise<void>((resolve) => setImmediate(resolve))
+              expect(getTracer().getActiveScopeSpan()).toBe(middlewareSpan)
+            }
+          )
+          expect(getTracer().getActiveScopeSpan()).toBeUndefined()
+        })
+
+        expect(getTracer().getActiveScopeSpan()).toBe(requestSpan)
+      }
+    )
+
+    const requestSpan = getSpanRecords({
+      name: BaseServerSpan.handleRequest,
+    })[0]
+    const middlewareSpan = getSpanRecords({ name: MiddlewareSpan.execute })[0]
+    expect(requestSpan).toBeDefined()
+    expect(middlewareSpan).toEqual(
+      expect.objectContaining({
+        parentSpanId: undefined,
+      })
+    )
+    expect(middlewareSpan.traceId).not.toBe(requestSpan.traceId)
   })
 
   it('only exports non-vanilla spans when verbose tracing is enabled', () => {

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -95,6 +95,8 @@ type TracerSpanOptions = Omit<SpanOptions, 'attributes'> & {
 interface NextTracer {
   getContext(): ContextAPI
 
+  runWithDetachedContext<T>(fn: () => T): T
+
   /**
    * Instruments a function by automatically creating a span activated on its
    * scope.
@@ -284,10 +286,21 @@ class NextTracerImpl implements NextTracer {
    * edge middleware which runs in a detached sandbox.
    */
   public runWithDetachedContext<T>(fn: () => T): T {
-    if (!NEXT_OTEL_PERFORMANCE_PREFIX && !this.isOpenTelemetryEnabled()) {
-      return fn()
+    const runWithRootContext = () => {
+      if (
+        !NEXT_OTEL_PERFORMANCE_PREFIX &&
+        !this.isOpenTelemetryEnabled() &&
+        !trace.getSpanContext(context.active())
+      ) {
+        return fn()
+      }
+      return context.with(ROOT_CONTEXT, fn)
     }
-    return context.with(ROOT_CONTEXT, fn)
+
+    const localSpanRecorder = getLocalSpanRecorder()
+    return localSpanRecorder
+      ? localSpanRecorder.runWithoutLocalSpan(runWithRootContext)
+      : runWithRootContext()
   }
 
   public withPropagatedContext<T, C>(


### PR DESCRIPTION
### What?

Add a tracing primitive for running work outside both the current local span and the propagated OpenTelemetry context.

### Why?

Long-lived work must not inherit a request span after that request has completed. WebSocket connection hooks need this behavior, but the underlying context-restoration contract also applies independently to middleware tracing.

### How?

- Add `runWithoutLocalSpan()` to the local span recorder.
- Clear and restore both local and propagated tracing contexts across synchronous and asynchronous work.
- Cover context restoration, unregistered recorders, and the middleware-only regression.

This is the first PR in the experimental WebSocket Route Handler stack. The transport and public API are added by the following PRs.

### Verification

- `pnpm exec jest --runInBand packages/next/src/server/lib/trace/tracer.test.ts`
- WebSocket hook-context coverage in the complete stack

### Stack status (2026-08-24)

Rebased onto canary `a1cc1eafb3`. Audit-hardening fixes from the stack-wide review are distributed into the layers that own them; none touch this tracing primitive. `pnpm exec jest --runInBand packages/next/src/server/lib/trace/tracer.test.ts` passes at this tip.
