### PR TITLE
Decouple loader tree construction from children ordering

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -406,8 +406,16 @@ impl AppPageLoaderTreeBuilder {
 
         let modules_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);
 
-        // add parallel_routes
-        for (key, parallel_route) in parallel_routes.iter() {
+        // Keep the serialized order stable for compatibility with existing
+        // clients, but don't make the loader tree representation itself depend
+        // on insertion order. Consumers that need the primary route should
+        // select `children` by key.
+        let ordered_parallel_routes = parallel_routes.get_key_value("children").into_iter().chain(
+            parallel_routes
+                .iter()
+                .filter(|(key, _)| key.as_str() != "children"),
+        );
+        for (key, parallel_route) in ordered_parallel_routes {
             write!(self.loader_tree_code, "{key}: ", key = StringifyJs(key))?;
             let next_depth = if key.as_str() == "children" {
                 depth + 1

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1475,14 +1475,6 @@ async fn directory_tree_to_loader_tree_internal(
         );
     }
 
-    if tree.parallel_routes.len() > 1
-        && tree.parallel_routes.keys().next().map(|s| s.as_str()) != Some("children")
-    {
-        // children must go first for next.js to work correctly
-        tree.parallel_routes
-            .move_index(tree.parallel_routes.len() - 1, 0);
-    }
-
     Ok(Some(tree))
 }
 


### PR DESCRIPTION
## Summary

The app loader tree currently mutates Turbopack's parallel route map to ensure `children` is inserted first. This makes the loader tree representation depend on a compatibility ordering that only matters when the tree is emitted as JavaScript.

This keeps the generated loader tree unchanged while moving `children`-first ordering to the Turbopack code generator. The output continues to preserve the rendering order added for head and CSS handling during client navigation, while consumers of the internal tree select `children` by key.

## Verification

- `pnpm build-all`

<!-- NEXT_JS_LLM -->
