### PR TITLE
Contrast Instant validation with request-time rendering

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -83,7 +83,9 @@ A validation insight or error tells you a route won't render instantly. Resolve 
 export const instant = false
 ```
 
-> **Good to know**: `instant = false` marks a segment as _allowed to block_. It does not force the route to be dynamic, so a genuinely prerenderable route still ships a static shell. It also does not clear synchronous IO build errors: calls like `new Date()`, `Math.random()`, and `crypto.randomUUID()` still fail the prerender. See [Adopting incrementally](#adopting-incrementally).
+Export `instant` from the segment's Server Component file (`page`, `layout`, or `default`). If that file has a `'use client'` directive, move the client code into a child component and keep the route file as a Server Component.
+
+> **Good to know**: `instant = false` skips instant-navigation validation and marks a segment as _allowed to block_. It does not opt the segment out of prerendering or force it to be dynamic, so a genuinely prerenderable route still ships a static shell. By contrast, [`connection()`](/docs/app/api-reference/functions/connection) defers the code below it until an actual request. Use `connection()` below a [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary when the work itself must not run during prerendering. These APIs are not interchangeable.
 
 ## Adopting incrementally
 

--- a/errors/instant-unrendered-segment.mdx
+++ b/errors/instant-unrendered-segment.mdx
@@ -55,11 +55,11 @@ This typically happens when a layout conditionally omits `{children}` or a paral
   />
   <FixCard
     group="ignore"
-    title="Skip validation on the segment"
+    title="Skip only this validation"
     href="#skip-validation-on-the-segment"
     snippets={[
-      { text: '// page.tsx or layout.tsx' },
-      { text: '' },
+      { text: '// Server page.tsx or layout.tsx' },
+      { text: '// Prerendering still runs' },
       { text: 'export const instant = false', highlight: true },
     ]}
   />
@@ -142,7 +142,7 @@ The segment is always in the render tree, which means Next.js validates it on ev
 
 ## Skip validation on the segment
 
-Choose this fix when the segment is intentionally not rendered in certain states (a modal that only appears on interaction, a slot gated by authentication). Setting [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) to `false` on the dropped segment tells Next.js to skip validation for it.
+Choose this fix when the segment is intentionally not rendered in certain states (a modal that only appears on interaction, a slot gated by authentication). Setting [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) to `false` on the dropped segment tells Next.js to skip this validation. It does not opt the segment out of prerendering or make it request-time rendered.
 
 ### Patterns
 
@@ -160,6 +160,29 @@ export default function ModalPage() {
 
 Learn more: [Route segment `instant` config](/docs/app/api-reference/file-conventions/route-segment-config/instant).
 
+#### Keep the route config in a Server Component
+
+Route segment config must be exported from the segment's Server Component file. If the page or layout is currently a Client Component, move its client code into a child and keep the route file as a Server Component:
+
+```jsx filename="app/dashboard/@modal/page.js"
+import { Modal } from './modal'
+
+export const instant = false
+
+export default function ModalPage() {
+  return <Modal />
+}
+```
+
+```jsx filename="app/dashboard/@modal/modal.js"
+'use client'
+
+export function Modal() {
+  // Client state and browser APIs can stay here.
+  return <div>Modal</div>
+}
+```
+
 ### Trade-off
 
 The segment is exempt from instant-navigation validation. If it has issues that would block navigation (uncached data outside Suspense, runtime APIs), those issues won't be caught during development.
@@ -167,7 +190,8 @@ The segment is exempt from instant-navigation validation. If it has issues that 
 ### Gotchas
 
 - The export must be on the **dropped segment's own file** (page or layout), not on a parent. The framework walks top-down and the first explicit config wins.
-- Setting [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) to `false` does not disable [prerendering](/docs/app/glossary#prerendering). The segment still prerenders if it can. It only disables the validation error.
+- The export must be in the segment's Server Component file. Do not add it to a file with the `'use client'` directive.
+- Setting [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) to `false` does not disable [prerendering](/docs/app/glossary#prerendering). The segment still prerenders if it can. It only disables the validation error. To defer work until an actual request, use [`connection()`](/docs/app/api-reference/functions/connection) in a component below a [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary instead.
 
 ## Verifying the fix
 


### PR DESCRIPTION
Stacked on #97169.

## What?

Explain where `instant = false` must be exported, show how to keep a Server Component route wrapper around client code, and contrast Instant validation opt-out with `connection()`.

## Why?

These APIs solve different migration problems but currently appear in separate sections. Teams can infer that `instant = false` stops prerendering, then discover during a production build that a separate prerender failure remains. Client-heavy applications also need an explicit pattern because a Client Component cannot carry route segment configuration.

## How?

Narrow the documented remedy to this validation, add a Server/Client split example, and state the decision rule: use `instant = false` to permit blocking navigation without disabling prerendering; use `connection()` below Suspense when work must wait for a real request.

## Verification

- Targeted Prettier and ESLint
- `git diff --check`
