### PR TITLE
Anchor the async local storage instances to global symbols

### DIFF
--- a/packages/next/src/server/app-render/action-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/action-async-storage-instance.ts
@@ -1,5 +1,5 @@
 import type { ActionAsyncStorage } from './action-async-storage.external'
-import { createAsyncLocalStorage } from './async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from './async-local-storage'
 
 export const actionAsyncStorageInstance: ActionAsyncStorage =
-  createAsyncLocalStorage()
+  getOrCreateGlobalAsyncLocalStorage('action-async-storage')

--- a/packages/next/src/server/app-render/after-task-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/after-task-async-storage-instance.ts
@@ -1,5 +1,5 @@
 import type { AfterTaskAsyncStorage } from './after-task-async-storage.external'
-import { createAsyncLocalStorage } from './async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from './async-local-storage'
 
 export const afterTaskAsyncStorageInstance: AfterTaskAsyncStorage =
-  createAsyncLocalStorage()
+  getOrCreateGlobalAsyncLocalStorage('after-task-async-storage')

--- a/packages/next/src/server/app-render/async-local-storage.ts
+++ b/packages/next/src/server/app-render/async-local-storage.ts
@@ -45,6 +45,43 @@ export function createAsyncLocalStorage<
   return new FakeAsyncLocalStorage()
 }
 
