### PR TITLE
Fix headers() stale snapshot after NextRequest mutation in Proxy

### DIFF
--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -30,29 +30,31 @@ import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 
+const HIDDEN_REQUEST_HEADERS: ReadonlySet<string> = new Set(
+  [
+    ...FLIGHT_HEADERS,
+    // The client sends these dev-only request IDs so the server can route debug
+    // information back to the originating request. Like the flight headers, they
+    // are internal plumbing and must not be exposed to userland `headers()`.
+    NEXT_REQUEST_ID_HEADER,
+    NEXT_HTML_REQUEST_ID_HEADER,
+  ].map((header) => header.toLowerCase())
+)
+
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
-  // `HeadersAdapter.from` wraps `IncomingHttpHeaders` (and returns a `Headers`
-  // instance unchanged) without copying, so the `delete` calls below would
-  // otherwise mutate the caller's underlying request headers. We copy first so
-  // that stripping internal headers only affects the sealed userland view, not
-  // the shared `req.headers`. The latter matters because the dev server reads
-  // the request-id headers from the raw request again (e.g. when rendering a
-  // redirect target after a server action), and mutating them there would break
-  // the dev debug channel routing.
-  const cleaned = HeadersAdapter.from(
-    headers instanceof Headers ? new Headers(headers) : { ...headers }
+  // Seal a live view over the shared request headers. Internal Next.js headers
+  // are hidden on read instead of being deleted from a copy:
+  //
+  // - Avoid mutating `IncomingHttpHeaders` / `NextRequest.headers` when
+  //   stripping internals (see #95116 — deleting request-id headers from the
+  //   shared object broke the dev debug channel after server-action redirects).
+  // - Keep Proxy/Middleware mutations to `NextRequest.headers` visible through
+  //   subsequent `headers()` reads (see #97049 — copying before seal made
+  //   `headers()` return a stale snapshot).
+  return HeadersAdapter.seal(
+    HeadersAdapter.from(headers),
+    HIDDEN_REQUEST_HEADERS
   )
-  for (const header of FLIGHT_HEADERS) {
-    cleaned.delete(header)
-  }
-
-  // The client sends these dev-only request IDs so the server can route debug
-  // information back to the originating request. Like the flight headers, they
-  // are internal plumbing and must not be exposed to userland `headers()`.
-  cleaned.delete(NEXT_REQUEST_ID_HEADER)
-  cleaned.delete(NEXT_HTML_REQUEST_ID_HEADER)
-
-  return HeadersAdapter.seal(cleaned)
 }
 
 function getMutableCookies(

--- a/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
@@ -318,5 +318,35 @@ describe('HeadersAdapter', () => {
       expect(headers.get('x-custom-header')).toBe('custom3')
       expect(sealed.get('x-custom-header')).toBe('custom3')
     })
+
+    it('should hide selected headers without copying or mutating the original', () => {
+      const headers = new Headers({
+        'content-type': 'application/json',
+        'x-nextjs-request-id': 'req-1',
+        rsc: '1',
+      })
+      const sealed = HeadersAdapter.seal(
+        headers,
+        new Set(['x-nextjs-request-id', 'rsc'])
+      )
+
+      expect(sealed.get('content-type')).toBe('application/json')
+      expect(sealed.get('x-nextjs-request-id')).toBeNull()
+      expect(sealed.get('rsc')).toBeNull()
+      expect(sealed.has('x-nextjs-request-id')).toBe(false)
+      expect(sealed.has('rsc')).toBe(false)
+      expect([...sealed.keys()]).toEqual(['content-type'])
+      expect([...sealed.entries()]).toEqual([
+        ['content-type', 'application/json'],
+      ])
+
+      // Underlying headers stay intact for framework plumbing.
+      expect(headers.get('x-nextjs-request-id')).toBe('req-1')
+      expect(headers.get('rsc')).toBe('1')
+
+      // Later mutations on the shared Headers remain visible through the seal.
+      headers.set('x-added-after-seal', 'live')
+      expect(sealed.get('x-added-after-seal')).toBe('live')
+    })
   })
 })

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -117,8 +117,22 @@ export class HeadersAdapter extends Headers {
   /**
    * Seals a Headers instance to prevent modification by throwing an error when
    * any mutating method is called.
+   *
+   * When `hidden` is provided, those header names are omitted from read
+   * operations (`get`/`has`/iteration) without copying or mutating the
+   * underlying headers. That keeps the sealed view live (mutations to the
+   * shared request headers remain visible) while still hiding internal
+   * Next.js headers from userland `headers()`.
    */
-  public static seal(headers: Headers): ReadonlyHeaders {
+  public static seal(
+    headers: Headers,
+    hidden?: ReadonlySet<string>
+  ): ReadonlyHeaders {
+    const isHidden =
+      hidden && hidden.size > 0
+        ? (name: string) => hidden.has(name.toLowerCase())
+        : null
+
     return new Proxy<ReadonlyHeaders>(headers, {
       get(target, prop, receiver) {
         switch (prop) {
@@ -126,6 +140,68 @@ export class HeadersAdapter extends Headers {
           case 'delete':
           case 'set':
             return ReadonlyHeadersError.callable
+          case 'get':
+            if (!isHidden) {
+              return ReflectAdapter.get(target, prop, receiver)
+            }
+            return (name: string) => (isHidden(name) ? null : target.get(name))
+          case 'has':
+            if (!isHidden) {
+              return ReflectAdapter.get(target, prop, receiver)
+            }
+            return (name: string) => (isHidden(name) ? false : target.has(name))
+          case 'entries':
+          case Symbol.iterator:
+            if (!isHidden) {
+              return ReflectAdapter.get(target, prop, receiver)
+            }
+            return function* (): HeadersIterator<[string, string]> {
+              for (const entry of target.entries()) {
+                if (!isHidden(entry[0])) {
+                  yield entry
+                }
+              }
+            }
+          case 'keys':
+            if (!isHidden) {
+              return ReflectAdapter.get(target, prop, receiver)
+            }
+            return function* (): HeadersIterator<string> {
+              for (const name of target.keys()) {
+                if (!isHidden(name)) {
+                  yield name
+                }
+              }
+            }
+          case 'values':
+            if (!isHidden) {
+              return ReflectAdapter.get(target, prop, receiver)
+            }
+            return function* (): HeadersIterator<string> {
+              for (const [name, value] of target.entries()) {
+                if (!isHidden(name)) {
+                  yield value
+                }
+              }
+            }
+          case 'forEach':
+            if (!isHidden) {
+              return ReflectAdapter.get(target, prop, receiver)
+            }
+            return (
+              callbackfn: (
+                value: string,
+                name: string,
+                parent: Headers
+              ) => void,
+              thisArg?: any
+            ) => {
+              for (const [name, value] of target.entries()) {
+                if (!isHidden(name)) {
+                  callbackfn.call(thisArg, value, name, receiver)
+                }
+              }
+            }
           default:
             return ReflectAdapter.get(target, prop, receiver)
         }

--- a/test/e2e/app-dir/proxy-headers-snapshot/app/layout.tsx
+++ b/test/e2e/app-dir/proxy-headers-snapshot/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/proxy-headers-snapshot/app/page.tsx
+++ b/test/e2e/app-dir/proxy-headers-snapshot/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/proxy-headers-snapshot/next.config.js
+++ b/test/e2e/app-dir/proxy-headers-snapshot/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/proxy-headers-snapshot/proxy-headers-snapshot.test.ts
+++ b/test/e2e/app-dir/proxy-headers-snapshot/proxy-headers-snapshot.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('proxy-headers-snapshot', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('headers() observes NextRequest.headers mutations during Proxy', async () => {
+    const res = await next.fetch('/')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body).toEqual({
+      valueBeforeMutation: null,
+      valueOnNextRequest: 'set-on-next-request',
+      valueFromFirstViewAfterMutation: 'set-on-next-request',
+      valueFromSecondViewAfterMutation: 'set-on-next-request',
+      sameHeadersObject: true,
+    })
+  })
+})

--- a/test/e2e/app-dir/proxy-headers-snapshot/proxy.ts
+++ b/test/e2e/app-dir/proxy-headers-snapshot/proxy.ts
@@ -1,0 +1,22 @@
+import { headers } from 'next/headers'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+const HEADER_NAME = 'x-added-after-headers-call'
+
+export async function proxy(request: NextRequest) {
+  const firstHeadersView = await headers()
+  const valueBeforeMutation = firstHeadersView.get(HEADER_NAME)
+
+  request.headers.set(HEADER_NAME, 'set-on-next-request')
+
+  const secondHeadersView = await headers()
+
+  return NextResponse.json({
+    valueBeforeMutation,
+    valueOnNextRequest: request.headers.get(HEADER_NAME),
+    valueFromFirstViewAfterMutation: firstHeadersView.get(HEADER_NAME),
+    valueFromSecondViewAfterMutation: secondHeadersView.get(HEADER_NAME),
+    sameHeadersObject: firstHeadersView === secondHeadersView,
+  })
+}


### PR DESCRIPTION
## Summary

Fixes `headers()` returning a stale snapshot in Proxy after `NextRequest.headers` is mutated.

## Problem

In Proxy, `headers()` and `NextRequest.headers` no longer stayed in sync.

A common pattern is:

1. Read headers with `headers()`
2. Mutate the incoming request with `request.headers.set(...)`
3. Read headers again with `headers()`

Starting in Next.js 16.3.0, step 2 succeeded on `NextRequest`, but both the original and a new `headers()` call still returned the pre-mutation value. In 16.2.4, both `headers()` views reflected the update.

So two APIs that should describe the same request could disagree during a single Proxy run.

## Solution

[#95116](https://github.com/vercel/next.js/pull/95116) copied request headers before stripping internal ones and sealing the userland view. That protected shared `req.headers` (including dev request-id headers), but made `headers()` a frozen snapshot.

This change keeps `headers()` as a live read-only view over the shared request headers, and hides internal headers on read (`get` / `has` / iteration) instead of copying and deleting them.

That restores Proxy consistency with `NextRequest.headers` while preserving the #95116 behavior: request-id headers stay on the real request for framework plumbing and stay hidden from userland `headers()`.

## Test plan

- [x] New e2e: `test/e2e/app-dir/proxy-headers-snapshot`
- [x] Existing `server-action-headers-redirect` (#95116) still passes
- [x] Extended `HeadersAdapter.seal` unit tests for hidden, live header views

Fixes #97049

<!-- NEXT_JS_LLM -->