### PR TITLE
Coordinate WebSocket server lifecycles

### DIFF
--- a/docs/01-app/02-guides/custom-server.mdx
+++ b/docs/01-app/02-guides/custom-server.mdx
@@ -127,7 +127,9 @@ app.prepare().then(() => {
 })
 ```
 
-Use one outer upgrade dispatcher when another WebSocket protocol shares the same server. Multiple independent upgrade listeners can race to write to the same socket. During shutdown, call `server.close()` to stop accepting new HTTP connections without awaiting it, await `app.close()` to drain Next.js-owned upgrades and connections, and then await the HTTP server's close callback. The HTTP server remains owned by your custom server.
+Use one outer upgrade dispatcher when multiple Next.js apps or another WebSocket protocol share the same server. The dispatcher must select exactly one owner, for example from the request pathname or host, before calling that app's `getUpgradeHandler()` result. Do not call multiple Next.js upgrade handlers for one request. For a selected WebSocket upgrade while the experiment is enabled, the handler owns the request and returns `404 Not Found` when no route matches. Multiple independent upgrade listeners can race to write to the same socket.
+
+During shutdown, call `server.close()` to stop accepting new HTTP connections without awaiting it, await `app.close()` to drain Next.js-owned upgrades and connections, and then await the HTTP server's close callback. The HTTP server remains owned by your custom server.
 
 </AppOnly>
 

--- a/packages/next/src/next-devtools/server/restart-dev-server-middleware.ts
+++ b/packages/next/src/next-devtools/server/restart-dev-server-middleware.ts
@@ -4,17 +4,20 @@ import { RESTART_EXIT_CODE } from '../../server/lib/utils'
 import { middlewareResponse } from './middleware-response'
 import type { Project } from '../../build/swc/types'
 import { invalidateFileSystemCache as invalidateWebpackFileSystemCache } from '../../build/webpack/cache-invalidation'
+import { scheduleServerCleanup } from '../../server/lib/server-cleanup'
 
 const EVENT_DEV_OVERLAY_RESTART_SERVER = 'DEV_OVERLAY_RESTART_SERVER'
 
 interface RestartDevServerMiddlewareConfig {
   telemetry: Telemetry
+  restartServer?: () => Promise<void>
   turbopackProject?: Project
   webpackCacheDirectories?: Set<string>
 }
 
 export function getRestartDevServerMiddleware({
   telemetry,
+  restartServer,
   turbopackProject,
   webpackCacheDirectories,
 }: RestartDevServerMiddlewareConfig) {
@@ -63,9 +66,15 @@ export function getRestartDevServerMiddleware({
 
     // do this async to try to give the response a chance to send
     // it's not really important if it doesn't though
-    setTimeout(() => {
-      process.exit(RESTART_EXIT_CODE)
-    }, 0)
+    scheduleServerCleanup(async () => {
+      if (restartServer) {
+        // Do not await shutdown from the request listener: the HTTP request
+        // itself is part of the server lifecycle which shutdown must drain.
+        await restartServer()
+      } else {
+        process.exit(RESTART_EXIT_CODE)
+      }
+    })
 
     return middlewareResponse.noContent(res)
   }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1227,6 +1227,7 @@ export async function createHotReloaderTurbopack(
     getDisableDevIndicatorMiddleware(),
     getRestartDevServerMiddleware({
       telemetry: opts.telemetry,
+      restartServer: opts.restartServer,
       turbopackProject: project,
     }),
     devToolsConfigMiddleware({

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -257,6 +257,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   protected appDir?: string
   private telemetry: Telemetry
   private resetFetch: () => void
+  private restartServer: (() => Promise<void>) | undefined
   private lockfile: Lockfile | undefined
   private versionInfo: VersionInfo = {
     staleness: 'unknown',
@@ -290,6 +291,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       resetFetch,
       lockfile,
       onDevServerCleanup,
+      restartServer,
     }: {
       config: NextConfigComplete
       isSrcDir: boolean
@@ -304,6 +306,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       resetFetch: () => void
       lockfile: Lockfile | undefined
       onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
+      restartServer?: () => Promise<void>
     }
   ) {
     this.hasAppRouterEntrypoints = false
@@ -322,6 +325,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.serverPrevDocumentHash = null
     this.telemetry = telemetry
     this.resetFetch = resetFetch
+    this.restartServer = restartServer
     this.lockfile = lockfile
 
     this.config = config
@@ -1693,6 +1697,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       getDisableDevIndicatorMiddleware(),
       getRestartDevServerMiddleware({
         telemetry: this.telemetry,
+        restartServer: this.restartServer,
         webpackCacheDirectories:
           this.activeWebpackConfigs != null
             ? getCacheDirectories(this.activeWebpackConfigs)

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -36,6 +36,10 @@ export type ServerInitResult = {
   agentRules?: boolean
   // Whether the development server memory threshold restart is enabled
   devMemoryThresholdRestart: boolean
+  // Whether public custom-server close() callers own WebSocket failures.
+  webSocketRouteHandlersEnabled: boolean
+  // Matches the live development HMR prefix for sibling Next apps.
+  isWebSocketHMRRequest?: (url: string | undefined) => boolean
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
@@ -117,6 +121,7 @@ async function initializeImpl(opts: {
   cacheComponents: boolean
   partialPrefetching?: boolean
   devMemoryThresholdRestart: boolean
+  webSocketRouteHandlersEnabled: boolean
 }): Promise<ServerInitResult> {
   const type = process.env.__NEXT_PRIVATE_RENDER_WORKER
   if (type) {
@@ -212,6 +217,7 @@ async function initializeImpl(opts: {
     cacheComponents: opts.cacheComponents,
     partialPrefetching: opts.partialPrefetching,
     devMemoryThresholdRestart: opts.devMemoryThresholdRestart,
+    webSocketRouteHandlersEnabled: opts.webSocketRouteHandlersEnabled,
   }
 }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -80,6 +80,7 @@ import {
   getRawHttpResponseStatus,
   isWebSocketUpgradeRequest,
   isWebSocketClientDisconnectError,
+  ownWebSocketUpgradeSocketErrors,
   preflightWebSocketUpgrade,
   validateWebSocketHandshake,
   validateWebSocketOrigin,
@@ -92,6 +93,12 @@ import {
   tryAcquireWebSocketScopeLease,
   type WebSocketScopeLease,
 } from '../websocket-connection-registry'
+import {
+  armUnclaimedUpgradeSocketTimeout,
+  claimWebSocketHMRRequestOnce,
+  isNextHMRUpgradeRequest,
+  UPGRADE_DELEGATION_MESSAGE,
+} from '../websocket-upgrade-listener'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -159,6 +166,7 @@ export async function initialize(opts: {
   customServer?: boolean
   experimentalHttpsServer?: boolean
   serverFastRefresh?: boolean
+  restartServer?: () => Promise<void>
   startServerSpan?: Span
   quiet?: boolean
 }): Promise<ServerInitResult> {
@@ -274,6 +282,7 @@ export async function initialize(opts: {
         turbo: !!process.env.TURBOPACK,
         port: opts.port,
         onDevServerCleanup: opts.onDevServerCleanup,
+        restartServer: opts.restartServer,
         resetFetch,
         serverFastRefresh: effectiveServerFastRefresh,
       })
@@ -935,6 +944,9 @@ export async function initialize(opts: {
     cacheComponents: config.cacheComponents,
     partialPrefetching: config.partialPrefetching,
     devMemoryThresholdRestart,
+    webSocketRouteHandlersEnabled: Boolean(
+      config.experimental.webSocketRouteHandlers
+    ),
   }
   renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
 
@@ -991,26 +1003,39 @@ export async function initialize(opts: {
     development?.bundler?.ensureMiddleware
   )
 
-  const upgradeHandler: WorkerUpgradeHandler = async (req, socket, head) => {
-    let isHMRRequest = false
-    if (opts.dev && development && req.url) {
-      const { basePath, assetPrefix } = config
-      let hmrPrefix = basePath
-      if (assetPrefix) {
-        hmrPrefix = normalizedAssetPrefix(assetPrefix)
-        if (URL.canParse(hmrPrefix)) {
-          hmrPrefix = new URL(hmrPrefix).pathname.replace(/\/$/, '')
-        }
+  const isWebSocketHMRRequest = (requestUrl: string | undefined): boolean => {
+    if (!opts.dev || !development) return false
+    const { basePath, assetPrefix } = config
+    let hmrPrefix = basePath
+    if (assetPrefix) {
+      hmrPrefix = normalizedAssetPrefix(assetPrefix)
+      if (URL.canParse(hmrPrefix)) {
+        hmrPrefix = new URL(hmrPrefix).pathname.replace(/\/$/, '')
       }
-      isHMRRequest = req.url.startsWith(
-        ensureLeadingSlash(`${hmrPrefix}/_next/hmr`)
-      )
     }
+    const hmrPath = ensureLeadingSlash(`${hmrPrefix}/_next/hmr`)
+    return isNextHMRUpgradeRequest(requestUrl, hmrPath)
+  }
 
-    const webSocketUpgradeExclusiveOwner = getRequestMeta(
-      req,
-      'webSocketUpgradeExclusiveOwner'
-    )
+  const upgradeHandler: WorkerUpgradeHandler = async (req, socket, head) => {
+    const isHMRRequest = isWebSocketHMRRequest(req.url)
+
+    const webSocketUpgradeOwnership =
+      getRequestMeta(req, 'webSocketUpgradeOwnership') ?? 'shared'
+
+    // Multiple automatic Next.js listeners share one Node upgrade event. Only
+    // the app whose base path matches may evaluate the request or apply its
+    // origin policy; the other apps leave the HMR socket untouched. The
+    // dispatch layer knows the live sibling matchers; trust its verdict rather
+    // than a URL-shape guess (a route path containing `/_next/hmr` must not be
+    // deferred by every app into a hang).
+    if (
+      webSocketUpgradeOwnership === 'sibling' &&
+      !isHMRRequest &&
+      getRequestMeta(req, 'webSocketSiblingHMR') === true
+    ) {
+      return
+    }
     let isWebSocketRequest = Boolean(
       config.experimental.webSocketRouteHandlers &&
         !isHMRRequest &&
@@ -1021,16 +1046,14 @@ export async function initialize(opts: {
     if (
       config.experimental.webSocketRouteHandlers &&
       !isHMRRequest &&
-      webSocketUpgradeExclusiveOwner === false
+      webSocketUpgradeOwnership === 'shared'
     ) {
       // Node dispatches upgrade listeners synchronously and does not await
       // their promises. Until the lifecycle layer installs a coordinated
       // dispatcher, a shared server must leave every non-HMR upgrade entirely
       // to its embedding listeners. Those listeners may already have accepted
       // the socket and are allowed to mutate the request headers.
-      Log.warnOnce(
-        'Next.js delegated an upgrade event because another custom-server upgrade listener may own the socket. WebSocket Route Handlers require Next.js to exclusively own the upgrade event; pass `httpServer` to `next()` without additional upgrade listeners.'
-      )
+      Log.warnOnce(UPGRADE_DELEGATION_MESSAGE)
       return
     }
 
@@ -1048,14 +1071,56 @@ export async function initialize(opts: {
       if (isWebSocketRequest) {
         addRequestMeta(req, 'webSocketRegistryScope', webSocketRegistryScope)
       }
-      req.on('error', (_err) => {
-        // TODO: log socket errors?
-        // console.error(_err);
-      })
-      socket.on('error', (_err) => {
-        // TODO: log socket errors?
-        // console.error(_err);
-      })
+      ownWebSocketUpgradeSocketErrors(req, socket)
+
+      // RFC order: development origin checks and the internal HMR channel
+      // claim come before any application WebSocket validation. The product
+      // origin policy below (same-origin default + allowedOrigins) is
+      // strictly stronger than allowedDevOrigins, so it intentionally
+      // supersedes it for application WebSocket routes.
+      if (opts.dev && development && req.url) {
+        if (
+          blockCrossSiteDEV(
+            req,
+            socket,
+            development.config.allowedDevOrigins,
+            opts.hostname
+          )
+        ) {
+          return
+        }
+
+        // only handle HMR requests if the basePath in the request
+        // matches the basePath for the handler responding to the request
+        if (isHMRRequest) {
+          // Two apps can share one HMR path (e.g. one app's basePath equals
+          // another's assetPrefix). The first app to reach this claims the
+          // connection; the sibling defers instead of both answering.
+          if (!claimWebSocketHMRRequestOnce(req)) return
+          return development.bundler.hotReloader.onHMR(
+            req,
+            socket,
+            head,
+            (client, { isLegacyClient }) => {
+              if (isLegacyClient) {
+                // Only send the ISR manifest to legacy clients, i.e. Pages
+                // Router clients, or App Router clients that have Cache
+                // Components disabled. The ISR manifest is only used to inform
+                // the static indicator, which currently does not provide useful
+                // information if Cache Components is enabled due to its binary
+                // nature (i.e. it does not support showing info for partially
+                // static pages).
+                client.send(
+                  JSON.stringify({
+                    type: HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST,
+                    data: development.service?.appIsrManifest || {},
+                  } satisfies AppIsrManifestMessage)
+                )
+              }
+            }
+          )
+        }
+      }
 
       if (config.experimental.webSocketRouteHandlers && !isHMRRequest) {
         const preflight = await preflightWebSocketUpgrade(req, socket)
@@ -1097,49 +1162,8 @@ export async function initialize(opts: {
         }
       }
 
-      if (opts.dev && development && req.url) {
-        if (
-          blockCrossSiteDEV(
-            req,
-            socket,
-            development.config.allowedDevOrigins,
-            opts.hostname
-          )
-        ) {
-          return
-        }
-
-        // only handle HMR requests if the basePath in the request
-        // matches the basePath for the handler responding to the request
-        if (isHMRRequest) {
-          return development.bundler.hotReloader.onHMR(
-            req,
-            socket,
-            head,
-            (client, { isLegacyClient }) => {
-              if (isLegacyClient) {
-                // Only send the ISR manifest to legacy clients, i.e. Pages
-                // Router clients, or App Router clients that have Cache
-                // Components disabled. The ISR manifest is only used to inform
-                // the static indicator, which currently does not provide useful
-                // information if Cache Components is enabled due to its binary
-                // nature (i.e. it does not support showing info for partially
-                // static pages).
-                client.send(
-                  JSON.stringify({
-                    type: HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST,
-                    data: development.service?.appIsrManifest || {},
-                  } satisfies AppIsrManifestMessage)
-                )
-              }
-            }
-          )
-        }
-      }
-
       if (!isWebSocketRequest) {
-        // Preserve the legacy upgrade path exactly when the flag is disabled
-        // or another protocol owns this request.
+        // Route legacy upgrades without invoking WebSocket Route Handlers.
         const res = new MockedResponse({
           resWriter: () => {
             throw new Error(
@@ -1155,13 +1179,19 @@ export async function initialize(opts: {
             signal: signalFromNodeResponse(socket),
           })
 
-        if (matchedOutput) return socket.end()
-        if (finished && parsedUrl.protocol) {
-          if (!statusCode) {
-            return await proxyRequest(req, socket, parsedUrl, head)
-          }
+        if (!matchedOutput && finished && parsedUrl.protocol && !statusCode) {
+          return await proxyRequest(req, socket, parsedUrl, head)
+        }
+        if (webSocketUpgradeOwnership === 'exclusive') {
+          socket.destroy()
+          return
+        }
+        if (matchedOutput || (finished && parsedUrl.protocol)) {
           return socket.end()
         }
+        // A shared listener may still claim the socket. Node's request
+        // timeouts no longer apply after the upgrade event.
+        armUnclaimedUpgradeSocketTimeout(socket)
         return
       }
 
@@ -1254,8 +1284,9 @@ export async function initialize(opts: {
         return
       }
 
-      // Shared-server requests return before route resolution, so reaching
-      // this point means Next.js exclusively owns the unmatched socket.
+      // Shared-server requests returned before route resolution. Direct and
+      // outer-dispatched handlers own both matched and unmatched sockets once
+      // they have been selected.
       await writeRawHttpError(req, socket, 404, 'Not Found')
     } catch (err) {
       if (!isWebSocketClientDisconnectError(err)) {
@@ -1303,5 +1334,9 @@ export async function initialize(opts: {
     partialPrefetching: config.partialPrefetching,
     agentRules: config.agentRules,
     devMemoryThresholdRestart,
+    webSocketRouteHandlersEnabled: Boolean(
+      config.experimental.webSocketRouteHandlers
+    ),
+    isWebSocketHMRRequest,
   }
 }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -133,6 +133,7 @@ export type SetupOpts = {
   nextConfig: NextConfigComplete
   port: number
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
+  restartServer?: () => Promise<void>
   resetFetch: () => void
   serverFastRefresh?: boolean
 }
@@ -288,6 +289,7 @@ async function startWatcher(
           resetFetch,
           lockfile,
           onDevServerCleanup: opts.onDevServerCleanup,
+          restartServer: opts.restartServer,
         })
       })()
 

--- a/packages/next/src/server/lib/server-cleanup.ts
+++ b/packages/next/src/server/lib/server-cleanup.ts
@@ -1,0 +1,80 @@
+export type ServerCleanupStage = () => void | PromiseLike<void>
+
+/** Flattens AggregateErrors in declaration order while preserving identity. */
+export function addDistinctServerCleanupFailures(
+  target: unknown[],
+  error: unknown
+): void {
+  const distinct = new Set(target)
+  const active = new Set<AggregateError>()
+
+  const visit = (failure: unknown) => {
+    if (failure instanceof AggregateError) {
+      if (active.has(failure)) {
+        if (!distinct.has(failure)) {
+          distinct.add(failure)
+          target.push(failure)
+        }
+        return
+      }
+
+      let nested: unknown[]
+      try {
+        nested = Array.from(failure.errors)
+      } catch {
+        nested = []
+      }
+      if (nested.length > 0) {
+        const previousLength = target.length
+        active.add(failure)
+        for (const value of nested) visit(value)
+        active.delete(failure)
+        if (target.length !== previousLength) return
+      }
+    }
+
+    if (!distinct.has(failure)) {
+      distinct.add(failure)
+      target.push(failure)
+    }
+  }
+
+  visit(error)
+}
+
+/** A termination signal overrides a restart which is already draining. */
+export function latchServerCleanupExitCode(
+  current: number | undefined,
+  requested: number
+): number {
+  return current === undefined || requested === 130 || requested === 143
+    ? requested
+    : current
+}
+
+/** Starts cleanup after the current request/listener callback can return. */
+export function scheduleServerCleanup(cleanup: () => Promise<void>): void {
+  setTimeout(() => {
+    void cleanup().catch(console.error)
+  }, 0)
+}
+
+/** Runs ordered cleanup phases while attempting every stage in each phase. */
+export async function runServerCleanupPhases(
+  phases: ReadonlyArray<ReadonlyArray<ServerCleanupStage>>,
+  onFailure: (error: unknown) => void = (error) => console.error(error)
+): Promise<void> {
+  for (const phase of phases) {
+    const results = await Promise.allSettled(
+      phase.map(async (stage) => stage())
+    )
+    for (const result of results) {
+      if (result.status !== 'rejected') continue
+      try {
+        onFailure(result.reason)
+      } catch {
+        // Diagnostics must not acquire ownership of process cleanup.
+      }
+    }
+  }
+}

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -44,7 +44,18 @@ import { AsyncCallbackSet } from './async-callback-set'
 import type { NextServer } from '../next'
 import { durationToString } from '../../build/duration-to-string'
 import { addRequestMeta } from '../request-meta'
-import { createWebSocketUpgradeListenerOwnershipTracker } from '../websocket-upgrade-listener'
+import { PendingWebSocketUpgradeTracker } from '../websocket-lifecycle'
+import { isRawHttpResponseCommitted } from '../websocket-http'
+import { HTTP_SERVER_CLOSE_GRACE_PERIOD_MS } from '../websocket-shutdown-budget'
+import {
+  armUnclaimedUpgradeSocketTimeout,
+  createWebSocketUpgradeListenerOwnershipTracker,
+} from '../websocket-upgrade-listener'
+import {
+  latchServerCleanupExitCode,
+  runServerCleanupPhases,
+  scheduleServerCleanup,
+} from './server-cleanup'
 
 const debug = setupDebug('next:start-server')
 let startServerSpan: Span | undefined
@@ -150,6 +161,7 @@ export async function getRequestHandlers({
   experimentalHttpsServer,
   serverFastRefresh,
   quiet,
+  restartServer,
 }: {
   dir: string
   port: number
@@ -162,6 +174,7 @@ export async function getRequestHandlers({
   experimentalHttpsServer?: boolean
   serverFastRefresh?: boolean
   quiet?: boolean
+  restartServer?: () => Promise<void>
 }): ReturnType<typeof initialize> {
   return initialize({
     dir,
@@ -176,6 +189,7 @@ export async function getRequestHandlers({
     serverFastRefresh,
     startServerSpan,
     quiet,
+    restartServer,
   })
 }
 
@@ -232,6 +246,11 @@ export async function startServer(
 
   let nextServer: NextServer | undefined
   let devMemoryThresholdRestart = true
+  let restartServer = async (): Promise<void> => {
+    await flushAllTraces()
+    process.exit(RESTART_EXIT_CODE)
+  }
+  const scheduleServerRestart = () => scheduleServerCleanup(restartServer)
 
   // setup server listener as fast as possible
   if (selfSignedCertificate && !isDev) {
@@ -266,8 +285,9 @@ export async function startServer(
           'memory.heapSizeLimit': String(memoryRestartStats.heap_size_limit),
           'memory.heapUsed': String(memoryRestartStats.used_heap_size),
         }).stop()
-        flushAllTraces()
-        process.exit(RESTART_EXIT_CODE)
+        // Let this request listener return before shutdown waits for the HTTP
+        // server to drain, otherwise server.close() would wait on itself.
+        scheduleServerRestart()
       }
     }
   }
@@ -285,22 +305,51 @@ export async function startServer(
   if (keepAliveTimeout) {
     server.keepAliveTimeout = keepAliveTimeout
   }
+  const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+  let isClosingUpgrades = false
   const handleServerUpgrade: WorkerUpgradeHandler = async (
     req,
     socket,
     head
   ) => {
-    addRequestMeta(
-      req,
-      'webSocketUpgradeExclusiveOwner',
-      webSocketUpgradeOwnership.isExclusiveOwner()
-    )
+    let finishUpgrade: (() => void) | undefined
     try {
+      finishUpgrade = pendingUpgrades.track(socket)
+      if (
+        isClosingUpgrades ||
+        socket.destroyed ||
+        socket.readableEnded ||
+        socket.writableEnded
+      ) {
+        if (!socket.destroyed) socket.destroy()
+        return
+      }
+      addRequestMeta(
+        req,
+        'webSocketUpgradeOwnership',
+        webSocketUpgradeOwnership.getOwnership()
+      )
       await upgradeHandler(req, socket, head)
     } catch (err) {
-      socket.destroy()
+      let committed = false
+      try {
+        committed = isRawHttpResponseCommitted(socket)
+      } catch {}
+      if ((!isClosingUpgrades || !committed) && !socket.destroyed) {
+        try {
+          socket.destroy()
+        } catch {}
+      }
       Log.error(`Failed to handle request for ${req.url}`)
       console.error(err)
+    } finally {
+      finishUpgrade?.()
+      // finishUpgrade clears the pre-commit idle timeout, so an upgrade no
+      // route, rewrite, or proxy claimed would leak its descriptor forever —
+      // Node's request timeouts stop applying once 'upgrade' fires. Re-arm a
+      // bounded idle reap; another listener that claimed the socket (an
+      // attached data reader, e.g. a custom WS server) is spared.
+      armUnclaimedUpgradeSocketTimeout(socket)
     }
   }
   const webSocketUpgradeOwnership =
@@ -330,6 +379,119 @@ export async function startServer(
   })
 
   let cleanupListeners = isDev ? new AsyncCallbackSet() : undefined
+  let closeUpgraded: ((code?: number) => Promise<void>) | null = null
+  let cleanupPromise: Promise<void> | undefined
+  let cleanupExitCode: number | undefined
+
+  const cleanup = (exitCode: number, webSocketCloseCode = 1001) => {
+    cleanupExitCode = latchServerCleanupExitCode(cleanupExitCode, exitCode)
+    if (cleanupPromise) return cleanupPromise
+
+    let resolveCleanup!: () => void
+    let rejectCleanup!: (error: unknown) => void
+    cleanupPromise = new Promise<void>((resolve, reject) => {
+      resolveCleanup = resolve
+      rejectCleanup = reject
+    })
+
+    // Publish cleanupPromise and close raw-upgrade admission before invoking
+    // EventEmitter hooks. A removeListener observer can synchronously request
+    // another restart, but it must join this cleanup generation.
+    isClosingUpgrades = true
+    const closePendingUpgrades = pendingUpgrades.closePending()
+    void closePendingUpgrades.catch(() => {})
+    let removeUpgradeListenerFailure: unknown
+    try {
+      server.off('upgrade', handleServerUpgrade)
+      webSocketUpgradeOwnership.dispose()
+    } catch (error) {
+      removeUpgradeListenerFailure = error
+    }
+
+    const runCleanup = async () => {
+      debug('start-server process cleanup')
+      try {
+        // Stop accepting HTTP connections immediately, but do not wait for the
+        // close callback before draining upgraded connections. Node keeps
+        // upgraded sockets in the server's connection set, so awaiting
+        // server.close() first can deadlock WebSocket shutdown.
+        const httpServerClosed = new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) reject(error)
+            else resolve()
+          })
+          if (isDev) server.closeAllConnections()
+        })
+        void httpServerClosed.catch(() => {})
+
+        // server.close() waits for connections with in-flight requests; only
+        // idle keep-alives are closed on our behalf. Bound the wait so a slow
+        // or stalled client cannot keep process exit open indefinitely.
+        const httpServerCloseBounded = () => {
+          const abandonTimer = setTimeout(() => {
+            try {
+              server.closeAllConnections()
+            } catch {}
+          }, HTTP_SERVER_CLOSE_GRACE_PERIOD_MS)
+          abandonTimer.unref?.()
+          return httpServerClosed.finally(() => clearTimeout(abandonTimer))
+        }
+
+        // A termination signal that lands while a restart is already draining
+        // must still tell clients the process is going away (1001), not to
+        // reconnect immediately (1012). The exit-code latch carries signal
+        // precedence, so read the close code at phase execution time.
+        const shutdownCloseCode = () =>
+          cleanupExitCode === 130 || cleanupExitCode === 143
+            ? 1001
+            : webSocketCloseCode
+
+        await runServerCleanupPhases([
+          [
+            () => {
+              if (removeUpgradeListenerFailure !== undefined) {
+                throw removeUpgradeListenerFailure
+              }
+            },
+            () => closePendingUpgrades,
+          ],
+          // Every admitted route has now either handed the connection to the
+          // registry or completed, so one snapshot closes all upgraded peers.
+          [() => closeUpgraded?.(shutdownCloseCode())],
+          [
+            httpServerCloseBounded,
+            () => nextServer?.close(),
+            () => cleanupListeners?.runAll(),
+          ],
+          [() => flushAllTraces()],
+        ])
+
+        if (isDev) {
+          try {
+            const { traceGlobals } =
+              require('../../trace/shared') as typeof import('../../trace/shared')
+            const telemetry = traceGlobals.get('telemetry') as
+              | InstanceType<typeof import('../../telemetry/storage').Telemetry>
+              | undefined
+            if (telemetry) telemetry.flushDetached('dev', dir)
+          } catch (_) {
+            // Ignore telemetry errors during cleanup.
+          }
+        }
+        resolveCleanup()
+      } catch (error) {
+        rejectCleanup(error)
+      } finally {
+        debug('start-server process cleanup finished')
+        process.exit(cleanupExitCode)
+      }
+    }
+
+    void runCleanup()
+    return cleanupPromise
+  }
+
+  restartServer = () => cleanup(RESTART_EXIT_CODE, 1012)
 
   const distDir = await new Promise<string>((resolve) => {
     server.on('listening', async () => {
@@ -409,93 +571,17 @@ export async function startServer(
       Log.event(`Ready in ${formattedStartDuration}`)
 
       try {
-        let cleanupStarted = false
-        let closeUpgraded: ((code?: number) => Promise<void>) | null = null
-        const cleanup = (signal: 'SIGINT' | 'SIGTERM') => {
-          if (cleanupStarted) {
-            // We can get duplicate signals, e.g. when `ctrl+c` is used in an
-            // interactive shell (i.e. bash, zsh), the shell will recursively
-            // send SIGINT to children. The parent `next-dev` process will also
-            // send us SIGINT.
-            return
-          }
-          cleanupStarted = true
-          ;(async () => {
-            debug('start-server process cleanup')
-
-            // First stop accepting new connections. Then finish pending HTTP
-            // requests and upgraded connections before `nextServer.close()`;
-            // either may still schedule `after` work while closing.
-            const closeHttpServer = new Promise<void>((res) => {
-              server.close((err) => {
-                if (err) console.error(err)
-                res()
-              })
-              if (isDev) {
-                server.closeAllConnections()
-              }
-            })
-            const closeUpgradedConnections = closeUpgraded
-              ? closeUpgraded(1001).catch(console.error)
-              : Promise.resolve()
-            await Promise.all([closeHttpServer, closeUpgradedConnections])
-
-            // now that no new requests can come in, clean up the rest
-            await Promise.all([
-              nextServer?.close().catch(console.error),
-              cleanupListeners?.runAll().catch(console.error),
-            ])
-
-            // Flush any remaining traces to the trace file on shutdown
-            flushAllTraces()
-
-            // Flush telemetry if this is a dev server
-            if (isDev) {
-              try {
-                const { traceGlobals } =
-                  require('../../trace/shared') as typeof import('../../trace/shared')
-                const telemetry = traceGlobals.get('telemetry') as
-                  | InstanceType<
-                      typeof import('../../telemetry/storage').Telemetry
-                    >
-                  | undefined
-                if (telemetry) {
-                  // Use flushDetached to avoid blocking process exit
-                  // Each process writes to a unique file (_events_${pid}.json)
-                  // to avoid race conditions with the parent process
-                  telemetry.flushDetached('dev', dir)
-                }
-              } catch (_) {
-                // Ignore telemetry errors during cleanup
-              }
-            }
-
-            debug('start-server process cleanup finished')
-
-            // Exit with signal-based exit code (128 + signal number) so that
-            // Node.js treats this as a signal termination, not a normal exit.
-            // This avoids waiting for the debugger to disconnect.
-            switch (signal) {
-              case 'SIGINT':
-                process.exit(130)
-                break
-              case 'SIGTERM':
-                process.exit(143)
-                break
-              default:
-                // Make sure all handled signals have explicit exit codes.
-                // This is just a fallback to guard against unsound types.
-                signal satisfies never
-                process.exit(128)
-            }
-          })()
+        const cleanupSignal = (signal: 'SIGINT' | 'SIGTERM') => {
+          // Do not await from the signal listener; cleanup drains the listener
+          // graph and exits with the latched signal code when it is complete.
+          void cleanup(signal === 'SIGINT' ? 130 : 143)
         }
 
         // Make sure commands gracefully respect termination signals (e.g. from Docker)
         // Allow the graceful termination to be manually configurable
         if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
-          process.on('SIGINT', cleanup)
-          process.on('SIGTERM', cleanup)
+          process.on('SIGINT', cleanupSignal)
+          process.on('SIGTERM', cleanupSignal)
         }
 
         // Now load config via getRequestHandlers (single loadConfig call)
@@ -512,6 +598,7 @@ export async function startServer(
           keepAliveTimeout,
           experimentalHttpsServer: !!selfSignedCertificate,
           serverFastRefresh,
+          restartServer,
         })
         devMemoryThresholdRestart = initResult.devMemoryThresholdRestart
         requestHandler = initResult.requestHandler
@@ -604,7 +691,7 @@ export async function startServer(
       files: configFiles,
       missing: dirWatchPaths,
     })
-    wp.on('change', async (filename) => {
+    wp.on('change', (filename) => {
       if (!configFiles.includes(filename)) {
         return
       }
@@ -613,7 +700,7 @@ export async function startServer(
           filename
         )}. Restarting the server to apply the changes...`
       )
