### PR TITLE
Track WebSocket route generations

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -140,6 +140,12 @@ import {
   writeRawHttpError,
 } from './websocket-http'
 import {
+  getWebSocketRouteBundlePath,
+  isWebSocketRouteLeaseCurrent,
+  ownWebSocketRouteLease,
+  tryAcquireWebSocketRouteLease,
+} from './websocket-connection-registry'
+import {
   ensureInstrumentationRegistered,
   getInstrumentationModule,
 } from './lib/router-utils/instrumentation-globals.external'
@@ -465,6 +471,13 @@ export default class NextNodeServer extends BaseServer<
       return
     }
 
+    const webSocketRegistryScope = getRequestMeta(req, 'webSocketRegistryScope')
+    if (!webSocketRegistryScope) {
+      await writeRawHttpError(req, socket, 500, 'Internal Server Error')
+      return
+    }
+
+    const webSocketBundlePath = getWebSocketRouteBundlePath(page)
     const findUpgradeComponents = async () => {
       try {
         if (this.dev) {
@@ -492,36 +505,89 @@ export default class NextNodeServer extends BaseServer<
       }
     }
 
-    const result = await findUpgradeComponents()
-    if (
-      !result ||
-      result.components.routeModule?.definition.kind !== RouteKind.APP_ROUTE ||
-      typeof (result.components.ComponentMod as AppRouteModule)
-        .upgradeHandler !== 'function'
-    ) {
-      await writeRawHttpError(req, socket, 404, 'Not Found')
-      return
-    }
-
-    if (!getRequestMeta(req, 'hmrRefreshHash')) {
-      addRequestMeta(
-        req,
-        'hmrRefreshHash',
-        this.getServerComponentsHmrRefreshHash()
+    // A route can change while its first dev compilation or async module is
+    // resolving. Retry that pre-handler window once with a fresh generation;
+    // never replay user handler side effects.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const webSocketRouteLease = tryAcquireWebSocketRouteLease(
+        webSocketRegistryScope,
+        webSocketBundlePath
       )
-    }
-    addRequestMeta(req, 'relativeProjectDir', relative(process.cwd(), this.dir))
-    addRequestMeta(req, 'distDir', this.distDir)
-    await (result.components.ComponentMod as AppRouteModule).upgradeHandler(
-      {
-        waitUntil: this.getWaitUntil(),
-        requestMeta: getRequestMeta(req),
-        responseHeaders: getRequestMeta(req, 'webSocketUpgradeHeaders'),
-      },
-      {
-        node: { req, socket, head },
+      if (!webSocketRouteLease) {
+        socket.destroy()
+        return
       }
-    )
+
+      let leaseOwnership: ReturnType<typeof ownWebSocketRouteLease> | undefined
+      try {
+        leaseOwnership = ownWebSocketRouteLease(webSocketRouteLease, socket)
+        addRequestMeta(req, 'webSocketRouteLease', webSocketRouteLease)
+
+        if (
+          leaseOwnership.isSocketEnded() ||
+          !isWebSocketRouteLeaseCurrent(webSocketRouteLease)
+        ) {
+          if (!leaseOwnership.isSocketEnded() && attempt === 0) continue
+          return
+        }
+
+        const result = await findUpgradeComponents()
+        if (!isWebSocketRouteLeaseCurrent(webSocketRouteLease)) {
+          if (!leaseOwnership.isSocketEnded() && attempt === 0) continue
+          if (!leaseOwnership.isSocketEnded()) {
+            await writeRawHttpError(req, socket, 503, 'Service Unavailable')
+          }
+          return
+        }
+
+        if (
+          !result ||
+          result.components.routeModule?.definition.kind !==
+            RouteKind.APP_ROUTE ||
+          typeof (result.components.ComponentMod as AppRouteModule)
+            .upgradeHandler !== 'function'
+        ) {
+          await writeRawHttpError(req, socket, 404, 'Not Found')
+          return
+        }
+
+        if (!getRequestMeta(req, 'hmrRefreshHash')) {
+          addRequestMeta(
+            req,
+            'hmrRefreshHash',
+            this.getServerComponentsHmrRefreshHash()
+          )
+        }
+        addRequestMeta(
+          req,
+          'relativeProjectDir',
+          relative(process.cwd(), this.dir)
+        )
+        addRequestMeta(req, 'distDir', this.distDir)
+        await (result.components.ComponentMod as AppRouteModule).upgradeHandler(
+          {
+            waitUntil: this.getWaitUntil(),
+            requestMeta: getRequestMeta(req),
+            responseHeaders: getRequestMeta(req, 'webSocketUpgradeHeaders'),
+          },
+          {
+            node: { req, socket, head },
+          }
+        )
+        return
+      } finally {
+        const failures = leaseOwnership?.release() ?? []
+        webSocketRouteLease.release()
+        for (const failure of failures) {
+          try {
+            console.error(
+              'Failed to release a WebSocket route lease listener:',
+              failure
+            )
+          } catch {}
+        }
+      }
+    }
   }
 
   protected async loadInstrumentationModule() {

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -232,6 +232,9 @@ export interface RequestMeta {
   /** Framework-owned lifecycle scope for a routed WebSocket upgrade. */
   webSocketRegistryScope?: object
 
+  /** Framework-owned generation lease for the resolved WebSocket App Route. */
+  webSocketRouteLease?: import('./websocket-connection-registry').WebSocketRouteLease
+
   /** How the embedding server dispatched this WebSocket upgrade. */
   webSocketUpgradeOwnership?: import('./websocket-upgrade-listener').WebSocketUpgradeOwnership
   /**

--- a/packages/next/src/server/route-modules/app-route/websocket-runtime.external.ts
+++ b/packages/next/src/server/route-modules/app-route/websocket-runtime.external.ts
@@ -260,17 +260,17 @@ export function createAppRouteWebSocketEntrypoint({
     if (webSocketUpgradeTransport) return webSocketUpgradeTransport
     const { createWebSocketUpgradeTransport } =
       require('../../websocket-upgrade') as typeof import('../../websocket-upgrade')
-    const { registerWebSocketPeer, unregisterWebSocketPeer } =
+    const { registerWebSocketRoutePeer, unregisterWebSocketRoutePeer } =
       getWebSocketRegistry()
     return (webSocketUpgradeTransport = createWebSocketUpgradeTransport({
       runInHookContext: runInWebSocketHookContext,
       registerPeer(_peer, connection, context) {
-        if (!context.registryScope) return
-        return registerWebSocketPeer(connection, context.registryScope)
+        if (!context.routeLease) return false
+        return registerWebSocketRoutePeer(connection, context.routeLease)
       },
       unregisterPeer(_peer, connection, context) {
-        if (context.registryScope) {
-          unregisterWebSocketPeer(connection, context.registryScope)
+        if (context.routeLease) {
+          unregisterWebSocketRoutePeer(connection, context.routeLease)
         }
       },
     }))
@@ -357,6 +357,7 @@ export function createAppRouteWebSocketEntrypoint({
               head,
               ctx,
               getRequestMeta(req, 'webSocketRegistryScope'),
+              getRequestMeta(req, 'webSocketRouteLease'),
               (report) => {
                 reportError = report
               },
@@ -433,16 +434,23 @@ export function createAppRouteWebSocketEntrypoint({
     head: Buffer,
     ctx: AppRouteHandlerContext,
     trustedRegistryScope: object | undefined,
+    trustedRouteLease:
+      | import('../../websocket-connection-registry').WebSocketRouteLease
+      | undefined,
     setReportError: (report: (error: unknown) => Promise<void>) => void,
     setRequestSignal: (signal: AbortSignal) => void
   ): Promise<AppRouteUpgradeOutcome> {
     if (ctx.requestMeta) {
       const requestMeta = { ...ctx.requestMeta }
       delete requestMeta.webSocketRegistryScope
+      delete requestMeta.webSocketRouteLease
       setRequestMeta(req, requestMeta)
     }
     if (trustedRegistryScope) {
       addRequestMeta(req, 'webSocketRegistryScope', trustedRegistryScope)
+    }
+    if (trustedRouteLease) {
+      addRequestMeta(req, 'webSocketRouteLease', trustedRouteLease)
     }
     filterWebSocketUpgradeRequestHeaders(req)
 
@@ -572,9 +580,15 @@ export function createAppRouteWebSocketEntrypoint({
         return { statusCode: response.status, upgraded: false }
       }
 
-      if (!trustedRegistryScope) {
+      if (!trustedRegistryScope || !trustedRouteLease) {
         await writeRawHttpError(req, socket, 500, 'Internal Server Error')
         return { statusCode: 500, upgraded: false }
+      }
+      if (
+        !getWebSocketRegistry().isWebSocketRouteLeaseCurrent(trustedRouteLease)
+      ) {
+        await writeRawHttpError(req, socket, 503, 'Service Unavailable')
+        return { statusCode: 503, upgraded: false }
       }
 
       const outcome = await getWebSocketUpgradeTransport().handleUpgrade(
@@ -591,7 +605,7 @@ export function createAppRouteWebSocketEntrypoint({
               trustedRegistryScope
             )
           },
-          registryScope: trustedRegistryScope,
+          routeLease: trustedRouteLease,
         }
       )
       return outcome

--- a/packages/next/src/server/websocket-connection-registry.test.ts
+++ b/packages/next/src/server/websocket-connection-registry.test.ts
@@ -1,11 +1,21 @@
-import type { WebSocketRegistryConnection } from './websocket-connection-registry'
+import type {
+  WebSocketRegistryConnection,
+  WebSocketRouteLeaseSocket,
+} from './websocket-connection-registry'
 import {
+  closeWebSocketRoute,
   closeWebSocketScope,
-  registerWebSocketPeer,
+  getWebSocketRouteBundlePath,
+  isWebSocketRouteActive,
+  isWebSocketRouteLeaseCurrent,
+  ownWebSocketRouteLease,
+  registerWebSocketRoutePeer,
+  reloadWebSocketScope,
   settleWebSocketShutdownStages,
   trackWebSocketTask,
+  tryAcquireWebSocketRouteLease,
   tryAcquireWebSocketScopeLease,
-  unregisterWebSocketPeer,
+  unregisterWebSocketRoutePeer,
 } from './websocket-connection-registry'
 
 function deferred() {
@@ -47,6 +57,49 @@ function createConnection(initialReadyState = 1) {
   }
 }
 
+function createLeaseSocket(
+  initial: Partial<
+    Pick<
+      WebSocketRouteLeaseSocket,
+      'destroyed' | 'readableEnded' | 'writableEnded'
+    >
+  > = {}
+) {
+  const listeners = new Map<'close' | 'end', () => void>()
+  const socket: WebSocketRouteLeaseSocket = {
+    destroyed: initial.destroyed ?? false,
+    readableEnded: initial.readableEnded ?? false,
+    writableEnded: initial.writableEnded ?? false,
+    once: jest.fn((event, listener) => {
+      listeners.set(event, listener)
+      return socket
+    }),
+    off: jest.fn((event, listener) => {
+      if (listeners.get(event) === listener) listeners.delete(event)
+      return socket
+    }),
+  }
+  return {
+    listeners,
+    socket,
+    emit(event: 'close' | 'end') {
+      listeners.get(event)?.()
+    },
+  }
+}
+
+/** Registers a connection on a route of `scope` through the lease path. */
+function registerRouteConnection(
+  scope: object,
+  bundlePath = getWebSocketRouteBundlePath('/ws'),
+  connection = createConnection()
+) {
+  const lease = tryAcquireWebSocketRouteLease(scope, bundlePath)
+  expect(lease).toBeDefined()
+  expect(registerWebSocketRoutePeer(connection.connection, lease!)).toBe(true)
+  return { ...connection, lease: lease! }
+}
+
 describe('WebSocket connection registry', () => {
   afterEach(() => {
     jest.useRealTimers()
@@ -59,10 +112,10 @@ describe('WebSocket connection registry', () => {
     const first = createConnection()
     const second = createConnection()
 
-    expect(registerWebSocketPeer(first.connection, scopeA)).toBe(true)
-    expect(registerWebSocketPeer(first.connection, scopeA)).toBe(true)
-    expect(registerWebSocketPeer(second.connection, scopeB)).toBe(true)
-    unregisterWebSocketPeer(first.connection, scopeA)
+    const firstRegistered = registerRouteConnection(scopeA, undefined, first)
+    registerRouteConnection(scopeB, undefined, second)
+    unregisterWebSocketRoutePeer(first.connection, firstRegistered.lease)
+    firstRegistered.lease.release()
 
     await closeWebSocketScope(scopeA)
     expect(first.connection.close).not.toHaveBeenCalled()
@@ -78,7 +131,7 @@ describe('WebSocket connection registry', () => {
   it('closes gracefully with 1001 and waits for the close event', async () => {
     const scope = {}
     const peer = createConnection()
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     let settled = false
     const closing = closeWebSocketScope(scope).then(() => {
@@ -99,8 +152,8 @@ describe('WebSocket connection registry', () => {
     const scope = {}
     const closingPeer = createConnection(2)
     const closedPeer = createConnection(3)
-    registerWebSocketPeer(closingPeer.connection, scope)
-    registerWebSocketPeer(closedPeer.connection, scope)
+    registerRouteConnection(scope, undefined, closingPeer)
+    registerRouteConnection(scope, undefined, closedPeer)
 
     const closing = closeWebSocketScope(scope, 1012)
     await Promise.resolve()
@@ -117,7 +170,7 @@ describe('WebSocket connection registry', () => {
     jest.useFakeTimers()
     const scope = {}
     const peer = createConnection()
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     const closing = closeWebSocketScope(scope)
     await Promise.resolve()
@@ -139,8 +192,8 @@ describe('WebSocket connection registry', () => {
     ;(second.connection.close as jest.Mock).mockImplementation(() => {
       second.emitClose()
     })
-    registerWebSocketPeer(first.connection, scope)
-    registerWebSocketPeer(second.connection, scope)
+    registerRouteConnection(scope, undefined, first)
+    registerRouteConnection(scope, undefined, second)
 
     await expect(closeWebSocketScope(scope)).rejects.toBe(closeError)
     expect(first.connection.terminate).toHaveBeenCalledTimes(1)
@@ -158,7 +211,7 @@ describe('WebSocket connection registry', () => {
     ;(peer.connection.terminate as jest.Mock).mockImplementation(() => {
       throw terminateError
     })
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     const error = await closeWebSocketScope(scope).catch((caught) => caught)
     expect(error).toBeInstanceOf(AggregateError)
@@ -172,7 +225,7 @@ describe('WebSocket connection registry', () => {
     ;(peer.connection.close as jest.Mock).mockImplementation(() => {
       reentrantDrain = closeWebSocketScope(scope, 1012)
     })
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     const drain = closeWebSocketScope(scope, 1001)
     await Promise.resolve()
@@ -181,11 +234,9 @@ describe('WebSocket connection registry', () => {
     peer.emitClose()
     await drain
 
-    const late = createConnection()
-    expect(registerWebSocketPeer(late.connection, scope)).toBe(false)
-    await Promise.resolve()
-    expect(late.connection.close).toHaveBeenCalledWith(1001)
-    late.emitClose()
+    expect(
+      tryAcquireWebSocketRouteLease(scope, getWebSocketRouteBundlePath('/ws'))
+    ).toBeUndefined()
   })
 
   it('handles a synchronous close during listener installation', async () => {
@@ -195,7 +246,7 @@ describe('WebSocket connection registry', () => {
       listener()
       return jest.fn()
     })
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     await expect(closeWebSocketScope(scope)).resolves.toBeUndefined()
     expect(peer.connection.close).not.toHaveBeenCalled()
@@ -211,7 +262,7 @@ describe('WebSocket connection registry', () => {
       trackWebSocketTask(hookTask.promise, scope)
       peer.emitClose()
     })
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     let settled = false
     const closing = closeWebSocketScope(scope).then(() => {
@@ -233,6 +284,15 @@ describe('WebSocket connection registry', () => {
     const lease = tryAcquireWebSocketScopeLease(scope)
     expect(lease).toBeDefined()
 
+    // Acquired before the close starts, registered after: refused with the
+    // shutdown close code.
+    const latePeer = createConnection()
+    const lateLease = tryAcquireWebSocketRouteLease(
+      scope,
+      getWebSocketRouteBundlePath('/ws')
+    )
+    expect(lateLease).toBeDefined()
+
     let settled = false
     const closing = closeWebSocketScope(scope).then(() => {
       settled = true
@@ -243,10 +303,12 @@ describe('WebSocket connection registry', () => {
     expect(settled).toBe(false)
     expect(tryAcquireWebSocketScopeLease(scope)).toBeUndefined()
 
-    const latePeer = createConnection()
-    expect(registerWebSocketPeer(latePeer.connection, scope)).toBe(false)
+    expect(registerWebSocketRoutePeer(latePeer.connection, lateLease!)).toBe(
+      false
+    )
     await Promise.resolve()
     expect(latePeer.connection.close).toHaveBeenCalledWith(1001)
+    lateLease!.release()
 
     lease!.release()
     lease!.release()
@@ -351,7 +413,7 @@ describe('WebSocket connection registry', () => {
       trackWebSocketTask(task.promise, scope)
       throw peerFailure
     })
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     const closing = closeWebSocketScope(scope)
     await Promise.resolve()
@@ -376,7 +438,7 @@ describe('WebSocket connection registry', () => {
         peer.emitClose()
       }, 10)
     })
-    registerWebSocketPeer(peer.connection, scope)
+    registerRouteConnection(scope, undefined, peer)
 
     let settled = false
     const closing = closeWebSocketScope(scope).then(() => {
@@ -394,6 +456,194 @@ describe('WebSocket connection registry', () => {
     await closing
     expect(settled).toBe(true)
     expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('normalizes the App Route bundle identity shared with dev bundlers', () => {
+    expect(getWebSocketRouteBundlePath('/chat/route')).toBe('app/chat/route')
+    expect(getWebSocketRouteBundlePath('chat\\route')).toBe('app/chat/route')
+  })
+
+  it('pins and prunes a route with an opaque idempotent lease', () => {
+    const scope = {}
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')
+
+    expect(lease).toBeDefined()
+    expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(true)
+    lease!.release()
+    lease!.release()
+    expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(false)
+  })
+
+  it('keeps a registered peer active after its request lease is released', () => {
+    const scope = {}
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    const peer = createConnection()
+    registerWebSocketRoutePeer(peer.connection, lease)
+
+    lease.release()
+    expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(true)
+    unregisterWebSocketRoutePeer(peer.connection, lease)
+    expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(false)
+  })
+
+  it('owns disconnect listeners without leaking or replacing failures', () => {
+    const scope = {}
+    const installFailure = new Error('listener install failed')
+    const cleanupFailure = new Error('listener cleanup failed')
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    const { listeners, socket } = createLeaseSocket()
+    ;(socket.once as jest.Mock).mockImplementationOnce(
+      (event: 'close' | 'end', listener: () => void) => {
+        listeners.set(event, listener)
+        throw installFailure
+      }
+    )
+    ;(socket.off as jest.Mock).mockImplementation(() => {
+      throw cleanupFailure
+    })
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    expect(() => ownWebSocketRouteLease(lease, socket)).toThrow(installFailure)
+    expect(isWebSocketRouteLeaseCurrent(lease)).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to release a WebSocket route lease listener:',
+      cleanupFailure
+    )
+  })
+
+  it('releases before reporting listener removal failures', () => {
+    const scope = {}
+    const cleanupFailure = new Error('listener cleanup failed')
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    const { socket } = createLeaseSocket()
+    const ownership = ownWebSocketRouteLease(lease, socket)
+    ;(socket.off as jest.Mock).mockImplementationOnce(() => {
+      throw cleanupFailure
+    })
+
+    expect(ownership.release()).toEqual([cleanupFailure])
+    expect(ownership.release()).toEqual([])
+    expect(isWebSocketRouteLeaseCurrent(lease)).toBe(false)
+  })
+
+  it.each([
+    ['already destroyed', { destroyed: true }],
+    ['already readable-ended', { readableEnded: true }],
+  ])('releases a lease for a socket which is %s', (_label, initial) => {
+    const scope = {}
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    const { socket } = createLeaseSocket(initial)
+    const ownership = ownWebSocketRouteLease(lease, socket)
+
+    expect(ownership.isSocketEnded()).toBe(true)
+    expect(isWebSocketRouteLeaseCurrent(lease)).toBe(false)
+    expect(ownership.release()).toEqual([])
+  })
+
+  it('handles a synchronous disconnect during listener installation', () => {
+    const scope = {}
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    const { socket } = createLeaseSocket()
+    ;(socket.once as jest.Mock).mockImplementationOnce(
+      (_event: 'close' | 'end', listener: () => void) => {
+        listener()
+        return socket
+      }
+    )
+
+    const ownership = ownWebSocketRouteLease(lease, socket)
+    expect(isWebSocketRouteLeaseCurrent(lease)).toBe(false)
+    expect(ownership.release()).toEqual([])
+  })
+
+  it('reloads one route without closing another route', async () => {
+    const scope = {}
+    const chatLease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    const feedLease = tryAcquireWebSocketRouteLease(scope, 'app/feed/route')!
+    const chat = createConnection()
+    const feed = createConnection()
+    expect(registerWebSocketRoutePeer(chat.connection, chatLease)).toBe(true)
+    expect(registerWebSocketRoutePeer(feed.connection, feedLease)).toBe(true)
+
+    const closing = closeWebSocketRoute(scope, 'app/chat/route')
+    expect(chat.connection.close).toHaveBeenCalledWith(1012)
+    expect(feed.connection.close).not.toHaveBeenCalled()
+    expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(false)
+    expect(isWebSocketRouteActive(scope, 'app/feed/route')).toBe(true)
+    chat.emitClose()
+    await closing
+
+    unregisterWebSocketRoutePeer(feed.connection, feedLease)
+    chatLease.release()
+    feedLease.release()
+  })
+
+  it('rejects a peer from an invalidated route generation without ABA', async () => {
+    const scope = {}
+    const staleLease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    await closeWebSocketRoute(scope, 'app/chat/route')
+    const currentLease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+
+    staleLease.release()
+    expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(true)
+
+    const stale = createConnection()
+    expect(registerWebSocketRoutePeer(stale.connection, staleLease)).toBe(false)
+    expect(stale.connection.close).toHaveBeenCalledWith(1012)
+    stale.emitClose()
+
+    const current = createConnection()
+    expect(registerWebSocketRoutePeer(current.connection, currentLease)).toBe(
+      true
+    )
+    expect(current.connection.close).not.toHaveBeenCalled()
+    unregisterWebSocketRoutePeer(current.connection, currentLease)
+    currentLease.release()
+    await Promise.resolve()
+  })
+
+  it('uses the terminal scope code for a late peer on a released lease', async () => {
+    const scope = {}
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+    lease.release()
+
+    const closing = closeWebSocketScope(scope, 1011)
+    const late = createConnection()
+    expect(registerWebSocketRoutePeer(late.connection, lease)).toBe(false)
+    expect(late.connection.close).toHaveBeenCalledWith(1011)
+    late.emitClose()
+    await closing
+  })
+
+  it('broadly reloads the current snapshot while preserving new routes', async () => {
+    const scope = {}
+    const firstLease = tryAcquireWebSocketRouteLease(scope, 'app/a/route')!
+    const secondLease = tryAcquireWebSocketRouteLease(scope, 'app/b/route')!
+    const first = createConnection()
+    const second = createConnection()
+    registerWebSocketRoutePeer(first.connection, firstLease)
+    registerWebSocketRoutePeer(second.connection, secondLease)
+
+    const reloading = reloadWebSocketScope(scope)
+    expect(first.connection.close).toHaveBeenCalledWith(1012)
+    expect(second.connection.close).toHaveBeenCalledWith(1012)
+
+    const currentLease = tryAcquireWebSocketRouteLease(scope, 'app/a/route')!
+    const current = createConnection()
+    expect(registerWebSocketRoutePeer(current.connection, currentLease)).toBe(
+      true
+    )
+    const stale = createConnection()
+    expect(registerWebSocketRoutePeer(stale.connection, firstLease)).toBe(false)
+    stale.emitClose()
+
+    first.emitClose()
+    second.emitClose()
+    await reloading
+    unregisterWebSocketRoutePeer(current.connection, currentLease)
+    firstLease.release()
+    secondLease.release()
+    currentLease.release()
   })
 
   it('settles every shutdown stage before reporting failures', async () => {

--- a/packages/next/src/server/websocket-connection-registry.ts
+++ b/packages/next/src/server/websocket-connection-registry.ts
@@ -1,8 +1,43 @@
 import type { WebSocketTransportConnection } from './websocket-upgrade'
+import { isSocketDisconnected, throwCombinedFailures } from './websocket-http'
+import {
+  CLOSE_GRACE_PERIOD_MS,
+  TERMINATE_CLOSE_EVENT_GRACE_PERIOD_MS,
+} from './websocket-shutdown-budget'
+
+/**
+ * Process-local registry for accepted WebSocket peers and in-flight upgrade
+ * leases, keyed by the emitted App Route bundle identity.
+ *
+ * Generation invariant: one route state = one generation. A route lease pins
+ * its generation; `closeWebSocketRoute` invalidates by deleting the state
+ * synchronously before closing (takeWebSocketRouteConnections), so every
+ * in-flight lease becomes stale and a replacement request creates a fresh
+ * state that the old drain cannot capture. `registerWebSocketRoutePeer`
+ * revalidates lease + generation identity synchronously at registration, in
+ * the same run-to-completion tick as the runtime's lease-current check, so
+ * no generation bump can interleave between check and registration.
+ *
+ * State is global (Symbol.for stores) because the app-route template bundles
+ * this module's consumers into user-compiled route entries: multiple module
+ * instances in one process must converge on one registry. Server instances
+ * are isolated from each other through their per-router-server registry
+ * scope objects (WeakMap-keyed), so sibling Next.js apps in one process do
+ * not share connection state.
+ *
+ * Lease lifetime: a route lease is released by the route handler's request
+ * finally or by its owning socket's close/end. A pre-handler hang (e.g. a
+ * stuck dev compilation) can pin the route entry; process shutdown is still
+ * bounded because the pending-upgrade tracker owns the raw socket until the
+ * registry accepts the peer.
+ */
 
 export type WebSocketRegistryConnection = WebSocketTransportConnection
 
 const REGISTRY_SYMBOL = Symbol.for('next.websocket.connection-registry')
+const ROUTE_LEASES_SYMBOL = Symbol.for(
+  'next.websocket.connection-registry-route-leases'
+)
 const CLOSED_SCOPES_SYMBOL = Symbol.for(
   'next.websocket.closed-connection-registry-scopes'
 )
@@ -19,10 +54,24 @@ const ABANDONED_TASKS_SYMBOL = Symbol.for(
 const TASK_ADMISSION_CLOSED_SCOPES_SYMBOL = Symbol.for(
   'next.websocket.connection-registry-task-admission-closed-scopes'
 )
-const CLOSE_GRACE_PERIOD_MS = 5_000
-const TERMINATE_CLOSE_EVENT_GRACE_PERIOD_MS = 1_000
-
-type ScopedRegistry = WeakMap<object, Set<WebSocketRegistryConnection>>
+type WebSocketRouteState = {
+  readonly peers: Set<WebSocketRegistryConnection>
+  leases: number
+}
+type WebSocketScopeRegistry = {
+  readonly routes: Map<string, WebSocketRouteState>
+}
+type ScopedRegistry = WeakMap<object, WebSocketScopeRegistry>
+type WebSocketRouteLeaseState = {
+  readonly scope: object
+  readonly bundlePath: string
+  readonly route: WebSocketRouteState
+  released: boolean
+}
+type WebSocketRouteLeases = WeakMap<
+  WebSocketRouteLease,
+  WebSocketRouteLeaseState
+>
 type ClosedScopes = WeakMap<object, number>
 type ScopeDrains = WeakMap<object, Promise<void>>
 type ScopedTasks = WeakMap<object, Set<Promise<void>>>
@@ -39,6 +88,48 @@ function getScopedRegistry(): ScopedRegistry {
     [REGISTRY_SYMBOL]?: ScopedRegistry
   }
   return (globalRegistry[REGISTRY_SYMBOL] ??= new WeakMap())
+}
+
+function getScopeRegistry(
+  scope: object,
+  create: boolean
+): WebSocketScopeRegistry | undefined {
+  const scopedRegistry = getScopedRegistry()
+  let registry = scopedRegistry.get(scope)
+  if (!registry && create) {
+    registry = { routes: new Map() }
+    scopedRegistry.set(scope, registry)
+  }
+  return registry
+}
+
+function getWebSocketRouteLeases(): WebSocketRouteLeases {
+  const globalRegistry = globalThis as typeof globalThis & {
+    [ROUTE_LEASES_SYMBOL]?: WebSocketRouteLeases
+  }
+  return (globalRegistry[ROUTE_LEASES_SYMBOL] ??= new WeakMap())
+}
+
+function pruneScopeRegistry(
+  scope: object,
+  registry: WebSocketScopeRegistry
+): void {
+  if (registry.routes.size === 0) {
+    const scopedRegistry = getScopedRegistry()
+    if (scopedRegistry.get(scope) === registry) scopedRegistry.delete(scope)
+  }
+}
+
+function pruneRouteState(
+  scope: object,
+  bundlePath: string,
+  route: WebSocketRouteState
+): void {
+  if (route.leases !== 0 || route.peers.size !== 0) return
+  const registry = getScopeRegistry(scope, false)
+  if (!registry || registry.routes.get(bundlePath) !== route) return
+  registry.routes.delete(bundlePath)
+  pruneScopeRegistry(scope, registry)
 }
 
 function getClosedScopes(): ClosedScopes {
@@ -146,6 +237,13 @@ export function trackWebSocketTask(task: Promise<void>, scope: object): void {
           'WebSocket lifecycle task failed after shutdown completed:',
           error
         )
+      } else if (getTaskAdmissionClosedScopes().has(scope)) {
+        // The drain that buffers failures for waitForWebSocketTasks has
+        // already completed, so nothing would read a buffered failure.
+        console.error(
+          'WebSocket lifecycle task failed after shutdown completed:',
+          error
+        )
       } else if (getClosedScopes().has(scope)) {
         failureState.failures.push({ order, error })
       } else {
@@ -158,6 +256,29 @@ export function trackWebSocketTask(task: Promise<void>, scope: object): void {
 
 export interface WebSocketScopeLease {
   release(): void
+}
+
+/** Opaque admission token for one resolved App Route generation. */
+export interface WebSocketRouteLease {
+  release(): void
+}
+
+export interface WebSocketRouteLeaseSocket {
+  readonly destroyed: boolean
+  readonly readableEnded: boolean
+  readonly writableEnded: boolean
+  once(event: 'close' | 'end', listener: () => void): unknown
+  off(event: 'close' | 'end', listener: () => void): unknown
+}
+
+export interface WebSocketRouteLeaseOwnership {
+  isSocketEnded(): boolean
+  release(): unknown[]
+}
+
+export function getWebSocketRouteBundlePath(page: string): string {
+  const normalizedPage = page.replaceAll('\\', '/')
+  return `app${normalizedPage.startsWith('/') ? '' : '/'}${normalizedPage}`
 }
 
 /** Admits one in-flight upgrade into a server scope's bounded shutdown. */
@@ -185,6 +306,114 @@ export function tryAcquireWebSocketScopeLease(
       resolve()
     },
   }
+}
+
+/**
+ * Pins the current generation of a resolved WebSocket App Route while its
+ * module and upgrade handler are running.
+ */
+export function tryAcquireWebSocketRouteLease(
+  scope: object,
+  bundlePath: string
+): WebSocketRouteLease | undefined {
+  if (
+    getClosedScopes().has(scope) ||
+    getTaskAdmissionClosedScopes().has(scope)
+  ) {
+    return undefined
+  }
+
+  const registry = getScopeRegistry(scope, true)!
+  let route = registry.routes.get(bundlePath)
+  if (!route) {
+    route = { peers: new Set(), leases: 0 }
+    registry.routes.set(bundlePath, route)
+  }
+  route.leases++
+
+  const lease: WebSocketRouteLease = {
+    release() {
+      const state = getWebSocketRouteLeases().get(lease)
+      if (!state || state.released) return
+      state.released = true
+      state.route.leases--
+      pruneRouteState(state.scope, state.bundlePath, state.route)
+    },
+  }
+  getWebSocketRouteLeases().set(lease, {
+    scope,
+    bundlePath,
+    route,
+    released: false,
+  })
+  return lease
+}
+
+export function isWebSocketRouteLeaseCurrent(
+  lease: WebSocketRouteLease
+): boolean {
+  const state = getWebSocketRouteLeases().get(lease)
+  if (
+    !state ||
+    state.released ||
+    getClosedScopes().has(state.scope) ||
+    getTaskAdmissionClosedScopes().has(state.scope)
+  ) {
+    return false
+  }
+  return (
+    getScopeRegistry(state.scope, false)?.routes.get(state.bundlePath) ===
+    state.route
+  )
+}
+
+/** Releases a route lease on disconnect without letting listener cleanup win. */
+export function ownWebSocketRouteLease(
+  lease: WebSocketRouteLease,
+  socket: WebSocketRouteLeaseSocket
+): WebSocketRouteLeaseOwnership {
+  const releaseLease = () => lease.release()
+  let ownershipReleased = false
+  const ownership: WebSocketRouteLeaseOwnership = {
+    isSocketEnded() {
+      return isSocketDisconnected(socket)
+    },
+    release() {
+      if (ownershipReleased) return []
+      ownershipReleased = true
+
+      // The lease must be released even if a user-visible EventEmitter hook
+      // makes listener removal throw.
+      lease.release()
+      const failures: unknown[] = []
+      for (const event of ['close', 'end'] as const) {
+        try {
+          socket.off(event, releaseLease)
+        } catch (error) {
+          failures.push(error)
+        }
+      }
+      return failures
+    },
+  }
+
+  try {
+    socket.once('close', releaseLease)
+    socket.once('end', releaseLease)
+    // A terminal event can happen immediately before listener installation,
+    // or synchronously from a custom EventEmitter hook during installation.
+    if (ownership.isSocketEnded()) releaseLease()
+  } catch (error) {
+    for (const cleanupError of ownership.release()) {
+      console.error(
+        'Failed to release a WebSocket route lease listener:',
+        cleanupError
+      )
+    }
+    throw error
+  }
+
+  return ownership
 }
 
 async function waitForWebSocketTasks(scope: object): Promise<void> {
@@ -226,12 +455,7 @@ async function waitForWebSocketTasks(scope: object): Promise<void> {
   const failures = (failureState?.failures.splice(0) ?? [])
     .sort((left, right) => left.order - right.order)
     .map(({ error }) => error)
-  if (failures.length === 1) throw failures[0]
-  if (failures.length > 1) {
-    throw new AggregateError(failures, 'WebSocket shutdown tasks failed', {
-      cause: failures[0],
-    })
-  }
+  throwCombinedFailures(failures, 'WebSocket shutdown tasks failed')
 }
 
 function waitForCloseOrTerminate(
@@ -279,6 +503,7 @@ function waitForCloseOrTerminate(
       return
     }
 
+    // Install-phase deferral latch (see ownWebSocketUpgradeSocketErrors).
     let closeDuringListenerRegistration = false
     let registeringCloseListener = true
     try {
@@ -365,47 +590,129 @@ async function closeConnections(
     )
   )
   const failures = connectionFailures.flat()
-  if (failures.length === 1) throw failures[0]
-  if (failures.length > 1) {
-    throw new AggregateError(
-      failures,
-      'Failed to close WebSocket connections',
-      {
-        cause: failures[0],
-      }
-    )
-  }
+  throwCombinedFailures(failures, 'Failed to close WebSocket connections')
 }
 
-export function registerWebSocketPeer(
+/** Registers a peer only if its route generation is still current. */
+export function registerWebSocketRoutePeer(
   connection: WebSocketRegistryConnection,
-  scope: object
+  lease: WebSocketRouteLease
 ): boolean {
-  const shutdownCode = getClosedScopes().get(scope)
-  if (shutdownCode !== undefined) {
-    trackWebSocketTask(closeConnections([connection], shutdownCode), scope)
+  const state = getWebSocketRouteLeases().get(lease)
+  if (!state) {
+    // Lease entries are never removed, so this branch is only reachable for a
+    // fabricated lease. There is no owning scope to charge failures to.
+    void closeConnections([connection], 1012).catch(() => {})
     return false
   }
 
-  const scopedRegistry = getScopedRegistry()
-  let connections = scopedRegistry.get(scope)
-  if (!connections) {
-    connections = new Set()
-    scopedRegistry.set(scope, connections)
+  const shutdownCode = getClosedScopes().get(state.scope)
+  if (shutdownCode !== undefined) {
+    trackWebSocketTask(
+      closeConnections([connection], shutdownCode),
+      state.scope
+    )
+    return false
   }
-  connections.add(connection)
+  if (state.released) {
+    trackWebSocketTask(closeConnections([connection], 1012), state.scope)
+    return false
+  }
+
+  const registry = getScopeRegistry(state.scope, false)
+  if (!registry || registry.routes.get(state.bundlePath) !== state.route) {
+    trackWebSocketTask(closeConnections([connection], 1012), state.scope)
+    return false
+  }
+
+  state.route.peers.add(connection)
   return true
 }
 
-export function unregisterWebSocketPeer(
+export function unregisterWebSocketRoutePeer(
   connection: WebSocketRegistryConnection,
-  scope: object
+  lease: WebSocketRouteLease
 ): void {
-  const scopedRegistry = getScopedRegistry()
-  const connections = scopedRegistry.get(scope)
-  if (!connections) return
-  connections.delete(connection)
-  if (connections.size === 0) scopedRegistry.delete(scope)
+  const state = getWebSocketRouteLeases().get(lease)
+  if (!state) return
+  state.route.peers.delete(connection)
+  pruneRouteState(state.scope, state.bundlePath, state.route)
+}
+
+export function isWebSocketRouteActive(
+  scope: object,
+  bundlePath: string
+): boolean {
+  const route = getScopeRegistry(scope, false)?.routes.get(bundlePath)
+  return Boolean(route && (route.leases !== 0 || route.peers.size !== 0))
+}
+
+function takeWebSocketRouteConnections(
+  scope: object,
+  bundlePath: string
+): Set<WebSocketRegistryConnection> | undefined {
+  const registry = getScopeRegistry(scope, false)
+  const route = registry?.routes.get(bundlePath)
+  if (!registry || !route) return undefined
+
+  // Removing the state before closing its peers makes every in-flight lease
+  // stale. A new request can create a fresh state without being captured by
+  // this reload.
+  registry.routes.delete(bundlePath)
+  const connections = new Set(route.peers)
+  route.peers.clear()
+  pruneScopeRegistry(scope, registry)
+  return connections
+}
+
+function takeWebSocketScopeConnections(
+  scope: object
+): Set<WebSocketRegistryConnection> {
+  const registry = getScopeRegistry(scope, false)
+  const connections = new Set<WebSocketRegistryConnection>()
+  if (!registry) return connections
+
+  for (const route of registry.routes.values()) {
+    for (const connection of route.peers) connections.add(connection)
+    route.peers.clear()
+  }
+  registry.routes.clear()
+  getScopedRegistry().delete(scope)
+  return connections
+}
+
+function trackConnectionReload(
+  scope: object,
+  connections: Set<WebSocketRegistryConnection>,
+  code: number
+): Promise<void> {
+  if (connections.size === 0) return Promise.resolve()
+  const closing = closeConnections(connections, code)
+  trackWebSocketTask(closing, scope)
+  return closing
+}
+
+export function closeWebSocketRoute(
+  scope: object,
+  bundlePath: string,
+  code: number = 1012
+): Promise<void> {
+  const connections = takeWebSocketRouteConnections(scope, bundlePath)
+  return connections
+    ? trackConnectionReload(scope, connections, code)
+    : Promise.resolve()
+}
+
+/** Reloads every current route without permanently closing the server scope. */
+export function reloadWebSocketScope(
+  scope: object,
+  code: number = 1012
+): Promise<void> {
+  return trackConnectionReload(
+    scope,
+    takeWebSocketScopeConnections(scope),
+    code
+  )
 }
 
 export function closeWebSocketScope(
@@ -426,9 +733,7 @@ export function closeWebSocketScope(
       if (!failures.includes(error)) failures.push(error)
     }
 
-    const scopedRegistry = getScopedRegistry()
-    const connections = scopedRegistry.get(scope) ?? []
-    scopedRegistry.delete(scope)
+    const connections = takeWebSocketScopeConnections(scope)
 
     try {
       await closeConnections(connections, shutdownCode)
@@ -441,12 +746,7 @@ export function closeWebSocketScope(
       addFailure(error)
     }
 
-    if (failures.length === 1) throw failures[0]
-    if (failures.length > 1) {
-      throw new AggregateError(failures, 'Failed to close WebSocket scope', {
-        cause: failures[0],
-      })
-    }
+    throwCombinedFailures(failures, 'Failed to close WebSocket scope')
   })
   scopeDrains.set(scope, drain)
   return drain
@@ -464,8 +764,5 @@ export async function settleWebSocketShutdownStages(
       failures.push(error)
     }
   }
-  if (failures.length === 1) throw failures[0]
-  if (failures.length > 1) {
-    throw new AggregateError(failures, message, { cause: failures[0] })
-  }
+  throwCombinedFailures(failures, message)
 }

--- a/packages/next/src/server/websocket-http.test.ts
+++ b/packages/next/src/server/websocket-http.test.ts
@@ -734,6 +734,37 @@ describe('raw WebSocket upgrade responses', () => {
     socket.destroy()
   })
 
+  it('settles a backpressured write once the socket drains', async () => {
+    // The write() -> drain happy path: the socket reports backpressure once,
+    // then drains, and the write resolves without involving the error path.
+    class BackpressuredSocket extends PassThrough {
+      override write(
+        chunk: any,
+        encodingOrCallback?: any,
+        callback?: any
+      ): boolean {
+        super.write(chunk, encodingOrCallback, callback)
+        return false
+      }
+    }
+
+    const socket = new BackpressuredSocket()
+    socket.resume()
+    const chunks: Buffer[] = []
+    socket.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+
+    const response = writeRawHttpResponse(
+      { method: 'GET', httpVersion: '1.1' } as IncomingMessage,
+      socket,
+      new Response('slow body', { status: 200 })
+    )
+
+    await expect(response).resolves.toBeUndefined()
+    expect(Buffer.concat(chunks).toString()).toContain('slow body')
+    expect(getRawHttpResponseStatus(socket)).toBe(200)
+    socket.destroy()
+  })
+
   it('cleans up the socket error owner when close-listener removal throws', async () => {
     const request = new PassThrough() as unknown as IncomingMessage
     const socket = new PassThrough()

--- a/packages/next/src/server/websocket-http.ts
+++ b/packages/next/src/server/websocket-http.ts
@@ -168,7 +168,12 @@ function getWebSocketRequestAuthority(req: IncomingMessage): URL | undefined {
   }
 }
 
-function isSocketDisconnected(socket: Duplex): boolean {
+/** True once the socket is done in both directions (or destroyed). */
+export function isSocketDisconnected(socket: {
+  destroyed: boolean
+  readableEnded: boolean
+  writableEnded: boolean
+}): boolean {
   return socket.destroyed || socket.writableEnded || socket.readableEnded
 }
 

--- a/packages/next/src/server/websocket-upgrade.ts
+++ b/packages/next/src/server/websocket-upgrade.ts
@@ -30,6 +30,8 @@ import {
 
 type WebSocketServerConstructor = typeof WebSocketServer
 
+// @types/ws (8.18.1) does not yet declare the options the vendored ws 8.21
+// exposes; drop this interface when the published types catch up.
 interface VendoredWebSocketServerOptions extends WebSocketServerOptions {
   closeTimeout: number
   maxBufferedChunks: number
@@ -128,7 +130,7 @@ export interface WebSocketTransportConnection {
 export interface WebSocketUpgradeTransportContext {
   onHookError?: (error: unknown) => void | Promise<void>
   trackTask?: (promise: Promise<void>) => void
-  registryScope?: object
+  routeLease?: import('./websocket-connection-registry').WebSocketRouteLease
 }
 
 export interface WebSocketUpgradeTransportOptions {
@@ -613,36 +615,32 @@ function handleMessageEvent(
   connection.pendingMessages++
   connection.pendingMessageBytes += messageBytes
   pauseConnection(owned)
-  connection.hookQueue = connection.runInHookContext(() =>
-    connection.hookQueue
-      .then(() => {
-        if (
-          connection.closed ||
-          connection.hookFailed ||
-          !isWebSocketOpen(owned.websocket)
-        ) {
-          return
-        }
-        return invokeHook(
-          owned,
-          connection,
-          () => hook(owned.peer, message),
-          true
-        )
-      })
-      .finally(() => {
-        connection.pendingMessages--
-        connection.pendingMessageBytes -= messageBytes
-        if (
-          connection.pendingMessages === 0 &&
-          !connection.closed &&
-          !connection.hookFailed &&
-          isWebSocketOpen(owned.websocket)
-        ) {
-          resumeConnection(owned)
-        }
-      })
-  )
+  queueHook(
+    owned,
+    connection,
+    () => {
+      if (
+        connection.closed ||
+        connection.hookFailed ||
+        !isWebSocketOpen(owned.websocket)
+      ) {
+        return
+      }
+      return hook(owned.peer, message)
+    },
+    true
+  ).finally(() => {
+    connection.pendingMessages--
+    connection.pendingMessageBytes -= messageBytes
+    if (
+      connection.pendingMessages === 0 &&
+      !connection.closed &&
+      !connection.hookFailed &&
+      isWebSocketOpen(owned.websocket)
+    ) {
+      resumeConnection(owned)
+    }
+  })
 }
 
 function handleCloseEvent(


### PR DESCRIPTION
### What?

Track active WebSocket connections and in-flight upgrade leases by emitted App Route bundle identity.

### Why?

HMR must distinguish an old route generation from the generation replacing it. Otherwise a newly accepted connection can be captured by the previous generation's drain, or an unrelated route can be disconnected unnecessarily.

### How?

- Add a process-local registry for active peers and pending request leases.
- Mark replaced route generations stale before closing their existing connections.
- Normalize the App Route bundle identity shared by the runtime and development bundlers.
- Keep registration and release idempotent across disconnect, shutdown, and failed-upgrade paths.

This PR is stacked on #97029. The Turbopack and Webpack consumers are added by the final PR.

### Verification

- `pnpm exec jest --runInBand packages/next/src/server/websocket-connection-registry.test.ts`
- Route-entry and bundle-identity coverage in the complete HMR suite
- Later: same pattern-marker note for the registry lease install site.
