### PR TITLE
[test] Compile the middleware redirect routes up front in dev

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -1031,6 +1031,17 @@ describe('app dir - navigation', () => {
 
   describe('middleware redirect', () => {
     it('should change browser location when router.refresh() gets a redirect response', async () => {
+      if (isNextDev) {
+        // The browser location only changes at the end of a chain of requests:
+        // the page posts to `/api/set-token`, calls `router.refresh()`, and the
+        // refresh gets a middleware redirect to the dashboard. In dev the first
+        // request to each of those routes compiles it on demand, which costs
+        // seconds on a CI runner. Hit them here so the chain below does not pay
+        // for it.
+        await next.fetch('/api/set-token', { method: 'POST' })
+        await next.fetch('/redirect-on-refresh/dashboard')
+      }
+
       const browser = await next.browser('/redirect-on-refresh/auth')
       await retry(async () =>
         expect(await browser.url()).toBe(


### PR DESCRIPTION
The `middleware redirect` test in the app dir navigation suite has been flaky for months. After hydration the fixture posts to `/api/set-token`, calls `router.refresh()`, receives a middleware redirect, and only then does the browser location change. In dev each of those routes is compiled on the first request that reaches it, so the assertion window paid for compilation: on a CI runner the `POST /api/set-token` took about 1.4s and the middleware redirect about 1.1s, while the second occurrence of each of those same requests took 10 to 30ms. With the default 3000ms budget and an attempt as cheap as `browser.url()`, `retry` stops after about 2.5s, which is the `waited 2505ms` that every failure reports, and a chain needing 2.6s of server time never fits.

The redirect itself always works. In the failing runs the `307` and the dashboard `200` are both in the server log; they simply arrive after `retry` has given up, so the assertion is the only thing that misses them.

Hitting the two routes before opening the browser moves that compilation out of the assertion window. The chain after hydration then costs about 50ms instead of 2.6s, so the existing budget is no longer the thing under test and a real slowdown in the redirect would still fail. The warm-up is skipped outside dev, where nothing is compiled on demand, so production and deploy runs are unaffected.

The flakiness predates #96354, which replaced the try counting in `retry` with a clock, but that change made it worse: the old implementation ran a seventh attempt at around 3.0s, which is exactly the window this location change lands in when the runner is slow.

[Flakiness metrics][flakiness-metrics]

[flakiness-metrics]: https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22app%20dir%20-%20navigation%20middleware%20redirect%20should%20change%20browser%20location%20when%20router.refresh%28%29%20gets%20a%20redirect%20response%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22%20%40git.branch%3Acanary&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1785174487274&end=1786470487274&paused=false