### PR TITLE
Reload affected WebSocket routes in development

### DIFF
--- a/crates/next-api/src/aggregate_hmr.rs
+++ b/crates/next-api/src/aggregate_hmr.rs
@@ -99,6 +99,7 @@ impl ServerHmrChunkListVersion {
 pub struct ChunkListUpdateBuilder {
     chunks: FxIndexMap<RcStr, ChunkUpdate>,
     merged: FxIndexSet<EcmascriptMergedUpdate>,
+    affected_entries: Vec<RcStr>,
 }
 
 impl ChunkListUpdateBuilder {
@@ -124,6 +125,17 @@ impl ChunkListUpdateBuilder {
         self.merged.insert(update.clone());
     }
 
+    /// Entry points whose runtime work this update carries. Each pull is
+    /// scoped to the requested entries, so a non-empty partial invalidates
+    /// exactly those entries' consumers (e.g. WebSocket routes). Sorted for
+    /// deterministic serialization.
+    pub fn set_affected_entries(&mut self, entries: &[RcStr]) {
+        let mut entries = entries.to_vec();
+        entries.sort_unstable();
+        entries.dedup();
+        self.affected_entries = entries;
+    }
+
     pub fn is_empty(&self) -> bool {
         self.chunks.is_empty() && self.merged.is_empty()
     }
@@ -132,6 +144,7 @@ impl ChunkListUpdateBuilder {
         ChunkListUpdate {
             chunks: self.chunks,
             merged: self.merged.into_iter().collect(),
+            affected_entries: self.affected_entries,
         }
         .into_instruction()
     }
@@ -275,6 +288,7 @@ fn classify_server_hmr_update<'a>(
     chunk_updates: impl IntoIterator<Item = ServerHmrChunkUpdate<'a>>,
     membership: ChunkListMembershipChange,
     to: ReadRef<ServerHmrChunkListVersion>,
+    affected_entries: &[RcStr],
 ) -> ServerHmrUpdate {
     if membership.has_removed {
         return ServerHmrUpdate::FullReevaluation { to };
@@ -298,6 +312,7 @@ fn classify_server_hmr_update<'a>(
         };
     }
 
+    builder.set_affected_entries(affected_entries);
     ServerHmrUpdate::Partial {
         to,
         instruction: builder.build(),
@@ -305,13 +320,31 @@ fn classify_server_hmr_update<'a>(
 }
 
 /// Kept outside Turbo Tasks so old pull baselines cannot reactivate.
+/// `affected_entries` are the entry paths this pull covers; a partial update
+/// with runtime work marks them for scoped invalidation.
 pub async fn compute_server_hmr_update(
     chunk_lists: &[ServerHmrChunkList],
     from: Option<&ServerHmrChunkListVersion>,
     to: ReadRef<ServerHmrChunkListVersion>,
+    affected_entries: &[RcStr],
 ) -> Result<ServerHmrUpdate> {
     if chunk_lists.is_empty() {
-        return Ok(ServerHmrUpdate::NoRuntimeUpdate { to: None });
+        return Ok(match from {
+            // Entries that previously produced server chunks no longer do
+            // (the route was deleted or moved to another runtime). There is
+            // nothing to apply, but consumers of these entries (e.g.
+            // WebSocket routes with live connections) must still be
+            // invalidated, so emit an affected-only partial.
+            Some(_) => {
+                let mut builder = ChunkListUpdateBuilder::default();
+                builder.set_affected_entries(affected_entries);
+                ServerHmrUpdate::Partial {
+                    to,
+                    instruction: builder.build(),
+                }
+            }
+            None => ServerHmrUpdate::NoRuntimeUpdate { to: None },
+        });
     }
 
     let Some(from) = from else {
@@ -329,11 +362,13 @@ pub async fn compute_server_hmr_update(
             .map(|update| ServerHmrChunkUpdate::from(&**update)),
         membership,
         to,
+        affected_entries,
     ))
 }
 
 #[cfg(test)]
 mod tests {
+    use turbo_rcstr::RcStr;
     use turbo_tasks::{FxIndexMap, FxIndexSet, ReadRef};
     use turbopack_core::update_instruction::UpdateInstruction;
     use turbopack_ecmascript::chunk_list::{
@@ -346,6 +381,7 @@ mod tests {
     use super::{
         ChunkListMembershipChange, ChunkListUpdateBuilder, ServerHmrChunkListVersion,
         ServerHmrChunkUpdate, ServerHmrUpdate, classify_server_hmr_update,
+        compute_server_hmr_update,
     };
 
     fn version() -> ReadRef<ServerHmrChunkListVersion> {
@@ -392,7 +428,8 @@ mod tests {
             classify_server_hmr_update(
                 [ServerHmrChunkUpdate::None],
                 unchanged_membership(),
-                version()
+                version(),
+                &[]
             ),
             ServerHmrUpdate::NoRuntimeUpdate { to: None }
         ));
@@ -404,7 +441,8 @@ mod tests {
             classify_server_hmr_update(
                 [ServerHmrChunkUpdate::Missing],
                 unchanged_membership(),
-                version()
+                version(),
+                &[]
             ),
             ServerHmrUpdate::FullReevaluation { .. }
         ));
@@ -416,7 +454,8 @@ mod tests {
             classify_server_hmr_update(
                 [ServerHmrChunkUpdate::Total],
                 unchanged_membership(),
-                version()
+                version(),
+                &[]
             ),
             ServerHmrUpdate::FullReevaluation { .. }
         ));
@@ -427,6 +466,7 @@ mod tests {
         let chunk_list = ChunkListUpdate {
             chunks: FxIndexMap::from_iter([("a.js".into(), ChunkUpdate::Added)]),
             merged: vec![],
+            affected_entries: vec![],
         }
         .into_instruction();
         let merged_instruction =
@@ -439,6 +479,7 @@ mod tests {
             ],
             unchanged_membership(),
             version(),
+            &["app/chat/route".into()],
         ) else {
             panic!("partial instructions should produce a partial aggregate update");
         };
@@ -450,12 +491,15 @@ mod tests {
         };
         assert_eq!(update.chunks["a.js"], ChunkUpdate::Added);
         assert_eq!(update.merged, [merged("b.js")]);
+        // A non-empty partial marks the entries this pull covered so consumers
+        // can scope invalidation (e.g. WebSocket route reloads).
+        assert_eq!(update.affected_entries, [RcStr::from("app/chat/route")]);
     }
 
     #[test]
     fn new_chunk_lists_advance_baseline_without_runtime_update() {
         assert!(matches!(
-            classify_server_hmr_update([], added_chunk_lists(), version()),
+            classify_server_hmr_update([], added_chunk_lists(), version(), &[]),
             ServerHmrUpdate::NoRuntimeUpdate { to: Some(_) }
         ));
     }
@@ -463,8 +507,46 @@ mod tests {
     #[test]
     fn removed_chunk_lists_produce_full_reevaluation() {
         assert!(matches!(
-            classify_server_hmr_update([], removed_chunk_lists(), version()),
+            classify_server_hmr_update([], removed_chunk_lists(), version(), &[]),
             ServerHmrUpdate::FullReevaluation { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vanished_entries_produce_affected_only_partial() {
+        // A pull whose entries previously produced server chunks but no
+        // longer have any (route deleted or moved to another runtime) cannot
+        // be diffed, but consumers of those entries must still be scoped out
+        // — e.g. WebSocket routes hold connections that never trigger another
+        // request-driven pull.
+        let ServerHmrUpdate::Partial { instruction, .. } = compute_server_hmr_update(
+            &[],
+            Some(&version()),
+            version(),
+            &[RcStr::from("app/chat/route")],
+        )
+        .await
+        .unwrap() else {
+            panic!("vanished entries with a baseline must produce a partial update");
+        };
+        let instruction = instruction
+            .downcast_ref::<EcmascriptUpdateInstruction>()
+            .expect("aggregate instruction is ECMAScript");
+        let EcmascriptUpdateInstruction::ChunkList(update) = instruction else {
+            panic!("aggregate instruction should be a chunk-list update");
+        };
+        assert!(update.chunks.is_empty());
+        assert!(update.merged.is_empty());
+        assert_eq!(update.affected_entries, [RcStr::from("app/chat/route")]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vanished_entries_without_baseline_produce_no_runtime_update() {
+        assert!(matches!(
+            compute_server_hmr_update(&[], None, version(), &[RcStr::from("app/chat/route")])
+                .await
+                .unwrap(),
+            ServerHmrUpdate::NoRuntimeUpdate { to: None }
         ));
     }
 
@@ -496,6 +578,7 @@ mod tests {
                 ("b.js".into(), ChunkUpdate::Added),
             ]),
             merged: vec![],
+            affected_entries: vec![],
         };
         let second = ChunkListUpdate {
             chunks: FxIndexMap::from_iter([
@@ -503,6 +586,7 @@ mod tests {
                 ("c.js".into(), ChunkUpdate::Total),
             ]),
             merged: vec![],
+            affected_entries: vec![],
         };
 
         builder.add_instruction(&first.into_instruction());

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1955,6 +1955,9 @@ pub async fn project_get_server_hmr_update(
     let container = project.container;
     let turbo_tasks = project.turbopack_ctx.turbo_tasks();
     let from = from.map(|from| from.0.clone());
+    // The pull's entries double as the update's affected-entry metadata for
+    // scoped invalidation (e.g. WebSocket route reloads).
+    let affected_entries = entry_paths.clone();
 
     let (project, read) = turbo_tasks
         .run(async move {
@@ -1982,9 +1985,13 @@ pub async fn project_get_server_hmr_update(
                 issues,
                 ..
             } = &*read;
-            let update =
-                compute_server_hmr_update(chunk_lists.as_slice(), from.as_deref(), version.clone())
-                    .await?;
+            let update = compute_server_hmr_update(
+                chunk_lists.as_slice(),
+                from.as_deref(),
+                version.clone(),
+                &affected_entries,
+            )
+            .await?;
             Ok::<_, anyhow::Error>((update, issues.clone()))
         })
         .await

--- a/docs/01-app/02-guides/custom-server.mdx
+++ b/docs/01-app/02-guides/custom-server.mdx
@@ -111,7 +111,7 @@ The returned `app` can then be used to let Next.js handle requests as required.
 
 ## WebSocket Route Handlers (experimental)
 
-When [`experimental.webSocketRouteHandlers`](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers) is enabled, attach `app.getUpgradeHandler()` to the custom HTTP server after `app.prepare()` finishes. This allows [`NextResponse.upgrade()`](/docs/app/api-reference/functions/next-response#upgrade) App Route Handlers to receive WebSocket upgrades, including when the WebSocket is the server's first request.
+When [`experimental.webSocketRouteHandlers`](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers) is enabled, attach `app.getUpgradeHandler()` to the custom HTTP server after `app.prepare()` finishes. This allows [`NextResponse.upgrade()`](/docs/app/api-reference/functions/next-response#upgrade) App Route Handlers to receive WebSocket upgrades, including when the WebSocket is the server's first request. For an end-to-end walkthrough, including client reconnection and connection policy guidance, see the [WebSockets guide](/docs/app/guides/websockets).
 
 ```js filename="server.js"
 import { createServer } from 'node:http'

--- a/docs/01-app/02-guides/websockets.mdx
+++ b/docs/01-app/02-guides/websockets.mdx
@@ -1,0 +1,366 @@
+---
+title: How to use WebSockets in Next.js
+nav_title: WebSockets
+description: Learn how to accept and manage WebSocket connections with App Router Route Handlers.
+version: experimental
+related:
+  title: Next steps
+  description: Review the WebSocket API, configuration, and deployment guidance.
+  links:
+    - app/api-reference/functions/next-response
+    - app/api-reference/config/next-config-js/webSocketRouteHandlers
+    - app/api-reference/file-conventions/route
+    - app/guides/custom-server
+---
+
+WebSocket Route Handlers let an App Router [Route Handler](/docs/app/api-reference/file-conventions/route) keep a full-duplex connection open after its initial HTTP request. The API is experimental and requires the Node.js runtime on a host that preserves raw sockets for the lifetime of each connection.
+
+WebSockets work with `next dev`, `next start`, [`output: 'standalone'`](/docs/app/api-reference/config/next-config-js/output), and [custom servers](/docs/app/guides/custom-server#websocket-route-handlers-experimental). They are not supported by the Edge Runtime, [static exports](/docs/app/guides/static-exports), or prerendered and ISR-cacheable Route Handlers: an upgrade targeting a cacheable route returns `404 Not Found` before the handler runs. [Draft Mode](/docs/app/guides/draft-mode) bypasses this cache restriction and runs the handler dynamically.
+
+## Enable WebSocket Route Handlers
+
+Enable the experimental flag in `next.config`:
+
+```ts filename="next.config.ts" highlight={5} switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    webSocketRouteHandlers: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" highlight={4} switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    webSocketRouteHandlers: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+## Create a WebSocket Route Handler
+
+Create a `GET` Route Handler and authenticate the handshake before returning [`NextResponse.upgrade()`](/docs/app/api-reference/functions/next-response#upgrade). The following example checks a session cookie and echoes complete text or binary messages back to the client. Replace the cookie presence check with your session verification:
+
+```ts filename="app/ws/route.ts" highlight={8-10,21} switcher
+import { cookies } from 'next/headers'
+import { NextResponse, type WebSocketHooks } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const cookieStore = await cookies()
+  if (!cookieStore.has('session')) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const hooks: WebSocketHooks = {
+    open(peer) {
+      peer.send(JSON.stringify({ type: 'connected' }))
+    },
+    message(peer, message) {
+      peer.send(message.rawData)
+    },
+  }
+
+  return NextResponse.upgrade(hooks)
+}
+```
+
+```js filename="app/ws/route.js" highlight={8-10,21} switcher
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const cookieStore = await cookies()
+  if (!cookieStore.has('session')) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const hooks = {
+    open(peer) {
+      peer.send(JSON.stringify({ type: 'connected' }))
+    },
+    message(peer, message) {
+      peer.send(message.rawData)
+    },
+  }
+
+  return NextResponse.upgrade(hooks)
+}
+```
+
+The handler runs once per handshake. It can return an ordinary `Response`, such as a `401`, to decline the connection. After an upgrade, Next.js runs the `open`, `message`, `close`, and `error` hooks serially for that connection. See the [`NextResponse.upgrade()` reference](/docs/app/api-reference/functions/next-response#upgrade) for hook semantics, subprotocol selection, peer methods, message conversions, connection limits, and close codes.
+
+## Parse JSON messages
+
+If an `open` or `message` hook throws, Next.js closes the connection with code `1011`, which signals a server failure to the client. Protocol-level client errors, such as malformed JSON, should close with `1008` instead. Parse the message inside a `try`/`catch` in the hook, and validate the shape of the parsed data before using it:
+
+```ts filename="app/ws/route.ts" highlight={8-13} switcher
+import { NextResponse, type WebSocketHooks } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+  const hooks: WebSocketHooks = {
+    message(peer, message) {
+      let data: unknown
+      try {
+        data = message.json()
+      } catch {
+        peer.close(1008, 'Invalid JSON.')
+        return
+      }
+      // Validate the shape of `data` before using it.
+    },
+  }
+
+  return NextResponse.upgrade(hooks)
+}
+```
+
+```js filename="app/ws/route.js" highlight={8-13} switcher
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+  const hooks = {
+    message(peer, message) {
+      let data
+      try {
+        data = message.json()
+      } catch {
+        peer.close(1008, 'Invalid JSON.')
+        return
+      }
+      // Validate the shape of `data` before using it.
+    },
+  }
+
+  return NextResponse.upgrade(hooks)
+}
+```
+
+## Connect from a Client Component
+
+Derive `ws:` or `wss:` from the page URL so development and HTTPS deployments use the correct scheme. This example closes the socket when the component unmounts and retries transient closes, including development close code `1012`, with bounded backoff:
+
+```tsx filename="app/components/websocket-status.tsx" switcher
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const RETRYABLE_CLOSE_CODES = new Set([1001, 1006, 1011, 1012])
+const MAX_RETRY_ATTEMPTS = 8
+
+export function WebSocketStatus() {
+  const [status, setStatus] = useState('connecting')
+  const [lastMessage, setLastMessage] = useState('')
+
+  useEffect(() => {
+    let socket: WebSocket | undefined
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
+    let stableTimer: ReturnType<typeof setTimeout> | undefined
+    let retryAttempt = 0
+    let stopped = false
+
+    function connect() {
+      const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:'
+      socket = new WebSocket(`${scheme}//${location.host}/ws`)
+
+      socket.addEventListener('open', () => {
+        setStatus('connected')
+        stableTimer = setTimeout(() => {
+          retryAttempt = 0
+        }, 30_000)
+      })
+      socket.addEventListener('message', (event) => {
+        setLastMessage(String(event.data))
+      })
+      socket.addEventListener('close', (event) => {
+        clearTimeout(stableTimer)
+        if (stopped) return
+        if (!RETRYABLE_CLOSE_CODES.has(event.code)) {
+          setStatus(`closed (${event.code})`)
+          return
+        }
+        if (retryAttempt >= MAX_RETRY_ATTEMPTS) {
+          setStatus('disconnected; retry when the session is ready')
+          return
+        }
+
+        const backoff = Math.min(500 * 2 ** retryAttempt, 10_000)
+        const delay = Math.round(backoff * (0.5 + Math.random() * 0.5))
+        retryAttempt += 1
+        setStatus(`reconnecting in ${delay}ms`)
+        retryTimer = setTimeout(connect, delay)
+      })
+    }
+
+    connect()
+    return () => {
+      stopped = true
+      clearTimeout(retryTimer)
+      clearTimeout(stableTimer)
+      socket?.close(1000, 'Component unmounted')
+    }
+  }, [])
+
+  return <p>{lastMessage ? `${status}: ${lastMessage}` : status}</p>
+}
+```
+
+```jsx filename="app/components/websocket-status.js" switcher
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const RETRYABLE_CLOSE_CODES = new Set([1001, 1006, 1011, 1012])
+const MAX_RETRY_ATTEMPTS = 8
+
+export function WebSocketStatus() {
+  const [status, setStatus] = useState('connecting')
+  const [lastMessage, setLastMessage] = useState('')
+
+  useEffect(() => {
+    let socket
+    let retryTimer
+    let stableTimer
+    let retryAttempt = 0
+    let stopped = false
+
+    function connect() {
+      const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:'
+      socket = new WebSocket(`${scheme}//${location.host}/ws`)
+
+      socket.addEventListener('open', () => {
+        setStatus('connected')
+        stableTimer = setTimeout(() => {
+          retryAttempt = 0
+        }, 30_000)
+      })
+      socket.addEventListener('message', (event) => {
+        setLastMessage(String(event.data))
+      })
+      socket.addEventListener('close', (event) => {
+        clearTimeout(stableTimer)
+        if (stopped) return
+        if (!RETRYABLE_CLOSE_CODES.has(event.code)) {
+          setStatus(`closed (${event.code})`)
+          return
+        }
+        if (retryAttempt >= MAX_RETRY_ATTEMPTS) {
+          setStatus('disconnected; retry when the session is ready')
+          return
+        }
+
+        const backoff = Math.min(500 * 2 ** retryAttempt, 10_000)
+        const delay = Math.round(backoff * (0.5 + Math.random() * 0.5))
+        retryAttempt += 1
+        setStatus(`reconnecting in ${delay}ms`)
+        retryTimer = setTimeout(connect, delay)
+      })
+    }
+
+    connect()
+    return () => {
+      stopped = true
+      clearTimeout(retryTimer)
+      clearTimeout(stableTimer)
+      socket?.close(1000, 'Component unmounted')
+    }
+  }, [])
+
+  return <p>{lastMessage ? `${status}: ${lastMessage}` : status}</p>
+}
+```
+
+The retry budget resets only after a connection stays open for 30 seconds, so a server that repeatedly accepts and immediately closes connections cannot create a tight reconnect loop. Same-origin browser WebSockets include cookies, so this client works with the HTTP-only session cookie from the server example. The browser `WebSocket` constructor cannot set an `Authorization` header; if your protocol uses another credential, prefer a short-lived, single-use value and account for where URLs and subprotocols may be logged. Browsers surface a rejected handshake as close code `1006`, so production clients should bound retries and restart them only after the application knows the session is valid.
+
+## Secure the handshake
+
+Treat every WebSocket Route Handler as a public endpoint:
+
+- Authenticate and authorize each handshake before returning the upgrade response. Origin checks do not replace authentication.
+- By default, browser handshakes must match the request's own origin, compared using the protocol of the Node.js socket and the request's `Host` header. Add exact trusted browser origins with [`allowedOrigins`](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers#allowedorigins).
+- Non-browser clients can omit the `Origin` header, so never use the presence of that header as an authentication signal.
+- Next.js does not trust forwarding headers such as `X-Forwarded-Host` or `X-Forwarded-Proto` for this comparison. If a reverse proxy terminates TLS or replaces `Host`, add the public origin to `allowedOrigins` explicitly.
+
+Origin validation runs before the matched Route Handler executes, so a disallowed browser origin is rejected with a `403` before your code runs.
+
+## Plan connection policy
+
+Next.js enforces [fixed per-connection limits](/docs/app/api-reference/functions/next-response#fixed-connection-limits) on message size, fragmentation, and queued work, and it answers WebSocket protocol pings from clients. Every policy that depends on your workload and deployment topology stays with your application and infrastructure:
+
+| Concern              | Recommended owner                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| Connection admission | Set process, replica, or load-balancer limits before accepting more sockets.                   |
+| Rate limiting        | Authenticate first, then enforce a distributed policy keyed on the trusted client identity.    |
+| Idle connections     | Apply load-balancer idle policies and application heartbeats appropriate for your protocol.    |
+| Backpressure         | Monitor `peer.bufferedAmount` and define stricter application limits when needed.              |
+| Reconnection         | Make clients reconnect after transient disconnects and development close code `1012`.          |
+| Broadcasting         | Track peers in application code, or use an external message broker to deliver across replicas. |
+
+There is no built-in process-wide connection cap, client rate limiter, idle timeout, or server-initiated heartbeat, and the `GET` handler has no execution deadline before the upgrade. Do not treat `peer.remoteAddress` as a client identity behind a proxy unless the deployment verifies and enforces that proxy boundary.
+
+For an application-level idle policy, track message activity in the connection hooks and call `peer.close()` after your chosen interval. This measures application-message inactivity; it is not protocol-level ping/pong and does not detect half-open TCP connections. Keep infrastructure idle timeouts in place as the backstop.
+
+## Broadcast to multiple clients
+
+Next.js does not include a broadcast or pub/sub API. For broadcasting within one process, keep an application-owned collection of peers: add each peer in `open`, remove it in `close`, and iterate the collection with `peer.send()` when publishing an event.
+
+```ts filename="app/ws/route.ts"
+import { NextResponse, type WebSocketPeer } from 'next/server'
+
+// Module-scope state resets on HMR: in development, an edit to this file (or
+// one of its dependencies) closes its connections with code 1012 and clients
+// should reconnect.
+const peers = new Set<WebSocketPeer>()
+
+export function GET() {
+  return NextResponse.upgrade({
+    open(peer) {
+      peers.add(peer)
+    },
+    message(peer, message) {
+      for (const other of peers) {
+        other.send(message.text())
+      }
+    },
+    close(peer) {
+      peers.delete(peer)
+    },
+  })
+}
+```
+
+A process-local collection only reaches the clients connected to that process. When your deployment runs multiple processes or replicas, route events through an external message broker so every replica receives them, and define ordering, retries, duplicate suppression, and authorization in your application protocol.
+
+## Deploy and shut down cleanly
+
+Choose a deployment that supports persistent Node.js sockets:
+
+| Deployment                                                                                           | Support                                                                                                                     |
+| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `next dev`                                                                                           | Supported for local development. Development updates close affected connections with code `1012`; clients should reconnect. |
+| `next start` and [`output: 'standalone'`](/docs/app/api-reference/config/next-config-js/output)      | Supported on a persistent Node.js host.                                                                                     |
+| [Custom Node.js server](/docs/app/guides/custom-server#websocket-route-handlers-experimental)        | Supported. Register `app.getUpgradeHandler()` before the server starts listening.                                           |
+| [`adapterPath`](/docs/app/api-reference/config/next-config-js/adapterPath)                           | Not supported. Next.js rejects the configuration while `webSocketRouteHandlers` is enabled.                                 |
+| Edge Runtime, [static exports](/docs/app/guides/static-exports), request-scoped serverless platforms | Not supported. WebSockets need a runtime that keeps the raw socket and process alive after the initial request finishes.    |
+
+If one custom Node.js server hosts multiple Next.js apps or another WebSocket protocol, install one outer `upgrade` listener. Select exactly one owner from the request host, pathname, or protocol before calling that app's `getUpgradeHandler()` result. Do not call multiple Next.js upgrade handlers for the same request.
+
+Configure the reverse proxy or load balancer to forward HTTP/1.1 upgrade requests, keep connections open for your expected session lengths, and allow enough time for graceful process termination.
+
+During graceful shutdown, Next.js closes accepted WebSocket Route Handler connections with close code `1001`; peers that finish their handshake while shutdown is in progress are closed with the same code. Custom servers own their HTTP server's lifecycle: see the [custom server guide](/docs/app/guides/custom-server#websocket-route-handlers-experimental) for the required registration and shutdown order.
+
+In `next dev`, editing a WebSocket Route Handler or one of its local dependencies closes the affected route's connections with code `1012` while unrelated routes stay connected. A development-server restart or a failed in-process update can close every WebSocket Route Handler connection, so clients should always treat `1012` as retryable.

--- a/docs/01-app/03-api-reference/04-functions/next-response.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-response.mdx
@@ -77,7 +77,7 @@ response.cookies.delete('experiments')
 
 ## `upgrade()`
 
-`upgrade()` is experimental. It upgrades a request to a WebSocket from a dynamic App Route Handler. Enable [`experimental.webSocketRouteHandlers`](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers) before using this method.
+`upgrade()` is experimental. It accepts a WebSocket handshake in a dynamic App Route Handler using the Node.js runtime and returns a response that switches the connection to the WebSocket protocol. Enable [`experimental.webSocketRouteHandlers`](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers) before using this method. For an end-to-end setup, see the [WebSockets guide](/docs/app/guides/websockets).
 
 ```ts filename="app/ws/route.ts" switcher
 import { NextResponse } from 'next/server'
@@ -113,27 +113,109 @@ export function GET() {
 }
 ```
 
-`upgrade(hooks, options)` accepts the following hooks:
+The handler runs once for each handshake. Validate authentication and authorization before returning `NextResponse.upgrade()`: the handler can return an ordinary `Response`, such as a `401`, to decline the connection, and Next.js writes that response to the raw socket without upgrading it. Cookies and application headers set on the upgrade response are included in the `101 Switching Protocols` response.
 
-- `open(peer)`: Runs after the connection is accepted.
-- `message(peer, message)`: Runs for each incoming text or binary message.
-- `close(peer, details)`: Runs when the connection closes. `details` contains `code` and `reason`.
-- `error(peer, error)`: Runs when the WebSocket transport emits an error.
+When an ordinary HTTP `GET` request, without a WebSocket handshake, reaches a handler that returns `NextResponse.upgrade()`, Next.js responds with `426 Upgrade Required` instead. The `426` response advertises `Upgrade: websocket` and `Sec-WebSocket-Version: 13`, sets `Connection: close`, is marked uncacheable, and carries the plain-text body `This route only accepts WebSocket upgrade requests.`. Cookies and other safe application headers are preserved on it.
 
-Hook callbacks can return a promise and run serially for each connection. The `peer` object exposes `id`, `remoteAddress`, the opening `request`, and `bufferedAmount`. Use `peer.send(data)`, `peer.close(code, reason)`, or `peer.terminate()` to control the connection. `send()` returns the current queued byte count.
-
-The `message` object exposes `rawData` and the `text()`, `json()`, `uint8Array()`, and `arrayBuffer()` conversion methods. The optional `protocol` option selects one WebSocket subprotocol that the client offered:
+### Parameters
 
 ```ts
-return NextResponse.upgrade(hooks, { protocol: 'chat.v1' })
+NextResponse.upgrade(hooks, options?)
 ```
 
-Validate authentication and authorization before returning `NextResponse.upgrade()`. You can return an ordinary `Response`, such as a `401`, to decline the upgrade.
+#### `hooks`
 
-> **Good to know**:
->
-> - This API is available only in dynamic App Route Handlers using the Node.js runtime. It is not supported in Proxy, the Edge Runtime, static exports, or prerendered and ISR-cached routes.
-> - Next.js closes accepted connections with code `1001` during graceful shutdown and `1012` when their route is replaced during development.
+The hooks for one WebSocket connection. Every hook is optional, and no other keys are accepted:
+
+| Hook                     | Runs when                                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `open(peer)`             | The handshake is committed and the connection is open.                                                             |
+| `message(peer, message)` | A complete text or binary message is received.                                                                     |
+| `close(peer, details)`   | The connection closes. `details` contains `code` and `reason`.                                                     |
+| `error(peer, error)`     | The transport reports a connection error. `error` is a plain `Error` — there is no separate `WebSocketError` type. |
+
+Hooks can return a promise. Next.js runs the hooks of one connection serially and waits for each returned promise before running the next hook. If an `open` or `message` hook throws or rejects, Next.js reports the error and closes the peer with code `1011`. While asynchronous `message` hooks are pending, the transport pauses inbound message delivery for that connection.
+
+#### `options`
+
+| Option     | Type     | Description                                                                                                                                   |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `protocol` | `string` | Selects one WebSocket subprotocol. The client must offer the exact token in its handshake; otherwise Next.js declines the upgrade with `400`. |
+
+Protocol-critical headers such as `Upgrade`, `Connection`, `Sec-WebSocket-Accept`, `Sec-WebSocket-Protocol`, `Content-Length`, and `Transfer-Encoding` are owned by Next.js and cannot be set on the returned response. Use the `protocol` option to select a subprotocol. Custom response headers and cookies on the `101` response must contain only visible ASCII characters, spaces, and tabs; percent-encode anything else.
+
+### Peer methods and properties
+
+The `peer` passed to every hook represents one connection:
+
+| Member                  | Description                                                         |
+| ----------------------- | ------------------------------------------------------------------- |
+| `id`                    | Unique identifier for the connection.                               |
+| `remoteAddress`         | Remote IP address when the Node.js transport exposes one.           |
+| `request`               | The `NextRequest` used for the handshake.                           |
+| `bufferedAmount`        | Bytes queued by the transport but not yet written to the network.   |
+| `send(data)`            | Sends text or binary data and returns the updated `bufferedAmount`. |
+| `close(code?, reason?)` | Starts the WebSocket closing handshake.                             |
+| `terminate()`           | Abruptly destroys the connection.                                   |
+
+`request.signal` is an `AbortSignal` that aborts when the connection closes. Because hooks run outside the original request's scope, use it as the cancellation primitive for work that should stop when the connection ends.
+
+`send()` accepts strings, `ArrayBuffer`, `SharedArrayBuffer`, and `ArrayBufferView` values; other values throw a `TypeError`, so serialize structured values explicitly, for example with `peer.send(JSON.stringify(value))`. After a successful send, `send()` returns the updated `bufferedAmount`. If the connection is not open, or a [connection limit](#fixed-connection-limits) rejects the message and starts a close, `send()` returns the last observed `bufferedAmount` without throwing.
+
+For `close()`, the code must be an integer from `1000` through `1014` (excluding `1004`, `1005`, and `1006`), or from `3000` through `4999`. The optional reason is limited to 123 UTF-8 bytes. Invalid arguments throw synchronously, including after closing has started. A `reason` without a `code` is ignored.
+
+Next.js does not negotiate `permessage-deflate` compression. If your application compresses payloads, evaluate compression side channels before combining sensitive and attacker-controlled data in one message.
+
+### Message methods and properties
+
+The `message` passed to the `message` hook exposes the following members:
+
+| Member          | Description                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| `rawData`       | The original data: a string for text messages, a `Uint8Array` for binary ones. |
+| `text()`        | Returns the message decoded as UTF-8 text.                                     |
+| `json<T>()`     | Parses the message text as JSON.                                               |
+| `uint8Array()`  | Returns the data as a `Uint8Array`.                                            |
+| `arrayBuffer()` | Returns the data as an `ArrayBuffer`.                                          |
+
+### Fixed connection limits
+
+These per-connection limits are fixed for the experimental transport:
+
+| Limit                                      | Threshold                      | Result when exceeded                                            |
+| ------------------------------------------ | ------------------------------ | --------------------------------------------------------------- |
+| Inbound message payload                    | 16 MiB                         | Closes the peer with `1009`.                                    |
+| Fragments in one inbound message           | 1,024                          | Closes the peer with `1008`.                                    |
+| Unread chunks buffered by the frame parser | 1,024                          | Closes the peer with `1008`.                                    |
+| Pending asynchronous `message` hooks       | 32 hooks or 16 MiB of messages | Closes the peer with `1008`.                                    |
+| One outbound message                       | 16 MiB                         | Closes the peer with `1009`.                                    |
+| Outbound transport queue                   | 16 MiB per peer                | Closes the peer with `1008`.                                    |
+| Closing-handshake grace                    | 5 seconds                      | Terminates the peer if the closing handshake has not completed. |
+
+The 5-second value is the per-connection closing-handshake window, not a process-shutdown deadline. These limits bound one connection: applications and deployment platforms still own workload-level policy such as connection counts, handshake rate limits, and idle timeouts. See [connection policy](/docs/app/guides/websockets#plan-connection-policy) in the WebSockets guide.
+
+### Origin and authentication
+
+Browser handshakes are limited to the request's own origin by default, compared using the protocol of the Node.js socket and the request's `Host` header. Forwarding headers such as `X-Forwarded-Host` and `X-Forwarded-Proto` are not trusted for this comparison. Allow exact cross-origin browser clients with [`allowedOrigins`](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers#allowedorigins). Origin validation runs before the matched Route Handler executes.
+
+Requests without an `Origin` header are accepted so non-browser WebSocket clients can connect. Origin checks are therefore not authentication: authenticate and authorize every connection in the `GET` handler before returning `NextResponse.upgrade()`.
+
+### Runtime and lifecycle
+
+`NextResponse.upgrade()` is available only in dynamic App Route Handlers using the Node.js runtime, on [deployments that keep the process and raw socket alive](/docs/app/api-reference/config/next-config-js/webSocketRouteHandlers#supported-deployments). It is not supported in Proxy, the Edge Runtime, static exports, or prerendered and ISR-cached routes. Returning `NextResponse.upgrade()` from `proxy.ts` throws an error at runtime instead of being silently ignored. An upgrade targeting a prerendered or ISR-cacheable route returns `404 Not Found` before the handler runs; Draft Mode bypasses this restriction and runs the handler dynamically.
+
+Connection hooks run after the HTTP request that accepted the connection has completed:
+
+- [`after()`](/docs/app/api-reference/functions/after) tasks start once the handshake response commits. They do not wait for the WebSocket to close.
+- The request trace ends at the handshake, and hooks execute outside the request context. Request-scoped APIs such as `cookies()` and `headers()` fail inside `open`, `message`, `close`, and `error`. Read request data in `GET` and capture the values the hooks need, or read immutable handshake data from `peer.request`.
+
+Next.js uses these close codes for framework lifecycle events, in addition to the policy codes listed under [fixed connection limits](#fixed-connection-limits):
+
+| Code   | Meaning                                                                    |
+| ------ | -------------------------------------------------------------------------- |
+| `1001` | The Next.js server or custom server is shutting down.                      |
+| `1011` | An application connection hook failed.                                     |
+| `1012` | The route was replaced during development and the client should reconnect. |
 
 </AppOnly>
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/webSocketRouteHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/webSocketRouteHandlers.mdx
@@ -1,14 +1,17 @@
 ---
 title: webSocketRouteHandlers
 description: Enable experimental WebSocket Route Handlers in the App Router.
-version: canary
+version: experimental
 related:
   links:
+    - app/guides/websockets
     - app/api-reference/functions/next-response
     - app/guides/custom-server
 ---
 
 The `webSocketRouteHandlers` experimental option allows a dynamic App Route Handler to return [`NextResponse.upgrade()`](/docs/app/api-reference/functions/next-response#upgrade) and accept a WebSocket connection.
+
+For an end-to-end setup, client reconnection guidance, and a deployment checklist, see the [WebSockets guide](/docs/app/guides/websockets).
 
 ## Usage
 
@@ -37,9 +40,11 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
+### `allowedOrigins`
+
 Browser WebSocket requests are restricted to the request's exact origin by default. To allow additional origins, use the object form:
 
-```ts filename="next.config.ts"
+```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
@@ -56,7 +61,25 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Each entry must be an exact HTTP or HTTPS origin, including the port when it is not the scheme's default. Wildcards, paths, queries, fragments, credentials, and forwarding headers are not used for origin authorization.
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    webSocketRouteHandlers: {
+      allowedOrigins: [
+        'https://app.example.com',
+        'https://preview.example.com',
+      ],
+    },
+  },
+}
+
+module.exports = nextConfig
+```
+
+Each entry must be an exact HTTP or HTTPS origin, including the port when it is not the scheme's default. Wildcards, paths, queries, fragments, credentials, and forwarding headers are not used for origin authorization. Same-origin browser requests remain allowed when this list is present, and requests without an `Origin` header (non-browser clients) are accepted, so the Route Handler must authenticate every connection.
+
+The default same-origin comparison uses the protocol of the Node.js socket and the request's `Host` header. If a reverse proxy terminates TLS or replaces `Host` before forwarding to Next.js, add the browser's exact public origin to `allowedOrigins`.
 
 ## Supported deployments
 
@@ -66,6 +89,15 @@ WebSocket Route Handlers require the Node.js runtime and work with `next dev`, `
 - [`output: 'export'`](/docs/app/guides/static-exports)
 - prerendered or ISR-cached Route Handlers
 - [`adapterPath`](/docs/app/api-reference/config/next-config-js/adapterPath), until an adapter contract for Node.js upgrade handling is available
-- rewrites to external destinations for WebSocket upgrade requests. When this option is enabled, Next.js returns `501 Not Implemented` instead of proxying these WebSocket rewrites.
+- rewrites to external destinations for WebSocket upgrade requests. While `experimental.webSocketRouteHandlers` is enabled, Next.js returns `501 Not Implemented` instead of proxying these WebSocket rewrites. When the option is disabled, the legacy proxying behavior for upgrade requests is unchanged.
 
-The built-in connection registry is process-local. Applications deployed across multiple processes or instances need an external broker for broadcasts or shared realtime state. Next.js does not impose an application-level connection count, rate limit, or idle timeout; enforce those policies in your application or reverse proxy.
+## Connection policy
+
+Next.js applies [fixed per-connection safety limits](/docs/app/api-reference/functions/next-response#fixed-connection-limits) to message size, fragmentation, and queued work. Policies that depend on your workload and deployment topology stay with your application and infrastructure:
+
+- **Concurrent connections**: Next.js does not impose a process-wide or global connection cap. Enforce admission limits at the load balancer, platform, or process manager.
+- **Handshake rate limiting**: the `GET` handler runs before the connection is accepted, so authenticate first and rate limit on the trusted identity there or in your proxy. Next.js does not provide a client rate limiter.
+- **Idle connections and heartbeats**: Next.js answers WebSocket protocol pings from clients but never initiates its own pings and applies no idle timeout. Apply load-balancer idle policies and application heartbeats appropriate for your protocol.
+- **Handler deadlines**: like other Route Handlers, the `GET` handler has no execution deadline before the upgrade. Use proxy or platform timeouts to bound slow handshakes.
+
+The built-in connection lifecycle tracking is process-local. Applications deployed across multiple processes or instances need an external broker for broadcasts or shared realtime state.

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -101,6 +101,12 @@ import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 import { setBundlerFindSourceMapImplementation } from '../patch-error-inspect'
 import { setBundlerFindSourceMapURLImplementation } from '../lib/source-maps'
 import {
+  getActiveWebSocketRouteBundlePaths,
+  getWebSocketRouteBundlePath,
+  invalidateWebSocketRoutes,
+  reloadWebSocketScope,
+} from '../websocket-connection-registry'
+import {
   formatIssue,
   isFileSystemCacheEnabledForDev,
   isWellKnownError,
@@ -274,6 +280,31 @@ function collectUpdatedChunkPaths(
     )
   }
   return Array.from(paths)
+}
+
+/** Maps a Turbopack entry chunk under `server/app` to its route bundle key. */
+export function getWebSocketRouteBundlePathFromTurbopackEntry(
+  entryPath: string
+): string | undefined {
+  const normalizedPath = entryPath.replaceAll('\\', '/')
+  if (
+    normalizedPath.startsWith('/') ||
+    /^[A-Za-z]:\//.test(normalizedPath) ||
+    !normalizedPath.endsWith('.js')
+  ) {
+    return undefined
+  }
+
+  const page = normalizedPath.slice(0, -'.js'.length)
+  if (
+    page.length === 0 ||
+    page
+      .split('/')
+      .some((segment) => segment === '' || segment === '.' || segment === '..')
+  ) {
+    return undefined
+  }
+  return getWebSocketRouteBundlePath(page)
 }
 
 function setupServerHmr(
@@ -652,6 +683,12 @@ export async function createHotReloaderTurbopack(
   const entrypointsSubscription = project.entrypointsSubscribe()
 
   const currentWrittenEntrypoints: Map<EntryKey, WrittenEndpoint> = new Map()
+  // WebSocket connections are long-lived: no future request will ever pull
+  // their route's server HMR update, so they cannot wait for the lazy
+  // request-driven pull. Keep the entry paths each route was last written
+  // with so project updates can pull for them eagerly (see the updateInfo
+  // 'end' handler in handleProjectUpdates).
+  const writtenServerHmrEntriesByRoute = new Map<string, string[]>()
   const currentEntrypoints: Entrypoints = {
     global: {
       app: undefined,
@@ -1930,6 +1967,12 @@ export async function createHotReloaderTurbopack(
       if (reloadAfterInvalidation) {
         await serverHmr?.reset()
 
+        if (
+          nextConfig.experimental.webSocketRouteHandlers &&
+          opts.webSocketRegistryScope
+        ) {
+          void reloadWebSocketScope(opts.webSocketRegistryScope)
+        }
         for (const [key, entrypoint] of currentWrittenEntrypoints) {
           clearRequireCache(key, entrypoint, { force: true })
         }
@@ -2121,6 +2164,16 @@ export async function createHotReloaderTurbopack(
                   shouldPullServerHmr ||= participatesInServerHmr(id, result)
                   if (result.serverHmrEntryPaths.length > 0) {
                     serverHmrEntryPaths = result.serverHmrEntryPaths
+                    for (const entryPath of result.serverHmrEntryPaths) {
+                      const bundlePath =
+                        getWebSocketRouteBundlePathFromTurbopackEntry(entryPath)
+                      if (bundlePath && bundlePath.endsWith('/route')) {
+                        writtenServerHmrEntriesByRoute.set(
+                          bundlePath,
+                          result.serverHmrEntryPaths
+                        )
+                      }
+                    }
                   }
                   return clearRequireCache(id, result, {
                     force: forceDeleteCache,
@@ -2271,6 +2324,22 @@ export async function createHotReloaderTurbopack(
           if (hasDeferredEntriesConfig) {
             callOnBeforeDeferredEntriesAfterHMR()
           }
+
+          // Server HMR applies lazily, driven by the request being built.
+          // WebSocket routes have live connections that never issue another
+          // request, so pull for them eagerly to close stale generations.
+          if (
+            serverHmr &&
+            opts.webSocketRegistryScope &&
+            nextConfig.experimental.webSocketRouteHandlers
+          ) {
+            for (const bundlePath of getActiveWebSocketRouteBundlePaths(
+              opts.webSocketRegistryScope
+            )) {
+              const entryPaths = writtenServerHmrEntriesByRoute.get(bundlePath)
+              if (entryPaths) await serverHmr.apply(entryPaths)
+            }
+          }
           break
         }
         default:
@@ -2285,9 +2354,58 @@ export async function createHotReloaderTurbopack(
 
   let serverHmr: ReturnType<typeof setupServerHmr> | undefined
   if (serverFastRefresh) {
+    const webSocketRegistryScope = opts.webSocketRegistryScope
+    const invalidateChangedWebSocketRoutes = ({
+      chunkPaths,
+      affectedEntries,
+      hasAffectedEntriesMetadata,
+    }: {
+      chunkPaths: string[]
+      affectedEntries: string[] | undefined
+      hasAffectedEntriesMetadata: boolean
+    }) => {
+      if (
+        !nextConfig.experimental.webSocketRouteHandlers ||
+        !webSocketRegistryScope
+      ) {
+        return
+      }
+
+      let affected: ReadonlySet<string> | 'unknown' = 'unknown'
+      if (
+        hasAffectedEntriesMetadata &&
+        Array.isArray(affectedEntries) &&
+        !(chunkPaths.length > 0 && affectedEntries.length === 0)
+      ) {
+        const bundlePaths = new Set<string>()
+        let unmapped = false
+        for (const entryPath of affectedEntries) {
+          const bundlePath =
+            typeof entryPath === 'string'
+              ? getWebSocketRouteBundlePathFromTurbopackEntry(entryPath)
+              : undefined
+          if (!bundlePath) {
+            // An unmapped entry shape means the affected set cannot be proven.
+            unmapped = true
+            break
+          }
+          bundlePaths.add(bundlePath)
+        }
+        affected = unmapped ? 'unknown' : bundlePaths
+      }
+      invalidateWebSocketRoutes(webSocketRegistryScope, affected)
+    }
+
     serverHmr = setupServerHmr(project, {
       runtimeRoot,
       reEvaluateAllModulesExpensive: async () => {
+        if (
+          nextConfig.experimental.webSocketRouteHandlers &&
+          webSocketRegistryScope
+        ) {
+          void reloadWebSocketScope(webSocketRegistryScope)
+        }
+
         // Evict every server-HMR-managed chunk from `require.cache`.
         // Trailing `sep` so e.g. `server/chunks-other/...` doesn't match.
         const serverChunksDir = join(distDir, SERVER_HMR_CHUNKS_DIR) + sep
@@ -2315,12 +2433,14 @@ export async function createHotReloaderTurbopack(
         // the next validation loads the build output afresh.
         dropDevValidationWorker()
       },
-      onApplied: ({ chunkPaths }) => {
+      onApplied: (update) => {
+        invalidateChangedWebSocketRoutes(update)
+
         // Clear the evalManifest() shared cache for each updated chunk so the
         // next RSC render picks up the HMR-applied module changes. Unlike
         // a full restart, this does NOT clear require.cache — the HMR-applied
         // modules in devModuleCache must persist for dep preservation.
-        const manifestPaths = chunkPaths.map((chunkPath) =>
+        const manifestPaths = update.chunkPaths.map((chunkPath) =>
           join(distDir, chunkPath)
         )
 

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -90,6 +90,12 @@ import { FAST_REFRESH_RUNTIME_RELOAD } from './messages'
 import { getDevOverlayFontMiddleware } from '../../next-devtools/server/font/get-dev-overlay-font-middleware'
 import { getDisableDevIndicatorMiddleware } from '../../next-devtools/server/dev-indicator-middleware'
 import getWebpackBundler from '../../shared/lib/get-webpack-bundler'
+import {
+  getActiveWebSocketRouteBundlePaths,
+  invalidateWebSocketRoutes,
+  isWebSocketRouteActive,
+  reloadWebSocketScope,
+} from '../websocket-connection-registry'
 import { getRestartDevServerMiddleware } from '../../next-devtools/server/restart-dev-server-middleware'
 import { checkFileSystemCacheInvalidationAndCleanup } from '../../build/webpack/cache-invalidation'
 import { receiveBrowserLogsWebpack } from './browser-logs/receive-logs'
@@ -262,6 +268,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private resetFetch: () => void
   private restartServer: (() => Promise<void>) | undefined
   private lockfile: Lockfile | undefined
+  private webSocketRegistryScope: object | undefined
   private versionInfo: VersionInfo = {
     staleness: 'unknown',
     installed: '0.0.0',
@@ -295,6 +302,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       lockfile,
       onDevServerCleanup,
       restartServer,
+      webSocketRegistryScope,
     }: {
       config: NextConfigComplete
       isSrcDir: boolean
@@ -310,6 +318,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       lockfile: Lockfile | undefined
       onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
       restartServer?: () => Promise<void>
+      webSocketRegistryScope?: object
     }
   ) {
     this.hasAppRouterEntrypoints = false
@@ -330,6 +339,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.resetFetch = resetFetch
     this.restartServer = restartServer
     this.lockfile = lockfile
+    this.webSocketRegistryScope = webSocketRegistryScope
 
     this.config = config
     this.previewProps = previewProps
@@ -1338,6 +1348,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     const prevServerPageHashes = new Map<string, string>()
     const prevEdgeServerPageHashes = new Map<string, string>()
     const prevCSSImportModuleHashes = new Map<string, string>()
+    let previousWebSocketRouteOwners = new Map<string, 'server' | 'edge'>()
 
     const pageExtensionRegex = new RegExp(
       `\\.(?:${this.config.pageExtensions.join('|')})$`
@@ -1561,6 +1572,75 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       const reloadAfterInvalidation = this.reloadAfterInvalidation
       this.reloadAfterInvalidation = false
 
+      const webSocketRegistryScope = this.webSocketRegistryScope
+      if (
+        this.config.experimental.webSocketRouteHandlers &&
+        webSocketRegistryScope
+      ) {
+        if (reloadAfterInvalidation) {
+          void reloadWebSocketScope(webSocketRegistryScope)
+        }
+        const serverStats = stats.stats[1]
+        const edgeServerStats = stats.stats[2]
+        if (
+          !serverStats ||
+          serverStats.hasErrors() ||
+          edgeServerStats?.hasErrors()
+        ) {
+          // An unknown graph shape must not leave a route executing code from
+          // a generation which may have changed.
+          invalidateWebSocketRoutes(webSocketRegistryScope, 'unknown')
+        } else {
+          try {
+            // trackPageChanges fingerprints entrypoint content on both server
+            // compilers at emit time, so this covers Node-runtime routes
+            // (server compilation) and Edge-runtime routes (edge-server
+            // compilation) through one detector. A route absent from the
+            // previous compilation compares as unchanged, so a connection
+            // accepted during its first compile is not spuriously bumped.
+            const activeBundlePaths = getActiveWebSocketRouteBundlePaths(
+              webSocketRegistryScope
+            )
+            if (activeBundlePaths.size !== 0) {
+              const serverEntrypoints = serverStats.compilation.entrypoints
+              const edgeEntrypoints = edgeServerStats?.compilation.entrypoints
+              const affected = new Set<string>()
+              const currentOwners = new Map<string, 'server' | 'edge'>()
+
+              for (const bundlePath of activeBundlePaths) {
+                const owner: 'server' | 'edge' | undefined =
+                  serverEntrypoints.has(bundlePath)
+                    ? 'server'
+                    : edgeEntrypoints?.has(bundlePath)
+                      ? 'edge'
+                      : undefined
+                if (owner !== undefined) currentOwners.set(bundlePath, owner)
+                const previousOwner =
+                  previousWebSocketRouteOwners.get(bundlePath)
+
+                if (
+                  owner === undefined ||
+                  (previousOwner !== undefined && previousOwner !== owner) ||
+                  changedServerPages.has(bundlePath) ||
+                  changedEdgeServerPages.has(bundlePath)
+                ) {
+                  // Deleted, moved runtimes, or content-changed.
+                  affected.add(bundlePath)
+                }
+              }
+              previousWebSocketRouteOwners = currentOwners
+
+              invalidateWebSocketRoutes(webSocketRegistryScope, affected)
+            } else {
+              previousWebSocketRouteOwners = new Map()
+            }
+          } catch (error) {
+            console.error(error)
+            invalidateWebSocketRoutes(webSocketRegistryScope, 'unknown')
+          }
+        }
+      }
+
       const serverOnlyChanges = difference<string>(
         changedServerPages,
         changedClientPages
@@ -1686,6 +1766,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       )
     })
 
+    const webSocketRegistryScope = this.webSocketRegistryScope
     this.onDemandEntries = onDemandEntryHandler({
       hotReloader: this,
       multiCompiler: this.multiCompiler,
@@ -1693,6 +1774,12 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       appDir: this.appDir,
       rootDir: this.dir,
       nextConfig: this.config,
+      isEntryPinned:
+        this.config.experimental.webSocketRouteHandlers &&
+        webSocketRegistryScope
+          ? (bundlePath) =>
+              isWebSocketRouteActive(webSocketRegistryScope, bundlePath)
+          : undefined,
       ...(this.config.onDemandEntries as {
         maxInactiveAge: number
         pagesBufferLength: number

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -412,7 +412,8 @@ class Invalidator {
 
 function disposeInactiveEntries(
   entries: NonNullable<ReturnType<(typeof entriesMap)['get']>>,
-  maxInactiveAge: number
+  maxInactiveAge: number,
+  isEntryPinned?: (bundlePath: string) => boolean
 ) {
   Object.keys(entries).forEach((entryKey) => {
     const entryData = entries[entryKey]
@@ -429,6 +430,11 @@ function disposeInactiveEntries(
       isMiddlewareFilename(bundlePath) ||
       isInstrumentationHookFilename(bundlePath)
     ) {
+      return
+    }
+
+    if (isEntryPinned?.(bundlePath)) {
+      entryData.dispose = false
       return
     }
 
@@ -632,6 +638,7 @@ export function onDemandEntryHandler({
   pagesDir,
   rootDir,
   appDir,
+  isEntryPinned,
 }: {
   hotReloader: NextJsHotReloaderInterface
   maxInactiveAge: number
@@ -641,6 +648,7 @@ export function onDemandEntryHandler({
   pagesDir?: string
   rootDir: string
   appDir?: string
+  isEntryPinned?: (bundlePath: string) => boolean
 }) {
   const hasAppDir = !!appDir
   let curInvalidator: Invalidator = getInvalidator(
@@ -820,7 +828,7 @@ export function onDemandEntryHandler({
   const pingIntervalTime = Math.max(1000, Math.min(5000, maxInactiveAge))
 
   setInterval(function () {
-    disposeInactiveEntries(curEntries, maxInactiveAge)
+    disposeInactiveEntries(curEntries, maxInactiveAge, isEntryPinned)
   }, pingIntervalTime + 1000).unref()
 
   function handleAppDirPing(tree: FlightRouterState): void {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -285,6 +285,7 @@ export async function initialize(opts: {
         restartServer: opts.restartServer,
         resetFetch,
         serverFastRefresh: effectiveServerFastRefresh,
+        webSocketRegistryScope,
       })
     )
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -291,6 +291,7 @@ async function startWatcher(
           lockfile,
           onDevServerCleanup: opts.onDevServerCleanup,
           restartServer: opts.restartServer,
+          webSocketRegistryScope: opts.webSocketRegistryScope,
         })
       })()
 

--- a/packages/next/src/server/websocket-connection-registry.test.ts
+++ b/packages/next/src/server/websocket-connection-registry.test.ts
@@ -5,6 +5,7 @@ import type {
 import {
   closeWebSocketRoute,
   closeWebSocketScope,
+  getActiveWebSocketRouteBundlePaths,
   getWebSocketRouteBundlePath,
   isWebSocketRouteActive,
   isWebSocketRouteLeaseCurrent,
@@ -472,6 +473,25 @@ describe('WebSocket connection registry', () => {
     lease!.release()
     lease!.release()
     expect(isWebSocketRouteActive(scope, 'app/chat/route')).toBe(false)
+  })
+
+  it('returns a snapshot of routes with in-flight leases or peers', () => {
+    const scope = {}
+    const lease = tryAcquireWebSocketRouteLease(scope, 'app/chat/route')!
+
+    const activeRoutes = getActiveWebSocketRouteBundlePaths(scope)
+    expect(activeRoutes).toEqual(new Set(['app/chat/route']))
+
+    const peer = createConnection()
+    expect(registerWebSocketRoutePeer(peer.connection, lease)).toBe(true)
+    lease.release()
+    expect(getActiveWebSocketRouteBundlePaths(scope)).toEqual(
+      new Set(['app/chat/route'])
+    )
+
+    unregisterWebSocketRoutePeer(peer.connection, lease)
+    expect(getActiveWebSocketRouteBundlePaths(scope)).toEqual(new Set())
+    expect(activeRoutes).toEqual(new Set(['app/chat/route']))
   })
 
   it('keeps a registered peer active after its request lease is released', () => {

--- a/packages/next/src/server/websocket-connection-registry.ts
+++ b/packages/next/src/server/websocket-connection-registry.ts
@@ -54,6 +54,7 @@ const ABANDONED_TASKS_SYMBOL = Symbol.for(
 const TASK_ADMISSION_CLOSED_SCOPES_SYMBOL = Symbol.for(
   'next.websocket.connection-registry-task-admission-closed-scopes'
 )
+
 type WebSocketRouteState = {
   readonly peers: Set<WebSocketRegistryConnection>
   leases: number
@@ -647,6 +648,13 @@ export function isWebSocketRouteActive(
   return Boolean(route && (route.leases !== 0 || route.peers.size !== 0))
 }
 
+export function getActiveWebSocketRouteBundlePaths(
+  scope: object
+): ReadonlySet<string> {
+  const routes = getScopeRegistry(scope, false)?.routes
+  return routes ? new Set(routes.keys()) : new Set()
+}
+
 function takeWebSocketRouteConnections(
   scope: object,
   bundlePath: string
@@ -713,6 +721,32 @@ export function reloadWebSocketScope(
     takeWebSocketScopeConnections(scope),
     code
   )
+}
+
+/**
+ * Invalidates WebSocket routes after a development update: closes the given
+ * routes with 1012, or reloads the whole scope when the bundler could not
+ * prove the affected set (compile errors, unknown graph shape, full reload).
+ * Over-closing is the designed safe direction; never silently keep a route
+ * executing code from a generation which may have changed. Both bundlers
+ * supply their bundler-specific affected-set computation to this one policy.
+ */
+export function invalidateWebSocketRoutes(
+  scope: object | undefined,
+  affected: ReadonlySet<string> | 'unknown'
+): void {
+  if (!scope) return
+  if (affected !== 'unknown' && affected.size === 0) return
+  if (affected === 'unknown') {
+    void reloadWebSocketScope(scope)
+    return
+  }
+  const activeBundlePaths = getActiveWebSocketRouteBundlePaths(scope)
+  for (const bundlePath of affected) {
+    if (activeBundlePaths.has(bundlePath)) {
+      void closeWebSocketRoute(scope, bundlePath)
+    }
+  }
 }
 
 export function closeWebSocketScope(

--- a/test/development/app-dir/server-hmr/app/ws-hmr/alpha/route.ts
+++ b/test/development/app-dir/server-hmr/app/ws-hmr/alpha/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+const version = 'alpha-v0'
+
+export function GET() {
+  return NextResponse.upgrade({
+    open(peer) {
+      peer.send(version)
+    },
+    message(peer, message) {
+      peer.send(`${version}:${message.text()}`)
+    },
+  })
+}

--- a/test/development/app-dir/server-hmr/app/ws-hmr/beta/route.ts
+++ b/test/development/app-dir/server-hmr/app/ws-hmr/beta/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+const version = 'beta-v0'
+
+export function GET() {
+  return NextResponse.upgrade({
+    open(peer) {
+      peer.send(version)
+    },
+    message(peer, message) {
+      peer.send(`${version}:${message.text()}`)
+    },
+  })
+}

--- a/test/development/app-dir/server-hmr/app/ws-hmr/shared-a/route.ts
+++ b/test/development/app-dir/server-hmr/app/ws-hmr/shared-a/route.ts
@@ -1,0 +1,5 @@
+import { upgrade } from '../shared'
+
+export function GET() {
+  return upgrade('shared-a')
+}

--- a/test/development/app-dir/server-hmr/app/ws-hmr/shared-b/route.ts
+++ b/test/development/app-dir/server-hmr/app/ws-hmr/shared-b/route.ts
@@ -1,0 +1,5 @@
+import { upgrade } from '../shared'
+
+export function GET() {
+  return upgrade('shared-b')
+}

--- a/test/development/app-dir/server-hmr/app/ws-hmr/shared.ts
+++ b/test/development/app-dir/server-hmr/app/ws-hmr/shared.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+const version = 'shared-v0'
+
+export function upgrade(name: string) {
+  return NextResponse.upgrade({
+    open(peer) {
+      peer.send(`${name}:${version}`)
+    },
+  })
+}

--- a/test/development/app-dir/server-hmr/next.config.js
+++ b/test/development/app-dir/server-hmr/next.config.js
@@ -1,6 +1,10 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    webSocketRouteHandlers: true,
+  },
+}
 
 module.exports = nextConfig

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -1,5 +1,6 @@
 import type { Response } from 'node-fetch'
 import { join } from 'path'
+import WebSocket from 'ws'
 import { nextTestSetup, FileRef } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 
@@ -744,6 +745,204 @@ describe('server-hmr', () => {
           // The unmodified dependency should NOT have been re-evaluated
           expect(updated.depEvaluatedAt).toBe(initialDepEvaluatedAt)
         })
+      }
+    )
+  })
+
+  describe('WebSocket route HMR', () => {
+    const itDev = isNextDev ? it : it.skip
+    // Edge runtime is not supported with Cache Components.
+    const itDevWithoutCacheComponents =
+      process.env.__NEXT_CACHE_COMPONENTS === 'true' ? it.skip : itDev
+    const sockets = new Set<WebSocket>()
+
+    function connect(pathname: string) {
+      return new Promise<{ socket: WebSocket; firstMessage: string }>(
+        (resolve, reject) => {
+          const socket = new WebSocket(
+            `ws://localhost:${next.appPort}${pathname}`
+          )
+          let settled = false
+          sockets.add(socket)
+
+          socket.once('message', (message) => {
+            settled = true
+            resolve({ socket, firstMessage: message.toString() })
+          })
+          socket.once('unexpected-response', (_request, response) => {
+            response.resume()
+            if (!settled) {
+              settled = true
+              reject(
+                new Error(`WebSocket upgrade failed (${response.statusCode})`)
+              )
+            }
+          })
+          socket.once('error', (error) => {
+            if (!settled) {
+              settled = true
+              reject(error)
+            }
+          })
+          socket.once('close', (code) => {
+            sockets.delete(socket)
+            if (!settled) {
+              settled = true
+              reject(new Error(`WebSocket closed before opening (${code})`))
+            }
+          })
+        }
+      )
+    }
+
+    async function connectWithMessage(pathname: string, expected: string) {
+      return retry(async () => {
+        const connection = await connect(pathname)
+        try {
+          expect(connection.firstMessage).toBe(expected)
+          return connection
+        } catch (error) {
+          connection.socket.terminate()
+          throw error
+        }
+      }, 15_000)
+    }
+
+    function observeRestartClose(socket: WebSocket) {
+      let closeCode: number | undefined
+      socket.once('close', (code) => {
+        closeCode = code
+      })
+      return () =>
+        retry(() => {
+          expect(closeCode).toBe(1012)
+        }, 15_000)
+    }
+
+    async function expectEcho(
+      socket: WebSocket,
+      message: string,
+      expected: string
+    ) {
+      let received: string | undefined
+      socket.once('message', (data) => {
+        received = data.toString()
+      })
+      expect(socket.readyState).toBe(WebSocket.OPEN)
+      socket.send(message)
+      await retry(() => {
+        expect(received).toBe(expected)
+      }, 15_000)
+    }
+
+    afterEach(() => {
+      for (const socket of sockets) socket.terminate()
+      sockets.clear()
+    })
+
+    itDev(
+      'closes only an edited route and serves its new generation',
+      async () => {
+        const alpha = await connectWithMessage('/ws-hmr/alpha', 'alpha-v0')
+        const beta = await connectWithMessage('/ws-hmr/beta', 'beta-v0')
+        const waitForAlphaClose = observeRestartClose(alpha.socket)
+
+        await next.patchFile(
+          'app/ws-hmr/alpha/route.ts',
+          (content) => content.replace('alpha-v0', 'alpha-v1'),
+          async () => {
+            await waitForAlphaClose()
+            await expectEcho(beta.socket, 'still-open', 'beta-v0:still-open')
+
+            const updated = await connectWithMessage(
+              '/ws-hmr/alpha',
+              'alpha-v1'
+            )
+            await expectEcho(updated.socket, 'new-code', 'alpha-v1:new-code')
+          }
+        )
+      }
+    )
+
+    itDev(
+      'closes every route that owns a changed shared dependency',
+      async () => {
+        const sharedA = await connectWithMessage(
+          '/ws-hmr/shared-a',
+          'shared-a:shared-v0'
+        )
+        const sharedB = await connectWithMessage(
+          '/ws-hmr/shared-b',
+          'shared-b:shared-v0'
+        )
+        const beta = await connectWithMessage('/ws-hmr/beta', 'beta-v0')
+        const waitForSharedA = observeRestartClose(sharedA.socket)
+        const waitForSharedB = observeRestartClose(sharedB.socket)
+
+        await next.patchFile(
+          'app/ws-hmr/shared.ts',
+          (content) => content.replace('shared-v0', 'shared-v1'),
+          async () => {
+            await Promise.all([waitForSharedA(), waitForSharedB()])
+            await expectEcho(beta.socket, 'still-open', 'beta-v0:still-open')
+
+            await Promise.all([
+              connectWithMessage('/ws-hmr/shared-a', 'shared-a:shared-v1'),
+              connectWithMessage('/ws-hmr/shared-b', 'shared-b:shared-v1'),
+            ])
+          }
+        )
+      }
+    )
+
+    itDev(
+      'closes a deleted route and serves it after restoration',
+      async () => {
+        const filename = 'app/ws-hmr/alpha/route.ts'
+        const source = await next.readFile(filename)
+        const alpha = await connectWithMessage('/ws-hmr/alpha', 'alpha-v0')
+        const waitForAlphaClose = observeRestartClose(alpha.socket)
+        let deleted = false
+
+        try {
+          await next.deleteFile(filename)
+          deleted = true
+          await waitForAlphaClose()
+          await retry(async () => {
+            expect((await next.fetch('/ws-hmr/alpha')).status).toBe(404)
+          }, 15_000)
+
+          await next.patchFile(filename, source)
+          deleted = false
+          const restored = await connectWithMessage('/ws-hmr/alpha', 'alpha-v0')
+          await expectEcho(restored.socket, 'restored', 'alpha-v0:restored')
+        } finally {
+          if (deleted) await next.patchFile(filename, source)
+        }
+      }
+    )
+
+    itDevWithoutCacheComponents(
+      'closes a Node route that moves to the Edge runtime',
+      async () => {
+        const alpha = await connectWithMessage('/ws-hmr/alpha', 'alpha-v0')
+        const beta = await connectWithMessage('/ws-hmr/beta', 'beta-v0')
+        const waitForAlphaClose = observeRestartClose(alpha.socket)
+
+        await next.patchFile(
+          'app/ws-hmr/alpha/route.ts',
+          (content) =>
+            content.replace(
+              "const version = 'alpha-v0'",
+              "export const runtime = 'edge'\n\nconst version = 'alpha-v0'"
+            ),
+          async () => {
+            await waitForAlphaClose()
+            await expectEcho(beta.socket, 'still-open', 'beta-v0:still-open')
+          }
+        )
+
+        await connectWithMessage('/ws-hmr/alpha', 'alpha-v0')
       }
     )
   })

--- a/test/unit/turbopack-subscription.test.ts
+++ b/test/unit/turbopack-subscription.test.ts
@@ -5,6 +5,7 @@ import {
 import {
   clearServerHmrChunkCaches,
   getServerHmrRuntimeRoot,
+  getWebSocketRouteBundlePathFromTurbopackEntry,
 } from 'next/dist/server/dev/hot-reloader-turbopack'
 import { backgroundLogCompilationEvents } from 'next/dist/shared/lib/turbopack/compilation-events'
 import type { Project } from 'next/dist/build/swc/types'
@@ -457,5 +458,22 @@ describe('server HMR runtime identity', () => {
     } finally {
       rmSync(temporaryDirectory, { force: true, recursive: true })
     }
+  })
+})
+
+describe('Turbopack WebSocket route mapping', () => {
+  it('accepts only relative JavaScript entry paths', () => {
+    expect(getWebSocketRouteBundlePathFromTurbopackEntry('chat/route.js')).toBe(
+      'app/chat/route'
+    )
+    expect(
+      getWebSocketRouteBundlePathFromTurbopackEntry('rooms\\[id]\\route.js')
+    ).toBe('app/rooms/[id]/route')
+    expect(
+      getWebSocketRouteBundlePathFromTurbopackEntry('../outside/route.js')
+    ).toBe(undefined)
+    expect(
+      getWebSocketRouteBundlePathFromTurbopackEntry('/chat/route.js')
+    ).toBe(undefined)
   })
 })

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_list/update.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_list/update.rs
@@ -29,6 +29,12 @@ pub struct ChunkListUpdate {
     /// List of merged updates since the last version.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub merged: Vec<EcmascriptMergedUpdate>,
+    /// Entry points whose runtime work this update carries, populated by
+    /// aggregate (multi-entry) update feeds so consumers can scope
+    /// invalidation to the entries that changed. Per-entry feeds leave this
+    /// empty. Sorted for deterministic serialization.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub affected_entries: Vec<RcStr>,
 }
 
 impl ChunkListUpdate {
@@ -168,7 +174,12 @@ pub async fn update_chunk_list(
             to: Vc::upcast::<Box<dyn Version>>(to_version)
                 .into_trait_ref()
                 .await?,
-            instruction: ChunkListUpdate { chunks, merged }.into_instruction(),
+            instruction: ChunkListUpdate {
+                chunks,
+                merged,
+                affected_entries: vec![],
+            }
+            .into_instruction(),
         })
     };
 
