### PR TITLE
Fix /sitemap catch-all conflict with sitemap.ts in Turbopack dev

### DIFF
--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.test.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.test.ts
@@ -3,6 +3,20 @@ import { RouteKind } from '../../route-kind'
 import { DevAppRouteRouteMatcherProvider } from './dev-app-route-route-matcher-provider'
 import type { FileReader } from './helpers/file-reader/file-reader'
 
+jest.mock('../../../build/analysis/get-page-static-info', () => ({
+  getPageStaticInfo: jest.fn(
+    async ({ pageFilePath }: { pageFilePath: string }) => {
+      if (pageFilePath.includes('generate-sitemaps')) {
+        return { generateSitemaps: true }
+      }
+      if (pageFilePath.includes('generate-image-metadata')) {
+        return { generateImageMetadata: true }
+      }
+      return {}
+    }
+  ),
+}))
+
 describe.each(['webpack', 'turbopack'])(
   'DevAppRouteRouteMatcher %s',
   (bundler) => {
@@ -82,6 +96,39 @@ describe.each(['webpack', 'turbopack'])(
           expect(matchers[0].definition).toEqual(route)
         }
       )
+    })
+
+    describe('metadata sitemap matchers', () => {
+      it('registers only /sitemap.xml when generateSitemaps is absent', async () => {
+        const filename = `${dir}/sitemap.ts`
+        const reader: FileReader = { read: jest.fn(() => [filename]) }
+        const matcher = new DevAppRouteRouteMatcherProvider(
+          dir,
+          extensions,
+          reader,
+          isTurbopack
+        )
+        const matchers = await matcher.matchers()
+        expect(matchers.map((m) => m.definition.pathname)).toEqual([
+          '/sitemap.xml',
+        ])
+      })
+
+      it('registers /sitemap.xml and /sitemap/[__metadata_id__] when generateSitemaps is present', async () => {
+        const filename = `${dir}/generate-sitemaps/sitemap.ts`
+        const reader: FileReader = { read: jest.fn(() => [filename]) }
+        const matcher = new DevAppRouteRouteMatcherProvider(
+          dir,
+          extensions,
+          reader,
+          isTurbopack
+        )
+        const matchers = await matcher.matchers()
+        expect(matchers.map((m) => m.definition.pathname).sort()).toEqual([
+          '/generate-sitemaps/sitemap.xml',
+          '/generate-sitemaps/sitemap/[__metadata_id__]',
+        ])
+      })
     })
   }
 )

--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../lib/metadata/is-metadata-route'
 import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata-route'
 import path from '../../../shared/lib/isomorphic/path'
