### PR TITLE
fix: retry HTTP access fallbacks after router refresh

### DIFF
--- a/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
+++ b/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
@@ -25,6 +25,8 @@ interface HTTPAccessFallbackBoundaryProps {
   notFound?: React.ReactNode
   forbidden?: React.ReactNode
   unauthorized?: React.ReactNode
+  /** Changes when the boundary should retry rendering its children. */
+  resetKey?: unknown
   // TODO: Make this required once `React.createElement` understands that positional args go into children
   children?: React.ReactNode
   missingSlots?: Set<string>
@@ -39,6 +41,7 @@ interface HTTPAccessFallbackErrorBoundaryProps
 interface HTTPAccessBoundaryState {
   triggeredStatus: number | undefined
   previousPathname: string | null
+  previousResetKey: unknown
 }
 
 class HTTPAccessFallbackErrorBoundary extends React.Component<
@@ -50,6 +53,7 @@ class HTTPAccessFallbackErrorBoundary extends React.Component<
     this.state = {
       triggeredStatus: undefined,
       previousPathname: props.pathname,
+      previousResetKey: props.resetKey,
     }
   }
 
@@ -94,20 +98,28 @@ class HTTPAccessFallbackErrorBoundary extends React.Component<
     state: HTTPAccessBoundaryState
   ): HTTPAccessBoundaryState | null {
     /**
-     * Handles reset of the error boundary when a navigation happens.
-     * Ensures the error boundary does not stay enabled when navigating to a new page.
-     * Approach of setState in render is safe as it checks the previous pathname and then overrides
-     * it as outlined in https://react.dev/reference/react/useState#storing-information-from-previous-renders
+     * Handles reset of the error boundary when a navigation happens or when
+     * data for the current segment is replaced. The latter is needed for
+     * same-path refreshes, which preserve the pathname and React state.
+     * Approach of setState in render is safe as it checks the previous values
+     * and then overrides them as outlined in
+     * https://react.dev/reference/react/useState#storing-information-from-previous-renders
      */
-    if (props.pathname !== state.previousPathname && state.triggeredStatus) {
+    if (
+      (props.pathname !== state.previousPathname ||
+        props.resetKey !== state.previousResetKey) &&
+      state.triggeredStatus
+    ) {
       return {
         triggeredStatus: undefined,
         previousPathname: props.pathname,
+        previousResetKey: props.resetKey,
       }
     }
     return {
       triggeredStatus: state.triggeredStatus,
       previousPathname: props.pathname,
+      previousResetKey: props.resetKey,
     }
   }
 
@@ -155,6 +167,7 @@ export function HTTPAccessFallbackBoundary({
   notFound,
   forbidden,
   unauthorized,
+  resetKey,
   children,
 }: HTTPAccessFallbackBoundaryProps) {
   // When we're rendering the missing params shell, this will return null. This
@@ -169,6 +182,7 @@ export function HTTPAccessFallbackBoundary({
     return (
       <HTTPAccessFallbackErrorBoundary
         pathname={pathname}
+        resetKey={resetKey}
         notFound={notFound}
         forbidden={forbidden}
         unauthorized={unauthorized}

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -699,6 +699,9 @@ export default function OuterLayoutRouter({
               notFound={notFound}
               forbidden={forbidden}
               unauthorized={unauthorized}
+              // A refresh replaces the segment's RSC attempt while preserving
+              // its React state identity.
+              resetKey={cacheNode.rsc}
             >
               <RedirectBoundary>
                 <InnerLayoutRouter

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -381,7 +381,7 @@ describe(`Terminal Logging (${bundlerName})`, () => {
              <InnerScrollHandler scrollRef={{scrollRef:null, ...}} cacheNode={{rsc:{...}, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary name="hydration-..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined} ...>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
                          <InnerLayoutRouter url="/hydration..." tree={[...]} params={{}} cacheNode={{rsc:{...}, ...}} ...>

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/blog/not-found.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/blog/not-found.tsx
@@ -1,0 +1,12 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function NotFound() {
+  return (
+    <main id="blog-not-found">
+      <p>Blog category not found</p>
+      <LinkAccordion href="/blog" prefetch={false}>
+        Visit all posts
+      </LinkAccordion>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/blog/page.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/blog/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
+
+async function BlogContent({
+  searchParams,
+}: {
+  searchParams: Promise<{ category?: string }>
+}) {
+  const { category } = await searchParams
+
+  if (category === 'invalid') {
+    notFound()
+  }
+
+  return (
+    <main id="blog-content">
+      <p>All posts</p>
+    </main>
+  )
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ category?: string }>
+}) {
+  return (
+    <Suspense fallback={<p id="loading">Loading...</p>}>
+      <BlogContent searchParams={searchParams} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/components/access-toggle.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/components/access-toggle.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useTransition } from 'react'
+
+export function AccessToggle({ access }: { access: 'grant' | 'revoke' }) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const isGrant = access === 'grant'
+
+  return (
+    <button
+      id={isGrant ? 'grant-access' : 'revoke-access'}
+      disabled={isPending}
+      onClick={() => {
+        document.cookie = isGrant
+          ? 'refresh-access=granted; path=/; SameSite=Lax'
+          : 'refresh-access=; path=/; max-age=0; SameSite=Lax'
+        startTransition(() => router.refresh())
+      }}
+    >
+      {isGrant ? 'Grant access' : 'Revoke access'}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/components/fallback-state.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/components/fallback-state.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState, useTransition } from 'react'
+
+export function FallbackState() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [value, setValue] = useState('')
+  const [mountId, setMountId] = useState('')
+  const didSetMountId = useRef(false)
+
+  useEffect(() => {
+    if (!didSetMountId.current) {
+      didSetMountId.current = true
+      setMountId(crypto.randomUUID())
+    }
+  }, [])
+
+  return (
+    <>
+      <label>
+        Fallback state
+        <input
+          id="fallback-state"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+      </label>
+      <output id="fallback-mount-id">{mountId}</output>
+      <button
+        id="refresh-not-found"
+        disabled={isPending}
+        onClick={() => startTransition(() => router.refresh())}
+      >
+        Refresh while not found
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/components/layout-state.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/components/layout-state.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useState } from 'react'
+
+export function LayoutState() {
+  const [value, setValue] = useState('')
+
+  return (
+    <label>
+      Layout state
+      <input
+        id="layout-state"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+      />
+    </label>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/components/link-accordion.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/components/link-accordion.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/layout.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+import { LayoutState } from './components/layout-state'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <LayoutState />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/not-found.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/not-found.tsx
@@ -1,0 +1,12 @@
+import { AccessToggle } from './components/access-toggle'
+import { FallbackState } from './components/fallback-state'
+
+export default function NotFound() {
+  return (
+    <main id="access-not-found">
+      <p>Access not found</p>
+      <FallbackState />
+      <AccessToggle access="grant" />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/page.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/page.tsx
@@ -1,0 +1,15 @@
+import { LinkAccordion } from './components/link-accordion'
+
+export default function Page() {
+  return (
+    <main id="home">
+      <p>Home</p>
+      <LinkAccordion href="/protected" prefetch={false}>
+        Visit protected page
+      </LinkAccordion>
+      <LinkAccordion href="/blog?category=invalid" prefetch={false}>
+        Visit invalid blog category
+      </LinkAccordion>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/app/protected/page.tsx
+++ b/test/e2e/app-dir/http-access-fallback-refresh/app/protected/page.tsx
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers'
+import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
+import { AccessToggle } from '../components/access-toggle'
+
+async function ProtectedContent() {
+  const cookieStore = await cookies()
+
+  if (cookieStore.get('refresh-access')?.value !== 'granted') {
+    notFound()
+  }
+
+  return (
+    <main id="protected-content">
+      <p>Protected content</p>
+      <AccessToggle access="revoke" />
+    </main>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="loading">Loading...</p>}>
+      <ProtectedContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts
+++ b/test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts
@@ -1,0 +1,152 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('HTTP access fallback refresh', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('resets a not-found boundary when the same route is refreshed', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await browser.waitForElementByCss('#home')
+
+    await browser.elementById('layout-state').type('preserved')
+    await browser.eval(`window.__httpAccessFallbackDocument = 'preserved'`)
+
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/protected"]')
+        .click()
+      await browser.elementByCss('a[href="/protected"]').click()
+    })
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#access-not-found')).toBe(true)
+    })
+    const protectedUrl = await browser.url()
+
+    await browser.elementById('fallback-state').type('preserved')
+    async function readFallbackMountId() {
+      let mountId = ''
+      await retry(async () => {
+        mountId = await browser.elementById('fallback-mount-id').text()
+        expect(mountId).not.toBe('')
+      })
+      return mountId
+    }
+
+    const initialFallbackMountId = await readFallbackMountId()
+
+    async function expectDocumentStateToBePreserved() {
+      expect(await browser.url()).toBe(protectedUrl)
+      expect(await browser.elementById('layout-state').getValue()).toBe(
+        'preserved'
+      )
+      expect(await browser.eval(`window.__httpAccessFallbackDocument`)).toBe(
+        'preserved'
+      )
+    }
+
+    await expectDocumentStateToBePreserved()
+
+    await act(
+      async () => {
+        await browser.elementById('refresh-not-found').click()
+      },
+      { includes: 'Access not found' }
+    )
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#access-not-found')).toBe(true)
+    })
+    const retriedFallbackMountId = await readFallbackMountId()
+    // Retrying a boundary that still throws replaces its fallback subtree once.
+    // It must then settle without replacing the document/layout or continuing
+    // to remount the fallback.
+    expect(retriedFallbackMountId).not.toBe(initialFallbackMountId)
+    expect(await browser.elementById('fallback-state').getValue()).toBe('')
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `document.getElementById('refresh-not-found').disabled`
+        )
+      ).toBe(false)
+    })
+    for (let i = 0; i < 3; i++) {
+      await browser.eval(`new Promise(requestAnimationFrame)`)
+      expect(await browser.elementById('fallback-mount-id').text()).toBe(
+        retriedFallbackMountId
+      )
+    }
+    await expectDocumentStateToBePreserved()
+
+    await act(
+      async () => {
+        await browser.elementById('grant-access').click()
+      },
+      { includes: 'Protected content' }
+    )
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#protected-content')).toBe(true)
+    })
+    await expectDocumentStateToBePreserved()
+
+    await act(async () => {
+      await browser.elementById('revoke-access').click()
+    })
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#access-not-found')).toBe(true)
+    })
+    await expectDocumentStateToBePreserved()
+
+    await act(
+      async () => {
+        await browser.elementById('grant-access').click()
+      },
+      { includes: 'Protected content' }
+    )
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#protected-content')).toBe(true)
+    })
+    await expectDocumentStateToBePreserved()
+  })
+
+  it('resets a not-found boundary after a search parameter change', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await browser.waitForElementByCss('#home')
+
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/blog?category=invalid"]')
+        .click()
+      await browser.elementByCss('a[href="/blog?category=invalid"]').click()
+    })
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#blog-not-found')).toBe(true)
+    })
+
+    await act(
+      async () => {
+        await browser.elementByCss('input[data-link-accordion="/blog"]').click()
+        await browser.elementByCss('a[href="/blog"]').click()
+      },
+      { includes: 'All posts' }
+    )
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#blog-content')).toBe(true)
+    })
+    expect(new URL(await browser.url()).search).toBe('')
+  })
+})

