### PR TITLE
[test] Unflake `use-cache-custom-handler-dev` tests

### DIFF
--- a/test/development/app-dir/use-cache-custom-handler-dev/use-cache-custom-handler-dev.test.ts
+++ b/test/development/app-dir/use-cache-custom-handler-dev/use-cache-custom-handler-dev.test.ts
@@ -10,6 +10,24 @@ describe('use-cache-custom-handler-dev', () => {
     return
   }
 
+  // Reads the rendered cache value over HTTP instead of through the browser. A
+  // dev page reload costs seconds on a CI runner, almost all of it downloading
+  // and evaluating the dev bundle, which keeps a retried read from fitting in
+  // its budget. The value is server-rendered, so a plain request observes the
+  // same cache state for a fraction of the cost.
+  async function readCachedValue(pathname: string): Promise<string> {
+    const $ = await next.render$(pathname)
+    const value = $('#value')
+
+    // Without this the callers, which all assert that the value changed, would
+    // accept the empty string that a missing element yields.
+    if (value.length === 0) {
+      throw new Error(`Found no cached value in the HTML of ${pathname}.`)
+    }
+
+    return value.text()
+  }
+
   it('shows the Cold cache badge on a cold load but not on a warm reload through a slow custom handler', async () => {
     const browser = await next.browser('/cold-badge')
 
@@ -64,11 +82,12 @@ describe('use-cache-custom-handler-dev', () => {
       await browser.elementByCss('#value', { waitUntil: false }).text()
     ).toBe(coldValue)
 
-    // Each warm reload re-executes the cache function and writes through to the
-    // backing, so reloads converge to a fresh value.
+    // Each warm read re-executes the cache function in the background and
+    // writes through to the backing, so reads converge to a fresh value. More
+    // than one read is needed, because the regeneration that the previous one
+    // started has not been written yet.
     await retry(async () => {
-      await browser.refresh()
-      expect(await browser.elementById('value').text()).not.toBe(coldValue)
+      expect(await readCachedValue('/expire-zero')).not.toBe(coldValue)
     })
   })
 
@@ -90,12 +109,13 @@ describe('use-cache-custom-handler-dev', () => {
     await next.fetch('/purge')
 
     // The reconcile can only evict the front entry once it has observed the
-    // backing miss, which happens one read after the purge. So reloads converge
-    // on a freshly generated value instead of serving the purged front copy
-    // forever.
+    // backing miss, so the read that observes it still serves the front copy
+    // one last time. Reads converge on a freshly generated value instead of
+    // serving the purged copy forever. How many reads that takes is not fixed:
+    // the reconcile runs in the background, so a read that lands before it
+    // finishes still gets the front copy.
     await retry(async () => {
-      await browser.refresh()
-      expect(await browser.elementById('value').text()).not.toBe(coldValue)
+      expect(await readCachedValue('/purged')).not.toBe(coldValue)
     })
   })
 })


### PR DESCRIPTION
Two assertions in `use-cache-custom-handler-dev` have been flaky since 2026-07-29. Both retried a full browser reload until the cached value changed, and on a CI runner one of those reloads costs 2.4 to 3.0s, nearly all of it downloading and evaluating the dev bundle. The retried operation was therefore too expensive for the default 3000ms budget to grant a second attempt, so the second attempt that both assertions need never ran. The failures report `waited 2608ms`, `waited 2628ms` and `waited 3037ms`.

The value is server-rendered, so a plain request observes the same cache state. Reading it with `next.render$` brings one attempt down to between 19 and 115ms and lets the default budget stand. It also puts the cost in the right place: the attempts that fail are now the cheap ones, and the only slow read is the 1.25s foreground regeneration that follows a miss in both tiers, which is the attempt that passes. Exhausting the budget now requires the cache to keep serving the old value across several reads spaced 500ms apart, which is the regression these tests exist to catch.

Raising the budget instead would have absorbed the reload cost rather than removed it, and would have hidden a slower convergence. Replacing the retry with an exact number of reads is not an option either. The reconcile that evicts the purged front entry runs in the background and the response does not wait for it: a warm read closes in about 30ms while the backing `get` alone takes 200ms. How many reads the eviction takes therefore depends on timing: a purge landing inside the previous read's reconcile window makes the very first read afterwards regenerate, reads spaced further apart than the reconcile give the documented single stale read followed by a fresh one, and reads issued faster than the reconcile keep getting the front copy.

The flakiness started with #96354, which replaced the try counting in `retry` with a clock. Before that change `retry` granted seven attempts regardless of how long each one took, so a 3s reload was affordable; after it, any attempt over 2500ms consumes the entire budget on its own.

Flakiness metrics: [short-expire test][expire-zero-flakes], [purged test][purged-flakes]

[expire-zero-flakes]: https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22use-cache-custom-handler-dev%20serves%20a%20short-expire%20value%20warm%20through%20a%20custom%20handler%20and%20re-warms%20it%20on%20each%20reload%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1785170650550&end=1786466650550&paused=false
[purged-flakes]: https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22use-cache-custom-handler-dev%20stops%20serving%20a%20front-cached%20entry%20after%20the%20backing%20cache%20is%20purged%20out-of-band%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1785170658875&end=1786466658875&paused=false
