### PR TITLE
[ci] Use short-lived access tokens for preview-build uploads instead of static token

### DIFF
--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -20,7 +20,6 @@ jobs:
     name: Upload preview tarballs to Blob
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
-    environment: preview-builds
     steps:
       # Checkout from the default branch (canary) -- workflow_run always uses
       # the default branch's version of the workflow file and this checkout

--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   actions: read
   contents: read
+  # Minting GitHub OIDC tokens to authorize uploads at vercel-packages.
+  id-token: write
 
 jobs:
   upload:
@@ -67,4 +69,4 @@ jobs:
           }}/preview-tarballs"
         env:
           BLOB_ACCESS: ${{ vars.PREVIEW_BUILDS_ACCESS }}
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.PREVIEW_BUILDS_BLOB_READ_WRITE_TOKEN }}
+          PREVIEW_BUILDS_BASE_URL: ${{ vars.PREVIEW_BUILDS_BASE_URL }}

--- a/scripts/upload-preview-tarballs.js
+++ b/scripts/upload-preview-tarballs.js
@@ -1,7 +1,68 @@
 // @ts-check
-const { put } = require('@vercel/blob')
+const { put } = require('@vercel/blob/client')
 const fs = require('node:fs/promises')
 const path = require('node:path')
+
+const PREVIEW_BUILDS_AUDIENCE = 'https://vercel-packages.vercel.app'
+const DEFAULT_PREVIEW_BUILDS_BASE_URL =
+  'https://vercel-packages.vercel.app/next'
+
+/**
+ * Mints a GitHub Actions OIDC token for the given audience.
+ *
+ * @param {string} audience
+ * @returns {Promise<string>}
+ */
+async function mintGitHubActionsOidcToken(audience) {
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  if (!requestUrl || !requestToken) {
+    throw new Error(
+      'ACTIONS_ID_TOKEN_REQUEST_URL is not set. ' +
+        'The job needs the `id-token: write` permission.'
+    )
+  }
+
+  const url = new URL(requestUrl)
+  url.searchParams.set('audience', audience)
+  const response = await fetch(url, {
+    headers: { authorization: `Bearer ${requestToken}` },
+  })
+  if (!response.ok) {
+    throw new Error(
+      `Failed to mint GitHub OIDC token: ${response.status} ${await response.text()}`
+    )
+  }
+
+  const { value } = await response.json()
+  return value
+}
+
+/**
+ * GitHub OIDC tokens expire about five minutes after issuance and uploading a
+ * batch of tarballs can take longer, so the token is re-minted shortly before
+ * it expires.
+ *
+ * @returns {() => Promise<string>}
+ */
+function createGitHubOidcTokenGetter() {
+  /** @type {string | null} */
+  let cachedToken = null
+  let cachedTokenExpiresAt = 0
+
+  return async () => {
+    if (cachedToken !== null && cachedTokenExpiresAt - 60_000 > Date.now()) {
+      return cachedToken
+    }
+    const token = await mintGitHubActionsOidcToken(PREVIEW_BUILDS_AUDIENCE)
+    const payload = JSON.parse(
+      Buffer.from(token.split('.')[1], 'base64url').toString()
+    )
+    cachedToken = token
+    cachedTokenExpiresAt = payload.exp * 1000
+    return token
+  }
+}
 
 /**
  * Yields one entry per package tarball under `tarballDirectory`. Scoped
@@ -55,31 +116,54 @@ async function main() {
     )
   }
 
-  if (!process.env.BLOB_READ_WRITE_TOKEN) {
-    throw new Error('BLOB_READ_WRITE_TOKEN environment variable is required')
-  }
   const blobAccess = process.env.BLOB_ACCESS
   if (blobAccess !== 'private' && blobAccess !== 'public') {
     throw new Error(
       `BLOB_ACCESS environment variable can only be "private" or "public" but got "${blobAccess}".`
     )
   }
+  const baseUrl =
+    process.env.PREVIEW_BUILDS_BASE_URL || DEFAULT_PREVIEW_BUILDS_BASE_URL
+  const getOidcToken = createGitHubOidcTokenGetter()
 
   for await (const { packageName, tarballPath } of findTarballs(
     tarballDirectory
   )) {
-    const blobPathname = `next/commits/${githubHeadSha}/${packageName}.tgz`
+    // vercel-packages authorizes the OIDC token and answers with a client
+    // token scoped to this exact blob path. The bytes then flow directly to
+    // the store, so the tarball size is not limited by a function's request
+    // body limit.
+    const response = await fetch(
+      `${baseUrl}/commits/${githubHeadSha}/${packageName}`,
+      {
+        method: 'POST',
+        headers: { authorization: `Bearer ${await getOidcToken()}` },
+      }
+    )
+    if (!response.ok) {
+      throw new Error(
+        `Failed to authorize the upload of ${packageName}: ${response.status}. ` +
+          `Response headers: ${JSON.stringify(Object.fromEntries(response.headers))}`
+      )
+    }
+    const { clientToken } = await response.json()
 
     const fileBuffer = await fs.readFile(tarballPath)
-    const { url } = await put(blobPathname, fileBuffer, {
-      access: blobAccess,
-      addRandomSuffix: false,
-      contentType: 'application/gzip',
-    })
+    const { url } = await put(
+      `next/commits/${githubHeadSha}/${packageName}.tgz`,
+      fileBuffer,
+      {
+        access: blobAccess,
+        token: clientToken,
+        addRandomSuffix: false,
+        contentType: 'application/gzip',
+        multipart: true,
+      }
+    )
     console.info(`Uploaded ${packageName} -> ${url}`)
   }
 
-  console.info('All tarballs uploaded to Vercel Blob')
+  console.info('All tarballs uploaded')
 }
 
 main().catch((err) => {

--- a/scripts/upload-preview-tarballs.js
+++ b/scripts/upload-preview-tarballs.js
@@ -155,7 +155,6 @@ async function main() {
       {
         access: blobAccess,
         token: clientToken,
-        addRandomSuffix: false,
         contentType: 'application/gzip',
         multipart: true,
       }


### PR DESCRIPTION
Replaces the static `PREVIEW_BUILDS_BLOB_READ_WRITE_TOKEN` secret with a short-lived access token to upload to Vercel Blob in exchange for a GitHub OIDC (endpoint side: https://github.com/vercel/vercel-packages/pull/98):

- the job mints GitHub Actions OIDC tokens for the `https://vercel-packages.vercel.app` audience itself (the workflow gains `id-token: write`) and re-mints shortly before expiry since a token lives about five minutes while a package batch can take longer
- `upload-preview-tarballs.js` exchanges the token at vercel-packages for scoped client-upload tokens via POST and uploads the tarball bytes directly to Blob storage with `@vercel/blob/client`'s `put`, so the blob read-write token never leaves vercel-packages
- the `preview-builds` environment is dropped from the job: it only existed to selectively expose the static token and restrict uploads to canary, and the canary binding is now enforced by the `job_workflow_ref` match at vercel-packages. 

## Test plan

- [x] throwaway branch targetting a preview deployment of https://github.com/vercel/vercel-packages/pull/98 can upload: https://github.com/vercel/next.js/actions/runs/32366292986


