### PR TITLE
[test] characterization for build-time seeding of `'use cache: remote'`

### DIFF
--- a/test/e2e/app-dir/use-cache-remote-build-seeding/app/cached-date.ts
+++ b/test/e2e/app-dir/use-cache-remote-build-seeding/app/cached-date.ts
@@ -1,0 +1,8 @@
+import { cacheLife } from 'next/cache'
+
+export async function getCachedDate() {
+  'use cache: remote'
+  cacheLife('max')
+
+  return new Date().toISOString()
+}

--- a/test/e2e/app-dir/use-cache-remote-build-seeding/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/use-cache-remote-build-seeding/app/dynamic/page.tsx
@@ -1,0 +1,17 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { getCachedDate } from '../cached-date'
+
+async function DynamicDate() {
+  await connection()
+
+  return <p id="cached-date">{await getCachedDate()}</p>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <DynamicDate />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-cache-remote-build-seeding/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-remote-build-seeding/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-remote-build-seeding/app/static/page.tsx
+++ b/test/e2e/app-dir/use-cache-remote-build-seeding/app/static/page.tsx
@@ -1,0 +1,5 @@
+import { getCachedDate } from '../cached-date'
+
+export default async function Page() {
+  return <p id="cached-date">{await getCachedDate()}</p>
+}

--- a/test/e2e/app-dir/use-cache-remote-build-seeding/next.config.js
+++ b/test/e2e/app-dir/use-cache-remote-build-seeding/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-remote-build-seeding/use-cache-remote-build-seeding.test.ts
+++ b/test/e2e/app-dir/use-cache-remote-build-seeding/use-cache-remote-build-seeding.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('use-cache-remote-build-seeding', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Characterizes current behavior, not intended behavior: a remote cache
+  // entry seeded during `next build` does not survive into runtime today.
+  // When build seeding for remote caches is implemented, the production
+  // expectation flips to `toBe`.
+  it('characterizes whether the build-time seeded remote cache entry reaches runtime', async () => {
+    // The static page is prerendered during `next build`, which fills the
+    // shared 'use cache: remote' entry. A browser visit (MPA, no client-side
+    // navigation) so that resumed segments are streamed in before reading.
+    const staticBrowser = await next.browser('/static')
+    const seededDate = await staticBrowser.elementByCss('#cached-date').text()
+    expect(seededDate).toBeTruthy()
+
+    // The dynamic page renders per request (behind `connection()`), so it can
+    // only show the same value if the seeded entry is visible at runtime.
+    const dynamicBrowser = await next.browser('/dynamic')
+    const dynamicDate = await dynamicBrowser.elementByCss('#cached-date').text()
+
+    if (isNextDev) {
+      // Dev has no build step; the first visit fills the dev server's shared
+      // in-memory handler and the dynamic page reuses it.
+      expect(dynamicDate).toBe(seededDate)
+    } else {
+      // The built-in remote handler is per-process, so the build's fill is
+      // gone when the server starts and the dynamic page regenerates.
+      expect(dynamicDate).not.toBe(seededDate)
+    }
+  })
+})


### PR DESCRIPTION

Adds an e2e characterization test for build-time seeding of `'use cache: remote'` entries. A fully static page seeds a shared cached function (current date, `cacheLife('max')`) during `next build`; a dynamic page reads the same function behind `connection()` in a Suspense boundary. The test documents current behavior: the seeded entry does not reach runtime today (the built-in remote handler is per-process), so the values differ in production and match in dev. The production expectation flips to `toBe` once build seeding for remote caches is implemented.
