### PR TITLE
Document navigation experimental config flags

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -522,8 +522,8 @@ export interface ExperimentalConfig {
    * prefetch to include dynamic route content when the user hovers or touches
    * it.
    *
-   * @internal This supports experimental Link behavior and is not a stable
-   * public configuration contract.
+   * This supports an internal Link experiment and is not a stable public
+   * configuration contract.
    */
   dynamicOnHover?: boolean
   /**
@@ -538,7 +538,7 @@ export interface ExperimentalConfig {
    * Uses known route patterns to construct an optimistic route tree when a
    * navigation does not have an exact prefetched route entry.
    *
-   * @internal This is a migration flag for the Segment Cache routing
+   * This is an internal migration flag for the Segment Cache routing
    * implementation and is not a stable public configuration contract.
    */
   optimisticRouting?: boolean

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -517,8 +517,30 @@ export interface ExperimentalConfig {
    * Cache Components.
    */
   cachedNavigations?: boolean
+  /**
+   * Allows a Link with `unstable_dynamicOnHover` to upgrade its static
+   * prefetch to include dynamic route content when the user hovers or touches
+   * it.
+   *
+   * @internal This supports experimental Link behavior and is not a stable
+   * public configuration contract.
+   */
   dynamicOnHover?: boolean
+  /**
+   * Enables connectivity detection and automatic retries for failed
+   * navigations, prefetches, and Server Actions. It also enables the
+   * `useOffline` hook from `next/offline`.
+   *
+   * @see https://nextjs.org/docs/app/api-reference/config/next-config-js/useOffline
+   */
   useOffline?: boolean
+  /**
+   * Uses known route patterns to construct an optimistic route tree when a
+   * navigation does not have an exact prefetched route entry.
+   *
+   * @internal This is a migration flag for the Segment Cache routing
+   * implementation and is not a stable public configuration contract.
+   */
   optimisticRouting?: boolean
   instrumentationClientRouterTransitionEvents?: boolean
   varyParams?: boolean


### PR DESCRIPTION
## What?

Add inline API documentation for `experimental.dynamicOnHover`, `experimental.useOffline`, and `experimental.optimisticRouting` in `NextConfig`.

## Why?

These flags are exposed through editor completion but currently have no description, so their scope and stability are easy to misread. `useOffline` is a documented public experiment, while `dynamicOnHover` and `optimisticRouting` are internal migration controls.

## How?

Describe the runtime behavior of each option, link `useOffline` to its API reference, and mark the two implementation flags as internal rather than presenting them as supported public APIs. This changes declarations only; runtime defaults and behavior are unchanged.

## Verification

- `pnpm build-all`
- `pnpm --filter=next build`
- `pnpm types-and-precompiled`
- Targeted Prettier and ESLint
