### PR TITLE
docs(mdx): fix package name in .md handling section

### DIFF
--- a/docs/01-app/02-guides/mdx.mdx
+++ b/docs/01-app/02-guides/mdx.mdx
@@ -74,7 +74,7 @@ This allows `.mdx` files to act as pages, routes, or imports in your application
 
 ### Handling `.md` files
 
-By default, `next/mdx` only compiles files with the `.mdx` extension. To handle `.md` files with webpack, update the `extension` option:
+By default, `@next/mdx` only compiles files with the `.mdx` extension. To handle `.md` files with webpack, update the `extension` option:
 
 ```js filename="next.config.mjs"
 const withMDX = createMDX({


### PR DESCRIPTION
The MDX guide’s “Handling `.md` files” section referenced `next/mdx`, but the package used throughout the guide is `@next/mdx`.
This updates the text to match the correct package name to avoid confusion for readers configuring `.md` support.

Attribution: This change was originally authored by @pavan-sh in #89710.
