### PR TITLE
Move raw search params onto the work unit store

### DIFF
--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -35,6 +35,7 @@ import { isPlainObject } from '../../shared/lib/is-plain-object'
 import {
   type GenerateStaticParamsStore,
   workUnitAsyncStorage,
+  EMPTY_SEARCH_PARAMS,
 } from '../../server/app-render/work-unit-async-storage.external'
 import type { ImplicitTags } from '../../server/lib/implicit-tags'
 import { getImplicitTags } from '../../server/lib/implicit-tags'
@@ -626,6 +627,7 @@ async function callGenerateStaticParams(
 
   const workUnitStore: GenerateStaticParamsStore = {
     type: 'generate-static-params',
+    searchParams: EMPTY_SEARCH_PARAMS,
     phase: 'render',
     implicitTags,
     rootParams,

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -2,7 +2,6 @@ import React, { Suspense, cache } from 'react'
 import type { ParsedUrlQuery } from 'querystring'
 import type { Params } from '../../server/request/params'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
-import type { SearchParams } from '../../server/request/search-params'
 import {
   type MetadataErrorType,
   resolveMetadata,
@@ -35,7 +34,6 @@ import { IconMark } from './generate/icon-mark'
 export function createMetadataComponents({
   tree,
   pathname,
-  parsedQuery,
   metadataContext,
   interpolatedParams,
   errorType,
@@ -43,7 +41,6 @@ export function createMetadataComponents({
 }: {
   tree: LoaderTree
   pathname: string
-  parsedQuery: SearchParams
   metadataContext: MetadataContext
   interpolatedParams: Params
   errorType?: MetadataErrorType | 'redirect'
@@ -53,7 +50,9 @@ export function createMetadataComponents({
   Metadata: React.ComponentType
   MetadataOutlet: React.ComponentType
 } {
-  const searchParams = createServerSearchParamsForMetadata(parsedQuery)
+  // Search params are read from the ambient work unit store (the request's
+  // parsed query), so there's nothing to thread in here.
+  const searchParams = createServerSearchParamsForMetadata()
   const pathnameForMetadata = createServerPathnameForMetadata(pathname)
 
   async function Viewport() {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -246,6 +246,7 @@ import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import {
   getHmrRefreshHash,
   workUnitAsyncStorage,
+  EMPTY_SEARCH_PARAMS,
   type PrerenderStore,
 } from './work-unit-async-storage.external'
 import { consoleAsyncStorage } from './console-async-storage.external'
@@ -724,7 +725,6 @@ async function generateDynamicRSCPayload(
 
     const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
       tree: loaderTree,
-      parsedQuery: query,
       pathname: url.pathname,
       metadataContext: createMetadataContext(ctx.renderOpts),
       interpolatedParams: ctx.interpolatedParams,
@@ -1689,6 +1689,10 @@ async function prospectiveRuntimeServerPrerender(
     phase: 'render',
     rootParams,
     implicitTags,
+    // A runtime prerender serves a concrete request URL, so its search params
+    // are the render's already-parsed query — the same source the by-value
+    // prop reads (see `CommonWorkUnitStore.searchParams`).
+    searchParams: ctx.query,
     renderSignal: initialServerRenderController.signal,
     controller: initialServerPrerenderController,
     // During the initial prerender we need to track all cache reads to ensure
@@ -1717,6 +1721,7 @@ async function prospectiveRuntimeServerPrerender(
     headers: HeadersAdapter.fresh(headers),
     cookies: RequestCookiesAdapter.fresh(cookies),
     draftMode,
+    url: ctx.url,
   }
 
   const { clientModules } = getClientReferenceManifest()
@@ -1873,6 +1878,9 @@ async function finalRuntimeServerPrerender(
     phase: 'render',
     rootParams,
     implicitTags,
+    // See `initialServerPrerenderStore` above: the runtime prerender's search
+    // params are the render's already-parsed query.
+    searchParams: ctx.query,
     renderSignal: finalServerController.signal,
     controller: finalServerController,
     // All caches we could read must already be filled so no tracking is necessary
@@ -1894,6 +1902,7 @@ async function finalRuntimeServerPrerender(
     headers: HeadersAdapter.fresh(headers),
     cookies: RequestCookiesAdapter.fresh(cookies),
     draftMode,
+    url: ctx.url,
   }
 
   trackStaleTime(finalServerPrerenderStore, staleTimeIterable, selectStaleTime)
@@ -2154,7 +2163,6 @@ async function getRSCPayload(
     // metadata from the not-found.js boundary.
     // TODO: remove this condition and keep it undefined when global-not-found is stabilized.
     errorType: is404 && !hasGlobalNotFound ? 'not-found' : undefined,
-    parsedQuery: query,
     pathname: url.pathname,
     metadataContext: createMetadataContext(ctx.renderOpts),
     interpolatedParams: ctx.interpolatedParams,
@@ -2297,7 +2305,6 @@ async function getErrorRSCPayload(
     const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
     const metadataComponents = createMetadataComponents({
       tree,
-      parsedQuery: query,
       pathname: url.pathname,
       metadataContext: createMetadataContext(ctx.renderOpts),
       errorType,
@@ -6948,6 +6955,7 @@ async function warmupClientModulesForStagedValidation(
   if (storeType === 'prerender-client') {
     const store: PrerenderStoreModernClient = {
       type: 'prerender-client',
+      searchParams: EMPTY_SEARCH_PARAMS,
       phase: 'render',
       rootParams,
       fallbackRouteParams,
@@ -6972,6 +6980,7 @@ async function warmupClientModulesForStagedValidation(
   } else {
     const store: ValidationStoreClient = {
       type: 'validation-client',
+      searchParams: EMPTY_SEARCH_PARAMS,
       phase: 'render',
       rootParams,
       implicitTags,
@@ -7126,6 +7135,7 @@ async function validateStagedShell(
 
   const finalClientPrerenderStore: PrerenderStore = {
     type: 'prerender-client',
+    searchParams: EMPTY_SEARCH_PARAMS,
     phase: 'render',
     rootParams,
     fallbackRouteParams,
@@ -7412,6 +7422,7 @@ async function validateInstantConfigs(
 
     const prerenderStore: PrerenderStore = {
       type: 'validation-client',
+      searchParams: EMPTY_SEARCH_PARAMS,
       phase: 'render',
       rootParams,
       implicitTags,
@@ -8225,6 +8236,8 @@ async function validateInstantConfigInBuildWithSample(
           pathname: sampleUrl.pathname,
           search: sampleUrl.search,
         },
+        // The parsed query for this validation sample's URL.
+        searchParams: sampleQuery,
         headers: sampleHeaders,
         cookies: sampleCookies,
         mutableCookies: unusedMutableCookies,
@@ -8679,6 +8692,7 @@ async function prerenderToStream(
 
       const initialServerPayloadPrerenderStore: PrerenderStore = {
         type: 'prerender',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         fallbackRouteParams,
@@ -8721,6 +8735,7 @@ async function prerenderToStream(
 
       const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
         type: 'prerender',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         fallbackRouteParams,
@@ -8847,6 +8862,7 @@ async function prerenderToStream(
 
         const initialClientPrerenderStore: PrerenderStore = {
           type: 'prerender-client',
+          searchParams: EMPTY_SEARCH_PARAMS,
           phase: 'render',
           rootParams,
           fallbackRouteParams,
@@ -8990,6 +9006,7 @@ async function prerenderToStream(
 
       const finalServerPayloadPrerenderStore: PrerenderStoreModernServer = {
         type: 'prerender',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         fallbackRouteParams,
@@ -9053,6 +9070,7 @@ async function prerenderToStream(
 
       const finalServerPrerenderStore: PrerenderStore = (prerenderStore = {
         type: 'prerender',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         fallbackRouteParams,
@@ -9291,6 +9309,7 @@ async function prerenderToStream(
 
       const finalClientPrerenderStore: PrerenderStore = {
         type: 'prerender-client',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         fallbackRouteParams,
@@ -9519,6 +9538,7 @@ async function prerenderToStream(
     } else {
       const prerenderLegacyStore: PrerenderStore = (prerenderStore = {
         type: 'prerender-legacy',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         implicitTags,
@@ -9740,6 +9760,7 @@ async function prerenderToStream(
       )
       const errorPrerenderStore: PrerenderStore = {
         type: 'prerender',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         rootParams,
         fallbackRouteParams,
@@ -9835,6 +9856,7 @@ async function prerenderToStream(
         const errorDynamicValidation = createDynamicValidationState()
         const errorClientPrerenderStore: PrerenderStore = {
           type: 'prerender-client',
+          searchParams: EMPTY_SEARCH_PARAMS,
           phase: 'render',
           rootParams,
           fallbackRouteParams,
@@ -10057,6 +10079,7 @@ async function prerenderToStream(
 
     const prerenderLegacyStore: PrerenderStore = {
       type: 'prerender-legacy',
+      searchParams: EMPTY_SEARCH_PARAMS,
       phase: 'render',
       rootParams,
       implicitTags: implicitTags,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -872,9 +872,9 @@ async function createComponentTreeInternal(
 
       // If we are passing searchParams to a server component Page we need to
       // track their usage in case the current render mode tracks dynamic API
-      // usage.
-      let searchParams = createServerSearchParamsForServerPage(
-        query,
+      // usage. The raw values are read from the ambient work unit store; the
+      // segment contributes only its vary-params accumulator.
+      const searchParams = createServerSearchParamsForServerPage(
         varyParamsAccumulator
       )
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -14,6 +14,7 @@ import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type { ResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
+import type { SearchParams } from '../request/search-params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -35,7 +36,24 @@ export interface CommonWorkUnitStore {
    * not outlive a single render pass.
    */
   segmentStore?: WeakMap<object, SegmentStore>
+
+  /**
+   * The raw search params for this work unit — the single source of truth
+   * that the search params machinery reads. Set by whoever creates the store:
+   * the parsed, internal-query-stripped query for stores that carry a request
+   * URL (`request`, `prerender-runtime`), and `EMPTY_SEARCH_PARAMS` for
+   * scopes without one (static prerenders, caches, `generateStaticParams`,
+   * ...), where the values are never observable anyway.
+   */
+  searchParams: SearchParams
 }
+
+/**
+ * The `searchParams` a work unit store carries when its scope has no request
+ * URL. Shared because it's never observed (the machinery hangs, postpones, or
+ * errors for those scopes rather than reading the values) and never mutated.
+ */
+export const EMPTY_SEARCH_PARAMS: SearchParams = {}
 
 export interface RequestStore extends CommonWorkUnitStore {
   readonly type: 'request'
@@ -240,6 +258,14 @@ export interface PrerenderStoreModernRuntime
   readonly headers: RequestStore['headers']
   readonly cookies: RequestStore['cookies']
   readonly draftMode: RequestStore['draftMode']
+
+  /**
+   * The URL of the runtime prefetch request this prerender is serving. Unlike
+   * a static prerender, a runtime prerender has a concrete request URL, so
+   * request data derived from it — notably `searchParams` — resolves to real
+   * values here.
+   */
+  readonly url: RequestStore['url']
 }
 
 export interface RevalidateStore {

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -27,8 +27,11 @@ import { splitCookiesString } from '../web/utils'
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type { ResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
+import type { SearchParams } from '../request/search-params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
+import { searchParamsToUrlQuery } from '../../shared/lib/router/utils/querystring'
+import { stripInternalQueries } from '../internal-utils'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   // `HeadersAdapter.from` wraps `IncomingHttpHeaders` (and returns a `Headers`
@@ -259,6 +262,7 @@ export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
     mutableCookies?: ResponseCookies
     userspaceMutableCookies?: ResponseCookies
     draftMode?: DraftModeProvider
+    searchParams?: SearchParams
   } = {}
 
   return {
@@ -270,6 +274,19 @@ export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
     // lets us avoid requiring an empty string for `search` in the type.
     url: { pathname: url.pathname, search: url.search ?? '' },
     rootParams,
+    get searchParams() {
+      if (!cache.searchParams) {
+        // Parse lazily so request stores that never render a page (e.g. API
+        // routes) don't pay for it. Mirrors the parse the render pipeline does
+        // for the by-value query, so the by-reference and by-value paths agree.
+        const parsed = searchParamsToUrlQuery(
+          new URLSearchParams(url.search ?? '')
+        ) as SearchParams
+        stripInternalQueries(parsed)
+        cache.searchParams = parsed
+      }
+      return cache.searchParams
+    },
     get headers() {
       if (!cache.headers) {
         // Seal the headers object that'll freeze out any methods that could

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -98,18 +98,23 @@ export function createSearchParamsFromClient(
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
-export function createServerSearchParamsForMetadata(
-  underlyingSearchParams: SearchParams
-): Promise<SearchParams> {
-  const metadataVaryParamsAccumulator = getMetadataVaryParamsAccumulator()
+export function createServerSearchParamsForMetadata(): Promise<SearchParams> {
   return createServerSearchParamsForServerPage(
-    underlyingSearchParams,
-    metadataVaryParamsAccumulator
+    getMetadataVaryParamsAccumulator()
   )
 }
 
+/**
+ * Resolves the ambient scope's `searchParams` into the promise a server page
+ * (or `generateMetadata`) receives. The raw values are read from the work unit
+ * store (`workUnitStore.searchParams` — the single source of truth), so the
+ * caller supplies only the vary-params accumulator to record access into (the
+ * segment's, or metadata's head accumulator). What a read means is decided per
+ * scope: real values in a request render or runtime prerender; and hang /
+ * postpone / interrupt / error in the scopes where the values are never
+ * observable.
+ */
 export function createServerSearchParamsForServerPage(
-  underlyingSearchParams: SearchParams,
   varyParamsAccumulator: VaryParamsAccumulator | null
 ): Promise<SearchParams> {
   const workStore = workAsyncStorage.getStore()
@@ -139,14 +144,14 @@ export function createServerSearchParamsForServerPage(
         )
       case 'prerender-runtime':
         return createRuntimePrerenderSearchParams(
-          underlyingSearchParams,
+          workUnitStore.searchParams,
           workStore,
           workUnitStore,
           varyParamsAccumulator
         )
       case 'request':
         return createRenderSearchParams(
-          underlyingSearchParams,
+          workUnitStore.searchParams,
           workStore,
           workUnitStore
         )

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -46,6 +46,7 @@ import {
 } from '../../app-render/work-async-storage.external'
 import {
   workUnitAsyncStorage,
+  EMPTY_SEARCH_PARAMS,
   type RequestStore,
   type PrerenderStore,
 } from '../../app-render/work-unit-async-storage.external'
@@ -559,6 +560,7 @@ export class AppRouteRouteModule extends RouteModule<
         const prospectiveRoutePrerenderStore: PrerenderStore = (prerenderStore =
           {
             type: 'prerender',
+            searchParams: EMPTY_SEARCH_PARAMS,
             phase: 'action',
             // This replicates prior behavior where rootParams is empty in routes
             // TODO we need to make this have the proper rootParams for this route
@@ -662,6 +664,7 @@ export class AppRouteRouteModule extends RouteModule<
 
         const finalRoutePrerenderStore: PrerenderStore = (prerenderStore = {
           type: 'prerender',
+          searchParams: EMPTY_SEARCH_PARAMS,
           phase: 'action',
           rootParams: {},
           fallbackRouteParams: null,
@@ -749,6 +752,7 @@ export class AppRouteRouteModule extends RouteModule<
       } else {
         prerenderStore = {
           type: 'prerender-legacy',
+          searchParams: EMPTY_SEARCH_PARAMS,
           phase: 'action',
           rootParams: {},
           implicitTags,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -30,6 +30,7 @@ import {
   getHmrRefreshHash,
   getResumeDataCache,
   workUnitAsyncStorage,
+  EMPTY_SEARCH_PARAMS,
   getDraftModeProviderForCacheScope,
   getCacheSignal,
   isHmrRefresh,
@@ -761,6 +762,7 @@ function createUseCacheStore(
 
     return {
       type: 'private-cache',
+      searchParams: EMPTY_SEARCH_PARAMS,
       phase: 'render',
       consumerWillServerCache: true,
       implicitTags: outerWorkUnitStore?.implicitTags,
@@ -810,6 +812,7 @@ function createUseCacheStore(
 
     return {
       type: 'cache',
+      searchParams: EMPTY_SEARCH_PARAMS,
       phase: 'render',
       consumerWillServerCache: true,
       implicitTags: outerWorkUnitStore.implicitTags,

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -12,6 +12,7 @@ import {
   getDraftModeProviderForCacheScope,
   willConsumerServerCache,
   workUnitAsyncStorage,
+  EMPTY_SEARCH_PARAMS,
 } from '../../app-render/work-unit-async-storage.external'
 import {
   CachedRouteKind,
@@ -160,6 +161,7 @@ export function unstable_cache<T extends Callback>(
 
       const innerCacheStore: UnstableCacheStore = {
         type: 'unstable-cache',
+        searchParams: EMPTY_SEARCH_PARAMS,
         phase: 'render',
         consumerWillServerCache: true,
         implicitTags,


### PR DESCRIPTION
Pure refactor, no behavior change.

Each work unit store now carries its own raw `searchParams` as the single source of truth:

- `request`: a lazy getter that parses the request URL's query and strips internal queries, mirroring the existing `headers`/`cookies` getters (lazy so request stores that never render a page don't pay for it).
- `prerender-runtime`: the parsed query of the runtime prefetch request. The store also gains the request `url` — unlike a static prerender, a runtime prerender has a concrete request URL, so request data derived from it resolves to real values.
- All other scopes (static prerenders, caches, `generateStaticParams`): a shared `EMPTY_SEARCH_PARAMS`, which is never observed — the search params machinery hangs, postpones, or errors for those scopes rather than reading the values.

`createServerSearchParamsForServerPage` (and the metadata variant) read the store instead of taking the query threaded in by the caller, so the `parsedQuery` prop threading through `createMetadataComponents` goes away.

Behavior-neutral because `store.searchParams` equals the previously threaded query in the request/runtime scopes and is ignored in all others.

Motivation (see the rest of the stack): once `searchParams` is delivered as a stable reference object that resolves against whichever request observes it, the raw values must be readable from the ambient store — there is no caller left to thread them in.