### PR TITLE
[15.5] [ci] Use OIDC tokens to read private preview builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -603,6 +603,11 @@ jobs:
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
 
+    permissions:
+      contents: read
+      # Minting GitHub OIDC tokens to read private preview builds. Dormant in
+      # this repo since builds here are public.
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -105,9 +105,7 @@ env:
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
   NEXT_TEST_PREFER_OFFLINE: 1
   NEXT_CI_RUNNER: ${{ inputs.runs_on_labels }}
-  # Read token for the auth-protected preview-builds npm mirror, used by deploy
-  # tests to install Next.js artifacts during the remote build.
-  PREVIEW_BUILDS_READ_TOKEN: ${{ secrets.PREVIEW_BUILDS_READ_TOKEN }}
+  PREVIEW_BUILDS_ACCESS: ${{ vars.PREVIEW_BUILDS_ACCESS }}
 
 jobs:
   build:

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -4,6 +4,38 @@ import yargs from 'yargs'
 import getChangedTests from './get-changed-tests.mjs'
 
 /**
+ * Mints a GitHub Actions OIDC token for the given audience.
+ *
+ * @param {string} audience
+ * @returns {Promise<string>}
+ */
+async function mintGitHubActionsOidcToken(audience) {
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  if (!requestUrl || !requestToken) {
+    throw new Error(
+      'Preview builds are private (PREVIEW_BUILDS_ACCESS=private) ' +
+        'but no GitHub Actions OIDC token can be minted. ' +
+        'Grant the job the `id-token: write` permission.'
+    )
+  }
+
+  const url = new URL(requestUrl)
+  url.searchParams.set('audience', audience)
+  const response = await fetch(url, {
+    headers: { authorization: `Bearer ${requestToken}` },
+  })
+  if (!response.ok) {
+    throw new Error(
+      `Failed to mint GitHub OIDC token: ${response.status} ${await response.text()}`
+    )
+  }
+
+  const { value } = await response.json()
+  return value
+}
+
+/**
  * Run tests for added/changed tests in the current branch
  * CLI Options:
  * --mode: test mode (dev, deploy, start)
@@ -90,10 +122,14 @@ async function main() {
       ? `${previewBuildsBaseUrl}/commits/${commitSha}/next`
       : undefined
 
-  const previewBuildsReadToken = process.env.PREVIEW_BUILDS_READ_TOKEN
-
   if (nextTestVersion) {
     console.log(`Verifying artifacts for commit ${commitSha}`)
+    // Private preview builds authenticate with a GitHub Actions OIDC token
+    // minted on demand. Public builds need no credentials.
+    const previewBuildsReadToken =
+      process.env.PREVIEW_BUILDS_ACCESS === 'private'
+        ? await mintGitHubActionsOidcToken('https://vercel-packages.vercel.app')
+        : null
     // Attempt to fetch the deploy artifacts for the commit
     // These might take a moment to become available, so we'll retry a few times
     const fetchHeaders = previewBuildsReadToken

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -169,18 +169,26 @@ export class NextDeployInstance extends NextInstance {
     this._cliOutput = buildLogs.stdout + buildLogs.stderr
   }
 
-  // When the preview-builds npm mirror is auth-protected, the deploy build
-  // installs Next.js artifacts from it and needs credentials. We write an
-  // `.npmrc` with a read token (provided as a CI secret) so the remote install
-  // can authenticate. Only written when the token is set, so unprotected and
-  // local deploy runs are unaffected.
+  // When preview builds are private, the deploy build installs Next.js
+  // artifacts from an auth-protected route and needs credentials. The build
+  // authenticates with the Vercel OIDC token that Vercel automatically
+  // provides to builds (vercel-packages accepts it for allowlisted teams), so
+  // we write an `.npmrc` referencing it. Referencing the environment variable
+  // instead of inlining a token keeps credentials out of the uploaded
+  // deployment source. Only written for private preview builds since public
+  // ones need no credentials and pnpm fails when an `.npmrc` references an
+  // unset environment variable.
+  // TODO: pnpm >= 10.34.2 no longer expands environment variables in
+  // repository .npmrc files (GHSA-3qhv-2rgh-x77r). An install command writing
+  // to the user-level pnpm config (like vercel/front does) did not work with
+  // `vercel deploy` and needs more investigation.
   private async writeMirrorNpmrcIfNecessary(): Promise<void> {
-    const token = process.env.PREVIEW_BUILDS_READ_TOKEN
     const baseUrlRaw = process.env.NEXT_TEST_PREVIEW_BUILDS_BASE_URL
+    const access = process.env.PREVIEW_BUILDS_ACCESS
 
-    if (!token || !baseUrlRaw) {
+    if (!baseUrlRaw || access !== 'private') {
       require('console').log(
-        `Skipping .npmrc write for preview-builds mirror: missing token or base URL`
+        `Skipping .npmrc write for preview-builds mirror: missing base URL or preview builds are public`
       )
       return
     }
@@ -195,7 +203,7 @@ export class NextDeployInstance extends NextInstance {
     )
     await fs.writeFile(
       path.join(this.testDir, '.npmrc'),
-      `${registryKey}:_authToken=${token}\n`
+      `${registryKey}:_authToken=\${VERCEL_OIDC_TOKEN}\n`
     )
   }
 


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/96919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
