### PR TITLE
Clarify Instant validation opt-out guidance

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance-data.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant/instant-guidance-data.ts
@@ -218,12 +218,12 @@ const unrenderedSegmentCards: FixCard[] = [
   },
   {
     id: 'skip-validation-on-the-segment',
-    title: 'Skip validation on the segment',
+    title: 'Skip only this validation',
     group: 'ignore',
     link: 'https://nextjs.org/docs/messages/instant-unrendered-segment#skip-validation-on-the-segment',
     snippets: [
-      { text: '// page.tsx or layout.tsx' },
-      { text: '' },
+      { text: '// Server page.tsx or layout.tsx' },
+      { text: '// Prerendering still runs' },
       { text: 'export const instant = false', highlight: true },
     ],
     copyable: true,

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.test.ts
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.test.ts
@@ -423,9 +423,20 @@ describe('card sets for all error families', () => {
   })
 
   it('unrendered-segment', () => {
-    expect(
-      getCards('unrendered-segment', 'runtime').map((card) => card.id)
-    ).toEqual(['render-the-dropped-segment', 'skip-validation-on-the-segment'])
+    const cards = getCards('unrendered-segment', 'runtime')
+
+    expect(cards.map((card) => card.id)).toEqual([
+      'render-the-dropped-segment',
+      'skip-validation-on-the-segment',
+    ])
+    expect(cards[1]).toMatchObject({
+      title: 'Skip only this validation',
+      snippets: [
+        { text: '// Server page.tsx or layout.tsx' },
+        { text: '// Prerendering still runs' },
+        { text: 'export const instant = false', highlight: true },
+      ],
+    })
   })
 
   it('link-prefetch-partial', () => {
@@ -517,7 +528,7 @@ describe('getUnrenderedSegmentErrorDetails', () => {
         `\n\n${label}:\n${files.map((p) => `  ${p}`).join('\n')}` +
         `\n\nWays to fix this:` +
         `\n  - [render] Render the dropped segment` +
-        `\n  - [ignore] Set \`export const instant = false\` on the dropped segment to skip validation` +
+        `\n  - [ignore] Set \`export const instant = false\` in the dropped segment's Server Component to skip only this validation (prerendering still runs)` +
         `\n\nLearn more: https://nextjs.org/docs/messages/instant-unrendered-segment`
     }
     return new Error(message)

--- a/packages/next/src/shared/lib/instant-messages.ts
+++ b/packages/next/src/shared/lib/instant-messages.ts
@@ -11,7 +11,7 @@ export function createUnrenderedSegmentError(
       `\n\n${label}:\n${missingFiles.map((p) => `  ${p}`).join('\n')}` +
       `\n\nWays to fix this:` +
       `\n  - [render] Render the dropped segment` +
-      `\n  - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation` +
+      `\n  - [ignore] Set \`export const instant = false\` in the dropped segment's Server Component to skip only this validation (prerendering still runs)` +
       `\n\nLearn more: https://nextjs.org/docs/messages/instant-unrendered-segment`
   }
   return new Error(message)

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -320,7 +320,7 @@ export function registerHeadAndReportingTests(
 
          Ways to fix this:
            - [render] Render the dropped segment
-           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
+           - [ignore] Set \`export const instant = false\` in the dropped segment's Server Component to skip only this validation (prerendering still runs)
 
          Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
              at ignore-listed frames
@@ -378,7 +378,7 @@ export function registerHeadAndReportingTests(
 
          Ways to fix this:
            - [render] Render the dropped segment
-           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
+           - [ignore] Set \`export const instant = false\` in the dropped segment's Server Component to skip only this validation (prerendering still runs)
 
          Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
              at ignore-listed frames
@@ -436,7 +436,7 @@ export function registerHeadAndReportingTests(
 
          Ways to fix this:
            - [render] Render the dropped segment
-           - [ignore] Set \`export const instant = false\` to opt the dropped segment out of instant-navigation validation
+           - [ignore] Set \`export const instant = false\` in the dropped segment's Server Component to skip only this validation (prerendering still runs)
 
          Learn more: https://nextjs.org/docs/messages/instant-unrendered-segment
              at ignore-listed frames


### PR DESCRIPTION
## What?

Scope the Instant Insights `instant = false` recommendation to the validation it actually disables. The overlay and terminal guidance now state that prerendering still runs and that the export belongs in a Server Component route file.

## Why?

“Skip validation on the segment” can be read as a general escape hatch after a production build failure. However, `instant = false` only disables Instant validation; it does not prevent App Shell prerendering or resolve a separate client-hook or synchronous-IO prerender error.

The existing snippet also appears usable in any `page.tsx` or `layout.tsx`, even though route segment configuration cannot be exported from a `'use client'` module.

## How?

Rename the card to “Skip only this validation,” add the prerendering and Server Component constraints to the overlay and terminal messages, and extend the existing card-set test to cover the copy and snippet.

## Verification

- `pnpm build-all`
- `pnpm exec jest packages/next/src/next-devtools/dev-overlay/container/errors.test.ts --runInBand` (95 tests)
- `__NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS=true __NEXT_EXPERIMENTAL_SERVER_COMPONENTS_HMR_CANCELLATION=true HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/instant-validation/head-and-reporting.partial-prefetching.test.ts` (27 tests)
