### PR TITLE
[PPF] Scaffold unstable_navigation()

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -725,6 +725,7 @@ impl ReactServerComponentValidator {
                         "unstable_cacheLife",
                         "cacheTag",
                         "unstable_cacheTag",
+                        "unstable_navigation",
                         // "unstable_noStore" // no-op in client, but allowed for legacy reasons
                     ],
                 ),

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/input.js
@@ -1,0 +1,6 @@
+import { unstable_navigation } from 'next/cache'
+
+export async function test() {
+  await unstable_navigation()
+  return null
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.js
@@ -1,0 +1,5 @@
+import { unstable_navigation } from 'next/cache';
+export async function test() {
+    await unstable_navigation();
+    return null;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/unstable-navigation/output.stderr
@@ -1,0 +1,9 @@
+  x You're importing a module that depends on "unstable_navigation" into a React Client Component module. This API is only available in Server Components but one of its parents is marked with "use
+  | client", so this module is also a Client Component.
+  | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+  | 
+  | 
+   ,-[input.js:1:1]
+ 1 | import { unstable_navigation } from 'next/cache'
+   :          ^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/input.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/input.js
@@ -1,0 +1,6 @@
+import { unstable_navigation } from 'next/cache'
+
+export async function test() {
+  await unstable_navigation()
+  return null
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.js
@@ -1,0 +1,5 @@
+import { unstable_navigation } from 'next/cache';
+export async function test() {
+    await unstable_navigation();
+    return null;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/unstable-navigation/output.stderr
@@ -1,0 +1,8 @@
+  x You're importing a module that depends on "unstable_navigation". This API is only available in Server Components in the App Router, but you are using it in the Pages Router.
+  | Learn more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+  | 
+  | 
+   ,-[input.js:1:1]
+ 1 | import { unstable_navigation } from 'next/cache'
+   :          ^^^^^^^^^^^^^^^^^^^
+   `----

--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -154,3 +154,5 @@ export function cacheLife(profile: {
 
 export const unstable_cacheLife: typeof cacheLife
 export const unstable_cacheTag: typeof cacheTag
+
+export { unstable_navigation } from 'next/dist/server/request/cache-stages'

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -25,6 +25,7 @@ if (process.env.NEXT_RUNTIME === '') {
     refresh: notAvailableInClient('refresh'),
     cacheLife: notAvailableInClient('cacheLife'),
     cacheTag: notAvailableInClient('cacheTag'),
+    unstable_navigation: notAvailableInClient('unstable_navigation'),
   }
 } else {
   // Keep server requires in this branch so browser builds can DCE them.
@@ -49,6 +50,8 @@ if (process.env.NEXT_RUNTIME === '') {
     io: require('next/dist/server/request/io').io,
     cacheLife: require('next/dist/server/use-cache/cache-life').cacheLife,
     cacheTag: require('next/dist/server/use-cache/cache-tag').cacheTag,
+    unstable_navigation: require('next/dist/server/request/cache-stages')
+      .unstable_navigation,
   }
 }
 
@@ -95,3 +98,4 @@ exports.cacheTag = cacheExports.cacheTag
 exports.unstable_cacheTag = cacheExports.unstable_cacheTag
 exports.refresh = cacheExports.refresh
 exports.io = cacheExports.io
+exports.unstable_navigation = cacheExports.unstable_navigation

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1474,5 +1474,6 @@
   "1473": "Invariant: image cache entry \"%s\" is empty",
   "1474": "Invariant: cannot write an empty buffer to the image cache",
   "1475": "Invariant: no direct app page entry found for %s",
-  "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled."
+  "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled.",
+  "1477": "unstable_navigation() is not implemented yet."
 }

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
@@ -30,6 +30,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
        
          /**
@@ -188,6 +189,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
        
          /**
@@ -266,6 +268,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
        
          /**
@@ -343,6 +346,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
        
          /**
@@ -421,6 +425,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
        
          /**
@@ -503,6 +508,7 @@ describe('cache-life-type-utils', () => {
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
        export { io } from 'next/dist/server/request/io'
+       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
        
          /**

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
@@ -178,6 +178,7 @@ declare module 'next/cache' {
   } from 'next/dist/server/web/spec-extension/revalidate'
   export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
   export { io } from 'next/dist/server/request/io'
+  export { unstable_navigation } from 'next/dist/server/request/cache-stages'
 
   ${overloads}
 

--- a/packages/next/src/server/request/cache-stages.ts
+++ b/packages/next/src/server/request/cache-stages.ts
@@ -1,0 +1,17 @@
+/**
+ * This function allows you to indicate that the subsequent code should be
+ * deferred to the actual navigation instead of rendering during a runtime
+ * prefetch. Runtime prefetches are rendered per-user, per-link, so deferring
+ * content below `await unstable_navigation()` saves that per-request
+ * rendering cost.
+ *
+ * It has no effect during static prerendering — static output is computed
+ * once and shared across many clients, so there's no per-request cost to
+ * save — and no effect on the initial load of a page.
+ *
+ * Unlike `connection()`, it does not mark the subtree as request-dependent —
+ * content below `await unstable_navigation()` remains fully cacheable.
+ */
+export function unstable_navigation(): Promise<void> {
+  throw new Error('unstable_navigation() is not implemented yet.')
+}


### PR DESCRIPTION
Scaffolds a new API, `unstable_navigation()`. It's only allowed in server code, so we ban it from being imported in the client.
Implementation follows upstack. Intended to be merged together.
