### PR TITLE
[test] Redirect the deployment host in-process for proxy deploy tests

### DIFF
--- a/test/lib/browsers/launch.js
+++ b/test/lib/browsers/launch.js
@@ -3,6 +3,15 @@
 const { chromium, firefox, webkit } = require('playwright')
 
 /**
+ * Tells the browser launcher which host to redirect, as `<hostname>=<address>`.
+ * A deploy test sets this when it redirects the deployment host inside the test
+ * process (`NEXT_TEST_PROXY_IN_PROCESS`), because the launcher runs in the same
+ * process but has no access to the test instance. The `/etc/hosts` mode never
+ * sets it, since that mode already covers every process on the machine.
+ */
+const PROXY_HOST_MAP_ENV_KEY = 'NEXT_TEST_PROXY_HOST_MAP'
+
+/**
  * Maps a test browser name (`BROWSER_NAME`) to a Playwright `BrowserType` and
  * the launch options we always use for it.
  *
@@ -49,4 +58,4 @@ function getBrowserLaunch(browserName, { headless }) {
   }
 }
 
-module.exports = { getBrowserLaunch }
+module.exports = { getBrowserLaunch, PROXY_HOST_MAP_ENV_KEY }

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -12,7 +12,7 @@ import {
   BrowserContextOptions,
 } from 'playwright'
 import path from 'path'
-import { getBrowserLaunch } from './launch'
+import { getBrowserLaunch, PROXY_HOST_MAP_ENV_KEY } from './launch'
 
 type EventType = 'request' | 'response'
 
@@ -234,13 +234,40 @@ export class Playwright<TCurrent = undefined> {
       headless,
     })
 
+    // A deploy test can redirect the deployment host to a proxy address inside
+    // this process (`NEXT_TEST_PROXY_IN_PROCESS`). The patched `dns.lookup`
+    // reaches only this process, so the browser needs the same mapping through
+    // a launch argument.
+    const [mappedHostname, mappedAddress] =
+      process.env[PROXY_HOST_MAP_ENV_KEY]?.split('=') ?? []
+    const hostRule =
+      mappedHostname && mappedAddress
+        ? `--host-rules=MAP ${mappedHostname} ${mappedAddress}`
+        : undefined
+
+    if (hostRule) {
+      if (browserType.name() !== 'chromium') {
+        throw new Error(
+          `NEXT_TEST_PROXY_IN_PROCESS redirects the browser with a Chromium launch argument, so it does not support BROWSER_NAME=${browserName}. Use the /etc/hosts mode instead.`
+        )
+      }
+
+      launchOptions.args = [...(launchOptions.args ?? []), hostRule]
+    }
+
     // `run-tests.js` launches a browser server that's shared across all test
     // suites. Connect to it if it's available, otherwise (e.g. when running a
     // test directly via the jest CLI) launch a browser owned by this process.
     // The shared server is always headless (`run-tests.js` sets HEADLESS=true
     // for all test suites), so only connect when we're headless too.
+    //
+    // A host mapping forces a browser owned by this process. The shared server
+    // starts before any mapping exists, and `connect` cannot add a launch
+    // argument, so its requests reach the deployment through the production
+    // CDN. The deployment is the same either way, which is why this is easy to
+    // miss: the test passes, and it exercises none of the proxy under test.
     const wsEndpoint = process.env.NEXT_TEST_BROWSER_WS_ENDPOINT
-    if (wsEndpoint && headless) {
+    if (wsEndpoint && headless && !hostRule) {
       return await browserType.connect(wsEndpoint)
     }
     return await browserType.launch(launchOptions)

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -1,5 +1,6 @@
 import os from 'os'
 import path from 'path'
+import dns from 'dns'
 import execa from 'execa'
 import fs from 'fs-extra'
 import { NextInstance, type NextInstanceOpts } from './base'
@@ -7,6 +8,7 @@ import * as projectEnv from '../../../scripts/reset-project.mjs'
 import { Span } from 'next/dist/trace'
 import { setTimeout } from 'timers/promises'
 import { FileRef } from '../e2e-utils'
+import { PROXY_HOST_MAP_ENV_KEY } from '../browsers/launch'
 
 export class NextDeployInstance extends NextInstance {
   private _cliOutput: string
@@ -14,6 +16,7 @@ export class NextDeployInstance extends NextInstance {
   private _deploymentId: string | undefined
   private _supportsImmutableAssets: boolean = false
   private _writtenHostsLine: string | null = null
+  private _restoreDnsLookup: (() => void) | null = null
 
   constructor(opts: NextInstanceOpts) {
     super(opts)
@@ -566,15 +569,78 @@ export class NextDeployInstance extends NextInstance {
     )
   }
 
+  /**
+   * Redirects the deployment host to the proxy address for this process only.
+   * The patched `dns.lookup` covers `fetch`, because Node resolves the
+   * connection through it while the TLS handshake still uses the original
+   * hostname for SNI. A valid certificate therefore still validates.
+   *
+   * This mode needs no `sudo`, and it keeps concurrent test files independent,
+   * unlike the shared `/etc/hosts` file.
+   */
+  private redirectHostInProcess(hostname: string, address: string): void {
+    require('console').log(
+      `Redirecting ${hostname} to ${address} for this process`
+    )
+
+    const originalLookup = dns.lookup
+
+    // `dns.lookup` answers for an IP address literal without a query, and it
+    // answers in the shape that the caller's options ask for. The redirection
+    // therefore replaces the hostname, passes the remaining arguments through
+    // untouched, and lets Node produce the result.
+    function patchedLookup(
+      this: unknown,
+      lookupHostname: string,
+      ...args: unknown[]
+    ): void {
+      Reflect.apply(originalLookup, this, [
+        lookupHostname === hostname ? address : lookupHostname,
+        ...args,
+      ])
+    }
+
+    // `dns.lookup` holds the argument names that `util.promisify` reads in a
+    // hidden symbol property. The wrapper takes over every own property, so the
+    // promisified form still resolves to an object instead of a bare address.
+    Object.defineProperties(
+      patchedLookup,
+      Object.getOwnPropertyDescriptors(originalLookup)
+    )
+
+    dns.lookup = Object.assign(patchedLookup, originalLookup)
+
+    this._restoreDnsLookup = () => {
+      dns.lookup = originalLookup
+    }
+
+    process.env[PROXY_HOST_MAP_ENV_KEY] = `${hostname}=${address}`
+  }
+
   private async configureProxyAddress(): Promise<void> {
-    // If configured, we should configure the `/etc/hosts` file to point the
-    // deployment domain to the specified proxy address.
-    if (
-      process.env.NEXT_TEST_PROXY_ADDRESS &&
-      // Validate that the proxy address is a valid IP address.
-      /^\d+\.\d+\.\d+\.\d+$/.test(process.env.NEXT_TEST_PROXY_ADDRESS)
-    ) {
-      this._writtenHostsLine = `${process.env.NEXT_TEST_PROXY_ADDRESS}\t${this._parsedUrl.hostname}\n`
+    const proxyAddress = process.env.NEXT_TEST_PROXY_ADDRESS
+    const redirectInProcess = !!process.env.NEXT_TEST_PROXY_IN_PROCESS
+
+    // Validate that the proxy address is a valid IP address.
+    if (!proxyAddress || !/^\d+\.\d+\.\d+\.\d+$/.test(proxyAddress)) {
+      // Without a redirection the production CDN serves the deployment, so the
+      // test passes and exercises none of the proxy under test. Fail instead of
+      // ignoring an incomplete request for in-process redirection.
+      if (redirectInProcess) {
+        throw new Error(
+          `NEXT_TEST_PROXY_IN_PROCESS needs a valid IP address in NEXT_TEST_PROXY_ADDRESS, received ${proxyAddress ? `"${proxyAddress}"` : 'no value'}.`
+        )
+      }
+
+      return
+    }
+
+    if (redirectInProcess) {
+      this.redirectHostInProcess(this._parsedUrl.hostname, proxyAddress)
+    } else {
+      // Otherwise we point the deployment domain to the proxy address through
+      // the `/etc/hosts` file.
+      this._writtenHostsLine = `${proxyAddress}\t${this._parsedUrl.hostname}\n`
 
       require('console').log(
         `Writing proxy address to hosts file: ${this._writtenHostsLine.trim()}`
@@ -609,6 +675,13 @@ export class NextDeployInstance extends NextInstance {
           err
         )
       })
+    }
+
+    if (this._restoreDnsLookup) {
+      require('console').log(`Removing the in-process host redirection`)
+      this._restoreDnsLookup()
+      this._restoreDnsLookup = null
+      delete process.env[PROXY_HOST_MAP_ENV_KEY]
     }
 
     // If configured, we should remove the proxy address from the hosts file.


### PR DESCRIPTION
`NEXT_TEST_PROXY_ADDRESS` routes a deploy test's request serving through a different proxy by adding a line to `/etc/hosts`, which needs `sudo`. That fails outright in a non-interactive shell, and because the teardown rewrites the whole file, two test files running at once can drop each other's entries. Both problems make the flag awkward for local work against a proxy running on the same machine, where the point is a fast loop with debug logging.

Setting `NEXT_TEST_PROXY_IN_PROCESS` now redirects the deployment host inside the test process instead. The harness patches `dns.lookup` for that one hostname and restores it on teardown, which covers every request the test process makes, because Node resolves the connection through it while the TLS handshake still uses the original hostname for SNI, so a valid certificate keeps validating. The wrapper replaces the hostname and hands the call back to the original, which answers for an IP address literal without a query, so Node keeps producing the result shape that each caller asked for. Subprocesses such as the custom deploy, logs, and cleanup scripts resolve the hostname normally, which the `/etc/hosts` mode would have redirected as well.

The browser needs the mapping too, so the instance publishes it through `NEXT_TEST_PROXY_HOST_MAP`, a name both sides read from the shared browser launch module, and the launcher turns that into a `--host-rules` argument. The `/etc/hosts` mode stays the default, and CI is unaffected.

A host mapping also forces a browser owned by the test process. The shared browser server starts before any mapping exists and `connect` cannot add a launch argument, so its requests would reach the deployment through the production CDN. The deployment is the same either way, so the test would pass while exercising none of the proxy under test. The launcher derives both the argument and that decision from the same value so the two cannot disagree, and it refuses to launch anything other than Chromium, because `--host-rules` is a Chromium switch and a browser that ignores it would produce the same silent pass. For the same reason, asking for in-process redirection without a valid
`NEXT_TEST_PROXY_ADDRESS` is an error rather than a silent no-op.

Verified against a locally running proxy:

- `VERCEL_TURBOPACK_TEST_TEAM=<team> NEXT_TEST_PROXY_ADDRESS=127.0.0.1 NEXT_TEST_PROXY_IN_PROCESS=1 pnpm test-deploy-turbo test/e2e/app-dir/hello-world/hello-world.test.ts` passes in full without  `sudo`, including the browser test.
- The proxy's nginx access log records the requests, which a redirect that silently did nothing would not.