### PR TITLE
fix: invalidate optimized local barrel cache

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
@@ -90,9 +90,10 @@ import path from 'path'
 import { transform } from '../../swc'
 import { installBindings } from '../../swc/install-bindings'
 
-// This is a in-memory cache for the mapping of barrel exports. This only applies
-// to the packages that we optimize. It will never change (e.g. upgrading packages)
-// during the lifetime of the server so we can safely cache it.
+// This is an in-memory cache for the mapping of barrel exports in installed
+// packages. They will never change (e.g. upgrading packages) during the lifetime
+// of the server so we can safely cache them. Local and workspace packages can
+// change during development and must rely on Webpack's dependency tracking.
 // There is also no need to collect the cache for the same reason.
 const barrelTransformMappingCache = new Map<
   string,
@@ -112,9 +113,10 @@ async function getBarrelMapping(
       path: string,
       callback: (err: any, data: string | Buffer | undefined) => void
     ) => void
-  }
+  },
+  cacheMapping: boolean
 ) {
-  if (barrelTransformMappingCache.has(resourcePath)) {
+  if (cacheMapping && barrelTransformMappingCache.has(resourcePath)) {
     return barrelTransformMappingCache.get(resourcePath)!
   }
 
@@ -239,7 +241,9 @@ async function getBarrelMapping(
   }
 
   const res = await getMatches(resourcePath, false, false)
-  barrelTransformMappingCache.set(resourcePath, res)
+  if (cacheMapping) {
+    barrelTransformMappingCache.set(resourcePath, res)
+  }
 
   return res
 }
@@ -264,19 +268,23 @@ const NextBarrelLoader = async function (
   const resolve = this.getResolve({
     mainFields: ['module', 'main'],
   })
+  const cacheMapping = /[\\/]node_modules[\\/]/.test(this.resourcePath)
 
   const mapping = await getBarrelMapping(
     this.resourcePath,
     swcCacheDir,
     resolve,
-    this.fs
+    this.fs,
+    cacheMapping
   )
 
-  // `resolve` adds all sub-paths to the dependency graph. However, we already
-  // cached the mapping and we assume them to not change. So, we can safely
-  // clear the dependencies here to avoid unnecessary watchers which turned out
-  // to be very expensive.
-  this.clearDependencies()
+  if (cacheMapping) {
+    // `resolve` adds all sub-paths to the dependency graph. However, installed
+    // packages are already cached and assumed not to change. So, we can safely
+    // clear their dependencies to avoid unnecessary watchers which turned out
+    // to be very expensive.
+    this.clearDependencies()
+  }
 
   if (!mapping) {
     // This file isn't a barrel and we can't apply any optimizations. Let's re-export everything.

--- a/test/development/app-dir/optimize-package-imports-local-barrel/app/layout.tsx
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/optimize-package-imports-local-barrel/app/page.tsx
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/app/page.tsx
@@ -1,0 +1,5 @@
+import { Button } from '@/ui'
+
+export default function Page() {
+  return <Button />
+}

--- a/test/development/app-dir/optimize-package-imports-local-barrel/next.config.js
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+nextConfig.experimental = {
+  optimizePackageImports: ['@/ui'],
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/optimize-package-imports-local-barrel/optimize-package-imports-local-barrel.test.ts
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/optimize-package-imports-local-barrel.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('optimize-package-imports-local-barrel', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+  if (skipped) return
+
+  if (!isNextDev) {
+    it('is only applicable in development mode', () => {})
+    return
+  }
+
+  beforeAll(() => next.start())
+
+  it('invalidates an optimized local barrel when its exports change', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#button').text()).toBe('button')
+
+    await next.patchFile(
+      'ui/index.ts',
+      `export { CounterButton as Button } from './CounterButton'\n`
+    )
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#button').text()).toBe('counter')
+    })
+  })
+})

--- a/test/development/app-dir/optimize-package-imports-local-barrel/tsconfig.json
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/test/development/app-dir/optimize-package-imports-local-barrel/ui/Button.tsx
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/ui/Button.tsx
@@ -1,0 +1,3 @@
+export function Button() {
+  return <p id="button">button</p>
+}

