### PR TITLE
Turbopack dev: drop stale partial manifests for deleted App Router routes

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.test.ts
+++ b/packages/next/src/server/dev/turbopack-utils.test.ts
@@ -1,0 +1,118 @@
+import { AssetMapper, handleEntrypoints } from './turbopack-utils'
+import { getEntryKey } from '../../shared/lib/turbopack/entry-key'
+import type { TurbopackManifestLoader } from '../../shared/lib/turbopack/manifest-loader'
+
+// Regression test for https://github.com/vercel/next.js/issues/97035
+//
+// When an App Router page is deleted during `next dev --turbopack`,
+// `handleEntrypointsDevCleanup` must drop the deleted route's partial
+// manifest (via `TurbopackManifestLoader.delete`) together with its asset
+// mapping and change subscription. Otherwise the stale app-paths manifest
+// keeps being merged into `app-paths-manifest.json` and can collide with a
+// newly added optional catch-all route of the same specificity, producing a
+// false "same specificity" error and 404s until the dev server is restarted.
+//
+// This file is a regular jest unit test. It is additionally structured so it
+// can run under a bare TypeScript runner (`npx tsx <file>`) to verify the
+// regression without the full monorepo jest setup: when `it` is not defined it
+// executes the scenario directly and exits non-zero on failure.
+
+const STALE_ROUTE = 'app/[locale]/project/page'
+
+async function runScenario(): Promise<string[]> {
+  const staleKey = getEntryKey('app', 'server', STALE_ROUTE)
+
+  const deletedKeys: string[] = []
+  const manifestLoader = {
+    delete: (key: string) => {
+      deletedKeys.push(key)
+    },
+    deleteMiddlewareManifest: () => {},
+    writeManifests: () => {},
+  } as unknown as TurbopackManifestLoader
+
+  // Simulate a previous compile that produced asset paths + a change
+  // subscription for a route that no longer exists in the latest entrypoints.
+  const assetMapper = new AssetMapper()
+  assetMapper.setPathsForKey(staleKey, ['static/chunks/1.js'])
+  const changeSubscriptions = new Map([[staleKey, () => {}]])
+
+  await handleEntrypoints({
+    entrypoints: {
+      routes: new Map(),
+      pagesAppEndpoint: undefined,
+      pagesDocumentEndpoint: undefined,
+      pagesErrorEndpoint: undefined,
+      instrumentation: null,
+      middleware: null,
+    } as any,
+    currentEntrypoints: {
+      app: new Map(),
+      page: new Map(),
+      global: {
+        app: undefined,
+        document: undefined,
+        error: undefined,
+        middleware: undefined,
+        instrumentation: undefined,
+      },
+    } as any,
+    currentEntryIssues: new Map(),
+    manifestLoader,
+    devRewrites: undefined,
+    productionRewrites: undefined,
+    logErrors: false,
+    // The dev hooks harness is intentionally minimal; only the parts exercised
+    // by the cleanup path (unsubscribeFromChanges) are ever invoked here.
+    dev: {
+      assetMapper,
+      changeSubscriptions,
+      clients: [],
+      clientStates: new Map(),
+      serverFields: {},
+      hooks: {
+        handleWrittenEndpoint: () => {},
+        propagateServerField: async () => {},
+        sendHmr: () => {},
+        startBuilding: () => {},
+        subscribeToChanges: () => {},
+        unsubscribeFromChanges: async () => {},
+        unsubscribeFromHmrEvents: () => {},
+      },
+    } as any,
+  })
+
+  return deletedKeys
+}
+
+function assertStaleManifestDeleted(deletedKeys: string[], staleKey: string) {
+  if (!deletedKeys.includes(staleKey)) {
+    throw new Error(
+      `expected handleEntrypointsDevCleanup to call ` +
+        `manifestLoader.delete(${staleKey}) for the deleted route; ` +
+        `got ${JSON.stringify(deletedKeys)}`
+    )
+  }
+}
+
+if (typeof it === 'function') {
+  it('drops the deleted route partial manifest from the manifest loader', async () => {
+    const staleKey = getEntryKey('app', 'server', STALE_ROUTE)
+    assertStaleManifestDeleted(await runScenario(), staleKey)
+  })
+} else {
+  // Standalone run (used by the regression harness):
+  //   npx tsx packages/next/src/server/dev/turbopack-utils.test.ts
+  runScenario()
+    .then((deletedKeys) => {
+      assertStaleManifestDeleted(
+        deletedKeys,
+        getEntryKey('app', 'server', STALE_ROUTE)
+      )
+      console.log('PASS: deleted route partial manifest is dropped')
+    })
+    .catch((error) => {
+      console.error('FAIL:', (error as Error).message)
+      process.exit(1)
+    })
+}

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -680,6 +680,7 @@ export async function handleEntrypoints({
     await handleEntrypointsDevCleanup({
       currentEntryIssues,
       currentEntrypoints,
+      manifestLoader,
 
       ...dev,
     })
@@ -844,6 +845,7 @@ export async function handleEntrypoints({
 async function handleEntrypointsDevCleanup({
   currentEntryIssues,
   currentEntrypoints,
+  manifestLoader,
 
   assetMapper,
   changeSubscriptions,
@@ -854,11 +856,17 @@ async function handleEntrypointsDevCleanup({
 }: {
   currentEntrypoints: Entrypoints
   currentEntryIssues: EntryIssuesMap
+  manifestLoader: TurbopackManifestLoader
 } & HandleEntrypointsDevOpts) {
   // this needs to be first as `hasEntrypointForKey` uses the `assetMapper`
   for (const key of assetMapper.keys()) {
     if (!hasEntrypointForKey(currentEntrypoints, key, assetMapper)) {
       assetMapper.delete(key)
+      // Drop the stale partial manifest from the manifest loader as well.
+      // Otherwise a deleted route's partial manifest (e.g. app-paths) keeps
+      // being merged into the on-disk manifest and can collide with a newly
+      // added route of the same specificity until the dev server restarts.
+      manifestLoader.delete(key)
     }
   }
 


### PR DESCRIPTION
### What

When an App Router page is deleted during `next dev --turbopack`, `handleEntrypointsDevCleanup` removes the stale asset mapping, change subscription and issue entries, but never removes the deleted route's partial manifest from `TurbopackManifestLoader`.

`TurbopackManifestLoader` already exposes `delete(key)` (it removes the key from `appPathsManifests` and the other partial manifest maps), so this change threads `manifestLoader` into `handleEntrypointsDevCleanup` and calls `manifestLoader.delete(key)` alongside `assetMapper.delete(key)` for every stale key.

### Why

Without it, a deleted route's `app-paths-manifest.json` partial keeps being merged into the on-disk manifest. In the reproduction from #97035, deleting `app/[locale]/project/page.js` and `app/[locale]/project/[projectId]/home/page.js`, then adding `app/[locale]/project/[[...slug]]/page.js`, left the deleted routes in `.next/dev/server/app-paths-manifest.json`. The new optional catch-all then collided with the stale `/[locale]/project/page` entry and produced a false "You cannot define a route with the same specificity as a optional catch-all route" error and 404s until the dev server was restarted.

### How it was verified

Added a unit test at `packages/next/src/server/dev/turbopack-utils.test.ts` that drives `handleEntrypoints` with a previously-compiled route that is no longer present in the latest entrypoints, then asserts `manifestLoader.delete` is invoked for the deleted route's key. The test fails against `canary` without the fix and passes with it. The test is a regular jest unit test and is additionally structured to run standalone via `npx tsx <file>` for a quick check without the full monorepo jest setup.

Fixes #97035