### PR TITLE
Invalidate deferred Webpack entry sources

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -12,7 +12,7 @@ import type {
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
-import { posix, join, normalize } from 'path'
+import { dirname, posix, join, normalize } from 'path'
 import { stringify } from 'querystring'
 import {
   PAGES_DIR_ALIAS,
@@ -385,6 +385,7 @@ export async function createEntrypoints(
   client: webpack.EntryObject
   server: webpack.EntryObject
   edgeServer: webpack.EntryObject
+  entrySourceDirectories: string[]
   middlewareMatchers: undefined
 }> {
   const {
@@ -404,6 +405,7 @@ export async function createEntrypoints(
   const edgeServer: webpack.EntryObject = {}
   const server: webpack.EntryObject = {}
   const client: webpack.EntryObject = {}
+  const entrySourceDirectories = new Set<string>()
   let middlewareMatchers: ProxyMatcher[] | undefined = undefined
 
   let appPathsPerRoute: Record<string, string[]> = {}
@@ -466,6 +468,10 @@ export async function createEntrypoints(
         appDir,
         rootDir,
       })
+      // A deferred-entry callback may materialize source beside this route.
+      // Keep the owning directory so the bundler can invalidate that subtree
+      // without discarding filesystem cache entries for the rest of the app.
+      entrySourceDirectories.add(dirname(pageFilePath))
 
       const isInsideAppDir =
         !!appDir &&
@@ -664,6 +670,7 @@ export async function createEntrypoints(
     client,
     server,
     edgeServer,
+    entrySourceDirectories: [...entrySourceDirectories].sort(),
     middlewareMatchers,
   }
 }

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -175,6 +175,8 @@ export async function webpackBuildImpl(
           compilerType: COMPILER_NAMES.client,
           entrypoints: entrypoints.client,
           deferredEntrypoints: deferredEntrypoints?.client,
+          deferredEntrySourceDirectories:
+            deferredEntrypoints?.entrySourceDirectories,
           ...info,
         }),
         getBaseWebpackConfig(dir, {
@@ -184,6 +186,8 @@ export async function webpackBuildImpl(
           compilerType: COMPILER_NAMES.server,
           entrypoints: entrypoints.server,
           deferredEntrypoints: deferredEntrypoints?.server,
+          deferredEntrySourceDirectories:
+            deferredEntrypoints?.entrySourceDirectories,
           ...info,
         }),
         getBaseWebpackConfig(dir, {
@@ -193,6 +197,8 @@ export async function webpackBuildImpl(
           compilerType: COMPILER_NAMES.edgeServer,
           entrypoints: entrypoints.edgeServer,
           deferredEntrypoints: deferredEntrypoints?.edgeServer,
+          deferredEntrySourceDirectories:
+            deferredEntrypoints?.entrySourceDirectories,
           ...info,
         }),
       ])

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -334,6 +334,7 @@ export default async function getBaseWebpackConfig(
     dev = false,
     entrypoints,
     deferredEntrypoints,
+    deferredEntrySourceDirectories,
     isDevFallback = false,
     pagesDir,
     rewrites,
@@ -361,6 +362,7 @@ export default async function getBaseWebpackConfig(
     dev?: boolean
     entrypoints: webpack.EntryObject
     deferredEntrypoints?: webpack.EntryObject
+    deferredEntrySourceDirectories?: string[]
     isDevFallback?: boolean
     pagesDir: string | undefined
     rewrites: CustomRoutes['rewrites']
@@ -2018,6 +2020,7 @@ export default async function getBaseWebpackConfig(
           dev,
           config,
           deferredEntrypoints,
+          deferredEntrySourceDirectories,
         }),
       isNodeServer &&
         new bundler.NormalModuleReplacementPlugin(

--- a/packages/next/src/build/webpack/plugins/deferred-entries-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/deferred-entries-plugin.ts
@@ -9,6 +9,7 @@ interface DeferredEntriesPluginOptions {
   dev: boolean
   config: NextConfigComplete
   deferredEntrypoints?: webpack.EntryObject
+  deferredEntrySourceDirectories?: string[]
 }
 
 /**
@@ -22,12 +23,14 @@ interface DeferredEntriesPluginOptions {
 export class DeferredEntriesPlugin {
   private onBeforeDeferredEntries?: () => Promise<void>
   private deferredEntrypoints?: webpack.EntryObject
+  private deferredEntrySourceDirectories?: string[]
   private callbackCalled: boolean = false
 
   constructor(options: DeferredEntriesPluginOptions) {
     this.onBeforeDeferredEntries =
       options.config.experimental.onBeforeDeferredEntries
     this.deferredEntrypoints = options.deferredEntrypoints
+    this.deferredEntrySourceDirectories = options.deferredEntrySourceDirectories
   }
 
   apply(compiler: webpack.Compiler) {
@@ -53,6 +56,12 @@ export class DeferredEntriesPlugin {
       if (this.onBeforeDeferredEntries) {
         debug('calling onBeforeDeferredEntries callback')
         await this.onBeforeDeferredEntries()
+        // The callback can update deferred entry source files after Webpack has
+        // already cached them while building the initial entries. Only purge
+        // their owning directories so unrelated entries keep their cache state.
+        if (this.deferredEntrySourceDirectories?.length) {
+          compiler.inputFileSystem?.purge?.(this.deferredEntrySourceDirectories)
+        }
         debug('onBeforeDeferredEntries callback completed')
       }
 

--- a/test/e2e/deferred-entries/next.config.js
+++ b/test/e2e/deferred-entries/next.config.js
@@ -14,6 +14,65 @@ const homePageFile = path.join(__dirname, 'app', 'page.tsx')
 
 let lastHomePageContent = null
 
+class PrimeDeferredEntryInputFileSystemPlugin {
+  apply(compiler) {
+    let cachedHomePage
+
+    compiler.hooks.make.tapPromise(
+      'PrimeDeferredEntryInputFileSystemPlugin',
+      async () => {
+        // Simulate another plugin observing deferred sources while Webpack is
+        // building the initial entries. The callback must be able to replace
+        // these cached contents before the deferred entries are compiled.
+        await Promise.all(
+          [deferredPageFile, routeHandlerFile, homePageFile].map(
+            (filePath) =>
+              new Promise((resolve, reject) => {
+                compiler.inputFileSystem.readFile(
+                  filePath,
+                  (error, content) => {
+                    if (error) {
+                      reject(error)
+                    } else {
+                      if (filePath === homePageFile) {
+                        cachedHomePage = content
+                      }
+                      resolve()
+                    }
+                  }
+                )
+              })
+          )
+        )
+      }
+    )
+
+    compiler.hooks.finishMake.tapPromise(
+      {
+        name: 'PrimeDeferredEntryInputFileSystemPlugin',
+        stage: 1,
+      },
+      async () => {
+        await new Promise((resolve, reject) => {
+          compiler.inputFileSystem.readFile(homePageFile, (error, content) => {
+            if (error) {
+              reject(error)
+            } else if (content !== cachedHomePage) {
+              reject(
+                new Error(
+                  'Deferred entry invalidation evicted an unrelated source file'
+                )
+              )
+            } else {
+              resolve()
+            }
+          })
+        })
+      }
+    )
+  }
+}
+
 /** @type {import('next').NextConfig} */
 module.exports = {
   experimental: {
@@ -89,7 +148,11 @@ module.exports = {
     },
   },
   // Webpack loader configuration
-  webpack: (config, { isServer }) => {
+  webpack: (config, { dev, isServer }) => {
+    if (!dev && isServer) {
+      config.plugins.push(new PrimeDeferredEntryInputFileSystemPlugin())
+    }
+
     // Add the entry logger loader to track when entries are processed
     config.module.rules.push({
       test: /\.(tsx|ts|js|jsx)$/,


### PR DESCRIPTION
## Summary

The onBeforeDeferredEntries callback can update deferred source files after Webpack has already cached their contents while building initial entries. This tracks the source directories represented by the deferred entrypoint set and purges only those paths before adding deferred entries so callback-time source is compiled without dropping unrelated filesystem cache state.

The deferred entries fixture now primes both deferred sources through Webpack before the callback and also primes a non-deferred source. It verifies deferred entries use updated content while the unrelated source remains cached.

## Verification

- `HEADLESS=true pnpm test-start-webpack test/e2e/deferred-entries/deferred-entries.test.ts`
- Control run with the old global purge: the build fails because the unrelated cached source is evicted

<!-- NEXT_JS_LLM -->