### PR TITLE
fix(typescript): detect the CLI entry when `typescript` is aliased to a fork with a non-`tsc` bin

### DIFF
--- a/packages/next/src/lib/typescript/runTypeScriptCli.test.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.test.ts
@@ -1,6 +1,9 @@
 import type { ChildProcess } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 const mockSpawn = jest.fn()
 
@@ -9,7 +12,7 @@ jest.mock('next/dist/compiled/cross-spawn', () => ({
   default: (...args: unknown[]) => mockSpawn(...args),
 }))
 
-const { runTypeScriptCli } =
+const { runTypeScriptCli, getTypeScriptPackageInfo } =
   require('./runTypeScriptCli') as typeof import('./runTypeScriptCli')
 
 const processEvents = ['exit', 'SIGINT', 'SIGTERM', 'SIGHUP'] as const
@@ -248,5 +251,56 @@ describe('runTypeScriptCli', () => {
       stderr: 'avertissement 💡',
     })
     expectListenersRestored()
+  })
+})
+
+describe('getTypeScriptPackageInfo', () => {
+  let fixtureDir: string
+
+  beforeEach(() => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-package-info-'))
+    const pkgDir = path.join(fixtureDir, 'node_modules', 'typescript')
+    fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true })
+    fs.mkdirSync(path.join(pkgDir, 'lib'), { recursive: true })
+
+    // `typescript` aliased to `@typescript/typescript6` — the package the
+    // TypeScript team recommends for adopting the native compiler
+    // incrementally. Its CLI ships as `tsc6` (not `tsc`) so it can coexist
+    // with the native compiler's bin.
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@typescript/typescript6',
+        version: '6.0.2',
+        main: './lib/typescript.js',
+        bin: { tsc6: './bin/tsc6' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(pkgDir, 'bin', 'tsc6'),
+      "#!/usr/bin/env node\nrequire('../lib/tsc.js')\n"
+    )
+    fs.writeFileSync(path.join(pkgDir, 'lib', 'tsc.js'), '// tsc entry\n')
+    fs.writeFileSync(path.join(pkgDir, 'lib', 'typescript.js'), '// api\n')
+  })
+
+  afterEach(() => {
+    fs.rmSync(fixtureDir, { recursive: true, force: true })
+  })
+
+  it('detects a CLI entry when `typescript` is aliased to a fork whose bin is not named `tsc`', () => {
+    const info = getTypeScriptPackageInfo(fixtureDir)
+
+    // Regression test for https://github.com/vercel/next.js/issues/97015.
+    // With the default `experimental.useTypeScriptCli`, Next runs
+    // `tsc --showConfig` to load tsconfig `paths` under `next build --webpack`.
+    // A `typescript` alias that only ships a `tsc6` bin must still be detected;
+    // otherwise `useTypeScript` resolves to false, the tsconfig `paths` are
+    // never loaded, and webpack fails to resolve every path alias.
+    expect(info).not.toBeNull()
+    expect(info!.version).toBe('6.0.2')
+    expect(info!.tscPath).toBeTruthy()
+    expect(path.basename(info!.tscPath!)).toBe('tsc.js')
+    expect(fs.existsSync(info!.tscPath!)).toBe(true)
   })
 })

--- a/packages/next/src/lib/typescript/runTypeScriptCli.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.ts
@@ -52,6 +52,17 @@ export function getTypeScriptPackageInfo(
     }
   }
 
+  // `typescript` may be aliased to a fork that ships its CLI under a different
+  // bin name so it can coexist with the native compiler (e.g.
+  // `npm:@typescript/typescript6` exposes only a `tsc6` bin). When no `tsc` bin
+  // is declared, fall back to the conventional `lib/tsc.js` entry so the CLI
+  // path (`experimental.useTypeScriptCli`) still finds a runnable `tsc` and
+  // keeps loading `paths` from the tsconfig under `next build --webpack`.
+  const fallbackTscJsPath = path.join(packageDir, 'lib', 'tsc.js')
+  if (!tscPath && existsSync(fallbackTscJsPath)) {
+    tscPath = fallbackTscJsPath
+  }
+
   return {
     packageJsonPath,
     packageDir,


### PR DESCRIPTION
Fixes #97015

## Problem

Under `next build --webpack`, when the `typescript` package is aliased to a fork that ships its CLI under a different bin name (e.g. `npm:@typescript/typescript6`, which exposes only `tsc6` so it can coexist with the native compiler's `tsc`), every tsconfig `paths` alias is silently dropped and the build fails with `Module not found: Can't resolve '@/lib/greet'`.

## Root cause

In 16.3.0 the default of `experimental.useTypeScriptCli` flipped to `true`, so builds run `tsc --showConfig` to load tsconfig `paths`. `getTypeScriptPackageInfo` only looks for a `bin.tsc` entry. For an aliased fork whose bin is named `tsc6`, `tscPath` is `undefined`, so `loadJsConfig` concludes TypeScript is not in use (`useTypeScript === false`), never loads the tsconfig, and webpack's `JsConfigPathsPlugin` receives an empty `paths` map. The issue's matrix confirms this: `experimental.useTypeScriptCli: false` (the API path, which uses `lib/typescript.js`) works, and `typescript@7` works because its bin is `tsc`.

## Fix

When no `tsc` bin is declared, fall back to the conventional `lib/tsc.js` CLI entry — the same entry the existing TypeScript 7 ESM-bin handling already uses. This keeps the CLI path able to run `tsc --showConfig` for any `typescript` alias that ships the JS compiler, restoring `paths` resolution under `--webpack`.

## Verification

- Added a unit test in `packages/next/src/lib/typescript/runTypeScriptCli.test.ts` that fakes a `typescript` package aliased to `@typescript/typescript6` (bin `tsc6` + `lib/tsc.js`) and asserts `getTypeScriptPackageInfo` still returns a usable `tscPath`. The new test fails on the current code and passes with this change.
- The existing `getTypeScriptConfigurationCli` / `loadJsConfig` flow is unchanged; only the package detection is fixed, so `useTypeScriptCli: false` and native `typescript@7` are unaffected.

Note: this touches a different subsystem (webpack/TS-CLI tsconfig loading) than my other open Next.js PR #97194 (Turbopack dev manifest handling).