### PR TITLE
docs: align Cache Components authentication guide title

### DIFF
--- a/docs/01-app/02-guides/authentication-with-cache-components.mdx
+++ b/docs/01-app/02-guides/authentication-with-cache-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to use authentication with Cache Components
+title: How to implement authentication with Cache Components
 nav_title: Authentication with Cache Components
 description: 'Learn how to read the user session, show authenticated UI without slowing down the page, and cache data derived from the session when Cache Components is enabled.'
 related:


### PR DESCRIPTION
## Summary

Rename the guide to `How to implement authentication with Cache Components` so it follows the wording of the main authentication guide while keeping the Cache Components context.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write docs/01-app/02-guides/authentication-with-cache-components.mdx`
- Not run: full test suite (frontmatter-only documentation change)

<!-- NEXT_JS_LLM -->