### PR TITLE
fix: typos in code comments

### DIFF
--- a/packages/next/src/server/stream-utils/encoded-tags.ts
+++ b/packages/next/src/server/stream-utils/encoded-tags.ts
@@ -21,7 +21,7 @@ export const ENCODED_TAGS = {
     ]),
   },
   META: {
-    // Only the match the prefix cause the suffix can be different wether it's xml compatible or not ">" or "/>"
+    // Only the match the prefix cause the suffix can be different whether it's xml compatible or not ">" or "/>"
     // <meta name="«nxt-icon»"
     // This is a special mark that will be replaced by the icon insertion script tag.
     ICON_MARK: new Uint8Array([

--- a/test/lib/router-act.ts
+++ b/test/lib/router-act.ts
@@ -595,7 +595,7 @@ ${fulfilled.body}
               // If the response doesn't match any of the expectations, that's
               // fine. If it does match an expectation, but the only thing
               // it matches is an expectation that was already claimed, then
-              // that's an error — each occurence of an expectation must be
+              // that's an error — each occurrence of an expectation must be
               // given separately.
               let responseWasClaimed = false
               let firstAlreadyClaimedMatch: ExpectedResponseConfig | null = null


### PR DESCRIPTION
## Summary

- Fix "occurence" → "occurrence" in `test/lib/router-act.ts`
- Fix "wether" → "whether" in `packages/next/src/server/stream-utils/encoded-tags.ts`

## Test plan

- [x] Changes are comment-only, no code logic affected

Attribution: This change was originally authored by @evandroreichert in #90785.
