### PR TITLE
[PPF] Only track runtime accesses when the promise is used

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -355,7 +355,7 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
   // promise (see makeRuntimeHangingPromise). Unlike
   // `abortOnSynchronousPlatformIOAccess`, which aborts a runtime prerender
   // all the same and therefore must not record anything.
-  trackRuntimeDataAccessed(prerenderStore)
+  trackRuntimeDataAccessed(prerenderStore, expression)
 
   const prerenderSignal = prerenderStore.controller.signal
   if (prerenderSignal.aborted === false) {

--- a/packages/next/src/server/dynamic-rendering-utils.test.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.test.ts
@@ -1,0 +1,114 @@
+import { createPromiseWithResolvers } from '../shared/lib/promise-with-resolvers'
+import { trackPromiseUsed } from './dynamic-rendering-utils'
+
+describe('trackPromiseUsed', () => {
+  it('`then` is tracked and forwards the value', async () => {
+    const underlying = createPromiseWithResolvers<typeof result>()
+
+    const onUse = jest.fn()
+
+    const trackedPromise = trackPromiseUsed(underlying.promise, onUse)
+    void trackedPromise.then // accessing the property does not count as a usage
+    expect(onUse).toHaveBeenCalledTimes(0)
+
+    const derived = trackedPromise.then((value) => {
+      return value
+    })
+    expect(onUse).toHaveBeenCalledTimes(1)
+    expect(derived).toBeInstanceOf(Promise)
+
+    const result = { foo: 'bar' }
+    underlying.resolve(result)
+
+    await expect(derived).resolves.toBe(result)
+  })
+
+  it('`catch` is tracked and forwards the error', async () => {
+    const underlying = createPromiseWithResolvers<never>()
+
+    const onUse = jest.fn()
+
+    const trackedPromise = trackPromiseUsed(underlying.promise, onUse)
+    void trackedPromise.catch // accessing the property does not count as a usage
+    expect(onUse).toHaveBeenCalledTimes(0)
+
+    const derived = trackedPromise.catch((error) => {
+      return error
+    })
+    expect(onUse).toHaveBeenCalledTimes(1)
+    expect(derived).toBeInstanceOf(Promise)
+
+    const error = new Error('kaboom')
+    underlying.reject(error)
+
+    // Note: we're catching the error, so it resolves, not rejects
+    await expect(derived).resolves.toBe(error)
+  })
+
+  it('`finally` is tracked and forwards the value', async () => {
+    const underlying = createPromiseWithResolvers<typeof result>()
+
+    const onUse = jest.fn()
+
+    const trackedPromise = trackPromiseUsed(underlying.promise, onUse)
+    void trackedPromise.finally // accessing the property does not count as a usage
+    expect(onUse).toHaveBeenCalledTimes(0)
+
+    const onFinally = jest.fn()
+    const derived = trackedPromise.finally(onFinally)
+    expect(onUse).toHaveBeenCalledTimes(1)
+    expect(derived).toBeInstanceOf(Promise)
+
+    const result = { foo: 'bar' }
+    underlying.resolve(result)
+
+    await expect(derived).resolves.toBe(result)
+    expect(onFinally).toHaveBeenCalledTimes(1)
+  })
+
+  it('`finally` is tracked and forwards the error', async () => {
+    const underlying = createPromiseWithResolvers<never>()
+
+    const onUse = jest.fn()
+
+    const trackedPromise = trackPromiseUsed(underlying.promise, onUse)
+    void trackedPromise.finally // accessing the property does not count as a usage
+    expect(onUse).toHaveBeenCalledTimes(0)
+
+    const onFinally = jest.fn()
+    const derived = trackedPromise.finally(onFinally)
+    expect(onUse).toHaveBeenCalledTimes(1)
+    expect(derived).toBeInstanceOf(Promise)
+
+    const error = new Error('kaboom')
+    underlying.reject(error)
+
+    await expect(derived).rejects.toBe(error)
+  })
+
+  it('native `await` is tracked', async () => {
+    const underlying = createPromiseWithResolvers<typeof result>()
+
+    const onUse = jest.fn()
+
+    const trackedPromise = trackPromiseUsed(underlying.promise, onUse)
+    expect(onUse).toHaveBeenCalledTimes(0)
+
+    const derived = (async () => {
+      const result = await trackedPromise
+      return result
+    })()
+
+    // Flush microtasks
+    await new Promise((resolve) =>
+      queueMicrotask(() => process.nextTick(resolve))
+    )
+
+    expect(onUse).toHaveBeenCalledTimes(1)
+
+    const result = { foo: 'bar' }
+    underlying.resolve(result)
+
+    await expect(derived).resolves.toBe(result)
+  })
+})

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -8,7 +8,6 @@ import type {
 } from './app-render/work-unit-async-storage.external'
 import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
 import { getServerReact, getClientReact } from './runtime-reacts.external'
-import { ReflectAdapter } from './web/spec-extension/adapters/reflect'
 
 export function isHangingPromiseRejectionError(
   err: unknown
@@ -112,7 +111,7 @@ export function makeUntrackedHangingPromise<T>(
  * searchParams, and cache entries that are excluded only from static
  * prerenders.
  *
- * Creating one of these during a static prerender records on the prerender
+ * Awaiting one of these during a static prerender records on the prerender
  * store that a runtime prefetch would produce more content than the static
  * response (`runtimeDataAccessed`), which the segment prefetch encoding uses
  * to tell the client whether a runtime prefetch request could be skipped.
@@ -121,13 +120,10 @@ export function makeUntrackedHangingPromise<T>(
  * cost of over-recording is a redundant runtime prefetch request; the cost of
  * under-recording is a permanently missing one.
  *
- * `workUnitStore` may be null ONLY when the caller tracks the access itself
- * at observation time instead of creation time. This is for promises the
- * framework creates eagerly whether or not anything reads them (e.g. the
- * `searchParams` prop constructed for every page): recording at creation
- * would mark every render. Such a caller MUST call `trackRuntimeDataAccessed`
- * from every path that observes the promise (e.g. the proxy traps for
- * `then`/`status`), against the work unit store active at access time.
+ * `workUnitStore` may be null ONLY when the caller tracks the access itself.
+ * Such a caller MUST call `trackRuntimeDataAccessed` from every path that
+ * observes the promise (e.g. the proxy traps for `then`/`status`),
+ * against the work unit store active at access time.
  *
  * For fallback-param data — data a concrete (ISR-upgraded) prerender would
  * resolve — use `makeFallbackParamsHangingPromise` instead, so the access
@@ -141,29 +137,31 @@ export function makeRuntimeHangingPromise<T>(
   expression: string,
   workUnitStore: WorkUnitStore | null
 ): Promise<T> {
-  if (workUnitStore !== null) {
-    trackRuntimeDataAccessed(workUnitStore)
-  }
-  return makeHangingPromiseWithError(
+  const promise = makeHangingPromiseWithError<T>(
     signal,
     new HangingPromiseRejectionError(route, expression)
+  )
+  if (workUnitStore === null) {
+    return promise
+  }
+  return trackPromiseUsed(
+    promise,
+    trackRuntimeDataAccessed.bind(null, workUnitStore)
   )
 }
 
 /**
  * Variant of `makeRuntimeHangingPromise` for *fallback-param* data: fallback
  * route params and values derived solely from them (`params`, `rootParams`,
- * `pathname` during a fallback prerender). Like every runtime data access it
- * records the access on the prerender store's response-level flag, but its
- * effect on the build-time static-prefetch hint differs — on a
+ * `pathname` during a fallback prerender). Like every runtime data access,
+ * awaiting it records the access on the prerender store's response-level flag,
+ * but its effect on the build-time static-prefetch hint differs — on a
  * fallback-upgradeable route the access is transient (a concrete prerender
- * resolves it), so it leaves the hint intact. See
- * `trackFallbackParamsAccessed`.
+ * resolves it), so it leaves the hint intact. See `trackFallbackParamsAccessed`.
  *
  * As with `makeRuntimeHangingPromise`, `workUnitStore` may be null ONLY when
- * the caller tracks the access itself at observation time instead of creation
- * time, by calling `trackFallbackParamsAccessed` from every path that
- * observes the promise.
+ * the caller tracks the access itself by calling `trackFallbackParamsAccessed`
+ * from every path that observes the promise.
  *
  * @internal
  */
@@ -173,12 +171,16 @@ export function makeFallbackParamsHangingPromise<T>(
   expression: string,
   workUnitStore: WorkUnitStore | null
 ): Promise<T> {
-  if (workUnitStore !== null) {
-    trackFallbackParamsAccessed(workUnitStore)
-  }
-  return makeHangingPromiseWithError(
+  const promise = makeHangingPromiseWithError<T>(
     signal,
     new HangingPromiseRejectionError(route, expression)
+  )
+  if (workUnitStore === null) {
+    return promise
+  }
+  return trackPromiseUsed(
+    promise,
+    trackFallbackParamsAccessed.bind(null, workUnitStore)
   )
 }
 
@@ -191,8 +193,8 @@ export function makeFallbackParamsHangingPromise<T>(
  *
  * A render that runs through the later stage would include the data; in
  * particular a runtime prefetch renders through its later stages, so on a
- * static prerender store this records `runtimeDataAccessed`, same as
- * `makeRuntimeHangingPromise`.
+ * static prerender store awaiting this promise records `runtimeDataAccessed`,
+ * same as `makeRuntimeHangingPromise`.
  *
  * @internal
  */
@@ -202,10 +204,12 @@ export function makeStageHangingPromise<T>(
   expression: string,
   workUnitStore: WorkUnitStore
 ): Promise<T> {
-  trackRuntimeDataAccessed(workUnitStore)
-  return makeHangingPromiseWithError(
-    signal,
-    new HangingPromiseRejectionError(route, expression)
+  return trackPromiseUsed(
+    makeHangingPromiseWithError<T>(
+      signal,
+      new HangingPromiseRejectionError(route, expression)
+    ),
+    trackRuntimeDataAccessed.bind(null, workUnitStore)
   )
 }
 
@@ -214,11 +218,8 @@ export function makeStageHangingPromise<T>(
  * which would have resolved during a runtime prerender. No-op for all other
  * store types.
  *
- * `makeRuntimeHangingPromise` and `makeStageHangingPromise` call this
- * automatically; call it directly only where the access is observed
- * separately from the promise's creation (see the null `workUnitStore` case
- * of `makeRuntimeHangingPromise`), or where the prerender is aborted
- * synchronously instead of hanging.
+ * Prefer `makeRuntimeHangingPromise` and `makeStageHangingPromise`.
+ * Use this method only when implementing similar tracking and those two are not enough.
  *
  * For fallback-param data, use `trackFallbackParamsAccessed` instead. When
  * unsure, this is the conservative choice: it unconditionally clears the
@@ -389,38 +390,72 @@ export function makeDevtoolsIOAwarePromise<T>(
   })
 }
 
-/** Invokes `onUse` whenever `then()/catch()/finally()` are called on the promise. */
-export function trackPromiseUsed<T>(promise: Promise<T>, onUse: () => void) {
-  const methodCache: Record<string, (...args: any[]) => any> = {}
-  return new Proxy(promise, {
-    get(target, prop, receiver) {
-      if (prop === 'then' || prop === 'catch' || prop === 'finally') {
-        let patchedMethod = methodCache[prop]
-        if (patchedMethod !== undefined) {
-          return patchedMethod
-        }
+/**
+ * Invokes `onUse` whenever `then()/catch()/finally()` are called on the promise
+ * or when the promise is awaited. */
+export function trackPromiseUsed<T>(
+  promise: Promise<T>,
+  onUse: () => void
+): Promise<T> {
+  // We can instrument `.then()/.catch()/.finally()` in one go by using a Promise subclass
+  // that implements a custom `.then()`, because `catch` and `finally` delegate to it.
+  //
+  // Alternative implementation ideas that were tried and rejected:
+  //
+  // 1. Patching the methods directly via `promise.then = (..args) => { ... }`:
+  //   doesn't work, because Node does not call the monkeypatched methods for native `await`:
+  //   > Native Promise [...]: The promise is directly used and awaited natively, without calling `then()`.
+  //   > https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#description
+  //
+  // 2. Wrapping in a proxy that returns a custom `then/catch/finally`:
+  //   breaks async stacks in React's IO tracking (stack becomes `Promise.then`)
+  return TrackedPromise.from<T>(promise, onUse)
+}
 
-        const originalMethod = ReflectAdapter.get(target, prop, receiver)
-        patchedMethod = {
-          [prop]: (...args: unknown[]) => {
-            try {
-              onUse()
-            } catch (err) {
-              // We don't want to break the method even if our tracking errored.
-              console.error(err)
-            }
+class TrackedPromise<T> extends Promise<T> {
+  #onUse: (() => void) | null = null
 
-            return originalMethod.apply(target, args)
-          },
-        }[prop]
+  // We don't need derived promises to also be a TrackedPromise.
+  // We only care about the first level of `.then()`.
+  static get [Symbol.species]() {
+    return Promise
+  }
 
-        methodCache[prop] = patchedMethod
-        return patchedMethod
+  static from<T>(promise: Promise<T>, onUse: () => void): TrackedPromise<T> {
+    // Whenever the promise we're tracking resolves/rejects, we should follow.
+    const tracked = new TrackedPromise<T>(promise.then.bind(promise))
+
+    tracked.#onUse = onUse
+
+    // Hanging promises catch rejections when created. Tracked promises are generally derived
+    // from promises that may hang & reject, so we need to do the same.
+    // However, we have to bypass the tracking we do in `TrackedPromise.then`.
+    // (we're using `then` directly, because `catch` ends up delegating `TrackedPromise.then`)
+    Promise.prototype.then.call(tracked, undefined, ignoreReject)
+
+    return tracked
+  }
+
+  then<TResult1, TResult2>(
+    onFulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>,
+    onRejected?: (reason: unknown) => TResult2 | PromiseLike<TResult2>
+  ): Promise<TResult1 | TResult2> {
+    const onUse = this.#onUse
+    if (onUse) {
+      try {
+        onUse()
+      } catch (err) {
+        // We don't want to break the method even if our tracking errored.
+        console.error(err)
       }
+    }
 
-      return ReflectAdapter.get(target, prop, receiver)
-    },
-  })
+    return Promise.prototype.then.call(
+      this,
+      onFulfilled,
+      onRejected
+    ) as Promise<TResult1 | TResult2>
+  }
 }
 
 export const RENDER_STAGES_BY_DATA_KIND = {

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -2,6 +2,7 @@ import {
   RenderStage,
   type AdvanceableRenderStage,
 } from './app-render/staged-rendering'
+import { workAsyncStorage } from './app-render/work-async-storage.external'
 import type {
   RequestStore,
   WorkUnitStore,
@@ -146,7 +147,7 @@ export function makeRuntimeHangingPromise<T>(
   }
   return trackPromiseUsed(
     promise,
-    trackRuntimeDataAccessed.bind(null, workUnitStore)
+    trackRuntimeDataAccessed.bind(null, workUnitStore, expression)
   )
 }
 
@@ -180,7 +181,7 @@ export function makeFallbackParamsHangingPromise<T>(
   }
   return trackPromiseUsed(
     promise,
-    trackFallbackParamsAccessed.bind(null, workUnitStore)
+    trackFallbackParamsAccessed.bind(null, workUnitStore, expression)
   )
 }
 
@@ -209,7 +210,7 @@ export function makeStageHangingPromise<T>(
       signal,
       new HangingPromiseRejectionError(route, expression)
     ),
-    trackRuntimeDataAccessed.bind(null, workUnitStore)
+    trackRuntimeDataAccessed.bind(null, workUnitStore, expression)
   )
 }
 
@@ -225,8 +226,11 @@ export function makeStageHangingPromise<T>(
  * unsure, this is the conservative choice: it unconditionally clears the
  * static-prefetch hint.
  */
-export function trackRuntimeDataAccessed(workUnitStore: WorkUnitStore): void {
-  trackRuntimeDataAccessedImpl(workUnitStore, false)
+export function trackRuntimeDataAccessed(
+  workUnitStore: WorkUnitStore,
+  expression: string
+): void {
+  trackRuntimeDataAccessedImpl(workUnitStore, false, expression)
 }
 
 /**
@@ -238,14 +242,16 @@ export function trackRuntimeDataAccessed(workUnitStore: WorkUnitStore): void {
  * concrete prerender that resolves it.
  */
 export function trackFallbackParamsAccessed(
-  workUnitStore: WorkUnitStore
+  workUnitStore: WorkUnitStore,
+  expression: string
 ): void {
-  trackRuntimeDataAccessedImpl(workUnitStore, true)
+  trackRuntimeDataAccessedImpl(workUnitStore, true, expression)
 }
 
 function trackRuntimeDataAccessedImpl(
   workUnitStore: WorkUnitStore,
-  isFallbackParamAccess: boolean
+  isFallbackParamAccess: boolean,
+  expression: string
 ): void {
   switch (workUnitStore.type) {
     case 'prerender': {
@@ -284,6 +290,13 @@ function trackRuntimeDataAccessedImpl(
         hintCell !== null &&
         (!isFallbackParamAccess || !workUnitStore.isFallbackUpgradeable)
       ) {
+        if (process.env.NEXT_PRIVATE_DEBUG_RUNTIME_DATA) {
+          const workStore = workAsyncStorage.getStore()
+          const route = workStore?.route ?? '<unknown route>'
+          console.log(
+            `Route '${route}' deopting to runtime requests because it used ${expression}`
+          )
+        }
         hintCell.current = false
       }
       break

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -724,9 +724,9 @@ function makeHangingParams(
       prerenderStore.renderSignal,
       workStore.route,
       '`params`',
-      // This promise is created for every segment on a fallback route whether
-      // or not it reads params, so recording the access at creation would mark
-      // every render. The access is tracked in the proxy traps instead.
+      // Passing `null` for the store disables tracking of params usage.
+      // Caches need the additional logic from `fallbackParamsProxyHandler`,
+      // so we track params usage there instead.
       null
     ),
     fallbackParamsProxyHandler

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -686,7 +686,7 @@ const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
           // rendering when it's finally awaited.
           const workUnitStore = workUnitAsyncStorage.getStore()
           if (workUnitStore !== undefined) {
-            trackFallbackParamsAccessed(workUnitStore)
+            trackFallbackParamsAccessed(workUnitStore, '`params`')
           }
 
           const store = dynamicAccessAsyncStorage.getStore()

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -393,7 +393,7 @@ function makeHangingSearchParams(
     // created while the RSC payload is constructed, but typically accessed
     // later, during the render, under a different store.
     const workUnitStore = workUnitAsyncStorage.getStore()
-    trackRuntimeDataAccessed(workUnitStore ?? prerenderStore)
+    trackRuntimeDataAccessed(workUnitStore ?? prerenderStore, '`searchParams`')
   }
 
   const proxyHandler: ProxyHandler<Promise<SearchParams>> = {

--- a/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
+++ b/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
@@ -61,19 +61,20 @@ describe(`Request Promises`, () => {
       const expectError = createExpectError(next.cliOutput)
 
       expectError(
-        'Error: During prerendering, `params` rejects when the prerender is complete'
+        'Error: During prerendering, `searchParams` rejects when the prerender is complete'
       )
       expectError(
-        'Error: During prerendering, `searchParams` rejects when the prerender is complete'
+        'Error: During prerendering, `params` rejects when the prerender is complete'
+      )
+
+      expectError(
+        'Error: During prerendering, `connection()` rejects when the prerender is complete'
       )
       expectError(
         'Error: During prerendering, `cookies()` rejects when the prerender is complete'
       )
       expectError(
         'Error: During prerendering, `headers()` rejects when the prerender is complete'
-      )
-      expectError(
-        'Error: During prerendering, `connection()` rejects when the prerender is complete'
       )
     })
   })
@@ -100,11 +101,12 @@ describe(`Request Promises`, () => {
       const expectError = createExpectError(next.cliOutput)
 
       expectError(
-        'Error: During prerendering, `params` rejects when the prerender is complete'
-      )
-      expectError(
         'Error: During prerendering, `searchParams` rejects when the prerender is complete'
       )
+      expectError(
+        'Error: During prerendering, `params` rejects when the prerender is complete'
+      )
+
       expectError(
         'Error: During prerendering, `cookies()` rejects when the prerender is complete'
       )

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { LinkAccordion } from '../components/link-accordion'
 
 export default function Page() {
@@ -16,6 +17,56 @@ export default function Page() {
         </li>
         <li>
           <LinkAccordion href="/uses-cookies">Uses cookies</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/runtime-called-but-not-awaited">
+            Calls Runtime APIs but does not await them
+          </LinkAccordion>
+        </li>
+        <li>
+          Params after dynamic content
+          <ul>
+            <li>
+              <LinkAccordion href="/params-used-after-dynamic/1">
+                Param 1
+              </LinkAccordion>
+            </li>
+            <li>
+              <Link href="/params-used-after-dynamic/2" prefetch={false}>
+                Param 2 (unprefetched)
+              </Link>
+            </li>
+          </ul>
+        </li>
+        <li>
+          Params after navigation()
+          <ul>
+            <li>
+              <LinkAccordion href="/params-used-after-navigation/1">
+                Param 1
+              </LinkAccordion>
+            </li>
+            <li>
+              <Link href="/params-used-after-navigation/2" prefetch={false}>
+                Param 2 (unprefetched)
+              </Link>
+            </li>
+          </ul>
+        </li>
+        <li>
+          Params used in icon
+          <ul>
+            <li>
+              <LinkAccordion href="/params-used-in-icon/1">
+                Param 1
+              </LinkAccordion>
+            </li>
+            <li>
+              <Link href="/params-used-in-icon/2" prefetch={false}>
+                Params 2
+              </Link>
+            </li>
+          </ul>
         </li>
         <li>
           <LinkAccordion href="/uses-search-params?q=test">

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-after-dynamic/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-after-dynamic/[id]/page.tsx
@@ -1,0 +1,34 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+type Props = { params: Promise<{ id: string }> }
+
+export default async function Page(props: Props) {
+  return (
+    <main>
+      <p id="page-content">Params awaited after dynamic data</p>
+      <Suspense
+        fallback={<p id="dynamic-loading">Loading dynamic content...</p>}
+      >
+        <Dynamic {...props} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic(props: Props) {
+  // The prerender ends here, so it doesn't observe params being awaited.
+  await connection()
+
+  return (
+    <>
+      <div id="dynamic-content">Dynamic content</div>
+      <ParamsDependent {...props} />
+    </>
+  )
+}
+
+async function ParamsDependent(props: Props) {
+  const { id } = await props.params
+  return <p id="param-value">Post: {id}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-after-navigation/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-after-navigation/[id]/page.tsx
@@ -1,0 +1,36 @@
+import { unstable_navigation as navigation } from 'next/cache'
+import { Suspense } from 'react'
+
+type Props = { params: Promise<{ id: string }> }
+
+export default async function Page(props: Props) {
+  return (
+    <main>
+      <p id="page-content">Params awaited after navigation</p>
+      <Suspense
+        fallback={<p id="navigation-loading">Loading navigation content...</p>}
+      >
+        <NavigationOnly {...props} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function NavigationOnly(props: Props) {
+  // navigation() does not resolve in runtime prefetches, so awaiting `params`
+  // after `navigation` should not deopt this page to using runtime requests
+  // (because runtime shells/prefetches would not provide more data)
+  await navigation()
+
+  return (
+    <>
+      <div id="navigation-content">Navigation content</div>
+      <ParamsDependent {...props} />
+    </>
+  )
+}
+
+async function ParamsDependent(props: Props) {
+  const { id } = await props.params
+  return <p id="param-value">Post: {id}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-in-icon/[id]/icon.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-in-icon/[id]/icon.tsx
@@ -1,0 +1,23 @@
+import { ImageResponse } from 'next/og'
+
+export default async function icon({ params }) {
+  const { id } = await params
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 500,
+          background: '#fff',
+          color: '#000',
+        }}
+      >
+        P{id}
+      </div>
+    )
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-in-icon/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/params-used-in-icon/[id]/page.tsx
@@ -1,0 +1,34 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+type Props = { params: Promise<{ id: string }> }
+
+export default async function Page(props: Props) {
+  return (
+    <main>
+      <p id="page-content">Params awaited in icon.tsx and after dynamic data</p>
+      <Suspense
+        fallback={<p id="dynamic-loading">Loading dynamic content...</p>}
+      >
+        <Dynamic {...props} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic(props: Props) {
+  // The prerender ends here, so it doesn't observe params being awaited.
+  await connection()
+
+  return (
+    <>
+      <div id="dynamic-content">Dynamic content</div>
+      <ParamsDependent {...props} />
+    </>
+  )
+}
+
+async function ParamsDependent(props: Props) {
+  const { id } = await props.params
+  return <p id="param-value">Post: {id}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/runtime-called-but-not-awaited/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/runtime-called-but-not-awaited/page.tsx
@@ -1,0 +1,43 @@
+// A page that calls cookies and headers, but doesn't await them during the prerender,
+// which means it can still be prefetched statically.
+//
+// Note the Shell phase is always permitted to issue a runtime shell request,
+// so the absence of one in the test is attributable to the static shell
+// attempt succeeding, not to configuration forbidding runtime requests.
+
+import { cacheLife } from 'next/dist/server/use-cache/cache-life'
+import { cookies, headers } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <main>
+      <p id="page-content">Runtime APIs called but not awaited</p>
+      <Suspense
+        fallback={<p id="dynamic-loading">Loading dynamic content...</p>}
+      >
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  const cookiesPromise = cookies()
+  const headersPromise = headers()
+  const cachePromise = shortStaleCache()
+
+  // The prerender ends here, so it doesn't observe cookies/headers being awaited.
+  await connection()
+
+  await Promise.all([cookiesPromise, headersPromise, cachePromise])
+
+  return <div id="dynamic-content">Dynamic content</div>
+}
+
+async function shortStaleCache() {
+  'use cache'
+  cacheLife({ stale: 300 - 1 }) // smaller than MIN_SHELL_STALE
+  return Date.now()
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
@@ -254,6 +254,249 @@ describe('static App Shell prefetch attempt', () => {
     ])
   })
 
+  it("uses a static app shell for a partial segment that calls runtime APIs but doesn't await them", async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /runtime-called-but-not-awaited.
+    // No runtime data was awaited, so a static app shell is sufficient
+    // (a runtime app shell would not provide more data)
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/runtime-called-but-not-awaited"]'
+        )
+        .click()
+    }, [
+      { includes: 'Runtime APIs called but not awaited', kind: 'static' },
+      // We only expect a static prefetch.
+      {
+        includes: 'Runtime APIs called but not awaited',
+        kind: 'runtime',
+        block: 'reject',
+      },
+      { includes: 'Dynamic content', kind: 'runtime', block: 'reject' },
+    ])
+
+    // Navigate. The prefetched shell renders instantly, and the dynamic data arrives
+    // later, as part of the navigation request.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('a[href="/runtime-called-but-not-awaited"]')
+          .click()
+
+        // While the navigation response is blocked (we're still inside the
+        // `act` scope), the prefetched shell is already visible, with the
+        // loading fallback in place of the dynamic content.
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Runtime APIs called but not awaited'
+        )
+        expect(await browser.elementById('dynamic-loading').text()).toBe(
+          'Loading dynamic content...'
+        )
+      },
+      // The dynamic content streams in with the navigation response.
+      { includes: 'Dynamic content' }
+    )
+
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Dynamic content'
+    )
+  })
+
+  it('uses a static app shell for a partial segment that only awaits params after dynamic data', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /params-used-after-dynamic/1.
+    // No runtime data was awaited, so a static app shell is sufficient
+    // (a runtime app shell would not provide more data)
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/params-used-after-dynamic/1"]'
+        )
+        .click()
+    }, [
+      { includes: 'Params awaited after dynamic data', kind: 'static' },
+      // We only expect a static prefetch, no runtime requests.
+      {
+        includes: 'Params awaited after dynamic data',
+        kind: 'runtime',
+        block: 'reject',
+      },
+      { includes: 'Dynamic content', kind: 'runtime', block: 'reject' },
+    ])
+
+    // Navigate to an unprefetched link with a different param value.
+    // This should re-use the app shell that we got when we prefetched /1.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('a[href="/params-used-after-dynamic/2"]')
+          .click()
+
+        // While the navigation response is blocked (we're still inside the
+        // `act` scope), the prefetched shell is already visible, with the
+        // loading fallback in place of the dynamic content.
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Params awaited after dynamic data'
+        )
+        expect(await browser.elementById('dynamic-loading').text()).toBe(
+          'Loading dynamic content...'
+        )
+      },
+      // The dynamic content streams in with the navigation response.
+      { includes: 'Dynamic content' }
+    )
+
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Dynamic content'
+    )
+    expect(await browser.elementById('param-value').text()).toBe('Post: 2')
+  })
+
+  it('uses a static app shell for a partial segment that only awaits params after navigation()', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /params-used-after-navigation/1.
+    // No runtime data was awaited, so a static app shell is sufficient
+    // (a runtime app shell would not provide more data)
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/params-used-after-navigation/1"]'
+        )
+        .click()
+    }, [
+      { includes: 'Params awaited after navigation', kind: 'static' },
+      // We only expect a static prefetch, no runtime requests.
+      {
+        includes: 'Params awaited after navigation',
+        kind: 'runtime',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to an unprefetched link with a different param value.
+    // This should re-use the app shell that we got when we prefetched /1.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('a[href="/params-used-after-navigation/2"]')
+          .click()
+
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Params awaited after navigation'
+        )
+
+        // `navigation()` *does* resolve in static prefetches so we have navigation-gated
+        // content for /1. However, it is not considered part of the app shell, so it should
+        // not be visible here.
+        expect(await browser.elementById('navigation-loading').text()).toBe(
+          'Loading navigation content...'
+        )
+      },
+      // The navigation content streams in with the navigation response.
+      { includes: 'Navigation content' }
+    )
+
+    expect(await browser.elementById('navigation-content').text()).toBe(
+      'Navigation content'
+    )
+    expect(await browser.elementById('param-value').text()).toBe('Post: 2')
+  })
+
+  it('uses a runtime shell for a partial segment that has a param-dependent icon.tsx', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the LinkAccordion for /params-used-in-icon/1.
+    // No runtime data was awaited in the page itself during the prerender,
+    // but the head is param-dependent because it needs to link to the
+    // param-dependent icon:
+    //
+    //   <link rel="icon" href="/params-only-in-icon/1/icon">
+    //
+    // which is tracked as a runtime data access and deopts the page
+    // to runtime requests.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/params-used-in-icon/1"]')
+        .click()
+    }, [
+      {
+        includes: 'Params awaited in icon.tsx and after dynamic data',
+        kind: 'runtime',
+      },
+      {
+        includes: 'Params awaited in icon.tsx and after dynamic data',
+        kind: 'static',
+        block: 'reject',
+      },
+      { includes: 'Dynamic content', kind: 'static', block: 'reject' },
+    ])
+
+    // Navigate to an unprefetched link with a different param value.
+    // This should re-use the app shell that we got when we prefetched /1.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/params-used-in-icon/2"]').click()
+
+        // While the navigation response is blocked (we're still inside the
+        // `act` scope), the prefetched shell is already visible, with the
+        // loading fallback in place of the dynamic content.
+        expect(await browser.elementById('page-content').text()).toBe(
+          'Params awaited in icon.tsx and after dynamic data'
+        )
+
+        // The icon is param-dependent and should not be part of the shell.
+        expect(await browser.locator('link[rel="icon"]').count()).toBe(0)
+
+        expect(await browser.elementById('dynamic-loading').text()).toBe(
+          'Loading dynamic content...'
+        )
+      },
+      // The dynamic content streams in with the navigation response.
+      { includes: 'Dynamic content' }
+    )
+
+    expect(await browser.elementById('dynamic-content').text()).toBe(
+      'Dynamic content'
+    )
+
+    expect(
+      new URL(
+        await browser.elementByCss('link[rel="icon"]').getAttribute('href'),
+        'http://__n'
+      ).pathname
+    ).toEqual('/params-used-in-icon/2/icon')
+
+    expect(await browser.elementById('param-value').text()).toBe('Post: 2')
+  })
+
   it('does not fall back to a runtime shell prefetch for a partial segment whose holes are dynamic (connection)', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -707,7 +707,6 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/server/route-modules/app-page/vendored/contexts/router-context.js",
            "/node_modules/next/dist/server/route-modules/app-page/vendored/contexts/server-inserted-html.js",
            "/node_modules/next/dist/server/runtime-reacts.external.js",
-           "/node_modules/next/dist/server/web/spec-extension/adapters/reflect.js",
            "/node_modules/next/dist/shared/lib/deep-freeze.js",
            "/node_modules/next/dist/shared/lib/instant-messages.js",
            "/node_modules/next/dist/shared/lib/invariant-error.js",


### PR DESCRIPTION
Improves how we track accesses of runtime data in static prerenders (which affects whether a page will use static or runtime shells).
Now, Instead of tracking it when the hanging promise is created, we'll track it when `then/catch/finally` is called on the promise (which we use as a signal for being used).

The promise tracking required some novel work, because:

- Using a proxy seems to cause `Promise.then` to show up in call stacks (we've had issues with proxies throwing off React's IO tracking before, i believe this is a similar problem)
- patching `then/catch/finally` on the promise directly doesn't work, because `then` doesn't get called for native `await`

The only way of doing this that i've found is a custom `Promise` subclass that tracks the access in its `then` implementation. This is what `TrackedPromise` does.

To improve the debuggability, i've added some debug logs enabled by `NEXT_PRIVATE_DEBUG_RUNTIME_DATA=1` to detect when a page is deopted to runtime and what expression caused it.

---

This fixes a false deopt caused by `createServerPathnameForMetadata` - when called on a route with fallback params, it would always track a fallback params access even if no icons/og images that actually use it exist. This meant that we'd never statically optimize any routes that had fallback params. After this PR, we only track a runtime data access if a metadata route that uses that params actually exists, in which case the `pathname` promise gets awaited.
(as a future optimization, we should do the equivalent of vary params tracking on metadata routes to know if the params are used at all. also, the logic in `pathname.ts` is generally in need of cleanup)