### PR TITLE
refactor: clean up branching and CC/non-CC code in connection()

### DIFF
--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -23,17 +23,23 @@ import { InvariantError } from '../../shared/lib/invariant-error'
  * During prerendering it will never resolve and during rendering it resolves immediately.
  */
 export function connection(): Promise<void> {
-  const callingExpression = 'connection'
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
+  if (!workStore || !workUnitStore) {
+    // TODO(NAR-789): connection() is not currently statically prevented from being imported in client components,
+    // so in the browser we'll always error about a missing work unit store.
+    const callingExpression = 'connection'
+    throwForMissingRequestStore(callingExpression)
+  }
 
-  if (workStore) {
-    if (workUnitStore && !isRequestApiAllowedInCurrentPhase(workUnitStore)) {
-      throw new Error(
-        `Route ${workStore.route} used \`connection()\` inside \`after()\` while rendering. The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but \`after()\` executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after`
-      )
-    }
+  if (!isRequestApiAllowedInCurrentPhase(workUnitStore)) {
+    throw new Error(
+      `Route ${workStore.route} used \`connection()\` inside \`after()\` while rendering. The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but \`after()\` executes after the request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/after`
+    )
+  }
 
+  if (!process.env.__NEXT_CACHE_COMPONENTS) {
+    // `export const dynamic = ...` is only supported pre-cacheComponents.
     if (workStore.forceStatic) {
       // When using forceStatic, we override all other logic and always just
       // return a resolving promise without tracking.
@@ -45,91 +51,83 @@ export function connection(): Promise<void> {
         `Route ${workStore.route} with \`dynamic = "error"\` couldn't be rendered statically because it used \`connection()\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
       )
     }
-
-    if (workUnitStore) {
-      switch (workUnitStore.type) {
-        case 'cache': {
-          const error = new Error(
-            `Route ${workStore.route} used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
-          )
-          Error.captureStackTrace(error, connection)
-          applyOwnerStack(error)
-          workStore.invalidDynamicUsageError ??= error
-          throw error
-        }
-        case 'private-cache': {
-          // It might not be intuitive to throw for private caches as well, but
-          // we don't consider runtime prefetches as "actual requests" (in the
-          // navigation sense), despite allowing them to read cookies.
-          const error = new Error(
-            `Route ${workStore.route} used \`connection()\` inside "use cache: private". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
-          )
-          Error.captureStackTrace(error, connection)
-          applyOwnerStack(error)
-          workStore.invalidDynamicUsageError ??= error
-          throw error
-        }
-        case 'unstable-cache':
-          throw new Error(
-            `Route ${workStore.route} used \`connection()\` inside a function cached with \`unstable_cache()\`. The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
-          )
-        case 'generate-static-params':
-          throw new Error(
-            `Route ${workStore.route} used \`connection()\` inside \`generateStaticParams\`. This is not supported because \`generateStaticParams\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
-          )
-        case 'prerender':
-        case 'prerender-client':
-        case 'prerender-runtime':
-          // We return a promise that never resolves to allow the prerender to
-          // stall at this point.
-          return makeDynamicHangingPromise(
-            workUnitStore.renderSignal,
-            workStore.route,
-            '`connection()`'
-          )
-        case 'validation-client': {
-          // TODO(NAR-789): make this consistent with the actual browser behavior when we change it.
-          // Until then, erroring is fine.
-          const exportName = '`connection`'
-          throw new InvariantError(
-            `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
-          )
-        }
-        case 'prerender-legacy':
-          // We throw an error here to interrupt prerendering to mark the route
-          // as dynamic
-          return throwToInterruptStaticGeneration(
-            'connection',
-            workStore,
-            workUnitStore
-          )
-        case 'request':
-          trackDynamicDataInDynamicRender(workUnitStore)
-          if (process.env.NODE_ENV === 'development') {
-            // Semantically we only need the dev tracking when running in `next dev`
-            // but since you would never use next dev with production NODE_ENV we use this
-            // as a proxy so we can statically exclude this code from production builds.
-            if (workUnitStore.asyncApiPromises) {
-              return workUnitStore.asyncApiPromises.connection
-            }
-            return makeDevtoolsIOAwarePromise(
-              undefined,
-              workUnitStore,
-              RenderStage.Dynamic
-            )
-          } else if (workUnitStore.asyncApiPromises) {
-            return workUnitStore.asyncApiPromises.connection
-          } else {
-            return Promise.resolve(undefined)
-          }
-        default:
-          workUnitStore satisfies never
-      }
-    }
   }
 
-  // If we end up here, there was no work store or work unit store present.
-  // TODO(NAR-789): connection() is not currently statically prevented from being imported in client components,
-  // so we always error about a missing work unit store.
-  throwForMissingRequestStore(callingExpression)
+  switch (workUnitStore.type) {
+    case 'cache': {
+      const error = new Error(
+        `Route ${workStore.route} used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+      )
+      Error.captureStackTrace(error, connection)
+      applyOwnerStack(error)
+      workStore.invalidDynamicUsageError ??= error
+      throw error
+    }
+    case 'private-cache': {
+      // It might not be intuitive to throw for private caches as well, but
+      // we don't consider runtime prefetches as "actual requests" (in the
+      // navigation sense), despite allowing them to read cookies.
+      const error = new Error(
+        `Route ${workStore.route} used \`connection()\` inside "use cache: private". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+      )
+      Error.captureStackTrace(error, connection)
+      applyOwnerStack(error)
+      workStore.invalidDynamicUsageError ??= error
+      throw error
+    }
+    case 'unstable-cache':
+      throw new Error(
+        `Route ${workStore.route} used \`connection()\` inside a function cached with \`unstable_cache()\`. The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+      )
+    case 'generate-static-params':
+      throw new Error(
+        `Route ${workStore.route} used \`connection()\` inside \`generateStaticParams\`. This is not supported because \`generateStaticParams\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
+      )
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-runtime':
+      // We return a promise that never resolves to allow the prerender to
+      // stall at this point.
+      return makeDynamicHangingPromise(
+        workUnitStore.renderSignal,
+        workStore.route,
+        '`connection()`'
+      )
+    case 'validation-client': {
+      const exportName = '`connection`'
+      throw new InvariantError(
+        `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
+      )
+    }
+    case 'prerender-legacy':
+      // We throw an error here to interrupt prerendering to mark the route
+      // as dynamic
+      return throwToInterruptStaticGeneration(
+        'connection',
+        workStore,
+        workUnitStore
+      )
+    case 'request': {
+      if (!process.env.__NEXT_CACHE_COMPONENTS) {
+        trackDynamicDataInDynamicRender(workUnitStore)
+      }
+
+      if (workUnitStore.asyncApiPromises) {
+        return workUnitStore.asyncApiPromises.connection
+      }
+      if (process.env.__NEXT_DEV_SERVER) {
+        return makeDevtoolsIOAwarePromise(
+          undefined,
+          workUnitStore,
+          RenderStage.Dynamic
+        )
+      } else {
+        return Promise.resolve(undefined)
+      }
+    }
+    default: {
+      workUnitStore satisfies never
+      return Promise.resolve(undefined)
+    }
+  }
 }


### PR DESCRIPTION
Simplifies the branching in connection() and isolates parts that don't run in cacheComponents.

- workStore and workUnitStore check can be an early return, `conneciton()`` is useless without them anyway
- `asyncApiPromises` check is the same in dev and prod
- `export const dynamic = ...` and `trackDynamicDataInDynamicRender` only runs if `cacheComponents` is off.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>