### PR TITLE
Make connection() work in the browser

### DIFF
--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -1,18 +1,46 @@
-const serverExports = {
-  NextRequest: require('next/dist/server/web/spec-extension/request')
-    .NextRequest,
-  NextResponse: require('next/dist/server/web/spec-extension/response')
-    .NextResponse,
-  ImageResponse: require('next/dist/server/web/spec-extension/image-response')
-    .ImageResponse,
-  userAgentFromString: require('next/dist/server/web/spec-extension/user-agent')
-    .userAgentFromString,
-  userAgent: require('next/dist/server/web/spec-extension/user-agent')
-    .userAgent,
-  URLPattern: require('next/dist/server/web/spec-extension/url-pattern')
-    .URLPattern,
-  after: require('next/dist/server/after').after,
-  connection: require('next/dist/server/request/connection').connection,
+let serverExports
+
+if (process.env.NEXT_RUNTIME === '') {
+  // Browser
+  const notAvailableInClient = (name) => {
+    return function notAvailable() {
+      throw new Error(`\`${name}\` is only available in a Server Component.`)
+    }
+  }
+  // NOTE: this diverges from `invalid_client_lib_apis_mapping`, which
+  // allows importing everything except `after`.
+  // We assume that this code is not useful in browser bundles and pulling it in
+  // would be undesireable, so we only allow `connection`.
+  serverExports = {
+    NextRequest: notAvailableInClient('NextRequest'),
+    NextResponse: notAvailableInClient('NextResponse'),
+    ImageResponse: notAvailableInClient('ImageResponse'),
+    userAgentFromString: notAvailableInClient('userAgentFromString'),
+    userAgent: notAvailableInClient('userAgent'),
+    URLPattern: notAvailableInClient('URLPattern'),
+    after: notAvailableInClient('after'),
+    connection: require('next/dist/client/request/connection.browser')
+      .connection,
+  }
+} else {
+  // Server (RSC or SSR)
+  serverExports = {
+    NextRequest: require('next/dist/server/web/spec-extension/request')
+      .NextRequest,
+    NextResponse: require('next/dist/server/web/spec-extension/response')
+      .NextResponse,
+    ImageResponse: require('next/dist/server/web/spec-extension/image-response')
+      .ImageResponse,
+    userAgentFromString:
+      require('next/dist/server/web/spec-extension/user-agent')
+        .userAgentFromString,
+    userAgent: require('next/dist/server/web/spec-extension/user-agent')
+      .userAgent,
+    URLPattern: require('next/dist/server/web/spec-extension/url-pattern')
+      .URLPattern,
+    after: require('next/dist/server/after').after,
+    connection: require('next/dist/server/request/connection').connection,
+  }
 }
 
 // https://nodejs.org/api/esm.html#commonjs-namespaces

--- a/packages/next/src/client/request/connection.browser.ts
+++ b/packages/next/src/client/request/connection.browser.ts
@@ -1,0 +1,12 @@
+import { createResolvedReactPromise } from '../../shared/lib/react-promise'
+
+// Reusing a single instance avoids allocating on every call.
+const resolvedConnectionPromise = createResolvedReactPromise(undefined)
+
+/**
+ * Browser implementation of connection(). On the client there is no
+ * prerender context, so we always resolve immediately.
+ */
+export function connection(): Promise<void> {
+  return resolvedConnectionPromise
+}

--- a/packages/next/src/client/request/io.browser.ts
+++ b/packages/next/src/client/request/io.browser.ts
@@ -1,8 +1,7 @@
-// A fulfilled thenable that React can unwrap synchronously via `use()` without
-// ever suspending. Reusing a single instance avoids allocating on every call.
-const resolvedIOPromise: Promise<void> = Promise.resolve(undefined)
-;(resolvedIOPromise as any).status = 'fulfilled'
-;(resolvedIOPromise as any).value = undefined
+import { createResolvedReactPromise } from '../../shared/lib/react-promise'
+
+// Reusing a single instance avoids allocating on every call.
+const resolvedIOPromise = createResolvedReactPromise(undefined)
 
 /**
  * Browser implementation of io(). On the client there is no

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -15,7 +15,9 @@ import {
 import { isRequestApiAllowedInCurrentPhase } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
 import { RenderStage } from '../app-render/staged-rendering'
-import { InvariantError } from '../../shared/lib/invariant-error'
+import { createResolvedReactPromise } from '../../shared/lib/react-promise'
+
+const resolvedConnectionPromise = createResolvedReactPromise(undefined)
 
 /**
  * This function allows you to indicate that you require an actual user Request before continuing.
@@ -26,8 +28,6 @@ export function connection(): Promise<void> {
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (!workStore || !workUnitStore) {
-    // TODO(NAR-789): connection() is not currently statically prevented from being imported in client components,
-    // so in the browser we'll always error about a missing work unit store.
     const callingExpression = 'connection'
     throwForMissingRequestStore(callingExpression)
   }
@@ -94,10 +94,8 @@ export function connection(): Promise<void> {
         '`connection()`'
       )
     case 'validation-client': {
-      const exportName = '`connection`'
-      throw new InvariantError(
-        `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
-      )
+      // use(connection()) does not suspend in the browser, so we simulate the same for validation.
+      return resolvedConnectionPromise
     }
     case 'prerender-legacy':
       // We throw an error here to interrupt prerendering to mark the route

--- a/packages/next/src/server/request/io.ts
+++ b/packages/next/src/server/request/io.ts
@@ -6,12 +6,10 @@ import {
 } from '../dynamic-rendering-utils'
 import { RenderStage } from '../app-render/staged-rendering'
 import { isRequestApiAllowedInCurrentPhase } from './utils'
+import { createResolvedReactPromise } from '../../shared/lib/react-promise'
 
-// A fulfilled thenable that React can unwrap synchronously via `use()` without
-// ever suspending. Reusing a single instance avoids allocating on every call.
-const resolvedIOPromise: Promise<void> = Promise.resolve(undefined)
-;(resolvedIOPromise as any).status = 'fulfilled'
-;(resolvedIOPromise as any).value = undefined
+// Reusing a single instance avoids allocating on every call.
+const resolvedIOPromise = createResolvedReactPromise(undefined)
 
 /**
  * This function allows you to indicate that the code following it performs

--- a/packages/next/src/shared/lib/react-promise.ts
+++ b/packages/next/src/shared/lib/react-promise.ts
@@ -1,0 +1,19 @@
+import type { FulfilledReactPromise } from 'react'
+
+/**
+ * Creates a fulfilled thenable that React can unwrap synchronously via `use()`
+ * without ever suspending.
+ * */
+export function createResolvedReactPromise<T>(
+  value: T
+): Promise<T> & FulfilledReactPromise<T> {
+  const promise: Promise<T> = Promise.resolve(value)
+
+  const fulfilledPromise = promise as unknown as Promise<T> &
+    FulfilledReactPromise<T>
+
+  fulfilledPromise.status = 'fulfilled'
+  fulfilledPromise.value = value
+
+  return fulfilledPromise
+}


### PR DESCRIPTION
Closes NAR-789

Makes `connection()` work in the browser, same as `use(io())`.

Note that in order to make `import { connection } from 'next/server'` not pull in a bunch of server code,
we have to exclude all other exports in `server.js`. This may technically be a breaking change, although
i don't believe any of those were actually useful in browser code, so this seems fine.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>