--- a/test/e2e/app-dir/http-access-fallback-refresh/next.config.js
+++ b/test/e2e/app-dir/http-access-fallback-refresh/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
## What?

Retry an HTTP access fallback when a router refresh or same-path search-parameter navigation supplies a new RSC rendering attempt.

Fixes #77086.

This also covers the exact invalid-search-parameter reproduction from #93311.

## Why?

The HTTP access fallback boundary remembers a caught `notFound()`, `forbidden()`, or `unauthorized()` result. It previously reset only when the pathname changed. A same-path update could return valid replacement RSC data while the boundary continued rendering the old fallback.

## How?

Pass the segment RSC value to the fallback boundary as its reset identity. New segment data replaces that identity, while CacheNode cloning and deferred completion preserve it, so ordinary renders do not retry the boundary.

The regression fixture covers same-route `404 -> content -> 404 -> content` refreshes and the `/blog?category=invalid -> /blog` case from #93311. It also refreshes while the route remains not found. That retry remounts the fallback subtree once and clears state local to the fallback, then settles without replacing the document or root layout.

## Verification

- `pnpm test-dev-turbo test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts`
- `pnpm test-dev-webpack test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts`
- `HEADLESS=true __NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true NEXT_ENABLE_ADAPTER=1 IS_TURBOPACK_TEST=1 pnpm test-start-turbo test/e2e/app-dir/http-access-fallback-refresh/http-access-fallback-refresh.test.ts`
- `pnpm test-dev-turbo test/development/browser-logs/browser-logs.test.ts`
- `pnpm test-dev-webpack test/development/browser-logs/browser-logs.test.ts`
- `pnpm --filter=next types`
