### PR TITLE
Deliver a page's searchParams as a stable per-segment reference object

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1467,5 +1467,6 @@
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1468": "Missing workUnitStore in createComponentTree",
-  "1469": "The payload's transport tree is missing a slot that exists in the loader tree: %s"
+  "1469": "The payload's transport tree is missing a slot that exists in the loader tree: %s",
+  "1470": "A server params reference can only be read within the scope of a request."
 }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -120,6 +120,19 @@ export type AppDirModules = {
   readonly metadata?: CollectedMetadata
 } & {
   readonly defaultPage?: ModuleTuple
+} & {
+  /**
+   * The page segment's `searchParams` (Turbopack-only): a promise-like object
+   * exported by the generated page entry that resolves to the current
+   * request's search params. Always emitted; under the experimental React
+   * channel (when this mechanism is enabled) it's additionally registered as
+   * a Server Object Reference so it serializes to clients by reference. The
+   * tree literal references the entry's own export directly, so this is the
+   * value itself rather than a module getter.
+   */
+  readonly searchParams?: PromiseLike<{
+    [key: string]: string | string[] | undefined
+  }>
 }
 
 const normalizeParallelKey = (key: string) =>

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/server-object-reference.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/server-object-reference.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
+// Only available in the experimental React channel
+// (`enableFlightObjectReferences`). Callers must be gated on
+// `process.env.__NEXT_EXPERIMENTAL_REACT` — on other channels this export
+// resolves to `undefined`.
+export { registerServerObjectReference } from 'react-server-dom-webpack/server'

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -23,6 +23,7 @@ import { getLayoutOrPageModule } from '../lib/app-dir-module'
 import type { LoaderTree } from '../lib/app-dir-module'
 import { interopDefault } from './interop-default'
 import { parseLoaderTree } from '../../shared/lib/router/utils/parse-loader-tree'
+import type { SearchParams } from '../request/search-params'
 import type { AppRenderContext, GetDynamicParamFromSegment } from './app-render'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
 import { getLayerAssets } from './get-layer-assets'