-      process.exit(RESTART_EXIT_CODE)
+      scheduleServerRestart()
     })
     wp.on('remove', (removedPath: string) => {
       if (dirWatchPaths.includes(removedPath)) {
@@ -622,7 +709,7 @@ export async function startServer(
             'Deleting this directory while Next.js is running can lead to ' +
             'undefined behavior. Restarting the server to recover...'
         )
-        process.exit(RESTART_EXIT_CODE)
+        scheduleServerRestart()
       }
     })
   }

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -6,8 +6,6 @@ import type {
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { Duplex } from 'stream'
 import type { NextUrlWithParsedQuery, RequestMeta } from './request-meta'
-import { addRequestMeta } from './request-meta'
-import { createWebSocketUpgradeListenerOwnershipTracker } from './websocket-upgrade-listener'
 
 import './require-hook'
 import './node-polyfill-crypto'
@@ -24,6 +22,7 @@ import {
 import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 import { getTracer } from './lib/trace/tracer'
 import { NextServerSpan } from './lib/trace/constants'
+import { flushAllTraces } from '../trace'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
 import type { ServerFields } from './lib/router-utils/setup-dev-bundler'
 import type { ServerInitResult } from './lib/render-server'
@@ -32,6 +31,35 @@ import {
   RouterServerContextSymbol,
   routerServerGlobal,
 } from './lib/router-utils/router-server-context'
+import { PendingWebSocketUpgradeTracker } from './websocket-lifecycle'
+import {
+  isRawHttpResponseCommitted,
+  isWebSocketUpgradeRequest,
+  writeRawHttpError,
+} from './websocket-http'
+import { addDistinctServerCleanupFailures } from './lib/server-cleanup'
+import { throwCombinedFailures } from './websocket-http'
+import { RESTART_EXIT_CODE } from './lib/utils'
+import { addRequestMeta } from './request-meta'
+import { createPromiseWithResolvers } from '../shared/lib/promise-with-resolvers'
+import {
+  classifyWebSocketUpgradeOwnership,
+  createWebSocketUpgradeListenerOwnershipTracker,
+  hasEnabledNextOwnedWebSocketUpgradeListener,
+  hasMatchingNextOwnedWebSocketHMRListener,
+  markNextOwnedWebSocketUpgradeListener,
+  UPGRADE_DELEGATION_MESSAGE,
+  type WebSocketUpgradeListenerOwnershipTracker,
+} from './websocket-upgrade-listener'
+import { PREPARE_CLOSE_GRACE_PERIOD_MS } from './websocket-shutdown-budget'
+
+const rejectedSiblingUpgradeRequests = new WeakSet<IncomingMessage>()
+// Pins sole ownership across apps: an outer dispatcher which accidentally
+// invokes two apps' public handlers with the same request cannot double-own
+// it. Sibling HMR channels claim only per app and are tracked apart.
+const claimedUpgradeRequests = new WeakSet<IncomingMessage>()
+const SIBLING_UPGRADE_MESSAGE =
+  'Multiple Next.js apps on one HTTP server require a single outer upgrade dispatcher for WebSocket Route Handlers. Select the app and call app.getUpgradeHandler().'
 
 let ServerImpl: typeof NextNodeServer
 
@@ -68,11 +96,39 @@ export type RequestHandler = (
   parsedUrl?: NextUrlWithParsedQuery | undefined
 ) => Promise<void>
 
+/** @experimental WebSocket Route Handlers are an experimental feature. */
 export type UpgradeHandler = (
   req: IncomingMessage,
   socket: Duplex,
   head: Buffer
 ) => Promise<void>
+
+function removeUpgradeListenerRegistrations(
+  server: import('http').Server,
+  listener: UpgradeHandler
+): unknown[] {
+  const failures: unknown[] = []
+  let registrationCount = 1
+  try {
+    registrationCount = server
+      .listeners('upgrade')
+      .filter((registered) => registered === listener).length
+  } catch (error) {
+    failures.push(error)
+  }
+
+  // EventEmitter.off() removes one matching registration. Snapshot the count
+  // so a hostile removeListener observer cannot keep this loop alive by
+  // re-registering the handler while teardown is in progress.
+  for (let index = 0; index < registrationCount; index++) {
+    try {
+      server.off('upgrade', listener)
+    } catch (error) {
+      if (!failures.includes(error)) failures.push(error)
+    }
+  }
+  return failures
+}
 
 const SYMBOL_LOAD_CONFIG = Symbol('next.load_config')
 
@@ -127,9 +183,22 @@ interface NextWrapperServer {
   prepare(serverFields?: ServerFields): Promise<void>
   /** @deprecated Configure `assetPrefix` in `next.config.js` instead. */
   setAssetPrefix(assetPrefix: string): void
+  /**
+   * Closes the Next.js server.
+   *
+   * With experimental WebSocket Route Handlers enabled, repeated calls share
+   * one teardown promise. A single teardown failure is rethrown unchanged;
+   * multiple distinct failures reject with an ordered `AggregateError`.
+   */
   close(): Promise<void>
 
-  // used internally
+  /**
+   * Returns the handler for a custom server's Node.js `upgrade` event.
+   * Call this after `prepare()` and attach the returned handler before the
+   * server starts accepting connections.
+   *
+   * @experimental WebSocket Route Handlers are an experimental feature.
+   */
   getUpgradeHandler(): UpgradeHandler
 
   // legacy methods that we left exposed in the past
@@ -240,6 +309,7 @@ export class NextServer implements NextWrapperServer {
     }
   }
 
+  /** @experimental WebSocket Route Handlers are an experimental feature. */
   getUpgradeHandler(): UpgradeHandler {
     return async (req: IncomingMessage, socket: any, head: any) => {
       const server = await this.getServer()
@@ -424,16 +494,36 @@ export class NextServer implements NextWrapperServer {
   }
 }
 
+interface CustomServerPrepareGeneration {
+  promise: Promise<void>
+  init?: ServerInitResult
+  pendingUpgrades: PendingWebSocketUpgradeTracker
+  cleanupListeners?: AsyncCallbackSet
+  reportCleanupFailures?: boolean
+}
+
+interface CustomServerCloseGeneration {
+  prepare: CustomServerPrepareGeneration
+  promise: Promise<void>
+}
+
 /** The wrapper server used for `import next from "next" (in a custom server)` */
 class NextCustomServer implements NextWrapperServer {
   private didWebSocketSetup: boolean = false
   private isClosing: boolean = false
+  private prepareGeneration?: CustomServerPrepareGeneration
+  private closeGeneration?: CustomServerCloseGeneration
+  private pendingUpgrades = new PendingWebSocketUpgradeTracker()
   private webSocketServer?: import('http').Server
-  private webSocketServers = new Set<import('http').Server>()
-  private webSocketUpgradeListener?: UpgradeHandler
-  private webSocketOwnershipTracker?: ReturnType<
-    typeof createWebSocketUpgradeListenerOwnershipTracker
-  >
+  private readonly webSocketUpgradeServers = new Set<import('http').Server>()
+  private webSocketUpgradeOwnership?: WebSocketUpgradeListenerOwnershipTracker
+  private webSocketRegistration?: Promise<void>
+  private webSocketAutomaticUpgradeListener?: UpgradeHandler
+  private webSocketUpgradeListener?: (
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer
+  ) => Promise<void>
   protected cleanupListeners?: AsyncCallbackSet
 
   protected init?: ServerInitResult
@@ -471,7 +561,74 @@ class NextCustomServer implements NextWrapperServer {
     return this.options.port
   }
 
-  async prepare() {
+  prepare(): Promise<void> {
+    if (this.prepareGeneration) return this.prepareGeneration.promise
+
+    // Publish the preparation generation before running any user- or
+    // adapter-controlled initialization. close() can then wait for this exact
+    // generation without mistaking an in-flight prepare for a pre-prepare
+    // no-op, and concurrent prepare callers cannot install competing servers.
+    const preparing = createPromiseWithResolvers<void>()
+    const generation: CustomServerPrepareGeneration = {
+      promise: preparing.promise,
+      pendingUpgrades: new PendingWebSocketUpgradeTracker(),
+    }
+    this.prepareGeneration = generation
+    this.pendingUpgrades = generation.pendingUpgrades
+    this.cleanupListeners = undefined
+    this.isClosing = false
+    void this.prepareImpl(generation).then(
+      async (init) => {
+        try {
+          generation.init = init
+          if (this.prepareGeneration === generation) this.init = init
+          this.setupWebSocketHandler(this.options.httpServer)
+          preparing.resolve()
+        } catch (error) {
+          // Listener registration is the final prepare step. If it fails, the
+          // router is already live and must be rolled back through the same
+          // authoritative close generation used by a concurrent close().
+          generation.reportCleanupFailures = true
+          const failures = [error]
+          try {
+            await this.closeImpl(1011)
+          } catch (cleanupError) {
+            addDistinctServerCleanupFailures(failures, cleanupError)
+          }
+          generation.init = undefined
+          if (this.prepareGeneration === generation) {
+            this.prepareGeneration = undefined
+            this.init = undefined
+            this.cleanupListeners = undefined
+          }
+          if (this.closeGeneration?.prepare === generation) {
+            this.closeGeneration = undefined
+          }
+          this.isClosing = false
+          preparing.reject(
+            failures.length === 1
+              ? error
+              : new AggregateError(
+                  failures,
+                  'Failed to prepare the Next.js custom server',
+                  { cause: error }
+                )
+          )
+        }
+      },
+      (error) => {
+        if (this.prepareGeneration === generation) {
+          this.prepareGeneration = undefined
+        }
+        preparing.reject(error)
+      }
+    )
+    return preparing.promise
+  }
+
+  private async prepareImpl(
+    generation: CustomServerPrepareGeneration
+  ): Promise<ServerInitResult> {
     if (this.options.dev) {
       process.env.__NEXT_DEV_SERVER = '1'
     }
@@ -481,8 +638,11 @@ class NextCustomServer implements NextWrapperServer {
 
     let onDevServerCleanup: AsyncCallbackSet['add'] | undefined
     if (this.options.dev) {
-      this.cleanupListeners = new AsyncCallbackSet()
-      onDevServerCleanup = this.cleanupListeners.add.bind(this.cleanupListeners)
+      generation.cleanupListeners = new AsyncCallbackSet()
+      this.cleanupListeners = generation.cleanupListeners
+      onDevServerCleanup = generation.cleanupListeners.add.bind(
+        generation.cleanupListeners
+      )
     }
 
     const initResult = await getRequestHandlers({
@@ -493,120 +653,348 @@ class NextCustomServer implements NextWrapperServer {
       hostname: this.options.hostname || 'localhost',
       minimalMode: this.options.minimalMode,
       quiet: this.options.quiet,
+      restartServer: async () => {
+        try {
+          try {
+            if (generation.init) {
+              await this.closeImpl(1012)
+            } else {
+              // getRequestHandlers() may request a restart before it returns
+              // the initialized server. Waiting for prepare() from inside that
+              // callback would form prepare -> restart -> close -> prepare.
+              // Only pre-initialization resources are reachable here; drain
+              // them without publishing a terminal close generation. In the
+              // normal path, where initialization has completed, closeImpl()
+              // remains the authoritative teardown.
+              await Promise.allSettled([
+                generation.pendingUpgrades.closePending(),
+                generation.cleanupListeners?.runAll(),
+              ])
+            }
+          } catch (error) {
+            // A restart must still flush its trace receipt before the process
+            // exits, even when experimental WebSocket teardown reports a
+            // failure to ordinary app.close() callers.
+            console.error(
+              'Failed to close the Next.js custom server during restart',
+              error
+            )
+          }
+          await flushAllTraces()
+        } finally {
+          process.exit(RESTART_EXIT_CODE)
+        }
+      },
     })
-    this.init = initResult
-    this.setupWebSocketHandler(this.options.httpServer)
+    return initResult
   }
 
   private setupWebSocketHandler(
     customServer?: import('http').Server,
     _req?: IncomingMessage
   ) {
-    if (this.didWebSocketSetup || this.isClosing) return
+    if (this.isClosing) return
 
-    const requestServer = customServer || (_req?.socket as any)?.server
-    if (!requestServer) return
+    customServer = customServer || (_req?.socket as any)?.server
+    if (!customServer) return
 
-    const upgradeListener = this.getOrCreateWebSocketUpgradeListener()
-    if (requestServer.listeners('upgrade').includes(upgradeListener)) {
-      // `getUpgradeHandler()` may already have been attached explicitly. Do
-      // not install a second copy when the first ordinary request discovers
-      // the server. Since that registration bypassed the ownership observer,
-      // its listener remains delegated for WebSocket Route Handlers.
-      this.didWebSocketSetup = true
-      this.webSocketServer = requestServer
-      this.webSocketServers.add(requestServer)
+    // app.getUpgradeHandler() marks explicit custom-server wiring only when
+    // the returned listener is actually attached to this server. Merely
+    // calling the getter (probing, conditional wiring) must not permanently
+    // disable the automatic path.
+    if (
+      this.didWebSocketSetup &&
+      (this.webSocketServer === customServer ||
+        customServer
+          .listeners('upgrade')
+          .includes(this.getOrCreateWebSocketUpgradeListener()))
+    ) {
       return
     }
 
-    const ownershipTracker = createWebSocketUpgradeListenerOwnershipTracker(
-      requestServer,
-      upgradeListener
-    )
-
+    const publicUpgradeListener = this.getOrCreateWebSocketUpgradeListener()
+    const upgradeListener = this.webSocketAutomaticUpgradeListener!
+    const registration = createPromiseWithResolvers<void>()
+    this.didWebSocketSetup = true
+    this.webSocketServer = customServer
+    this.webSocketRegistration = registration.promise
+    const serverWasTracked = this.webSocketUpgradeServers.has(customServer)
+    this.webSocketUpgradeServers.add(customServer)
+    let ownership: WebSocketUpgradeListenerOwnershipTracker | undefined
+    let ownershipDisposed = false
+    const disposeOwnership = () => {
+      if (!ownership || ownershipDisposed) return
+      ownershipDisposed = true
+      ownership.dispose()
+    }
+    let registered = false
     try {
-      requestServer.on('upgrade', upgradeListener)
-      if (this.isClosing) {
-        requestServer.off('upgrade', upgradeListener)
-        ownershipTracker.dispose()
-        return
+      ownership = createWebSocketUpgradeListenerOwnershipTracker(
+        customServer,
+        upgradeListener,
+        [publicUpgradeListener]
+      )
+      this.webSocketUpgradeOwnership = ownership
+      customServer.on('upgrade', upgradeListener)
+      registered = true
+      if (
+        this.webSocketRegistration !== registration.promise ||
+        this.webSocketServer !== customServer ||
+        this.isClosing
+      ) {
+        // EventEmitter emits `newListener` before inserting the listener. A
+        // public observer can begin close() during that callback, so detach
+        // the listener which `on()` just inserted before publishing
+        // registration completion.
+        registered = false
+        customServer.off('upgrade', upgradeListener)
       }
     } catch (error) {
-      ownershipTracker.dispose()
-      throw error
-    }
-
-    this.didWebSocketSetup = true
-    this.webSocketServer = requestServer
-    this.webSocketServers.add(requestServer)
-    this.webSocketUpgradeListener = upgradeListener
-    this.webSocketOwnershipTracker = ownershipTracker
-  }
-
-  private removeWebSocketUpgradeListener(
-    server: import('http').Server,
-    listener: UpgradeHandler
-  ): void {
-    let registrationCount: number
-    try {
-      registrationCount = server
-        .listeners('upgrade')
-        .filter((registeredListener) => registeredListener === listener).length
-    } catch (error) {
-      console.error(
-        'Failed to inspect custom-server WebSocket upgrade listeners',
-        error
-      )
-      return
-    }
-
-    for (let index = 0; index < registrationCount; index++) {
+      const failures = [error]
+      // `EventEmitter.on()` is a public synchronous capability. A subclass can
+      // insert the listener and then throw, so registration failure still owes
+      // an explicit rollback before this instance drops ownership state.
       try {
-        server.off('upgrade', listener)
-      } catch (error) {
-        console.error(
-          'Failed to remove the custom-server WebSocket upgrade listener',
-          error
-        )
+        customServer.off('upgrade', upgradeListener)
+      } catch (cleanupError) {
+        if (!failures.includes(cleanupError)) failures.push(cleanupError)
+      }
+      try {
+        disposeOwnership()
+      } catch (cleanupError) {
+        if (!failures.includes(cleanupError)) failures.push(cleanupError)
+      }
+      throwCombinedFailures(
+        failures,
+        'Failed to register the custom-server WebSocket upgrade listener'
+      )
+    } finally {
+      registration.resolve()
+      if (!registered && this.webSocketRegistration === registration.promise) {
+        this.didWebSocketSetup = false
+        this.webSocketServer = undefined
+        this.webSocketUpgradeOwnership = undefined
+        this.webSocketRegistration = undefined
+        if (!serverWasTracked) this.webSocketUpgradeServers.delete(customServer)
+        disposeOwnership()
       }
     }
   }
 
   private getOrCreateWebSocketUpgradeListener(): UpgradeHandler {
     if (!this.webSocketUpgradeListener) {
-      const upgradeListener: UpgradeHandler = async (req, socket, head) => {
-        const requestServer = (
-          req.socket as typeof req.socket & {
-            server?: import('http').Server
-          }
-        ).server
-        if (this.isClosing) {
-          if (requestServer) {
-            this.removeWebSocketUpgradeListener(requestServer, upgradeListener)
-          }
-          socket.destroy()
-          return
-        }
-
-        if (requestServer) this.webSocketServers.add(requestServer)
-        const ownershipTracker =
-          requestServer === this.webSocketServer
-            ? this.webSocketOwnershipTracker
-            : undefined
-        addRequestMeta(
-          req,
-          'webSocketUpgradeExclusiveOwner',
-          ownershipTracker?.isExclusiveOwner() ?? false
-        )
+      const claimedRequests = new WeakSet<IncomingMessage>()
+      const dispatchUpgrade = async (
+        invokedListener: UpgradeHandler,
+        otherOwnedListener: UpgradeHandler,
+        req: IncomingMessage,
+        socket: Duplex,
+        head: Buffer
+      ) => {
+        let finishUpgrade: (() => void) | undefined
         try {
+          const requestServer = (
+            req.socket as typeof req.socket & {
+              server?: import('http').Server
+            }
+          ).server
+          const upgradeListeners = requestServer?.listeners('upgrade')
+          const ownsServerRegistration = Boolean(
+            requestServer &&
+              upgradeListeners?.some(
+                (listener) =>
+                  listener === invokedListener ||
+                  listener === otherOwnedListener
+              )
+          )
+          if (requestServer && ownsServerRegistration) {
+            this.webSocketUpgradeServers.add(requestServer)
+          }
+          const ownership =
+            invokedListener === this.webSocketAutomaticUpgradeListener &&
+            requestServer === this.webSocketServer &&
+            this.webSocketUpgradeOwnership
+              ? this.webSocketUpgradeOwnership.getOwnership()
+              : classifyWebSocketUpgradeOwnership(
+                  upgradeListeners,
+                  invokedListener,
+                  [otherOwnedListener]
+                )
+          const isSiblingHMRRequest =
+            ownership === 'sibling' &&
+            hasMatchingNextOwnedWebSocketHMRListener(upgradeListeners, req.url)
+
+          // Shared dispatch is intentionally left unclaimed so one outer
+          // dispatcher can call the public handler with coordinated ownership.
+          // Every Next-owned path claims synchronously before touching request
+          // metadata, upgrade admission, or the socket. Sibling deferral claims
+          // only within the app, so every sibling still processes its own HMR
+          // channel; sole ownership (coordinated through an outer dispatcher,
+          // or exclusive) is pinned across apps.
+          if (ownership !== 'shared') {
+            if (claimedRequests.has(req) || claimedUpgradeRequests.has(req)) {
+              return
+            }
+            claimedRequests.add(req)
+            if (ownership !== 'sibling') claimedUpgradeRequests.add(req)
+          }
+
+          if (this.isClosing) {
+            if (requestServer && ownsServerRegistration) {
+              const removalFailures = [
+                ...removeUpgradeListenerRegistrations(
+                  requestServer,
+                  invokedListener
+                ),
+                ...removeUpgradeListenerRegistrations(
+                  requestServer,
+                  otherOwnedListener
+                ),
+              ]
+              this.webSocketUpgradeServers.delete(requestServer)
+              if (removalFailures.length > 0) {
+                console.error(
+                  'Failed to remove a custom-server WebSocket upgrade listener during shutdown',
+                  removalFailures.length === 1
+                    ? removalFailures[0]
+                    : new AggregateError(removalFailures)
+                )
+              }
+            }
+            // Shared dispatchers may own this socket. A closing app that just
+            // de-registered its own listeners must reap upgrade sockets
+            // matched only by its own HMR endpoint (no remaining listener
+            // will ever claim them); sibling-owned sockets are left for the
+            // sibling.
+            if (
+              ownership !== 'shared' &&
+              !socket.destroyed &&
+              (!isSiblingHMRRequest ||
+                (ownsServerRegistration &&
+                  Boolean(this.init?.isWebSocketHMRRequest?.(req.url))))
+            ) {
+              socket.destroy()
+            }
+            return
+          }
+
+          // Node invokes sibling upgrade listeners synchronously without
+          // awaiting promises. Leave a shared dispatch untouched so another
+          // listener can make the ownership decision.
+          if (ownership === 'shared') {
+            if (this.getInit().webSocketRouteHandlersEnabled) {
+              // Warn only if no listener ultimately claims the request: a
+              // correctly configured outer dispatcher claims it during the
+              // same emit pass, so a next-tick check is what separates
+              // actionable guidance from noise.
+              setImmediate(() => {
+                if (!claimedUpgradeRequests.has(req) && !socket.destroyed) {
+                  log.warnOnce(UPGRADE_DELEGATION_MESSAGE)
+                }
+              })
+            }
+            return
+          }
+
+          // Track admitted sockets before any raw response write so the
+          // bounded pending-upgrade drain sees them (including the 501 path
+          // below, which can stall on a zero-window client).
+          if (!isSiblingHMRRequest) {
+            finishUpgrade = this.pendingUpgrades.track(socket)
+          }
+
+          if (
+            ownership === 'sibling' &&
+            !isSiblingHMRRequest &&
+            hasEnabledNextOwnedWebSocketUpgradeListener(upgradeListeners) &&
+            isWebSocketUpgradeRequest(req)
+          ) {
+            if (rejectedSiblingUpgradeRequests.has(req)) {
+              return
+            }
+            rejectedSiblingUpgradeRequests.add(req)
+            log.warnOnce(SIBLING_UPGRADE_MESSAGE)
+            await writeRawHttpError(req, socket, 501, SIBLING_UPGRADE_MESSAGE)
+            return
+          }
+
+          addRequestMeta(req, 'webSocketUpgradeOwnership', ownership)
+          if (ownership === 'sibling') {
+            // The router defers to the sibling only when a live sibling HMR
+            // matcher actually claims this request; URL shape alone is not
+            // enough (a route path containing `/_next/hmr` must not hang).
+            addRequestMeta(req, 'webSocketSiblingHMR', isSiblingHMRRequest)
+          }
+          if (
+            this.isClosing ||
+            socket.destroyed ||
+            socket.readableEnded ||
+            socket.writableEnded
+          ) {
+            if (!isSiblingHMRRequest && !socket.destroyed) socket.destroy()
+            return
+          }
           await this.upgradeHandler(req, socket, head)
         } catch (error) {
-          socket.destroy()
-          log.error(`Failed to handle request for ${req.url}`)
-          console.error(error)
+          let shouldDestroy = true
+          try {
+            shouldDestroy =
+              !this.isClosing || !isRawHttpResponseCommitted(socket)
+          } catch {}
+          if (shouldDestroy && !socket.destroyed) {
+            try {
+              socket.destroy()
+            } catch (destroyError) {
+              console.error(
+                'Failed to destroy a custom-server WebSocket upgrade after an error',
+                destroyError
+              )
+            }
+          }
+          console.error('Error handling upgrade request', error)
+        } finally {
+          try {
+            finishUpgrade?.()
+          } catch (error) {
+            console.error(
+              'Failed to release custom-server WebSocket upgrade tracking',
+              error
+            )
+          }
         }
       }
-      this.webSocketUpgradeListener = upgradeListener
+      let publicUpgradeListener!: UpgradeHandler
+      let automaticUpgradeListener!: UpgradeHandler
+      const isWebSocketRouteHandlersEnabled = () =>
+        Boolean(this.init?.webSocketRouteHandlersEnabled)
+      const isHMRRequest = (url: string | undefined) =>
+        Boolean(this.init?.isWebSocketHMRRequest?.(url))
+      publicUpgradeListener = markNextOwnedWebSocketUpgradeListener(
+        (req, socket, head) =>
+          dispatchUpgrade(
+            publicUpgradeListener,
+            automaticUpgradeListener,
+            req,
+            socket,
+            head
+          ),
+        isWebSocketRouteHandlersEnabled,
+        isHMRRequest
+      )
+      automaticUpgradeListener = markNextOwnedWebSocketUpgradeListener(
+        (req, socket, head) =>
+          dispatchUpgrade(
+            automaticUpgradeListener,
+            publicUpgradeListener,
+            req,
+            socket,
+            head
+          ),
+        isWebSocketRouteHandlersEnabled,
+        isHMRRequest
+      )
+      this.webSocketUpgradeListener = publicUpgradeListener
+      this.webSocketAutomaticUpgradeListener = automaticUpgradeListener
     }
     return this.webSocketUpgradeListener
   }
@@ -669,8 +1057,14 @@ class NextCustomServer implements NextWrapperServer {
     }
   }
 
+  /** @experimental WebSocket Route Handlers are an experimental feature. */
   getUpgradeHandler(): UpgradeHandler {
+    // Resolve the initialized router wrapper now so callers get a useful
+    // error if prepare() was skipped. The listener itself stays stable so an
+    // ordinary HTTP request cannot install a second copy after explicit
+    // custom-server wiring.
     this.getInit()
+    this.didWebSocketSetup = true
     return this.getOrCreateWebSocketUpgradeListener()
   }
 
@@ -711,40 +1105,166 @@ class NextCustomServer implements NextWrapperServer {
     return this.server.render404(...args)
   }
 
-  async close() {
-    const init = this.init
-    if (init) {
-      this.isClosing = true
-      const webSocketServer = this.webSocketServer
-      const webSocketServers = this.webSocketServers
-      const webSocketUpgradeListener = this.webSocketUpgradeListener
-      const webSocketOwnershipTracker = this.webSocketOwnershipTracker
-      this.webSocketServer = undefined
-      this.webSocketServers = new Set()
-      this.webSocketUpgradeListener = undefined
-      this.webSocketOwnershipTracker = undefined
+  private closeImpl(code?: number): Promise<void> {
+    const generation = this.prepareGeneration
+    if (!generation) {
+      if (this.closeGeneration && !this.closeGeneration.prepare.init) {
+        return this.closeGeneration.promise
+      }
+      // close() historically did nothing before prepare(). Do not memoize that
+      // no-op: a later preparation creates the first closeable generation.
+      return Promise.resolve()
+    }
+    if (this.closeGeneration?.prepare === generation) {
+      return this.closeGeneration.promise
+    }
 
-      if (webSocketServer) webSocketServers.add(webSocketServer)
-      if (webSocketUpgradeListener) {
-        for (const server of webSocketServers) {
-          this.removeWebSocketUpgradeListener(server, webSocketUpgradeListener)
+    // Install the authoritative promise before changing EventEmitter state or
+    // invoking any lifecycle capability. In particular, server.off() emits the
+    // public removeListener event synchronously and can re-enter app.close().
+    const closing = createPromiseWithResolvers<void>()
+    this.closeGeneration = { prepare: generation, promise: closing.promise }
+
+    this.isClosing = true
+    const closePending = generation.pendingUpgrades.closePending()
+    // Preparation can still be settling. Mark the eagerly-latched drain as
+    // observed until the ordered shutdown phase awaits its real result.
+    void closePending.catch(() => {})
+    const webSocketServer = this.webSocketServer
+    const webSocketUpgradeListener = this.webSocketUpgradeListener
+    const webSocketAutomaticUpgradeListener =
+      this.webSocketAutomaticUpgradeListener
+    const webSocketUpgradeOwnership = this.webSocketUpgradeOwnership
+    const webSocketRegistration = this.webSocketRegistration
+    const webSocketUpgradeServers = new Set(this.webSocketUpgradeServers)
+    if (webSocketServer) webSocketUpgradeServers.add(webSocketServer)
+
+    // Clear owned registration state before invoking public EventEmitter
+    // removal hooks. Re-entrant close() callers observe the promise above.
+    this.webSocketServer = undefined
+    this.webSocketUpgradeOwnership = undefined
+    this.webSocketRegistration = undefined
+    this.webSocketUpgradeServers.clear()
+
+    const runClose = async () => {
+      const failures: unknown[] = []
+      const addFailure = (error: unknown) => {
+        addDistinctServerCleanupFailures(failures, error)
+      }
+      const settle = async (stages: Array<() => void | PromiseLike<void>>) => {
+        const results = await Promise.allSettled(
+          stages.map(async (stage) => stage())
+        )
+        for (const result of results) {
+          if (result.status === 'rejected') addFailure(result.reason)
         }
       }
-      try {
-        webSocketOwnershipTracker?.dispose()
-      } catch (error) {
-        console.error(
-          'Failed to dispose the custom-server WebSocket ownership tracker',
-          error
-        )
+
+      await settle([
+        async () => {
+          await webSocketRegistration
+          if (webSocketUpgradeListener || webSocketAutomaticUpgradeListener) {
+            const removalFailures: unknown[] = []
+            try {
+              webSocketUpgradeOwnership?.dispose()
+            } catch (error) {
+              removalFailures.push(error)
+            }
+            for (const server of webSocketUpgradeServers) {
+              for (const listener of [
+                webSocketAutomaticUpgradeListener,
+                webSocketUpgradeListener,
+              ]) {
+                if (!listener) continue
+                for (const error of removeUpgradeListenerRegistrations(
+                  server,
+                  listener
+                )) {
+                  addDistinctServerCleanupFailures(removalFailures, error)
+                }
+              }
+            }
+            throwCombinedFailures(
+              removalFailures,
+              'Failed to remove the custom-server WebSocket upgrade listener'
+            )
+          }
+        },
+      ])
+
+      let prepareFailed = false
+      if (!generation.init) {
+        // Bound the wait: a dev compile can take minutes while close() must
+        // return. Past the grace period proceed without the init stage; a
+        // later completing prepare never becomes closeable.
+        let prepareTimer: ReturnType<typeof setTimeout> | undefined
+        try {
+          await new Promise<void>((resolve, reject) => {
+            prepareTimer = setTimeout(() => {
+              prepareFailed = true
+              log.warnOnce(
+                'Custom server close() is proceeding without an in-flight prepare() settling.'
+              )
+              resolve()
+            }, PREPARE_CLOSE_GRACE_PERIOD_MS)
+            prepareTimer.unref?.()
+            generation.promise.then(() => resolve(), reject)
+          })
+        } catch {
+          prepareFailed = true
+        } finally {
+          if (prepareTimer !== undefined) clearTimeout(prepareTimer)
+        }
       }
 
-      await init.closeUpgraded(1001).catch(console.error)
+      const init = generation.init
+      // Complete every admitted raw handler before taking the one
+      // authoritative registry snapshot. No peer can register after this
+      // phase because closePending() latched admission synchronously above.
+      await settle([() => closePending])
+      await settle([() => init?.closeUpgraded(code)])
+      await settle([
+        () => init?.server.close(),
+        () => generation.cleanupListeners?.runAll(),
+      ])
+
+      // close() predates WebSocket Route Handlers and historically swallowed
+      // every cleanup rejection. Preserve that behavior unless the application
+      // explicitly opts into the experimental public teardown contract.
+      if (
+        prepareFailed ||
+        (!init?.webSocketRouteHandlersEnabled &&
+          !generation.reportCleanupFailures)
+      ) {
+        return
+      }
+      throwCombinedFailures(
+        failures,
+        'Failed to close the Next.js custom server'
+      )
     }
-    await Promise.allSettled([
-      init?.server.close(),
-      this.cleanupListeners?.runAll(),
-    ])
+
+    void runClose().then(
+      () => {
+        // A failed preparation never created a closeable generation. Release
+        // the terminal state so a later successful prepare() can be closed.
+        if (!generation.init) {
+          if (this.closeGeneration?.promise === closing.promise) {
+            this.closeGeneration = undefined
+          }
+          if (!this.prepareGeneration) this.isClosing = false
+        }
+        closing.resolve()
+      },
+      (error) => {
+        closing.reject(error)
+      }
+    )
+    return closing.promise
+  }
+
+  close(): Promise<void> {
+    return this.closeImpl()
   }
 }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -232,8 +232,14 @@ export interface RequestMeta {
   /** Framework-owned lifecycle scope for a routed WebSocket upgrade. */
   webSocketRegistryScope?: object
 
-  /** Whether no external upgrade listener has existed on this request's server. */
-  webSocketUpgradeExclusiveOwner?: boolean
+  /** How the embedding server dispatched this WebSocket upgrade. */
+  webSocketUpgradeOwnership?: import('./websocket-upgrade-listener').WebSocketUpgradeOwnership
+  /**
+   * Set by the custom-server dispatch layer when a sibling Next.js app's live
+   * HMR matcher claims this request. Lets the router defer to that sibling
+   * instead of guessing from the URL shape.
+   */
+  webSocketSiblingHMR?: boolean
 
   /**
    * Whether the request should render the fallback shell or not.

--- a/packages/next/src/server/websocket-http.test.ts
+++ b/packages/next/src/server/websocket-http.test.ts
@@ -18,27 +18,125 @@ import {
   writeRawHttpError,
   writeRawHttpResponse,
 } from './websocket-http'
-import { createWebSocketUpgradeListenerOwnershipTracker } from './websocket-upgrade-listener'
+import {
+  claimWebSocketHMRRequestOnce,
+  classifyWebSocketUpgradeOwnership,
+  createWebSocketUpgradeListenerOwnershipTracker,
+  hasMatchingNextOwnedWebSocketHMRListener,
+  isNextHMRUpgradeRequest,
+  markNextOwnedWebSocketUpgradeListener,
+} from './websocket-upgrade-listener'
+import { PendingWebSocketUpgradeTracker } from './websocket-lifecycle'
 
 describe('WebSocket upgrade listener ownership', () => {
+  it.each([
+    ['/_next/hmr', true],
+    ['/guest/_next/hmr?session=1', true],
+    ['/socket', false],
+    ['/socket?next=/_next/hmr', false],
+    ['/_next/hmr-other', false],
+    [undefined, false],
+  ] as const)('classifies HMR upgrade paths %#', (url, expected) => {
+    expect(isNextHMRUpgradeRequest(url)).toBe(expected)
+  })
+
+  it.each([
+    [undefined, 'shared'],
+    [[], 'shared'],
+  ] as const)(
+    'fails closed for opaque listener state %#',
+    (listeners, owner) => {
+      expect(classifyWebSocketUpgradeOwnership(listeners, jest.fn())).toBe(
+        owner
+      )
+    }
+  )
+
+  it('classifies exclusive, coordinated, sibling, duplicate-own, and shared dispatch', () => {
+    const own = jest.fn()
+    const automatic = jest.fn()
+    const outer = jest.fn()
+    const sibling = markNextOwnedWebSocketUpgradeListener(jest.fn())
+
+    expect(classifyWebSocketUpgradeOwnership([own], own)).toBe('exclusive')
+    expect(classifyWebSocketUpgradeOwnership([outer], own)).toBe('coordinated')
+    expect(classifyWebSocketUpgradeOwnership([own, own], own)).toBe('exclusive')
+    expect(classifyWebSocketUpgradeOwnership([own, outer], own)).toBe('shared')
+    expect(classifyWebSocketUpgradeOwnership([own, sibling], own)).toBe(
+      'sibling'
+    )
+    expect(
+      classifyWebSocketUpgradeOwnership([automatic, sibling, outer], own, [
+        automatic,
+      ])
+    ).toBe('coordinated')
+    expect(classifyWebSocketUpgradeOwnership([outer, jest.fn()], own)).toBe(
+      'shared'
+    )
+    expect(
+      classifyWebSocketUpgradeOwnership([automatic, outer], own, [automatic])
+    ).toBe('coordinated')
+    expect(
+      classifyWebSocketUpgradeOwnership([automatic, own], own, [automatic])
+    ).toBe('exclusive')
+  })
+
+  it('matches only development HMR paths owned by registered listeners', () => {
+    const host = markNextOwnedWebSocketUpgradeListener(
+      jest.fn(),
+      () => true,
+      (url) => Boolean(url?.startsWith('/_next/hmr'))
+    )
+    const guest = markNextOwnedWebSocketUpgradeListener(
+      jest.fn(),
+      () => true,
+      (url) => Boolean(url?.startsWith('/guest/_next/hmr'))
+    )
+
+    expect(
+      hasMatchingNextOwnedWebSocketHMRListener(
+        [host, guest],
+        '/guest/_next/hmr?session=1'
+      )
+    ).toBe(true)
+    expect(
+      hasMatchingNextOwnedWebSocketHMRListener(
+        [host, guest],
+        '/bogus/_next/hmr'
+      )
+    ).toBe(false)
+  })
+
+  it('claims an HMR upgrade exactly once for overlapping sibling prefixes', () => {
+    const request = { url: '/assets/_next/hmr' }
+
+    // Two apps share one HMR path (e.g. one basePath overlapping another's
+    // assetPrefix). The first app to reach the claim owns the connection;
+    // the sibling defers instead of both answering.
+    expect(claimWebSocketHMRRequestOnce(request)).toBe(true)
+    expect(claimWebSocketHMRRequestOnce(request)).toBe(false)
+  })
+
   it.each(['on', 'once', 'prependListener', 'prependOnceListener'] as const)(
     'permanently delegates after an external %s listener is registered',
     (method) => {
       const server = new EventEmitter()
       const ownListener = jest.fn()
       const externalListener = jest.fn()
-      const { isExclusiveOwner } =
-        createWebSocketUpgradeListenerOwnershipTracker(server, ownListener)
+      const { getOwnership } = createWebSocketUpgradeListenerOwnershipTracker(
+        server,
+        ownListener
+      )
 
       server.on('upgrade', ownListener)
-      expect(isExclusiveOwner()).toBe(true)
+      expect(getOwnership()).toBe('exclusive')
 
       server[method]('upgrade', externalListener)
       server.emit('upgrade')
       server.removeListener('upgrade', externalListener)
 
       expect(server.listeners('upgrade')).toEqual([ownListener])
-      expect(isExclusiveOwner()).toBe(false)
+      expect(getOwnership()).toBe('shared')
     }
   )
 
@@ -48,47 +146,81 @@ describe('WebSocket upgrade listener ownership', () => {
     const ownListener = jest.fn()
 
     server.on('upgrade', externalListener)
-    const { isExclusiveOwner } = createWebSocketUpgradeListenerOwnershipTracker(
+    const { getOwnership } = createWebSocketUpgradeListenerOwnershipTracker(
       server,
       ownListener
     )
     server.on('upgrade', ownListener)
     server.removeListener('upgrade', externalListener)
 
-    expect(isExclusiveOwner()).toBe(false)
+    expect(getOwnership()).toBe('shared')
   })
 
-  it('rejects duplicate and multiple Next listener registrations', () => {
+  it('accepts duplicate copies of one Next listener but rejects distinct listeners', () => {
     const duplicateServer = new EventEmitter()
     const duplicateListener = jest.fn()
-    const { isExclusiveOwner: isDuplicateExclusiveOwner } =
+    const { getOwnership: getDuplicateOwnership } =
       createWebSocketUpgradeListenerOwnershipTracker(
         duplicateServer,
         duplicateListener
       )
     duplicateServer.on('upgrade', duplicateListener)
-    expect(isDuplicateExclusiveOwner()).toBe(true)
+    expect(getDuplicateOwnership()).toBe('exclusive')
     duplicateServer.on('upgrade', duplicateListener)
-    expect(isDuplicateExclusiveOwner()).toBe(false)
+    expect(getDuplicateOwnership()).toBe('exclusive')
 
     const sharedServer = new EventEmitter()
     const firstOwnListener = jest.fn()
     const secondOwnListener = jest.fn()
-    const { isExclusiveOwner: isFirstExclusiveOwner } =
+    const { getOwnership: getFirstOwnership } =
       createWebSocketUpgradeListenerOwnershipTracker(
         sharedServer,
         firstOwnListener
       )
     sharedServer.on('upgrade', firstOwnListener)
-    const { isExclusiveOwner: isSecondExclusiveOwner } =
+    const { getOwnership: getSecondOwnership } =
       createWebSocketUpgradeListenerOwnershipTracker(
         sharedServer,
         secondOwnListener
       )
     sharedServer.on('upgrade', secondOwnListener)
 
-    expect(isFirstExclusiveOwner()).toBe(false)
-    expect(isSecondExclusiveOwner()).toBe(false)
+    expect(getFirstOwnership()).toBe('shared')
+    expect(getSecondOwnership()).toBe('shared')
+  })
+
+  it('distinguishes listeners owned by sibling Next.js instances', () => {
+    const server = new EventEmitter()
+    const firstListener = markNextOwnedWebSocketUpgradeListener(jest.fn())
+    const secondListener = markNextOwnedWebSocketUpgradeListener(jest.fn())
+    const { getOwnership: getFirstOwnership } =
+      createWebSocketUpgradeListenerOwnershipTracker(server, firstListener)
+    server.on('upgrade', firstListener)
+    const { getOwnership: getSecondOwnership } =
+      createWebSocketUpgradeListenerOwnershipTracker(server, secondListener)
+    server.on('upgrade', secondListener)
+
+    expect(getFirstOwnership()).toBe('sibling')
+    expect(getSecondOwnership()).toBe('sibling')
+  })
+
+  it('recognizes distinct automatic and public Next listeners as one owner', () => {
+    const server = new EventEmitter()
+    const automaticListener = jest.fn()
+    const publicListener = jest.fn()
+    const externalListener = jest.fn()
+    const { getOwnership } = createWebSocketUpgradeListenerOwnershipTracker(
+      server,
+      automaticListener,
+      [publicListener]
+    )
+
+    server.on('upgrade', automaticListener)
+    server.on('upgrade', publicListener)
+    expect(getOwnership()).toBe('exclusive')
+
+    server.on('upgrade', externalListener)
+    expect(getOwnership()).toBe('shared')
   })
 
   it('disposes its new-listener observer', () => {
@@ -105,7 +237,87 @@ describe('WebSocket upgrade listener ownership', () => {
     tracker.dispose()
 
     expect(server.listenerCount('newListener')).toBe(baseline)
-    expect(tracker.isExclusiveOwner()).toBe(false)
+    expect(tracker.getOwnership()).toBe('shared')
+  })
+})
+
+describe('pending WebSocket upgrade lifecycle', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('memoizes close and synchronously rejects later admission', async () => {
+    const tracker = new PendingWebSocketUpgradeTracker()
+    const firstClose = tracker.closePending()
+    const lateSocket = new PassThrough()
+
+    expect(tracker.closePending()).toBe(firstClose)
+    tracker.track(lateSocket)
+    expect(lateSocket.destroyed).toBe(true)
+    await expect(firstClose).resolves.toBeUndefined()
+  })
+
+  it('lets an admitted handler finish during the bounded grace period', async () => {
+    jest.useFakeTimers()
+    const tracker = new PendingWebSocketUpgradeTracker()
+    const socket = new PassThrough()
+    const finish = tracker.track(socket)
+
+    const close = tracker.closePending()
+    jest.advanceTimersByTime(4_999)
+    await Promise.resolve()
+    expect(socket.destroyed).toBe(false)
+
+    finish()
+    await expect(close).resolves.toBeUndefined()
+    expect(socket.destroyed).toBe(false)
+    socket.destroy()
+  })
+
+  it('gives a committed response bounded grace before forcing close', async () => {
+    jest.useFakeTimers()
+    const tracker = new PendingWebSocketUpgradeTracker()
+    const socket = new PassThrough()
+    markRawHttpResponseCommitted(socket, 101)
+    tracker.track(socket)
+
+    const close = tracker.closePending()
+    jest.advanceTimersByTime(4_999)
+    await Promise.resolve()
+    expect(socket.destroyed).toBe(false)
+
+    jest.advanceTimersByTime(1)
+    await expect(close).resolves.toBeUndefined()
+    expect(socket.destroyed).toBe(true)
+  })
+
+  it('does not truncate a response ending before its commit marker', async () => {
+    const tracker = new PendingWebSocketUpgradeTracker()
+    const socket = new PassThrough()
+    tracker.track(socket)
+    socket.end('upstream response')
+
+    const close = tracker.closePending()
+
+    expect(socket.writableEnded).toBe(true)
+    expect(socket.destroyed).toBe(false)
+    socket.destroy()
+    await expect(close).resolves.toBeUndefined()
+  })
+
+  it('removes listeners inserted after a reentrant terminal event', async () => {
+    const tracker = new PendingWebSocketUpgradeTracker()
+    const socket = new PassThrough()
+    socket.on('newListener', (event) => {
+      if (event === 'close') socket.emit('end')
+    })
+
+    tracker.track(socket)
+
+    expect(socket.destroyed).toBe(true)
+    expect(socket.listenerCount('end')).toBe(0)
+    expect(socket.listenerCount('close')).toBe(0)
+    await expect(tracker.closePending()).resolves.toBeUndefined()
   })
 })
 
@@ -540,6 +752,30 @@ describe('raw WebSocket upgrade responses', () => {
       'Failed to remove a WebSocket upgrade socket error owner',
       failure
     )
+  })
+
+  it('releases only Next.js error listeners before coordinated delegation', () => {
+    const request = new PassThrough() as unknown as IncomingMessage
+    const socket = new PassThrough()
+    const requestOwner = jest.fn()
+    const socketOwner = jest.fn()
+    request.on('error', requestOwner)
+    socket.on('error', socketOwner)
+    const requestBaseline = request.listenerCount('error')
+    const socketErrorBaseline = socket.listenerCount('error')
+    const socketCloseBaseline = socket.listenerCount('close')
+
+    const release = ownWebSocketUpgradeSocketErrors(request, socket)
+    expect(ownWebSocketUpgradeSocketErrors(request, socket)).toBe(release)
+    expect(release()).toEqual([])
+
+    expect(request.listenerCount('error')).toBe(requestBaseline)
+    expect(socket.listenerCount('error')).toBe(socketErrorBaseline)
+    expect(socket.listenerCount('close')).toBe(socketCloseBaseline)
+    expect(request.listeners('error')).toContain(requestOwner)
+    expect(socket.listeners('error')).toContain(socketOwner)
+    expect(socket.destroyed).toBe(false)
+    socket.destroy()
   })
 
   it('settles final socket teardown when close-listener removal throws', async () => {

--- a/packages/next/src/server/websocket-http.ts
+++ b/packages/next/src/server/websocket-http.ts
@@ -315,13 +315,14 @@ export function createOwnedListeners(): {
 export function ownWebSocketUpgradeSocketErrors(
   req: IncomingMessage,
   socket: Duplex
-): void {
+): () => unknown[] {
   const ownedSocket = socket as Duplex & {
-    [RAW_UPGRADE_ERROR_OWNER]?: object
+    [RAW_UPGRADE_ERROR_OWNER]?: { release?: () => unknown[] }
   }
-  if (ownedSocket[RAW_UPGRADE_ERROR_OWNER]) return
+  const existingOwner = ownedSocket[RAW_UPGRADE_ERROR_OWNER]
+  if (existingOwner) return existingOwner.release ?? (() => [])
 
-  const owner = {}
+  const owner: { release?: () => unknown[] } = {}
   // Install-phase deferral latch (shared pattern with the other raw-socket
   // sites): events arriving synchronously from hostile EventEmitter hooks
   // during install() are deferred and replayed after installation completes.
@@ -362,6 +363,7 @@ export function ownWebSocketUpgradeSocketErrors(
     }
   }
 
+  owner.release = cleanup
   Object.defineProperty(ownedSocket, RAW_UPGRADE_ERROR_OWNER, {
     configurable: true,
     value: owner,
@@ -380,6 +382,7 @@ export function ownWebSocketUpgradeSocketErrors(
     )
   }
   if (closeRequested || isSocketWriteClosed(socket)) onClose()
+  return cleanup
 }
 
 async function writeSocket(socket: Duplex, chunk: Uint8Array | string) {

--- a/packages/next/src/server/websocket-lifecycle.ts
+++ b/packages/next/src/server/websocket-lifecycle.ts
@@ -1,0 +1,207 @@
+import type { Duplex } from 'node:stream'
+
+import {
+  createOwnedListeners,
+  isRawHttpResponseCommitted,
+  throwCombinedFailures,
+  tryDestroySocket,
+} from './websocket-http'
+import {
+  UPGRADE_HANDLER_CLOSE_GRACE_PERIOD_MS,
+  PENDING_UPGRADE_IDLE_TIMEOUT_MS,
+} from './websocket-shutdown-budget'
+
+interface PendingUpgrade {
+  socket: Duplex
+  done: Promise<void>
+  finish(): unknown[]
+}
+
+function isCommittedOrFlushing(socket: Duplex): boolean {
+  return (
+    isRawHttpResponseCommitted(socket) ||
+    socket.writableEnded ||
+    socket.writableFinished
+  )
+}
+
+/**
+ * Tracks raw Node.js upgrade handlers until ownership moves to either a
+ * committed response or the WebSocket connection registry.
+ */
+export class PendingWebSocketUpgradeTracker {
+  private admissionClosed = false
+  private closePromise?: Promise<void>
+  private readonly pending = new Set<PendingUpgrade>()
+  private readonly failures: unknown[] = []
+
+  private record(failures: unknown[]): void {
+    for (const failure of failures) {
+      if (!this.failures.includes(failure)) this.failures.push(failure)
+    }
+  }
+
+  private destroy(socket: Duplex): void {
+    tryDestroySocket(socket, (error) => {
+      if (!this.failures.includes(error)) this.failures.push(error)
+    })
+  }
+
+  track(socket: Duplex): () => void {
+    if (this.admissionClosed) {
+      this.destroy(socket)
+      return () => {}
+    }
+
+    let resolve!: () => void
+    const done = new Promise<void>((complete) => {
+      resolve = complete
+    })
+    // Bound the pre-commit window: after Node emits `upgrade`, its HTTP
+    // request timeouts no longer govern the socket. Destroy connections that
+    // move no bytes for the whole budget so a client cannot pin a stalled
+    // handler or a backpressured raw response write indefinitely. Cleared on
+    // handoff to a committed response or the connection registry.
+    const setSocketTimeout = (
+      socket as { setTimeout?: (ms: number) => void }
+    ).setTimeout?.bind(socket)
+    setSocketTimeout?.(PENDING_UPGRADE_IDLE_TIMEOUT_MS)
+
+    let finished = false
+    // Install-phase deferral latch (see ownWebSocketUpgradeSocketErrors).
+    let installing = true
+    let finishRequested = false
+    let endRemovalRequested = false
+    const listeners = createOwnedListeners()
+    const pending: PendingUpgrade = {
+      socket,
+      done,
+      finish: () => {
+        if (finished) return []
+        if (installing) {
+          finishRequested = true
+          return []
+        }
+        finished = true
+        try {
+          setSocketTimeout?.(0)
+          return listeners.remove()
+        } finally {
+          this.pending.delete(pending)
+          resolve()
+        }
+      },
+    }
+    this.pending.add(pending)
+    const onClose = () => {
+      this.record(pending.finish())
+    }
+    const onEnd = () => {
+      let committed = false
+      try {
+        committed = isCommittedOrFlushing(socket)
+      } catch (error) {
+        if (!this.failures.includes(error)) this.failures.push(error)
+      }
+      if (committed) {
+        if (installing) {
+          endRemovalRequested = true
+        } else {
+          this.record(listeners.remove(endEntry))
+        }
+        return
+      }
+      this.destroy(socket)
+      this.record(pending.finish())
+    }
+    // Total inactivity for the whole budget destroys the pinned connection and
+    // settles tracking through the ordinary finish path.
+    const onIdleTimeout = () => {
+      this.destroy(socket)
+      this.record(pending.finish())
+    }
+    const endEntry = { target: socket, event: 'end', listener: onEnd }
+    const closeEntry = { target: socket, event: 'close', listener: onClose }
+    const timeoutEntry = {
+      target: socket,
+      event: 'timeout',
+      listener: onIdleTimeout,
+    }
+
+    const installFailures = listeners.install([
+      endEntry,
+      closeEntry,
+      timeoutEntry,
+    ])
+    installing = false
+    if (installFailures.length > 0) {
+      finished = true
+      this.pending.delete(pending)
+      resolve()
+      this.record(installFailures)
+      throwCombinedFailures(
+        installFailures,
+        'Failed to close pending WebSocket upgrades'
+      )
+    }
+
+    if (endRemovalRequested) {
+      this.record(listeners.remove(endEntry))
+    }
+
+    if (finishRequested || socket.destroyed || socket.closed) {
+      this.record(pending.finish())
+    } else if (socket.readableEnded) {
+      onEnd()
+    }
+
+    return () => {
+      this.record(pending.finish())
+    }
+  }
+
+  closePending(): Promise<void> {
+    if (this.closePromise) return this.closePromise
+
+    // Close admission synchronously so a re-entrant upgrade cannot enter after
+    // the shutdown snapshot but before the async drain starts.
+    this.admissionClosed = true
+    const pending = Array.from(this.pending)
+    this.closePromise = this.drain(pending)
+    return this.closePromise
+  }
+
+  private async drain(pending: PendingUpgrade[]): Promise<void> {
+    if (pending.length > 0) {
+      let timeout: NodeJS.Timeout | undefined
+      try {
+        const result = await Promise.race([
+          Promise.allSettled(pending.map((upgrade) => upgrade.done)).then(
+            () => 'settled' as const
+          ),
+          new Promise<'timeout'>((resolve) => {
+            timeout = setTimeout(
+              () => resolve('timeout'),
+              UPGRADE_HANDLER_CLOSE_GRACE_PERIOD_MS
+            )
+          }),
+        ])
+        if (result === 'timeout') {
+          for (const upgrade of pending) {
+            if (this.pending.has(upgrade)) {
+              this.destroy(upgrade.socket)
+              this.record(upgrade.finish())
+            }
+          }
+        }
+      } finally {
+        if (timeout) clearTimeout(timeout)
+      }
+    }
+
+    throwCombinedFailures(
+      this.failures,
+      'Failed to close pending WebSocket upgrades'
+    )
+  }
+}

--- a/packages/next/src/server/websocket-upgrade-listener.test.ts
+++ b/packages/next/src/server/websocket-upgrade-listener.test.ts
@@ -1,0 +1,47 @@
+import { PassThrough } from 'node:stream'
+import { armUnclaimedUpgradeSocketTimeout } from './websocket-upgrade-listener'
+import { PENDING_UPGRADE_IDLE_TIMEOUT_MS } from './websocket-shutdown-budget'
+
+function fakeSocket() {
+  const socket = new PassThrough()
+  const setTimeout = jest.fn()
+  Object.assign(socket, { setTimeout })
+  return { socket, setTimeout }
+}
+
+describe('armUnclaimedUpgradeSocketTimeout', () => {
+  it('arms the idle budget and destroys an unclaimed socket on timeout', () => {
+    const { socket, setTimeout } = fakeSocket()
+    armUnclaimedUpgradeSocketTimeout(socket)
+    expect(setTimeout).toHaveBeenCalledWith(PENDING_UPGRADE_IDLE_TIMEOUT_MS)
+
+    socket.emit('timeout')
+    expect(socket.destroyed).toBe(true)
+  })
+
+  it('does not arm when another listener already claimed the socket', () => {
+    const { socket, setTimeout } = fakeSocket()
+    socket.on('data', () => {})
+    armUnclaimedUpgradeSocketTimeout(socket)
+    expect(setTimeout).not.toHaveBeenCalled()
+  })
+
+  it('spares a socket claimed after arming and disarms the timeout', () => {
+    const { socket, setTimeout } = fakeSocket()
+    armUnclaimedUpgradeSocketTimeout(socket)
+
+    // A listener claims the socket after our handler returned.
+    socket.on('data', () => {})
+    socket.emit('timeout')
+    expect(socket.destroyed).toBe(false)
+    // The timeout was disarmed.
+    expect(setTimeout).toHaveBeenLastCalledWith(0)
+  })
+
+  it('is a no-op for sockets without setTimeout', () => {
+    const socket = new PassThrough()
+    expect(() => armUnclaimedUpgradeSocketTimeout(socket)).not.toThrow()
+    expect(socket.destroyed).toBe(false)
+    socket.destroy()
+  })
+})

--- a/packages/next/src/server/websocket-upgrade-listener.ts
+++ b/packages/next/src/server/websocket-upgrade-listener.ts
@@ -1,22 +1,169 @@
 import type { EventEmitter } from 'node:events'
+import type { Duplex } from 'node:stream'
+import { PENDING_UPGRADE_IDLE_TIMEOUT_MS } from './websocket-shutdown-budget'
 
 type UpgradeListenerOwnershipState = {
-  ownListenerRegistered: boolean
   externalListenerSeen: boolean
   onNewListener?: (eventName: string | symbol, listener: unknown) => void
 }
 
 export interface WebSocketUpgradeListenerOwnershipTracker {
-  isExclusiveOwner(): boolean
+  getOwnership(): WebSocketUpgradeOwnership
   dispose(): void
+}
+
+export type WebSocketUpgradeOwnership =
+  | 'exclusive'
+  | 'coordinated'
+  | 'sibling'
+  | 'shared'
+
+/** Shared guidance emitted by both dispatch layers when an upgrade is delegated. */
+export const UPGRADE_DELEGATION_MESSAGE =
+  'Next.js delegated an upgrade event because another custom-server upgrade listener may own the socket. Use app.getUpgradeHandler() from one outer dispatcher to coordinate WebSocket Route Handlers with another protocol.'
+
+type NextOwnedUpgradeListener = {
+  isWebSocketRouteHandlersEnabled: () => boolean
+  isHMRRequest: (url: string | undefined) => boolean
+}
+
+const nextOwnedUpgradeListeners = new WeakMap<
+  object,
+  NextOwnedUpgradeListener
+>()
+
+/** Marks a listener so sibling Next.js custom-server instances can be detected. */
+export function markNextOwnedWebSocketUpgradeListener<T extends object>(
+  listener: T,
+  isWebSocketRouteHandlersEnabled: () => boolean = () => false,
+  isHMRRequest: (url: string | undefined) => boolean = () => false
+): T {
+  nextOwnedUpgradeListeners.set(listener, {
+    isWebSocketRouteHandlersEnabled,
+    isHMRRequest,
+  })
+  return listener
+}
+
+export function hasEnabledNextOwnedWebSocketUpgradeListener(
+  listeners: readonly unknown[] | undefined
+): boolean {
+  return Boolean(
+    listeners?.some(
+      (listener) =>
+        (typeof listener === 'object' || typeof listener === 'function') &&
+        listener !== null &&
+        nextOwnedUpgradeListeners
+          .get(listener as object)
+          ?.isWebSocketRouteHandlersEnabled()
+    )
+  )
+}
+
+const claimedHMRUpgradeRequests = new WeakSet<object>()
+
+/**
+ * Claims an HMR upgrade request for the first app to reach it. Two apps can
+ * share one live HMR path (e.g. one app's basePath overlapping another's
+ * assetPrefix); only the earliest-reaching app may run its HMR handler on the
+ * socket. Requests are single-use, so the claim never needs releasing.
+ */
+export function claimWebSocketHMRRequestOnce(req: object): boolean {
+  if (claimedHMRUpgradeRequests.has(req)) return false
+  claimedHMRUpgradeRequests.add(req)
+  return true
+}
+
+export function hasMatchingNextOwnedWebSocketHMRListener(
+  listeners: readonly unknown[] | undefined,
+  url: string | undefined
+): boolean {
+  return Boolean(
+    listeners?.some(
+      (listener) =>
+        (typeof listener === 'object' || typeof listener === 'function') &&
+        listener !== null &&
+        nextOwnedUpgradeListeners.get(listener as object)?.isHMRRequest(url)
+    )
+  )
+}
+
+export function isNextHMRUpgradeRequest(
+  url: string | undefined,
+  hmrPath?: string
+): boolean {
+  const pathname = url?.split(/[?#]/, 1)[0] ?? ''
+  if (hmrPath) {
+    return pathname === hmrPath || pathname.startsWith(`${hmrPath}/`)
+  }
+  return /(?:^|\/)_next\/hmr(?:\/|$)/.test(pathname)
+}
+
+function isNextOwnedUpgradeListener(listener: unknown): boolean {
+  return (
+    (typeof listener === 'object' || typeof listener === 'function') &&
+    listener !== null &&
+    nextOwnedUpgradeListeners.has(listener as object)
+  )
+}
+
+function isOwnedUpgradeListener(
+  listener: unknown,
+  ownListener: object,
+  additionalOwnListeners: readonly object[]
+): boolean {
+  return (
+    listener === ownListener ||
+    additionalOwnListeners.includes(listener as object)
+  )
+}
+
+export function classifyWebSocketUpgradeOwnership(
+  listeners: readonly unknown[] | undefined,
+  ownListener: object,
+  additionalOwnListeners: readonly object[] = []
+): WebSocketUpgradeOwnership {
+  if (!listeners || listeners.length === 0) return 'shared'
+  const ownRegistered = listeners.includes(ownListener)
+  if (ownRegistered) {
+    if (
+      listeners.every((listener) =>
+        isOwnedUpgradeListener(listener, ownListener, additionalOwnListeners)
+      )
+    ) {
+      return 'exclusive'
+    }
+    return listeners.every(
+      (listener) =>
+        isOwnedUpgradeListener(listener, ownListener, additionalOwnListeners) ||
+        isNextOwnedUpgradeListener(listener)
+    )
+      ? 'sibling'
+      : 'shared'
+  }
+  let externalListenerCount = 0
+  for (const listener of listeners) {
+    if (
+      !isOwnedUpgradeListener(listener, ownListener, additionalOwnListeners) &&
+      !isNextOwnedUpgradeListener(listener)
+    ) {
+      externalListenerCount++
+    }
+  }
+  return externalListenerCount === 1 ? 'coordinated' : 'shared'
 }
 
 function hasExternalUpgradeListener(
   server: EventEmitter,
-  ownListener: object
+  ownListener: object,
+  additionalOwnListeners: readonly object[]
 ): boolean {
   const listeners = server.listeners('upgrade')
-  return listeners.length !== 1 || listeners[0] !== ownListener
+  return listeners.some(
+    (listener) =>
+      !isOwnedUpgradeListener(listener, ownListener, additionalOwnListeners) &&
+      !isNextOwnedUpgradeListener(listener)
+  )
 }
 
 function markExternalUpgradeListener(
@@ -40,18 +187,24 @@ function markExternalUpgradeListener(
  */
 export function createWebSocketUpgradeListenerOwnershipTracker(
   server: EventEmitter,
-  ownListener: object
+  ownListener: object,
+  additionalOwnListeners: readonly object[] = []
 ): WebSocketUpgradeListenerOwnershipTracker {
   const state: UpgradeListenerOwnershipState = {
-    ownListenerRegistered: false,
-    externalListenerSeen: server.listenerCount('upgrade') !== 0,
+    externalListenerSeen: hasExternalUpgradeListener(
+      server,
+      ownListener,
+      additionalOwnListeners
+    ),
   }
 
   if (!state.externalListenerSeen) {
     state.onNewListener = (eventName, listener) => {
       if (eventName !== 'upgrade') return
-      if (listener === ownListener && !state.ownListenerRegistered) {
-        state.ownListenerRegistered = true
+      if (
+        isOwnedUpgradeListener(listener, ownListener, additionalOwnListeners) ||
+        isNextOwnedUpgradeListener(listener)
+      ) {
         return
       }
       markExternalUpgradeListener(server, state)
@@ -64,24 +217,30 @@ export function createWebSocketUpgradeListenerOwnershipTracker(
   // upgrade listener in that gap.
   if (
     server.listenerCount('upgrade') !== 0 &&
-    hasExternalUpgradeListener(server, ownListener)
+    hasExternalUpgradeListener(server, ownListener, additionalOwnListeners)
   ) {
     markExternalUpgradeListener(server, state)
   }
 
   let disposed = false
   return {
-    isExclusiveOwner() {
-      if (disposed) return false
+    getOwnership() {
+      if (disposed) return 'shared'
       // Retain a live scan as a fallback if embedding code removed the
       // observer.
       if (
         !state.externalListenerSeen &&
-        hasExternalUpgradeListener(server, ownListener)
+        hasExternalUpgradeListener(server, ownListener, additionalOwnListeners)
       ) {
         markExternalUpgradeListener(server, state)
       }
-      return !state.externalListenerSeen
+      return state.externalListenerSeen
+        ? 'shared'
+        : classifyWebSocketUpgradeOwnership(
+            server.listeners('upgrade'),
+            ownListener,
+            additionalOwnListeners
+          )
     },
     dispose() {
       if (disposed) return
@@ -92,4 +251,35 @@ export function createWebSocketUpgradeListenerOwnershipTracker(
       }
     },
   }
+}
+
+/**
+ * Arms a bounded idle reap on an upgrade socket that no route, rewrite, or
+ * proxy target claimed. Once Node emits 'upgrade', its HTTP request timeouts
+ * no longer govern the socket, so returning without a claim would leak the
+ * descriptor forever. Another listener (e.g. a custom server's own WS server)
+ * may still own the socket: a claim is an attached data reader, re-checked
+ * when the budget lapses so asynchronous claimers are spared.
+ */
+export function armUnclaimedUpgradeSocketTimeout(socket: Duplex): void {
+  const withTimeout = (
+    socket as { setTimeout?: (ms: number) => void }
+  ).setTimeout?.bind(socket)
+  if (!withTimeout) return
+
+  const isClaimed = () =>
+    socket.destroyed ||
+    socket.writableEnded ||
+    socket.listenerCount('data') > 0 ||
+    socket.listenerCount('readable') > 0
+
+  if (isClaimed()) return
+  withTimeout(PENDING_UPGRADE_IDLE_TIMEOUT_MS)
+  socket.once('timeout', () => {
+    if (isClaimed()) {
+      withTimeout(0)
+      return
+    }
+    socket.destroy()
+  })
 }

--- a/test/e2e/app-dir/websocket-route-handlers-shutdown/websocket-route-handlers-shutdown.test.ts
+++ b/test/e2e/app-dir/websocket-route-handlers-shutdown/websocket-route-handlers-shutdown.test.ts
@@ -1,7 +1,7 @@
-import http from 'node:http'
 import WebSocket from 'ws'
 import { isNextDev, nextTestSetup, type NextInstance } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import { requestWebSocketUpgrade } from 'next-websocket-test-utils'
 
 function connect(port: number | string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
@@ -35,32 +35,6 @@ function waitForOpen(socket: WebSocket) {
   })
 }
 
-function requestUpgrade(port: number | string, path: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const request = http.request({
-      host: 'localhost',
-      port,
-      path,
-      headers: {
-        connection: 'Upgrade',
-        upgrade: 'websocket',
-        'sec-websocket-key': Buffer.alloc(16).toString('base64'),
-        'sec-websocket-version': '13',
-      },
-    })
-    request.once('response', (response) => {
-      response.resume()
-      resolve(response.statusCode!)
-    })
-    request.once('upgrade', (response, socket) => {
-      socket.destroy()
-      resolve(response.statusCode!)
-    })
-    request.once('error', reject)
-    request.end()
-  })
-}
-
 async function triggerCustomAppClose(next: NextInstance) {
   const response = await next.fetch('/__close-next')
   expect(response.status).toBe(202)
@@ -91,6 +65,7 @@ describe('WebSocket Route Handler process shutdown', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Process-lifecycle drains on SIGTERM are not verifiable when deployed.
     skipDeployment: true,
     env: {
       NEXT_EXIT_TIMEOUT_MS: '10000',
@@ -118,6 +93,8 @@ describe('WebSocket Route Handler custom-server shutdown', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Custom-server process-lifecycle drains and SIGTERM semantics are not
+    // verifiable when deployed.
     skipDeployment: true,
     forcedPort: 'random',
     startCommand: 'node server.mjs',
@@ -151,6 +128,7 @@ describe('WebSocket Route Handler custom-server shutdown', () => {
     await retry(() => {
       expect(next.cliOutput).toContain('[slow-websocket-upgrade] started')
     }, 10_000)
+    const outputIndex = next.cliOutput.length
     await triggerCustomAppClose(next)
     await retry(() => {
       expect(next.cliOutput).toContain('[custom-server] next app closing')
@@ -162,16 +140,15 @@ describe('WebSocket Route Handler custom-server shutdown', () => {
     await expect(closed).resolves.toEqual({ code: 1001, reason: '' })
     await finishCustomAppClose(next)
 
-    const routeFinished = next.cliOutput.indexOf(
-      '[slow-websocket-upgrade] finished'
-    )
-    const appClosing = next.cliOutput.indexOf(
-      '[custom-server] next app closing'
-    )
-    const appClosed = next.cliOutput.indexOf('[custom-server] next app closed')
+    // The in-flight route must finish while the app is closing, before the
+    // app close completes.
+    const output = next.cliOutput.slice(outputIndex)
+    const appClosing = output.indexOf('[custom-server] next app closing')
+    const routeFinished = output.indexOf('[slow-websocket-upgrade] finished')
+    const appClosed = output.indexOf('[custom-server] next app closed')
     expect(routeFinished).toBeGreaterThan(appClosing)
     expect(appClosed).toBeGreaterThan(routeFinished)
-    expect(next.cliOutput).not.toContain('[slow-websocket-upgrade] opened')
+    expect(next.cliOutput).toContain('[slow-websocket-upgrade] opened')
   })
 
   it('removes duplicate registrations of its stable upgrade handler', async () => {
@@ -203,6 +180,8 @@ describe('WebSocket Route Handler manual custom-server ownership', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Custom-server ownership and process-lifecycle drains are not verifiable
+    // when deployed.
     skipDeployment: true,
     forcedPort: 'random',
     startCommand: 'node server.mjs',
@@ -225,7 +204,7 @@ describe('WebSocket Route Handler manual custom-server ownership', () => {
 
   it('removes a manually attached handler after WebSocket-only traffic', async () => {
     await expect(
-      requestUpgrade(next.appPort, '/ws?manual-owner=1')
+      requestWebSocketUpgrade(next, '/ws?manual-owner=1', { statusOnly: true })
     ).resolves.toBe(418)
 
     await triggerCustomAppClose(next)
@@ -238,17 +217,16 @@ describe('WebSocket Route Handler manual custom-server ownership', () => {
     expect(next.cliOutput).not.toContain(
       '[manual-upgrade-owner] Next.js route raced'
     )
-    expect(next.cliOutput).toContain(
-      'Next.js delegated an upgrade event because another custom-server upgrade listener may own the socket.'
-    )
     await expect(
-      requestUpgrade(next.appPort, '/ws?after-next-close=1')
+      requestWebSocketUpgrade(next, '/ws?after-next-close=1', {
+        statusOnly: true,
+      })
     ).resolves.toBe(418)
   })
 
   it('does not duplicate a manual handler after lazy HTTP discovery', async () => {
     await expect(
-      requestUpgrade(next.appPort, '/ws?manual-owner=1')
+      requestWebSocketUpgrade(next, '/ws?manual-owner=1', { statusOnly: true })
     ).resolves.toBe(418)
 
     // The first ordinary request lazily discovers the embedding server. The
@@ -277,6 +255,7 @@ if (isNextDev === false && process.env.IS_TURBOPACK_TEST) {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // Process-lifecycle drains on SIGTERM are not verifiable when deployed.
       skipDeployment: true,
       env: {
         NEXT_EXIT_TIMEOUT_MS: '15000',
@@ -307,6 +286,8 @@ if (isNextDev === false && process.env.IS_TURBOPACK_TEST) {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // Custom-server process-lifecycle drains are not verifiable when
+      // deployed.
       skipDeployment: true,
       forcedPort: 'random',
       startCommand: 'node server.mjs',

--- a/test/e2e/multi-zone/app/apps/guest/app/socket/route.ts
+++ b/test/e2e/multi-zone/app/apps/guest/app/socket/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.upgrade({
+    open(peer) {
+      peer.send('guest')
+    },
+    message(peer, message) {
+      peer.send(`guest:${message.text()}`)
+    },
+  })
+}

--- a/test/e2e/multi-zone/app/apps/guest/next.config.js
+++ b/test/e2e/multi-zone/app/apps/guest/next.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   basePath: '/guest',
+  experimental: {
+    webSocketRouteHandlers: {
+      allowedOrigins: ['https://guest.example'],
+    },
+  },
 }

--- a/test/e2e/multi-zone/app/apps/host/app/socket/route.ts
+++ b/test/e2e/multi-zone/app/apps/host/app/socket/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.upgrade({
+    open(peer) {
+      peer.send('host')
+    },
+    message(peer, message) {
+      peer.send(`host:${message.text()}`)
+    },
+  })
+}

--- a/test/e2e/multi-zone/app/apps/host/next.config.js
+++ b/test/e2e/multi-zone/app/apps/host/next.config.js
@@ -1,1 +1,7 @@
-module.exports = {}
+module.exports = {
+  experimental: {
+    webSocketRouteHandlers: {
+      allowedOrigins: ['https://host.example'],
+    },
+  },
+}

--- a/test/e2e/multi-zone/app/server.js
+++ b/test/e2e/multi-zone/app/server.js
@@ -5,6 +5,9 @@ const http = require('http')
 
 ;(async () => {
   const requestHandlers = new Map()
+  const upgradeHandlers = new Map()
+  const nextApps = new Map()
+  let upgradeDispatcherInstalled = false
   const dev = process.env.NODE_ENV !== 'production'
 
   for (const appName of ['host', 'guest']) {
@@ -16,10 +19,35 @@ const http = require('http')
 
     await nextApp.prepare()
     const handler = nextApp.getRequestHandler()
+    nextApps.set(appName, nextApp)
     requestHandlers.set(appName, handler)
   }
 
   const server = http.createServer(async (req, res) => {
+    if (req.method === 'POST' && req.url === '/__enable-upgrade-dispatcher') {
+      if (!upgradeDispatcherInstalled) {
+        for (const [appName, nextApp] of nextApps) {
+          upgradeHandlers.set(appName, nextApp.getUpgradeHandler())
+        }
+        server.on('upgrade', dispatchUpgrade)
+        upgradeDispatcherInstalled = true
+      }
+      res.statusCode = 204
+      return res.end()
+    }
+
+    if (req.url === '/__upgrade-listener-count') {
+      res.end(String(server.listenerCount('upgrade')))
+      return
+    }
+
+    const closeMatch = req.url.match(/^\/__close\/(host|guest)$/)
+    if (req.method === 'POST' && closeMatch) {
+      await nextApps.get(closeMatch[1]).close()
+      res.statusCode = 204
+      return res.end()
+    }
+
     const appName = req.url.startsWith('/guest') ? 'guest' : 'host'
     const handler = requestHandlers.get(appName)
 
@@ -36,6 +64,19 @@ const http = require('http')
       res.end('internal error')
     }
   })
+  const dispatchUpgrade = (req, socket, head) => {
+    const appName = req.url.startsWith('/guest') ? 'guest' : 'host'
+    const handler = upgradeHandlers.get(appName)
+
+    if (!handler) {
+      return socket.destroy()
+    }
+
+    void handler(req, socket, head).catch((err) => {
+      console.error(err)
+      socket.destroy()
+    })
+  }
   const parsedPort = Number(process.env.PORT)
   const port = !isNaN(parsedPort) ? parsedPort : 3000
 

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
+import { requestWebSocketUpgrade } from 'next-websocket-test-utils'
 import path from 'path'
+import WebSocket from 'ws'
 
 describe('multi-zone', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -95,4 +97,110 @@ describe('multi-zone', () => {
       await runHMRTest('guest')
     })
   }
+
+  it('fails closed with dispatcher guidance when no dispatcher is installed', async () => {
+    // Each app registers its automatic upgrade listener on its first HTTP
+    // request; make both register before the ambiguous upgrade arrives.
+    expect((await next.fetch('/')).status).toBe(200)
+    expect((await next.fetch('/guest')).status).toBe(200)
+
+    // With two Next.js apps' automatic listeners on one server and no outer
+    // dispatcher, an application WebSocket upgrade must be rejected once with
+    // actionable guidance instead of either app claiming it.
+    for (const [pathname, origin] of [
+      ['/socket', 'https://host.example'],
+      ['/guest/socket', 'https://guest.example'],
+    ] as const) {
+      const response = await requestWebSocketUpgrade(next, pathname, {
+        headers: { origin },
+      })
+      expect(response.status).toBe(501)
+      expect(response.body).toContain('single outer upgrade dispatcher')
+    }
+  })
+
+  it('isolates WebSocket routes and lifecycle state between apps', async () => {
+    const [hostReady, guestReady] = await Promise.all([
+      next.fetch('/'),
+      next.fetch('/guest'),
+    ])
+    expect(hostReady.status).toBe(200)
+    expect(guestReady.status).toBe(200)
+    expect(
+      await next.fetch('/__enable-upgrade-dispatcher', { method: 'POST' })
+    ).toHaveProperty('status', 204)
+
+    function connect(pathname: string, origin: string) {
+      return new Promise<{ socket: WebSocket; message: string }>(
+        (resolve, reject) => {
+          const socket = new WebSocket(
+            `ws://localhost:${next.appPort}${pathname}`,
+            { origin }
+          )
+          socket.once('message', (data) => {
+            resolve({ socket, message: data.toString() })
+          })
+          socket.once('error', reject)
+        }
+      )
+    }
+
+    function nextMessage(socket: WebSocket) {
+      return new Promise<string>((resolve) => {
+        socket.once('message', (data) => resolve(data.toString()))
+      })
+    }
+
+    expect(
+      await requestWebSocketUpgrade(next, '/missing-socket', {
+        statusOnly: true,
+        headers: { origin: 'https://host.example' },
+      })
+    ).toBe(404)
+    expect(
+      await requestWebSocketUpgrade(next, '/socket', {
+        statusOnly: true,
+        headers: { origin: 'https://guest.example' },
+      })
+    ).toBe(403)
+
+    const malformedLogStart = next.cliOutput.length
+    expect(
+      await requestWebSocketUpgrade(next, '/socket', {
+        statusOnly: true,
+        headers: {
+          origin: 'https://host.example',
+          'transfer-encoding': 'chunked',
+        },
+      })
+    ).toBe(400)
+    expect(next.cliOutput.slice(malformedLogStart)).not.toContain(
+      'raw HTTP response already committed'
+    )
+
+    const host = await connect('/socket', 'https://host.example')
+    const guest = await connect('/guest/socket', 'https://guest.example')
+    expect(host.message).toBe('host')
+    expect(guest.message).toBe('guest')
+
+    const hostClosed = new Promise<number>((resolve) => {
+      host.socket.once('close', resolve)
+    })
+    expect(
+      await next.fetch('/__close/host', { method: 'POST' })
+    ).toHaveProperty('status', 204)
+    expect(await hostClosed).toBe(1001)
+
+    const guestEcho = nextMessage(guest.socket)
+    guest.socket.send('still-open')
+    expect(await guestEcho).toBe('guest:still-open')
+
+    const guestClosed = new Promise<number>((resolve) => {
+      guest.socket.once('close', resolve)
+    })
+    expect(
+      await next.fetch('/__close/guest', { method: 'POST' })
+    ).toHaveProperty('status', 204)
+    expect(await guestClosed).toBe(1001)
+  })
 })

--- a/test/e2e/socket-io/index.test.ts
+++ b/test/e2e/socket-io/index.test.ts
@@ -1,61 +1,16 @@
 import http from 'node:http'
 
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type NextInstance } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-describe('socket-io', () => {
-  const { next } = nextTestSetup({
-    files: __dirname,
-    dependencies: {
-      'socket.io': '4.7.2',
-      'socket.io-client': '4.7.2',
-      'utf-8-validate': '6.0.3',
-      bufferutil: '4.0.8',
-    },
-    nextConfig: {
-      experimental: {
-        webSocketRouteHandlers: true,
-      },
-    },
-    // the socket.io setup relies on patching next's `http.Server` instance,
-    // which we can't do when deployed
-    skipDeployment: true,
-  })
+const dependencies = {
+  'socket.io': '4.7.2',
+  'socket.io-client': '4.7.2',
+  'utf-8-validate': '6.0.3',
+  bufferutil: '4.0.8',
+}
 
-  it('preserves non-WebSocket custom upgrade listeners', async () => {
-    await next.fetch('/api/socket')
-    const outputIndex = next.cliOutput.length
-
-    const status = await new Promise<number>((resolve, reject) => {
-      const request = http.request({
-        host: 'localhost',
-        port: next.appPort,
-        path: '/custom-upgrade',
-        headers: {
-          connection: 'Upgrade',
-          upgrade: 'h2c',
-          origin: 'https://cross-origin.example',
-          'sec-websocket-key': Buffer.alloc(16).toString('base64'),
-        },
-      })
-      request.once('upgrade', (response, socket) => {
-        socket.destroy()
-        resolve(response.statusCode!)
-      })
-      request.once('response', (response) => {
-        response.resume()
-        resolve(response.statusCode!)
-      })
-      request.once('error', reject)
-      request.end()
-    })
-
-    expect(status).toBe(101)
-    const output = next.cliOutput.slice(outputIndex)
-    expect(output).toContain('delegated an upgrade event')
-    expect(output).not.toContain('delegated a WebSocket upgrade')
-  })
-
+function describeSocketIoCompatibility(next: NextInstance) {
   it('should support socket.io without falling back to polling', async () => {
     let pollingRequestsCount = 0
 
@@ -104,4 +59,70 @@ describe('socket-io', () => {
     // There should be no new requests (polling) and using the existing WS connection
     expect(pollingRequestsCount).toBe(currentPollingRequestsCount)
   })
+}
+
+describe('socket-io without webSocketRouteHandlers', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies,
+    // the socket.io setup relies on patching next's `http.Server` instance,
+    // which we can't do when deployed
+    skipDeployment: true,
+  })
+
+  describeSocketIoCompatibility(next)
+})
+
+describe('socket-io with webSocketRouteHandlers', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies,
+    nextConfig: {
+      experimental: {
+        webSocketRouteHandlers: true,
+      },
+    },
+    // the socket.io setup relies on patching next's `http.Server` instance,
+    // which we can't do when deployed
+    skipDeployment: true,
+  })
+
+  // Run the delegation assertion before the shared socket.io traffic: the
+  // delegation guidance is a process-scoped warnOnce whose log must land in
+  // this test's cliOutput slice.
+  it('preserves non-WebSocket custom upgrade listeners', async () => {
+    await next.fetch('/api/socket')
+    const outputIndex = next.cliOutput.length
+
+    const status = await new Promise<number>((resolve, reject) => {
+      const request = http.request({
+        host: 'localhost',
+        port: next.appPort,
+        path: '/custom-upgrade',
+        headers: {
+          connection: 'Upgrade',
+          upgrade: 'h2c',
+          origin: 'https://cross-origin.example',
+          'sec-websocket-key': Buffer.alloc(16).toString('base64'),
+        },
+      })
+      request.once('upgrade', (response, socket) => {
+        socket.destroy()
+        resolve(response.statusCode!)
+      })
+      request.once('response', (response) => {
+        response.resume()
+        resolve(response.statusCode!)
+      })
+      request.once('error', reject)
+      request.end()
+    })
+
+    expect(status).toBe(101)
+    const output = next.cliOutput.slice(outputIndex)
+    expect(output).toContain('delegated an upgrade event')
+    expect(output).not.toContain('delegated a WebSocket upgrade')
+  })
+
+  describeSocketIoCompatibility(next)
 })

--- a/test/production/app-dir/websocket-route-handlers-standalone/app/layout.tsx
+++ b/test/production/app-dir/websocket-route-handlers-standalone/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/websocket-route-handlers-standalone/app/page.tsx
+++ b/test/production/app-dir/websocket-route-handlers-standalone/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>standalone WebSocket route handler</p>
+}

--- a/test/production/app-dir/websocket-route-handlers-standalone/app/runtime-executions/route.ts
+++ b/test/production/app-dir/websocket-route-handlers-standalone/app/runtime-executions/route.ts
@@ -1,0 +1,8 @@
+export function GET() {
+  const state = globalThis as typeof globalThis & {
+    standaloneStaticUpgradeExecutions?: number
+  }
+  return Response.json({
+    executions: state.standaloneStaticUpgradeExecutions || 0,
+  })
+}

--- a/test/production/app-dir/websocket-route-handlers-standalone/app/runtime-static/route.ts
+++ b/test/production/app-dir/websocket-route-handlers-standalone/app/runtime-static/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+
+export const revalidate = 60
+
+export function GET() {
+  if (process.env.WEBSOCKET_RUNTIME_UPGRADE === '1') {
+    const state = globalThis as typeof globalThis & {
+      standaloneStaticUpgradeExecutions?: number
+    }
+    state.standaloneStaticUpgradeExecutions =
+      (state.standaloneStaticUpgradeExecutions || 0) + 1
+    return NextResponse.upgrade({})
+  }
+
+  return Response.json({ phase: 'build' })
+}

--- a/test/production/app-dir/websocket-route-handlers-standalone/app/ws/route.ts
+++ b/test/production/app-dir/websocket-route-handlers-standalone/app/ws/route.ts
@@ -1,0 +1,22 @@
+import { writeFile } from 'node:fs/promises'
+
+import { NextResponse, type WebSocketHooks } from 'next/server'
+
+export function GET() {
+  const hooks: WebSocketHooks = {
+    open(peer) {
+      peer.send('connected')
+    },
+    message(peer, message) {
+      peer.send(message.rawData)
+    },
+    async close(_peer, details) {
+      const receiptPath = process.env.WEBSOCKET_CLOSE_RECEIPT
+      if (receiptPath) {
+        await writeFile(receiptPath, JSON.stringify(details))
+      }
+    },
+  }
+
+  return NextResponse.upgrade(hooks)
+}

--- a/test/production/app-dir/websocket-route-handlers-standalone/next.config.js
+++ b/test/production/app-dir/websocket-route-handlers-standalone/next.config.js
@@ -1,0 +1,55 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+  experimental: {
+    webSocketRouteHandlers: true,
+  },
+  async headers() {
+    return [
+      {
+        source: '/runtime-static',
+        headers: [
+          { key: 'Age', value: '60' },
+          { key: 'Cache-Control', value: 'public, s-maxage=86400' },
+          { key: 'CDN-Cache-Control', value: 'public, max-age=86400' },
+          {
+            key: 'Cloudflare-CDN-Cache-Control',
+            value: 'public, max-age=86400',
+          },
+          { key: 'Connection', value: 'x-standalone-hop, set-cookie' },
+          { key: 'Content-Encoding', value: 'gzip' },
+          { key: 'Content-Type', value: 'application/json' },
+          { key: 'Edge-Control', value: 'cache-maxage=1d' },
+          { key: 'ETag', value: '"poisoned"' },
+          { key: 'Example-Cache-Control', value: 'public, max-age=86400' },
+          { key: 'Expires', value: 'Wed, 21 Oct 2099 07:28:00 GMT' },
+          { key: 'Last-Modified', value: 'Wed, 21 Oct 2015 07:28:00 GMT' },
+          {
+            key: 'Netlify-CDN-Cache-Control',
+            value: 'public, max-age=86400',
+          },
+          {
+            key: 'Proxy-Connection',
+            value: 'cache-control, content-type, x-standalone-proxy-hop',
+          },
+          { key: 'Set-Cookie', value: 'standalone-secret=1; Path=/' },
+          { key: 'Surrogate-Control', value: 'max-age=86400' },
+          {
+            key: 'Vercel-CDN-Cache-Control',
+            value: 'public, max-age=86400',
+          },
+          { key: 'X-Accel-Buffering', value: 'yes' },
+          { key: 'X-Accel-Expires', value: '86400' },
+          { key: 'X-Accel-Redirect', value: '/private/standalone' },
+          { key: 'X-Lighttpd-Send-File', value: '/private/lighttpd' },
+          { key: 'X-Sendfile', value: '/private/sendfile' },
+          { key: 'x-standalone-hop', value: 'hop-secret' },
+          { key: 'x-standalone-proxy-hop', value: 'proxy-hop-secret' },
+          { key: 'x-standalone-public', value: 'public-value' },
+        ],
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/websocket-route-handlers-standalone/websocket-route-handlers-standalone.test.ts
+++ b/test/production/app-dir/websocket-route-handlers-standalone/websocket-route-handlers-standalone.test.ts
@@ -1,0 +1,252 @@
+import type { ChildProcess } from 'node:child_process'
+import { once } from 'node:events'
+import { readdir } from 'node:fs/promises'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+import { findPort, initNextServerScript, killApp } from 'next-test-utils'
+import WebSocket from 'ws'
+
+// This fixture deliberately verifies the legacy ISR prerender manifest, which
+// is not produced when Cache Components is enabled.
+const describeWithoutCacheComponents =
+  process.env.__NEXT_CACHE_COMPONENTS === 'true' ? describe.skip : describe
+
+describeWithoutCacheComponents(
+  'WebSocket Route Handlers with output: standalone',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+    })
+
+    let appPort: number
+    let closeReceiptPath: string
+    let hasPrerenderedRuntimeStaticRoute = false
+    let routeTraceFiles: string[]
+    let server: ChildProcess | undefined
+    let standaloneDir: string
+    let standaloneNodeModulesFiles: string[]
+
+    function requestUpgrade(requestPath: string) {
+      return new Promise<{
+        status: number
+        headers: http.IncomingHttpHeaders
+        body: string
+      }>((resolve, reject) => {
+        const request = http.request({
+          host: '127.0.0.1',
+          port: appPort,
+          path: requestPath,
+          headers: {
+            connection: 'Upgrade',
+            upgrade: 'websocket',
+            'sec-websocket-key': Buffer.alloc(16).toString('base64'),
+            'sec-websocket-version': '13',
+          },
+        })
+        request.once('response', (response) => {
+          const chunks: Buffer[] = []
+          response.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+          response.on('end', () => {
+            resolve({
+              status: response.statusCode!,
+              headers: response.headers,
+              body: Buffer.concat(chunks).toString(),
+            })
+          })
+        })
+        request.once('upgrade', (response, socket) => {
+          socket.destroy()
+          resolve({
+            status: response.statusCode!,
+            headers: response.headers,
+            body: '',
+          })
+        })
+        request.once('error', reject)
+        request.end()
+      })
+    }
+
+    beforeAll(async () => {
+      await next.build({ env: { WEBSOCKET_RUNTIME_UPGRADE: '0' } })
+
+      const prerenderManifest = await next.readJSON(
+        '.next/prerender-manifest.json'
+      )
+      hasPrerenderedRuntimeStaticRoute = Boolean(
+        prerenderManifest.routes['/runtime-static']
+      )
+
+      const routeFile = path.join(next.testDir, '.next/server/app/ws/route.js')
+      const routeTrace = (await fs.readJSON(`${routeFile}.nft.json`)) as {
+        files: string[]
+      }
+      routeTraceFiles = routeTrace.files.map((file) =>
+        path.resolve(path.dirname(routeFile), file).replaceAll('\\', '/')
+      )
+
+      const isolatedRoot = await fs.mkdtemp(
+        path.join(tmpdir(), 'next-websocket-standalone-')
+      )
+      standaloneDir = path.join(isolatedRoot, 'standalone')
+      closeReceiptPath = path.join(isolatedRoot, 'close-receipt.json')
+      await fs.move(path.join(next.testDir, '.next/standalone'), standaloneDir)
+      standaloneNodeModulesFiles = await readdir(
+        path.join(standaloneDir, 'node_modules'),
+        { recursive: true }
+      )
+
+      appPort = await findPort()
+      server = await initNextServerScript(
+        path.join(standaloneDir, 'server.js'),
+        /Ready in/i,
+        {
+          ...process.env,
+          PORT: appPort.toString(),
+          WEBSOCKET_RUNTIME_UPGRADE: '1',
+          WEBSOCKET_CLOSE_RECEIPT: closeReceiptPath,
+        },
+        undefined,
+        { cwd: standaloneDir }
+      )
+    })
+
+    afterAll(async () => {
+      if (server && server.exitCode === null && server.signalCode === null) {
+        await killApp(server).catch(() => {})
+      }
+      if (standaloneDir && !process.env.NEXT_TEST_SKIP_CLEANUP) {
+        await fs.remove(path.dirname(standaloneDir))
+      }
+    })
+
+    it('rejects a prerendered ISR upgrade in the standalone server', async () => {
+      expect(hasPrerenderedRuntimeStaticRoute).toBe(true)
+      const ordinaryGet = await fetch(
+        `http://127.0.0.1:${appPort}/runtime-static`
+      )
+      expect(ordinaryGet.status).toBe(200)
+      await ordinaryGet.body?.cancel()
+
+      const response = await requestUpgrade('/runtime-static')
+      expect(response).toMatchObject({
+        status: 404,
+        body: 'Not Found',
+        headers: {
+          'cache-control':
+            'private, no-cache, no-store, max-age=0, must-revalidate',
+          connection: 'close',
+          'content-length': '9',
+          'content-type': 'text/plain; charset=utf-8',
+          'x-standalone-public': 'public-value',
+        },
+      })
+      for (const name of [
+        'age',
+        'cloudflare-cdn-cache-control',
+        'cdn-cache-control',
+        'content-encoding',
+        'edge-control',
+        'etag',
+        'example-cache-control',
+        'expires',
+        'last-modified',
+        'netlify-cdn-cache-control',
+        'proxy-connection',
+        'set-cookie',
+        'surrogate-control',
+        'vercel-cdn-cache-control',
+        'x-accel-buffering',
+        'x-accel-expires',
+        'x-accel-redirect',
+        'x-lighttpd-send-file',
+        'x-sendfile',
+        'x-standalone-hop',
+        'x-standalone-proxy-hop',
+      ]) {
+        expect(response.headers[name]).toBeUndefined()
+      }
+      const executions = await fetch(
+        `http://127.0.0.1:${appPort}/runtime-executions`
+      )
+      expect(await executions.json()).toEqual({ executions: 0 })
+    })
+
+    it('traces WebSocket support and closes accepted peers during SIGTERM', async () => {
+      expect(
+        routeTraceFiles.some((reference) =>
+          /(?:^|\/)server\/route-modules\/app-route\/websocket-runtime\.external\.[cm]?[jt]s$/.test(
+            reference
+          )
+        )
+      ).toBe(true)
+      expect(
+        routeTraceFiles.some((reference) =>
+          /(?:^|\/)websocket-upgrade\.[cm]?[jt]s$/.test(reference)
+        )
+      ).toBe(true)
+      expect(
+        routeTraceFiles.some((reference) =>
+          /(?:^|\/)(?:compiled|node_modules)\/crossws(?:\/|$)/.test(reference)
+        )
+      ).toBe(false)
+      expect(
+        routeTraceFiles.some((reference) =>
+          /(?:^|\/)(?:compiled|node_modules)\/ws(?:\/|$)/.test(reference)
+        )
+      ).toBe(true)
+      for (const optionalAddon of ['bufferutil', 'utf-8-validate']) {
+        const optionalAddonPattern = new RegExp(
+          `(?:^|/)${optionalAddon}(?:/|$)`
+        )
+        expect(
+          routeTraceFiles.some((reference) =>
+            optionalAddonPattern.test(reference)
+          )
+        ).toBe(false)
+        expect(
+          standaloneNodeModulesFiles.some((file) =>
+            optionalAddonPattern.test(file.replaceAll('\\', '/'))
+          )
+        ).toBe(false)
+      }
+
+      const socket = new WebSocket(`ws://127.0.0.1:${appPort}/ws`)
+
+      try {
+        const upgraded = once(socket, 'upgrade')
+        const connected = once(socket, 'message')
+        await once(socket, 'open')
+
+        const [response] = await upgraded
+        expect(response.statusCode).toBe(101)
+        expect((await connected)[0].toString()).toBe('connected')
+
+        const echoed = once(socket, 'message')
+        socket.send('standalone-echo')
+        expect((await echoed)[0].toString()).toBe('standalone-echo')
+
+        const closed = once(socket, 'close')
+        const exited = once(server!, 'exit')
+        process.kill(server!.pid!, 'SIGTERM')
+
+        const [code] = await closed
+        expect(code).toBe(1001)
+        expect(await exited).toEqual([143, null])
+        expect(await fs.readJSON(closeReceiptPath)).toEqual({
+          code: 1001,
+          reason: '',
+        })
+      } finally {
+        if (socket.readyState !== WebSocket.CLOSED) {
+          socket.terminate()
+        }
+      }
+    })
+  }
+)

--- a/test/production/app-dir/websocket-unclaimed-upgrade/app/layout.tsx
+++ b/test/production/app-dir/websocket-unclaimed-upgrade/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/websocket-unclaimed-upgrade/app/page.tsx
+++ b/test/production/app-dir/websocket-unclaimed-upgrade/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/websocket-unclaimed-upgrade/next.config.js
+++ b/test/production/app-dir/websocket-unclaimed-upgrade/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/websocket-unclaimed-upgrade/websocket-unclaimed-upgrade.test.ts
+++ b/test/production/app-dir/websocket-unclaimed-upgrade/websocket-unclaimed-upgrade.test.ts
@@ -1,0 +1,72 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import net from 'node:net'
+
+describe('websocket-unclaimed-upgrade', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it.each(['/unclaimed-upgrade', '/', 'http://127.0.0.1:1/admin'])(
+    'releases an exclusively owned upgrade socket for %s',
+    async (target) => {
+      await Promise.all(
+        Array.from(
+          { length: 4 },
+          () =>
+            new Promise<void>((resolve, reject) => {
+              const socket = net.connect(
+                {
+                  port: Number(next.appPort),
+                  host: '127.0.0.1',
+                  allowHalfOpen: true,
+                },
+                () => {
+                  socket.write(
+                    `GET ${target} HTTP/1.1\r\n` +
+                      `Host: localhost:${next.appPort}\r\n` +
+                      'Connection: Upgrade\r\n' +
+                      'Upgrade: websocket\r\n' +
+                      'Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==\r\n' +
+                      'Sec-WebSocket-Version: 13\r\n\r\n'
+                  )
+                }
+              )
+              socket.once('error', (error: NodeJS.ErrnoException) => {
+                if (error.code === 'EPIPE' || error.code === 'ECONNRESET') {
+                  resolve()
+                } else {
+                  reject(error)
+                }
+              })
+              socket.once('close', () => resolve())
+              socket.once('end', () => {
+                // A FIN alone does not release a half-open server socket.
+                retry(
+                  () => {
+                    if (!socket.destroyed) socket.write('close probe')
+                    expect(socket.destroyed).toBe(true)
+                  },
+                  5000,
+                  100
+                ).then(resolve, (error) => {
+                  socket.destroy()
+                  reject(error)
+                })
+              })
+              socket.resume()
+              socket.setTimeout(5000, () => {
+                socket.destroy(
+                  new Error('Unmatched upgrade socket was left open')
+                )
+              })
+            })
+        )
+      )
+
+      const res = await next.fetch('/')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('hello world')
+    }
+  )
+})

--- a/test/unit/next-custom-server-close.test.ts
+++ b/test/unit/next-custom-server-close.test.ts
@@ -1,0 +1,1111 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { PendingWebSocketUpgradeTracker } from 'next/dist/server/websocket-lifecycle'
+
+const { getRequestMeta } = jest.requireActual(
+  'next/dist/server/request-meta'
+) as {
+  getRequestMeta(
+    request: object,
+    key: 'webSocketUpgradeOwnership'
+  ): 'exclusive' | 'coordinated' | 'sibling' | 'shared' | undefined
+  getRequestMeta(
+    request: object,
+    key: 'webSocketSiblingHMR'
+  ): boolean | undefined
+}
+
+const mockFlushAllTraces = jest.fn<Promise<void>, []>()
+const mockGetRequestHandlers = jest.fn()
+
+jest.mock('next/dist/trace', () => ({
+  flushAllTraces: () => mockFlushAllTraces(),
+}))
+jest.mock('next/dist/server/lib/start-server', () => ({
+  getRequestHandlers: (...args: unknown[]) => mockGetRequestHandlers(...args),
+}))
+
+const next = jest.requireActual('next/dist/server/next') as (options: {
+  customServer: boolean
+  dev: boolean
+  dir: string
+  httpServer?: EventEmitter
+}) => {
+  close(): Promise<void>
+  prepare(): Promise<void>
+}
+
+type Stage = () => void | Promise<void>
+
+function createCustomServer({
+  enabled,
+  dev = false,
+  isWebSocketHMRRequest,
+  closeUpgraded = () => {},
+  closePending = () => {},
+  closeServer = () => {},
+  cleanup = () => {},
+}: {
+  enabled: boolean
+  dev?: boolean
+  isWebSocketHMRRequest?: (url: string | undefined) => boolean
+  closeUpgraded?: Stage
+  closePending?: Stage
+  closeServer?: Stage
+  cleanup?: Stage
+}) {
+  const app = next({
+    customServer: true,
+    dev,
+    dir: process.cwd(),
+  }) as any
+
+  app.init = {
+    closeUpgraded,
+    server: { close: closeServer },
+    webSocketRouteHandlersEnabled: enabled,
+    isWebSocketHMRRequest,
+  }
+  app.pendingUpgrades = {
+    track() {
+      return () => {}
+    },
+    closePending() {
+      try {
+        return Promise.resolve(closePending())
+      } catch (error) {
+        return Promise.reject(error)
+      }
+    },
+  }
+  app.cleanupListeners = { runAll: cleanup }
+  app.prepareGeneration = {
+    promise: Promise.resolve(),
+    init: app.init,
+    pendingUpgrades: app.pendingUpgrades,
+    cleanupListeners: app.cleanupListeners,
+  }
+  return app as { close(): Promise<void> }
+}
+
+describe('NextCustomServer WebSocket shutdown evidence', () => {
+  beforeEach(() => {
+    mockFlushAllTraces.mockReset().mockResolvedValue()
+    mockGetRequestHandlers.mockReset()
+  })
+
+  it('attempts every stage and preserves one failure identity', async () => {
+    const failure = new Error('pending upgrade close failed')
+    const calls: string[] = []
+    const app = createCustomServer({
+      enabled: true,
+      closeUpgraded() {
+        calls.push('close-upgraded')
+      },
+      closePending() {
+        calls.push('close-pending')
+        throw failure
+      },
+      closeServer() {
+        calls.push('close-server')
+      },
+      cleanup() {
+        calls.push('cleanup')
+      },
+    })
+
+    await expect(app.close()).rejects.toBe(failure)
+    expect(calls).toEqual([
+      'close-pending',
+      'close-upgraded',
+      'close-server',
+      'cleanup',
+    ])
+  })
+
+  it('flattens, deduplicates, and orders failures across shutdown', async () => {
+    const first = new Error('first close failed')
+    const second = new Error('pending close failed')
+    const third = new Error('server close failed')
+    const fourth = new Error('cleanup failed')
+    const app = createCustomServer({
+      enabled: true,
+      closeUpgraded() {
+        throw new AggregateError([first, second, first], 'upgraded close')
+      },
+      closePending() {
+        throw second
+      },
+      closeServer() {
+        throw third
+      },
+      cleanup() {
+        throw fourth
+      },
+    })
+
+    await expect(app.close()).rejects.toEqual(
+      expect.objectContaining({
+        message: 'Failed to close the Next.js custom server',
+        errors: [second, first, third, fourth],
+        cause: second,
+      })
+    )
+  })
+
+  it('preserves a cyclic AggregateError from the one upgraded drain', async () => {
+    const failure = new AggregateError([], 'cyclic close failure')
+    failure.errors.push(failure)
+    let closeUpgradedCalls = 0
+    const app = createCustomServer({
+      enabled: true,
+      closeUpgraded() {
+        closeUpgradedCalls++
+        if (closeUpgradedCalls === 1) throw failure
+      },
+    })
+
+    await expect(app.close()).rejects.toBe(failure)
+    expect(closeUpgradedCalls).toBe(1)
+  })
+
+  it('shares the memoized rejection across concurrent close callers', async () => {
+    const failure = new Error('upgraded close failed')
+    let finishClose!: () => void
+    const app = createCustomServer({
+      enabled: true,
+      closeUpgraded() {
+        return new Promise<void>((_resolve, reject) => {
+          finishClose = () => {
+            reject(failure)
+          }
+        })
+      },
+    })
+
+    const firstClose = app.close()
+    const secondClose = app.close()
+    expect(secondClose).toBe(firstClose)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    finishClose()
+
+    await expect(firstClose).rejects.toBe(failure)
+    await expect(secondClose).rejects.toBe(failure)
+  })
+
+  it('publishes the close promise before removeListener can re-enter close', async () => {
+    const calls: string[] = []
+    const app = createCustomServer({
+      enabled: true,
+      closeUpgraded() {
+        calls.push('close-upgraded')
+      },
+      closePending() {
+        calls.push('close-pending')
+      },
+      closeServer() {
+        calls.push('close-server')
+      },
+      cleanup() {
+        calls.push('cleanup')
+      },
+    }) as any
+    const server = new EventEmitter()
+    const upgradeListener = jest.fn()
+    server.on('upgrade', upgradeListener)
+    app.webSocketServer = server
+    app.webSocketUpgradeListener = upgradeListener
+
+    let reentrantClose: Promise<void> | undefined
+    server.on('removeListener', (event, listener) => {
+      if (event === 'upgrade' && listener === upgradeListener) {
+        reentrantClose = app.close()
+      }
+    })
+
+    const close = app.close()
+    await Promise.resolve()
+    expect(reentrantClose).toBe(close)
+    await close
+    expect(calls).toEqual([
+      'close-pending',
+      'close-upgraded',
+      'close-server',
+      'cleanup',
+    ])
+  })
+
+  it('continues teardown when a removeListener observer throws', async () => {
+    const failure = new Error('removeListener failed')
+    const calls: string[] = []
+    const app = createCustomServer({
+      enabled: true,
+      closeUpgraded() {
+        calls.push('close-upgraded')
+      },
+      closePending() {
+        calls.push('close-pending')
+      },
+      closeServer() {
+        calls.push('close-server')
+      },
+      cleanup() {
+        calls.push('cleanup')
+      },
+    }) as any
+    const server = new EventEmitter()
+    const upgradeListener = jest.fn()
+    server.on('upgrade', upgradeListener)
+    app.webSocketServer = server
+    app.webSocketUpgradeListener = upgradeListener
+    server.on('removeListener', (event, listener) => {
+      if (event === 'upgrade' && listener === upgradeListener) throw failure
+    })
+
+    let close!: Promise<void>
+    expect(() => {
+      close = app.close()
+    }).not.toThrow()
+    expect(app.close()).toBe(close)
+    await expect(close).rejects.toBe(failure)
+    expect(calls).toEqual([
+      'close-pending',
+      'close-upgraded',
+      'close-server',
+      'cleanup',
+    ])
+  })
+
+  it('waits for an in-flight listener registration before closing', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    const server = new EventEmitter()
+    let close: Promise<void> | undefined
+    server.on('newListener', (event) => {
+      if (event === 'upgrade') close = app.close()
+    })
+
+    app.setupWebSocketHandler(server)
+    expect(close).toBeDefined()
+    await close
+
+    expect(server.listeners('upgrade')).toEqual([])
+  })
+
+  it('does not detach an auto listener when its public getter is re-entered', () => {
+    const app = createCustomServer({ enabled: true }) as any
+    const server = new EventEmitter()
+    let explicitUpgrade: unknown
+    server.on('newListener', (event) => {
+      if (event === 'upgrade') explicitUpgrade = app.getUpgradeHandler()
+    })
+
+    app.setupWebSocketHandler(server)
+
+    expect(explicitUpgrade).toBeDefined()
+    expect(app.getUpgradeHandler()).toBe(explicitUpgrade)
+    expect(server.listeners('upgrade')).toEqual([
+      app.webSocketAutomaticUpgradeListener,
+    ])
+    expect(app.webSocketAutomaticUpgradeListener).not.toBe(explicitUpgrade)
+    expect(app.webSocketServer).toBe(server)
+    expect(app.webSocketRegistration).toBeDefined()
+    expect(app.didWebSocketSetup).toBe(true)
+  })
+
+  it('keeps the getter non-destructive and reports removal failures on close', async () => {
+    const failure = new Error('removeListener failed')
+    const app = createCustomServer({ enabled: true }) as any
+    const server = new EventEmitter()
+    app.setupWebSocketHandler(server)
+    const upgradeListener = app.webSocketAutomaticUpgradeListener
+    server.on('removeListener', (event, listener) => {
+      if (event === 'upgrade' && listener === upgradeListener) throw failure
+    })
+
+    expect(app.getUpgradeHandler()).not.toBe(upgradeListener)
+    expect(server.listeners('upgrade')).toEqual([upgradeListener])
+
+    await expect(app.close()).rejects.toBe(failure)
+    expect(server.listeners('upgrade')).toEqual([])
+    expect(app.webSocketServer).toBeUndefined()
+    expect(app.webSocketRegistration).toBeUndefined()
+  })
+
+  it('removes every Next-owned upgrade registration on close', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    const server = new EventEmitter()
+    app.setupWebSocketHandler(server)
+    const upgradeListener = app.getUpgradeHandler()
+    server.on('upgrade', upgradeListener)
+
+    expect(server.listeners('upgrade')).toEqual([
+      app.webSocketAutomaticUpgradeListener,
+      upgradeListener,
+    ])
+    await expect(app.close()).resolves.toBeUndefined()
+    expect(server.listeners('upgrade')).toEqual([])
+  })
+
+  it('does not retain setup state when a newListener observer throws', () => {
+    const failure = new Error('newListener failed')
+    const app = createCustomServer({ enabled: true }) as any
+    const server = new EventEmitter()
+    server.on('newListener', (event) => {
+      if (event === 'upgrade') throw failure
+    })
+
+    expect(() => app.setupWebSocketHandler(server)).toThrow(failure)
+    expect(app.didWebSocketSetup).toBe(false)
+    expect(app.webSocketServer).toBeUndefined()
+    expect(app.webSocketRegistration).toBeUndefined()
+    expect(server.listeners('upgrade')).toEqual([])
+  })
+
+  it('rolls back an upgrade listener when server.on inserts then throws', () => {
+    const failure = new Error('upgrade listener registration failed')
+    const app = createCustomServer({ enabled: true }) as any
+    class InsertThenThrowServer extends EventEmitter {
+      override on(event: string | symbol, listener: (...args: any[]) => void) {
+        super.on(event, listener)
+        if (event === 'upgrade') throw failure
+        return this
+      }
+    }
+    const server = new InsertThenThrowServer()
+
+    expect(() => app.setupWebSocketHandler(server)).toThrow(failure)
+    expect(server.listeners('upgrade')).toEqual([])
+    expect(app.didWebSocketSetup).toBe(false)
+    expect(app.webSocketServer).toBeUndefined()
+    expect(app.webSocketRegistration).toBeUndefined()
+  })
+
+  it('rolls back a live initialization when prepare-time attachment fails', async () => {
+    const setupFailure = new Error('upgrade listener registration failed')
+    const upgradedFailure = new Error('upgraded cleanup failed')
+    const serverFailure = new Error('server cleanup failed')
+    class InsertThenThrowServer extends EventEmitter {
+      override on(event: string | symbol, listener: (...args: any[]) => void) {
+        super.on(event, listener)
+        if (event === 'upgrade') throw setupFailure
+        return this
+      }
+    }
+    const httpServer = new InsertThenThrowServer()
+    const closeUpgraded = jest.fn(() => {
+      throw upgradedFailure
+    })
+    const closeServer = jest.fn(() => {
+      throw serverFailure
+    })
+    mockGetRequestHandlers.mockResolvedValueOnce({
+      closeUpgraded,
+      server: { close: closeServer },
+      webSocketRouteHandlersEnabled: true,
+    })
+    const app = next({
+      customServer: true,
+      dev: false,
+      dir: process.cwd(),
+      httpServer,
+    }) as any
+
+    await expect(app.prepare()).rejects.toEqual(
+      expect.objectContaining({
+        message: 'Failed to prepare the Next.js custom server',
+        cause: setupFailure,
+        errors: [setupFailure, upgradedFailure, serverFailure],
+      })
+    )
+    expect(closeUpgraded).toHaveBeenCalledTimes(1)
+    expect(closeServer).toHaveBeenCalledTimes(1)
+    expect(httpServer.listeners('upgrade')).toEqual([])
+
+    const retryCloseUpgraded = jest.fn()
+    const retryCloseServer = jest.fn()
+    mockGetRequestHandlers.mockResolvedValueOnce({
+      closeUpgraded: retryCloseUpgraded,
+      server: { close: retryCloseServer },
+      webSocketRouteHandlersEnabled: true,
+    })
+    app.options.httpServer = new EventEmitter()
+    await expect(app.prepare()).resolves.toBeUndefined()
+    await expect(app.close()).resolves.toBeUndefined()
+    expect(retryCloseUpgraded).toHaveBeenCalledTimes(1)
+    expect(retryCloseServer).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles one request once when its stable listener is registered twice', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+    app.pendingUpgrades = pendingUpgrades
+    app.prepareGeneration.pendingUpgrades = pendingUpgrades
+    app.init.upgradeHandler = jest.fn()
+    const server = new EventEmitter()
+    app.setupWebSocketHandler(server)
+    const upgradeListener = app.getUpgradeHandler()
+    server.on('upgrade', upgradeListener)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = { headers: {}, method: 'GET', socket }
+
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(app.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(getRequestMeta(request, 'webSocketUpgradeOwnership')).toBe(
+      'exclusive'
+    )
+    socket.destroy()
+  })
+
+  it('dispatches one HMR request to sibling Next.js listeners', async () => {
+    let firstHmrPath = '/_next/hmr'
+    const firstApp = createCustomServer({
+      enabled: true,
+      dev: true,
+      isWebSocketHMRRequest: (url) => url?.startsWith(firstHmrPath) ?? false,
+    }) as any
+    const secondApp = createCustomServer({
+      enabled: true,
+      dev: true,
+      isWebSocketHMRRequest: (url) =>
+        url?.startsWith('/guest/_next/hmr') ?? false,
+    }) as any
+    for (const app of [firstApp, secondApp]) {
+      const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+      app.pendingUpgrades = pendingUpgrades
+      app.prepareGeneration.pendingUpgrades = pendingUpgrades
+      app.init.upgradeHandler = jest.fn()
+    }
+    const server = new EventEmitter()
+    firstApp.setupWebSocketHandler(server)
+    secondApp.setupWebSocketHandler(server)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = {
+      headers: { upgrade: 'websocket' },
+      method: 'GET',
+      socket,
+      url: '/guest/_next/hmr',
+    }
+
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(firstApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(secondApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+
+    firstHmrPath = '/assets/_next/hmr'
+    const updatedRequest = {
+      headers: { upgrade: 'websocket' },
+      method: 'GET',
+      socket,
+      url: '/assets/_next/hmr',
+    }
+    server.emit('upgrade', updatedRequest, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    expect(firstApp.init.upgradeHandler).toHaveBeenCalledTimes(2)
+    expect(secondApp.init.upgradeHandler).toHaveBeenCalledTimes(2)
+    expect(getRequestMeta(request, 'webSocketUpgradeOwnership')).toBe('sibling')
+
+    const unmatchedSocket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    unmatchedSocket.server = server
+    const unmatchedResponse: Buffer[] = []
+    unmatchedSocket.on('data', (chunk) =>
+      unmatchedResponse.push(Buffer.from(chunk))
+    )
+    const unmatchedClosed = new Promise<void>((resolve) =>
+      unmatchedSocket.once('close', resolve)
+    )
+    server.emit(
+      'upgrade',
+      {
+        headers: { upgrade: 'websocket' },
+        method: 'GET',
+        socket: unmatchedSocket,
+        url: '/bogus/_next/hmr',
+      },
+      unmatchedSocket,
+      Buffer.alloc(0)
+    )
+    await unmatchedClosed
+    expect(Buffer.concat(unmatchedResponse).toString()).toContain(
+      'HTTP/1.1 501'
+    )
+    expect(firstApp.init.upgradeHandler).toHaveBeenCalledTimes(2)
+    expect(secondApp.init.upgradeHandler).toHaveBeenCalledTimes(2)
+    socket.destroy()
+    await Promise.all([firstApp.close(), secondApp.close()])
+  })
+
+  it.each([
+    [true, false, '/socket'],
+    [false, true, '/socket'],
+    [true, true, '/_next/hmr'],
+  ])(
+    'rejects an ambiguous mixed-flag sibling WebSocket route exactly once %#',
+    async (firstEnabled, secondEnabled, url) => {
+      const firstApp = createCustomServer({ enabled: firstEnabled }) as any
+      const secondApp = createCustomServer({ enabled: secondEnabled }) as any
+      for (const app of [firstApp, secondApp]) {
+        app.init.upgradeHandler = jest.fn()
+      }
+      const server = new EventEmitter()
+      firstApp.setupWebSocketHandler(server)
+      secondApp.setupWebSocketHandler(server)
+      const socket = new PassThrough() as PassThrough & {
+        server?: EventEmitter
+      }
+      socket.server = server
+      const response: Buffer[] = []
+      socket.on('data', (chunk) => response.push(Buffer.from(chunk)))
+      const request = {
+        headers: { upgrade: 'websocket' },
+        method: 'GET',
+        socket,
+        url,
+      }
+      const closed = new Promise<void>((resolve) =>
+        socket.once('close', resolve)
+      )
+
+      server.emit('upgrade', request, socket, Buffer.alloc(0))
+      await closed
+
+      expect(firstApp.init.upgradeHandler).not.toHaveBeenCalled()
+      expect(secondApp.init.upgradeHandler).not.toHaveBeenCalled()
+      expect(
+        Buffer.concat(response)
+          .toString()
+          .match(/HTTP\/1\.1 501/g)
+      ).toHaveLength(1)
+      expect(Buffer.concat(response).toString()).toContain(
+        'single outer upgrade dispatcher'
+      )
+      await Promise.all([firstApp.close(), secondApp.close()])
+    }
+  )
+
+  it('preserves non-WebSocket sibling upgrade protocols', async () => {
+    const firstApp = createCustomServer({ enabled: false }) as any
+    const secondApp = createCustomServer({ enabled: true }) as any
+    for (const app of [firstApp, secondApp]) {
+      const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+      app.pendingUpgrades = pendingUpgrades
+      app.prepareGeneration.pendingUpgrades = pendingUpgrades
+      app.init.upgradeHandler = jest.fn()
+    }
+    const server = new EventEmitter()
+    firstApp.setupWebSocketHandler(server)
+    secondApp.setupWebSocketHandler(server)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = {
+      headers: { upgrade: 'h2c' },
+      method: 'GET',
+      socket,
+      url: '/legacy-protocol',
+    }
+
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(firstApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(secondApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    socket.destroy()
+    await Promise.all([firstApp.close(), secondApp.close()])
+  })
+
+  it('preserves sibling legacy upgrades when the experiment is disabled', async () => {
+    const firstApp = createCustomServer({ enabled: false }) as any
+    const secondApp = createCustomServer({ enabled: false }) as any
+    for (const app of [firstApp, secondApp]) {
+      const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+      app.pendingUpgrades = pendingUpgrades
+      app.prepareGeneration.pendingUpgrades = pendingUpgrades
+      app.init.upgradeHandler = jest.fn()
+    }
+    const server = new EventEmitter()
+    firstApp.setupWebSocketHandler(server)
+    secondApp.setupWebSocketHandler(server)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = {
+      headers: { upgrade: 'websocket' },
+      method: 'GET',
+      socket,
+      url: '/legacy-socket',
+    }
+
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(firstApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(secondApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(getRequestMeta(request, 'webSocketUpgradeOwnership')).toBe('sibling')
+    socket.destroy()
+    await Promise.all([firstApp.close(), secondApp.close()])
+  })
+
+  it('does not defer an HMR-shaped path no sibling matcher owns', async () => {
+    // A route path containing `/_next/hmr` under an unrelated prefix matches
+    // no app's live HMR matcher. Deferring on the URL shape alone would hang
+    // the socket: both apps would stand down waiting for each other.
+    const firstApp = createCustomServer({
+      enabled: false,
+      isWebSocketHMRRequest: (url) => url?.startsWith('/_next/hmr') ?? false,
+    }) as any
+    const secondApp = createCustomServer({
+      enabled: false,
+      isWebSocketHMRRequest: (url) =>
+        url?.startsWith('/guest/_next/hmr') ?? false,
+    }) as any
+    for (const app of [firstApp, secondApp]) {
+      const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+      app.pendingUpgrades = pendingUpgrades
+      app.prepareGeneration.pendingUpgrades = pendingUpgrades
+      app.init.upgradeHandler = jest.fn()
+    }
+    const server = new EventEmitter()
+    firstApp.setupWebSocketHandler(server)
+    secondApp.setupWebSocketHandler(server)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = {
+      headers: { upgrade: 'websocket' },
+      method: 'GET',
+      socket,
+      url: '/dashboard/_next/hmr',
+    }
+
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(firstApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(secondApp.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(getRequestMeta(request, 'webSocketSiblingHMR')).toBe(false)
+    socket.destroy()
+    await Promise.all([firstApp.close(), secondApp.close()])
+  })
+
+  it('coordinates through one outer dispatcher after automatic setup', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+    app.pendingUpgrades = pendingUpgrades
+    app.prepareGeneration.pendingUpgrades = pendingUpgrades
+    app.init.upgradeHandler = jest.fn()
+    const server = new EventEmitter()
+    app.setupWebSocketHandler(server)
+    const nextUpgrade = app.getUpgradeHandler()
+    const outerDispatcher = jest.fn((request: any, socket: any, head: Buffer) =>
+      nextUpgrade(request, socket, head)
+    )
+    server.on('upgrade', outerDispatcher)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = { headers: {}, method: 'GET', socket }
+
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(outerDispatcher).toHaveBeenCalledTimes(1)
+    expect(app.init.upgradeHandler).toHaveBeenCalledTimes(1)
+    expect(getRequestMeta(request, 'webSocketUpgradeOwnership')).toBe(
+      'coordinated'
+    )
+    socket.destroy()
+  })
+
+  it('fails closed when a one-shot listener disappears before dispatch', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    app.pendingUpgrades = new PendingWebSocketUpgradeTracker()
+    app.prepareGeneration.pendingUpgrades = app.pendingUpgrades
+    const server = new EventEmitter()
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+    const request = {
+      headers: {},
+      method: 'GET',
+      socket,
+    }
+    let ownership:
+      | 'exclusive'
+      | 'coordinated'
+      | 'sibling'
+      | 'shared'
+      | undefined
+    app.init.upgradeHandler = jest.fn(async () => {
+      ownership = getRequestMeta(request as any, 'webSocketUpgradeOwnership')
+    })
+
+    server.once('upgrade', app.getUpgradeHandler())
+    server.emit('upgrade', request, socket, Buffer.alloc(0))
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(app.init.upgradeHandler).not.toHaveBeenCalled()
+    expect(ownership).toBeUndefined()
+    socket.destroy()
+  })
+
+  it('does not reclaim an upgrade from an external listener emit snapshot', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    app.pendingUpgrades = new PendingWebSocketUpgradeTracker()
+    app.prepareGeneration.pendingUpgrades = app.pendingUpgrades
+    app.init.upgradeHandler = jest.fn()
+    const server = new EventEmitter()
+    const externalListener = jest.fn(() => {
+      server.off('upgrade', externalListener)
+    })
+    server.on('upgrade', externalListener)
+    app.setupWebSocketHandler(server)
+    const socket = new PassThrough() as PassThrough & {
+      server?: EventEmitter
+    }
+    socket.server = server
+
+    server.emit(
+      'upgrade',
+      { headers: {}, method: 'GET', socket },
+      socket,
+      Buffer.alloc(0)
+    )
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(externalListener).toHaveBeenCalledTimes(1)
+    expect(app.init.upgradeHandler).not.toHaveBeenCalled()
+    expect(socket.destroyed).toBe(false)
+    socket.destroy()
+  })
+
+  it('does not invoke the route after upgrade tracking re-enters close', async () => {
+    const app = createCustomServer({ enabled: true }) as any
+    const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+    app.pendingUpgrades = pendingUpgrades
+    app.prepareGeneration.pendingUpgrades = pendingUpgrades
+    app.init.upgradeHandler = jest.fn()
+    const socket = new EventEmitter() as any
+    socket.destroyed = false
+    socket.readableEnded = false
+    socket.writableEnded = false
+    socket.destroy = jest.fn(() => {
+      if (socket.destroyed) return
+      socket.destroyed = true
+      socket.emit('close')
+    })
+    let close: Promise<void> | undefined
+    socket.on('newListener', (event) => {
+      if (event === 'end' && !close) close = app.close()
+    })
+    const listener = app.getOrCreateWebSocketUpgradeListener()
+    const server = new EventEmitter()
+    server.on('upgrade', listener)
+
+    await listener(
+      { headers: {}, socket: { server }, method: 'GET' },
+      socket,
+      Buffer.alloc(0)
+    )
+    await close
+
+    expect(app.init.upgradeHandler).not.toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalled()
+  })
+
+  it('contains a pending-upgrade listener installation failure', async () => {
+    const failure = new Error('pending listener installation failed')
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+    const app = createCustomServer({ enabled: true }) as any
+    const pendingUpgrades = new PendingWebSocketUpgradeTracker()
+    app.pendingUpgrades = pendingUpgrades
+    app.prepareGeneration.pendingUpgrades = pendingUpgrades
+    app.init.upgradeHandler = jest.fn()
+    const socket = new EventEmitter() as any
+    socket.destroyed = false
+    socket.readableEnded = false
+    socket.writableEnded = false
+    socket.destroy = jest.fn(() => {
+      socket.destroyed = true
+      socket.emit('close')
+    })
+    socket.on('newListener', (event) => {
+      if (event === 'end') throw failure
+    })
+    const listener = app.getOrCreateWebSocketUpgradeListener()
+    const server = new EventEmitter()
+    server.on('upgrade', listener)
+
+    await expect(
+      listener(
+        { headers: {}, socket: { server }, method: 'GET' },
+        socket,
+        Buffer.alloc(0)
+      )
+    ).resolves.toBeUndefined()
+
+    expect(app.init.upgradeHandler).not.toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalledTimes(1)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error handling upgrade request',
+      failure
+    )
+  })
+
+  it('waits for an active prepare generation and closes it exactly once', async () => {
+    let finishPrepare!: (value: any) => void
+    const closeUpgraded = jest.fn()
+    const closeServer = jest.fn()
+    mockGetRequestHandlers.mockReturnValue(
+      new Promise((resolve) => {
+        finishPrepare = resolve
+      })
+    )
+    const app = next({
+      customServer: true,
+      dev: false,
+      dir: process.cwd(),
+    })
+
+    const firstPrepare = app.prepare()
+    const secondPrepare = app.prepare()
+    expect(secondPrepare).toBe(firstPrepare)
+
+    const firstClose = app.close()
+    const secondClose = app.close()
+    expect(secondClose).toBe(firstClose)
+    let closeSettled = false
+    void firstClose.finally(() => {
+      closeSettled = true
+    })
+    await Promise.resolve()
+    expect(closeSettled).toBe(false)
+
+    finishPrepare({
+      closeUpgraded,
+      server: { close: closeServer },
+      webSocketRouteHandlersEnabled: true,
+    })
+    await firstPrepare
+    await firstClose
+
+    expect(closeUpgraded).toHaveBeenCalledTimes(1)
+    expect(closeServer).toHaveBeenCalledTimes(1)
+    expect(app.close()).toBe(firstClose)
+  })
+
+  it('does not let a pre-prepare close poison the prepared generation', async () => {
+    const closeUpgraded = jest.fn()
+    const closeServer = jest.fn()
+    mockGetRequestHandlers.mockResolvedValue({
+      closeUpgraded,
+      server: { close: closeServer },
+      webSocketRouteHandlersEnabled: true,
+    })
+    const app = next({
+      customServer: true,
+      dev: false,
+      dir: process.cwd(),
+    })
+
+    await expect(app.close()).resolves.toBeUndefined()
+    await app.prepare()
+    await app.close()
+
+    expect(closeUpgraded).toHaveBeenCalledTimes(1)
+    expect(closeServer).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases a failed prepare generation without poisoning a racing retry', async () => {
+    const prepareFailure = new Error('prepare failed')
+    let rejectPrepare!: (error: Error) => void
+    let markCleanupStarted!: () => void
+    let finishCleanup!: () => void
+    const cleanupStarted = new Promise<void>((resolve) => {
+      markCleanupStarted = resolve
+    })
+    const cleanupGate = new Promise<void>((resolve) => {
+      finishCleanup = resolve
+    })
+    mockGetRequestHandlers.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectPrepare = reject
+      })
+    )
+    const app = next({
+      customServer: true,
+      dev: false,
+      dir: process.cwd(),
+    })
+
+    const firstPrepare = app.prepare()
+    const firstClose = app.close()
+    expect(app.close()).toBe(firstClose)
+    ;(app as any).prepareGeneration.cleanupListeners = {
+      runAll() {
+        markCleanupStarted()
+        return cleanupGate
+      },
+    }
+    rejectPrepare(prepareFailure)
+
+    await expect(firstPrepare).rejects.toBe(prepareFailure)
+    await cleanupStarted
+    const repeatedFailedGenerationClose = app.close()
+    expect(repeatedFailedGenerationClose).toBe(firstClose)
+    let failedGenerationCloseSettled = false
+    void repeatedFailedGenerationClose.finally(() => {
+      failedGenerationCloseSettled = true
+    })
+    await Promise.resolve()
+    expect(failedGenerationCloseSettled).toBe(false)
+
+    const closeUpgraded = jest.fn()
+    const closeServer = jest.fn()
+    mockGetRequestHandlers.mockResolvedValueOnce({
+      closeUpgraded,
+      server: { close: closeServer },
+      webSocketRouteHandlersEnabled: true,
+    })
+    await app.prepare()
+    const retryClose = app.close()
+    await retryClose
+
+    finishCleanup()
+    await expect(firstClose).resolves.toBeUndefined()
+
+    expect(mockGetRequestHandlers).toHaveBeenCalledTimes(2)
+    expect(closeUpgraded).toHaveBeenCalledTimes(1)
+    expect(closeServer).toHaveBeenCalledTimes(1)
+    expect(app.close()).toBe(retryClose)
+  })
+
+  it('does not deadlock when initialization requests an early restart', async () => {
+    const calls: string[] = []
+    const closeServer = jest.fn(() => calls.push('close-server'))
+    mockGetRequestHandlers.mockImplementationOnce(async (options) => {
+      await options.restartServer()
+      calls.push('finish-prepare')
+      return {
+        closeUpgraded: jest.fn(),
+        server: { close: closeServer },
+        webSocketRouteHandlersEnabled: true,
+      }
+    })
+    mockFlushAllTraces.mockImplementation(async () => {
+      calls.push('flush-traces')
+    })
+    const exit = jest.spyOn(process, 'exit').mockImplementation((() => {
+      calls.push('exit')
+    }) as never)
+
+    try {
+      const app = next({
+        customServer: true,
+        dev: false,
+        dir: process.cwd(),
+      })
+      await app.prepare()
+      await app.close()
+
+      expect(calls).toEqual([
+        'flush-traces',
+        'exit',
+        'finish-prepare',
+        'close-server',
+      ])
+    } finally {
+      exit.mockRestore()
+    }
+  })
+
+  it('retains legacy silent close semantics when the flag is disabled', async () => {
+    const calls: string[] = []
+    const fail = (stage: string) => {
+      calls.push(stage)
+      throw new Error(`${stage} failed`)
+    }
+    const app = createCustomServer({
+      enabled: false,
+      closeUpgraded: () => fail('close-upgraded'),
+      closePending: () => fail('close-pending'),
+      closeServer: () => fail('close-server'),
+      cleanup: () => fail('cleanup'),
+    })
+
+    await expect(app.close()).resolves.toBeUndefined()
+    expect(calls).toEqual([
+      'close-pending',
+      'close-upgraded',
+      'close-server',
+      'cleanup',
+    ])
+  })
+
+  it('flushes traces after a restart close failure before exiting', async () => {
+    const failure = new Error('restart close failed')
+    const calls: string[] = []
+    let restartServer!: () => Promise<void>
+    mockGetRequestHandlers.mockImplementation(async (options) => {
+      restartServer = options.restartServer
+      return {
+        closeUpgraded() {
+          calls.push('close-upgraded')
+          throw failure
+        },
+        server: {
+          close() {
+            calls.push('close-server')
+          },
+        },
+        webSocketRouteHandlersEnabled: true,
+      }
+    })
+    mockFlushAllTraces.mockImplementation(async () => {
+      calls.push('flush-traces')
+    })
+    const exit = jest.spyOn(process, 'exit').mockImplementation((() => {
+      calls.push('exit')
+    }) as never)
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    try {
+      const app = next({
+        customServer: true,
+        dev: false,
+        dir: process.cwd(),
+      })
+      await app.prepare()
+      await restartServer()
+
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to close the Next.js custom server during restart',
+        failure
+      )
+      expect(calls).toEqual([
+        'close-upgraded',
+        'close-server',
+        'flush-traces',
+        'exit',
+      ])
+    } finally {
+      consoleError.mockRestore()
+      exit.mockRestore()
+    }
+  })
+})

--- a/test/unit/server-cleanup.test.ts
+++ b/test/unit/server-cleanup.test.ts
@@ -1,0 +1,100 @@
+import {
+  latchServerCleanupExitCode,
+  runServerCleanupPhases,
+  scheduleServerCleanup,
+} from 'next/dist/server/lib/server-cleanup'
+
+describe('server process cleanup phases', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('schedules cleanup after the owner returns and observes rejection', async () => {
+    jest.useFakeTimers()
+    const failure = new Error('scheduled cleanup failed')
+    const cleanup = jest.fn(async () => {
+      throw failure
+    })
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    scheduleServerCleanup(cleanup)
+    expect(cleanup).not.toHaveBeenCalled()
+
+    jest.runOnlyPendingTimers()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(consoleError).toHaveBeenCalledWith(failure)
+  })
+
+  it('lets a termination signal override an in-flight restart', () => {
+    let exitCode = latchServerCleanupExitCode(undefined, 77)
+    exitCode = latchServerCleanupExitCode(exitCode, 143)
+    exitCode = latchServerCleanupExitCode(exitCode, 77)
+
+    expect(exitCode).toBe(143)
+  })
+
+  it('attempts every stage and phase with deterministic diagnostics', async () => {
+    const firstFailure = new Error('first phase failed')
+    const secondFailure = new Error('second phase failed')
+    const events: string[] = []
+    let finishParallelStage!: () => void
+
+    const cleanup = runServerCleanupPhases(
+      [
+        [
+          () => {
+            events.push('phase-1:first')
+            throw firstFailure
+          },
+          () =>
+            new Promise<void>((resolve) => {
+              events.push('phase-1:parallel')
+              finishParallelStage = resolve
+            }),
+        ],
+        [
+          () => {
+            events.push('phase-2')
+            throw secondFailure
+          },
+        ],
+        [
+          () => {
+            events.push('phase-3')
+          },
+        ],
+      ],
+      (error) => events.push(`failure:${(error as Error).message}`)
+    )
+
+    await Promise.resolve()
+    expect(events).toEqual(['phase-1:first', 'phase-1:parallel'])
+    finishParallelStage()
+    await cleanup
+
+    expect(events).toEqual([
+      'phase-1:first',
+      'phase-1:parallel',
+      'failure:first phase failed',
+      'phase-2',
+      'failure:second phase failed',
+      'phase-3',
+    ])
+  })
+
+  it('keeps cleaning up when the diagnostic sink throws', async () => {
+    const laterStage = jest.fn()
+
+    await expect(
+      runServerCleanupPhases(
+        [[() => Promise.reject(new Error('cleanup failed'))], [laterStage]],
+        () => {
+          throw new Error('diagnostic failed')
+        }
+      )
+    ).resolves.toBeUndefined()
+    expect(laterStage).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
### What?

Coordinate the lifecycle of pending WebSocket upgrades and accepted connections across Next.js server entry points.

### Why?

An upgraded connection outlives the HTTP request that created it. `next dev`, `next start`, standalone output, and custom servers therefore need explicit ownership for listener installation, registration rollback, shutdown ordering, and connections that do not complete a close handshake.

### How?

- Add stable custom-server upgrade handlers without replacing an application-owned listener.
- Track pending upgrades before handoff and accepted connections after the `101` response.
- Close accepted connections with `1001` during shutdown and bound peers or hooks that do not settle within the grace period.
- Make listener cleanup exact, idempotent, re-entrant, and failure-preserving.
- Distinguish automatic sibling Next.js listeners from a single outer dispatcher: automatic siblings handle only their matching HMR endpoint, while ordinary WebSocket routes fail closed with guidance to select one app explicitly.
- Match sibling HMR against each app's live base path or asset prefix, including changes made with `setAssetPrefix()`.
- Treat a public handler selected by an outer dispatcher as the sole owner of that request, including owner-specific origin validation and unmatched `404` responses.
- Preserve single-app custom-server behavior when the experiment is disabled and continue delegating to genuinely external upgrade owners.

This PR is stacked directly on #95574 and contains the server-lifecycle portion of the feature.

### Verification

- `pnpm exec jest --runInBand packages/next/src/server/websocket-http.test.ts test/unit/next-custom-server-close.test.ts` (87 tests)
- `pnpm test-dev-turbo test/e2e/app-dir/websocket-route-handlers-shutdown/websocket-route-handlers-shutdown.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/websocket-route-handlers-shutdown/websocket-route-handlers-shutdown.test.ts`
- The same shutdown matrix with Cache Components enabled
- Multi-zone HTTP, HMR, origin, malformed-handshake, route, and close-isolation coverage in dev and production with both Turbopack and webpack
- Socket.IO compatibility with the experiment disabled
- Configuration-mismatch coverage with and without Cache Components
- Standalone WebSocket deployment coverage with Webpack; Cache Components skips the legacy ISR-only contract
- `pnpm --filter=next build`
- Later: sibling HMR deferral is now driven by the dispatch layer's live matcher verdict (request meta), not a URL-shape regex — a route path containing `/_next/hmr` that no sibling owns no longer hangs in multi-app custom servers; new unit coverage included.