+import { PAGE_TYPES } from '../../../lib/page-types'
 
 export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvider<AppRouteRouteMatcher> {
   private readonly normalizers: {
@@ -72,7 +73,12 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
 
       if (isEntryMetadataRouteFile && !isStaticMetadataRoute(page)) {
         // Matching dynamic metadata routes.
-        // Add 2 possibilities for both single and multiple routes:
+        // Always register the single-route matcher (e.g. /sitemap.xml).
+        // Only register the multi-dynamic matcher (/[__metadata_id__]) when
+        // the file actually exports generateSitemaps / generateImageMetadata —
+        // same gate as production route discovery. Unconditionally registering
+        // the multi matcher shadows user pages like /sitemap/[...attrs] when a
+        // proxy rewrites /sitemap to a child path (see #96966).
         {
           // single:
           // /sitemap.ts -> /sitemap.xml/route
@@ -96,7 +102,26 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
           })
           matchers.push(matcher)
         }
-        {
+
+        let isMultiDynamic = false
+        try {
+          const { getPageStaticInfo } =
+            require('../../../build/analysis/get-page-static-info') as typeof import('../../../build/analysis/get-page-static-info')
+          const staticInfo = await getPageStaticInfo({
+            pageFilePath: filename,
+            nextConfig: {},
+            page,
+            isDev: true,
+            pageType: PAGE_TYPES.APP,
+          })
+          isMultiDynamic = !!(
+            staticInfo.generateSitemaps || staticInfo.generateImageMetadata
+          )
+        } catch {
+          // If static analysis fails, keep only the single-route matcher.
+        }
+
+        if (isMultiDynamic) {
           // multiple:
           // /sitemap.ts -> /sitemap/[__metadata_id__]/route
           // /icon.ts -> /icon/[__metadata_id__]/route

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -103,14 +103,18 @@ const getManifestPath = (
     if (!existsSync(manifestPath) && page.endsWith('/route')) {
       // TODO: Improve implementation of metadata routes, currently it requires this extra check for the variants of the files that can be written.
       let basePage = removeRouteSuffix(page)
-      // For sitemap.xml routes with generateSitemaps, the manifest is at
-      // /sitemap/[__metadata_id__]/route (without .xml), because the route
-      // handler serves at /sitemap/[id] not /sitemap.xml/[id]
-      if (basePage.endsWith('/sitemap.xml')) {
-        basePage = basePage.slice(0, -'.xml'.length)
+      // Avoid doubling [__metadata_id__] when the page already uses that
+      // segment (e.g. a phantom multi-sitemap match that never wrote manifests).
+      if (!basePage.includes('/[__metadata_id__]')) {
+        // For sitemap.xml routes with generateSitemaps, the manifest is at
+        // /sitemap/[__metadata_id__]/route (without .xml), because the route
+        // handler serves at /sitemap/[id] not /sitemap.xml/[id]
+        if (basePage.endsWith('/sitemap.xml')) {
+          basePage = basePage.slice(0, -'.xml'.length)
+        }
+        let metadataPage = addRouteSuffix(addMetadataIdToRoute(basePage))
+        manifestPath = getManifestPath(metadataPage, distDir, name, type, false)
       }
-      let metadataPage = addRouteSuffix(addMetadataIdToRoute(basePage))
-      manifestPath = getManifestPath(metadataPage, distDir, name, type, false)
     }
   }
 

--- a/test/e2e/app-dir/sitemap-catchall-metadata-conflict/app/(site)/sitemap/[...attrs]/page.tsx
+++ b/test/e2e/app-dir/sitemap-catchall-metadata-conflict/app/(site)/sitemap/[...attrs]/page.tsx
@@ -1,0 +1,14 @@
+export default async function HtmlSitemapPage({
+  params,
+}: {
+  params: Promise<{ attrs: string[] }>
+}) {
+  const { attrs } = await params
+
+  return (
+    <main>
+      <h1>HTML sitemap</h1>
+      <p>Internal route attributes: {attrs.join('/')}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/sitemap-catchall-metadata-conflict/app/layout.tsx
+++ b/test/e2e/app-dir/sitemap-catchall-metadata-conflict/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/sitemap-catchall-metadata-conflict/app/sitemap.ts
+++ b/test/e2e/app-dir/sitemap-catchall-metadata-conflict/app/sitemap.ts
@@ -1,0 +1,5 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [{ url: 'http://localhost:3000' }]
+}

--- a/test/e2e/app-dir/sitemap-catchall-metadata-conflict/proxy.ts
+++ b/test/e2e/app-dir/sitemap-catchall-metadata-conflict/proxy.ts
@@ -1,0 +1,12 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  const destination = request.nextUrl.clone()
+  destination.pathname = '/sitemap/region=default&locale=en'
+
+  return NextResponse.rewrite(destination)
+}
+
+export const config = {
+  matcher: '/sitemap',
+}

--- a/test/e2e/app-dir/sitemap-catchall-metadata-conflict/sitemap-catchall-metadata-conflict.test.ts
+++ b/test/e2e/app-dir/sitemap-catchall-metadata-conflict/sitemap-catchall-metadata-conflict.test.ts
@@ -1,0 +1,22 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('sitemap-catchall-metadata-conflict', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should serve the HTML sitemap page at /sitemap via proxy rewrite', async () => {
+    const res = await next.fetch('/sitemap')
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('HTML sitemap')
+    expect(html).toContain('region%3Ddefault%26locale%3Den')
+  })
+
+  it('should serve the metadata XML sitemap at /sitemap.xml', async () => {
+    const res = await next.fetch('/sitemap.xml')
+    expect(res.status).toBe(200)
+    const xml = await res.text()
+    expect(xml).toContain('urlset')
+  })
+})


### PR DESCRIPTION
## What

In Turbopack `next dev`, a user page at `/sitemap/[...attrs]` could 500 when a proxy rewrote `/sitemap` to a child path while `app/sitemap.ts` also existed. `/sitemap.xml` still worked.

## Why

Dev route matching always registered a phantom `/sitemap/[__metadata_id__]` matcher for every `sitemap.ts`, even without `generateSitemaps`. That single-dynamic route sorted ahead of the catch-all, so the rewrite was treated as a metadata route. Manifest loading then appended another `[__metadata_id__]` and failed with ENOENT.

Production already gates the multi-dynamic route on `generateSitemaps` / `generateImageMetadata`.

## How

- Gate the multi-dynamic matcher in `DevAppRouteRouteMatcherProvider` on static analysis of those exports.
- Skip the manifest-loader `[__metadata_id__]` fallback when the path already includes that segment.
- Add unit coverage and an e2e fixture with `sitemap.ts` + catch-all + `proxy.ts` rewrite.

## Test plan

- [x] `pnpm test-unit packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.test.ts`
- [x] `HEADLESS=true NEXT_SKIP_ISOLATE=1 pnpm test-dev-turbo test/e2e/app-dir/sitemap-catchall-metadata-conflict/sitemap-catchall-metadata-conflict.test.ts`
- [ ] Manual: repro from #96966 — `/sitemap` HTML 200, `/sitemap.xml` XML 200

Fixes #96966