### PR TITLE
Allow literal exports in `'use cache'` files

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1908,15 +1908,20 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 let mut has_export_needing_wrapper = false;
 
                                 for decl in &var.decls {
-                                    if let Pat::Ident(_) = &decl.name
+                                    if in_action_file
+                                        && let Pat::Ident(_) = &decl.name
                                         && let Some(init) = &decl.init
                                     {
-                                        // Disallow exporting literals. Admittedly, this is
-                                        // pretty arbitrary. We don't disallow exporting object
-                                        // and array literals, as that would be too restrictive,
-                                        // especially for page and layout files with
-                                        // 'use cache', that may want to export metadata or
-                                        // viewport objects.
+                                        // In a "use server" file every export becomes a server
+                                        // reference, and a runtime check asserts that each one is a
+                                        // function. Reject exported literals at build time instead.
+                                        // Object and array literals stay allowed, as rejecting them
+                                        // would be too restrictive.
+                                        //
+                                        // A "use cache" file wraps only exports that are, or might
+                                        // be, functions. Known non-function values pass through.
+                                        // Page and layout files need this for route segment
+                                        // configs, metadata, and viewport.
                                         if let Expr::Lit(_) = &**init {
                                             disallowed_export_span = *span;
                                         }

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/14/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/14/output.js
@@ -1,0 +1,4 @@
+export default function() {}
+export function foo() {}
+export const bar = ()=>{};
+export const baz = 42;

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/14/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/14/output.stderr
@@ -22,10 +22,3 @@
    :              ^^^
  6 | export const baz = 42
    `----
-  x Only async functions are allowed to be exported in a "use cache" file.
-  | 
-   ,-[input.js:6:1]
- 5 | export const bar = () => {}
- 6 | export const baz = 42
-   : ^^^^^^^^^^^^^^^^^^^^^
-   `----

--- a/crates/next-custom-transforms/tests/fixture/server-actions/client-graph/18/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client-graph/18/input.js
@@ -1,0 +1,13 @@
+'use cache'
+
+// Only the exports that got a reference ID in the server graph become server
+// references here. The statically known non-function values are dropped.
+export const instant = false
+export const dynamicParams = true
+export const prefetch = 'partial'
+export const maxDuration = 5
+export const metadata = { title: 'Hello' }
+
+export default async function Page() {
+  return null
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/client-graph/18/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client-graph/18/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_action_entry_do_not_use__ {"80c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":{"name":"default"}} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
+export default /*#__PURE__*/ createServerReference("80c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", callServer, void 0, findSourceMapURL, "default");

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/input.js
@@ -1,0 +1,14 @@
+'use cache'
+
+// Route segment configs, metadata, and viewport are statically known
+// non-function values. They should be exported as-is, without cache runtime
+// wrappers.
+export const instant = false
+export const dynamicParams = true
+export const prefetch = 'partial'
+export const maxDuration = 5
+export const metadata = { title: 'Hello' }
+
+export default async function Page() {
+  return null
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/output.js
@@ -1,0 +1,24 @@
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":{"name":"$$RSC_SERVER_CACHE_0"}} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+import { cache as $$reactCache__ } from "react";
+// Route segment configs, metadata, and viewport are statically known
+// non-function values. They should be exported as-is, without cache runtime
+// wrappers.
+export const instant = false;
+export const dynamicParams = true;
+export const prefetch = 'partial';
+export const maxDuration = 5;
+export const metadata = {
+    title: 'Hello'
+};
+const $$RSC_SERVER_CACHE_0_INNER = async function Page() {
+    return null;
+};
+export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function Page() {
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
+});
+registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "Page"
+});
+export default $$RSC_SERVER_CACHE_0;

--- a/test/e2e/app-dir/instant-validation/app/shells/(default)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shells/(default)/page.tsx
@@ -24,6 +24,9 @@ export default async function Page() {
           <DebugLinks href="/shells/valid-static-with-gsp/123" />
         </li>
         <li>
+          <DebugLinks href="/shells/valid-use-cache-instant-false" />
+        </li>
+        <li>
           <DebugLinks href="/shells/invalid-runtime-params/123" />
         </li>
         <li>

--- a/test/e2e/app-dir/instant-validation/app/shells/(default)/valid-use-cache-instant-false/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shells/(default)/valid-use-cache-instant-false/layout.tsx
@@ -1,0 +1,10 @@
+'use cache'
+
+// A file-level `"use cache"` directive wraps every exported function in a cache
+// boundary. `instant` is a statically known non-function value, so it stays a
+// plain export and is read as route segment config.
+export const instant = false
+
+export default async function IgnoreStaticShellValidationLayout({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/instant-validation/app/shells/(default)/valid-use-cache-instant-false/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/shells/(default)/valid-use-cache-instant-false/page.tsx
@@ -1,0 +1,28 @@
+import { Instant } from 'next'
+import { cookies } from 'next/headers'
+
+export const instant: Instant = {
+  level: 'experimental-error',
+  unstable_samples: [{ cookies: [] }],
+}
+
+export const prefetch = 'partial'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>
+        This page has an unguarded session data access, which is allowed in a
+        shell but leaves the static shell empty. The parent layout opts out of
+        static shell validation with <code>instant = false</code>, exported from
+        a file with a top-level <code>"use cache"</code> directive.
+      </p>
+      <SessionData />
+    </main>
+  )
+}
+
+async function SessionData() {
+  await cookies()
+  return <div>Session data (cookies)</div>
+}

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -605,6 +605,20 @@ export function registerHeadAndReportingTests(
         }
       })
 
+      it('valid - instant = false in a "use cache" layout opts out of static shell validation', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/shells/valid-use-cache-instant-false'
+          )
+          await expectNoDevValidationErrors(browser, await browser.url())
+        } else {
+          const result = await prerender(
+            '/shells/(default)/valid-use-cache-instant-false'
+          )
+          expectNoBuildValidationErrors(result)
+        }
+      })
+
       it('invalid - unguarded params in a runtime-prefetchable shell', async () => {
         if (isNextDev) {
           const browser = await navigateTo('/shells/invalid-runtime-params/123')


### PR DESCRIPTION
A file-level `'use cache'` directive rejected any export initialized with a literal, so `export const instant = false` in a page or layout failed the build with "Only async functions are allowed to be exported in a `'use cache'` file". Object and array literals were already exempt, which meant that `export const instant = { level: 'warning' }` compiled while `export const instant = false` did not.

The ban was never needed for cache files. `may_need_cache_runtime_wrapper` already groups literals with object and array literals as statically known non-functions that need no cache wrapper, and `'use cache'` files deliberately skip the `ensureServerEntryExports` runtime check that `"use server"` files use to assert that every export is a function. The check now applies only when `in_action_file` is set, so a `"use server"` file keeps failing at build time on an exported literal.

Route segment config is read from the module's runtime exports, in `app-segments.ts` during build and in `instant-config.tsx` at render time, so the export has to survive the transform as a plain value rather than being stripped or wrapped. The Cache Components migration codemod relies on this when it adds `export const instant = false` to page and layout files.

The new transform fixtures `server-graph/73` and `client-graph/18` pin the server and client output for a `'use cache'` module that exports route segment config. The expected stderr for `errors/server-graph/14` loses the error for its `export const baz = 42`, and its `output.js` is no longer empty because the validation pass no longer returns early. A new end-to-end case in `test/e2e/app-dir/instant-validation` puts `export const instant = false` in a layout with a file-level `'use cache'` directive and asserts that the route still opts out of static shell validation.