+/**
+ * Returns the storage registered under `name`, and creates it on first use.
+ *
+ * These storages must be singletons within a realm. A store that is entered
+ * through one reference to a storage must be readable through every other
+ * reference to it. If it is not, code that runs inside the scope sees no store
+ * at all. Module identity does not guarantee this. A realm can evaluate the
+ * same `next` file more than once if the package is reachable through more than
+ * one path, and then each evaluation creates a storage of its own. A global
+ * symbol keeps the singleton intact for any number of copies. Worker threads
+ * and edge sandboxes still get separate storages, because each of them has its
+ * own `globalThis`.
+ *
+ * Module identity broke this way in `next dev`. A bug in Node's
+ * `fs.realpathSync` can return a path with its symlinks unresolved, and the
+ * module loader keys the module cache on that path. On a pnpm install it then
+ * resolves `next/dist/...` through the `node_modules/next` symlink instead of
+ * the real path, so the file is evaluated a second time. See
+ * https://github.com/nodejs/node/pull/65113. Node versions without that fix
+ * stay affected.
+ *
+ * The key includes the Next.js version, so two different versions of Next.js in
+ * the same realm keep separate storages. Their store shapes might not be
+ * compatible.
+ */
+export function getOrCreateGlobalAsyncLocalStorage<Store extends {}>(
+  name: string
+): AsyncLocalStorage<Store> {
+  const key = Symbol.for(`@next/${name}@${process.env.__NEXT_VERSION}`)
+
+  const globalStore = globalThis as typeof globalThis & {
+    [key: symbol]: AsyncLocalStorage<Store> | undefined
+  }
+
+  return (globalStore[key] ??= createAsyncLocalStorage<Store>())
+}
+
 export function bindSnapshot<T>(
   // WARNING: Don't pass a named function to this argument! See: https://github.com/facebook/react/pull/34911
   fn: T

--- a/packages/next/src/server/app-render/console-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/console-async-storage-instance.ts
@@ -1,5 +1,5 @@
-import { createAsyncLocalStorage } from './async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from './async-local-storage'
 import type { ConsoleAsyncStorage } from './console-async-storage.external'
 
 export const consoleAsyncStorageInstance: ConsoleAsyncStorage =
-  createAsyncLocalStorage()
+  getOrCreateGlobalAsyncLocalStorage('console-async-storage')

--- a/packages/next/src/server/app-render/dynamic-access-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/dynamic-access-async-storage-instance.ts
@@ -1,5 +1,5 @@
-import { createAsyncLocalStorage } from './async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from './async-local-storage'
 import type { DynamicAccessStorage } from './dynamic-access-async-storage.external'
 
 export const dynamicAccessAsyncStorageInstance: DynamicAccessStorage =
-  createAsyncLocalStorage()
+  getOrCreateGlobalAsyncLocalStorage('dynamic-access-async-storage')

--- a/packages/next/src/server/app-render/work-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/work-async-storage-instance.ts
@@ -1,5 +1,5 @@
 import type { WorkAsyncStorage } from './work-async-storage.external'
-import { createAsyncLocalStorage } from './async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from './async-local-storage'
 
 export const workAsyncStorageInstance: WorkAsyncStorage =
-  createAsyncLocalStorage()
+  getOrCreateGlobalAsyncLocalStorage('work-async-storage')

--- a/packages/next/src/server/app-render/work-unit-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage-instance.ts
@@ -1,5 +1,5 @@
-import { createAsyncLocalStorage } from './async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from './async-local-storage'
 import type { WorkUnitAsyncStorage } from './work-unit-async-storage.external'
 
 export const workUnitAsyncStorageInstance: WorkUnitAsyncStorage =
-  createAsyncLocalStorage()
+  getOrCreateGlobalAsyncLocalStorage('work-unit-async-storage')

--- a/packages/next/src/server/lib/trace/request-insights-identity.ts
+++ b/packages/next/src/server/lib/trace/request-insights-identity.ts
@@ -1,6 +1,6 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { RequestInsightKind } from '../../../next-devtools/shared/request-insights'
-import { createAsyncLocalStorage } from '../../app-render/async-local-storage'
+import { getOrCreateGlobalAsyncLocalStorage } from '../../app-render/async-local-storage'
 
 export type RequestInsightsIdentity = {
   requestId: string
@@ -12,17 +12,8 @@ export type RequestInsightsIdentity = {
 // This storage covers the part of BaseServer request handling that runs before
 // App Render creates workAsyncStorage. Once available, workStore remains the
 // primary identity source for locally recorded spans.
-const REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY = Symbol.for(
-  '@next/request-insights-identity-storage'
-)
-
 function getRequestInsightsIdentityStorage(): AsyncLocalStorage<RequestInsightsIdentity> {
-  const globalStore = globalThis as typeof globalThis & {
-    [REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY]?: AsyncLocalStorage<RequestInsightsIdentity>
-  }
-
-  return (globalStore[REQUEST_INSIGHTS_IDENTITY_STORAGE_KEY] ??=
-    createAsyncLocalStorage())
+  return getOrCreateGlobalAsyncLocalStorage('request-insights-identity-storage')
 }
 
 export function runWithRequestInsightsIdentity<T>(

--- a/test/development/app-dir/cache-components-dev-warmup/dev-warmup.util.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/dev-warmup.util.ts
@@ -25,7 +25,7 @@ export function runDevWarmupTests({
     : 'fixtures/without-prefetch-config'
 
   describe(`cache-components-dev-warmup - ${description}`, () => {
-    const { next, isTurbopack } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: nodePath.join(__dirname, fixturePath),
     })
 
@@ -102,19 +102,6 @@ export function runDevWarmupTests({
         'AbortError: This operation was aborted'
       )
 
-      if (isTurbopack) {
-        // FIXME:
-        // In Turbopack, requests to the /revalidate route seem to occasionally crash
-        // due to some HMR or compilation issue. `revalidatePath` throws this error:
-        //
-        //   Invariant: static generation store missing in revalidatePath <path>
-        //
-        // This is unrelated to the logic being tested here, so for now, we skip the assertions
-        // that require us to revalidate.
-        console.log('WARNING: skipping revalidation assertions in turbopack')
-        return
-      }
-
       // After a revalidation the subsequent render must discard the stale cache
       // entries. This should not affect the environment labels once the caches
       // are warm again.
@@ -170,19 +157,6 @@ export function runDevWarmupTests({
       expect(next.cliOutput).not.toContain(
         'AbortError: This operation was aborted'
       )
-
-      if (isTurbopack) {
-        // FIXME:
-        // In Turbopack, requests to the /revalidate route seem to occasionally crash
-        // due to some HMR or compilation issue. `revalidatePath` throws this error:
-        //
-        //   Invariant: static generation store missing in revalidatePath <path>
-        //
-        // This is unrelated to the logic being tested here, so for now, we skip the assertions
-        // that require us to revalidate.
-        console.log('WARNING: skipping revalidation assertions in turbopack')
-        return
-      }
 
       // After a revalidation the subsequent render must discard the stale cache
       // entries. This should not affect the environment labels once the caches
@@ -443,58 +417,52 @@ export function runDevWarmupTests({
         })
       })
 
-      // FIXME: it seems like in Turbopack we sometimes get two instances of `workUnitAsyncStorage` --
-      // `app-render` gets a second, newer instance, different from `io()`.
-      // Thus, `io()` gets an undefined `workUnitStore` and does nothing, so sync IO does not get tracked at all.
-      // This is likely caused by the same bug that breaks `/revalidate` (see other FIXME above),
-      // where a route crashes due to a missing `workStore`.
-      if (!isTurbopack) {
-        it('sync IO in the static phase', async () => {
-          const path = '/sync-io/static'
+      it('sync IO in the static phase', async () => {
+        const path = '/sync-io/static'
 
-          const assertLogs = async (browser: Playwright) => {
-            const logs = await browser.log()
+        const assertLogs = async (browser: Playwright) => {
+          const logs = await browser.log()
 
-            assertLog(logs, 'after first cache', 'Prerender')
-            // sync IO in the static stage errors and advances to Server.
+          assertLog(logs, 'after first cache', 'Prerender')
+          // sync IO in the static stage errors and advances to Server.
+          assertLog(logs, 'after sync io', 'Server')
+          assertLog(logs, 'after cache read - page', 'Server')
+        }
+
+        if (isInitialLoad) {
+          await testInitialLoad(path, assertLogs)
+        } else {
+          await testNavigation(path, assertLogs)
+        }
+      })
+
+      it('sync IO in the runtime phase', async () => {
+        const path = '/sync-io/runtime'
+
+        const assertLogs = async (browser: Playwright) => {
+          const logs = await browser.log()
+
+          assertLog(logs, 'after first cache', 'Prerender')
+          assertLog(logs, 'after cookies', 'Prefetch')
+          if (hasRuntimePrefetch || partialPrefetching) {
+            // in partialPrefetching (via per-segment config or global flag),
+            // sync IO in the runtime stage errors and advances to Server.
             assertLog(logs, 'after sync io', 'Server')
             assertLog(logs, 'after cache read - page', 'Server')
-          }
-
-          if (isInitialLoad) {
-            await testInitialLoad(path, assertLogs)
           } else {
-            await testNavigation(path, assertLogs)
+            // if runtime prefetching is not on, sync IO in the runtime stage
+            // does nothing.
+            assertLog(logs, 'after sync io', 'Prefetch')
+            assertLog(logs, 'after cache read - page', 'Prefetch')
           }
-        })
+        }
 
-        it('sync IO in the runtime phase', async () => {
-          const path = '/sync-io/runtime'
-
-          const assertLogs = async (browser: Playwright) => {
-            const logs = await browser.log()
-
-            assertLog(logs, 'after first cache', 'Prerender')
-            assertLog(logs, 'after cookies', 'Prefetch')
-            if (hasRuntimePrefetch || partialPrefetching) {
-              // in partialPrefetching (via per-segment config or global flag),
-              // sync IO in the runtime stage errors and advances to Server.
-              assertLog(logs, 'after sync io', 'Server')
-              assertLog(logs, 'after cache read - page', 'Server')
-            } else {
-              // if runtime prefetching is not on, sync IO in the runtime stage does nothing.
-              assertLog(logs, 'after sync io', 'Prefetch')
-              assertLog(logs, 'after cache read - page', 'Prefetch')
-            }
-          }
-
-          if (isInitialLoad) {
-            await testInitialLoad(path, assertLogs)
-          } else {
-            await testNavigation(path, assertLogs)
-          }
-        })
-      }
+        if (isInitialLoad) {
+          await testInitialLoad(path, assertLogs)
+        } else {
+          await testNavigation(path, assertLogs)
+        }
+      })
     })
   })
 }

--- a/test/development/app-dir/cache-components-tasks/cache-components-tasks.test.ts
+++ b/test/development/app-dir/cache-components-tasks/cache-components-tasks.test.ts
@@ -16,7 +16,7 @@ describe.each([
 ])(
   'cache-components-tasks - $description',
   ({ fixturePath, hasRuntimePrefetch }) => {
-    const { next, isTurbopack, isNextDev } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: nodePath.join(__dirname, fixturePath),
     })
 
@@ -79,19 +79,6 @@ describe.each([
       await retry(() => assertLogs(browser))
       assertNoUnexpectedErrorsInCli()
 
-      if (isNextDev && isTurbopack) {
-        // FIXME:
-        // In Turbopack, requests to the /revalidate route seem to occasionally crash
-        // due to some HMR or compilation issue. `revalidatePath` throws this error:
-        //
-        //   Invariant: static generation store missing in revalidatePath <path>
-        //
-        // This is unrelated to the logic being tested here, so for now, we skip the assertions
-        // that require us to revalidate.
-        console.log('WARNING: skipping revalidation assertions in turbopack')
-        return
-      }
-
       // After a revalidation the subsequent warmup render must discard stale
       // cache entries.
       // This should not affect the environment labels.
@@ -118,19 +105,6 @@ describe.each([
       await browser.elementByCss(`a[href="${path}"]`).click()
       await retry(() => assertLogs(browser))
       assertNoUnexpectedErrorsInCli()
-
-      if (isNextDev && isTurbopack) {
-        // FIXME:
-        // In Turbopack, requests to the /revalidate route seem to occasionally crash
-        // due to some HMR or compilation issue. `revalidatePath` throws this error:
-        //
-        //   Invariant: static generation store missing in revalidatePath <path>
-        //
-        // This is unrelated to the logic being tested here, so for now, we skip the assertions
-        // that require us to revalidate.
-        console.log('WARNING: skipping revalidation assertions in turbopack')
-        return
-      }
 
       // After a revalidation the subsequent warmup render must discard stale
       // cache entries.


### PR DESCRIPTION
The six async local storages must be singletons within a realm. A store entered through one reference has to be readable through every other reference, otherwise code running inside the scope sees no store at all. Until now that relied on module identity, which is a weaker guarantee than the requirement. A realm evaluates the same `next` file more than once if the package is reachable through more than one path, and each evaluation then created a storage of its own. The `.external.js` rewrite in `handle-externals.ts` pins which specifier every layer requires, but it cannot help when one specifier resolves to two filenames.

That is what we hit intermittently in `next dev` with Cache Components. A bug in Node's `fs.realpathSync` can return a path with its symlinks unresolved, and the module loader keys the module cache on that path, so on a pnpm install `next/dist/...` is evaluated twice. A Route Handler calling `revalidatePath` then read a `workAsyncStorage` that nothing had ever entered and crashed, and `io()` read a `workUnitAsyncStorage` that was not the one `app-render` had entered, so sync IO went untracked. The Node fix is nodejs/node#65113, which is not in a release yet, and versions without it stay affected once it is.

Each instance is now anchored to a global symbol, which holds the singleton for any number of copies. Worker threads and edge sandboxes still get their own storages, because each has its own `globalThis`. The key includes the Next.js version, so a realm that holds two different versions of Next.js keeps them apart rather than letting one version read a store that the other shaped, which we cannot assume is compatible. The helper itself is stateless and all state lives on `globalThis`, so `async-local-storage.ts` being duplicated along with everything else does not matter. `getOrCreateGlobalAsyncLocalStorage` also replaces the equivalent code in `request-insights-identity.ts`, which was already anchoring its storage this way.

The tests that skipped this under Turbopack are enabled again, and they are what covers the fix. In `dev-warmup.util.ts` both `testInitialLoad` and `testNavigation` returned early under Turbopack, before the revalidation and every assertion after it, and the two `sync IO` tests were never registered at all, which takes that suite from 72 to 88 tests under Turbopack. `cache-components-tasks.test.ts` had the same two early returns.

This does not make duplicate module instances go away, it only removes the consequence that is fatal. A realm that loads `next/dist` twice still pays for two module registries and twice the memory.