### PR TITLE
Skip the initial history write on any activation-key mismatch

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -56,13 +56,10 @@ const globalMutable: {
   pendingMpaPath?: string
 } = {}
 
-// A Back/Forward press before the router's popstate listener exists moves the
-// browser to a different history entry than the one the document was activated
-// on, and the resulting popstate fires with nobody listening. The activation
-// entry is fixed for the document's lifetime and entry keys are stable across
-// replaceState, so until the listener is installed a key mismatch means a
-// traversal went unobserved.
-function hasMissedTraversal(): boolean {
+// The current entry is not the one this document was activated on. Entry keys
+// are stable across replaceState, so until the popstate listener is installed
+// this means a traversal or history write went unobserved.
+function isOnUnobservedEntry(): boolean {
   if (typeof window.navigation === 'undefined') {
     return false
   }
@@ -71,10 +68,7 @@ function hasMissedTraversal(): boolean {
   return (
     activationEntry != null &&
     currentEntry != null &&
-    activationEntry.key !== currentEntry.key &&
-    // Only entries written by the app router can be restored; on any other
-    // entry the traversal is left unhandled, as before.
-    window.history.state?.__NA === true
+    activationEntry.key !== currentEntry.key
   )
 }
 
@@ -125,8 +119,8 @@ function HistoryUpdater({
 
     if (!checkedMissedTraversalBeforeHistoryWrite) {
       checkedMissedTraversalBeforeHistoryWrite = true
-      if (hasMissedTraversal()) {
-        // Skip the write: it would overwrite the traversed-to entry's state.
+      if (isOnUnobservedEntry()) {
+        // This render does not describe the current entry; don't write to it.
         // The tree was rendered even though the history write is skipped.
         setLastCommittedTree(tree)
         return
@@ -440,7 +434,12 @@ function Router({
 
     if (!checkedMissedTraversalBeforeReplay) {
       checkedMissedTraversalBeforeReplay = true
-      if (hasMissedTraversal()) {
+      if (
+        isOnUnobservedEntry() &&
+        // Only entries written by the app router can be restored; on any
+        // other entry the traversal is left unhandled.
+        window.history.state?.__NA === true
+      ) {
         handlePopState(window.history.state)
       }
     }

--- a/test/e2e/app-dir/back-before-hydration/app/third-party-push.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/third-party-push.tsx
@@ -2,18 +2,33 @@
 
 import { useEffect } from 'react'
 
-// Simulates a third-party script writing to history between the router's
-// traversal detection and its popstate replay: this component's effect runs
-// after all insertion effects but before the parent router's effects.
+// Simulates a third-party script writing to history at one of two points the
+// router cares about. The test picks one by setting `window.__thirdPartyPush`:
+//
+// 'render' — during hydration, after the router's store captured the URL but
+//   before its first history write. A real script gets here from a timer or a
+//   deferred script that fires while the page is hydrating.
+// 'effect' — after the router detected the missed traversal but before it
+//   replays it. Child effects run before the parent router's.
+function pushIfArmed(at: 'render' | 'effect') {
+  if (
+    typeof window === 'undefined' ||
+    (window as any).__thirdPartyPush !== at
+  ) {
+    return
+  }
+  ;(window as any).__thirdPartyPush = undefined
+  window.history.pushState(
+    { thirdParty: true },
+    '',
+    window.location.pathname + '?tp=1'
+  )
+}
+
 export function ThirdPartyPush() {
+  pushIfArmed('render')
   useEffect(() => {
-    if ((window as any).__injectThirdPartyPush) {
-      window.history.pushState(
-        { thirdParty: true },
-        '',
-        window.location.pathname + '?tp=1'
-      )
-    }
+    pushIfArmed('effect')
   }, [])
   return null
 }

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -191,7 +191,38 @@ describe('back navigation before hydration after reload', () => {
           expect(new URL(await browser.url()).search).toBe('?tp=1')
         })
 
+        // The router must not claim an entry it did not write.
+        expect(await browser.eval('window.history.state')).toEqual({
+          thirdParty: true,
+        })
+
         // The router still navigates.
+        await browser.elementById('to-home').click()
+        await waitForPage(browser, '#home')
+      })
+
+      it('keeps a pushState that lands during hydration', async () => {
+        const { browser, page, releaseScripts } = await loadStalled(
+          postPath,
+          '#post'
+        )
+
+        // Unlike the test above, this one pushes after the router's store has
+        // captured the URL. Writing to the entry would put that captured URL
+        // back and undo the push.
+        await page.evaluate("window.__thirdPartyPush = 'render'")
+        releaseScripts()
+
+        await retry(async () => {
+          expect(await browser.eval('window.__stayed')).toBe(true)
+          expect(await browser.elementByCss('h1').text()).toBe('Post')
+          expect(new URL(await browser.url()).search).toBe('?tp=1')
+        })
+
+        expect(await browser.eval('window.history.state')).toEqual({
+          thirdParty: true,
+        })
+
         await browser.elementById('to-home').click()
         await waitForPage(browser, '#home')
       })
@@ -211,6 +242,9 @@ describe('back navigation before hydration after reload', () => {
           expect(await browser.elementByCss('h1').text()).toBe('Post')
           expect(new URL(await browser.url()).hash).toBe('#section')
         })
+
+        // The browser created this entry, not the router.
+        expect(await browser.eval('window.history.state')).toBe(null)
 
         // Hash traversals keep behaving like same-page jumps.
         await browser.back()
@@ -241,6 +275,8 @@ describe('back navigation before hydration after reload', () => {
           expect(await browser.elementByCss('h1').text()).toBe('Post')
           expect(new URL(await browser.url()).hash).toBe('#section')
         })
+
+        expect(await browser.eval('window.history.state')).toBe(null)
 
         // Traversing over the hash entry and the pushState entry still works.
         await browser.back() // -> post
@@ -285,7 +321,7 @@ describe('back navigation before hydration after reload', () => {
 
         // Arms an effect in the fixture that pushes a third-party history
         // entry between the router's traversal detection and its replay.
-        await page.evaluate('window.__injectThirdPartyPush = true')
+        await page.evaluate("window.__thirdPartyPush = 'effect'")
         releaseScripts()
 
         await retry(async () => {
@@ -323,6 +359,8 @@ describe('back navigation before hydration after reload', () => {
           expect(await browser.eval('window.__stayed')).toBe(true)
           expect(await browser.elementByCss('h1').text()).toBe('Post')
         })
+
+        expect(await browser.eval('window.history.state')).toEqual({ a: 1 })
       })
     })
   })


### PR DESCRIPTION
When the router hydrates, it does a `replaceState` to the current history entry with the tree it just rendered and a marker (`__NA`) saying the entry is ours. Normally the current entry is the one the document loaded on, so that's fine.

#96252 fixed one case where the current entry is *not* the document entry.

With the fix, it *also added a bunch of new tests* for this case, but they seem to be flaky.

It turns out that the fix wasn't *broad enough*, and the new tests were surfacing *an even older* issue.

This PR seems to improve the flakiness by broadening the fix to cover that older issue. Details below.

## What motivated #96252

Suppose you navigate from A to B inside the app, reload B, and press Back before B hydrates. The URL goes back to A (and the browser treats it as `popstate`), but the router isn't running yet, so nothing responds and the page still shows B. Then the router starts, and its first write would put B's tree on A's entry, breaking Back/Forward navigation.

The fix in #96252 was to *skip the history write* in that case, and also to replay `handlePopState` the router missed.

That's two decisions, and #96252 used one condition for both: we're not on the entry the document loaded on, *and* the entry has our marker (`__NA`) on it. However, these two decisions ask different questions:

- Replaying asks whether we can recover the missed Back. Recovering it means restoring the tree the entry was left with, and only our own entries have one, so we *do* need to check them for `__NA`.

- Skipping the write asks whether what we rendered describes the entry we're about to write to. If it isn't the entry we loaded on, our tree doesn't belong on it, no matter who created it. So the `__NA` check **isn't relevant here**.
  - That's what this PR fixes — it removes the `__NA` check here.

This fixes a preexisting issue described below.

## When is this distinction relevant?

For the case #96252 aimed to fix, it is not relevant.

However, it is relevant when something other than the router changes history before hydration.

Some examples:

1. You click an in-page anchor (`/post` → `/post#section`) before hydration.
2. Or a script runs a `pushState` of its own (`/post` → `/post?tp=1`) before hydration.

Either way the current entry is no longer the document's entry, and since the router didn't create it, it has no `__NA`.

To solve the flakes, we need to *broaden the fix* to include these two cases.

Behavior matrix:

| what happens before hydration | 16.3.0 and canary | this PR |
| --- | --- | --- |
| anchor click to `#section` | we overwrite the entry's `null` state with ours | we leave the entry alone |
| script pushes `?tp=1` | we merge our marker and tree into their state | we leave the entry alone |
| script pushes `?tp=1` while the page is hydrating | **`?tp=1` is thrown away** | `?tp=1` survives |

The main observable behavior (predating the Back fix) is the last row (`pushState` query getting thrown away). This is the preexisting bug exposed by the new tests, that we are fixing in this PR.

Starting with #96252, we were also doing an unnecessary no-op `handlePopState` for these cases, because we put `__NA` on the entry with a write and then immediately checked for it. 

This PR actually fixes these cases (by not doing `replaceState`).

As a result:

- We no longer overwrite these entries.
- Our tests, which verify that, no longer have races caused by hydration.

## Testing

The first commit adds the assertions for all three rows. 10 of the 18 tests fail without the second commit and all 18 pass with it.