@@ -209,6 +220,7 @@ mod tests {
                     }),
                 )]),
             }],
+            affected_entries: vec![],
         });
 
         assert_eq!(


### PR DESCRIPTION
### What?

Reload only the WebSocket Route Handlers affected by a development server update, and document the completed experimental feature.

### Why?

Closing every persistent connection on each development update makes WebSocket applications difficult to work on. Once lifecycle and route-generation ownership exist, Next.js can invalidate only the routes whose server code changed while leaving unrelated connections alive.

### How?

- Close affected connections with `1012` when their route or one of its dependencies changes.
- Support Turbopack and Webpack, shared dependencies, deletion and restoration, route-group moves, and Node-to-Edge transitions.
- Avoid route-graph traversal when no WebSocket route is active.
- Keep the compatible route-HMR cases running under Cache Components, skipping only the unsupported Node-to-Edge runtime transition.
- Add the complete `NextResponse.upgrade()` guide, API reference, deployment behavior, reconnection guidance, and process-local policy boundaries.
- Document the single-owner dispatcher contract for custom servers hosting multiple Next.js apps or WebSocket protocols.

This is stacked on #97030 and completes the seven-PR experimental WebSocket Route Handler stack.

### Verification

- `pnpm test-dev-turbo test/development/app-dir/server-hmr/server-hmr.test.ts -t "WebSocket route HMR"`
- The same focused suite with Cache Components enabled
- Corresponding webpack WebSocket HMR coverage
- `pnpm test-dev-turbo test/e2e/app-dir/websocket-route-handlers/websocket-route-handlers.test.ts`
- `pnpm build-all`
- `pnpm types-and-precompiled`
- Documentation formatting and link validation

### Stack status (2026-08-24)

Rebased onto canary `a1cc1eafb3`, completing the stack. This layer now also carries: the shared `invalidateWebSocketRoutes()` policy consumed by both bundlers (webpack drives off `trackPageChanges` on both server compilers plus a per-route owner map; the ~160-line duplicate fingerprinter and its retained-Compilation leak are gone, fixing edge-runtime routes being closed on every compile and first-connect spurious bumps), the Turbopack affected-entry mapping fix, Rust `affectedEntries` ported onto canary's typed instructions with the invariant pinned by test, docs (JSON-close guard, `peer.request.signal`, proxy.ts runtime throw, frontmatter). Full verification matrix green at this tip: 1126 unit tests, both bundlers' WS HMR e2e (8/8), prod + dev WS route-handler e2e (40/40), shutdown (8/8), socket.io (3/3), telemetry, build + precompiled, cargo checks.
