### PR TITLE
examples: fix Webiny API env variable name

### DIFF
--- a/examples/cms-webiny/lib/api.ts
+++ b/examples/cms-webiny/lib/api.ts
@@ -5,7 +5,7 @@ async function fetchAPI(
 ) {
   const url = preview
     ? `${process.env.NEXT_PUBLIC_WEBINY_PREVIEW_API_URL}`
-    : `${process.env.NEXT_PUBLIC_WEBINY_API_UR}`;
+    : `${process.env.NEXT_PUBLIC_WEBINY_API_URL}`;
 
   const res = await fetch(url, {
     method: "POST",


### PR DESCRIPTION
## Summary

Fix the `cms-webiny` example so non-preview requests read `NEXT_PUBLIC_WEBINY_API_URL`, matching the README, deploy button, and `.env.local.example`. The previous `NEXT_PUBLIC_WEBINY_API_UR` typo caused the default API endpoint to resolve to `undefined`.

## Verification

- `rg -n "NEXT_PUBLIC_WEBINY_API_UR|NEXT_PUBLIC_WEBINY_API_URL|NEXT_PUBLIC_WEBINY_PREVIEW_API_URL" examples/cms-webiny`
- `git diff --check`
- Not run: full example runtime (`cms-webiny` requires external Webiny API credentials)

Attribution: This change was originally authored by @tianma-if in #95413.

<!-- NEXT_JS_LLM_PR -->
