### PR TITLE
[turbopack] Only use the shared runtime by default on canary

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2645,7 +2645,7 @@ impl NextConfig {
             // The shared runtime / inlined bootstrap is a production-only optimization; in
             // development the per-route runtime is required for HMR.
             NextMode::Development => false,
-            NextMode::Build => self.experimental.turbopack_shared_runtime.unwrap_or(true),
+            NextMode::Build => self.experimental.turbopack_shared_runtime.unwrap_or(false),
         }))
     }
 

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -169,8 +169,9 @@ export function getDefineEnv({
     'process.env.__NEXT_APP_NAV_FAIL_HANDLING': Boolean(
       config.experimental.appNavFailHandling
     ),
-    'process.env.__NEXT_TURBOPACK_SHARED_RUNTIME':
-      config.experimental.turbopackSharedRuntime !== false,
+    'process.env.__NEXT_TURBOPACK_SHARED_RUNTIME': Boolean(
+      config.experimental.turbopackSharedRuntime
+    ),
     'process.env.__NEXT_CACHE_COMPONENTS': isCacheComponentsEnabled,
     'process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS': Boolean(
       config.experimental.cachedNavigations

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -12,6 +12,7 @@ import type { NextParsedUrlQuery } from './request-meta'
 import type { SizeLimit } from '../types'
 import type { SupportedTestRunners } from '../cli/next-test'
 import { INFINITE_CACHE } from '../lib/constants'
+import { isStableBuild } from '../shared/lib/errors/canary-only-config-error'
 import type { FallbackRouteParam } from '../build/static-paths/types'
 import type { MemoryEvictionMode } from '../build/swc/types'
 import type { CacheLife } from './use-cache/cache-life'
@@ -794,7 +795,8 @@ export interface ExperimentalConfig {
   /**
    * Share the browser runtime across routes in a single `runtime.js` asset and inline the
    * per-route chunk-group bootstrap into the HTML, dropping the per-route runtime. Defaults to
-   * true. Only applies to production builds; has no effect in development mode.
+   * true on canary releases and false on stable releases. Only applies to production builds; has
+   * no effect in development mode.
    */
   turbopackSharedRuntime?: boolean
 
@@ -2291,6 +2293,7 @@ export const defaultConfig = Object.freeze({
     turbopackFileSystemCacheForBuild: true,
     turbopackInferModuleSideEffects: true,
     turbopackPluginRuntimeStrategy: 'childProcesses',
+    turbopackSharedRuntime: !isStableBuild(),
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,


### PR DESCRIPTION
This should not be on in 16.3.1. 