### PR TITLE
Document build and runtime config parity

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -73,6 +73,8 @@ export default nextConfig
 
 > **Good to know:** If you were using `experimental.dynamicIO` or `experimental.useCache`, `cacheComponents` replaces them. See the [version 16 upgrade guide](/docs/app/guides/upgrading/version-16#experimentaldynamicio-and-experimentalusecache).
 
+When self-hosting, make sure the runtime process uses the same Next.js configuration as the build. This is especially important for multi-stage Docker images that run `next start`. See [Build and runtime configuration](/docs/app/guides/self-hosting#build-and-runtime-configuration).
+
 After enabling the flag, route segments that still export `dynamic`, `revalidate`, or `fetchCache` will error. Start by replacing those configs. The sections below explain what to do for each one.
 
 ## Opting out of validation

--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -82,6 +82,14 @@ This allows you to use a singular Docker image that can be promoted through mult
 >
 > - You can run code on server startup using the [`register` function](/docs/app/guides/instrumentation).
 
+## Build and runtime configuration
+
+`next build` and `next start` both load your Next.js configuration. Build-shaping options must have the same values in both processes. If you build an application in one Docker stage and run `next start` in another, copy the same `next.config.*` file into the runtime image along with the build output.
+
+Alternatively, use [`output: 'standalone'`](/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files). The generated `server.js` includes the resolved Next.js configuration, so you do not need to copy `next.config.*` separately.
+
+Runtime environment variables can still differ between environments as described above. The parity requirement applies to configuration that shapes the build. For example, a build created with [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled cannot be started with Cache Components disabled. Next.js exits during startup when it detects that mismatch.
+
 ## Caching and ISR
 
 Next.js can cache responses, generated static pages, build outputs, and other static assets like images, fonts, and scripts.


### PR DESCRIPTION
Stacked on #97167.

## What?

Document that `cacheComponents` must resolve to the same value during `next build` and `next start`, and link the self-hosting guidance from the Cache Components migration guide.

## Why?

A multi-stage Docker image can copy `.next` without copying `next.config.*`. When a Cache Components build is started under the default disabled configuration, requests can fail later with `DYNAMIC_SERVER_USAGE` instead of identifying the deployment mismatch.

Runtime environment variables are a separate concern: one Docker image can still be promoted through environments with different runtime values.

## How?

Describe the two supported self-hosted shapes: copy the same `next.config.*` when running `next start`, or use standalone output, whose generated server embeds the resolved configuration. Keep the requirement specific to `cacheComponents` instead of claiming that every build-shaping option has an identical runtime contract.

## Verification

- Targeted Prettier and ESLint
- `git diff --check`
