### PR TITLE
docs: clarify when router events are emitted

### DIFF
--- a/docs/02-pages/04-api-reference/03-functions/use-router.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/use-router.mdx
@@ -364,15 +364,18 @@ export default function Page() {
 
 You can listen to different events happening inside the Next.js Router. Here's a list of supported events:
 
-- `routeChangeStart(url, { shallow })` - Fires when a route starts to change
-- `routeChangeComplete(url, { shallow })` - Fires when a route changed completely
+- `routeChangeStart(url, { shallow })` - Fires when a client-side route transition starts
+- `routeChangeComplete(url, { shallow })` - Fires when a client-side route transition completes
 - `routeChangeError(err, url, { shallow })` - Fires when there's an error when changing routes, or a route load is cancelled
   - `err.cancelled` - Indicates if the navigation was cancelled
 - `beforeHistoryChange(url, { shallow })` - Fires before changing the browser's history
 - `hashChangeStart(url, { shallow })` - Fires when the hash will change but not the page
 - `hashChangeComplete(url, { shallow })` - Fires when the hash has changed but not the page
 
-> **Good to know**: Here `url` is the URL shown in the browser, including the [`basePath`](/docs/app/api-reference/config/next-config-js/basePath).
+> **Good to know**:
+>
+> - Here `url` is the URL shown in the browser, including the [`basePath`](/docs/app/api-reference/config/next-config-js/basePath).
+> - `routeChangeStart` and `routeChangeComplete` do not fire for initial page loads or query updates during hydration because neither is a client-side route transition.
 
 For example, to listen to the router event `routeChangeStart`, open or create `pages/_app.js` and subscribe to the event, like so:
 


### PR DESCRIPTION
### What?

Clarify the behavior of `routeChangeStart` and `routeChangeComplete` in the Pages Router documentation.

The `router.events` section now notes that these events do not fire on initial page loads or for query updates during hydration, since neither is a client-side route transition.

### Why?

#11639 reported inconsistent `routeChangeComplete` behavior during initial page loads and raised uncertainty about what the expected behavior should be.

The router behavior has since changed. In particular, #37815 prevents route change events from being emitted for hydration-related query updates because they can otherwise be false signals of a route transition.

I also verified the current behavior on both the latest stable release and canary:

- Direct load of `/?id=1`: `routeChangeComplete` does not fire
- Direct load of `/posts/1`: `routeChangeComplete` does not fire
- Client-side navigation with `<Link>`: `routeChangeComplete` fires as expected

However, the current `useRouter` documentation does not explicitly describe this distinction.

### How?

Expand the existing `Good to know` note in the `router.events` section to clarify the difference between initial page loads, hydration-related query updates, and client-side route transitions.

Related to #11639.
See also #37815.