### PR TITLE
Fix spelling in two comments

### DIFF
--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -88,7 +88,7 @@ function isMatchableSlot(segment: string): boolean {
 const catchAllRouteRegex = /\[?\[\.\.\./
 
 function isCatchAllRoute(pathname: string): boolean {
-  // Optional catch-all slots are not currently supported, and as such they are not considered when checking for match compatability.
+  // Optional catch-all slots are not currently supported, and as such they are not considered when checking for match compatibility.
   return !isOptionalCatchAll(pathname) && isCatchAll(pathname)
 }
 

--- a/test/lib/router-act.ts
+++ b/test/lib/router-act.ts
@@ -595,7 +595,7 @@ ${fulfilled.body}
               // If the response doesn't match any of the expectations, that's
               // fine. If it does match an expectation, but the only thing
               // it matches is an expectation that was already claimed, then
-              // that's an error — each occurence of an expectation must be
+              // that's an error — each occurrence of an expectation must be
               // given separately.
               let responseWasClaimed = false
               let firstAlreadyClaimedMatch: ExpectedResponseConfig | null = null


### PR DESCRIPTION
### What?

Fix two spelling mistakes in comments.

### Why?

Readability.

### How?

Updated comment text only.

Attribution: This change was originally authored by @adityagiri3600 in #90594.
