### PR TITLE
Improve error hint when functions cross a "use cache" boundary

### DIFF
--- a/errors/use-cache-function.mdx
+++ b/errors/use-cache-function.mdx
@@ -4,22 +4,22 @@ title: Functions cannot be passed into or returned from `"use cache"`
 
 ## Why This Error Occurred
 
-A function (including a React component) was passed into or returned from a `"use cache"` function.
+A function (including a React component reference) was passed into or returned from a `"use cache"` function in a way that requires serialization.
 
-`"use cache"` is a serialization boundary. Cached arguments and return values must be serializable so they can be stored and reused later. Plain functions are not serializable, so React rejects them.
+Per the [`use cache`](/docs/app/api-reference/directives/use-cache) docs, arguments and return values must be serializable. **Functions are unsupported**, except as [pass-through](/docs/app/api-reference/directives/use-cache#pass-through-non-serializable-arguments) props that you do not call or inspect. **JSX elements are valid return values** — returning `<Component />` is fine; returning `Component` itself is not.
 
-The overlay may still mention Client Components — that is React's generic serialization message. In this case the failure is the `"use cache"` boundary, not a Client Component prop.
+Return values use React Client Components serialization, which is why the overlay may mention Client Components even though the real issue is the `"use cache"` boundary.
 
 React may also show a short value preview under the message, such as `[function fn]` or `{}`. That preview is not part of the Next.js hint; it is React describing the non-serializable value.
 
 Common cases:
 
 - Returning an MDX or Server Component function from a cached helper, then rendering it as `<Content />`
-- Closing over a local function and calling it inside `"use cache"`
+- Closing over a local function and calling it inside `"use cache"` (captured closed-over values become part of the cache key / bound args)
 
 ## Possible Ways to Fix It
 
-### Return JSX or data instead of a component function
+### Return JSX or serializable data instead of a component function
 
 Before:
 
@@ -59,9 +59,12 @@ export default async function Page({ params }) {
 
 ### Avoid closing over non-serializable functions
 
-Move helper logic into the cached function, or pass serializable data instead of a function reference. If you need a callable that crosses the boundary, use a Server Action (`"use server"`).
+Move helper logic into the cached function, or pass serializable data instead of a function reference.
+
+If you only need to pass a Server Action through a cached component without calling it inside the cache scope, that [pass-through](/docs/app/api-reference/directives/use-cache#pass-through-non-serializable-arguments) pattern is supported — mark the action with `"use server"` and do not invoke it inside `"use cache"`.
 
 ## Useful Links
 
-- [`use cache` directive](/docs/app/api-reference/directives/use-cache)
+- [`use cache` directive — Serialization](/docs/app/api-reference/directives/use-cache#serialization)
+- [`use cache` directive — Pass-through](/docs/app/api-reference/directives/use-cache#pass-through-non-serializable-arguments)
 - [Caching in Next.js](/docs/app/getting-started/caching)

--- a/errors/use-cache-function.mdx
+++ b/errors/use-cache-function.mdx
@@ -6,7 +6,11 @@ title: Functions cannot be passed into or returned from `"use cache"`
 
 A function (including a React component) was passed into or returned from a `"use cache"` function.
 
-`"use cache"` is a serialization boundary. Cached arguments and return values must be serializable so they can be stored and reused later. Plain functions are not serializable, so React rejects them. The underlying error often mentions Client Components, which is confusing in this context — the failure is the cache boundary, not a Client Component prop.
+`"use cache"` is a serialization boundary. Cached arguments and return values must be serializable so they can be stored and reused later. Plain functions are not serializable, so React rejects them.
+
+The overlay may still mention Client Components — that is React's generic serialization message. In this case the failure is the `"use cache"` boundary, not a Client Component prop.
+
+React may also show a short value preview under the message, such as `[function fn]` or `{}`. That preview is not part of the Next.js hint; it is React describing the non-serializable value.
 
 Common cases:
 

--- a/errors/use-cache-function.mdx
+++ b/errors/use-cache-function.mdx
@@ -1,0 +1,63 @@
+---
+title: Functions cannot be passed into or returned from `"use cache"`
+---
+
+## Why This Error Occurred
+
+A function (including a React component) was passed into or returned from a `"use cache"` function.
+
+`"use cache"` is a serialization boundary. Cached arguments and return values must be serializable so they can be stored and reused later. Plain functions are not serializable, so React rejects them. The underlying error often mentions Client Components, which is confusing in this context — the failure is the cache boundary, not a Client Component prop.
+
+Common cases:
+
+- Returning an MDX or Server Component function from a cached helper, then rendering it as `<Content />`
+- Closing over a local function and calling it inside `"use cache"`
+
+## Possible Ways to Fix It
+
+### Return JSX or data instead of a component function
+
+Before:
+
+```jsx filename="app/lib/post.js"
+export async function getPostContent(slug) {
+  'use cache'
+  const { default: Post } = await import(`../content/${slug}.mdx`)
+  return Post // ❌ function — not serializable
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js"
+export default async function Page({ params }) {
+  const { slug } = await params
+  const Content = await getPostContent(slug)
+  return <Content />
+}
+```
+
+After:
+
+```jsx filename="app/lib/post.js"
+export async function getPostContent(slug) {
+  'use cache'
+  const { default: Post } = await import(`../content/${slug}.mdx`)
+  return <Post /> // ✅ cache the rendered output
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js"
+export default async function Page({ params }) {
+  const { slug } = await params
+  const content = await getPostContent(slug)
+  return <>{content}</>
+}
+```
+
+### Avoid closing over non-serializable functions
+
+Move helper logic into the cached function, or pass serializable data instead of a function reference. If you need a callable that crosses the boundary, use a Server Action (`"use server"`).
+
+## Useful Links
+
+- [`use cache` directive](/docs/app/api-reference/directives/use-cache)
+- [Caching in Next.js](/docs/app/getting-started/caching)

--- a/packages/next/src/lib/format-server-error.test.ts
+++ b/packages/next/src/lib/format-server-error.test.ts
@@ -11,7 +11,7 @@ describe('formatServerError', () => {
 
     expect(err.message).toContain('"use cache"')
     expect(err.message).toContain(
-      'https://nextjs.org/docs/messages/use-cache-function'
+      'https://nextjs.org/docs/app/api-reference/directives/use-cache'
     )
     expect(err.message).toContain('[function fn]')
     expect(err.stack?.match(/\[function fn\]/g)).toHaveLength(1)

--- a/packages/next/src/lib/format-server-error.test.ts
+++ b/packages/next/src/lib/format-server-error.test.ts
@@ -1,6 +1,24 @@
 import { formatServerError } from './format-server-error'
 
 describe('formatServerError', () => {
+  it('should hint about use cache when a function fails to serialize', () => {
+    const err = new Error(
+      'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.\n  [function fn]\n   ^^^^^^^^^^^'
+    )
+
+    formatServerError(err)
+
+    expect(err.message).toContain('"use cache"')
+    expect(err.message).toContain(
+      'https://nextjs.org/docs/messages/use-cache-function'
+    )
+    expect(err.message).toContain('[function fn]')
+
+    const once = err.message
+    formatServerError(err)
+    expect(err.message).toBe(once)
+  })
+
   it('should not append message several times', () => {
     const err = new Error(
       'Class extends value undefined is not a constructor or null'

--- a/packages/next/src/lib/format-server-error.test.ts
+++ b/packages/next/src/lib/format-server-error.test.ts
@@ -5,6 +5,7 @@ describe('formatServerError', () => {
     const err = new Error(
       'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.\n  [function fn]\n   ^^^^^^^^^^^'
     )
+    err.stack = `${err.name}: ${err.message}\n    at createCachedFn (app/page.tsx:8:3)`
 
     formatServerError(err)
 
@@ -13,6 +14,9 @@ describe('formatServerError', () => {
       'https://nextjs.org/docs/messages/use-cache-function'
     )
     expect(err.message).toContain('[function fn]')
+    expect(err.stack?.match(/\[function fn\]/g)).toHaveLength(1)
+    expect(err.stack?.match(/^\s+\^\^\^/gm)).toHaveLength(1)
+    expect(err.stack).toContain('at createCachedFn (app/page.tsx:8:3)')
 
     const once = err.message
     formatServerError(err)

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -39,8 +39,29 @@ export function getStackWithoutErrorMessage(error: Error): string {
   return stack.replace(/^[^\n]*\n/, '')
 }
 
+const REACT_FUNCTION_SERIALIZATION_ERROR =
+  'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
+
+const USE_CACHE_FUNCTION_SERIALIZATION_HINT =
+  'If this error occurred inside `"use cache"`, that directive is a serialization boundary — functions (including React components) cannot be passed in or returned. Return JSX (for example `<Component />`) or serializable data instead. Read more: https://nextjs.org/docs/messages/use-cache-function'
+
 export function formatServerError(error: Error): void {
   if (typeof error?.message !== 'string') return
+
+  if (
+    error.message.includes(REACT_FUNCTION_SERIALIZATION_ERROR) &&
+    !error.message.includes(
+      'https://nextjs.org/docs/messages/use-cache-function'
+    )
+  ) {
+    setMessage(
+      error,
+      `${error.message}
+
+${USE_CACHE_FUNCTION_SERIALIZATION_HINT}`
+    )
+    return
+  }
 
   if (
     error.message.includes(

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -14,12 +14,35 @@ const invalidServerComponentReactHooks = [
   'useOptimistic',
 ]
 
-function setMessage(error: Error, message: string): void {
+/**
+ * Updates `error.message` and keeps `error.stack` in sync.
+ *
+ * React function-serialization errors put the `[function …]` / `^^^`
+ * annotation in the message (and therefore in the stack prefix). Replacing only
+ * the first stack line would leave those annotation lines in place and
+ * duplicate them when the new message already includes them.
+ */
+export function setErrorMessage(error: Error, message: string): void {
+  const previousMessage = error.message
   error.message = message
-  if (error.stack) {
-    const lines = error.stack.split('\n')
-    lines[0] = message
-    error.stack = lines.join('\n')
+
+  if (!error.stack) return
+
+  const previousPrefix = `${error.name}: ${previousMessage}`
+  const nextPrefix = `${error.name}: ${message}`
+
+  if (error.stack.startsWith(previousPrefix)) {
+    error.stack = nextPrefix + error.stack.slice(previousPrefix.length)
+    return
+  }
+
+  // Fallback when the engine omitted the usual `Name: message` prefix: keep
+  // only call-site frames.
+  const frameIndex = error.stack.search(/\n\s+at /)
+  if (frameIndex === -1) {
+    error.stack = nextPrefix
+  } else {
+    error.stack = nextPrefix + error.stack.slice(frameIndex)
   }
 }
 
@@ -36,6 +59,14 @@ function setMessage(error: Error, message: string): void {
 export function getStackWithoutErrorMessage(error: Error): string {
   const stack = error.stack
   if (!stack) return ''
+
+  // Prefer stripping a multi-line message prefix when present (e.g. React's
+  // function-serialization annotation), then fall back to the first line.
+  const messagePrefix = `${error.name}: ${error.message}`
+  if (stack.startsWith(messagePrefix)) {
+    return stack.slice(messagePrefix.length).replace(/^\n/, '')
+  }
+
   return stack.replace(/^[^\n]*\n/, '')
 }
 
@@ -54,7 +85,7 @@ export function formatServerError(error: Error): void {
       'https://nextjs.org/docs/messages/use-cache-function'
     )
   ) {
-    setMessage(
+    setErrorMessage(
       error,
       `${error.message}
 
@@ -74,7 +105,7 @@ ${USE_CACHE_FUNCTION_SERIALIZATION_HINT}`
     // If this error instance already has the message, don't add it again
     if (error.message.includes(addedMessage)) return
 
-    setMessage(
+    setErrorMessage(
       error,
       `${error.message}
 
@@ -84,7 +115,7 @@ ${addedMessage}`
   }
 
   if (error.message.includes('createContext is not a function')) {
-    setMessage(
+    setErrorMessage(
       error,
       'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
     )
@@ -94,7 +125,7 @@ ${addedMessage}`
   for (const clientHook of invalidServerComponentReactHooks) {
     const regex = new RegExp(`\\b${clientHook}\\b.*is not a function`)
     if (regex.test(error.message)) {
-      setMessage(
+      setErrorMessage(
         error,
         `${clientHook} only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component`
       )

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -73,17 +73,17 @@ export function getStackWithoutErrorMessage(error: Error): string {
 const REACT_FUNCTION_SERIALIZATION_ERROR =
   'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
 
-const USE_CACHE_FUNCTION_SERIALIZATION_HINT =
-  'If this error occurred inside `"use cache"`, that directive is a serialization boundary — functions (including React components) cannot be passed in or returned. Return JSX (for example `<Component />`) or serializable data instead. Read more: https://nextjs.org/docs/messages/use-cache-function'
+const USE_CACHE_FUNCTION_DOCS_URL =
+  'https://nextjs.org/docs/app/api-reference/directives/use-cache'
+
+const USE_CACHE_FUNCTION_SERIALIZATION_HINT = `If this is from \`"use cache"\`, return JSX or data instead of a function. See ${USE_CACHE_FUNCTION_DOCS_URL}`
 
 export function formatServerError(error: Error): void {
   if (typeof error?.message !== 'string') return
 
   if (
     error.message.includes(REACT_FUNCTION_SERIALIZATION_ERROR) &&
-    !error.message.includes(
-      'https://nextjs.org/docs/messages/use-cache-function'
-    )
+    !error.message.includes(USE_CACHE_FUNCTION_DOCS_URL)
   ) {
     setErrorMessage(
       error,

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -76,7 +76,7 @@ const REACT_FUNCTION_SERIALIZATION_ERROR =
 const USE_CACHE_FUNCTION_DOCS_URL =
   'https://nextjs.org/docs/app/api-reference/directives/use-cache'
 
-const USE_CACHE_FUNCTION_SERIALIZATION_HINT = `If this is from \`"use cache"\`, return JSX or data instead of a function. See ${USE_CACHE_FUNCTION_DOCS_URL}`
+const USE_CACHE_FUNCTION_SERIALIZATION_HINT = `If this is from \`"use cache"\`, return JSX or serializable data — not a function (including a component reference). See ${USE_CACHE_FUNCTION_DOCS_URL}`
 
 export function formatServerError(error: Error): void {
   if (typeof error?.message !== 'string') return

--- a/packages/next/src/next-devtools/userspace/app/errors/use-error-handler.ts
+++ b/packages/next/src/next-devtools/userspace/app/errors/use-error-handler.ts
@@ -4,6 +4,7 @@ import {
   formatConsoleArgs,
   parseConsoleArgs,
 } from '../../../../client/lib/console'
+import { formatServerError } from '../../../../lib/format-server-error'
 import isError from '../../../../lib/is-error'
 import { createConsoleError } from '../../../shared/console-error'
 import { coerceError, setOwnerStackIfAvailable } from './stitched-error'
@@ -33,6 +34,9 @@ export function handleConsoleError(
       environmentName
     )
   }
+  // React may replay the original message before server-side formatting ran.
+  // Re-apply helpful rewrites so the overlay matches the terminal.
+  formatServerError(error)
   setOwnerStackIfAvailable(error)
 
   errorQueue.push(error)
@@ -46,6 +50,7 @@ export function handleConsoleError(
 }
 
 export function handleClientError(error: Error) {
+  formatServerError(error)
   errorQueue.push(error)
   for (const handler of errorHandlers) {
     // Delayed the error being passed to React Dev Overlay,

--- a/packages/next/src/server/use-cache/use-cache-errors.test.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.test.ts
@@ -1,0 +1,35 @@
+import { annotateUseCacheFunctionSerializationError } from './use-cache-errors'
+
+const REACT_MESSAGE =
+  'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
+
+describe('annotateUseCacheFunctionSerializationError', () => {
+  it('appends a use cache serialization hint', () => {
+    const error = new Error(
+      REACT_MESSAGE + '\n  [function PostContent]\n   ^^^^^^^^^^^'
+    )
+
+    annotateUseCacheFunctionSerializationError(error)
+
+    expect(error.message).toContain(REACT_MESSAGE)
+    expect(error.message).toContain('"use cache"')
+    expect(error.message).toContain(
+      'https://nextjs.org/docs/messages/use-cache-function'
+    )
+    expect(error.message).toContain('[function PostContent]')
+  })
+
+  it('does not annotate unrelated errors', () => {
+    const error = new Error('Something else went wrong')
+    annotateUseCacheFunctionSerializationError(error)
+    expect(error.message).toBe('Something else went wrong')
+  })
+
+  it('does not append the hint twice', () => {
+    const error = new Error(REACT_MESSAGE)
+    annotateUseCacheFunctionSerializationError(error)
+    const once = error.message
+    annotateUseCacheFunctionSerializationError(error)
+    expect(error.message).toBe(once)
+  })
+})

--- a/packages/next/src/server/use-cache/use-cache-errors.test.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.test.ts
@@ -8,6 +8,8 @@ describe('annotateUseCacheFunctionSerializationError', () => {
     const error = new Error(
       REACT_MESSAGE + '\n  [function PostContent]\n   ^^^^^^^^^^^'
     )
+    // Simulate V8's multi-line message prefix in the stack.
+    error.stack = `${error.name}: ${error.message}\n    at getCachedComponent (app/page.tsx:3:1)`
 
     annotateUseCacheFunctionSerializationError(error)
 
@@ -17,6 +19,12 @@ describe('annotateUseCacheFunctionSerializationError', () => {
       'https://nextjs.org/docs/messages/use-cache-function'
     )
     expect(error.message).toContain('[function PostContent]')
+
+    // React's annotation must appear once in the stack, not duplicated by a
+    // first-line-only message rewrite.
+    expect(error.stack?.match(/\[function PostContent\]/g)).toHaveLength(1)
+    expect(error.stack?.match(/^\s+\^\^\^/gm)).toHaveLength(1)
+    expect(error.stack).toContain('at getCachedComponent (app/page.tsx:3:1)')
   })
 
   it('does not annotate unrelated errors', () => {

--- a/packages/next/src/server/use-cache/use-cache-errors.test.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.test.ts
@@ -18,7 +18,8 @@ describe('annotateUseCacheFunctionSerializationError', () => {
     expect(error.message).toContain(
       'https://nextjs.org/docs/app/api-reference/directives/use-cache'
     )
-    expect(error.message).toContain('return JSX or data')
+    expect(error.message).toContain('return JSX or serializable data')
+    expect(error.message).toContain('component reference')
     expect(error.message).toContain('[function PostContent]')
 
     // React's annotation must appear once in the stack, not duplicated by a

--- a/packages/next/src/server/use-cache/use-cache-errors.test.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.test.ts
@@ -16,8 +16,9 @@ describe('annotateUseCacheFunctionSerializationError', () => {
     expect(error.message).toContain(REACT_MESSAGE)
     expect(error.message).toContain('"use cache"')
     expect(error.message).toContain(
-      'https://nextjs.org/docs/messages/use-cache-function'
+      'https://nextjs.org/docs/app/api-reference/directives/use-cache'
     )
+    expect(error.message).toContain('return JSX or data')
     expect(error.message).toContain('[function PostContent]')
 
     // React's annotation must appear once in the stack, not duplicated by a

--- a/packages/next/src/server/use-cache/use-cache-errors.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.ts
@@ -1,3 +1,5 @@
+import { setErrorMessage } from '../../lib/format-server-error'
+
 export class UseCacheTimeoutError extends Error {
   constructor() {
     super(
@@ -41,15 +43,6 @@ const REACT_FUNCTION_SERIALIZATION_ERROR =
 const USE_CACHE_FUNCTION_SERIALIZATION_HINT =
   'This error occurred while serializing a value for `"use cache"`. `"use cache"` is a serialization boundary, so functions (including React components) cannot be passed in or returned. Return JSX (for example `<Component />`) or serializable data instead of the function itself. If you meant a Server Action, mark the function with `"use server"`. Read more: https://nextjs.org/docs/messages/use-cache-function'
 
-function setMessage(error: Error, message: string): void {
-  error.message = message
-  if (error.stack) {
-    const lines = error.stack.split('\n')
-    lines[0] = message
-    error.stack = lines.join('\n')
-  }
-}
-
 export function annotateUseCacheFunctionSerializationError(
   error: unknown
 ): void {
@@ -66,7 +59,7 @@ export function annotateUseCacheFunctionSerializationError(
     return
   }
 
-  setMessage(
+  setErrorMessage(
     error,
     error.message.replace(
       REACT_FUNCTION_SERIALIZATION_ERROR,

--- a/packages/next/src/server/use-cache/use-cache-errors.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.ts
@@ -43,7 +43,9 @@ const REACT_FUNCTION_SERIALIZATION_ERROR =
 const USE_CACHE_FUNCTION_DOCS_URL =
   'https://nextjs.org/docs/app/api-reference/directives/use-cache'
 
-const USE_CACHE_FUNCTION_SERIALIZATION_HINT = `Inside \`"use cache"\`, return JSX or data — not a function or component. See ${USE_CACHE_FUNCTION_DOCS_URL}`
+// Docs: return values may include JSX; bare functions are unsupported (except
+// pass-through args). See /docs/app/api-reference/directives/use-cache.
+const USE_CACHE_FUNCTION_SERIALIZATION_HINT = `Inside \`"use cache"\`, return JSX or serializable data — not a function (including a component reference). See ${USE_CACHE_FUNCTION_DOCS_URL}`
 
 export function annotateUseCacheFunctionSerializationError(
   error: unknown

--- a/packages/next/src/server/use-cache/use-cache-errors.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.ts
@@ -40,8 +40,10 @@ export class NestedDynamicUseCacheError extends Error {
 const REACT_FUNCTION_SERIALIZATION_ERROR =
   'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
 
-const USE_CACHE_FUNCTION_SERIALIZATION_HINT =
-  'This error occurred while serializing a value for `"use cache"`. `"use cache"` is a serialization boundary, so functions (including React components) cannot be passed in or returned. Return JSX (for example `<Component />`) or serializable data instead of the function itself. If you meant a Server Action, mark the function with `"use server"`. Read more: https://nextjs.org/docs/messages/use-cache-function'
+const USE_CACHE_FUNCTION_DOCS_URL =
+  'https://nextjs.org/docs/app/api-reference/directives/use-cache'
+
+const USE_CACHE_FUNCTION_SERIALIZATION_HINT = `Inside \`"use cache"\`, return JSX or data — not a function or component. See ${USE_CACHE_FUNCTION_DOCS_URL}`
 
 export function annotateUseCacheFunctionSerializationError(
   error: unknown
@@ -55,7 +57,7 @@ export function annotateUseCacheFunctionSerializationError(
   }
 
   // Avoid appending the hint more than once if the error is reported again.
-  if (error.message.includes(USE_CACHE_FUNCTION_SERIALIZATION_HINT)) {
+  if (error.message.includes(USE_CACHE_FUNCTION_DOCS_URL)) {
     return
   }
 

--- a/packages/next/src/server/use-cache/use-cache-errors.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.ts
@@ -28,3 +28,49 @@ export class NestedDynamicUseCacheError extends Error {
     this.name = 'Nested dynamic "use cache"'
   }
 }
+
+/**
+ * React Flight reports non-serializable functions with a Client Components
+ * message. Inside `"use cache"` that framing is misleading — the real issue is
+ * the cache serialization boundary. Append a clearer hint while preserving
+ * React's function annotation (e.g. `[function fn]`).
+ */
+const REACT_FUNCTION_SERIALIZATION_ERROR =
+  'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
+
+const USE_CACHE_FUNCTION_SERIALIZATION_HINT =
+  'This error occurred while serializing a value for `"use cache"`. `"use cache"` is a serialization boundary, so functions (including React components) cannot be passed in or returned. Return JSX (for example `<Component />`) or serializable data instead of the function itself. If you meant a Server Action, mark the function with `"use server"`. Read more: https://nextjs.org/docs/messages/use-cache-function'
+
+function setMessage(error: Error, message: string): void {
+  error.message = message
+  if (error.stack) {
+    const lines = error.stack.split('\n')
+    lines[0] = message
+    error.stack = lines.join('\n')
+  }
+}
+
+export function annotateUseCacheFunctionSerializationError(
+  error: unknown
+): void {
+  if (!(error instanceof Error) || typeof error.message !== 'string') {
+    return
+  }
+
+  if (!error.message.includes(REACT_FUNCTION_SERIALIZATION_ERROR)) {
+    return
+  }
+
+  // Avoid appending the hint more than once if the error is reported again.
+  if (error.message.includes(USE_CACHE_FUNCTION_SERIALIZATION_HINT)) {
+    return
+  }
+
+  setMessage(
+    error,
+    error.message.replace(
+      REACT_FUNCTION_SERIALIZATION_ERROR,
+      `${REACT_FUNCTION_SERIALIZATION_ERROR}\n\n${USE_CACHE_FUNCTION_SERIALIZATION_HINT}`
+    )
+  )
+}

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -89,6 +89,7 @@ import {
   type ReadonlyHeaders,
 } from '../web/spec-extension/adapters/headers'
 import {
+  annotateUseCacheFunctionSerializationError,
   NestedDynamicUseCacheError,
   UseCacheDeadlockError,
   UseCacheTimeoutError,
@@ -1356,7 +1357,7 @@ async function generateCacheEntryImpl(
   // digests are handled correctly. Error formatting and reporting is not
   // necessary here; the errors are encoded in the stream, and will be reported
   // in the "Server" environment.
-  const handleError = createReactServerErrorHandler(
+  const reactServerHandleError = createReactServerErrorHandler(
     process.env.NODE_ENV === 'development',
     workStore.isBuildTimePrerendering ?? false,
     workStore.reactServerErrorsByDigest,
@@ -1373,6 +1374,14 @@ async function generateCacheEntryImpl(
       errors.push(error)
     }
   )
+
+  // React's default function-serialization error talks about Client Components.
+  // Inside `"use cache"` that framing is misleading — annotate before the error
+  // is digested/encoded so the Cache stream carries a clearer hint.
+  const handleError = (error: unknown) => {
+    annotateUseCacheFunctionSerializationError(error)
+    return reactServerHandleError(error)
+  }
 
   let stream: ReadableStream<Uint8Array>
   let devTimeoutAbortController: AbortController | undefined
@@ -2171,11 +2180,19 @@ export async function cache(
     ? [buildId, id, args, hmrRefreshHash]
     : [buildId, id, args]
 
-  const encodeCacheKeyParts = () =>
-    encodeReply(cacheKeyParts, {
-      temporaryReferences,
-      signal: hangingInputAbortSignal,
-    })
+  const encodeCacheKeyParts = async () => {
+    try {
+      return await encodeReply(cacheKeyParts, {
+        temporaryReferences,
+        signal: hangingInputAbortSignal,
+      })
+    } catch (error) {
+      // Closed-over or argument functions fail while encoding the cache key,
+      // outside the Flight `onError` path used for return-value serialization.
+      annotateUseCacheFunctionSerializationError(error)
+      throw error
+    }
+  }
 
   let encodedCacheKeyParts: FormData | string
 

--- a/test/e2e/app-dir/use-cache-close-over-function/app/return-component/page.tsx
+++ b/test/e2e/app-dir/use-cache-close-over-function/app/return-component/page.tsx
@@ -1,0 +1,15 @@
+async function getCachedComponent() {
+  'use cache'
+
+  function PostContent() {
+    return <p>hello from cached component</p>
+  }
+
+  // Intentionally return the component function — this is not serializable.
+  return PostContent
+}
+
+export default async function Page() {
+  const Content = await getCachedComponent()
+  return <Content />
+}

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -11,7 +11,7 @@ const reactFunctionError =
   'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
 
 const useCacheFunctionDocs =
-  'https://nextjs.org/docs/messages/use-cache-function'
+  'https://nextjs.org/docs/app/api-reference/directives/use-cache'
 
 describe('use-cache-close-over-function', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
@@ -107,9 +107,7 @@ describe('use-cache-close-over-function', () => {
       expect(errorDescription).toContain('"use cache"')
       expect(errorDescription).toContain(useCacheFunctionDocs)
       // Stronger wording when the failure is definitely inside the cache fill.
-      expect(errorDescription).toContain(
-        'This error occurred while serializing a value for `"use cache"`'
-      )
+      expect(errorDescription).toContain('Inside `"use cache"`')
     })
   } else {
     it('should fail the build with an error', async () => {

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -108,6 +108,7 @@ describe('use-cache-close-over-function', () => {
       expect(errorDescription).toContain(useCacheFunctionDocs)
       // Stronger wording when the failure is definitely inside the cache fill.
       expect(errorDescription).toContain('Inside `"use cache"`')
+      expect(errorDescription).toContain('component reference')
     })
   } else {
     it('should fail the build with an error', async () => {

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -7,6 +7,12 @@ import {
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+const reactFunctionError =
+  'Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.'
+
+const useCacheFunctionDocs =
+  'https://nextjs.org/docs/messages/use-cache-function'
+
 describe('use-cache-close-over-function', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
@@ -28,11 +34,10 @@ describe('use-cache-close-over-function', () => {
       const errorDescription = await getRedboxDescription(browser)
       const errorSource = await getRedboxSource(browser)
 
-      expect(errorDescription).toMatchInlineSnapshot(`
-        "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
-          [function fn]
-           ^^^^^^^^^^^"
-      `)
+      expect(errorDescription).toContain(reactFunctionError)
+      expect(errorDescription).toContain('"use cache"')
+      expect(errorDescription).toContain(useCacheFunctionDocs)
+      expect(errorDescription).toContain('[function fn]')
 
       expect(errorSource).toMatchInlineSnapshot(`
         "app/client/page.tsx (8:3) @ createCachedFn
@@ -47,21 +52,10 @@ describe('use-cache-close-over-function', () => {
       `)
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
-      expect(cliOutput).toContain(
-        '' +
-          'Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.' +
-          '\n  [function fn]' +
-          '\n   ^^^^^^^^^^^' +
-          '\n    at createCachedFn (app/client/page.tsx:8:3)' +
-          '\n    at Page (app/client/page.tsx:15:28)' +
-          '\n   6 |   }' +
-          '\n   7 |' +
-          '\n>  8 |   return async () => {' +
-          '\n     |   ^' +
-          "\n   9 |     'use cache'" +
-          '\n  10 |     return Math.random() + fn()' +
-          '\n  11 |   }'
-      )
+      expect(cliOutput).toContain(reactFunctionError)
+      expect(cliOutput).toContain(useCacheFunctionDocs)
+      expect(cliOutput).toContain('at createCachedFn (app/client/page.tsx:8:3)')
+      expect(cliOutput).toContain('at Page (app/client/page.tsx:15:28)')
     })
 
     it('should show the error overlay for server-side usage', async () => {
@@ -73,11 +67,10 @@ describe('use-cache-close-over-function', () => {
       const errorDescription = await getRedboxDescription(browser)
       const errorSource = await getRedboxSource(browser)
 
-      expect(errorDescription).toMatchInlineSnapshot(`
-        "Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
-          [function fn]
-           ^^^^^^^^^^^"
-      `)
+      expect(errorDescription).toContain(reactFunctionError)
+      expect(errorDescription).toContain('"use cache"')
+      expect(errorDescription).toContain(useCacheFunctionDocs)
+      expect(errorDescription).toContain('[function fn]')
 
       expect(errorSource).toMatchInlineSnapshot(`
         "app/server/page.tsx (6:3) @ createCachedFn
@@ -92,41 +85,41 @@ describe('use-cache-close-over-function', () => {
       `)
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
-      expect(cliOutput).toContain(
-        isTurbopack
-          ? '' +
-              'Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.' +
-              '\n  [function fn]' +
-              '\n   ^^^^^^^^^^^' +
-              '\n    at createCachedFn (app/server/page.tsx:6:3)' +
-              '\n    at module evaluation (app/server/page.tsx:12:24)'
-          : '' +
-              'Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.' +
-              '\n  [function fn]' +
-              '\n   ^^^^^^^^^^^' +
-              '\n    at createCachedFn (app/server/page.tsx:6:3)' +
-              '\n    at eval (app/server/page.tsx:12:24)' +
-              // TODO(veil): Should be source-mapped.
-              '\n    at <unknown> (rsc)'
-      )
-      expect(cliOutput).toContain(
-        '' +
-          '\n> 6 |   return async () => {' +
-          '\n    |   ^' +
-          "\n  7 |     'use cache'"
+      expect(cliOutput).toContain(reactFunctionError)
+      expect(cliOutput).toContain(useCacheFunctionDocs)
+      expect(cliOutput).toContain('at createCachedFn (app/server/page.tsx:6:3)')
+      if (isTurbopack) {
+        expect(cliOutput).toContain(
+          'at module evaluation (app/server/page.tsx:12:24)'
+        )
+      } else {
+        expect(cliOutput).toContain('at eval (app/server/page.tsx:12:24)')
+      }
+    })
+
+    it('should hint when a component function is returned from use cache', async () => {
+      const browser = await next.browser('/return-component')
+
+      await waitForRedbox(browser)
+
+      const errorDescription = await getRedboxDescription(browser)
+      expect(errorDescription).toContain(reactFunctionError)
+      expect(errorDescription).toContain('"use cache"')
+      expect(errorDescription).toContain(useCacheFunctionDocs)
+      // Stronger wording when the failure is definitely inside the cache fill.
+      expect(errorDescription).toContain(
+        'This error occurred while serializing a value for `"use cache"`'
       )
     })
   } else {
     it('should fail the build with an error', async () => {
       const { cliOutput } = await next.build()
 
-      expect(cliOutput).toInclude(`
-Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server". Or maybe you meant to call this function rather than return it.
-  [function]
-   ^^^^^^^^`)
+      expect(cliOutput).toContain(reactFunctionError)
+      expect(cliOutput).toContain(useCacheFunctionDocs)
 
       expect(cliOutput).toMatch(
-        /Error occurred prerendering page "\/(client|server)"/
+        /Error occurred prerendering page "\/(client|server|return-component)"/
       )
     })
   }


### PR DESCRIPTION
## Summary

Improves the error developers see when a non-serializable function (including a React/MDX component reference) is passed into or returned from `"use cache"`.

React currently reports this as a Client Components serialization failure, which is misleading in a cache context (see #96677). This change appends a short `"use cache"`-specific hint and links to the official [`use cache` docs](https://nextjs.org/docs/app/api-reference/directives/use-cache).

## Problem

Returning a component function from `"use cache"` (or closing over a bare function) fails serialization. The overlay only said functions cannot be passed to Client Components, with no mention of `"use cache"` or the usual fix: return JSX / serializable data (e.g. `<Component />`), not the function itself.

## Solution

- Annotate the error during `"use cache"` fill / cache-key encoding when we know the failure is on the cache boundary
- Also append a softer hint via `formatServerError` for close-over / related cases
- Re-apply formatting when errors are replayed into the dev overlay
- Rewrite the full multi-line `error.stack` message prefix so React’s `[function …]` / `^^^` annotation is not duplicated
- Add `errors/use-cache-function.mdx` with the MDX before/after pattern and pass-through notes

Hint shown today:

> Inside `"use cache"`, return JSX or serializable data — not a function (including a component reference). See https://nextjs.org/docs/app/api-reference/directives/use-cache

## Test plan

- [x] `pnpm jest packages/next/src/lib/format-server-error.test.ts packages/next/src/server/use-cache/use-cache-errors.test.ts`
- [x] `pnpm test-dev-turbo test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts`
- [x] `pnpm test-start-turbo test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts`
- [x] New case: returning a component function from `"use cache"` (`/return-component`)
- [x] Verified against the #96677 MDX reproduction with a local Next build

Fixes #96677

<!-- NEXT_JS_LLM -->