### PR TITLE
Remove HmrTarget

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -179,39 +179,6 @@ pub struct DebugBuildPaths {
     pub pages: Vec<RcStr>,
 }
 
-/// Target for HMR operations - client-side (browser) or server-side (Node.js).
-#[turbo_tasks::task_input]
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, TraceRawVcs, Encode, Decode)]
-pub enum HmrTarget {
-    #[default]
-    Client,
-    Server,
-}
-
-impl std::fmt::Display for HmrTarget {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HmrTarget::Client => write!(f, "client"),
-            HmrTarget::Server => write!(f, "server"),
-        }
-    }
-}
-
-impl std::str::FromStr for HmrTarget {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "client" => Ok(HmrTarget::Client),
-            "server" => Ok(HmrTarget::Server),
-            _ => Err(format!(
-                "Invalid HMR target: '{}'. Expected 'client' or 'server'",
-                s
-            )),
-        }
-    }
-}
-
 /// Pre-converted route keys from debug build paths for O(1) lookups.
 struct DebugBuildPathsRouteKeys {
     app: FxHashSet<RcStr>,
@@ -894,8 +861,8 @@ impl ProjectContainer {
 
     /// See [`Project::hmr_chunk_names`].
     #[turbo_tasks::function]
-    pub fn hmr_chunk_names(self: Vc<Self>, target: HmrTarget) -> Vc<Vec<RcStr>> {
-        self.project().hmr_chunk_names(target)
+    pub fn hmr_chunk_names(self: Vc<Self>) -> Vc<Vec<RcStr>> {
+        self.project().hmr_chunk_names()
     }
 
     /// Gets a source map for a particular `file_path`. If `dev` mode is disabled, this will always
@@ -2491,36 +2458,16 @@ impl Project {
         .await
     }
 
-    /// Returns the root path for HMR content based on the target.
-    /// Client uses client_relative_path, Server uses node_root.
     #[turbo_tasks::function]
-    async fn hmr_root_path(self: Vc<Self>, target: HmrTarget) -> Result<Vc<FileSystemPath>> {
-        Ok(match target {
-            HmrTarget::Client => self.client_relative_path(),
-            HmrTarget::Server => self.node_root(),
-        })
+    async fn server_hmr_root_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
+        Ok(self.node_root().await?.join("server/app")?.cell())
     }
 
+    /// Get client HMR content by chunk_name.
     #[turbo_tasks::function]
-    async fn aggregate_hmr_root_path(
-        self: Vc<Self>,
-        target: HmrTarget,
-    ) -> Result<Vc<FileSystemPath>> {
-        match target {
-            HmrTarget::Client => bail!("aggregate HMR is not implemented for the client"),
-            HmrTarget::Server => Ok(self.node_root().await?.join("server/app")?.cell()),
-        }
-    }
-
-    /// Get HMR content by chunk_name for the specified target.
-    #[turbo_tasks::function]
-    async fn hmr_content(
-        self: Vc<Self>,
-        chunk_name: RcStr,
-        target: HmrTarget,
-    ) -> Result<Vc<OptionVersionedContent>> {
+    async fn hmr_content(self: Vc<Self>, chunk_name: RcStr) -> Result<Vc<OptionVersionedContent>> {
         if let Some(map) = self.await?.versioned_content_map {
-            let content = map.get(self.hmr_root_path(target).await?.join(&chunk_name)?);
+            let content = map.get(self.client_relative_path().await?.join(&chunk_name)?);
             Ok(content)
         } else {
             bail!("must be in dev mode to hmr")
@@ -2533,7 +2480,6 @@ impl Project {
     pub async fn hmr_version_state(
         self: ResolvedVc<Self>,
         chunk_name: RcStr,
-        target: HmrTarget,
         session: TransientInstance<()>,
     ) -> Result<Vc<VersionState>> {
         // The session argument is important to avoid caching this function between
@@ -2544,23 +2490,22 @@ impl Project {
             level = "info",
             name = "get HMR version",
             skip_all,
-            fields(chunk_name = %chunk_name, target = %target),
+            fields(chunk_name = %chunk_name),
         )]
         #[turbo_tasks::function(operation, root)]
         async fn hmr_version_operation(
             this: ResolvedVc<Project>,
             chunk_name: RcStr,
-            target: HmrTarget,
         ) -> Result<Vc<Box<dyn Version>>> {
-            tracing::info!(chunk_name = %chunk_name, target = %target, "hmr subscription");
-            let content = this.hmr_content(chunk_name, target).await?;
+            tracing::info!(chunk_name = %chunk_name, "hmr subscription");
+            let content = this.hmr_content(chunk_name).await?;
             if let Some(content) = &*content {
                 Ok(content.version())
             } else {
                 Ok(Vc::upcast(NotFoundVersion::new()))
             }
         }
-        let version_op = hmr_version_operation(self, chunk_name, target);
+        let version_op = hmr_version_operation(self, chunk_name);
 
         // INVALIDATION: This is intentionally untracked to avoid invalidating this
         // function completely. We want to initialize the VersionState with the
@@ -2576,16 +2521,15 @@ impl Project {
     }
 
     /// Emits opaque HMR events whenever a change is detected in the chunk group
-    /// internally known as `chunk_name` for the specified target.
+    /// internally known as `chunk_name`.
     #[turbo_tasks::function]
     pub async fn hmr_update(
         self: Vc<Self>,
         chunk_name: RcStr,
-        target: HmrTarget,
         from: Vc<VersionState>,
     ) -> Result<Vc<Update>> {
         let from = from.get();
-        let content = self.hmr_content(chunk_name, target).await?;
+        let content = self.hmr_content(chunk_name).await?;
         if let Some(content) = *content {
             Ok(content.update(from))
         } else {
@@ -2594,35 +2538,21 @@ impl Project {
     }
 
     /// Aggregate counterpart to [`Self::hmr_version_state`]: one [`VersionState`]
-    /// covering every HMR-eligible chunk under `target`'s root. See
-    /// [`Self::all_hmr_update`].
+    /// covering every server HMR-eligible chunk. See [`Self::server_hmr_update`].
     #[turbo_tasks::function(session_dependent)]
-    pub async fn all_hmr_version_state(
-        self: ResolvedVc<Self>,
-        target: HmrTarget,
-    ) -> Result<Vc<VersionState>> {
-        if target == HmrTarget::Client {
-            bail!("all_hmr_version_state is not yet implemented for the client target");
-        }
-
-        #[tracing::instrument(
-            level = "info",
-            name = "get aggregate HMR version",
-            skip_all,
-            fields(target = %target),
-        )]
+    pub async fn server_hmr_version_state(self: ResolvedVc<Self>) -> Result<Vc<VersionState>> {
+        #[tracing::instrument(level = "info", name = "get server HMR version", skip_all)]
         #[turbo_tasks::function(operation, root)]
-        async fn aggregate_hmr_version_operation(
+        async fn server_hmr_version_operation(
             this: ResolvedVc<Project>,
-            target: HmrTarget,
         ) -> Result<Vc<Box<dyn Version>>> {
             let Some(map) = this.await?.versioned_content_map else {
                 bail!("must be in dev mode to hmr")
             };
-            let root = this.aggregate_hmr_root_path(target).owned().await?;
+            let root = this.server_hmr_root_path().owned().await?;
             AggregateHmrVersion::from_map(*map, root).await
         }
-        let version_op = aggregate_hmr_version_operation(self, target);
+        let version_op = server_hmr_version_operation(self);
 
         // INVALIDATION: untracked initial read; the subscription drives invalidation.
         let state = VersionState::new(
@@ -2636,8 +2566,7 @@ impl Project {
     }
 
     /// Aggregate counterpart to [`Self::hmr_update`]: a single `Update` whose
-    /// combined `ChunkListUpdate` is the union of the per-entry-chunk diffs
-    /// under `target`'s root.
+    /// combined `ChunkListUpdate` is the union of the server entry chunk diffs.
     ///
     /// Each tracked entry chunk's own update is a `ChunkListUpdate` (carrying
     /// the module deltas for its shared chunks via the merger) or a bare
@@ -2649,19 +2578,11 @@ impl Project {
     /// chunks absent from `from` are skipped; the runtime require()s them on
     /// demand.
     #[turbo_tasks::function]
-    pub async fn all_hmr_update(
-        self: Vc<Self>,
-        target: HmrTarget,
-        from: Vc<VersionState>,
-    ) -> Result<Vc<Update>> {
-        if target == HmrTarget::Client {
-            bail!("all_hmr_update is not yet implemented for the client target");
-        }
-
+    pub async fn server_hmr_update(self: Vc<Self>, from: Vc<VersionState>) -> Result<Vc<Update>> {
         let Some(map) = self.await?.versioned_content_map else {
             bail!("must be in dev mode to hmr")
         };
-        let root = self.aggregate_hmr_root_path(target).owned().await?;
+        let root = self.server_hmr_root_path().owned().await?;
         let chunks_versioned_content = map.hmr_chunks_in_path(root).await?;
 
         // No chunks to diff yet (e.g. before any endpoints have been written).
@@ -2710,14 +2631,11 @@ impl Project {
         Ok(builder.build(to_ref).cell())
     }
 
-    /// Gets a list of all HMR chunk names that can be subscribed to for the
-    /// specified target. Used by the dev server to set up server-side HMR
-    /// subscriptions for all Node.js App Router entries (pages and route
-    /// handlers).
+    /// Gets a list of all client HMR chunk names that can be subscribed to.
     #[turbo_tasks::function]
-    pub async fn hmr_chunk_names(self: Vc<Self>, target: HmrTarget) -> Result<Vc<Vec<RcStr>>> {
+    pub async fn hmr_chunk_names(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
         if let Some(map) = self.await?.versioned_content_map {
-            Ok(map.keys_in_path(self.hmr_root_path(target).owned().await?))
+            Ok(map.keys_in_path(self.client_relative_path().owned().await?))
         } else {
             bail!("must be in dev mode to hmr")
         }

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use futures_util::{StreamExt, TryStreamExt};
 use next_api::{
     entrypoints::Entrypoints,
-    project::{HmrTarget, ProjectContainer, ProjectOptions},
+    project::{ProjectContainer, ProjectOptions},
     route::{Endpoint, EndpointOutputPaths, Route, endpoint_write_to_disk},
 };
 use turbo_rcstr::{RcStr, rcstr};
@@ -292,7 +292,7 @@ async fn hmr(
 
     #[turbo_tasks::function(operation, root)]
     fn project_hmr_chunk_names_operation(project: ResolvedVc<ProjectContainer>) -> Vc<Vec<RcStr>> {
-        project.hmr_chunk_names(HmrTarget::Client)
+        project.hmr_chunk_names()
     }
 
     let idents = tt
@@ -316,10 +316,8 @@ async fn hmr(
             let ident = ident_for_task.clone();
             async move {
                 let project = project.project();
-                let state = project.hmr_version_state(ident.clone(), HmrTarget::Client, session);
-                project
-                    .hmr_update(ident.clone(), HmrTarget::Client, state)
-                    .await?;
+                let state = project.hmr_version_state(ident.clone(), session);
+                project.hmr_update(ident.clone(), state).await?;
                 Ok(Vc::<()>::cell(()))
             }
         });

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -26,7 +26,7 @@ use next_api::{
         RouteOperation,
     },
     project::{
-        DebugBuildPaths, DefineEnv, DraftModeOptions, HmrTarget, PartialProjectOptions, Project,
+        DebugBuildPaths, DefineEnv, DraftModeOptions, PartialProjectOptions, Project,
         ProjectContainer, ProjectOptions, WatchOptions,
     },
     project_asset_hashes_manifest::immutable_hashes_manifest_asset_if_enabled,
@@ -1814,27 +1814,25 @@ struct HmrUpdateWithIssues {
 fn project_hmr_update_operation(
     project: ResolvedVc<Project>,
     chunk_name: RcStr,
-    target: HmrTarget,
     state: ResolvedVc<VersionState>,
 ) -> Vc<Update> {
-    project.hmr_update(chunk_name, target, *state)
+    project.hmr_update(chunk_name, *state)
 }
 
 #[tracing::instrument(
     level = "info",
     name = "hmr subscription",
     skip_all,
-    fields(chunk_name = %chunk_name, target = %target),
+    fields(chunk_name = %chunk_name),
 )]
 #[turbo_tasks::function(operation, root)]
 async fn hmr_update_with_issues_operation(
     project: ResolvedVc<Project>,
     chunk_name: RcStr,
     state: ResolvedVc<VersionState>,
-    target: HmrTarget,
 ) -> Result<Vc<HmrUpdateWithIssues>> {
-    tracing::info!(chunk_name = %chunk_name, target = %target, "hmr subscription");
-    let update_op = project_hmr_update_operation(project, chunk_name, target, state);
+    tracing::info!(chunk_name = %chunk_name, "hmr subscription");
+    let update_op = project_hmr_update_operation(project, chunk_name, state);
     // NOTE: we do not use `strongly_consistent_catch_collectables` here. The JS HMR
     // consumers in `hot-reloader-turbopack.ts` (`subscribeToServerHmr` and
     // `subscribeToClientHmrEvents`) rely on this read *throwing* on build-graph
@@ -1853,29 +1851,22 @@ async fn hmr_update_with_issues_operation(
 
 /// Aggregate counterpart to [`project_hmr_update_operation`].
 #[turbo_tasks::function(operation, root)]
-fn project_all_hmr_update_operation(
+fn project_server_hmr_update_operation(
     project: ResolvedVc<Project>,
-    target: HmrTarget,
     state: ResolvedVc<VersionState>,
 ) -> Vc<Update> {
-    project.all_hmr_update(target, *state)
+    project.server_hmr_update(*state)
 }
 
 /// Aggregate counterpart to [`hmr_update_with_issues_operation`].
-#[tracing::instrument(
-    level = "info",
-    name = "aggregate hmr subscription",
-    skip_all,
-    fields(target = %target),
-)]
+#[tracing::instrument(level = "info", name = "server hmr subscription", skip_all)]
 #[turbo_tasks::function(operation, root)]
-async fn all_hmr_update_with_issues_operation(
+async fn server_hmr_update_with_issues_operation(
     project: ResolvedVc<Project>,
     state: ResolvedVc<VersionState>,
-    target: HmrTarget,
 ) -> Result<Vc<HmrUpdateWithIssues>> {
-    tracing::info!(target = %target, "aggregate hmr subscription");
-    let update_op = project_all_hmr_update_operation(project, target, state);
+    tracing::info!("server hmr subscription");
+    let update_op = project_server_hmr_update_operation(project, state);
     // See `hmr_update_with_issues_operation`: the JS consumer relies on this
     // read *throwing* on build-graph failures; don't swallow errors.
     let update = update_op
@@ -1893,19 +1884,18 @@ async fn all_hmr_update_with_issues_operation(
     .cell())
 }
 
-#[tracing::instrument(level = "info", name = "get all HMR events", skip(env, project, func), fields(target = %target))]
+#[tracing::instrument(
+    level = "info",
+    name = "get server HMR events",
+    skip(env, project, func)
+)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
-pub fn project_all_hmr_events(
+pub fn project_server_hmr_events(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-    target: String,
     #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<NodeJsHmrUpdate>) => void")]
     func: FunctionRef<TurbopackResult<Unknown<'static>>, ()>,
 ) -> napi::Result<External<RootTask>> {
-    let hmr_target = target
-        .parse::<HmrTarget>()
-        .map_err(napi::Error::from_reason)?;
-
     let container = project.container;
     // Sentinel resource id for the aggregated stream (no real chunk path).
     let identifier_path: RcStr = rcstr!("__next_all_hmr__");
@@ -1918,12 +1908,9 @@ pub fn project_all_hmr_events(
             unmark_top_level_task_may_leak_eventually_consistent_state();
 
             let project = container.project().to_resolved().await?;
-            let state = project
-                .all_hmr_version_state(hmr_target)
-                .to_resolved()
-                .await?;
+            let state = project.server_hmr_version_state().to_resolved().await?;
 
-            let update_op = all_hmr_update_with_issues_operation(project, state, hmr_target);
+            let update_op = server_hmr_update_with_issues_operation(project, state);
 
             // HACK(bgw): Remove this mark call
             mark_top_level_task();
@@ -1982,20 +1969,17 @@ pub fn project_all_hmr_events(
     )
 }
 
-#[tracing::instrument(level = "info", name = "get HMR events", skip(env, project, func), fields(target = %target, chunk_name = %chunk_name))]
+#[tracing::instrument(level = "info", name = "get client HMR events", skip(env, project, func), fields(chunk_name = %chunk_name))]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
-pub fn project_hmr_events(
+pub fn project_client_hmr_events(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
     chunk_name: RcStr,
-    target: String,
-    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<Update | NodeJsHmrUpdate>) => void")]
-    func: FunctionRef<TurbopackResult<Unknown<'static>>, ()>,
+    #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<Update>) => void")] func: FunctionRef<
+        TurbopackResult<Unknown<'static>>,
+        (),
+    >,
 ) -> napi::Result<External<RootTask>> {
-    let hmr_target = target
-        .parse::<HmrTarget>()
-        .map_err(napi::Error::from_reason)?;
-
     let container = project.container;
     let session = TransientInstance::new(());
     subscribe(
@@ -2013,16 +1997,12 @@ pub fn project_hmr_events(
                     unmark_top_level_task_may_leak_eventually_consistent_state();
                     let project = container.project().to_resolved().await?;
                     let state = project
-                        .hmr_version_state(chunk_name.clone(), hmr_target, session)
+                        .hmr_version_state(chunk_name.clone(), session)
                         .to_resolved()
                         .await?;
 
-                    let update_op = hmr_update_with_issues_operation(
-                        project,
-                        chunk_name.clone(),
-                        state,
-                        hmr_target,
-                    );
+                    let update_op =
+                        hmr_update_with_issues_operation(project, chunk_name.clone(), state);
                     // HACK(bgw): Remove this mark call
                     mark_top_level_task();
                     let read =
@@ -2093,19 +2073,17 @@ struct HmrChunkNamesWithIssues {
 }
 
 #[turbo_tasks::function(operation, root)]
-fn project_hmr_chunk_names_operation(
+fn project_client_hmr_chunk_names_operation(
     container: ResolvedVc<ProjectContainer>,
-    target: HmrTarget,
 ) -> Vc<Vec<RcStr>> {
-    container.hmr_chunk_names(target)
+    container.hmr_chunk_names()
 }
 
 #[turbo_tasks::function(operation, root)]
-async fn get_hmr_chunk_names_with_issues_operation(
+async fn get_client_hmr_chunk_names_with_issues_operation(
     container: ResolvedVc<ProjectContainer>,
-    target: HmrTarget,
 ) -> Result<Vc<HmrChunkNamesWithIssues>> {
-    let hmr_chunk_names_op = project_hmr_chunk_names_operation(container, target);
+    let hmr_chunk_names_op = project_client_hmr_chunk_names_operation(container);
     // Do NOT switch this to `strongly_consistent_catch_collectables`. The JS HMR
     // chunk-names consumer in `hot-reloader-turbopack.ts` relies on this read
     // *throwing* on build-graph failures so its outer `try` block exits the
@@ -2124,19 +2102,18 @@ async fn get_hmr_chunk_names_with_issues_operation(
     .cell())
 }
 
-#[tracing::instrument(level = "info", name = "get HMR chunk names", skip(env, project, func), fields(target = %target))]
+#[tracing::instrument(
+    level = "info",
+    name = "get client HMR chunk names",
+    skip(env, project, func)
+)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
-pub fn project_hmr_chunk_names_subscribe(
+pub fn project_client_hmr_chunk_names_subscribe(
     env: Env,
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: &External<ProjectInstance>,
-    target: String,
     #[napi(ts_arg_type = "(err: Error, value: TurbopackResult<HmrChunkNames>) => void")]
     func: FunctionRef<TurbopackResult<HmrChunkNames>, ()>,
 ) -> napi::Result<External<RootTask>> {
-    let hmr_target = target
-        .parse::<HmrTarget>()
-        .map_err(napi::Error::from_reason)?;
-
     let container = project.container;
     subscribe(
         project.turbopack_ctx.clone(),
@@ -2144,7 +2121,7 @@ pub fn project_hmr_chunk_names_subscribe(
         &func,
         move || async move {
             let hmr_chunk_names_with_issues_op =
-                get_hmr_chunk_names_with_issues_operation(container, hmr_target);
+                get_client_hmr_chunk_names_with_issues_operation(container);
             let read =
                 read_strongly_consistent_and_apply_effects(hmr_chunk_names_with_issues_op, |v| {
                     &v.effects

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -581,10 +581,15 @@ export declare function parse(
   signal?: AbortSignal | undefined | null
 ): Promise<string>
 
-export declare function projectAllHmrEvents(
+export declare function projectClientHmrChunkNamesSubscribe(
   project: { __napiType: 'Project' },
-  target: string,
-  func: (err: Error, value: TurbopackResult<NodeJsHmrUpdate>) => void
+  func: (err: Error, value: TurbopackResult<HmrChunkNames>) => void
+): { __napiType: 'RootTask' }
+
+export declare function projectClientHmrEvents(
+  project: { __napiType: 'Project' },
+  chunkName: RcStr,
+  func: (err: Error, value: TurbopackResult<Update>) => void
 ): { __napiType: 'RootTask' }
 
 /** Subscribes to all compilation events that are not cached like timing and progress information. */
@@ -634,19 +639,6 @@ export declare function projectGetSourceMapSync(
   sourceMapUrl: RcStr
 ): string | null
 
-export declare function projectHmrChunkNamesSubscribe(
-  project: { __napiType: 'Project' },
-  target: string,
-  func: (err: Error, value: TurbopackResult<HmrChunkNames>) => void
-): { __napiType: 'RootTask' }
-
-export declare function projectHmrEvents(
-  project: { __napiType: 'Project' },
-  chunkName: RcStr,
-  target: string,
-  func: (err: Error, value: TurbopackResult<Update | NodeJsHmrUpdate>) => void
-): { __napiType: 'RootTask' }
-
 /**
  * Invalidates the filesystem cache so that it will be deleted next time that a turbopack project
  * is created with filesystem cache enabled.
@@ -670,6 +662,11 @@ export declare function projectNew(
 export declare function projectOnExit(project: {
   __napiType: 'Project'
 }): Promise<void>
+
+export declare function projectServerHmrEvents(
+  project: { __napiType: 'Project' },
+  func: (err: Error, value: TurbopackResult<NodeJsHmrUpdate>) => void
+): { __napiType: 'RootTask' }
 
 /**
  * Runs `project_on_exit`, and then waits for turbo_tasks to gracefully shut down.

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -43,11 +43,6 @@ import type {
 } from './types'
 import { runLoaderWorkerPool } from './loaderWorkerPool'
 
-export enum HmrTarget {
-  Client = 'client',
-  Server = 'server',
-}
-
 type RawBindings = typeof import('./generated-native')
 type RawWasmBindings = typeof import('./generated-wasm') & {
   default?(): Promise<typeof import('./generated-wasm')>
@@ -762,47 +757,27 @@ function bindingToApi(
       })()
     }
 
-    // Note: only the Server target is implemented in the native binding;
-    // add a Client overload once `all_hmr_update` supports it.
-    allHmrEvents(
-      target: HmrTarget.Server
-    ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>> {
+    serverHmrEvents(): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>> {
       return subscribe(true, async (callback) =>
-        binding.projectAllHmrEvents(this._nativeProject, target, callback)
+        binding.projectServerHmrEvents(this._nativeProject, callback)
       )
     }
 
-    hmrEvents(
-      chunkName: string,
-      target: HmrTarget.Client
-    ): AsyncIterableIterator<TurbopackResult<Update>>
-    hmrEvents(
-      chunkName: string,
-      target: HmrTarget.Server
-    ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
-    hmrEvents(chunkName: string, target: HmrTarget.Client | HmrTarget.Server) {
+    clientHmrEvents(
+      chunkName: string
+    ): AsyncIterableIterator<TurbopackResult<Update>> {
       return subscribe(true, async (callback) =>
-        binding.projectHmrEvents(
-          this._nativeProject,
-          chunkName,
-          target,
-          callback
-        )
+        binding.projectClientHmrEvents(this._nativeProject, chunkName, callback)
       )
     }
 
-    /**
-     * Subscribe to the list of output chunk paths that can receive HMR updates.
-     * Chunk paths are output file paths like "server/chunks/ssr/..._.js" for server
-     * or "_next/static/chunks/app/page.js" for client.
-     */
-    hmrChunkNamesSubscribe(target: HmrTarget) {
+    /** Subscribe to client output chunk paths that can receive HMR updates. */
+    clientHmrChunkNamesSubscribe() {
       return subscribe<TurbopackResult<HmrChunkNames>>(
         false,
         async (callback) =>
-          binding.projectHmrChunkNamesSubscribe(
+          binding.projectClientHmrChunkNamesSubscribe(
             this._nativeProject,
-            target,
             callback
           )
       )

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -334,24 +334,15 @@ export interface Project {
     TurbopackResult<RawEntrypoints | {}>
   >
 
-  // Note: only the Server target is implemented in the native binding;
-  // add a Client overload once `all_hmr_update` supports it.
-  allHmrEvents(
-    target: import('./index').HmrTarget.Server
-  ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
+  serverHmrEvents(): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
 
-  hmrEvents(
-    identifier: string,
-    target: import('./index').HmrTarget.Client
+  clientHmrEvents(
+    identifier: string
   ): AsyncIterableIterator<TurbopackResult<Update>>
-  hmrEvents(
-    identifier: string,
-    target: import('./index').HmrTarget.Server
-  ): AsyncIterableIterator<TurbopackResult<NodeJsHmrUpdate>>
 
-  hmrChunkNamesSubscribe(
-    target: import('./index').HmrTarget
-  ): AsyncIterableIterator<TurbopackResult<HmrChunkNames>>
+  clientHmrChunkNamesSubscribe(): AsyncIterableIterator<
+    TurbopackResult<HmrChunkNames>
+  >
 
   getSourceForAsset(filePath: string): Promise<string | null>
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -28,7 +28,7 @@ import type {
   NodeJsHmrUpdate,
   NodeJsPartialHmrUpdate,
 } from '../../build/swc/types'
-import { createDefineEnv, getBindingsSync, HmrTarget } from '../../build/swc'
+import { createDefineEnv, getBindingsSync } from '../../build/swc'
 import * as Log from '../../build/output/log'
 import { BLOCKED_PAGES } from '../../shared/lib/constants'
 import {
@@ -217,7 +217,7 @@ function setupServerHmr(
   }
 ) {
   async function runSubscription() {
-    const subscription = project.allHmrEvents(HmrTarget.Server)
+    const subscription = project.serverHmrEvents()
 
     // Subscribing immediately emits one event describing the current state.
     // There's no previous state to diff it against, so it never carries anything
@@ -988,7 +988,7 @@ export async function createHotReloaderTurbopack(
       return
     }
 
-    const subscription = project!.hmrEvents(id, HmrTarget.Client)
+    const subscription = project!.clientHmrEvents(id)
     state.subscriptions.set(id, subscription)
 
     // The subscription will always emit once, which is the initial

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
-import { createDefineEnv, loadBindings, HmrTarget } from 'next/dist/build/swc'
+import { createDefineEnv, loadBindings } from 'next/dist/build/swc'
 import type {
   Issue,
   MemoryEvictionMode,
@@ -618,15 +618,13 @@ describe('next.rs api', () => {
           }
         }
 
-        const result = await project
-          .hmrChunkNamesSubscribe(HmrTarget.Client)
-          .next()
+        const result = await project.clientHmrChunkNamesSubscribe().next()
         expect(result.done).toBe(false)
         const chunkNames = result.value.chunkNames
         expect(chunkNames).toHaveProperty('length', expect.toBePositive())
 
         const subscriptions = chunkNames.map((chunkName) =>
-          project.hmrEvents(chunkName, HmrTarget.Client)
+          project.clientHmrEvents(chunkName)
         )
         await Promise.all(
           subscriptions.map(async (subscription) => {
@@ -740,12 +738,12 @@ describe('next.rs api', () => {
     if (route.type !== 'page') throw new Error('unknown route type')
     await route.htmlEndpoint.writeToDisk()
 
-    const result = await project.hmrChunkNamesSubscribe(HmrTarget.Client).next()
+    const result = await project.clientHmrChunkNamesSubscribe().next()
     expect(result.done).toBe(false)
     const chunkNames = result.value.chunkNames
 
     const subscriptions = chunkNames.map((chunkName) =>
-      project.hmrEvents(chunkName, HmrTarget.Client)
+      project.clientHmrEvents(chunkName)
     )
     await Promise.all(
       subscriptions.map(async (subscription) => {


### PR DESCRIPTION
With #94948 we intended to move the client over to the firehose feed of HMR events with the intent of unifying the code paths for maintenance. However, now that Server HMR is moving to a pull-based model (which client HMR will not be able to implement), let's keep the split. 

There's no need to encode the HmrTarget into each surface, and we can just use the function name to indicate which mode of HMR it's for.