### PR TITLE
Thread CSP nonce to the React render in Pages Router

### DIFF
--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1379,6 +1379,7 @@ export async function renderToHTMLImpl(
       return await renderToInitialFizzStream({
         ReactDOMServer: ReactDOMServerPages,
         element: content,
+        streamOptions: { nonce },
       })
     }
 

--- a/test/e2e/csp-nonce-pages-router-large-suspense-payload/index.test.ts
+++ b/test/e2e/csp-nonce-pages-router-large-suspense-payload/index.test.ts
@@ -1,0 +1,41 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('Pages Router streaming with CSP nonce', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // React's streaming renderer defers a Suspense boundary into a separate
+  // completion segment (with its own $RV/$RC helper scripts) once the
+  // boundary's rendered byte size crosses `progressiveChunkSize` (12_800
+  // bytes by default) — independent of whether anything in it is actually
+  // asynchronous. The fixture page renders comfortably past that threshold.
+  it('should apply the CSP nonce to inline scripts emitted for a large Suspense boundary', async () => {
+    const $ = await next.render$('/')
+
+    const streamingHelperScripts = $('script:not([src])').filter(
+      (_, el) => $(el).html()?.includes('$R') ?? false
+    )
+
+    expect(streamingHelperScripts.length).toBeGreaterThan(0)
+    streamingHelperScripts.each((_, el) => {
+      expect(el.attribs['nonce']).toBe('test-nonce')
+    })
+  })
+
+  it('should not raise CSP violations or hydration errors in the browser', async () => {
+    const browser = await next.browser('/')
+
+    expect(await browser.eval('document.body.innerText')).toContain(
+      'padding content'
+    )
+
+    if (global.browserName === 'chrome') {
+      const logs = await browser.log()
+      const cspViolations = logs.filter((log) =>
+        log.message.includes('Content Security Policy')
+      )
+      expect(cspViolations).toEqual([])
+    }
+  })
+})

--- a/test/e2e/csp-nonce-pages-router-large-suspense-payload/middleware.js
+++ b/test/e2e/csp-nonce-pages-router-large-suspense-payload/middleware.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+// A fixed nonce keeps the test deterministic. Real apps use a fresh
+// per-request nonce (e.g. via crypto.randomUUID()).
+const nonce = 'test-nonce'
+const csp = `script-src 'nonce-${nonce}'`
+
+export function middleware(request) {
+  // Pages Router's SSR renderer reads the nonce back out of the request's
+  // own Content-Security-Policy header, so it has to be set on the
+  // outgoing request (not just the response the browser sees).
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('Content-Security-Policy', csp)
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  response.headers.set('Content-Security-Policy', csp)
+  return response
+}

--- a/test/e2e/csp-nonce-pages-router-large-suspense-payload/pages/index.js
+++ b/test/e2e/csp-nonce-pages-router-large-suspense-payload/pages/index.js
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+
+function Big() {
+  const items = []
+  for (let i = 0; i < 500; i++) {
+    items.push(
+      'padding content to grow the payload past the stream chunk threshold '
+    )
+  }
+  return <div>{items.join('')}</div>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="suspense_fallback">
+      <Big />
+    </Suspense>
+  )
+}
+
+export function getServerSideProps() {
+  return { props: {} }
+}


### PR DESCRIPTION
Fixes #96443

## What?

In Next.js Pages Router the server side renderer doesn't forward Content Security Policy nonce to the React streaming call. This causes React's inline helper scripts to lose the nonce. Normally this is not a problem but on large Suspense boundaries the nonce gets discarded and these get blocked by the nonce CSPs.

## Why?

The React renderer splits the Suspense boundary based on progressiveChunkSize, 12 800 bytes by default. If you exceed that then you surface the problem. The App Router already threads the nonce correctly but Pages Router forgot to add it.

## How to fix it?

just pass the streamOptions { nonce } to the renderToInitialFizzStream in render.tsx. You can see that this mirrors the way App Router has been implemented in app-render.tsx. Respective e2e tests added.