### PR TITLE
test: Add failing `global-not-found` case for dynamic root segments

### DIFF
--- a/test/e2e/app-dir/global-not-found/dynamic-root-segment/app/[locale]/layout.tsx
+++ b/test/e2e/app-dir/global-not-found/dynamic-root-segment/app/[locale]/layout.tsx
@@ -1,0 +1,23 @@
+import { notFound } from 'next/navigation'
+
+const locales = ['en', 'de']
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+
+  if (!locales.includes(locale)) {
+    notFound()
+  }
+
+  return (
+    <html lang={locale}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/dynamic-root-segment/app/[locale]/page.tsx
+++ b/test/e2e/app-dir/global-not-found/dynamic-root-segment/app/[locale]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page">hello</p>
+}

--- a/test/e2e/app-dir/global-not-found/dynamic-root-segment/app/global-not-found.tsx
+++ b/test/e2e/app-dir/global-not-found/dynamic-root-segment/app/global-not-found.tsx
@@ -1,0 +1,10 @@
+export default function GlobalNotFound() {
+  return (
+    // html tag is different from actual page's layout
+    <html data-global-not-found="true">
+      <body>
+        <h1 id="global-error-title">global-not-found</h1>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/dynamic-root-segment/dynamic-root-segment.test.ts
+++ b/test/e2e/app-dir/global-not-found/dynamic-root-segment/dynamic-root-segment.test.ts
@@ -1,0 +1,63 @@
+import { nextTestSetup } from 'e2e-utils'
+import { waitForNoRedbox } from 'next-test-utils'
+
+describe('global-not-found - dynamic-root-segment', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render the page for a matched root param', async () => {
+    const browser = await next.browser('/en')
+    expect(await browser.elementByCss('#page').text()).toBe('hello')
+    expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
+  })
+
+  it('should render global-not-found for an unmatched route', async () => {
+    const browser = await next.browser('/en/does-not-exist')
+    if (isNextDev) {
+      await waitForNoRedbox(browser)
+    }
+
+    const errorTitle = await browser.elementByCss('#global-error-title').text()
+    expect(errorTitle).toBe('global-not-found')
+    const notFoundHtmlProp = await browser
+      .elementByCss('html')
+      .getAttribute('data-global-not-found')
+    expect(notFoundHtmlProp).toBe('true')
+  })
+
+  it('should ssr global-not-found for an unmatched route', async () => {
+    const $ = await next.render$('/en/does-not-exist')
+    const errorTitle = $('#global-error-title').text()
+    expect(errorTitle).toBe('global-not-found')
+    const notFoundHtmlProp = $('html').attr('data-global-not-found')
+    expect(notFoundHtmlProp).toBe('true')
+  })
+
+  it('should render global-not-found when calling notFound() in the root layout', async () => {
+    const browser = await next.browser('/does-not-exist')
+    if (isNextDev) {
+      await waitForNoRedbox(browser)
+    }
+
+    const errorTitle = await browser.elementByCss('#global-error-title').text()
+    expect(errorTitle).toBe('global-not-found')
+    const notFoundHtmlProp = await browser
+      .elementByCss('html')
+      .getAttribute('data-global-not-found')
+    expect(notFoundHtmlProp).toBe('true')
+  })
+
+  it('should ssr global-not-found when calling notFound() in the root layout', async () => {
+    const $ = await next.render$('/does-not-exist')
+    const errorTitle = $('#global-error-title').text()
+    expect(errorTitle).toBe('global-not-found')
+    const notFoundHtmlProp = $('html').attr('data-global-not-found')
+    expect(notFoundHtmlProp).toBe('true')
+  })
+
+  it('should respond with 404 when calling notFound() in the root layout', async () => {
+    const res = await next.fetch('/does-not-exist')
+    expect(res.status).toBe(404)
+  })
+})

--- a/test/e2e/app-dir/global-not-found/dynamic-root-segment/next.config.js
+++ b/test/e2e/app-dir/global-not-found/dynamic-root-segment/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    globalNotFound: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Ref https://github.com/vercel/next.js/issues/86095
Ref https://github.com/vercel/next.js/issues/85446

`global-not-found` is documented as the solution for apps whose root layout is defined with a top-level dynamic segment (e.g. `app/[country]/layout.tsx`), but that case has no e2e coverage: the existing `no-root-layout` fixture uses route groups, not dynamic root segments.

This adds a fixture that mirrors an i18n app (`app/[locale]/layout.tsx` calling `notFound()` for an unknown locale). 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