@@ -172,7 +173,7 @@ async function createComponentTreeInternal(
       RenderFromTemplateContext,
       ClientPageRoot,
       ClientSegmentRoot,
-      createServerSearchParamsForServerPage,
+      createSearchParamsReference,
       createPrerenderSearchParamsForClientPage,
       createServerParamsForServerSegment,
       createPrerenderParamsForClientSegment,
@@ -810,12 +811,27 @@ async function createComponentTreeInternal(
   const Component = MaybeComponent
   const isClientComponent = isClientReference(layoutOrPageMod)
 
+  // A page's `searchParams` is delivered as a stable per-segment reference:
+  // the generated entry's export when present (Turbopack), or a synthesized
+  // unregistered one otherwise (webpack, or when the mechanism is off — the
+  // unregistered object still works, it just serializes by value). It's both
+  // the segment's accumulator key and its `searchParams` prop, so the render
+  // pipeline and the reference's dereference rendezvous on one object. Only
+  // pages have one; layouts key their accumulator on the loader tree node.
+  const searchParamsReference: Promise<SearchParams> | null = isPage
+    ? ((modules.searchParams as Promise<SearchParams> | undefined) ??
+      createSearchParamsReference())
+    : null
+
   const varyParamsAccumulator: VaryParamsAccumulator | null =
     isClientComponent && cacheComponents
       ? // Client components with Cache Components enabled don't receive params
         // from the server, so they have an empty vary params set.
         emptyVaryParamsAccumulator
-      : getSegmentVaryParamsAccumulator(workUnitStore, tree)
+      : getSegmentVaryParamsAccumulator(
+          workUnitStore,
+          searchParamsReference ?? tree
+        )
 
   if (
     process.env.NODE_ENV === 'development' &&
@@ -870,13 +886,12 @@ async function createComponentTreeInternal(
         varyParamsAccumulator
       )
 
-      // If we are passing searchParams to a server component Page we need to
-      // track their usage in case the current render mode tracks dynamic API
-      // usage. The raw values are read from the ambient work unit store; the
-      // segment contributes only its vary-params accumulator.
-      const searchParams = createServerSearchParamsForServerPage(
-        varyParamsAccumulator
-      )
+      // The segment's `searchParams` reference (see above). Awaiting it
+      // dereferences, per request, to the real values; when registered (see
+      // `registerSearchParamsServerReference`) it serializes to client
+      // components by reference as an opaque token. Non-null here because
+      // `isPage`.
+      const searchParams = searchParamsReference!
 
       if (isUseCacheFunction(PageComponent)) {
         const UseCachePageComponent: ComponentType<UseCachePageProps> =

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -52,6 +52,10 @@ export {
   createServerSearchParamsForServerPage,
   createPrerenderSearchParamsForClientPage,
 } from '../request/search-params'
+// The reference-proxy machinery lives in the react-server-dom module; entry
+// base is the RSC-layer boundary that's allowed to import it (create-component
+// -tree reaches this through `componentMod` at runtime, never statically).
+export { createSearchParamsReference } from '../request/server-params-references'
 export {
   createServerParamsForServerSegment,
   createPrerenderParamsForClientSegment,

--- a/packages/next/src/server/app-render/segment-store.ts
+++ b/packages/next/src/server/app-render/segment-store.ts
@@ -2,17 +2,25 @@ import {
   createVaryParamsAccumulator,
   type VaryParamsAccumulator,
 } from './vary-params'
-import type { WorkUnitStore } from './work-unit-async-storage.external'
+import type {
+  WorkUnitStore,
+  WorkUnitPhase,
+} from './work-unit-async-storage.external'
 
 /**
- * Per-segment state for a single work unit, keyed by an object that is
- * stable and unique per segment: its loader tree node.
+ * Per-segment state for a single work unit, keyed by any object that is
+ * stable and unique per segment. Two such objects exist depending on the
+ * segment: its loader tree node (used for layouts and by-value pages), or
+ * its `searchParams` object (used by pages that receive it by reference —
+ * the render pipeline holds the tree node while the reference's dereference
+ * only holds the searchParams object, and both are unique per render per
+ * segment, so either serves as the rendezvous key).
  *
  * Everything in here is response-scoped: the map of segment stores hangs off
  * the work unit store, so no field can outlive a single render pass.
  *
  * Fields are owned by their respective domains and accessed through the
- * helpers below; they start `null` and are populated lazily on first use.
+ * helpers below; both start `null` and are populated lazily on first use.
  * This module only provides the record and its per-(work unit, segment)
  * identity.
  */
@@ -24,6 +32,16 @@ export type SegmentStore = {
    * track vary params.
    */
   varyParamsAccumulator: VaryParamsAccumulator | null
+
+  /**
+   * The promise the segment's params/searchParams reference resolves to,
+   * memoized per phase. `null` until the reference is first observed, then a
+   * map populated lazily by `getSegmentReferenceValue`. The value is
+   * `Promise<SearchParams>` (later also `Promise<Params>`); it's stored
+   * untyped because a given segment store entry is keyed by one specific
+   * reference and only ever holds that reference's value.
+   */
+  resolvedByPhase: { [K in WorkUnitPhase]?: Promise<unknown> } | null
 }
 
 export function getSegmentStore(
@@ -33,7 +51,7 @@ export function getSegmentStore(
   const segmentStores = (workUnitStore.segmentStore ??= new WeakMap())
   let segmentStore = segmentStores.get(segment)
   if (segmentStore === undefined) {
-    segmentStore = { varyParamsAccumulator: null }
+    segmentStore = { varyParamsAccumulator: null, resolvedByPhase: null }
     segmentStores.set(segment, segmentStore)
   }
   return segmentStore
@@ -42,12 +60,13 @@ export function getSegmentStore(
 /**
  * The single source of truth for a segment's vary-params accumulator. Created
  * lazily on first access and stored on the segment, so every consumer that
- * tracks the segment's param access shares the one accumulator that ends up
- * embedded in the segment's transport node. Returns `null` when the current
- * render doesn't track vary params.
+ * tracks the segment's param access — the render pipeline building the segment,
+ * and a `searchParams` reference dereferencing against it — shares the one
+ * accumulator that ends up embedded in the segment's transport node. Returns
+ * `null` when the current render doesn't track vary params.
  *
  * `segment` is the segment's stable key (see `SegmentStore`): its loader tree
- * node.
+ * node, or — for a page received by reference — its `searchParams` object.
  */
 export function getSegmentVaryParamsAccumulator(
   workUnitStore: WorkUnitStore,
@@ -63,4 +82,42 @@ export function getSegmentVaryParamsAccumulator(
     segmentStore.varyParamsAccumulator = createVaryParamsAccumulator()
   }
   return segmentStore.varyParamsAccumulator
+}
+
+/**
+ * The single source of truth for the promise a segment's params/searchParams
+ * reference resolves to, memoized per phase on the segment store. Created
+ * lazily via `resolve` on first observation and reused thereafter, so every
+ * observation within a phase hits the *same* promise — required for
+ * correctness, not just perf: React's `use()` protocol writes `status`/`value`
+ * onto the thenable and re-reads them across suspends, and the staged (Cache
+ * Components) resolver returns a fresh promise per call.
+ *
+ * `segment` is the reference itself (a page's stable per-segment key), so this
+ * shares the segment store with `getSegmentVaryParamsAccumulator` — one
+ * per-(request, segment) container. Because the store hangs off the work unit
+ * store, the memo never leaks into another request.
+ *
+ * TODO: keying by phase is a code smell — it exists only because a single
+ * request store is *mutated* across phases (`action` → `render` → `after`; see
+ * `action-handler`) and the same reference can be dereferenced in more than
+ * one of them, resolving differently each time. The right fix is a separate
+ * WorkUnitStore per phase, so phase is immutable for a store's lifetime and
+ * this can drop the phase dimension.
+ */
+export function getSegmentReferenceValue<T>(
+  workUnitStore: WorkUnitStore,
+  segment: object,
+  resolve: (workUnitStore: WorkUnitStore, segment: object) => Promise<T>
+): Promise<T> {
+  const segmentStore = getSegmentStore(workUnitStore, segment)
+  const byPhase = (segmentStore.resolvedByPhase ??= {})
+  const phase = workUnitStore.phase
+  const existing = byPhase[phase]
+  if (existing !== undefined) {
+    return existing as Promise<T>
+  }
+  const value = resolve(workUnitStore, segment)
+  byPhase[phase] = value
+  return value
 }

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -110,9 +110,10 @@ export function createServerSearchParamsForMetadata(): Promise<SearchParams> {
  * store (`workUnitStore.searchParams` — the single source of truth), so the
  * caller supplies only the vary-params accumulator to record access into (the
  * segment's, or metadata's head accumulator). What a read means is decided per
- * scope: real values in a request render or runtime prerender; and hang /
- * postpone / interrupt / error in the scopes where the values are never
- * observable.
+ * scope: real values in a request render or runtime prerender; a direct
+ * resolve in a request's `action`/`after` phases (a server-function read, with
+ * no render driving the staged rendering); and hang / postpone / interrupt /
+ * error in the scopes where the values are never observable.
  */
 export function createServerSearchParamsForServerPage(
   varyParamsAccumulator: VaryParamsAccumulator | null
@@ -150,6 +151,14 @@ export function createServerSearchParamsForServerPage(
           varyParamsAccumulator
         )
       case 'request':
+        if (workUnitStore.phase !== 'render') {
+          // A server-function read in the `action`/`after` phases: React
+          // resolved a search params reference from a round-tripped token,
+          // outside of any render. No render is driving the staged rendering,
+          // so the staged path would await a stage that never advances and
+          // deadlock — resolve the values directly instead.
+          return makeUntrackedSearchParams(workUnitStore.searchParams)
+        }
         return createRenderSearchParams(
           workUnitStore.searchParams,
           workStore,

--- a/packages/next/src/server/request/server-params-references.ts
+++ b/packages/next/src/server/request/server-params-references.ts
@@ -1,0 +1,154 @@
+import type { SearchParams } from './search-params'
+import { createServerSearchParamsForServerPage } from './search-params'
+import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
+import {
+  workUnitAsyncStorage,
+  type WorkUnitStore,
+} from '../app-render/work-unit-async-storage.external'
+import {
+  getSegmentReferenceValue,
+  getSegmentVaryParamsAccumulator,
+} from '../app-render/segment-store'
+// Resolves to `undefined` outside the experimental React channel (see the
+// shim); the call below is gated on `__NEXT_EXPERIMENTAL_PARAMS_BY_REFERENCE`,
+// which implies that channel, so the import is the real API where it runs.
+// This react-server-dom import is why this module must only ever be reached
+// through the generated page entry / the RSC-layer entry base — never imported
+// by the pre-compiled runtime bundle. Runtime callers that need to *create* a
+// reference reach `createSearchParamsReference` through the entry base
+// (`componentMod`) at runtime, not by importing this module.
+import { registerServerObjectReference } from '../../build/webpack/loaders/next-flight-loader/server-object-reference'
+
+/**
+ * Server params references: `searchParams` (and eventually `params`) are
+ * passed to route components as a stable per-page-segment object exported by
+ * the framework-generated app page entry, instead of by value. Reading the
+ * object resolves the real values against whichever request observes it, and —
+ * when registered — it round-trips through the client as an opaque Server
+ * Object Reference.
+ *
+ * The reference-proxy machinery (`createReferenceProxy`) lives here and is
+ * generic, so a future `params` reference reuses it with its own
+ * `dereference…` resolver; only the value-specific resolution is factored out
+ * into the runtime-safe `search-params.ts`.
+ */
+
+/**
+ * Builds a `Promise`-shaped Proxy over a request-scoped value. Every
+ * observation resolves against the ambient work unit store via `resolve`, and
+ * the result is memoized on that store's segment store (see
+ * `getSegmentReferenceValue`) so that React's `use()` protocol — which writes
+ * `status`/`value` onto the thenable and re-reads them across suspends —
+ * always sees the same underlying promise (the staged Cache Components
+ * resolver returns a fresh promise per call, so the memo is required for
+ * correctness, not just perf). The reference is its own segment key, so its
+ * resolved value lives alongside its vary-params accumulator in one
+ * per-(request, segment) container, and never leaks between requests.
+ *
+ * The object is a single module-lifetime value, so it can't capture any one
+ * request's values — hence the inert target and the per-observation
+ * forwarding. React's `use()` bookkeeping writes (`status`/`value`/`reason`)
+ * are redirected to the per-request promise too, so they never accumulate on
+ * the shared object and leak between requests.
+ */
+function createReferenceProxy<T extends object>(
+  resolve: (workUnitStore: WorkUnitStore, reference: object) => Promise<T>
+): Promise<T> {
+  function getUnderlying(): Promise<T> {
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    if (!workUnitStore) {
+      throw new Error(
+        'A server params reference can only be read within the scope of a request.'
+      )
+    }
+    return getSegmentReferenceValue(workUnitStore, reference, resolve)
+  }
+
+  // A real (inert, never-observed) promise, so the reference passes
+  // `instanceof Promise` and inherits `Promise.prototype`. Registration
+  // metadata (`$$typeof`/`$$id`), if any, is defined on it by the wrapper;
+  // React Flight reads `$$typeof` to serialize the reference as `$H` before it
+  // ever probes `then`.
+  const inertTarget: Promise<T> = Promise.resolve({} as T)
+
+  const reference: Promise<T> = new Proxy(inertTarget, {
+    get(target, prop, receiver) {
+      if (Object.hasOwn(target, prop)) {
+        // Registration metadata (`$$typeof`/`$$id`) written onto the target.
+        // It identifies the reference and must resolve from the target, not a
+        // request's value — Flight reads `$$typeof` to serialize the reference
+        // as `$H` before it ever probes `then`.
+        return ReflectAdapter.get(target, prop, receiver)
+      }
+      // Everything else is an observation — awaiting, `use()` (including
+      // reading back the bookkeeping the set trap wrote), Flight probing it as
+      // a thenable, inspection, and so on. Forward it to the per-request
+      // promise; there's no need to enumerate which properties matter, since
+      // React instruments the inner promise via `then`/`status`/`value` and
+      // reading the rest from it is harmless.
+      const underlying = getUnderlying()
+      return ReflectAdapter.get(underlying, prop, underlying)
+    },
+    set(target, prop, value, receiver) {
+      if (prop === 'status' || prop === 'value' || prop === 'reason') {
+        // React's `use()` thenable bookkeeping. Redirect to the per-request
+        // underlying promise so the shared reference never carries one
+        // request's resolution into the next.
+        const underlying = getUnderlying()
+        return Reflect.set(underlying, prop, value)
+      }
+      return ReflectAdapter.set(target, prop, value, receiver)
+    },
+  })
+
+  return reference
+}
+
+/**
+ * Builds a page segment's `searchParams` object: the generic reference proxy
+ * wired to the searchParams resolver. Each observation resolves the ambient
+ * scope's search params (`createServerSearchParamsForServerPage`, which reads
+ * them from the store), recording access into this segment's vary-params
+ * accumulator. This is the unregistered core — awaiting it resolves the
+ * current request's values and passing it to a client component serializes it
+ * by value like any promise. `registerSearchParamsServerReference` wraps it to
+ * additionally register it as a Server Object Reference (the only thing that
+ * makes it serialize *by reference*).
+ */
+export function createSearchParamsReference(): Promise<SearchParams> {
+  return createReferenceProxy((workUnitStore, reference) =>
+    createServerSearchParamsForServerPage(
+      getSegmentVaryParamsAccumulator(workUnitStore, reference)
+    )
+  )
+}
+
+/**
+ * Wraps `createSearchParamsReference` to register the object as a Server
+ * Object Reference (mirroring how the SWC transform registers `'use server'`
+ * functions with `registerServerReference`):
+ *
+ * - Rendering it into a client component serializes it by reference (`$H`).
+ * - The client can only round-trip it back to the server (opaque token).
+ * - `decodeReply` resolves the id through the server reference manifest back
+ *   to this export, without calling it.
+ *
+ * Called by the generated app page entry with the segment's reference id.
+ */
+export function registerSearchParamsServerReference(
+  id: string
+): Promise<SearchParams> {
+  const reference = createSearchParamsReference()
+
+  // Gated on this mechanism's flag, not the experimental React channel: other
+  // features also enable that channel, but registration (and the by-reference
+  // serialization it enables) must happen only when this feature is on. The
+  // flag forces the experimental channel, so when this is true the
+  // `registerServerObjectReference` import above is the real API; otherwise
+  // the whole branch is eliminated (and the import resolves to `undefined`).
+  if (process.env.__NEXT_EXPERIMENTAL_PARAMS_BY_REFERENCE) {
+    registerServerObjectReference(reference, id, null)
+  }
+
+  return reference
+}

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -208,6 +208,17 @@ declare module 'react-server-dom-webpack/server.edge' {
     exportName: string | null
   ): unknown
 
+  /**
+   * Registers a non-function value (object or Promise) as a Server Object
+   * Reference. Only available in the experimental React channel
+   * (`enableFlightObjectReferences`).
+   */
+  export function registerServerObjectReference<T extends object>(
+    reference: T,
+    id: string,
+    exportName: string | null
+  ): T
+
   export function createClientModuleProxy(moduleId: string): unknown
 }
 
@@ -222,6 +233,7 @@ declare module 'react-server-dom-webpack/server.node' {
     createClientModuleProxy,
     decodeReplyFromAsyncIterable,
     registerServerReference,
+    registerServerObjectReference,
     renderToReadableStream,
   } from 'react-server-dom-webpack/server.edge'
 

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -246,6 +246,7 @@ describe('dynamic-data with dynamic = "error"', () => {
          > 12 |         {Object.entries(await searchParams).map(([key, value]) => {
               |                               ^",
            "stack": [
+             "Reflect.get <anonymous>",
              "Page app/search/page.js (12:31)",
            ],
          }


### PR DESCRIPTION
This is the core of the stack: the `searchParams` prop a server page receives is now a stable Promise-shaped proxy (`createSearchParamsReference`) that resolves the values by looking them up on the ambient work unit store, instead of a promise created per render with the values baked in.

### Why

Preparation for passing `searchParams` (and eventually `params`) to segments **by reference**. Once React's Object Server References land in the experimental channel, the reference object — reachable via the module system through the generated page entry (next PR in the stack) — can be registered as a Server Object Reference, so it serializes to clients as an opaque token (`$H`) and the Flight reply handler can resolve it through the server reference manifest on the way back.

The mechanism runs unconditionally, including with the feature disabled: all `searchParams` objects go through the same proxy machinery so the behavior stays consistent and there are no forked ways of passing them around. Registration is the only thing the future flag gates (`__NEXT_EXPERIMENTAL_PARAMS_BY_REFERENCE`, which nothing sets yet). Unregistered — which is currently always — the reference is a plain thenable that serializes by value.

### How it works

- Every observation (await, `use()`, Flight probing it as a thenable) resolves against the ambient work unit store via the same by-value machinery as before (`createServerSearchParamsForServerPage`), recording access into the segment's vary-params accumulator.
- The resolution is memoized per (work unit store, phase) on the segment store. This is required for correctness, not just perf: React's `use()` protocol writes `status`/`value` onto the thenable and re-reads them across suspends, while the staged (Cache Components) resolver returns a fresh promise per call. `use()` bookkeeping writes are redirected to the per-request underlying promise so the shared module-lifetime object never carries one request's resolution into the next.
- The reference is its own segment key: it lives alongside the segment's vary-params accumulator in the per-(work unit, segment) store, so the render pipeline (which keys by the loader tree node) and the reference's resolution (which only holds the reference itself) rendezvous on the same accumulator.
- Reads outside the render phase (`action`/`after` — e.g. a reference resolved during server-function decode, or awaited inside `after()`) resolve directly instead of going through staged rendering, which would await a stage that never advances and deadlock.
- `registerServerObjectReference` comes from a shim that resolves to `undefined` outside the experimental React channel; the call is gated on the (not yet wired) feature flag, which will force that channel. The module importing it is only reachable through the RSC-layer entry base / generated page entry, never the pre-compiled runtime bundle.

### Behavior notes

- No generated entry exports the reference yet: `create-component-tree` uses the entry's `modules.searchParams` export when present, falling back to a synthesized unregistered reference. The Turbopack codegen that emits the export lands in the next PR; webpack keeps the fallback.
- One observable change: dev error stacks for dynamic API access through `searchParams` gain a `Reflect.get` frame from the proxy indirection (snapshot updated in `dynamic-data.test.ts`).

`params` is intentionally out of scope for this stack, but the segment store and the reference proxy are designed to extend to it — and the same treatment will eventually be needed for variants.