### PR TITLE
Prefix `'use cache'` debug logs with the full directive

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -339,8 +339,10 @@ const crossRequestPendingCacheInvocations = new Map<
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
+// The first argument at each call site is the full directive that produced
+// the invocation, e.g. "'use cache'" or "'use cache: remote'".
 const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
-  ? console.debug.bind(console, 'use-cache:')
+  ? console.debug.bind(console)
   : undefined
 
 const filterStackFrame =
@@ -491,7 +493,8 @@ function computePrivateCacheKeyRequestSuffix(
 function saveToResumeDataCache(
   resumeDataCache: ResumeDataCache | null,
   serializedCacheKey: string,
-  pendingCacheResult: Promise<CollectedCacheResult>
+  pendingCacheResult: Promise<CollectedCacheResult>,
+  logPrefix: string
 ): Promise<CollectedCacheResult> {
   if (!resumeDataCache?.mutable) {
     return pendingCacheResult
@@ -505,7 +508,7 @@ function saveToResumeDataCache(
   // use the coarse key (without root param suffix). Unlike the cache handler,
   // the RDC doesn't need root-param-specific keys for isolation.
   resumeDataCache.cache.set(serializedCacheKey, rdcResult)
-  debug?.('Resume Data Cache entry saved', serializedCacheKey)
+  debug?.(logPrefix, 'Resume Data Cache entry saved', serializedCacheKey)
 
   return savedCacheResult
 }
@@ -529,7 +532,8 @@ function saveToResumeDataCache(
 function saveSharedCacheEntryToResumeDataCache(
   serializedCacheKey: string,
   sharedCacheEntry: SharedCacheEntry,
-  resumeDataCache: ResumeDataCache | null
+  resumeDataCache: ResumeDataCache | null,
+  logPrefix: string
 ): void {
   if (
     !resumeDataCache?.mutable ||
@@ -555,7 +559,11 @@ function saveSharedCacheEntryToResumeDataCache(
     }))
 
   resumeDataCache.cache.set(serializedCacheKey, rdcResult)
-  debug?.('Resume Data Cache entry saved by joiner', serializedCacheKey)
+  debug?.(
+    logPrefix,
+    'Resume Data Cache entry saved by joiner',
+    serializedCacheKey
+  )
 }
 
 /**
@@ -569,7 +577,8 @@ function serveJoinedCacheEntry(
   serializedCacheKey: string,
   resumeDataCache: ResumeDataCache | null,
   cacheContext: CacheContext,
-  cacheSignal: CacheSignal | null
+  cacheSignal: CacheSignal | null,
+  logPrefix: string
 ): ReadableStream<Uint8Array> {
   const stream = sharedCacheEntry.fork()
 
@@ -580,7 +589,8 @@ function serveJoinedCacheEntry(
   saveSharedCacheEntryToResumeDataCache(
     serializedCacheKey,
     sharedCacheEntry,
-    resumeDataCache
+    resumeDataCache,
+    logPrefix
   )
 
   // End the cache signal read when the result is fully collected, not when the
@@ -1719,6 +1729,9 @@ export async function cache(
 ) {
   const isPrivate = kind === 'private'
 
+  // The default handler kind corresponds to the bare 'use cache' directive.
+  const logPrefix = kind === 'default' ? `'use cache'` : `'use cache: ${kind}'`
+
   const workStore = workAsyncStorage.getStore()
   if (workStore === undefined) {
     throw new Error(
@@ -2377,13 +2390,14 @@ export async function cache(
 
         if (
           rdcResult.entry.tags.some((tag) =>
-            isRevalidatedAfter(tag, timestamp, workStore)
+            isRevalidatedAfter(tag, timestamp, workStore, logPrefix)
           ) ||
           implicitTags.some((tag) =>
-            isRevalidatedAfter(tag, timestamp, workStore)
+            isRevalidatedAfter(tag, timestamp, workStore, logPrefix)
           )
         ) {
           debug?.(
+            logPrefix,
             'discarding RDC entry due to recently revalidated tags',
             serializedCacheKey
           )
@@ -2432,6 +2446,7 @@ export async function cache(
                   )
                 }
                 debug?.(
+                  logPrefix,
                   'omitting entry',
                   serializedCacheKey,
                   'from static shell due to revalidate: 0'
@@ -2448,6 +2463,7 @@ export async function cache(
                   )
                 }
                 debug?.(
+                  logPrefix,
                   'omitting entry',
                   serializedCacheKey,
                   'from static shell due to short expire value:',
@@ -2571,6 +2587,7 @@ export async function cache(
                   stagedRendering.finalStage < postShellStage)
               ) {
                 debug?.(
+                  logPrefix,
                   'omitting entry',
                   serializedCacheKey,
                   'from shell due to short stale value:',
@@ -2600,6 +2617,7 @@ export async function cache(
               }
               if (stagedRendering !== null) {
                 debug?.(
+                  logPrefix,
                   'delaying entry',
                   serializedCacheKey,
                   'until after the shell stage due to short stale value:',
@@ -2659,7 +2677,7 @@ export async function cache(
       }
 
       if (rdcResult !== undefined) {
-        debug?.('Resume Data Cache entry found', serializedCacheKey)
+        debug?.(logPrefix, 'Resume Data Cache entry found', serializedCacheKey)
 
         if (
           rdcResult.readRootParamNames &&
@@ -2697,14 +2715,22 @@ export async function cache(
         }
       } else {
         // Entry was discarded (e.g. due to recently revalidated tags)
-        debug?.('Resume Data Cache entry discarded', serializedCacheKey)
+        debug?.(
+          logPrefix,
+          'Resume Data Cache entry discarded',
+          serializedCacheKey
+        )
 
         if (cacheSignal) {
           cacheSignal.endRead()
         }
       }
     } else {
-      debug?.('Resume Data Cache entry not found', serializedCacheKey)
+      debug?.(
+        logPrefix,
+        'Resume Data Cache entry not found',
+        serializedCacheKey
+      )
 
       if (cacheSignal) {
         cacheSignal.endRead()
@@ -2801,11 +2827,15 @@ export async function cache(
       const cacheSignal = getCacheSignal(workUnitStore)
       cacheSignal?.beginRead()
 
-      debug?.('joining intra-request invocation', serializedCacheKey)
+      debug?.(logPrefix, 'joining intra-request invocation', serializedCacheKey)
       const sharedCacheResult = await joinedInvocation
 
       if (sharedCacheResult.type === 'prerender-dynamic') {
-        debug?.('joined invocation is prerender-dynamic', serializedCacheKey)
+        debug?.(
+          logPrefix,
+          'joined invocation is prerender-dynamic',
+          serializedCacheKey
+        )
         cacheSignal?.endRead()
         return sharedCacheResult.hangingPromise
       }
@@ -2828,10 +2858,15 @@ export async function cache(
           workStore,
           workUnitStore,
           implicitTags,
-          0
+          0,
+          logPrefix
         )
       ) {
-        debug?.('discarding completed invocation', serializedCacheKey)
+        debug?.(
+          logPrefix,
+          'discarding completed invocation',
+          serializedCacheKey
+        )
         workStore.completedCacheInvocations?.delete(serializedCacheKey)
 
         // This can take the signal's count to zero. The leader path below opens
@@ -2841,6 +2876,7 @@ export async function cache(
         cacheSignal?.endRead()
       } else {
         debug?.(
+          logPrefix,
           'joined invocation resolved with cached entry',
           serializedCacheKey
         )
@@ -2850,7 +2886,8 @@ export async function cache(
           serializedCacheKey,
           resumeDataCache,
           cacheContext,
-          cacheSignal
+          cacheSignal,
+          logPrefix
         )
       }
     }
@@ -2862,6 +2899,7 @@ export async function cache(
     const resolvableSharedCacheResult = new ResolvableSharedCacheResult()
 
     debug?.(
+      logPrefix,
       'registering as intra-request invocation leader',
       serializedCacheKey
     )
@@ -2915,7 +2953,11 @@ export async function cache(
           const cacheSignal = getCacheSignal(workUnitStore)
           cacheSignal?.beginRead()
 
-          debug?.('joining pending cross-request invocation', cacheHandlerKey)
+          debug?.(
+            logPrefix,
+            'joining pending cross-request invocation',
+            cacheHandlerKey
+          )
           const sharedCacheResult = await crossRequestPendingCacheInvocation
 
           if (sharedCacheResult.type === 'cached') {
@@ -2942,6 +2984,7 @@ export async function cache(
 
               if (newCacheHandlerKey !== cacheHandlerKey) {
                 debug?.(
+                  logPrefix,
                   'cross-request root param mismatch, retrying',
                   cacheHandlerKey,
                   '→',
@@ -2955,6 +2998,7 @@ export async function cache(
 
             // Key matches — safe to fork.
             debug?.(
+              logPrefix,
               'cross-request invocation matched, forking result',
               cacheHandlerKey
             )
@@ -2968,7 +3012,8 @@ export async function cache(
             saveSharedCacheEntryToResumeDataCache(
               serializedCacheKey,
               sharedCacheResult.entry,
-              resumeDataCache
+              resumeDataCache,
+              logPrefix
             )
 
             // Resolve for intra-request joiners in this request. They get
@@ -2988,6 +3033,7 @@ export async function cache(
 
               if (newCacheHandlerKey !== cacheHandlerKey) {
                 debug?.(
+                  logPrefix,
                   'cross-request root param mismatch, retrying',
                   cacheHandlerKey,
                   '→',
@@ -3000,6 +3046,7 @@ export async function cache(
             }
 
             debug?.(
+              logPrefix,
               'cross-request invocation is prerender-dynamic',
               cacheHandlerKey
             )
@@ -3015,6 +3062,7 @@ export async function cache(
         // No pending cross-request invocation — become the leader.
         if (!skipCrossRequestDedupe) {
           debug?.(
+            logPrefix,
             'registering as cross-request invocation leader',
             cacheHandlerKey
           )
@@ -3092,10 +3140,11 @@ export async function cache(
               workStore,
               workUnitStore,
               implicitTags,
-              implicitTagsExpiration
+              implicitTagsExpiration,
+              logPrefix
             )
           ) {
-            debug?.('discarding expired entry', cacheHandlerKey)
+            debug?.(logPrefix, 'discarding expired entry', cacheHandlerKey)
             entry = undefined
           }
         }
@@ -3115,12 +3164,14 @@ export async function cache(
               // entry.
               if (entry.revalidate === 0) {
                 debug?.(
+                  logPrefix,
                   'omitting entry',
                   cacheHandlerKey,
                   'from static shell due to revalidate: 0'
                 )
               } else {
                 debug?.(
+                  logPrefix,
                   'omitting entry',
                   cacheHandlerKey,
                   'from static shell due to short expire value:',
@@ -3140,7 +3191,11 @@ export async function cache(
                 'dynamic "use cache"',
                 workUnitStore
               )
-              debug?.('leader resolved as prerender-dynamic', cacheHandlerKey)
+              debug?.(
+                logPrefix,
+                'leader resolved as prerender-dynamic',
+                cacheHandlerKey
+              )
               resolvableSharedCacheResult.resolve({
                 type: 'prerender-dynamic',
                 hangingPromise,
@@ -3272,7 +3327,7 @@ export async function cache(
 
           if (entry) {
             if (currentTime > entry.timestamp + entry.expire * 1000) {
-              debug?.('entry is expired', cacheHandlerKey)
+              debug?.(logPrefix, 'entry is expired', cacheHandlerKey)
             }
 
             if (
@@ -3280,6 +3335,7 @@ export async function cache(
               currentTime > entry.timestamp + entry.revalidate * 1000
             ) {
               debug?.(
+                logPrefix,
                 'foreground revalidation, entry is stale',
                 cacheHandlerKey
               )
@@ -3309,6 +3365,7 @@ export async function cache(
 
           if (result.type === 'prerender-dynamic') {
             debug?.(
+              logPrefix,
               'leader resolved as prerender-dynamic (generation)',
               cacheHandlerKey
             )
@@ -3333,7 +3390,8 @@ export async function cache(
             const savedCacheResult = saveToResumeDataCache(
               resumeDataCache,
               serializedCacheKey,
-              pendingCacheResult
+              pendingCacheResult,
+              logPrefix
             )
 
             if (cacheHandler) {
@@ -3348,7 +3406,11 @@ export async function cache(
             }
           }
 
-          debug?.('leader resolved with generated entry', cacheHandlerKey)
+          debug?.(
+            logPrefix,
+            'leader resolved with generated entry',
+            cacheHandlerKey
+          )
 
           const pendingMetadata: Promise<CacheResultMetadata> =
             metadataSource.then((collected) => ({
@@ -3429,7 +3491,11 @@ export async function cache(
             cacheSignal?.endRead()
           }
 
-          debug?.('leader resolved with cache handler hit', cacheHandlerKey)
+          debug?.(
+            logPrefix,
+            'leader resolved with cache handler hit',
+            cacheHandlerKey
+          )
 
           const sharedCacheEntry = new SharedCacheEntry(
             stream,
@@ -3504,7 +3570,8 @@ export async function cache(
                   const savedCacheResult = saveToResumeDataCache(
                     resumeDataCache,
                     serializedCacheKey,
-                    pendingCacheResult
+                    pendingCacheResult,
+                    logPrefix
                   )
 
                   if (cacheHandler) {
@@ -3523,6 +3590,7 @@ export async function cache(
               })
               .catch((error) => {
                 debug?.(
+                  logPrefix,
                   'background cache revalidation failed for',
                   revalidateCacheHandlerKey,
                   error
@@ -3637,12 +3705,14 @@ function shouldDiscardCacheEntry(
   workStore: WorkStore,
   workUnitStore: WorkUnitStore,
   implicitTags: string[],
-  implicitTagsExpiration: number
+  implicitTagsExpiration: number,
+  logPrefix: string
 ): boolean {
   // If the cache entry was created before any of the implicit tags were
   // revalidated last, we need to discard it.
   if (entry.timestamp <= implicitTagsExpiration) {
     debug?.(
+      logPrefix,
       'entry was created at',
       entry.timestamp,
       'before implicit tags were revalidated at',
@@ -3679,7 +3749,7 @@ function shouldDiscardCacheEntry(
   // not know about yet, we need to discard it.
   if (
     entry.tags.some((tag) =>
-      isRevalidatedAfter(tag, entry.timestamp, workStore)
+      isRevalidatedAfter(tag, entry.timestamp, workStore, logPrefix)
     )
   ) {
     return true
@@ -3689,7 +3759,7 @@ function shouldDiscardCacheEntry(
   // also need to discard the cache entry.
   if (
     implicitTags.some((tag) =>
-      isRevalidatedAfter(tag, entry.timestamp, workStore)
+      isRevalidatedAfter(tag, entry.timestamp, workStore, logPrefix)
     )
   ) {
     return true
@@ -3706,7 +3776,8 @@ function shouldDiscardCacheEntry(
 function isRevalidatedAfter(
   tag: string,
   entryTimestamp: number,
-  workStore: WorkStore
+  workStore: WorkStore,
+  logPrefix: string
 ): boolean {
   const {
     previouslyRevalidatedTags,
@@ -3721,7 +3792,7 @@ function isRevalidatedAfter(
     entryTimestamp <= requestStartTime &&
     previouslyRevalidatedTags.includes(tag)
   ) {
-    debug?.('tag', tag, 'was previously revalidated')
+    debug?.(logPrefix, 'tag', tag, 'was previously revalidated')
 
     return true
   }
@@ -3735,7 +3806,7 @@ function isRevalidatedAfter(
       (item) => item.tag === tag && item.revalidatedAt > entryTimestamp
     )
   ) {
-    debug?.('tag', tag, 'was just revalidated')
+    debug?.(logPrefix, 'tag', tag, 'was just revalidated')
 
     return true
   }


### PR DESCRIPTION

With `NEXT_PRIVATE_DEBUG_CACHE` enabled, every log line from the "use cache" wrapper used the same generic `use-cache:` prefix, so output from `"use cache: remote"` or `"use cache: private"` functions was indistinguishable from plain `"use cache"`. Each wrapper line is now prefixed with the full quoted directive, derived from the handler kind: `'use cache'` for the default kind, `'use cache: <kind>'` otherwise.
