### PR TITLE
[CC] Track APIs that cause incompatible static/app shells

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -336,7 +336,6 @@ import { isInstantValidationError } from './instant-validation/instant-validatio
 import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
 import { RENDER_STAGES_BY_DATA_KIND } from '../dynamic-rendering-utils'
 import type { StageEndTimes } from './instant-validation/instant-validation'
-import { hasNonRootStaticParams } from '../lib/params-utils'
 
 export type GetDynamicParamFromSegment = (
   // The LoaderTree to extract the dynamic param from
@@ -5081,13 +5080,12 @@ async function prepareValidationInputsInPartialPrefetching(
   const needsInstantValidation =
     await anySegmentNeedsInstantValidationInDev(loaderTree)
 
-  // If we have static params that aren't root params, then the static stages are incompatible
-  // between the Static shell and the App Shell, and we can't use the same render for both.
-  const areStagesCompatible = !hasNonRootStaticParams(
-    ctx.interpolatedParams,
-    requestStore.rootParams,
-    requestStore.fallbackParams
-  )
+  // Certain APIs (static `params`, `unstable_navigation()`, `unstable_prefetch()`) resolve
+  // in either static or runtime stages depending on the context (see `needsAppShell`).
+  // If one of these APIs is used, the render can't be used for both Instant Validation and
+  // Static Shell Validation and we'll need to perform a secondary render.
+  // All relevant uses are tracked on the request store.
+  const areStagesCompatible = !requestStore.hasIncompatibleShellContent
 
   const LAZY_FULL_RENDER = createLazyDevValidationInputs(async () => {
     const shouldRenderWithAppShell = true
@@ -5343,7 +5341,8 @@ function setUpStagedDevRender(
   })
   requestStore.resumeDataCache = prerenderResumeDataCache
   requestStore.stagedRendering = stageController
-  requestStore.needsSessionShell = shouldRenderWithAppShell
+  requestStore.needsAppShell = shouldRenderWithAppShell
+  requestStore.hasIncompatibleShellContent = false
   requestStore.asyncApiPromises = createAsyncApiPromises(
     stageController,
     requestStore.cookies,
@@ -5702,7 +5701,8 @@ async function renderWithWarmCachesForValidationInDev(
     prerenderResumeDataCache
   )
   requestStore.stagedRendering = stageController
-  requestStore.needsSessionShell = shouldRenderWithAppShell
+  requestStore.needsAppShell = shouldRenderWithAppShell
+  requestStore.hasIncompatibleShellContent = false
   requestStore.cacheSignal = null
   requestStore.asyncApiPromises = createAsyncApiPromises(
     stageController,
@@ -5811,7 +5811,8 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
     prerenderResumeDataCache
   )
   requestStore.stagedRendering = stageController
-  requestStore.needsSessionShell = false
+  requestStore.needsAppShell = false
+  requestStore.hasIncompatibleShellContent = false
   requestStore.cacheSignal = null
   requestStore.asyncApiPromises = createAsyncApiPromises(
     stageController,
@@ -7747,7 +7748,8 @@ async function renderWithRestartOnCacheMissInValidation(
 
   requestStore.resumeDataCache = prerenderResumeDataCache
   requestStore.stagedRendering = initialStageController
-  requestStore.needsSessionShell = shouldRenderAppShell
+  requestStore.needsAppShell = shouldRenderAppShell
+  requestStore.hasIncompatibleShellContent = false
   requestStore.cacheSignal = cacheSignal
   requestStore.asyncApiPromises = createAsyncApiPromises(
     initialStageController,
@@ -7864,7 +7866,8 @@ async function renderWithRestartOnCacheMissInValidation(
     prerenderResumeDataCache
   )
   requestStore.stagedRendering = finalStageController
-  requestStore.needsSessionShell = shouldRenderAppShell
+  requestStore.needsAppShell = shouldRenderAppShell
+  requestStore.hasIncompatibleShellContent = false
   requestStore.cacheSignal = null
   requestStore.asyncApiPromises = createAsyncApiPromises(
     finalStageController,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -76,7 +76,22 @@ export interface RequestStore extends CommonWorkUnitStore {
 
   stagedRendering?: StagedRenderingController | null
   asyncApiPromises?: AsyncApiPromises
-  needsSessionShell?: boolean // DEV-only
+
+  /**
+   * DEV-only.
+   * Certain APIs have different behavior in static and runtime prerenders.
+   * - if `false`, they will follow static semantics
+   * - if `true`, they will follow runtime semantics
+   * */
+  needsAppShell?: boolean // DEV-only
+  /**
+   * DEV-only, mutable.
+   * Whether any APIs that resolve in different stages in static and
+   * runtime prerenders (i.e. whose behavior varies on `needsAppShell`)
+   * were used during this render.
+   * */
+  hasIncompatibleShellContent?: boolean
+
   cacheSignal?: CacheSignal | null
   fallbackParams?: OpaqueFallbackRouteParams | null
   varyParamsAccumulator?: ResponseVaryParamsAccumulator | null

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -8,6 +8,7 @@ import type {
 } from './app-render/work-unit-async-storage.external'
 import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
 import { getServerReact, getClientReact } from './runtime-reacts.external'
+import { ReflectAdapter } from './web/spec-extension/adapters/reflect'
 
 export function isHangingPromiseRejectionError(
   err: unknown
@@ -291,6 +292,10 @@ function trackRuntimeDataAccessedImpl(
   }
 }
 
+export function trackIncompatibleShellContent(workUnitStore: RequestStore) {
+  workUnitStore.hasIncompatibleShellContent = true
+}
+
 export function makeClientHookHangingPromise<T>(
   signal: AbortSignal,
   error: ClientHookDynamicError
@@ -369,6 +374,40 @@ export function makeDevtoolsIOAwarePromise<T>(
     setTimeout(() => {
       resolve(underlying)
     }, 0)
+  })
+}
+
+/** Invokes `onUse` whenever `then()/catch()/finally()` are called on the promise. */
+export function trackPromiseUsed<T>(promise: Promise<T>, onUse: () => void) {
+  const methodCache: Record<string, (...args: any[]) => any> = {}
+  return new Proxy(promise, {
+    get(target, prop, receiver) {
+      if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+        let patchedMethod = methodCache[prop]
+        if (patchedMethod !== undefined) {
+          return patchedMethod
+        }
+
+        const originalMethod = ReflectAdapter.get(target, prop, receiver)
+        patchedMethod = {
+          [prop]: (...args: unknown[]) => {
+            try {
+              onUse()
+            } catch (err) {
+              // We don't want to break the method even if our tracking errored.
+              console.error(err)
+            }
+
+            return originalMethod.apply(target, args)
+          },
+        }[prop]
+
+        methodCache[prop] = patchedMethod
+        return patchedMethod
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
   })
 }
 

--- a/packages/next/src/server/lib/params-utils.ts
+++ b/packages/next/src/server/lib/params-utils.ts
@@ -1,32 +1,6 @@
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 import type { Params } from '../request/params'
 
-export function hasNonRootStaticParams(
-  params: Params,
-  rootParams: Params,
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined
-) {
-  for (const paramName in params) {
-    if (
-      !Object.hasOwn(rootParams, paramName) &&
-      isStaticParam(paramName, fallbackParams)
-    ) {
-      return true
-    }
-  }
-  return false
-}
-
-function isStaticParam(
-  paramName: string,
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined
-) {
-  // NOTE: Assume that undefined fallback params mean that all of the params are static.
-  if (!fallbackParams) return true
-  // If the param isn't a fallback param, it must be static.
-  return !fallbackParams.has(paramName)
-}
-
 export function allParamsAreRootParams(
   underlyingParams: Params,
   rootParams: Params

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -37,6 +37,8 @@ import {
   makePromiseFromTrigger,
   trackFallbackParamsAccessed,
   RENDER_STAGES_BY_DATA_KIND,
+  trackPromiseUsed,
+  trackIncompatibleShellContent,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
@@ -597,15 +599,25 @@ function createStagedRenderParamsImpl(
     // so static params can resolve in the static stage, because session
     // shells are handled with a separate render.
     // However, in dev we might need to recover a session shell for instant validation.
-    // This is indicated by `needsSessionShell`.
-    const staticParamsStage = workUnitStore.needsSessionShell
+    // This is indicated by `needsAppShell`.
+    const staticParamsStage = workUnitStore.needsAppShell
       ? RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
       : RENDER_STAGES_BY_DATA_KIND.staticLinkData
-    return stagedRendering.delayUntilStage(
+
+    const promise = stagedRendering.delayUntilStage(
       staticParamsStage,
       'params',
       userspaceParams
     )
+    if (process.env.__NEXT_DEV_SERVER) {
+      // If static params are accessed, we can recover a static shell or a session shell, but not both.
+      return trackPromiseUsed(
+        promise,
+        trackIncompatibleShellContent.bind(null, workUnitStore)
+      )
+    } else {
+      return promise
+    }
   }
 
   return makeUntrackedParams(userspaceParams)

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2644,13 +2644,13 @@ export async function cache(
                 // resolves in the dynamic stage. Otherwise, a dynamic request
                 // generally recovers a static shell, so the entry can resolve
                 // in the static link data stage. If we need to recover a
-                // session shell instead, as indicated by `needsSessionShell`,
+                // session shell instead, as indicated by `needsAppShell`,
                 // the entry must resolve after the session data stage that
                 // the shell includes.
                 let stage: AdvanceableRenderStage
                 if (!isPrefetchable) {
                   stage = RenderStage.Dynamic
-                } else if (workUnitStore.needsSessionShell) {
+                } else if (workUnitStore.needsAppShell) {
                   stage = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
                 } else {
                   stage = RENDER_STAGES_BY_DATA_KIND.staticLinkData
@@ -3257,13 +3257,13 @@ export async function cache(
                 // resolves in the dynamic stage. Otherwise, a dynamic request
                 // generally recovers a static shell, so the entry can resolve
                 // in the static link data stage. If we need to recover a
-                // session shell instead, as indicated by `needsSessionShell`,
+                // session shell instead, as indicated by `needsAppShell`,
                 // the entry must resolve after the session data stage that
                 // the shell includes.
                 let stage: AdvanceableRenderStage
                 if (entry.stale < MIN_PREFETCHABLE_STALE) {
                   stage = RenderStage.Dynamic
-                } else if (workUnitStore.needsSessionShell) {
+                } else if (workUnitStore.needsAppShell) {
                   stage = RENDER_STAGES_BY_DATA_KIND.runtimeLinkData
                 } else {
                   stage = RENDER_STAGES_BY_DATA_KIND.staticLinkData

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -705,6 +705,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/server/route-modules/app-page/vendored/contexts/router-context.js",
            "/node_modules/next/dist/server/route-modules/app-page/vendored/contexts/server-inserted-html.js",
            "/node_modules/next/dist/server/runtime-reacts.external.js",
+           "/node_modules/next/dist/server/web/spec-extension/adapters/reflect.js",
            "/node_modules/next/dist/shared/lib/deep-freeze.js",
            "/node_modules/next/dist/shared/lib/instant-messages.js",
            "/node_modules/next/dist/shared/lib/invariant-error.js",


### PR DESCRIPTION
Certain APIs resolve in different stages depending on whether they're in a static prerender or a runtime prerender:
- static params
- navigation() and prefetch() (upcoming)

When a page uses one of these, we need separate renders for Static and Instant validation. 

Previously, static `params` was the only instance of this, and we could detect those for a route statically. However, we have no way of statically knowing if the upcoming `navigation()` or `prefetch()` are going to be called on a given route, so we need to switch to dynamically tracking API usage instead.

We do this via a mutable field `workUnitStore.hasIncompatibleShellContent`, which starts out as `false` and may get set to `true` if one of the APIs is used. Conceptually, the field works in tandem with `workUnitStore.needsAppShell`¹  -- `needsAppShell` controls when things resolve, and `hasIncompatibleShellContent` tracks whether the result would've been equivalent if `needsAppShell` was set to the opposite value (i.e. are the static and runtime shells equivalent)

This PR moves static `params` to use this new method. We instrument the resulting `params` promise and set `hasIncompatibleShellContent` when it's `then()`ed, which seems close enough to tracking use.

No new tests are added, because the existing tests that check if unguarded `generateStaticParams` trigger instant validation errors in `partialPrefetching` exercise this codepath already.

---
¹ `needsSessionShell` was renamed to `needsAppShell`, because "session shell" is not really a term we're using anywhere else right now, it's basically a leftover