--- a/test/development/app-dir/optimize-package-imports-local-barrel/ui/CounterButton.tsx
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/ui/CounterButton.tsx
@@ -1,0 +1,3 @@
+export function CounterButton() {
+  return <p id="button">counter</p>
+}

--- a/test/development/app-dir/optimize-package-imports-local-barrel/ui/index.ts
+++ b/test/development/app-dir/optimize-package-imports-local-barrel/ui/index.ts
@@ -1,0 +1,1 @@
+export { Button } from './Button'

--- a/test/production/app-dir/optimize-package-imports-local-barrel/app/layout.tsx
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/optimize-package-imports-local-barrel/app/page.tsx
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/app/page.tsx
@@ -1,0 +1,5 @@
+import { Button } from '@/ui'
+
+export default function Page() {
+  return <Button />
+}

--- a/test/production/app-dir/optimize-package-imports-local-barrel/next.config.js
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+nextConfig.experimental = {
+  optimizePackageImports: ['@/ui'],
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/optimize-package-imports-local-barrel/optimize-package-imports-local-barrel.test.ts
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/optimize-package-imports-local-barrel.test.ts
@@ -1,0 +1,38 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('optimize-package-imports-local-barrel', () => {
+  const { next, isNextStart, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+  if (skipped) return
+
+  if (!isNextStart) {
+    it('is only applicable in production mode', () => {})
+    return
+  }
+
+  beforeAll(() => next.start())
+
+  it('invalidates an optimized local barrel between builds', async () => {
+    expect(await next.render('/')).toContain('button')
+
+    await next.stop()
+    await next.renameFile('ui/Button.tsx', 'ui/CounterButton.tsx')
+    await next.patchFile(
+      'ui/CounterButton.tsx',
+      `export function Button() {\n  return <p id="button">counter</p>\n}\n`
+    )
+    await next.patchFile(
+      'ui/index.ts',
+      `export { Button } from './CounterButton'\n`
+    )
+
+    const { exitCode, cliOutput } = await next.build()
+    expect(exitCode).toBe(0)
+    expect(cliOutput).not.toContain("Can't resolve './Button'")
+
+    await next.start({ skipBuild: true })
+    expect(await next.render('/')).toContain('counter')
+  })
+})

--- a/test/production/app-dir/optimize-package-imports-local-barrel/tsconfig.json
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/test/production/app-dir/optimize-package-imports-local-barrel/ui/Button.tsx
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/ui/Button.tsx
@@ -1,0 +1,3 @@
+export function Button() {
+  return <p id="button">button</p>
+}

--- a/test/production/app-dir/optimize-package-imports-local-barrel/ui/index.ts
+++ b/test/production/app-dir/optimize-package-imports-local-barrel/ui/index.ts
@@ -1,0 +1,1 @@
+export { Button } from './Button'


### PR DESCRIPTION
### What?

Fixes #65630.

When we used `optimizePackageImports` with a local barrel in our project, changing the barrel left stale exports in both the development server and the next production build.

### Why?

The barrel loader assumes optimized packages do not change during the lifetime of the server. That assumption is valid for installed dependencies, but local and workspace source files can change during development.

As a result, the in-memory mapping cache returned stale exports during development, while clearing Webpack dependencies allowed stale loader results to remain in the persistent build cache.

### How?

This change keeps the existing mapping cache and dependency-clearing optimization for packages inside `node_modules`.

For local and workspace barrels outside `node_modules`, it avoids the global mapping cache and preserves Webpack dependency tracking so changes correctly invalidate both development and production caches.

Regression tests cover:

- Updating a local barrel while the Webpack development server is running
- Renaming an exported module between consecutive Webpack production builds without deleting `.next`
- Existing optimized package behavior for dependencies inside `node_modules`

### Tests

- `pnpm test-dev-webpack test/development/app-dir/optimize-package-imports-local-barrel/optimize-package-imports-local-barrel.test.ts`
- `pnpm test-start-webpack test/production/app-dir/optimize-package-imports-local-barrel/optimize-package-imports-local-barrel.test.ts`
- `pnpm test-dev-webpack test/development/basic/barrel-optimization/barrel-optimization.test.ts`
- `pnpm test-start-webpack test/production/app-dir/barrel-optimization/basic/index.test.ts`
- `pnpm test-types`
- `pnpm --filter=next types`
- `pnpm --filter=next build`