### PR TITLE
Retain interception route host slots

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1422,13 +1422,16 @@ async fn directory_tree_to_loader_tree_internal(
         }
     }
 
-    // make sure we don't have a match for other slots if there's an intercepting route match
-    // we only check subtrees as the current level could trigger `is_intercepting`
-    if tree
-        .parallel_routes
-        .iter()
-        .any(|(_, parallel_tree)| parallel_tree.is_intercepting())
-    {
+    // An interception match is a partial update of its host's slots. Retain
+    // every non-intercepting sibling above the interception marker, but keep
+    // normal matching semantics inside the newly selected subtree.
+    let is_interception_host = !app_path.contains_interception()
+        && tree
+            .parallel_routes
+            .iter()
+            .any(|(_, parallel_tree)| parallel_tree.is_intercepting());
+
+    if is_interception_host {
         let mut keys_to_replace = Vec::new();
 
         for (key, parallel_tree) in &tree.parallel_routes {
@@ -1438,47 +1441,9 @@ async fn directory_tree_to_loader_tree_internal(
         }
 
         for key in keys_to_replace {
-            let subdir_name: RcStr = format!("@{key}").into();
-
-            let default = if key == "children" {
-                modules.default.clone()
-            } else if let Some(subdirectory) = directory_tree.subdirectories.get(&subdir_name) {
-                subdirectory.modules.default.clone()
-            } else {
-                None
-            };
-
-            let is_inside_catchall = app_page.is_catchall();
-
-            // Check if this is a leaf segment (no child routes).
-            let is_leaf_segment = !has_child_routes(directory_tree);
-
-            // Only emit the issue if this is not the children slot and there's no default
-            // component. The children slot is implicit and doesn't require a default.js
-            // file. Also skip validation if the slot is UNDER a catch-all route or if
-            // this is a leaf segment (no child routes).
-            if default.is_none() && key != "children" && !is_inside_catchall && !is_leaf_segment {
-                missing_default_parallel_route_issue(
-                    app_dir.clone(),
-                    app_page.clone(),
-                    key.clone(),
-                )
-                .to_resolved()
-                .await?
-                .emit();
-            }
-
             tree.parallel_routes.insert(
                 key.clone(),
-                default_route_tree(
-                    app_dir.clone(),
-                    global_metadata,
-                    app_page.clone(),
-                    default,
-                    key.clone(),
-                    for_app_path.clone(),
-                )
-                .await?,
+                retained_route_tree(app_dir.clone(), global_metadata, app_page.clone()).await?,
             );
         }
     }
@@ -1498,8 +1463,9 @@ async fn directory_tree_to_loader_tree_internal(
             return Ok(None);
         }
     } else if tree.parallel_routes.get("children").is_none() {
-        tree.parallel_routes.insert(
-            rcstr!("children"),
+        let children = if is_interception_host {
+            retained_route_tree(app_dir.clone(), global_metadata, app_page.clone()).await?
+        } else {
             default_route_tree(
                 app_dir.clone(),
                 global_metadata,
@@ -1508,8 +1474,9 @@ async fn directory_tree_to_loader_tree_internal(
                 rcstr!("children"),
                 for_app_path.clone(),
             )
-            .await?,
-        );
+            .await?
+        };
+        tree.parallel_routes.insert(rcstr!("children"), children);
     }
 
     Ok(Some(tree))
@@ -1523,28 +1490,50 @@ async fn default_route_tree(
     slot_name: RcStr,
     for_app_path: AppPath,
 ) -> Result<AppPageLoaderTree> {
+    let default = if let Some(default) = default_component {
+        default
+    } else {
+        let contains_interception = for_app_path.contains_interception();
+
+        // Slot discovery can synthesize a children slot inside an
+        // interception subtree even when no ordinary route declares it.
+        // Keep the historical null fallback for that structural child;
+        // host-slot retention above only applies outside the new subtree.
+        let default_file = if contains_interception && slot_name == "children" {
+            "dist/client/components/builtin/default-null.js"
+        } else {
+            "dist/client/components/builtin/default.js"
+        };
+
+        get_next_package(app_dir).await?.join(default_file)?
+    };
+
+    synthetic_default_route_tree(global_metadata, app_page, default).await
+}
+
+async fn retained_route_tree(
+    app_dir: FileSystemPath,
+    global_metadata: Vc<GlobalMetadata>,
+    app_page: AppPage,
+) -> Result<AppPageLoaderTree> {
+    let default_null = get_next_package(app_dir)
+        .await?
+        .join("dist/client/components/builtin/default-null.js")?;
+    synthetic_default_route_tree(global_metadata, app_page, default_null).await
+}
+
+async fn synthetic_default_route_tree(
+    global_metadata: Vc<GlobalMetadata>,
+    app_page: AppPage,
+    default: FileSystemPath,
+) -> Result<AppPageLoaderTree> {
     Ok(AppPageLoaderTree {
-        page: app_page.clone(),
+        page: app_page,
         segment: rcstr!("__DEFAULT__"),
         parallel_routes: FxIndexMap::default(),
-        modules: if let Some(default) = default_component {
-            AppDirModules {
-                default: Some(default),
-                ..Default::default()
-            }
-        } else {
-            let contains_interception = for_app_path.contains_interception();
-
-            let default_file = if contains_interception && slot_name == "children" {
-                "dist/client/components/builtin/default-null.js"
-            } else {
-                "dist/client/components/builtin/default.js"
-            };
-
-            AppDirModules {
-                default: Some(get_next_package(app_dir).await?.join(default_file)?),
-                ..Default::default()
-            }
+        modules: AppDirModules {
+            default: Some(default),
+            ..Default::default()
         },
         global_metadata: global_metadata.to_resolved().await?,
         static_siblings: Vec::new(),

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -418,9 +418,9 @@ impl AppPath {
         true
     }
 
-    /// Returns true if ANY segment in the entire path is an interception route.
-    /// This is different from `is_intercepting()` which only checks the last
-    /// segment.
+    /// Returns true if any segment in the path is an interception route.
+    /// Unlike `AppPage::is_intercepting()`, this also identifies descendants
+    /// below the interception marker.
     pub fn contains_interception(&self) -> bool {
         self.iter().any(|segment| {
             matches!(

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -224,11 +224,13 @@ async function createTreeCodeFromPath(
     nestedCollectedDeclarations: [string, string][]
   ): Promise<{
     treeCode: string
+    containsInterception: boolean
   }> {
     const segmentPath = segments.join('/')
 
     // Existing tree are the children of the current segment
     const props: Record<string, string> = {}
+    const interceptingParallelKeys = new Set<string>()
     // Root layer could be 1st layer of normal routes
     const isRootLayer = segments.length === 0
     const isRootLayoutOrRootPage = segments.length <= 1
@@ -272,6 +274,10 @@ async function createTreeCodeFromPath(
         if (resolvedPagePath) {
           const varName = `page${nestedCollectedDeclarations.length}`
           nestedCollectedDeclarations.push([varName, resolvedPagePath])
+
+          if (isInterceptionRouteAppPath(matchedPagePath)) {
+            interceptingParallelKeys.add(normalizeParallelKey(parallelKey))
+          }
 
           // Use '' for segment as it's the page. There can't be a segment called '' so this is the safest way to add it.
           props[normalizeParallelKey(parallelKey)] =
@@ -537,13 +543,18 @@ async function createTreeCodeFromPath(
       }`
 
       if (!subtreeCode) {
-        const { treeCode: pageSubtreeCode } =
-          await createSubtreePropsFromSegmentPath(
-            subSegmentPath,
-            nestedCollectedDeclarations
-          )
+        const {
+          treeCode: pageSubtreeCode,
+          containsInterception: subtreeContainsInterception,
+        } = await createSubtreePropsFromSegmentPath(
+          subSegmentPath,
+          nestedCollectedDeclarations
+        )
 
         subtreeCode = pageSubtreeCode
+        if (subtreeContainsInterception) {
+          interceptingParallelKeys.add(normalizedParallelKey)
+        }
       }
 
       // Compute static siblings for dynamic segments. In dev mode, routes are
@@ -562,6 +573,39 @@ async function createTreeCodeFromPath(
     const adjacentParallelSegments =
       await resolveAdjacentParallelSegments(segmentPath)
 
+    // This is the level whose parallel child contains the interception match,
+    // rather than a layout inside the newly matched interception subtree.
+    // Only the former is a partial update of an already active slot owner.
+    const isInterceptionHost =
+      !isInterceptionRouteAppPath(segmentPath) &&
+      interceptingParallelKeys.size > 0
+
+    function setSyntheticDefault(key: string, defaultPath: string) {
+      const varName = `default${nestedCollectedDeclarations.length}`
+      nestedCollectedDeclarations.push([varName, defaultPath])
+      props[key] = `[
+        '${DEFAULT_SEGMENT_KEY}',
+        {},
+        {
+          defaultPage: [${varName}, ${JSON.stringify(defaultPath)}],
+        }
+      ]`
+    }
+
+    if (isInterceptionHost) {
+      // A host may have produced a normal match for another slot while the
+      // tree was being assembled. The interception match takes precedence:
+      // every other slot owned at this level is retained. Its synthetic
+      // `__DEFAULT__` branch renders null if evaluated; a user-authored
+      // default is not the meaning of this partial update.
+      for (const adjacentParallelSegment of adjacentParallelSegments) {
+        const normalizedKey = normalizeParallelKey(adjacentParallelSegment)
+        if (!interceptingParallelKeys.has(normalizedKey)) {
+          setSyntheticDefault(normalizedKey, PARALLEL_ROUTE_DEFAULT_NULL_PATH)
+        }
+      }
+    }
+
     for (const adjacentParallelSegment of adjacentParallelSegments) {
       if (!props[normalizeParallelKey(adjacentParallelSegment)]) {
         const actualSegment =
@@ -577,18 +621,13 @@ async function createTreeCodeFromPath(
         let defaultPath = await resolver(`${fullSegmentPath}/default`)
         if (!defaultPath) {
           if (adjacentParallelSegment === 'children') {
-            // When we host applications on Vercel, the status code affects the
-            // underlying behavior of the route, which when we are missing the
-            // children slot of an interception route, will yield a full 404
-            // response for the RSC request instead. For this reason, we expect
-            // that if a default file is missing when we're rendering an
-            // interception route, we instead always render null for the default
-            // slot to avoid the full 404 response.
-            if (isInterceptionRouteAppPath(page)) {
-              defaultPath = PARALLEL_ROUTE_DEFAULT_NULL_PATH
-            } else {
-              defaultPath = PARALLEL_ROUTE_DEFAULT_PATH
-            }
+            // Slot discovery can synthesize children inside an interception
+            // subtree even when no ordinary route declares it. Keep the
+            // historical null fallback for that structural child; host-slot
+            // retention above only applies outside the new subtree.
+            defaultPath = isInterceptionRouteAppPath(page)
+              ? PARALLEL_ROUTE_DEFAULT_NULL_PATH
+              : PARALLEL_ROUTE_DEFAULT_PATH
           } else {
             // Check if we're inside a catch-all route (i.e., the parallel route is a child
             // of a catch-all segment). Only skip validation if the slot is UNDER a catch-all.
@@ -621,15 +660,10 @@ async function createTreeCodeFromPath(
           }
         }
 
-        const varName = `default${nestedCollectedDeclarations.length}`
-        nestedCollectedDeclarations.push([varName, defaultPath])
-        props[normalizeParallelKey(adjacentParallelSegment)] = `[
-          '${DEFAULT_SEGMENT_KEY}',
-          {},
-          {
-            defaultPage: [${varName}, ${JSON.stringify(defaultPath)}],
-          }
-        ]`
+        setSyntheticDefault(
+          normalizeParallelKey(adjacentParallelSegment),
+          defaultPath
+        )
       }
     }
     return {
@@ -638,6 +672,9 @@ async function createTreeCodeFromPath(
           .map(([key, value]) => `${key}: ${value}`)
           .join(',\n')}
       }`,
+      containsInterception:
+        isInterceptionRouteAppPath(segmentPath) ||
+        interceptingParallelKeys.size > 0,
     }
   }
 

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/@panel/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/@panel/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <p>Intercepted panel default</p>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/layout.tsx
@@ -1,13 +1,10 @@
-export default function Layout({
-  children,
-  sidebar,
-}: {
-  children: React.ReactNode
-  sidebar: React.ReactNode
-}) {
+// The two generated LayoutProps implementations currently disagree on whether
+// a default-only parallel route contributes a required prop.
+export default function Layout({ children, panel, sidebar }: any) {
   return (
     <div>
       <div>{sidebar}</div>
+      <div>{panel}</div>
       <div>{children}</div>
     </div>
   )

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@content/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@content/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  throw new Error('A retained slot must not render its user default')
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@content/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@content/page.tsx
@@ -1,0 +1,11 @@
+import { LinkAccordion, RetainedCounter } from '../../page.client'
+
+export default function Page() {
+  return (
+    <div>
+      <p>Named content slot</p>
+      <RetainedCounter />
+      <LinkAccordion href="/named-target" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@modal/(..)named-target/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@modal/(..)named-target/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Intercepted named target</p>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@secondary/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-host/@secondary/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Named secondary slot without a default</p>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-host/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-host/layout.tsx
@@ -1,0 +1,17 @@
+export default function Layout({
+  content,
+  modal,
+  secondary,
+}: {
+  content: React.ReactNode
+  modal: React.ReactNode
+  secondary: React.ReactNode
+}) {
+  return (
+    <main id="named-host">
+      <section id="named-host-content">{content}</section>
+      <section id="named-host-secondary">{secondary}</section>
+      <section id="named-host-modal">{modal}</section>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/named-target/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/named-target/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="canonical-named-target">Canonical named target</p>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/page.client.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/page.client.tsx
@@ -3,6 +3,19 @@
 import Link from 'next/link'
 import { useState } from 'react'
 
+export function RetainedCounter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <button
+      id="retained-counter"
+      onClick={() => setCount((value) => value + 1)}
+    >
+      Retained count: {count}
+    </button>
+  )
+}
+
 export function LinkAccordion({ href }: { href: string }) {
   const [isOpen, setIsOpen] = useState(false)
 

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -262,11 +262,44 @@ describe('interception-dynamic-segment', () => {
         })
       })
 
+      it('should retain named host slots instead of rendering their defaults', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/named-host')
+
+        await browser.elementById('retained-counter').click()
+
+        await act(async () => {
+          await navigate(browser, '/named-target')
+        })
+
+        expect(await browser.elementById('named-host-modal').text()).toContain(
+          'Intercepted named target'
+        )
+        expect(
+          await browser.elementById('named-host-content').text()
+        ).toContain('Named content slot')
+        expect(
+          await browser.elementById('named-host-secondary').text()
+        ).toContain('Named secondary slot without a default')
+        expect(await browser.elementById('retained-counter').text()).toBe(
+          'Retained count: 1'
+        )
+
+        await browser.refresh()
+
+        expect(await browser.elementById('canonical-named-target').text()).toBe(
+          'Canonical named target'
+        )
+        expect(await browser.hasElementByCss('#named-host')).toBe(false)
+      })
+
       /**
-       * Test Case 4: Has @sidebar but NO page.tsx (THE KEY BUG CASE)
-       * Structure: @modal/(.)test-nested/@sidebar/page.tsx (NO page.tsx at root)
+       * Test Case 4: Has named slots but NO page.tsx (THE KEY BUG CASE)
+       * Structure: @modal/(.)test-nested has @sidebar/page.tsx and
+       * @panel/default.tsx, but NO page.tsx at root.
        * Expected: Should work WITHOUT explicit default.tsx (auto null default)
-       * Reason: Interception + parallel routes should inject null default
+       * Reason: Legacy matching still injects a null children fallback inside
+       * the interception subtree. The real @panel default renders normally
+       * because it belongs to the newly entered subtree, not the host update.
        *
        * This is the critical test! Without the fix:
        * 1. Server returns 404 (default.js calls notFound())
@@ -287,6 +320,7 @@ describe('interception-dynamic-segment', () => {
           // Modal should show intercepted content
           const modalContent = await browser.elementByCss('#modal').text()
           expect(modalContent).toContain('Intercepted test-nested sidebar')
+          expect(modalContent).toContain('Intercepted panel default')
         })
 
         await retry(async () => {


### PR DESCRIPTION
## Summary

Interception routes represent a partial update to the layout that hosts them. Today we model this for `children` by synthesizing a `__DEFAULT__` route backed by `default-null`, but named siblings still use normal default matching even though they should retain their active state too.

This makes retention relative to the interception host instead of the `children` key. Every non-intercepting sibling gets the existing `__DEFAULT__` marker backed by `default-null`, while slots inside the newly selected interception subtree continue to use normal matching and real defaults.

The coverage uses a named-only host to verify that named siblings retain client state without evaluating a user default, that a sibling without a default also retains, and that a hard refresh still loads the canonical route.

## Example

Consider this route tree:

```text
app/
├── named-host/
│   ├── layout.tsx                  # renders canonical, content, secondary, and modal
│   ├── @canonical/
│   │   └── page.tsx
│   ├── @content/
│   │   ├── page.tsx                # renders a stateful counter
│   │   └── default.tsx             # throws if evaluated
│   ├── @secondary/
│   │   └── page.tsx                # has no default.tsx
│   └── @modal/
│       ├── default.tsx
│       └── (..)named-target/
│           └── page.tsx            # intercepted target
└── named-target/
    └── page.tsx                    # canonical route
```

Before this change, a soft navigation from `/named-host` to `/named-target` could replace `@content` with its throwing default and treat `@secondary` as missing because only `children` had retain semantics. After this change, only `@modal` switches to the intercepted page; `@content` and `@secondary` keep their existing UI and the counter keeps its state. A hard refresh still renders the canonical `/named-target` route instead of the interception host.

## Verification

- Turbopack and webpack production coverage in `interception-dynamic-segment`
- The same production coverage with Cache Components enabled

<!-- NEXT_JS_LLM -->
