### PR TITLE
examples: fix pnpm builds in Docker examples

### DIFF
--- a/examples/with-docker-export-output/Dockerfile
+++ b/examples/with-docker-export-output/Dockerfile
@@ -15,7 +15,7 @@ FROM node:${NODE_VERSION} AS dependencies
 WORKDIR /app
 
 # Copy package-related files first to leverage Docker's caching mechanism
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* pnpm-workspace.yaml* .npmrc* ./
 
 # Install project dependencies with frozen lockfile for reproducible builds
 RUN --mount=type=cache,target=/root/.npm \

--- a/examples/with-docker-export-output/Dockerfile.serve
+++ b/examples/with-docker-export-output/Dockerfile.serve
@@ -13,7 +13,7 @@ FROM node:${NODE_VERSION} AS dependencies
 WORKDIR /app
 
 # Copy package-related files first to leverage Docker's caching mechanism
-COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* ./
+COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* pnpm-workspace.yaml* .npmrc* ./
 
 # Install project dependencies with frozen lockfile for reproducible builds
 RUN --mount=type=cache,target=/root/.npm \

--- a/examples/with-docker-export-output/README.md
+++ b/examples/with-docker-export-output/README.md
@@ -92,6 +92,7 @@ nextjs-docker/
 ├── postcss.config.js       # PostCSS configuration for Tailwind CSS
 ├── tsconfig.json           # TypeScript configuration
 ├── package.json            # Dependencies and scripts
+├── pnpm-workspace.yaml     # pnpm dependency build approvals
 └── README.md              # This file
 ```
 

--- a/examples/with-docker-export-output/pnpm-workspace.yaml
+++ b/examples/with-docker-export-output/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: false

--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -13,7 +13,7 @@ FROM node:${NODE_VERSION} AS dependencies
 WORKDIR /app
 
 # Copy package-related files first to leverage Docker's caching mechanism
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* pnpm-workspace.yaml* .npmrc* ./
 
 # Install project dependencies with frozen lockfile for reproducible builds
 RUN --mount=type=cache,target=/root/.npm \

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -100,6 +100,7 @@ nextjs-docker/
 ├── postcss.config.js       # PostCSS configuration for Tailwind CSS
 ├── tsconfig.json           # TypeScript configuration
 ├── package.json            # Dependencies and scripts
+├── pnpm-workspace.yaml     # pnpm dependency build approvals
 └── README.md               # This file
 ```
 

--- a/examples/with-docker/pnpm-workspace.yaml
+++ b/examples/with-docker/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: false


### PR DESCRIPTION
## What?

Fix pnpm 11 dependency installation in the Node.js Docker variants of:

- `examples/with-docker`
- `examples/with-docker-export-output`

This change:

- adds a narrowly scoped pnpm build policy for `sharp` to both examples
- copies `pnpm-workspace.yaml` into all three pnpm-capable Docker dependency stages
- makes `Dockerfile.serve` copy optional `.npmrc` configuration consistently with the other Node.js Dockerfiles

## Why?

The Dockerfiles run `pnpm install --frozen-lockfile`, but they do not provide an explicit build-script policy for `sharp`, an optional Next.js dependency.

With pnpm 11, dependency build scripts require an explicit decision. The documented Docker build consequently exits during dependency installation with:

```text
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: sharp@0.34.5

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

The same installation pattern appears in three Dockerfiles:

- `examples/with-docker/Dockerfile`
- `examples/with-docker-export-output/Dockerfile`
- `examples/with-docker-export-output/Dockerfile.serve`

## How?

Each example now includes the following pnpm policy:

```yaml
allowBuilds:
  sharp: false
```

This records an explicit decision not to run Sharp's lifecycle script. Sharp provides prebuilt binaries for the platforms supported by Next.js, so the Docker examples do not need to grant the script permission to execute.

Each affected dependency stage copies `pnpm-workspace.yaml` before running the frozen installation. `Dockerfile.serve` also copies optional `.npmrc` configuration for consistency.

The npm and Yarn installation branches are unchanged, and the Bun Dockerfile is unaffected.

## Validation

- [x] `docker build --no-cache -t nextjs-standalone-image examples/with-docker`
- [x] `docker build --no-cache -t nextjs-static-export examples/with-docker-export-output`
- [x] `docker build --no-cache -f examples/with-docker-export-output/Dockerfile.serve -t nextjs-static-export-serve examples/with-docker-export-output`
- [x] Confirmed that `ERR_PNPM_IGNORED_BUILDS` is no longer reported
- [x] Confirmed that neither `pnpm-lock.yaml` file changes
- [x] `git diff --check`

<!-- NEXT_JS_LLM -->