### PR TITLE
Centralize per-segment vary-params accumulator in a segment store

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -39,10 +39,10 @@ import {
 } from './work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
-  createVaryParamsAccumulator,
   emptyVaryParamsAccumulator,
   type VaryParamsAccumulator,
 } from './vary-params'
+import { getSegmentVaryParamsAccumulator } from './segment-store'
 import type {
   UseCacheLayoutProps,
   UseCachePageProps,
@@ -810,12 +810,12 @@ async function createComponentTreeInternal(
   const Component = MaybeComponent
   const isClientComponent = isClientReference(layoutOrPageMod)
 
-  const varyParamsAccumulator =
+  const varyParamsAccumulator: VaryParamsAccumulator | null =
     isClientComponent && cacheComponents
       ? // Client components with Cache Components enabled don't receive params
         // from the server, so they have an empty vary params set.
         emptyVaryParamsAccumulator
-      : createVaryParamsAccumulator()
+      : getSegmentVaryParamsAccumulator(workUnitStore, tree)
 
   if (
     process.env.NODE_ENV === 'development' &&

--- a/packages/next/src/server/app-render/segment-store.ts
+++ b/packages/next/src/server/app-render/segment-store.ts
@@ -1,0 +1,66 @@
+import {
+  createVaryParamsAccumulator,
+  type VaryParamsAccumulator,
+} from './vary-params'
+import type { WorkUnitStore } from './work-unit-async-storage.external'
+
+/**
+ * Per-segment state for a single work unit, keyed by an object that is
+ * stable and unique per segment: its loader tree node.
+ *
+ * Everything in here is response-scoped: the map of segment stores hangs off
+ * the work unit store, so no field can outlive a single render pass.
+ *
+ * Fields are owned by their respective domains and accessed through the
+ * helpers below; they start `null` and are populated lazily on first use.
+ * This module only provides the record and its per-(work unit, segment)
+ * identity.
+ */
+export type SegmentStore = {
+  /**
+   * The segment's vary-params accumulator: tracks which params the segment
+   * accessed during a prerender, for the segment's transport node. `null`
+   * until first requested, and stays `null` when the current render doesn't
+   * track vary params.
+   */
+  varyParamsAccumulator: VaryParamsAccumulator | null
+}
+
+export function getSegmentStore(
+  workUnitStore: WorkUnitStore,
+  segment: object
+): SegmentStore {
+  const segmentStores = (workUnitStore.segmentStore ??= new WeakMap())
+  let segmentStore = segmentStores.get(segment)
+  if (segmentStore === undefined) {
+    segmentStore = { varyParamsAccumulator: null }
+    segmentStores.set(segment, segmentStore)
+  }
+  return segmentStore
+}
+
+/**
+ * The single source of truth for a segment's vary-params accumulator. Created
+ * lazily on first access and stored on the segment, so every consumer that
+ * tracks the segment's param access shares the one accumulator that ends up
+ * embedded in the segment's transport node. Returns `null` when the current
+ * render doesn't track vary params.
+ *
+ * `segment` is the segment's stable key (see `SegmentStore`): its loader tree
+ * node.
+ */
+export function getSegmentVaryParamsAccumulator(
+  workUnitStore: WorkUnitStore,
+  segment: object
+): VaryParamsAccumulator | null {
+  const segmentStore = getSegmentStore(workUnitStore, segment)
+  if (segmentStore.varyParamsAccumulator === null) {
+    // `createVaryParamsAccumulator` returns `null` when the ambient render
+    // isn't tracking vary params. Caching a non-null accumulator keeps it a
+    // single create-once (and a single registration into the response
+    // accumulator); the `null` case has no side effect, so re-running it on a
+    // later access is harmless.
+    segmentStore.varyParamsAccumulator = createVaryParamsAccumulator()
+  }
+  return segmentStore.varyParamsAccumulator
+}

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -4,6 +4,7 @@ import type { ResponseCookies } from '../web/spec-extension/cookies'
 import type { ReadonlyHeaders } from '../web/spec-extension/adapters/headers'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
 import type { CacheSignal } from './cache-signal'
+import type { SegmentStore } from './segment-store'
 import type { ResponseVaryParamsAccumulator } from './vary-params'
 import type { DynamicTrackingState } from './dynamic-rendering'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
@@ -26,6 +27,14 @@ export interface CommonWorkUnitStore {
   /** NOTE: Will be mutated as phases change */
   phase: WorkUnitPhase
   readonly implicitTags: ImplicitTags
+
+  /**
+   * Per-segment state for this work unit, keyed by a stable per-segment
+   * object (see `SegmentStore`). Lives on the work unit store because its
+   * contents (e.g. vary-params accumulators) are response-scoped and must
+   * not outlive a single render pass.
+   */
+  segmentStore?: WeakMap<object, SegmentStore>
 }
 
 export interface RequestStore extends CommonWorkUnitStore {


### PR DESCRIPTION
Pure refactor, no behavior change.

The per-segment vary-params accumulator was created inline in `create-component-tree`. This moves it behind a lazy accessor (`getSegmentVaryParamsAccumulator`) on a new per-segment store that hangs off the work unit store, keyed by the segment's loader tree node.

This gives per-segment state a single home (the `SegmentStore` record) so that any consumer that needs to track a segment's param access resolves to the same accumulator instance — the one embedded in the segment's transport node. Later in this stack, a page's `searchParams` reference becomes a second consumer that must rendezvous on that same accumulator without holding the loader tree node.

The store is response-scoped by construction: the WeakMap lives on the work unit store, so nothing can outlive a single render pass.