### PR TITLE
Fixing a bug - typo issue fixed

### DIFF
--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -835,7 +835,7 @@ export class TurbopackManifestLoader {
     )
 
     // Client middleware manifest This is only used in dev though, packages/next/src/build/index.ts
-    // writes the mainfest again for builds.
+    // writes the manifest again for builds.
     const matchers = middlewareManifest?.middleware['/']?.matchers || []
 
     const clientMiddlewareManifestJs = `self.__MIDDLEWARE_MATCHERS = ${JSON.stringify(


### PR DESCRIPTION
Fix typo issue for comment
// writes the manifest again for builds.

Attribution: This change was originally authored by @keithjackson1031 in #89841.
