### PR TITLE
Forward a build-container pin to deploy-test deployments

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -22,6 +22,15 @@ on:
         description: Override the proxy address to use for the test
         default: ''
         type: string
+      forceBuildInHive:
+        description: Hive ID to force the build onto
+        default: ''
+        type: string
+      buildContainerVersion:
+        description: >-
+          Build container image tag. Requires forceBuildInHive.
+        default: ''
+        type: string
       deployScriptPath:
         description: Custom deploy script path (NEXT_TEST_DEPLOY_SCRIPT_PATH)
         default: ''
@@ -147,6 +156,8 @@ jobs:
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
         NEXT_TEST_VERSION="${{ needs.setup.outputs.next-version }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \
+        VERCEL_FORCE_BUILD_IN_HIVE="${{ github.event.inputs.forceBuildInHive || '' }}" \
+        VERCEL_BUILD_CONTAINER_VERSION="${{ github.event.inputs.buildContainerVersion || '' }}" \
         NEXT_TEST_DEPLOY_SCRIPT_PATH="${{ github.event.inputs.deployScriptPath || '' }}" \
         NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH="${{ github.event.inputs.deployLogsScriptPath || '' }}" \
         NEXT_TEST_CLEANUP_SCRIPT_PATH="${{ github.event.inputs.cleanupScriptPath || '' }}" \
@@ -194,6 +205,8 @@ jobs:
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
         NEXT_TEST_VERSION="${{ needs.setup.outputs.next-version }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \
+        VERCEL_FORCE_BUILD_IN_HIVE="${{ github.event.inputs.forceBuildInHive || '' }}" \
+        VERCEL_BUILD_CONTAINER_VERSION="${{ github.event.inputs.buildContainerVersion || '' }}" \
         NEXT_TEST_DEPLOY_SCRIPT_PATH="${{ github.event.inputs.deployScriptPath || '' }}" \
         NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH="${{ github.event.inputs.deployLogsScriptPath || '' }}" \
         NEXT_TEST_CLEANUP_SCRIPT_PATH="${{ github.event.inputs.cleanupScriptPath || '' }}" \
@@ -241,6 +254,8 @@ jobs:
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
         NEXT_TEST_VERSION="${{ needs.setup.outputs.next-version }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \
+        VERCEL_FORCE_BUILD_IN_HIVE="${{ github.event.inputs.forceBuildInHive || '' }}" \
+        VERCEL_BUILD_CONTAINER_VERSION="${{ github.event.inputs.buildContainerVersion || '' }}" \
         NEXT_TEST_PREVIEW_BUILDS_BASE_URL="${{ vars.PREVIEW_BUILDS_BASE_URL }}" \
         node run-tests.js --timings --require-timings -g ${{ matrix.group }} -c 2 --type e2e
       testTimingsArtifact: 'test-timings'

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -421,6 +421,29 @@ export class NextDeployInstance extends NextInstance {
       `VERCEL_CLI_VERSION=${process.env.VERCEL_CLI_VERSION || 'vercel@latest'}`
     )
 
+    // Route the build to a named hive, and to a specific build-container image.
+    // The dispatcher reads the image version only for a build on a forced hive.
+    // A version without a hive falls back to the default image and reports no
+    // error, so reject that combination here.
+    const forceBuildInHive = process.env.VERCEL_FORCE_BUILD_IN_HIVE
+    const buildContainerVersion = process.env.VERCEL_BUILD_CONTAINER_VERSION
+
+    if (buildContainerVersion && !forceBuildInHive) {
+      throw new Error(
+        'VERCEL_BUILD_CONTAINER_VERSION requires VERCEL_FORCE_BUILD_IN_HIVE to be set to a hive ID.'
+      )
+    }
+
+    if (forceBuildInHive) {
+      additionalEnv.push(`VERCEL_FORCE_BUILD_IN_HIVE=${forceBuildInHive}`)
+    }
+
+    if (buildContainerVersion) {
+      additionalEnv.push(
+        `VERCEL_BUILD_CONTAINER_VERSION=${buildContainerVersion}`
+      )
+    }
+
     // Add experimental feature flags
 
     if (process.env.__NEXT_CACHE_COMPONENTS) {


### PR DESCRIPTION
The Vercel build container resolves which image to run from the `VERCEL_FORCE_BUILD_IN_HIVE` and `VERCEL_BUILD_CONTAINER_VERSION` build environment variables, which is how an unreleased build-container change gets exercised against a real deployment. The deploy-test harness had no way to set them, so testing a build-pipeline change together with a Next.js change meant editing a fixture by hand.

The harness now forwards both variables from its own environment onto `vercel deploy`, the same way it already forwards `VERCEL_CLI_VERSION`, and `test_e2e_deploy_release.yml` exposes them as `forceBuildInHive` and `buildContainerVersion` dispatch inputs. A version without a hive is rejected rather than passed along, because the dispatcher reads the image version only for a build that is forced onto a hive and would otherwise fall back to the default image without reporting anything.