### PR TITLE
[turbopack] Bail CJS tree-shaking on `var x = module.exports = {}`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -764,6 +764,21 @@ pub fn as_parent_path_with_in<'a>(
     path.into_boxed_slice()
 }
 
+/// Whether the node at `ast_path` is a whole statement, so its value goes nowhere:
+/// true for `module.exports = {};` and `(module.exports = {});`, false for
+/// `var x = module.exports = {}` or `f(module.exports = {})`.
+fn is_expression_statement(ast_path: &AstNodePath<AstParentNodeRef<'_>>) -> bool {
+    for node_ref in ast_path.iter().rev() {
+        match node_ref {
+            // The `Expr` wrapper of the node itself, and of a parenthesized one.
+            AstParentNodeRef::Expr(..) | AstParentNodeRef::ParenExpr(_, ParenExprField::Expr) => {}
+            AstParentNodeRef::ExprStmt(_, ExprStmtField::Expr) => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
 /// Returns the [`MemberExpr`] where the current node is the object:
 /// `<node>.<prop>` or `<node>[<expr>]`.
 fn member_access_parent<'r>(
@@ -1398,6 +1413,11 @@ impl<'a> Analyzer<'a, '_> {
             self.taint_cjs_exports();
             return;
         }
+        // Catches `var Self = Object.defineProperty(exports, …)`: the call returns exports.
+        if !is_expression_statement(ast_path) {
+            self.taint_cjs_exports();
+            return;
+        }
         let dead = self.cjs_exports_object_replaced()
             && !n.args.first().is_some_and(|target| {
                 is_module_exports_chain(&target.expr, self.eval_context.unresolved_mark)
@@ -1432,13 +1452,13 @@ impl<'a> Analyzer<'a, '_> {
         else {
             return;
         };
-        // Only a statement-position assignment definitely runs.
-        if matches!(
-            ast_path.len().checked_sub(2).and_then(|i| ast_path.get(i)),
-            Some(AstParentNodeRef::ExprStmt(_, ExprStmtField::Expr))
-        ) {
-            self.replace_cjs_exports_object();
+        // Catches `var Self = module.exports = { … }`: the alias reads exports back.
+        if !is_expression_statement(ast_path) {
+            self.taint_cjs_exports();
+            return;
         }
+        // A statement-position assignment definitely runs.
+        self.replace_cjs_exports_object();
         let mut names = Vec::new();
         for prop in &obj.props {
             // A spread makes the export set unknowable.

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/alias-exports-define.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/alias-exports-define.js
@@ -1,0 +1,9 @@
+var Self = Object.defineProperty(exports, 'helper', {
+  value: function () {
+    return 'abc'
+  },
+})
+
+exports.abc = function () {
+  return Self.helper()
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/alias-exports-object-chain.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/alias-exports-object-chain.js
@@ -1,0 +1,10 @@
+var Self
+
+Self = module.exports = {
+  helper: function () {
+    return 'abc'
+  },
+  abc: function () {
+    return Self.helper()
+  },
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/alias-exports-object.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/alias-exports-object.js
@@ -1,0 +1,8 @@
+var Self = (module.exports = {
+  helper: function () {
+    return 'abc'
+  },
+  abc: function () {
+    return Self.helper()
+  },
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/webpack/cjs-tree-shaking/bailouts/input/index.js
@@ -54,3 +54,15 @@ it('should be able to use AMD to define exports', () => {
   expect(require('./using-amd').abc).toBe('abc')
   expect(require('./using-amd').def).toBe('def')
 })
+
+it('should bailout when a variable aliases a replaced exports object', () => {
+  expect(require('./alias-exports-object').abc()).toBe('abc')
+})
+
+it('should bailout when an assignment chain aliases a replaced exports object', () => {
+  expect(require('./alias-exports-object-chain').abc()).toBe('abc')
+})
+
+it('should bailout when a variable aliases the result of defineProperty', () => {
+  expect(require('./alias-exports-define').abc()).toBe('abc')
+})


### PR DESCRIPTION
This code was causing issues for the CJS tree-shaker:


```javascript
```js
"use strict";
var utils = require('./utils');

var LinkedList = module.exports = {          // ← line 4: local alias for module.exports
    // basic validity tests on a circular linked list a
    valid: function(a) {
        utils.assert(a, "list falsy");
        utils.assert(a._previousSibling, "previous falsy");
        utils.assert(a._nextSibling, "next falsy");
        return true;
    },
    // insert a before b
    insertBefore: function(a, b) {
        utils.assert(LinkedList.valid(a) && LinkedList.valid(b));   // ← line 15: THROWS
        var a_first = a, a_last = a._previousSibling;
        var b_first = b, b_last = b._previousSibling;
        a_first._previousSibling = b_last;
        a_last._nextSibling = b_first;
        b_last._nextSibling = a_first;
        b_first._previousSibling = a_last;
        utils.assert(LinkedList.valid(a) && LinkedList.valid(b));   // line 22
    },
    // replace a single node a with a list b (which could be null)
    replace: function(a, b) {
        utils.assert(LinkedList.valid(a) && (b===null || LinkedList.valid(b)));  // line 26
        if (b!==null) {
            LinkedList.insertBefore(b, a);
        }
        LinkedList.remove(a);
        utils.assert(LinkedList.valid(a) && (b===null || LinkedList.valid(b)));  // line 31
    },
    // remove single node a from its list
    remove: function(a) {
        utils.assert(LinkedList.valid(a));                          // line 35
        var prev = a._previousSibling;
        if (prev === a) { return; }
        var next = a._nextSibling;
        prev._nextSibling = next;
        next._previousSibling = prev;
        a._previousSibling = a._nextSibling = a;
        utils.assert(LinkedList.valid(a));                          // line 42
    }
};
```

Because we were shaking `valid` as it was only used via the `LinkedList` alias. Now we bail if you set up an alias like that.