### PR TITLE
Detect Cache Components config mismatches at startup

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -9,6 +9,7 @@ import '../require-hook'
 
 import url from 'url'
 import path from 'path'
+import { readFileSync } from 'fs'
 import loadConfig, { type ConfiguredExperimentalFeature } from '../config'
 import { finalizeBundlerFromConfig, getBundlerFromEnv } from '../../lib/bundler'
 import { serveStatic } from '../serve-static'
@@ -38,6 +39,7 @@ import {
   PHASE_PRODUCTION_SERVER,
   PHASE_DEVELOPMENT_SERVER,
   REQUEST_INSIGHTS_DEV_ENDPOINT,
+  SERVER_FILES_MANIFEST,
   UNDERSCORE_NOT_FOUND_ROUTE,
 } from '../../shared/lib/constants'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
@@ -113,6 +115,33 @@ function getErrorMessage(error: unknown): string {
   return deobfuscateText(String(error))
 }
 
+function validateCacheComponentsConfig(
+  dir: string,
+  config: Pick<NextConfigComplete, 'cacheComponents' | 'distDir'>
+): void {
+  let buildConfig: { cacheComponents?: boolean }
+
+  try {
+    buildConfig = JSON.parse(
+      readFileSync(
+        path.join(dir, config.distDir, SERVER_FILES_MANIFEST + '.json'),
+        'utf8'
+      )
+    ).config
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return
+    }
+    throw error
+  }
+
+  if (!!buildConfig.cacheComponents !== config.cacheComponents) {
+    throw new Error(
+      `The production build was created with \`cacheComponents: ${!!buildConfig.cacheComponents}\`, but the runtime configuration has \`cacheComponents: ${config.cacheComponents}\`. \`next start\` must use the same Cache Components setting as \`next build\`. Ensure the same Next.js configuration is available at build time and runtime, or rebuild the application after changing it.\nLearn more: https://nextjs.org/docs/app/guides/self-hosting`
+    )
+  }
+}
+
 export type RenderServer = Pick<
   typeof import('./render-server'),
   | 'initialize'
@@ -163,6 +192,9 @@ export async function initialize(opts: {
       },
     }
   )
+  if (!opts.dev) {
+    validateCacheComponentsConfig(opts.dir, config)
+  }
   if (bundlerBeforeConfig !== undefined) {
     finalizeBundlerFromConfig(bundlerBeforeConfig)
   }

--- a/test/production/cache-components-config-parity/app/layout.tsx
+++ b/test/production/cache-components-config-parity/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/cache-components-config-parity/app/page.tsx
+++ b/test/production/cache-components-config-parity/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello</p>
+}

--- a/test/production/cache-components-config-parity/cache-components-config-parity.test.ts
+++ b/test/production/cache-components-config-parity/cache-components-config-parity.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+jest.setTimeout(120_000)
+
+describe('Cache Components config parity', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  it('rejects a production server when its build config is omitted', async () => {
+    await next.build()
+    await next.deleteFile('next.config.js')
+
+    await next.start({ skipBuild: true })
+    await retry(async () => {
+      expect(next.cliOutput).toContain(
+        'The production build was created with `cacheComponents: true`, but the runtime configuration has `cacheComponents: false`.'
+      )
+      await expect(next.fetch('/')).rejects.toThrow()
+    })
+  })
+})

--- a/test/production/cache-components-config-parity/next.config.js
+++ b/test/production/cache-components-config-parity/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  cacheComponents: true,
+}


### PR DESCRIPTION
## What?

Make `next start` reject a production build when the build-time and runtime `cacheComponents` settings do not match. The regression fixture builds with Cache Components enabled, removes `next.config.js`, and verifies that the server exits before it can serve a request.

## Why?

A multi-stage Docker image can accidentally copy `.next` without copying `next.config.*`. The build then contains Cache Components output, while `next start` reloads the default configuration with Cache Components disabled. Request-time routes subsequently fail with `DYNAMIC_SERVER_USAGE`, but startup does not identify the underlying configuration mismatch.

The resolved build configuration is already recorded in `required-server-files.json`, so this incompatible deployment can be rejected before request handling instead of failing route by route.

## How?

During production router initialization, compare the built `cacheComponents` value with the runtime configuration. When they differ, throw an actionable error containing both values, recovery guidance, and the self-hosting documentation link. Missing build output retains the existing `next start` diagnostic.

The regression test covers the observed build-on/start-off failure. The startup check rejects the reverse mismatch as part of the same exact-parity deployment invariant; the minimal reverse control did not independently reproduce the request-time failure.

## Verification

- `pnpm build-all`
- Next.js watch build and types: zero errors
- `HEADLESS=true pnpm test-start-turbo test/production/cache-components-config-parity/cache-components-config-parity.test.ts`
- `HEADLESS=true pnpm test-start-webpack test/production/cache-components-config-parity/cache-components-config-parity.test.ts`
- Targeted Prettier, ESLint, and `git diff --check`
